### PR TITLE
Staticroute::assemble() - "/" should not be forbidden

### DIFF
--- a/pimcore/models/Staticroute.php
+++ b/pimcore/models/Staticroute.php
@@ -366,7 +366,7 @@ class Staticroute extends Pimcore_Model_Abstract {
         $parametersGet = array();
         $parametersNotNamed = array();
         $url = $this->getReverse();
-        $forbiddenCharacters = array("#","/",":","?");
+        $forbiddenCharacters = array("#",":","?");
 
         // check for named variables
         foreach ($urlParams as $key => $param) {


### PR DESCRIPTION
Slash it's regular path separator and should be acceptable, I think.

See discussion about nested object routing: http://www.pimcore.org/board/viewtopic.php?f=24&t=703
