### PR TITLE
Don't html encode double quotes on paste

### DIFF
--- a/pimcore/static/js/pimcore/document/tags/textarea.js
+++ b/pimcore/static/js/pimcore/document/tags/textarea.js
@@ -74,7 +74,7 @@ pimcore.document.tags.textarea = Class.create(pimcore.document.tag, {
                 text = window.clipboardData.getData("Text");
             }
 
-            text = htmlentities(text, null, null, false);
+            text = htmlentities(text, 'ENT_NOQUOTES', null, false);
 
             try {
                 document.execCommand("insertHTML", false, text);


### PR DESCRIPTION
When pasting HTML code with double quotes they are encoded to ```&quot;```. This doesn't happen with single quotes. This pull request leaves quotes as they are after pasting.