### PR TITLE
ghostscript gets stuck on error with some pdfs on Ubuntu 13.10 and resul...

### DIFF
--- a/pimcore/lib/Pimcore/Document/Adapter/Ghostscript.php
+++ b/pimcore/lib/Pimcore/Document/Adapter/Ghostscript.php
@@ -163,14 +163,23 @@ class Pimcore_Document_Adapter_Ghostscript extends Pimcore_Document_Adapter {
             }
 
             $textFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . "/pdf-text-extract-" . uniqid() . ".txt";
-            Pimcore_Tool_Console::exec(self::getGhostscriptCli() . " -dBATCH -dNOPAUSE -sDEVICE=txtwrite " . $pageRange . "-dTextFormat=2 -sOutputFile=" . $textFile . " " . $path);
+            if(file_exists('/usr/bin/pdftotext')){
+                Pimcore_Tool_Console::exec("/usr/bin/pdftotext $path $textFile");
+            }
+            else{
+                Pimcore_Tool_Console::exec(self::getGhostscriptCli() . " -dBATCH -dNOPAUSE -sDEVICE=txtwrite " . $pageRange . "-dTextFormat=2 -sOutputFile=" . $textFile . " " . $path);
+            }
+
 
             if(is_file($textFile)) {
                 $text =  file_get_contents($textFile);
 
                 // this is a little bit strange the default option -dTextFormat=3 from ghostscript should return utf-8 but it doesn't
                 // so we use option 2 which returns UCS-2LE and convert it here back to UTF-8 which works fine
-                $text = mb_convert_encoding($text, 'UTF-8', 'UCS-2LE');
+                if(!file_exists('/usr/bin/pdftotext')){
+                    $text = mb_convert_encoding($text, 'UTF-8', 'UCS-2LE');
+                }
+
                 unlink($textFile);
                 return $text;
             }


### PR DESCRIPTION
...ts are bad.

implemented check for pdftotext from poppler-utils package for better results and no getting stuck on error.
