### PR TITLE
Added PHPDoc to improve type hinting in user defined Objects.

### DIFF
--- a/pimcore/models/Object/ClassDefinition.php
+++ b/pimcore/models/Object/ClassDefinition.php
@@ -265,6 +265,15 @@ class ClassDefinition extends Model\AbstractModel {
         $cd .= "namespace Pimcore\\Model\\Object;";
         $cd .= "\n\n";
         $cd .= "\n\n";
+        $cd .= "/**\n";
+        if (is_array($this->getFieldDefinitions()) && count($this->getFieldDefinitions())) {
+            foreach ($this->getFieldDefinitions() as $key => $def) {
+                if (!(method_exists($def,"isRemoteOwner") and $def->isRemoteOwner())) {
+                    $cd .= $def->getClassPhpDoc($this);
+                }
+            }
+        }
+        $cd .= "*/\n";
 
         $cd .= "class " . ucfirst($this->getName()) . " extends " . $extendClass . " {";
         $cd .= "\n\n";
@@ -349,6 +358,10 @@ class ClassDefinition extends Model\AbstractModel {
         $cd .= "namespace Pimcore\\Model\\Object\\" . ucfirst($this->getName()) . ";";
         $cd .= "\n\n";
         $cd .= "use Pimcore\\Model\\Object;";
+        $cd .= "\n\n";
+        $cd .= "/**\n";
+        $cd .= " * @method Object\\" . ucfirst($this->getName()) . " current()\n";
+        $cd .= " */";
         $cd .= "\n\n";
         $cd .= "class Listing extends Object\\Listing\\Concrete {";
         $cd .= "\n\n";

--- a/pimcore/models/Object/ClassDefinition/Data.php
+++ b/pimcore/models/Object/ClassDefinition/Data.php
@@ -1012,4 +1012,16 @@ abstract class Data
             }
         }
     }
+
+    /**
+     * @param $class
+     * @return string
+     */
+    public function getClassPhpDoc($class) {
+        $code = "";
+        $key = $this->getName();
+        $code .= "* @method static \\Pimcore\\Model\\Object\\" . ucfirst($class->getName()) . ' getBy' . ucfirst($key) . ' ($value, $limit = 0) ' ."\n";
+        return $code;
+    }
+
 }


### PR DESCRIPTION
- @method tag in Listings for the Iterator Interface. This enables type hinting e.g. for foreach
- @method tag in Class for methods provided by the resource. This enables type hinting for getByXXXX() methods