### PR TITLE
pimcore should not overwrite a custom profiler

### DIFF
--- a/pimcore/lib/Pimcore/Resource/Mysql.php
+++ b/pimcore/lib/Pimcore/Resource/Mysql.php
@@ -60,7 +60,7 @@ class Pimcore_Resource_Mysql {
             Logger::warn($e);
         }
 
-        if(PIMCORE_DEVMODE) {
+        if(PIMCORE_DEVMODE && !$db->getProfiler()->getEnabled()) {
             $profiler = new Pimcore_Db_Profiler('All DB Queries');
             $profiler->setEnabled(true);
             $db->setProfiler($profiler);


### PR DESCRIPTION
Wenn man in der settings,xml einen profiler setzt und im dev mode ist, so wird dieser nach exakt 3 queries von Pimcore überschrieben.
