### PR TITLE
Extension of javascript abstract plugin class.

### DIFF
--- a/pimcore/static/css/icons.css
+++ b/pimcore/static/css/icons.css
@@ -195,6 +195,10 @@
 	background: url(/pimcore/static/img/icon/plugin.png) no-repeat !important;
 }
 
+.pimcore_icon_menu_plugins {
+	background: url(/pimcore/static/img/icon/plugin.png) no-repeat !important;
+}
+
 .pimcore_icon_menu_settings {
 	background: url(/pimcore/static/img/icon/wrench.png) no-repeat !important;
 }

--- a/pimcore/static/js/pimcore/layout/toolbar.js
+++ b/pimcore/static/js/pimcore/layout/toolbar.js
@@ -207,6 +207,20 @@ pimcore.layout.toolbar = Class.create({
             });
         }
 
+        // menu items from registered plugins
+        var pluginItems = [];
+        Ext.each(pimcore.plugin.broker.getPlugins(), function(plugin){
+            var menu = plugin.getMenu();
+            if(typeof menu == 'object') {
+                pluginItems.push(menu);
+            }
+        });
+        if (pluginItems.length > 0) {
+            this.pluginMenu = new Ext.menu.Menu({
+                items: pluginItems
+            });
+        }
+
         // settings menu
         var settingsItems = [];
 
@@ -405,6 +419,16 @@ pimcore.layout.toolbar = Class.create({
         }
 
 
+        if (this.pluginMenu) {
+            this.toolbar.add({
+                text: t('plugins'),
+                iconCls: "pimcore_icon_menu_plugins",
+                cls: "pimcore_main_menu",
+                menu: this.pluginMenu
+            });
+        }
+
+
         if (this.settingsMenu) {
             this.toolbar.add({
                 text: t('settings'),
@@ -413,7 +437,7 @@ pimcore.layout.toolbar = Class.create({
                 menu: this.settingsMenu
             });
         }
-        
+
         this.toolbar.add({
             text: t('search'),
             iconCls: "pimcore_icon_menu_search",
@@ -424,9 +448,9 @@ pimcore.layout.toolbar = Class.create({
                 }, null, {moveToTab: true} );
             }
         });
-        
+
         this.toolbar.add("->");
-        
+
 
         if (user.isAllowed("seemode")) {
             this.toolbar.add({

--- a/pimcore/static/js/pimcore/plugin/plugin.js
+++ b/pimcore/static/js/pimcore/plugin/plugin.js
@@ -24,6 +24,13 @@ pimcore.plugin.admin = Class.create({
     uninstall: function() {
     },
 
+    /**
+     * Called on admin toolbar initialization.
+     * Must return instance of Ext.menu.Item or Object with item definition.
+     */
+    getMenu: function() {
+    },
+
 
     /* events */
 


### PR DESCRIPTION
Allows to easily integrate custom plugin menu item(s) with admin toolbar.
Menu is automaticaly included if plugin class implements getMenu() abstract method.

Example (pimcore.plugin.poll class):

``` javascript
getMenu: function(){
    return new Ext.menu.Item({
        text: t("polls"),
        iconCls: "poll_plugin_menu_icon",
        hideOnClick: false,
        menu: [{
            text: t("create_poll"),
            iconCls: "poll_plugin_menu_new",
            handler: this.openCreateTab
        },{
            text: t("manage_polls"),
            iconCls: "poll_plugin_menu_list",
            handler: this.openListTab
        },{
            text: t("settings"),
            iconCls: "poll_plugin_settings",
            handler: this.openSettingsTab
        }]
    });
}
```

PS: If this code will be accepted i will update plugin anatomy section in docs.
PS2: I think that this aproach could replace existing <pluginIframeSrc/> option for plugin settings management.
