### PR TITLE
Fixes PIMCORE-1744 - Wysiwyg thumbnail creation

### DIFF
--- a/pimcore/lib/Pimcore/Tool/Text.php
+++ b/pimcore/lib/Pimcore/Tool/Text.php
@@ -86,7 +86,7 @@ class Pimcore_Tool_Text
                             );
                         }
 
-                        if ($styleAttr[1] && preg_match("/(width|height)/",$styleAttr[1])) {
+                        if ($styleAttr[1] && preg_match("/[^-](width|height)/",$styleAttr[1])) {
 
                             $config = array(); // reset the config if it was set already before (attributes)
 


### PR DESCRIPTION
This commit fixes PIMCORE-1744 - Wysiwyg thumbnail creation possibly matches incorrect attributes (border-width, line-height, etc)
