### PR TITLE
Added getPriorities() on Pimcore\Logger

### DIFF
--- a/pimcore/lib/Logger.php
+++ b/pimcore/lib/Logger.php
@@ -45,7 +45,16 @@ Logger {
 	public static function setPriorities ($prios) {
 		self::$priorities = $prios;
 	}
-	
+
+    /**
+     * return priorities, an array of log levels that will be logged by this logger
+     *
+     * @return array
+     */
+    public static function getPriorities () {
+        return self::$priorities;
+    }
+
 	public static function initDummy() {
 		self::$enabled = false;
 	}


### PR DESCRIPTION
Added public static method getPriorities() in Pimcore\Logger. This can be used if you want to create a seperate logger but don't want to extent on the Pimcore logger.

The logger has the priorities already mapped from the system config to Zend_Log constants.