### PR TITLE
Use classmapping to overwrite 'save' method in importProcessAction

### DIFF
--- a/pimcore/modules/admin/controllers/ObjectHelperController.php
+++ b/pimcore/modules/admin/controllers/ObjectHelperController.php
@@ -541,6 +541,9 @@ class Admin_ObjectHelperController extends Pimcore_Controller_Action_Admin {
 
         // create new object
         $className = "Object_" . ucfirst($this->getParam("className"));
+        // Instantiate child class so that we can use overwritten save method
+        $classMapping = Pimcore_Config::getModelClassMappingConfig();
+				if (!empty($classMapping->$className)) $className = $classMapping->$className;
 
         $parent = Object_Abstract::getById($this->getParam("parentId"));
 


### PR DESCRIPTION
When importing data in Pimcore using CSVImport one cannot use
classmapping to overwrite methods such as save. Say you want to import
some addresses and geocode them at import. One way to do this would be
to create a class called Address (Object_Address), derive a class
called Geocoded_Address, update classmapping.xml, overwrite the save
method with geocoding logic and CSVImport the addresses. With this
patch it's now possible to do this.
