### PR TITLE
Fix bug with asset folder view restrictions

### DIFF
--- a/pimcore/models/Asset/Resource.php
+++ b/pimcore/models/Asset/Resource.php
@@ -431,7 +431,7 @@ class Asset_Resource extends Element_Resource
                     $path = "/";
                 }
 
-                $permissionsChilds = $this->db->fetchOne("SELECT list FROM users_workspaces_asset WHERE cpath LIKE ? AND userId IN (" . implode(",", $userIds) . ") LIMIT 1", $path . "%");
+                $permissionsChilds = $this->db->fetchOne("SELECT list FROM users_workspaces_asset WHERE cpath LIKE ? AND userId IN (" . implode(",", $userIds) . ") AND list = 1 LIMIT 1", $path . "%");
                 if ($permissionsChilds) {
                     return true;
                 }


### PR DESCRIPTION
In the rare occasion that you have specified several folders in the workspace of an user, and the the first that is found when searched for root-folders (here: id 1) has explicitly set this right to 0, the root folder is also considered to be forbidden even if there are other folders that have the right to be viewed.

This fix searches just for folders that have the right to be viewed, thus passing this to the root folder.
