### PR TITLE
Fix for issue #1600 (CSS Minifier)

### DIFF
--- a/pimcore/lib/Pimcore/Controller/Plugin/CssMinify.php
+++ b/pimcore/lib/Pimcore/Controller/Plugin/CssMinify.php
@@ -57,25 +57,27 @@ class Pimcore_Controller_Plugin_CssMinify extends Zend_Controller_Plugin_Abstrac
                         $stylesheetContent .= $style->innertext;
                     }
                     else {
-                        if($style->media == "screen" || !$style->media) {
-                            $source = $style->href;
-                            $path = "";
 
-                            if(!preg_match("@http(s)?://@i", $source)) {
-                                if (is_file(PIMCORE_ASSET_DIRECTORY . $source)) {
-                                    $path = PIMCORE_ASSET_DIRECTORY . $source;
-                                }
-                                else if (is_file(PIMCORE_DOCUMENT_ROOT . $source)) {
-                                    $path = PIMCORE_DOCUMENT_ROOT . $source;
-                                }
+                        $source = $style->href;
+                        $path = "";
+                        if (is_file(PIMCORE_ASSET_DIRECTORY . $source)) {
+                            $path = PIMCORE_ASSET_DIRECTORY . $source;
+                        }
+                        else if (is_file(PIMCORE_DOCUMENT_ROOT . $source)) {
+                            $path = PIMCORE_DOCUMENT_ROOT . $source;
+                        }
+
+                        if (!empty($path) && is_file("file://".$path)) {
+                            $content = file_get_contents($path);
+                            $content = $this->correctReferences($source,$content);
+
+                            if($style->media) {
+                                $content = "@media ".$style->media." {" . $content . "}";
                             }
 
-                            if (!empty($path) && is_file("file://".$path)) {
-                                $content = file_get_contents($path);
-                                $content = $this->correctReferences($source,$content);
-                                $stylesheetContent .= $content;
-                                $style->outertext = "";
-                            }
+                            $stylesheetContent .= $content;
+                            $style->outertext = "";
+
                         }
                     }
                 }
@@ -93,7 +95,7 @@ class Pimcore_Controller_Plugin_CssMinify extends Zend_Controller_Plugin_Abstrac
                     }
 
                     $head = $html->find("head",0);
-                    $head->innertext = $head->innertext . "\n" . '<link rel="stylesheet" media="screen" type="text/css" href="' . str_replace(PIMCORE_DOCUMENT_ROOT,"",$stylesheetPath) . '" />'."\n";
+                    $head->innertext = $head->innertext . "\n" . '<link rel="stylesheet" type="text/css" href="' . str_replace(PIMCORE_DOCUMENT_ROOT,"",$stylesheetPath) . '" />'."\n";
                 }
 
                 $body = $html->save();


### PR DESCRIPTION
I have implemented a fix for [Pimcore issue #1600](http://www.pimcore.org/issues/browse/PIMCORE-1600) that I hereby submit to be merged into the Pimcore master repository.

This fixes the problem with print (and other) stylesheets not working because of the order is changed, and not being minified.
- All stylesheets are now minified in a single file. Before only the ones with the media type "screen" or none were minified.
- All media types are supported.
- The order of the stylesheets is preserved so that they will cascade properly.
- HTML media-attribute is replaced with @media in CSS. Source CSS should NOT contain @media.
- Faster because more CSS is minified and amount of requests is reduced.
