### PR TITLE
Removal of strict and notice php errors for frontend and backend

### DIFF
--- a/pimcore/lib/Pimcore.php
+++ b/pimcore/lib/Pimcore.php
@@ -233,7 +233,7 @@ class Pimcore {
 
         // check if webdav is configured and add router
         if ($conf instanceof Zend_Config) {
-            if ($conf->assets->webdav->hostname) {
+            if (isset($conf->assets->webdav->hostname) && $conf->assets->webdav->hostname) {
                 $routeWebdav = new Zend_Controller_Router_Route_Hostname(
                     $conf->assets->webdav->hostname,
                     array(

--- a/pimcore/lib/Pimcore/Backup.php
+++ b/pimcore/lib/Pimcore/Backup.php
@@ -133,6 +133,7 @@ class Pimcore_Backup {
         $tables = $this->getTables();
 
 
+        if (!isset($this->options['mysql-tables'])) $this->options['mysql-tables'] = null;
         $steps[] = array("mysql-tables", $this->options['mysql-tables']);
 
         // tables
@@ -167,6 +168,7 @@ class Pimcore_Backup {
 
         $steps[] = array("mysql-complete", null);
 
+        if (!isset($options['only-mysql-related-tasks'])) $options['only-mysql-related-tasks'] = null;
         if(!$options['only-mysql-related-tasks']){
             // check files
             $currentFileCount = 0;
@@ -290,6 +292,7 @@ class Pimcore_Backup {
     protected function getTables(){
         $db = Pimcore_Resource::get();
 
+        if (!isset($this->options['mysql-tables'])) $this->options['mysql-tables'] = null;
         if($mysqlTables = $this->options['mysql-tables']){
             $specificTables = explode(',',$mysqlTables);
             $databaseName = (string)Pimcore_Config::getSystemConfig()->database->params->dbname;

--- a/pimcore/lib/Pimcore/Controller/Action/Admin/Document.php
+++ b/pimcore/lib/Pimcore/Controller/Action/Admin/Document.php
@@ -69,7 +69,7 @@ abstract class Pimcore_Controller_Action_Admin_Document extends Pimcore_Controll
         // force loading of properties
         $document->getProperties();
     }
-    
+
     protected function addSchedulerToDocument(Document $document) {
 
         // scheduled tasks
@@ -79,6 +79,7 @@ abstract class Pimcore_Controller_Action_Admin_Document extends Pimcore_Controll
 
             if (!empty($tasksData)) {
                 foreach ($tasksData as $taskData) {
+                    if (!isset($taskData["time"])) $taskData["time"] = null;
                     $taskData["date"] = strtotime($taskData["date"] . " " . $taskData["time"]);
 
                     $task = new Schedule_Task($taskData);
@@ -129,7 +130,7 @@ abstract class Pimcore_Controller_Action_Admin_Document extends Pimcore_Controll
                 $document = $this->getLatestVersion($document);
             }
 
-            // set _fulldump otherwise the properties will be removed because of the session-serialize 
+            // set _fulldump otherwise the properties will be removed because of the session-serialize
             $document->_fulldump = true;
             $this->setValuesToDocument($document);
 
@@ -191,9 +192,9 @@ abstract class Pimcore_Controller_Action_Admin_Document extends Pimcore_Controll
         $properties = Element_Service::minimizePropertiesForEditmode($document->getProperties());
         $document->setProperties($properties);
     }
-    
+
     protected function getLatestVersion (Document $document) {
-        
+
         $latestVersion = $document->getLatestVersion();
         if($latestVersion) {
             $latestDoc = $latestVersion->loadData();

--- a/pimcore/lib/Pimcore/Controller/Action/Admin/Element.php
+++ b/pimcore/lib/Pimcore/Controller/Action/Admin/Element.php
@@ -34,7 +34,7 @@ abstract class Pimcore_Controller_Action_Admin_Element extends Pimcore_Controlle
         $this->_helper->json(array("success" => false, "message" => "missing_permission"));
     }
 
-    protected function getTreeNodeConfig() {
+    protected function getTreeNodeConfig($childDocument) {
         return [];
     }
 

--- a/pimcore/lib/Pimcore/Controller/Action/Frontend.php
+++ b/pimcore/lib/Pimcore/Controller/Action/Frontend.php
@@ -55,13 +55,13 @@ abstract class Pimcore_Controller_Action_Frontend extends Pimcore_Controller_Act
         }
 
         // assign variables
-        $this->view->controller = $this; 
-        
+        $this->view->controller = $this;
+
         // init website config
         $config = Pimcore_Config::getWebsiteConfig();
         $this->config = $config;
         $this->view->config = $config;
-        
+
         $document = $this->getParam("document");
         if (!$document instanceof Document) {
             Zend_Registry::set("pimcore_editmode", false);
@@ -245,7 +245,7 @@ abstract class Pimcore_Controller_Action_Frontend extends Pimcore_Controller_Act
 
         self::$isInitial = false;
     }
-    
+
     public function getConfig () {
         return $this->config;
     }
@@ -290,7 +290,7 @@ abstract class Pimcore_Controller_Action_Frontend extends Pimcore_Controller_Act
                 $translate = new Pimcore_Translate_Website($locale);
 
                 if(Pimcore_Tool::isValidLanguage($locale)) {
-                    $translate->setLocale($locale);    
+                    $translate->setLocale($locale);
                 } else {
                     Logger::error("You want to use an invalid language which is not defined in the system settings: " . $locale);
                     // fall back to the first (default) language defined
@@ -338,7 +338,7 @@ abstract class Pimcore_Controller_Action_Frontend extends Pimcore_Controller_Act
 
     protected function forceRender() {
 
-        if (!$this->viewRendered) {
+        if (!(isset($this->viewRendered) && $this->viewRendered)) {
             if ($script = $this->getRenderScript()) {
                 $this->renderScript($script);
                 $this->viewRendered = true;

--- a/pimcore/lib/Pimcore/Controller/Plugin/Less.php
+++ b/pimcore/lib/Pimcore/Controller/Plugin/Less.php
@@ -25,7 +25,7 @@ class Pimcore_Controller_Plugin_Less extends Zend_Controller_Plugin_Abstract {
 
         $this->conf = Pimcore_Config::getSystemConfig();
 
-        if($request->getParam('disable_less_compiler') || $_COOKIE["disable_less_compiler"]){
+        if($request->getParam('disable_less_compiler') || (isset($_COOKIE["disable_less_compiler"]) && $_COOKIE["disable_less_compiler"])){
             return $this->disable();
         }
 
@@ -49,7 +49,7 @@ class Pimcore_Controller_Plugin_Less extends Zend_Controller_Plugin_Abstract {
         if(!Pimcore_Tool::isHtmlResponse($this->getResponse())) {
             return;
         }
-        
+
         if ($this->enabled) {
 
             include_once("simple_html_dom.php");

--- a/pimcore/lib/Pimcore/Controller/Plugin/Webmastertools.php
+++ b/pimcore/lib/Pimcore/Controller/Plugin/Webmastertools.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Pimcore
  *
@@ -16,11 +16,11 @@
 class Pimcore_Controller_Plugin_Webmastertools extends Zend_Controller_Plugin_Abstract {
 
     public function routeStartup(Zend_Controller_Request_Abstract $request) {
-            
+
         $conf = Pimcore_Config::getReportConfig();
-        if($conf->webmastertools->sites) {
+        if(isset($conf->webmastertools->sites) && $conf->webmastertools->sites) {
             $sites = $conf->webmastertools->sites->toArray();
-            
+
             if(is_array($sites)) {
                 foreach ($sites as $site) {
                     if($site["verification"]) {

--- a/pimcore/lib/Pimcore/Google/Api.php
+++ b/pimcore/lib/Pimcore/Google/Api.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Pimcore
  *
@@ -22,7 +22,7 @@ class Pimcore_Google_Api {
     }
 
     public static function getConfig () {
-        return Pimcore_Config::getSystemConfig()->services->google;
+        return isset(Pimcore_Config::getSystemConfig()->services->google)?Pimcore_Config::getSystemConfig()->services->google:null;
     }
 
     public static function isConfigured($type = "service") {
@@ -36,7 +36,7 @@ class Pimcore_Google_Api {
     public static function isServiceConfigured() {
         $config = self::getConfig();
 
-        if($config->client_id && $config->email && file_exists(self::getPrivateKeyPath())) {
+        if(isset($config->client_id) && $config->client_id && isset($config->email) && $config->email && file_exists(self::getPrivateKeyPath())) {
             return true;
         }
         return false;
@@ -45,7 +45,7 @@ class Pimcore_Google_Api {
     public static function isSimpleConfigured() {
         $config = self::getConfig();
 
-        if($config->simpleapikey) {
+        if(isset($config->simpleapikey) && $config->simpleapikey) {
             return true;
         }
         return false;

--- a/pimcore/lib/Pimcore/Google/Webmastertools.php
+++ b/pimcore/lib/Pimcore/Google/Webmastertools.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Pimcore
  *
@@ -14,22 +14,22 @@
  */
 
 class Pimcore_Google_Webmastertools {
-    
+
     public static $stack = array();
-    
+
     public static function isConfigured (Site $site = null) {
         if(self::getSiteConfig($site)) {
             return true;
         }
         return false;
     }
-    
+
 
     public static function getSiteConfig ($site = null) {
-        
+
         $siteKey = Pimcore_Tool_Frontend::getSiteKey($site);
-        
-        if(Pimcore_Config::getReportConfig()->webmastertools->sites->$siteKey->verification) {
+
+        if(isset(Pimcore_Config::getReportConfig()->webmastertools->sites->$siteKey->verification) && Pimcore_Config::getReportConfig()->webmastertools->sites->$siteKey->verification) {
             return Pimcore_Config::getReportConfig()->webmastertools->sites->$siteKey;
         }
         return false;

--- a/pimcore/lib/Pimcore/Image/Adapter.php
+++ b/pimcore/lib/Pimcore/Image/Adapter.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Pimcore
  *
@@ -12,7 +12,7 @@
  * @copyright  Copyright (c) 2009-2014 pimcore GmbH (http://www.pimcore.org)
  * @license    http://www.pimcore.org/license     New BSD License
  */
- 
+
 abstract class Pimcore_Image_Adapter {
 
     /**
@@ -237,7 +237,7 @@ abstract class Pimcore_Image_Adapter {
      * @return Pimcore_Image_Adapter
      */
     public function frame ($width, $height) {
-        
+
         return $this;
     }
 
@@ -287,7 +287,7 @@ abstract class Pimcore_Image_Adapter {
      * @return Pimcore_Image_Adapter
      */
     public function setBackgroundImage ($image) {
-        
+
         return $this;
     }
 
@@ -377,7 +377,7 @@ abstract class Pimcore_Image_Adapter {
     /**
      * @return Pimcore_Image_Adapter
      */
-    public function mirror () {
+    public function mirror ($mode) {
 
         return $this;
     }
@@ -439,7 +439,7 @@ abstract class Pimcore_Image_Adapter {
     }
 
     /**
-     * 
+     *
      */
     public function __destruct() {
         $this->destroy();

--- a/pimcore/lib/Pimcore/Tool.php
+++ b/pimcore/lib/Pimcore/Tool.php
@@ -167,7 +167,7 @@ class Pimcore_Tool {
             $systemRoutingDefaults = $config->documents->toArray();
 
             foreach ($routeingDefaults as $key => $value) {
-                if ($systemRoutingDefaults["default_" . $key]) {
+                if (isset($systemRoutingDefaults["default_" . $key]) && $systemRoutingDefaults["default_" . $key]) {
                     $routeingDefaults[$key] = $systemRoutingDefaults["default_" . $key];
                 }
             }
@@ -310,7 +310,7 @@ class Pimcore_Tool {
             if (empty($confArray["views"]["view"])) {
                 return array();
             }
-            else if ($confArray["views"]["view"][0]) {
+            else if (isset($confArray["views"]["view"][0]) && $confArray["views"]["view"][0]) {
                 $cvData = $confArray["views"]["view"];
             }
             else {
@@ -368,10 +368,10 @@ class Pimcore_Tool {
                 }
             }
         }
-        
+
         return true;
     }
-    
+
     /**
      * @static
      * @throws Exception
@@ -383,15 +383,15 @@ class Pimcore_Tool {
         $config = Pimcore_Config::getSystemConfig();
         $clientConfig = $config->httpclient->toArray();
         $clientConfig["adapter"] = $clientConfig["adapter"] ? $clientConfig["adapter"] : "Zend_Http_Client_Adapter_Socket";
-        $clientConfig["maxredirects"] = $options["maxredirects"] ? $options["maxredirects"] : 2;
-        $clientConfig["timeout"] = $options["timeout"] ? $options["timeout"] : 3600;
+        $clientConfig["maxredirects"] = (isset($options["maxredirects"]) && $options["maxredirects"]) ? $options["maxredirects"] : 2;
+        $clientConfig["timeout"] = (isset($options["timeout"]) && $options["timeout"]) ? $options["timeout"] : 3600;
         $type = empty($type) ? "Zend_Http_Client" : $type;
 
         if(Pimcore_Tool::classExists($type)) {
             $client = new $type(null, $clientConfig);
 
             // workaround/for ZF (Proxy-authorization isn't added by ZF)
-            if ($clientConfig['proxy_user']) {
+            if (isset($clientConfig['proxy_user']) && $clientConfig['proxy_user']) {
                 $client->setHeaders('Proxy-authorization',  Zend_Http_Client::encodeAuthHeader(
                     $clientConfig['proxy_user'], $clientConfig['proxy_pass'], Zend_Http_Client::AUTH_BASIC
                     ));
@@ -411,7 +411,7 @@ class Pimcore_Tool {
      * @return bool|string
      */
     public static function getHttpData($url, $paramsGet = array(), $paramsPost = array()) {
-        
+
         $client = self::getHttpClient();
         $client->setUri($url);
         $requestType = Zend_Http_Client::GET;

--- a/pimcore/lib/Pimcore/Tool/Text.php
+++ b/pimcore/lib/Pimcore/Tool/Text.php
@@ -26,7 +26,7 @@ class Pimcore_Tool_Text
 
         return $text;
     }
-    
+
     public static function wysiwygText($text)
     {
         if(empty($text)) {
@@ -82,7 +82,7 @@ class Pimcore_Tool_Text
                         preg_match("/height=\"([^\"]+)*\"/", $oldTag, $heightAttr);
                         preg_match("/style=\"([^\"]+)*\"/", $oldTag, $styleAttr);
 
-                        if ($widthAttr[1] || $heightAttr[1]) {
+                        if ((isset($widthAttr[1]) && $widthAttr[1]) || (isset($heightAttr[1]) && $heightAttr[1])) {
                             $config = array(
                                 "width" => intval($widthAttr[1]),
                                 "height" => intval($heightAttr[1])
@@ -294,7 +294,7 @@ class Pimcore_Tool_Text
     public static function getCacheTagsOfWysiwygText($text, $tags = array())
     {
         $tags = is_array($tags) ? $tags : array();
-        
+
         if (!empty($text)) {
             $elements = self::getElementsInWysiwyg($text);
             foreach ($elements as $element) {

--- a/pimcore/models/Asset/Image/Thumbnail/Config.php
+++ b/pimcore/models/Asset/Image/Thumbnail/Config.php
@@ -14,7 +14,7 @@
  * @copyright  Copyright (c) 2009-2014 pimcore GmbH (http://www.pimcore.org)
  * @license    http://www.pimcore.org/license     New BSD License
  */
- 
+
 class Asset_Image_Thumbnail_Config {
 
     /**
@@ -503,17 +503,17 @@ class Asset_Image_Thumbnail_Config {
     public static function getByArrayConfig ($config) {
         $pipe = new Asset_Image_Thumbnail_Config();
 
-        if($config["format"]) {
+        if(isset($config["format"]) && $config["format"]) {
             $pipe->setFormat($config["format"]);
         }
-        if($config["quality"]) {
+        if(isset($config["quality"]) && $config["quality"]) {
             $pipe->setQuality($config["quality"]);
         }
-        if($config["items"]) {
+        if(isset($config["items"]) && $config["items"]) {
             $pipe->setItems($config["items"]);
         }
 
-        if($config["highResolution"]) {
+        if(isset($config["highResolution"]) && $config["highResolution"]) {
             $pipe->setHighResolution($config["highResolution"]);
         }
 

--- a/pimcore/models/Document/Link.php
+++ b/pimcore/models/Document/Link.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Pimcore
  *
@@ -100,7 +100,7 @@ class Document_Link extends Document
     public function getCacheTags($tags = array())
     {
         $tags = is_array($tags) ? $tags : array();
-        
+
         $tags = parent::getCacheTags($tags);
 
         if ($this->getLinktype() == "internal") {
@@ -379,7 +379,7 @@ class Document_Link extends Document
      */
     public function getTitle()
     {
-        return $this->title;
+        return isset($this->title)?$this->title:null;
     }
 
     /**

--- a/pimcore/models/Document/Tag/Area.php
+++ b/pimcore/models/Document/Tag/Area.php
@@ -206,11 +206,11 @@ class Document_Tag_Area extends Document_Tag {
 
         
         $suffixes = Zend_Registry::get("pimcore_tag_block_numeration");
-        array_pop($suffixes);
+        if (is_array($suffixes)) array_pop($suffixes);
         Zend_Registry::set("pimcore_tag_block_numeration", $suffixes);
         
         $suffixes = Zend_Registry::get("pimcore_tag_block_current");
-        array_pop($suffixes);
+        if (is_array($suffixes)) array_pop($suffixes);
         Zend_Registry::set("pimcore_tag_block_current", $suffixes);
     }
 

--- a/pimcore/models/Document/Tag/Areablock.php
+++ b/pimcore/models/Document/Tag/Areablock.php
@@ -180,7 +180,7 @@ class Document_Tag_Areablock extends Document_Tag {
             $edit = $areas[$this->currentIndex["type"]] . "/edit.php";
             $options = $this->getOptions();
             $params = array();
-            if(is_array($options["params"]) && array_key_exists($this->currentIndex["type"], $options["params"])) {
+            if(isset($options["params"]) && is_array($options["params"]) && array_key_exists($this->currentIndex["type"], $options["params"])) {
                 if(is_array($options["params"][$this->currentIndex["type"]])) {
                     $params = $options["params"][$this->currentIndex["type"]];
                 }
@@ -227,7 +227,7 @@ class Document_Tag_Areablock extends Document_Tag {
             if(is_file($view)) {
                 $editmode = $this->getView()->editmode;
 
-                if(method_exists($actionObject,"getBrickHtmlTagOpen")) {
+                if(isset($actionObject) && method_exists($actionObject,"getBrickHtmlTagOpen")) {
                     echo $actionObject->getBrickHtmlTagOpen($this);
                 }else{
                     echo '<div class="pimcore_area_' . $this->currentIndex["type"] . ' pimcore_area_content">';
@@ -252,13 +252,13 @@ class Document_Tag_Areablock extends Document_Tag {
                     echo '</div>';
                 }
 
-                if(method_exists($actionObject,"getBrickHtmlTagClose")) {
+                if(isset($actionObject) && method_exists($actionObject,"getBrickHtmlTagClose")) {
                     echo $actionObject->getBrickHtmlTagClose($this);
                 }else{
                     echo '</div>';
                 }
 
-                if(is_object($actionObject) && method_exists($actionObject,"postRenderAction")) {
+                if(isset($actionObject) && is_object($actionObject) && method_exists($actionObject,"postRenderAction")) {
                     $actionObject->postRenderAction();
                 }
             }
@@ -305,7 +305,7 @@ class Document_Tag_Areablock extends Document_Tag {
      */
     public function blockDestruct() {
         $suffixes = Zend_Registry::get("pimcore_tag_block_numeration");
-        array_pop($suffixes);
+        if (is_array($suffixes)) array_pop($suffixes);
         Zend_Registry::set("pimcore_tag_block_numeration", $suffixes);
     }
 
@@ -381,7 +381,7 @@ class Document_Tag_Areablock extends Document_Tag {
 
         // remove the suffix which was set by self::start()
         $suffixes = Zend_Registry::get("pimcore_tag_block_current");
-        array_pop($suffixes);
+        if (is_array($suffixes)) array_pop($suffixes);
         Zend_Registry::set("pimcore_tag_block_current", $suffixes);
 
         $this->outputEditmode("</div>");
@@ -478,7 +478,7 @@ class Document_Tag_Areablock extends Document_Tag {
         foreach ($areaConfigs as $areaName => $areaConfig) {
 
             // don't show disabled bricks
-            if(!$options['dontCheckEnabled']){
+            if(!(isset($options['dontCheckEnabled']) && $options['dontCheckEnabled'])){
                 if(!$this->isBrickEnabled($areaName)) {
                     continue;
                 }

--- a/pimcore/models/Document/Tag/Block.php
+++ b/pimcore/models/Document/Tag/Block.php
@@ -138,7 +138,7 @@ class Document_Tag_Block extends Document_Tag {
             return false;
         }
     }
-    
+
     /**
      * Alias for loop
      * @deprecated
@@ -157,7 +157,7 @@ class Document_Tag_Block extends Document_Tag {
     public function start() {
 
         $this->setupStaticEnvironment();
-        
+
         // get configuration data for admin
         if (method_exists($this, "getDataEditmode")) {
             $data = $this->getDataEditmode();
@@ -176,13 +176,13 @@ class Document_Tag_Block extends Document_Tag {
         );
         $options = @Zend_Json::encode($options);
         //$options = base64_encode($options);
-        
+
         $this->outputEditmode('
             <script type="text/javascript">
                 editableConfigurations.push('.$options.');
             </script>
         ');
-        
+
         // set name suffix for the whole block element, this will be addet to all child elements of the block
         $suffixes = Zend_Registry::get("pimcore_tag_block_current");
         $suffixes[] = $this->getName();
@@ -204,7 +204,7 @@ class Document_Tag_Block extends Document_Tag {
 
         // remove the suffix which was set by self::start()
         $suffixes = Zend_Registry::get("pimcore_tag_block_current");
-        array_pop($suffixes);
+        if (is_array($suffixes)) array_pop($suffixes);
         Zend_Registry::set("pimcore_tag_block_current", $suffixes);
 
         $this->outputEditmode("</div>");
@@ -226,7 +226,7 @@ class Document_Tag_Block extends Document_Tag {
      */
     public function blockDestruct () {
         $suffixes = Zend_Registry::get("pimcore_tag_block_numeration");
-        array_pop($suffixes);
+        if (is_array($suffixes)) array_pop($suffixes);
         Zend_Registry::set("pimcore_tag_block_numeration", $suffixes);
     }
 
@@ -333,7 +333,7 @@ class Document_Tag_Block extends Document_Tag {
     public function getCurrent() {
         return $this->current-1;
     }
-    
+
     /**
      * Return current index
      *
@@ -351,7 +351,7 @@ class Document_Tag_Block extends Document_Tag {
     public function __wakeup() {
         $this->current = 0;
     }
-    
+
     /**
      * @return bool
      */

--- a/pimcore/models/Document/Tag/Href.php
+++ b/pimcore/models/Document/Tag/Href.php
@@ -73,9 +73,9 @@ class Document_Tag_Href extends Document_Tag {
      * @return mixed
      */
     public function getDataEditmode() {
-	
+
 		$this->setElement();
-	
+
         if ($this->element instanceof Element_Interface) {
             return array(
                 "id" => $this->id,
@@ -95,7 +95,7 @@ class Document_Tag_Href extends Document_Tag {
     public function frontend() {
 
 		$this->setElement();
-	
+
         //don't give unpublished elements in frontend
         if (Document::doHideUnpublished() and !Element_Service::isPublished($this->element)) {
             return "";
@@ -124,8 +124,8 @@ class Document_Tag_Href extends Document_Tag {
         }
 
         $this->id = $data["id"];
-        $this->type = $data["type"];
-        $this->subtype = $data["subtype"];
+        $this->type = isset($data["type"])?$data["type"]:null;
+        $this->subtype = isset($data["subtype"])?$data["subtype"]:null;
 
         $this->setElement();
         return $this;
@@ -139,8 +139,8 @@ class Document_Tag_Href extends Document_Tag {
     public function setDataFromEditmode($data) {
 
         $this->id = $data["id"];
-        $this->type = $data["type"];
-        $this->subtype = $data["subtype"];
+        $this->type = isset($data["type"])?$data["type"]:null;
+        $this->subtype = isset($data["subtype"])?$data["subtype"]:null;
 
         $this->setElement();
         return $this;
@@ -166,7 +166,7 @@ class Document_Tag_Href extends Document_Tag {
     public function getElement() {
 
 		$this->setElement();
-	
+
         //don't give unpublished elements in frontend
         if (Document::doHideUnpublished() and !Element_Service::isPublished($this->element)) {
             return false;
@@ -183,7 +183,7 @@ class Document_Tag_Href extends Document_Tag {
     public function getFullPath() {
 
 		$this->setElement();
-	
+
         //don't give unpublished elements in frontend
         if (Document::doHideUnpublished() and !Element_Service::isPublished($this->element)) {
             return false;
@@ -198,9 +198,9 @@ class Document_Tag_Href extends Document_Tag {
      * @return boolean
      */
     public function isEmpty() {
-		
+
 		$this->setElement();
-	
+
         if ($this->getElement() instanceof Element_Interface) {
             return false;
         }
@@ -308,7 +308,7 @@ class Document_Tag_Href extends Document_Tag {
             }
         }
         return $sane;
-    
+
     }
 
     /**

--- a/pimcore/models/Document/Tag/Image.php
+++ b/pimcore/models/Document/Tag/Image.php
@@ -223,7 +223,7 @@ class Document_Tag_Image extends Document_Tag {
                     $autoName = true;
                 }
 
-                if($this->options["highResolution"] && $this->options["highResolution"] > 1) {
+                if(isset($this->options["highResolution"]) && $this->options["highResolution"] && $this->options["highResolution"] > 1) {
                     $thumbConfig->setHighResolution($this->options["highResolution"]);
                 }
 

--- a/pimcore/models/Document/Tag/Link.php
+++ b/pimcore/models/Document/Tag/Link.php
@@ -100,7 +100,7 @@ class Document_Tag_Link extends Document_Tag
     public function checkValidity()
     {
         $sane = true;
-        if (is_array($this->data) && $this->data["internal"]) {
+        if (is_array($this->data) && isset($this->data["internal"]) && $this->data["internal"]) {
             if ($this->data["internalType"] == "document") {
                 $doc = Document::getById($this->data["internalId"]);
                 if (!$doc) {
@@ -129,7 +129,7 @@ class Document_Tag_Link extends Document_Tag
     public function getHref()
     {
 
-        if ($this->data["internal"]) {
+        if (isset($this->data["internal"]) && $this->data["internal"]) {
             if ($this->data["internalType"] == "document") {
                 if ($doc = Document::getById($this->data["internalId"])) {
                     if (!Document::doHideUnpublished() || $doc->isPublished()) {
@@ -258,7 +258,7 @@ class Document_Tag_Link extends Document_Tag
             }
         }
 
-        if (!$data["internal"]) {
+        if (!(isset($data["internal"]) && $data["internal"])) {
             if ($asset = Asset::getByPath($data["path"])) {
                 if ($asset instanceof Asset) {
                     $data["internal"] = true;
@@ -290,7 +290,7 @@ class Document_Tag_Link extends Document_Tag
 
         $tags = array();
 
-        if ($this->data["internal"]) {
+        if (isset($this->data["internal"]) && $this->data["internal"]) {
             if ($this->data["internalType"] == "document") {
                 if ($doc = Document::getById($this->data["internalId"])) {
                     if ($doc->getId() != $ownerDocument->getId() and !in_array($doc->getCacheTag(), $blockedTags)) {
@@ -316,7 +316,7 @@ class Document_Tag_Link extends Document_Tag
 
         $dependencies = array();
 
-        if (is_array($this->data) && $this->data["internal"]) {
+        if (is_array($this->data) && isset($this->data["internal"]) && $this->data["internal"]) {
 
             if (intval($this->data["internalId"]) > 0) {
                 if ($this->data["internalType"] == "document") {
@@ -360,7 +360,7 @@ class Document_Tag_Link extends Document_Tag
         if (empty($wsElement->value->data) or is_array($wsElement->value->data)) {
 
             $this->data = $wsElement->value->data;
-            if ($this->data["internal"]) {
+            if (isset($this->data["internal"]) && $this->data["internal"]) {
                 if (intval($this->data["internalId"]) > 0) {
                     $id = $this->data["internalId"];
 
@@ -408,7 +408,7 @@ class Document_Tag_Link extends Document_Tag
     public function getForWebserviceExport()
     {
         $el = parent::getForWebserviceExport();
-        if ($this->data["internal"]) {
+        if (isset($this->data["internal"]) && $this->data["internal"]) {
             if (intval($this->data["internalId"]) > 0) {
                 if ($this->data["internalType"] == "document") {
                     $referencedDocument = Document::getById($this->data["internalId"]);
@@ -446,7 +446,7 @@ class Document_Tag_Link extends Document_Tag
      */
     public function rewriteIds($idMapping)
     {
-        if ($this->data["internal"]) {
+        if (isset($this->data["internal"]) && $this->data["internal"]) {
             $type = $this->data["internalType"];
             $id = (int)$this->data["internalId"];
 

--- a/pimcore/models/Document/Tag/Pdf.php
+++ b/pimcore/models/Document/Tag/Pdf.php
@@ -356,7 +356,7 @@ class Document_Tag_Pdf extends Document_Tag
     public function getWidth()
     {
         $options = $this->getOptions();
-        if ($options["width"]) {
+        if (isset($options["width"]) && $options["width"]) {
             return $options["width"];
         }
         return "100%";
@@ -365,7 +365,7 @@ class Document_Tag_Pdf extends Document_Tag
     public function getHeight()
     {
         $options = $this->getOptions();
-        if ($options["height"]) {
+        if (isset($options["height"]) && $options["height"]) {
             return $options["height"];
         }
         return 300;

--- a/pimcore/models/Document/Tag/Textarea.php
+++ b/pimcore/models/Document/Tag/Textarea.php
@@ -50,11 +50,11 @@ class Document_Tag_Textarea extends Document_Tag {
         $options = $this->getOptions();
 
         $text = $this->text;
-        if ($options["htmlspecialchars"] !== false) {
+        if (isset($options["htmlspecialchars"]) && $options["htmlspecialchars"] !== false) {
             $text = htmlspecialchars($this->text);
         }
 
-        if ($options["nl2br"]) {
+        if (isset($options["nl2br"]) && $options["nl2br"]) {
             $text = nl2br($text);
         }
 

--- a/pimcore/models/Document/Tag/Video.php
+++ b/pimcore/models/Document/Tag/Video.php
@@ -303,7 +303,7 @@ class Document_Tag_Video extends Document_Tag
     public function getWidth()
     {
         $options = $this->getOptions();
-        if ($options["width"]) {
+        if (isset($options["width"]) && $options["width"]) {
             return $options["width"];
         }
         return "100%";
@@ -312,7 +312,7 @@ class Document_Tag_Video extends Document_Tag
     public function getHeight()
     {
         $options = $this->getOptions();
-        if ($options["height"]) {
+        if (isset($options["height"]) && $options["height"]) {
             return $options["height"];
         }
         return 300;

--- a/pimcore/models/Element/Service.php
+++ b/pimcore/models/Element/Service.php
@@ -179,6 +179,7 @@ class Element_Service extends Pimcore_Model_Abstract {
      */
     public static function getElementByPath($type, $path)
     {
+        $element = null;
         if ($type == "asset") {
             $element = Asset::getByPath($path);
         } else if ($type == "object") {

--- a/pimcore/models/Object/Class.php
+++ b/pimcore/models/Object/Class.php
@@ -308,6 +308,7 @@ class Object_Class extends Pimcore_Model_Abstract {
                 }
             }
 
+            if (!isset($lazyLoadedFields)) $lazyLoadedFields = null;
             $cd .= 'protected static $_relationFields = ' . var_export($relationTypes, true) . ";\n\n";
             $cd .= 'public $lazyLoadedFields = ' . var_export($lazyLoadedFields, true) . ";\n\n";
         }

--- a/pimcore/models/Object/Class/Data/Localizedfields.php
+++ b/pimcore/models/Object/Class/Data/Localizedfields.php
@@ -572,7 +572,7 @@ class Object_Class_Data_Localizedfields extends Object_Class_Data
     public function getFielddefinition($name)
     {
         $fds = $this->getFieldDefinitions();
-        if ($fds[$name]) {
+        if (isset($fds[$name]) && $fds[$name]) {
             return $fds[$name];
         }
         return;

--- a/pimcore/models/Object/Class/Data/Objectbricks.php
+++ b/pimcore/models/Object/Class/Data/Objectbricks.php
@@ -362,7 +362,7 @@ class Object_Class_Data_Objectbricks extends Object_Class_Data
      * @param mixed $value
      * @return mixed
      */
-    public function getFromWebserviceImport($data, $relatedObject, $idMapper = null)
+    public function getFromWebserviceImport($data, $relatedObject = null, $idMapper = null)
     {
         $containerName = "Object_" . ucfirst($relatedObject->getClass()->getName()) . "_" . ucfirst($this->getName());
         $container = new $containerName($relatedObject, $this->getName());

--- a/pimcore/models/Object/Class/Service.php
+++ b/pimcore/models/Object/Class/Service.php
@@ -32,7 +32,7 @@ class Object_Class_Service  {
         unset($data->userOwner);
         unset($data->userModification);
         unset($data->fieldDefinitions);
-        
+
         //add propertyVisibility to export data
         $data->propertyVisibility = $class->propertyVisibility;
 
@@ -177,7 +177,7 @@ class Object_Class_Service  {
 
                     $item->setValues($array, array("childs"));
 
-                    if(is_array($array) && is_array($array["childs"]) && $array["childs"]["datatype"]){
+                    if(is_array($array) && is_array($array["childs"]) && isset($array["childs"]["datatype"]) && $array["childs"]["datatype"]){
                         $childO = self::generateLayoutTreeFromArray($array["childs"], $throwException);
                         $item->addChild($childO);
                     } else if (is_array($array["childs"]) && count($array["childs"]) > 0) {

--- a/pimcore/models/Object/Fieldcollection/Definition.php
+++ b/pimcore/models/Object/Fieldcollection/Definition.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Pimcore
  *
@@ -16,23 +16,23 @@
  */
 
 class Object_Fieldcollection_Definition extends Pimcore_Model_Abstract {
-    
+
     /**
      * @var string
      */
     public $key;
-    
+
     /**
      * @var string
      */
     public $parentClass;
-    
+
     /**
      * @var array
      */
     public $layoutDefinitions;
-    
-    
+
+
     /**
      * @return string
      */
@@ -48,7 +48,7 @@ class Object_Fieldcollection_Definition extends Pimcore_Model_Abstract {
         $this->key = $key;
         return $this;
     }
-    
+
     /**
      * @return string
      */
@@ -64,7 +64,7 @@ class Object_Fieldcollection_Definition extends Pimcore_Model_Abstract {
         $this->parentClass = $parentClass;
         return $this;
     }
-    
+
     /**
      * @return array
      */
@@ -78,17 +78,17 @@ class Object_Fieldcollection_Definition extends Pimcore_Model_Abstract {
      */
     public function setLayoutDefinitions($layoutDefinitions) {
         $this->layoutDefinitions = $layoutDefinitions;
-        
+
         $this->fieldDefinitions = array();
         $this->extractDataDefinitions($this->layoutDefinitions);
         return $this;
     }
-    
+
     /**
      * @return array
      */
     public function getFieldDefinitions() {
-        return $this->fieldDefinitions;
+        return (isset($this->fieldDefinitions) ? $this->fieldDefinitions : null);
     }
 
     /**
@@ -120,7 +120,7 @@ class Object_Fieldcollection_Definition extends Pimcore_Model_Abstract {
         }
         return false;
     }
-    
+
     /**
      * @param array|Object_Class_Layout|Object_Class_Data $def
      * @return void
@@ -139,8 +139,8 @@ class Object_Fieldcollection_Definition extends Pimcore_Model_Abstract {
             $this->addFieldDefinition($def->getName(), $def);
         }
     }
-    
-    
+
+
     public static function getByKey ($key) {
 
         $fc = null;
@@ -166,23 +166,23 @@ class Object_Fieldcollection_Definition extends Pimcore_Model_Abstract {
         if($fc) {
             return $fc;
         }
-        
+
         throw new Exception("Field-Collection with key: " . $key . " does not exist.");
     }
-    
+
     public function save () {
-        
+
         if(!$this->getKey()) {
             throw new Exception("A field-collection needs a key to be saved!");
         }
-        
+
         $fieldCollectionFolder = PIMCORE_CLASS_DIRECTORY . "/fieldcollections";
-        
+
         // create folder if not exist
         if(!is_dir($fieldCollectionFolder)) {
             Pimcore_File::mkdir($fieldCollectionFolder);
         }
-        
+
         $serialized = Pimcore_Tool_Serialize::serialize($this);
 
         $definitionFile = $fieldCollectionFolder . "/" . $this->getKey() . ".psf";
@@ -192,13 +192,13 @@ class Object_Fieldcollection_Definition extends Pimcore_Model_Abstract {
         }
 
         Pimcore_File::put($definitionFile, $serialized);
-        
+
         $extendClass = "Object_Fieldcollection_Data_Abstract";
         if ($this->getParentClass()) {
             $extendClass = $this->getParentClass();
         }
 
-        
+
         // create class file
         $cd = '<?php ';
 
@@ -243,8 +243,8 @@ class Object_Fieldcollection_Definition extends Pimcore_Model_Abstract {
 
         $cd .= "}\n";
         $cd .= "\n";
-        
-        $fieldClassFolder = PIMCORE_CLASS_DIRECTORY . "/Object/Fieldcollection/Data"; 
+
+        $fieldClassFolder = PIMCORE_CLASS_DIRECTORY . "/Object/Fieldcollection/Data";
         if(!is_dir($fieldClassFolder)) {
             Pimcore_File::mkdir($fieldClassFolder);
         }
@@ -256,7 +256,7 @@ class Object_Fieldcollection_Definition extends Pimcore_Model_Abstract {
         }
 
         Pimcore_File::put($classFile,$cd);
-        
+
         // update classes
         $classList = new Object_Class_List();
         $classes = $classList->load();
@@ -273,19 +273,19 @@ class Object_Fieldcollection_Definition extends Pimcore_Model_Abstract {
             }
         }
     }
-    
+
     public function delete () {
         $fieldCollectionFolder = PIMCORE_CLASS_DIRECTORY . "/fieldcollections";
         $fieldFile = $fieldCollectionFolder . "/" . $this->getKey() . ".psf";
-        
+
         @unlink($fieldFile);
-        
-        $fieldClassFolder = PIMCORE_CLASS_DIRECTORY . "/Object/Fieldcollection/Data"; 
+
+        $fieldClassFolder = PIMCORE_CLASS_DIRECTORY . "/Object/Fieldcollection/Data";
         $fieldClass = $fieldClassFolder . "/" . ucfirst($this->getKey()) . ".php";
-        
+
         @unlink($fieldClass);
-        
-        
+
+
         // update classes
         $classList = new Object_Class_List();
         $classes = $classList->load();

--- a/pimcore/models/Object/KeyValue/Helper.php
+++ b/pimcore/models/Object/KeyValue/Helper.php
@@ -20,7 +20,7 @@ class Object_KeyValue_Helper {
     /** Returns the group/key config as XML.
      * @return mixed
      */
-    public function export() {
+    public static function export() {
         $xml = new SimpleXMLElement('<xml/>');
 
         $list = new Object_KeyValue_GroupConfig_List();

--- a/pimcore/models/Object/Objectbrick/Definition.php
+++ b/pimcore/models/Object/Objectbrick/Definition.php
@@ -186,6 +186,7 @@ class Object_Objectbrick_Definition extends Object_Fieldcollection_Definition {
      */
     private function cleanupOldFiles($serializedFilename) {
         $this->oldClassDefinitions = array();
+        $prevSerialized = null;
         if(file_exists($serializedFilename)) {
             $prevSerialized = file_get_contents($serializedFilename);
         }

--- a/pimcore/models/Object/Service.php
+++ b/pimcore/models/Object/Service.php
@@ -313,6 +313,7 @@ class Object_Service extends Element_Service {
                             $data[$dataKey] = $object->$getter();
                         } else {
 
+                            if (!isset($brickKey)) $brickKey = null;
                             $valueObject = self::getValueForObject($object, $key, $brickType, $brickKey);
                             $data['inheritedFields'][$dataKey] = array("inherited" => $valueObject->objectid != $object->getId(), "objectid" => $valueObject->objectid);
 

--- a/pimcore/models/Tool/CustomReport/Adapter/Sql.php
+++ b/pimcore/models/Tool/CustomReport/Adapter/Sql.php
@@ -66,7 +66,7 @@ class Tool_CustomReport_Adapter_Sql extends Tool_CustomReport_Adapter_Abstract {
 
     protected function buildQueryString($config, $ignoreSelectAndGroupBy = false, $drillDownFilters = null, $selectField = null) {
         $sql = "";
-        if($config->sql && !$ignoreSelectAndGroupBy) {
+        if(isset($config->sql) && $config->sql && !$ignoreSelectAndGroupBy) {
             if(strpos(strtoupper(trim($config->sql)), "SELECT") === false || strpos(strtoupper(trim($config->sql)), "SELECT") > 5) {
                 $sql .= "SELECT ";
             }
@@ -77,13 +77,13 @@ class Tool_CustomReport_Adapter_Sql extends Tool_CustomReport_Adapter_Abstract {
         } else {
             $sql .= "SELECT *";
         }
-        if($config->from) {
+        if(isset($config->from) && $config->from) {
             if(strpos(strtoupper(trim($config->from)), "FROM") === false) {
                 $sql .= " FROM ";
             }
             $sql .= " " . str_replace("\n", " ", $config->from);
         }
-        if($config->where || $drillDownFilters) {
+        if((isset($config->where) && $config->where) || $drillDownFilters) {
             $whereParts = array();
             if($config->where) {
                 $whereParts[] = "(" . str_replace("\n", " ", $config->where) . ")";
@@ -106,7 +106,7 @@ class Tool_CustomReport_Adapter_Sql extends Tool_CustomReport_Adapter_Abstract {
                 $sql .= " " . implode(" AND ", $whereParts);
             }
         }
-        if($config->groupby && !$ignoreSelectAndGroupBy) {
+        if(isset($config->groupby) && $config->groupby && !$ignoreSelectAndGroupBy) {
             if(strpos(strtoupper($config->groupby), "GROUP BY") === false) {
                 $sql .= " GROUP BY ";
             }

--- a/pimcore/models/Tool/CustomReport/Config.php
+++ b/pimcore/models/Tool/CustomReport/Config.php
@@ -208,7 +208,7 @@ class Tool_CustomReport_Config {
     /**
      * @return array
      */
-    public function getReportsList () {
+    public static function getReportsList () {
         $dir = Tool_CustomReport_Config::getWorkingDir();
 
         $reports = array();
@@ -227,9 +227,9 @@ class Tool_CustomReport_Config {
 
     }
 
-    public function getAdapter($configuration, $fullConfig = null) {
+    public static function getAdapter($configuration, $fullConfig = null) {
 
-        $type = $configuration->type ? ucfirst($configuration->type) : 'Sql';
+        $type = (isset($configuration->type) && $configuration->type) ? ucfirst($configuration->type) : 'Sql';
         $adapter = "Tool_CustomReport_Adapter_{$type}";
         return new $adapter($configuration, $fullConfig);
     }

--- a/pimcore/models/Tool/Targeting/Persona/Resource.php
+++ b/pimcore/models/Tool/Targeting/Persona/Resource.php
@@ -49,7 +49,7 @@ class Tool_Targeting_Persona_Resource extends Pimcore_Model_Resource_Abstract {
 
         if($data["id"]) {
             $data["conditions"] = Pimcore_Tool_Serialize::unserialize($data["conditions"]);
-            $data["actions"] = Pimcore_Tool_Serialize::unserialize($data["actions"]);
+            $data["actions"] = Pimcore_Tool_Serialize::unserialize(isset($data["actions"])?$data["actions"]:null);
             $this->assignVariablesToModel($data);
         } else {
             throw new Exception("persona with id " . $this->model->getId() . " doesn't exist");

--- a/pimcore/models/Translation/Abstract/List/Resource.php
+++ b/pimcore/models/Translation/Abstract/List/Resource.php
@@ -40,7 +40,7 @@ abstract class Translation_Abstract_List_Resource extends Pimcore_Model_List_Res
             $translationsData = $this->db->fetchAll("SELECT * FROM " . static::getTableName());
 
             foreach ($translationsData as $t) {
-                if(!$translations[$t["key"]]) {
+                if(!(isset($translations[$t["key"]]) && $translations[$t["key"]])) {
                     $translations[$t["key"]] = new $itemClass();
                     $translations[$t["key"]]->setKey($t["key"]);
                 }
@@ -59,7 +59,7 @@ abstract class Translation_Abstract_List_Resource extends Pimcore_Model_List_Res
             Pimcore_Model_Cache::save($translations, $cacheKey, array("translator","translate"), 999);
         }
 
-        
+
         return $translations;
     }
 

--- a/pimcore/models/Translation/Admin.php
+++ b/pimcore/models/Translation/Admin.php
@@ -27,7 +27,7 @@ class Translation_Admin extends Translation_Abstract {
      * @return string
      * @throws Exception
      */
-    public static function getByKeyLocalized($id, $create = false, $returnIdIfEmpty = false)
+    public static function getByKeyLocalized($id, $create = false, $returnIdIfEmpty = false, $language = null)
     {
         if($user = Pimcore_Tool_Admin::getCurrentUser()) {
             $language = $user->getLanguage();

--- a/pimcore/models/Webservice/Data/Class.php
+++ b/pimcore/models/Webservice/Data/Class.php
@@ -95,12 +95,13 @@ class Webservice_Data_Class extends Webservice_Data {
     public $previewUrl;
 
 
-  
 
-    public function map ($class) {
+
+    public function map ($class, $options = null) {
 
         $arr = $class->fieldDefinitions;
         $result = array();
+        $item = null;
         foreach ($arr as $item) {
             $result[] = $item;
         }
@@ -129,5 +130,5 @@ class Webservice_Data_Class extends Webservice_Data {
 
 
 
-    
+
 }

--- a/pimcore/modules/admin/controllers/AssetController.php
+++ b/pimcore/modules/admin/controllers/AssetController.php
@@ -715,6 +715,7 @@ class Admin_AssetController extends Pimcore_Controller_Action_Admin_Element
 
                     if (!empty($tasksData)) {
                         foreach ($tasksData as $taskData) {
+                            if (!isset($taskData["time"])) $taskData["time"] = null;
                             $taskData["date"] = strtotime($taskData["date"] . " " . $taskData["time"]);
 
                             $task = new Schedule_Task($taskData);

--- a/pimcore/modules/admin/controllers/ClassController.php
+++ b/pimcore/modules/admin/controllers/ClassController.php
@@ -113,7 +113,7 @@ class Admin_ClassController extends Pimcore_Controller_Action_Admin {
             {
                 /* @var Object_Class $classItem */
                 $currentClass = $classes[$i];
-                $nextClass = $classes[$i+1];
+                $nextClass = isset($classes[$i+1]) ? $classes[$i+1] : null;
 
                 // check last group
                 $className = $currentClass->getName();
@@ -640,7 +640,7 @@ class Admin_ClassController extends Pimcore_Controller_Action_Admin {
 
         $filteredDefinitions = Object_Service::getCustomLayoutDefinitionForGridColumnConfig($class, $objectId);;
         $layoutDefinitions = $filteredDefinitions["layoutDefinition"];
-        $filteredFieldDefinition = $filteredDefinitions["fieldDefinition"];
+        $filteredFieldDefinition = isset($filteredDefinitions["fieldDefinition"])?$filteredDefinitions["fieldDefinition"]:null;
 
         $class->setFieldDefinitions(null);
 

--- a/pimcore/modules/admin/controllers/ElementController.php
+++ b/pimcore/modules/admin/controllers/ElementController.php
@@ -12,9 +12,9 @@
  * @copyright  Copyright (c) 2009-2014 pimcore GmbH (http://www.pimcore.org)
  * @license    http://www.pimcore.org/license     New BSD License
  */
- 
+
 class Admin_ElementController extends Pimcore_Controller_Action_Admin {
-    
+
     public function lockElementAction()
     {
         Element_Editlock::lock($this->getParam("id"), $this->getParam("type"));
@@ -220,7 +220,7 @@ class Admin_ElementController extends Pimcore_Controller_Action_Admin {
         $results = array();
         $success = false;
 
-        if($element) {
+        if(isset($element) && $element) {
             $elements = $element->getDependencies()->getRequiredBy();
             foreach ($elements as $el) {
                 $item = Element_Service::getElementById($el["type"], $el["id"]);

--- a/pimcore/modules/admin/controllers/EmailController.php
+++ b/pimcore/modules/admin/controllers/EmailController.php
@@ -29,7 +29,8 @@ class Admin_EmailController extends Pimcore_Controller_Action_Admin_Document
 
         $email = Document_Email::getById($this->getParam("id"));
         $email = $this->getLatestVersion($email);
-        $email->setVersions(array_splice($email->getVersions(), 0, 1));
+		$versions = $email->getVersions(); // Only variables should be passed by reference
+        $email->setVersions(array_splice($versions, 0, 1));
         $email->idPath = Element_Service::getIdPath($email);
         $email->userPermissions = $email->getUserPermissions();
         $email->setLocked($email->isLocked());

--- a/pimcore/modules/admin/controllers/KeyValueController.php
+++ b/pimcore/modules/admin/controllers/KeyValueController.php
@@ -310,7 +310,7 @@ class Admin_KeyValueController extends Pimcore_Controller_Action_Admin
             "possiblevalues" => $config->getPossibleValues(),
             "group" => $config->getGroup(),
             "groupdescription" => $groupDescription,
-            "groupName" => $groupName,
+                    "groupName" => isset($groupName)?$groupName:null,
             "translator" => $config->getTranslator(),
             "mandatory" => $config->getMandatory()
         );

--- a/pimcore/modules/admin/controllers/MiscController.php
+++ b/pimcore/modules/admin/controllers/MiscController.php
@@ -47,7 +47,7 @@ class Admin_MiscController extends Pimcore_Controller_Action_Admin
         $row = 1;
         $handle = fopen($languageFile, "r");
         while (($data = fgetcsv($handle, 0, ",")) !== FALSE) {
-            $translations[$data[0]] = $data[1];
+            $translations[$data[0]] = isset($data[1])?$data[1]:null;
         }
         fclose($handle);
 
@@ -487,11 +487,11 @@ class Admin_MiscController extends Pimcore_Controller_Action_Admin
         $limit = ($this->getParam("limit")) ? $this->getParam("limit") : 40;
 
         $mail = $this->getBounceMailbox();
-        $mail->seek($offset);
+        if ($mail) $mail->seek($offset);
 
         $mails = array();
         $count = 0;
-        while ($mail->valid()) {
+        if ($mail) while ($mail->valid()) {
             $count++;
 
             $message = $mail->current();
@@ -518,7 +518,7 @@ class Admin_MiscController extends Pimcore_Controller_Action_Admin
         $this->_helper->json(array(
             "data" => $mails,
             "success" => true,
-            "total" => $mail->countMessages()
+            "total" => $mail?$mail->countMessages():0
         ));
     }
 

--- a/pimcore/modules/admin/controllers/ObjectController.php
+++ b/pimcore/modules/admin/controllers/ObjectController.php
@@ -113,6 +113,7 @@ class Admin_ObjectController extends Pimcore_Controller_Action_Admin_Element
 
         //Hook for modifying return value - e.g. for changing permissions based on object data
         //data need to wrapped into a container in order to pass parameter to event listeners by reference so that they can change the values
+        if (!isset($objects)) $objects = null;
         $returnValueContainer = new Tool_Admin_EventDataContainer($objects);
         Pimcore::getEventManager()->trigger("admin.object.treeGetChildsById.preSendData", $this, array("returnValueContainer" => $returnValueContainer));
 
@@ -308,7 +309,8 @@ class Admin_ObjectController extends Pimcore_Controller_Action_Admin_Element
 
             $objectData["properties"] = Element_Service::minimizePropertiesForEditmode($object->getProperties());
             $objectData["userPermissions"] = $object->getUserPermissions();
-            $objectData["versions"] = array_splice($object->getVersions(), 0, 1);
+			$versions = $object->getVersions(); // Only variables should be passed by reference
+            $objectData["versions"] = array_splice($versions, 0, 1);
             $objectData["scheduledTasks"] = $object->getScheduledTasks();
             $objectData["general"]["allowVariants"] = $object->getClass()->getAllowVariants();
             $objectData["general"]["showVariants"] = $object->getClass()->getShowVariants();
@@ -878,14 +880,14 @@ class Admin_ObjectController extends Pimcore_Controller_Action_Admin_Element
 
         if ($object->isAllowed("settings")) {
 
-
+            if (!isset($values["key"])) $values["key"] = null;
             if ($values["key"] && $object->isAllowed("rename")) {
                 $object->setKey($values["key"]);
             } else if ($values["key"] != $object->getKey()) {
                 Logger::debug("prevented renaming object because of missing permissions ");
             }
 
-            if ($values["parentId"]) {
+            if (isset($values["parentId"]) && $values["parentId"]) {
                 $parent = Object_Abstract::getById($values["parentId"]);
 
                 //check if parent is changed
@@ -1017,6 +1019,7 @@ class Admin_ObjectController extends Pimcore_Controller_Action_Admin_Element
 
             if (!empty($tasksData)) {
                 foreach ($tasksData as $taskData) {
+                    if (!isset($taskData["time"])) $taskData["time"] = null;
                     $taskData["date"] = strtotime($taskData["date"] . " " . $taskData["time"]);
 
                     $task = new Schedule_Task($taskData);

--- a/pimcore/modules/admin/controllers/ObjectHelperController.php
+++ b/pimcore/modules/admin/controllers/ObjectHelperController.php
@@ -68,7 +68,7 @@ class Admin_ObjectHelperController extends Pimcore_Controller_Action_Admin {
             foreach ($configFiles as $configFile) {
                 if (is_file($configFile)) {
                     $gridConfig = Pimcore_Tool_Serialize::unserialize(file_get_contents($configFile));
-                    if(array_key_exists("classId", $gridConfig)) {
+                    if(is_array($gridConfig) && array_key_exists("classId", $gridConfig)) {
                         if($gridConfig["classId"] == $class->getId()) {
                             break;
                         } else {
@@ -105,7 +105,7 @@ class Admin_ObjectHelperController extends Pimcore_Controller_Action_Admin {
                         $key = "path";
                     }
 
-                    if(empty($types) && ($vis[$gridType][$key] || $gridType == "all")) {
+                    if(empty($types) && ((isset($vis[$gridType][$key]) && $vis[$gridType][$key]) || $gridType == "all")) {
                         $availableFields[] = array(
                             "key" => $sc,
                             "type" => "system",
@@ -171,7 +171,7 @@ class Admin_ObjectHelperController extends Pimcore_Controller_Action_Admin {
         } else {
             $savedColumns = $gridConfig['columns'];
             foreach($savedColumns as $key => $sc) {
-                if(!$sc['hidden']) {
+                if(!(isset($sc['hidden']) && $sc['hidden'])) {
                     if(in_array($key, $systemColumns)) {
                         $colConfig = array(
                             "key" => $key,
@@ -254,10 +254,10 @@ class Admin_ObjectHelperController extends Pimcore_Controller_Action_Admin {
             $language = $gridConfig['language'];
         }
         $this->_helper->json(array(
-            "sortinfo" => $gridConfig['sortinfo'],
+            "sortinfo" => isset($gridConfig['sortinfo'])?$gridConfig['sortinfo']:null,
             "language" => $language,
             "availableFields" => $availableFields,
-            "onlyDirectChildren" => $gridConfig['onlyDirectChildren']
+            "onlyDirectChildren" => isset($gridConfig['onlyDirectChildren'])?$gridConfig['onlyDirectChildren']:null
         ));
     }
 

--- a/pimcore/modules/admin/controllers/PageController.php
+++ b/pimcore/modules/admin/controllers/PageController.php
@@ -28,7 +28,8 @@ class Admin_PageController extends Pimcore_Controller_Action_Admin_Document {
         $page = Document_Page::getById($this->getParam("id"));
         $page = $this->getLatestVersion($page);
 
-        $page->setVersions(array_splice($page->getVersions(), 0, 1));
+        $versions = $page->getVersions(); // Only variables should be passed by reference
+        $page->setVersions(array_splice($versions, 0, 1));
         $page->getScheduledTasks();
         $page->idPath = Element_Service::getIdPath($page);
         $page->userPermissions = $page->getUserPermissions();

--- a/pimcore/modules/admin/controllers/PortalController.php
+++ b/pimcore/modules/admin/controllers/PortalController.php
@@ -50,7 +50,7 @@ class Admin_PortalController extends Pimcore_Controller_Action_Admin {
         $dashboards = $this->dashboardHelper->getAllDashboards();
         $key = trim($this->getParam("key"));
 
-        if($dashboards[$key]) {
+        if(isset($dashboards[$key]) && $dashboards[$key]) {
             $this->_helper->json(array("success" => false, "message" => "dashboard_already_exists"));
         } else if (!empty($key)) {
             $this->dashboardHelper->saveDashboard($key);

--- a/pimcore/modules/admin/controllers/SettingsController.php
+++ b/pimcore/modules/admin/controllers/SettingsController.php
@@ -326,7 +326,7 @@ class Admin_SettingsController extends Pimcore_Controller_Action_Admin {
                 "language" => $values["general.language"],
                 "validLanguages" => implode(",", $filteredLanguages),
                 "fallbackLanguages" => $fallbackLanguages,
-                "theme" => $values["general.theme"],
+                "theme" => isset($values["general.theme"])?$values["general.theme"]:null,
                 "contactemail" => $values["general.contactemail"],
                 "loginscreencustomimage" => $values["general.loginscreencustomimage"],
                 "disableusagestatistics" => $values["general.disableusagestatistics"],
@@ -348,8 +348,8 @@ class Admin_SettingsController extends Pimcore_Controller_Action_Admin {
             "database" => $oldValues["database"], // db cannot be changed here
             "documents" => array(
                 "versions" => array(
-                    "days" => $values["documents.versions.days"],
-                    "steps" => $values["documents.versions.steps"]
+                    "days" => isset($values["documents.versions.days"])?$values["documents.versions.days"]:null,
+                    "steps" => isset($values["documents.versions.steps"])?$values["documents.versions.steps"]:null
                 ),
                 "default_controller" => $values["documents.default_controller"],
                 "default_action" => $values["documents.default_action"],
@@ -365,8 +365,8 @@ class Admin_SettingsController extends Pimcore_Controller_Action_Admin {
             ),
             "objects" => array(
                 "versions" => array(
-                    "days" => $values["objects.versions.days"],
-                    "steps" => $values["objects.versions.steps"]
+                    "days" => isset($values["objects.versions.days"])?$values["objects.versions.days"]:null,
+                    "steps" => isset($values["objects.versions.steps"])?$values["objects.versions.steps"]:null
                 )
             ),
             "assets" => array(
@@ -374,8 +374,8 @@ class Admin_SettingsController extends Pimcore_Controller_Action_Admin {
                     "hostname" => $values["assets.webdav.hostname"]
                 ),
                 "versions" => array(
-                    "days" => $values["assets.versions.days"],
-                    "steps" => $values["assets.versions.steps"]
+                    "days" => isset($values["assets.versions.days"])?$values["assets.versions.days"]:null,
+                    "steps" => isset($values["assets.versions.steps"])?$values["assets.versions.steps"]:null
                 ),
                 "ffmpeg" => $values["assets.ffmpeg"],
                 "ghostscript" => $values["assets.ghostscript"],
@@ -424,7 +424,7 @@ class Admin_SettingsController extends Pimcore_Controller_Action_Admin {
         foreach(array("email", "newsletter") as $type) {
             $smtpPassword = $values[$type . ".smtp.auth.password"];
             if (empty($smtpPassword)) {
-                $smtpPassword = $oldValues[$type]['smtp']['auth']['password'];
+                $smtpPassword = isset($oldValues[$type]['smtp']['auth']['password'])?$oldValues[$type]['smtp']['auth']['password']:null;
             }
 
             $settings[$type] = array(
@@ -1427,11 +1427,11 @@ class Admin_SettingsController extends Pimcore_Controller_Action_Admin {
         }
         return $resultItem;
     }
-    
+
     public function getAvailableAlgorithmsAction () {
-        
+
     	$options = array();
-		
+
     	$algorithms = hash_algos();
         foreach ($algorithms as $algorithm) {
 
@@ -1439,7 +1439,7 @@ class Admin_SettingsController extends Pimcore_Controller_Action_Admin {
                 "key" => $algorithm,
                 "value" => $algorithm
             );
-            
+
         }
 
         $result = array("data" => $options, "success" => true, "total" => count($options));

--- a/pimcore/modules/admin/controllers/SnippetController.php
+++ b/pimcore/modules/admin/controllers/SnippetController.php
@@ -27,10 +27,11 @@ class Admin_SnippetController extends Pimcore_Controller_Action_Admin_Document {
 
         $snippet = Document_Snippet::getById($this->getParam("id"));
         $modificationDate = $snippet->getModificationDate();
-        
+
         $snippet = $this->getLatestVersion($snippet);
 
-        $snippet->setVersions(array_splice($snippet->getVersions(), 0, 1));
+        $versions = $snippet->getVersions(); // Only variables should be passed by reference
+        $snippet->setVersions(array_splice($versions, 0, 1));
         $snippet->getScheduledTasks();
         $snippet->idPath = Element_Service::getIdPath($snippet);
         $snippet->userPermissions = $snippet->getUserPermissions();

--- a/pimcore/modules/admin/controllers/TranslationController.php
+++ b/pimcore/modules/admin/controllers/TranslationController.php
@@ -114,7 +114,7 @@ class Admin_TranslationController extends Pimcore_Controller_Action_Admin {
         foreach ($translations as $t) {
             $tempRow = array();
             foreach ($columns as $key) {
-                $value = $t[$key];
+                $value = isset($t[$key])?$t[$key]:null;
                 //clean value of evil stuff such as " and linebreaks
                 if (is_string($value)) {
                     $value = Pimcore_Tool_Text::removeLineBreaks($value);

--- a/pimcore/modules/admin/controllers/UserController.php
+++ b/pimcore/modules/admin/controllers/UserController.php
@@ -311,7 +311,7 @@ class Admin_UserController extends Pimcore_Controller_Action_Admin {
             "permissions" => $user->generatePermissionList(),
             "availablePermissions" => $availableUserPermissions,
             "objectDependencies" => array(
-                "hasHidden" => $hasHidden,
+                "hasHidden" => isset($hasHidden)?$hasHidden:null,
                 "dependencies" => $userObjectData
             )
         ));

--- a/pimcore/modules/admin/views/scripts/asset/get-preview-document.php
+++ b/pimcore/modules/admin/views/scripts/asset/get-preview-document.php
@@ -15,7 +15,7 @@ if (strpos($this->asset->getFilename(), ".pdf") !== false) {
     $pdfPath = $this->asset->getFullpath();
 }
 
-if($pdfPath) {
+if(isset($pdfPath) && $pdfPath) {
     if($this->getParam("native-viewer")) {
         header("Location: " . $pdfPath, true, 301);
         exit;

--- a/pimcore/modules/admin/views/scripts/index/index.php
+++ b/pimcore/modules/admin/views/scripts/index/index.php
@@ -477,7 +477,7 @@ $scripts = array(
 );
 
 // google maps API key
-$googleMapsApiKey = $this->config->services->google->browserapikey;
+$googleMapsApiKey = isset($this->config->services->google->browserapikey)?$this->config->services->google->browserapikey:null;
 
 ?>
 
@@ -500,7 +500,7 @@ $googleMapsApiKey = $this->config->services->google->browserapikey;
         customviews: <?php echo Zend_Json::encode($this->customview_config) ?>,
         language: '<?php echo $this->language; ?>',
         websiteLanguages: <?php echo Zend_Json::encode(explode(",",$this->config->general->validLanguages)); ?>,
-        google_translate_api_key: "<?php echo $this->config->services->translate->apikey; ?>",
+        google_translate_api_key: "<?php echo isset($this->config->services->translate->apikey)?$this->config->services->translate->apikey:null; ?>",
         google_maps_api_key: "<?php echo $googleMapsApiKey ?>",
         showCloseConfirmation: true,
         debug_admin_translations: <?php echo Zend_Json::encode((bool) $this->config->general->debug_admin_translations) ?>,

--- a/pimcore/modules/reports/controllers/CustomReportController.php
+++ b/pimcore/modules/reports/controllers/CustomReportController.php
@@ -88,7 +88,7 @@ class Reports_CustomReportController extends Pimcore_Controller_Action_Admin_Rep
     public function columnConfigAction() {
 
         $configuration = json_decode($this->getParam("configuration"));
-        $configuration = $configuration[0];
+        $configuration = isset($configuration[0])?$configuration[0]:null;
 
         $success = false;
         $columns = null;

--- a/pimcore/modules/reports/controllers/TargetingController.php
+++ b/pimcore/modules/reports/controllers/TargetingController.php
@@ -91,7 +91,7 @@ class Reports_TargetingController extends Pimcore_Controller_Action_Admin {
         $actions = new Tool_Targeting_Rule_Actions();
         $actions->setRedirectEnabled($data["actions"]["redirect.enabled"]);
         $actions->setRedirectUrl($data["actions"]["redirect.url"]);
-        $actions->setRedirectCode($data["actions"]["redirect.code"]);
+        $actions->setRedirectCode(isset($data["actions"]["redirect.code"])?$data["actions"]["redirect.code"]:null);
         $actions->setEventEnabled($data["actions"]["event.enabled"]);
         $actions->setEventKey($data["actions"]["event.key"]);
         $actions->setEventValue($data["actions"]["event.value"]);

--- a/pimcore/modules/searchadmin/controllers/SearchController.php
+++ b/pimcore/modules/searchadmin/controllers/SearchController.php
@@ -94,7 +94,7 @@ class Searchadmin_SearchController extends Pimcore_Controller_Action_Admin {
             }
         }
 
-        if ($forbiddenConditions) {
+        if (isset($forbiddenConditions) && $forbiddenConditions) {
             $conditionParts[] = "(" . implode(" AND ", $forbiddenConditions) . ")";
         }
 
@@ -109,7 +109,7 @@ class Searchadmin_SearchController extends Pimcore_Controller_Action_Admin {
             //}
 
             $conditionParts[] = $queryCondition;
-        }                      
+        }
 
 
         //For objects - handling of bricks
@@ -129,7 +129,7 @@ class Searchadmin_SearchController extends Pimcore_Controller_Action_Admin {
                     $bricks[$parts[0]] = $parts[0];
                 }
             }
-        }        
+        }
 
         // filtering for objects
         if ($this->getParam("filter") && $this->getParam("class")) {
@@ -162,7 +162,7 @@ class Searchadmin_SearchController extends Pimcore_Controller_Action_Admin {
 
         if (is_array($classnames) and !empty($classnames[0])) {
             if(in_array("folder",$subtypes)){
-                $classnames[]="folder";    
+                $classnames[]="folder";
             }
             foreach ($classnames as $classname) {
                 $conditionClassnameParts[] = $db->quote($classname);

--- a/pimcore/modules/searchadmin/models/Search/Backend/Data/List/Resource.php
+++ b/pimcore/modules/searchadmin/models/Search/Backend/Data/List/Resource.php
@@ -24,7 +24,7 @@ class Search_Backend_Data_List_Resource extends Pimcore_Model_List_Resource_Abst
 
         $entries = array();
         $data = $this->db->fetchAll("SELECT * FROM search_backend_data" .  $this->getCondition() . $this->getGroupBy() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
-     
+
         foreach ($data as $entryData) {
 
              if($entryData['maintype']=='document'){
@@ -42,10 +42,10 @@ class Search_Backend_Data_List_Resource extends Pimcore_Model_List_Resource_Abst
                 $entry->setFullPath($entryData['fullpath']);
                 $entry->setType($entryData['type']);
                 $entry->setSubtype($entryData['subtype']);
-                $entry->setUserOwner($entryData['userowner']);
-                $entry->setUserModification($entryData['usermodification']);
-                $entry->setCreationDate($entryData['creationdate']);
-                $entry->setModificationDate($entryData['modificationdate']);
+                $entry->setUserOwner(isset($entryData['userowner'])?$entryData['userowner']:null);
+                $entry->setUserModification(isset($entryData['usermodification'])?$entryData['usermodification']:null);
+                $entry->setCreationDate(isset($entryData['creationdate'])?$entryData['creationdate']:null);
+                $entry->setModificationDate(isset($entryData['modificationdate'])?$entryData['modificationdate']:null);
                 $entry->setPublished($entryData['published']=== 0 ? false : true);
                 $entries[]=$entry;
             }


### PR DESCRIPTION
I deleted my previous fork, and here is a clean one up-to-date (i fetch pimcore/pimcore until your last commit "PIMCORE-2474 - Word export freeze on grey owerlay if just the button..." so there shouldn't be any merge conflict). You have just to review it and if all is ok, to merge it. I try to minimise correction to not introduce any new bug.

---

Purpose of the correction is to provide Pimcore free of error even on E_ALL level. Corrections have been made by viewing all the front web page from the demo_website, and all the menu, sub-menu, window, tab, etc., in the backend as much as possible.
If E_ALL is activated, Pimcore demo front and admin run now without any strict/notice warning! So great. I imagine there are some left, but it should be a good base.

Advantages of providing this:
- quality of the Pimcore application seen by the developpers. Having an application wich bootstrap without any strict/notice error means quality of the product.
- quality of futur plugins: E_ALL level can now be activated in the startup.php for developpers and they can have a working backend and develop their own plugin with this level. Actually this is not possible, bringing less quality code for the plugins or difficulty for developpers to achieve this.
- strategic feature provided by some competitor of Pimcore, so Pimcore has to improve on this field. One of them (PIM Akeneo) is proud to said their application has no strict error (see github they are chasing them) for exemple.
- the more important is this one: possibility to develop an application based on Pimcore with level E_ALL without having to add @ in many Pimcore method, slowing down developement, hidding errors, ... Final application is stacked beetwen a clean developper work / Pimcore / Zend... Pimcore fill the logs... : ((

I started this because I try to make my developer team work in E_ALL level for quality of the code, but Pimcore has not this level of agrement and it is a shame as there is not so much things to change. It is a good basis, but I hope one day, for the long run, Pimcore would be unit tested/developped by core team in E_ALL level. Zend reporting zero notice/strict, and work transparent at this level, that is what we can call quality professional framework, and really Pimcore deserve to be able to work flawlessly too, it is a so good PIM/WCMS : )
