### PR TITLE
transmit optional mongoDB params

### DIFF
--- a/pimcore/lib/Pimcore/Cache/Backend/Mongodb.php
+++ b/pimcore/lib/Pimcore/Cache/Backend/Mongodb.php
@@ -50,6 +50,7 @@ class Pimcore_Cache_Backend_Mongodb extends Zend_Cache_Backend implements Zend_C
         'port'       => self::DEFAULT_PORT,
         'collection' => self::DEFAULT_COLLECTION,
         'dbname'     => self::DEFAULT_DBNAME,
+        'optional'   => array()
     );
 
     /**
@@ -65,7 +66,7 @@ class Pimcore_Cache_Backend_Mongodb extends Zend_Cache_Backend implements Zend_C
         // Merge the options passed in; overridding any default options
         $this->_options = array_merge($this->_options, $options);
 
-        $this->_conn       = new MongoClient('mongodb://' . $this->_options['host'] . ':' . $this->_options['port'], array());
+        $this->_conn       = new MongoClient('mongodb://' . $this->_options['host'] . ':' . $this->_options['port'], $this->_options['optional']);
         $this->_db         = $this->_conn->selectDB($this->_options['dbname']);
         $this->_collection = $this->_db->selectCollection($this->_options['collection']);
 


### PR DESCRIPTION
Transmitting the optional params to ensure that the protected databases can be accessed.
Consult the PHP documentation for more information: http://php.net/manual/de/mongoclient.construct.php

cache.xml example:

``` xml
    <backend>
        <type>Pimcore_Cache_Backend_Mongodb</type>
        <custom>true</custom>
        <options>
            <dbname>dbName</dbname>
            <optional>
                <db>dbName</db>
                <username>dbUser</username>
                <password>dbPassord</password>
            </optional>
        </options>
    </backend>
```
