### PR TITLE
Update StructuredTable.php - default db column width from 50 to 255

### DIFF
--- a/pimcore/models/Object/Class/Data/StructuredTable.php
+++ b/pimcore/models/Object/Class/Data/StructuredTable.php
@@ -488,7 +488,7 @@ class Object_Class_Data_StructuredTable extends Object_Class_Data {
 
     protected function typeMapper($type) {
         $mapper = array(
-            "text" => "varchar(50)",
+            "text" => "varchar(255)",
             "number" => "double",
             "bool" => "tinyint(1)"
         );


### PR DESCRIPTION
This is a varchar column anyway. It does not hurt to increase the limit to 255. Otherwise Pimcore (mysql, infact) will truncate values added in the backend to 50 chars (we are storing urls in this column ..)
