### PR TITLE
lockfree session

### DIFF
--- a/pimcore/lib/Pimcore/Controller/Action/Admin/Document.php
+++ b/pimcore/lib/Pimcore/Controller/Action/Admin/Document.php
@@ -133,6 +133,7 @@ abstract class Pimcore_Controller_Action_Admin_Document extends Pimcore_Controll
             $this->setValuesToDocument($document);
 
             $session->$key = $document;
+            Zend_Session::writeClose(false);
         }
 
         $this->removeViewRenderer();
@@ -171,6 +172,7 @@ abstract class Pimcore_Controller_Action_Admin_Document extends Pimcore_Controll
         $session = new Zend_Session_Namespace("pimcore_documents");
 
         $session->$key = null;
+        Zend_Session::writeClose(false);
 
         $this->removeViewRenderer();
     }

--- a/pimcore/lib/Pimcore/Controller/Action/Frontend.php
+++ b/pimcore/lib/Pimcore/Controller/Action/Frontend.php
@@ -139,6 +139,8 @@ abstract class Pimcore_Controller_Action_Frontend extends Pimcore_Controller_Act
                         }
                     }
                 }
+
+                Zend_Session::writeClose(false);
                 
                 // register editmode plugin
                 $front = Zend_Controller_Front::getInstance();
@@ -163,6 +165,8 @@ abstract class Pimcore_Controller_Action_Frontend extends Pimcore_Controller_Act
                 if ($docSession->$docKey) {
                     $this->setDocument($docSession->$docKey);
                 }
+
+                Zend_Session::writeClose(false);
             }
 
             // object preview
@@ -174,6 +178,7 @@ abstract class Pimcore_Controller_Action_Frontend extends Pimcore_Controller_Act
                     // add the object to the registry so every call to Object_Abstract::getById() will return this object instead of the real one
                     Zend_Registry::set("object_" . $object->getId(), $object);
                 }
+                Zend_Session::writeClose(false);
             }
         }
 

--- a/pimcore/lib/Pimcore/Liveconnect.php
+++ b/pimcore/lib/Pimcore/Liveconnect.php
@@ -15,26 +15,23 @@
  
 class Pimcore_Liveconnect {
 
-    public static function getSession () {
-        return Pimcore_Tool_Authentication::getSession();
-    }
-
     public static function setToken ($token) {
-        $session = self::getSession();
-        $session->liveconnectToken = $token;
-        $session->liveconnectLastUpdate = time();
+        Pimcore_Tool_Authentication::useSession(function($session)use ($token) {
+            $session->liveconnectToken = $token;
+            $session->liveconnectLastUpdate = time();
+        });
     }
 
     public static function getToken () {
-        $session = self::getSession();
+        return Pimcore_Tool_Authentication::useSession(function($session) {
+            $timeout = 300;
+            if($session->liveconnectLastUpdate < (time()-$timeout)) {
+                $session->liveconnectToken = null;
+            } else {
+                $session->liveconnectLastUpdate = time();
+            }
 
-        $timeout = 300;
-        if($session->liveconnectLastUpdate < (time()-$timeout)) {
-            $session->liveconnectToken = null;
-        } else {
-            $session->liveconnectLastUpdate = time();
-        }
-
-        return $session->liveconnectToken;
+            return $session->liveconnectToken;
+        });
     }
 }

--- a/pimcore/lib/Pimcore/Tool/Authentication.php
+++ b/pimcore/lib/Pimcore/Tool/Authentication.php
@@ -27,23 +27,18 @@ class Pimcore_Tool_Authentication {
      * @return User
      */
     public static function authenticateSession () {
-
-        // start session if necessary
-        self::initSession();
-
-        // get session namespace
-        $adminSession = self::getSession();
-
-        $user = $adminSession->user;
-        if ($user instanceof User) {
-            // renew user
-            $user = User::getById($user->getId());
-            if($user && $user->isActive()) {
-                return $user;
+        return self::useSession(function($adminSession) {
+            $user = $adminSession->user;
+            if ($user instanceof User) {
+                // renew user
+                $user = User::getById($user->getId());
+                if($user && $user->isActive()) {
+                    return $user;
+                }
             }
-        }
 
-        return null;
+            return null;
+        });
     }
 
     /**
@@ -109,9 +104,6 @@ class Pimcore_Tool_Authentication {
                         // get zend_session work with session-id via get (since SwfUpload doesn't support cookies)
                         Zend_Session::setId($_REQUEST[$sName]);
                     }
-
-                    // register session
-                    Zend_Session::start();
                 }
             }
             catch (Exception $e) {
@@ -125,9 +117,24 @@ class Pimcore_Tool_Authentication {
         }
     }
 
-    public static function getSession () {
+    public static function useSession($func) {
+        if(!Zend_Session::isStarted()) {
+            Zend_Session::start();
+        }
+
+        @session_start();
+
+        $ret = $func(self::getSession());
+
+        session_write_close();
+
+        return $ret;
+    }
+
+    protected static function getSession () {
         if(!Zend_Session::isStarted()) {
             self::initSession();
+            Zend_Session::start();
         }
 
         if(!self::$session) {

--- a/pimcore/modules/admin/controllers/LoginController.php
+++ b/pimcore/modules/admin/controllers/LoginController.php
@@ -109,8 +109,9 @@ class Admin_LoginController extends Pimcore_Controller_Action_Admin {
                         // save the information to session when the user want's to reset the password
                         // this is because otherwise the old password is required => see also PIMCORE-1468
                         if($this->getParam("reset")) {
-                            $adminSession = Pimcore_Tool_Authentication::getSession();
-                            $adminSession->password_reset = true;
+                            Pimcore_Tool_Authentication::useSession(function($adminSession) {
+                                $adminSession->password_reset = true;
+                            });
                         }
                     }
                     else {
@@ -118,10 +119,10 @@ class Admin_LoginController extends Pimcore_Controller_Action_Admin {
                     }
 
                     if ($authenticated) {
-                        $adminSession = Pimcore_Tool_Authentication::getSession();
-                        $adminSession->user = $user;
-
-                        Zend_Session::regenerateId();
+                        Pimcore_Tool_Authentication::useSession(function($adminSession) use ($user) {
+                            $adminSession->user = $user;
+                            // Zend_Session::regenerateId();
+                        });
                     }
 
                 } else {
@@ -139,8 +140,9 @@ class Admin_LoginController extends Pimcore_Controller_Action_Admin {
             //see if module or plugin authenticates user
             $user = Pimcore_API_Plugin_Broker::getInstance()->authenticateUser($this->getParam("username"),$this->getParam("password"));
             if($user instanceof User){
-                $adminSession = Pimcore_Tool_Authentication::getSession();
-                $adminSession->user = $user;
+                Pimcore_Tool_Authentication::useSession(function($adminSession) use ($user) {
+                    $adminSession->user = $user;
+                });
                 $this->redirect("/admin/?_dc=" . time());
             } else {
                 $this->writeLogFile($this->getParam("username"), $e->getMessage());
@@ -155,14 +157,15 @@ class Admin_LoginController extends Pimcore_Controller_Action_Admin {
     }
 
     public function logoutAction() {
-        $adminSession = Pimcore_Tool_Authentication::getSession();
 
-        if ($adminSession->user instanceof User) {
-            Pimcore_API_Plugin_Broker::getInstance()->preLogoutUser($adminSession->user);
-            $adminSession->user = null;
-        }
+        Pimcore_Tool_Authentication::useSession(function($adminSession) {
+            if ($adminSession->user instanceof User) {
+                Pimcore_API_Plugin_Broker::getInstance()->preLogoutUser($adminSession->user);
+                $adminSession->user = null;
+            }
 
-        Zend_Session::destroy();
+            Zend_Session::destroy();
+       });
 
         // cleanup pimcore-cookies => 315554400 => strtotime('1980-01-01')
         setcookie("pimcore_opentabs", false, 315554400, "/");

--- a/pimcore/modules/admin/controllers/UserController.php
+++ b/pimcore/modules/admin/controllers/UserController.php
@@ -279,10 +279,12 @@ class Admin_UserController extends Pimcore_Controller_Action_Admin {
 
                     if(empty($values["old_password"])) {
                         // if the user want to reset the password, the old password isn't required
-                        $adminSession = Pimcore_Tool_Authentication::getSession();
-                        if($adminSession->password_reset) {
-                            $oldPasswordCheck = true;
-                        }
+                        Pimcore_Tool_Authentication::useSession(function($adminSession) {
+                            if($adminSession->password_reset) {
+                                $oldPasswordCheck = true;
+                            }
+                        });
+
                     } else {
                         // the password have to match
                         $oldPassword = Pimcore_Tool_Authentication::getPasswordHash($user->getName(),$values["old_password"]);


### PR DESCRIPTION
the main problem is that pimcore uses session_start and not session_write_close. session_start by defaut locks the session file, so you are not able to start 2 times the same session. php just waits for the session release - but pimcore never release the session, you have to wait until the request is finised. especially in the ajax driven backend this is very slow.
for example i did some benchmarks (open some folders, get some thumbs) and session_start() blocks for 2 - 30 seconds.

using this merge request pimcore closes the session immediately. on my local machine the backend is much more fluent using this merge request.

please review this patch carefully and play around with this issue.
