### PR TITLE
Fix for PIMCORE-1670

### DIFF
--- a/pimcore/modules/admin/controllers/MiscController.php
+++ b/pimcore/modules/admin/controllers/MiscController.php
@@ -124,7 +124,7 @@ class Admin_MiscController extends Pimcore_Controller_Action_Admin
         $validLanguages = array();
         foreach ($languages as $short => $translation) {
 
-            if (strlen($short) == 2 or (strlen($short) == 5 and strpos($short, "_") == 2)) {
+            if (strlen($short) == 2 or (strlen($short) == 5 and strpos($short, "_") == 2) or (strlen($short) == 7 and strpos($short, "_") == 2)) {
                 $languageOptions[$short] = $translation;
             }
         }


### PR DESCRIPTION
This fixes PIMCORE-1670 - Traditional Chinese and Simplified Chinese can't be show in localizedfields

The MiscController checked if the short code for a language was either 2 characters or 5 characters long, but the short codes for Simplified and Tradititional Chinese are 7 characters long.
