### PR TITLE
warnings for the autoloader

### DIFF
--- a/pimcore/lib/Pimcore.php
+++ b/pimcore/lib/Pimcore.php
@@ -210,8 +210,8 @@ class Pimcore {
             @ini_set("display_errors", "On");
             @ini_set("display_startup_errors", "On");
 
-            //$autoloader = Zend_Loader_Autoloader::getInstance();
-            //$autoloader->suppressNotFoundWarnings(false);
+            $autoloader = Zend_Loader_Autoloader::getInstance();
+            $autoloader->suppressNotFoundWarnings(false);
             $front->throwExceptions(true);
 
             try {


### PR DESCRIPTION
dadurch das suppressNotFoundWarnings Fehler unterdrückt, ist es extrem undankbar zu debuggen.
