### PR TITLE
performance issue on recursive templates

### DIFF
--- a/pimcore/lib/Pimcore/Controller/Action/Helper/ViewRenderer.php
+++ b/pimcore/lib/Pimcore/Controller/Action/Helper/ViewRenderer.php
@@ -42,8 +42,10 @@ class Pimcore_Controller_Action_Helper_ViewRenderer extends Zend_Controller_Acti
 
         // this is very important, the initView could be called multiple times.
         // if we add the path on every call, we have big performance issues.
-        if(!$this->isInitialized)
-            $this->isInitialized = true;
+        if($this->isInitialized)
+            return;
+
+        $this->isInitialized = true;
 
         $paths = $this->view->getScriptPaths();
         // script pathes for layout path


### PR DESCRIPTION
if you use the Zend_View_Helper_Action for dispatching recursive the Pimcore_Controller_Action_Helper_ViewRenderer will re-add all template paths. Everytime pimcore try to include all the files. For example we had ~300 recursive calls, pimcore needs around 90 Seconds (i think around 300.000 includes) to deliver the page.

this pull request should fix this issue.

to reproduce

an Action:

``` php
 public function fooAction() {
  if(!$this->_getParam('inkr'))
   return die();

 $inkr = $this->_getParam('inkr');
 $this->view->inkr =  --$inkr;
}
```

and a view

``` php
   if($this->inkr)
      echo $this->action('foo', 'default', null, array('inkr' => $this->inkr));
```
