### PR TITLE
PIMCORE-1062 - chmod file permissions make dirs unreadable for suphp / c...

### DIFF
--- a/pimcore/models/Asset.php
+++ b/pimcore/models/Asset.php
@@ -543,7 +543,7 @@ class Asset extends Pimcore_Model_Abstract implements Element_Interface {
         // create foldertree
         $destinationPath = $this->getFileSystemPath();
         if (!is_dir(dirname($destinationPath))) {
-            mkdir(dirname($destinationPath), self::$chmod, true);
+            mkdir(dirname($destinationPath), 0777, true); // note that the permission in mkdir is umasked
         }
 
         if ($this->getType() != "folder") {


### PR DESCRIPTION
...li php

Reverted mkdir to PHP's default behavior. Note that the permission bits in mkdir are masked with the current umask, so the directory created does not become 777. In a typical CentOS/Debian LAMP stack it will become rwxrxrx.
