### PR TITLE
Admin: Added try-catch around document delete

### DIFF
--- a/pimcore/modules/admin/controllers/DocumentController.php
+++ b/pimcore/modules/admin/controllers/DocumentController.php
@@ -13,8 +13,8 @@
  * @license    http://www.pimcore.org/license     New BSD License
  */
 
-use Pimcore\Tool\Session; 
-use Pimcore\Tool; 
+use Pimcore\Tool\Session;
+use Pimcore\Tool;
 Use Pimcore\Config;
 use Pimcore\Model\Document;
 use Pimcore\Model\Version;
@@ -251,8 +251,13 @@ class Admin_DocumentController extends \Pimcore\Controller\Action\Admin\Element
         } else if ($this->getParam("id")) {
             $document = Document::getById($this->getParam("id"));
             if ($document->isAllowed("delete")) {
-                $document->delete();
-                $this->_helper->json(array("success" => true));
+                try {
+                    $document->delete();
+                    $this->_helper->json(array("success" => true));
+                } catch (\Exception $e) {
+                    \Logger::err($e);
+                    $this->_helper->json(array("success" => false, "message" => $e->getMessage()));
+                }
             }
         }
 


### PR DESCRIPTION
Added a try-catch block around $document->delete() in Admin_DocumentController, conform the $page->save() call in Admin_PageController
