### PR TITLE
Let exceptions propagate in portal

### DIFF
--- a/pimcore/static/js/pimcore/layout/portal.js
+++ b/pimcore/static/js/pimcore/layout/portal.js
@@ -42,7 +42,6 @@ pimcore.layout.portal = Class.create({
 
             for (var i = 0; i < 2; i++) {
                 for (var c = 0; c <= userConf.positions[i].length; c++) {
-                    try {
                         dynClass = eval(userConf.positions[i][c]);
                         if (dynClass) {
                             portletInstance = new dynClass();
@@ -50,10 +49,6 @@ pimcore.layout.portal = Class.create({
                             config[i].push(portletInstance.getLayout());
                             this.activePortlets.push(userConf.positions[i][c]);
                         }
-                    }
-                    catch (e) {
-                        console.log(e);
-                    }
                 }
             }
             this.getTabPanel(config);


### PR DESCRIPTION
When a portlet fails to load, it's better to let the browser handle the
exception, so that developer tools can be used to get the full stack
trace and pinpoint the problem.
