### PR TITLE
added autoScroll: true to allow to define more key value pairs for selec...

### DIFF
--- a/pimcore/static/js/pimcore/object/keyvalue/specialConfigWindow.js
+++ b/pimcore/static/js/pimcore/object/keyvalue/specialConfigWindow.js
@@ -89,6 +89,7 @@ pimcore.object.keyvalue.specialconfigwindow = Class.create({
     getEditPanel: function () {
         this.resultPanel = new Ext.Panel({
             layout: "fit",
+            autoScroll: true,
             items: [this.getGridPanel()],
             tbar: [
                 {


### PR DESCRIPTION
added autoScroll: true to allow to define more key value pairs for select, right now it was impossible to see more than 16 pairs as window is not resizable or panel scrollable
