### PR TITLE
A small fix to prevent PHP Notice

### DIFF
--- a/pimcore/lib/Pimcore/Google/Analytics.php
+++ b/pimcore/lib/Pimcore/Google/Analytics.php
@@ -28,7 +28,12 @@ class Pimcore_Google_Analytics {
         
         $siteKey = Pimcore_Tool_Frontend::getSiteKey($site);
         
-        if(Pimcore_Config::getReportConfig()->analytics->sites->$siteKey) {
+        $config = Pimcore_Config::getReportConfig();
+        if (!$config->analytics) {
+            return false;
+        }
+
+        if($config->analytics->sites->$siteKey) {
             return Pimcore_Config::getReportConfig()->analytics->sites->$siteKey;
         }
         return false;


### PR DESCRIPTION
I enabled error_reporting(E_ALL) in my dev environment, and I'm getting a notice... this little change gets rid of it.
