### PR TITLE
PIMCORE 1837 - Honor the order of bricks in areablock

### DIFF
--- a/pimcore/models/Document/Tag/Areablock.php
+++ b/pimcore/models/Document/Tag/Areablock.php
@@ -551,9 +551,6 @@ class Areablock extends Model\Document\Tag {
             }
         }
 
-        //set default sorting method
-        $options['sorting'] = empty($options['allowed']) ? 'name' : $options['sorting'];
-
         if (count($availableAreas["name"])) {
             // sort with translated names
             usort($availableAreas["name"], function ($a, $b) {


### PR DESCRIPTION
Example:

``` php
echo $this->areablock($id, [
     'allowed' => $allowedAreas,
     'sorting' => 'allowed', // allowed || name (default)
     ...
]);
```
