### PR TITLE
Feature/combine plugin js

### DIFF
--- a/pimcore/modules/admin/views/scripts/index/index.php
+++ b/pimcore/modules/admin/views/scripts/index/index.php
@@ -530,17 +530,33 @@
             if ($pluginBroker instanceof Pimcore_API_Plugin_Broker) {
                 foreach ($pluginBroker->getPlugins() as $plugin) {
                     if ($plugin->isInstalled()) {
-                        $jsPaths = $plugin->getJsPaths();
-                        if (!empty($jsPaths)) {
-                            foreach ($jsPaths as $jsPath) {
-                                $jsPath=trim($jsPath);
-                                if (!empty($jsPath)) {
+                        if (PIMCORE_DEVMODE) {
+                            $jsPaths = $plugin->getJsPaths();
+                            if (!empty($jsPaths)) {
+                                foreach ($jsPaths as $jsPath) {
+                                    $jsPath=trim($jsPath);
+                                    if (!empty($jsPath)) {
                                     ?>
-                                    <script type="text/javascript" src="<?php echo $jsPath ?>?_dc=<?php echo $pluginDcValue; ?>"></script>
+                                        <script type="text/javascript" src="<?php echo $jsPath ?>?_dc=<?php echo $pluginDcValue; ?>"></script>
                                     <?php
-        
+                                    }
                                 }
                             }
+                        } else {
+                            $pluginScr = '';
+                            $jsPaths = $plugin->getJsPaths();
+
+                        if (!empty($jsPaths)) {
+                            foreach ($jsPaths as $jsPath) {
+                                $jsPath = PIMCORE_DOCUMENT_ROOT . $jsPath;
+                                if(is_file($jsPath)) {
+                                    $pluginScr .= file_get_contents($jsPath);
+                                }
+                            }
+                            ?>
+                            <script type="text/javascript" src="<?php echo Pimcore_Tool_Admin::getMinimizedScriptPath($pluginScr) ?>?_dc=<?php echo Pimcore_Version::$revision ?>"></script>
+                        <?php
+                        }
                         }
                         $cssPaths = $plugin->getCssPaths();
                         if (!empty($cssPaths)) {


### PR DESCRIPTION
I created a small optimization for loading plugin JavaScript. The main problem I ran into while using the ZendFormBuilder plugin for example was the massive amount of JavaScript loaded in separate files. This causes massive delays in loading the backend.

I could also look into introducing a new flag in the plugin configuration for disabling the combining. If that is desired let me know and I'll amend the commit.
