### PR TITLE
Fix for a bug for class selector in grid view

### DIFF
--- a/pimcore/models/Object/Abstract/Resource.php
+++ b/pimcore/models/Object/Abstract/Resource.php
@@ -323,7 +323,7 @@ class Object_Abstract_Resource extends Element_Resource {
 
     public function getClasses() {
         if($this->getChildAmount()) {
-            $classIds = $this->db->fetchCol("SELECT o_classId FROM objects WHERE o_path LIKE ? AND o_type = 'object' GROUP BY o_classId", $this->model->getFullPath() . "%");
+            $classIds = $this->db->fetchCol("SELECT o_classId FROM objects WHERE o_path LIKE ? AND o_type = 'object' GROUP BY o_classId", $this->model->getFullPath() . "/%");
 
             $classes = array();
             foreach ($classIds as $classId) {


### PR DESCRIPTION
 This fixes a bug when two object folders start with the same letters, like "news" and "newsletter". Class selector will appear for "news" folder in grid view, although it only contains objects of one class as it will also take classes of "newsletter" folder.
