### PR TITLE
Limit reached when maxItem=1

### DIFF
--- a/pimcore/static/js/pimcore/object/tags/multihref.js
+++ b/pimcore/static/js/pimcore/object/tags/multihref.js
@@ -350,7 +350,7 @@ pimcore.object.tags.multihref = Class.create(pimcore.object.tags.abstract, {
     elementAlreadyExists: function (id, type) {
 
         // check max amount in field
-        if(this.fieldConfig["maxItems"] && this.fieldConfig["maxItems"] > 1) {
+        if(this.fieldConfig["maxItems"] && this.fieldConfig["maxItems"] >= 1) {
             if(this.store.getCount() >= this.fieldConfig.maxItems) {
                 Ext.Msg.alert(t("error"),t("limit_reached"));
                 return true;

--- a/pimcore/static/js/pimcore/object/tags/objects.js
+++ b/pimcore/static/js/pimcore/object/tags/objects.js
@@ -543,7 +543,7 @@ pimcore.object.tags.objects = Class.create(pimcore.object.tags.abstract, {
     objectAlreadyExists: function (id) {
 
         // check max amount in field
-        if(this.fieldConfig["maxItems"] && this.fieldConfig["maxItems"] > 1) {
+        if(this.fieldConfig["maxItems"] && this.fieldConfig["maxItems"] >= 1) {
             if(this.store.getCount() >= this.fieldConfig.maxItems) {
                 Ext.Msg.alert(t("error"),t("limit_reached"));
                 return true;


### PR DESCRIPTION
admin ui allowed me to drop more than 1 object onto a relation that I restricted to maxItems=1 during class definition without firing the 'Limit reached' popup.
