### PR TITLE
Prevent integrity violation in CustomLayout create()

### DIFF
--- a/pimcore/models/Object/ClassDefinition/CustomLayout/Resource.php
+++ b/pimcore/models/Object/ClassDefinition/CustomLayout/Resource.php
@@ -134,7 +134,7 @@ class Resource extends Model\Resource\AbstractResource {
      * @return boolean
      */
     public function create() {
-        $this->db->insert("custom_layouts", array("name" => $this->model->getName()));
+        $this->db->insert("custom_layouts", array("name" => $this->model->getName(), "classId" => $this->model->getClassId()));
 
         $this->model->setId($this->db->lastInsertId());
         $this->model->setCreationDate(time());


### PR DESCRIPTION
Set classId during INSERT to avoid cluttering the database with
classId=0, as the next UPDATE may fail for some reason (like race
condition)