### PR TITLE
Object class resource cleanup

### DIFF
--- a/pimcore/models/Object/Class/Resource.php
+++ b/pimcore/models/Object/Class/Resource.php
@@ -458,8 +458,13 @@ class Object_Class_Resource extends Pimcore_Model_Resource_Abstract {
             if(defined("PIMCORE_DB_CHANGELOG_DIRECTORY")) {
                 $file = PIMCORE_DB_CHANGELOG_DIRECTORY."/".$filename;
             }
-            
-            file_put_contents($file, $log);
+
+            $logContent = '';
+
+            if(file_exists($filename) && is_readable($filename))
+                $logContent = file_get_contents($filename)."\n\n\n";
+
+            file_put_contents($logContent.$file, $log);
             chmod($file, 0766);
             $this->_sqlChangeLog = array();
         }


### PR DESCRIPTION
das grundproblem welches hier existiert(e) ist, dass der speichervorgang von neuen klassen nicht insich abgeschlossen war, ein unset auf die resource führte nicht zum letzten schreibvorgang auf die datei, dafür verantwortlich war das array _sqlChangeLog welches weiterhin logs zum schreiben hatte.

jedoch kann es sein, dass eine datei schon existiert (zugriff in der selben sekunde), demnach muss beim schreibvorgang geprüft werden die datei schon existiert - wenn ja werden die logs nur angehangen.
