### PR TITLE
in-template cache never forced

### DIFF
--- a/pimcore/lib/Pimcore/View/Helper/Cache.php
+++ b/pimcore/lib/Pimcore/View/Helper/Cache.php
@@ -36,7 +36,7 @@ class Cache extends \Zend_View_Helper_Abstract {
             return self::$_caches[$name];
         }
 
-        $cache = new CacheController($name, $lifetime, $this->view->editmode);
+        $cache = new CacheController($name, $lifetime, $this->view->editmode, $force);
         self::$_caches[$name] = $cache;
 
         return self::$_caches[$name];


### PR DESCRIPTION
while cache view helper has $force option, it was actually never passed to cache controller effectively blocking the forcing so admin's would always get uncached version which sometimes pretty bad for debugging purpose
