### PR TITLE
updated path which caused problems when pimcore is not located in PIMCOR...

### DIFF
--- a/pimcore/config/startup.php
+++ b/pimcore/config/startup.php
@@ -73,10 +73,10 @@ set_include_path(implode(PATH_SEPARATOR, $includePaths) . PATH_SEPARATOR);
 include(dirname(__FILE__) . "/helper.php");
 
 // setup zend framework and pimcore
-require_once PIMCORE_DOCUMENT_ROOT . "/pimcore/lib/Pimcore.php";
-require_once PIMCORE_DOCUMENT_ROOT . "/pimcore/lib/Logger.php";
-require_once PIMCORE_DOCUMENT_ROOT . "/pimcore/lib/Zend/Loader.php";
-require_once PIMCORE_DOCUMENT_ROOT . "/pimcore/lib/Zend/Loader/Autoloader.php";
+require_once PIMCORE_PATH . "/lib/Pimcore.php";
+require_once PIMCORE_PATH . "/lib/Logger.php";
+require_once PIMCORE_PATH . "/lib/Zend/Loader.php";
+require_once PIMCORE_PATH . "/lib/Zend/Loader/Autoloader.php";
 
 $autoloader = Zend_Loader_Autoloader::getInstance();
 $autoloader->suppressNotFoundWarnings(false);


### PR DESCRIPTION
We have pimcore moved to folder out of PIMCORE_DOCUMENT_ROOT and set PIMCORE_DOCUMENT_ROOT value before startup.php is called. It was working great for past few years, however current version of startup.php has broken this. I think PIMCORE_PATH constant should be used in this situation anyway.
