### PR TITLE
Targeting FIX - targets didn't save

### DIFF
--- a/pimcore/models/Tool/Targeting/Rule/Actions.php
+++ b/pimcore/models/Tool/Targeting/Rule/Actions.php
@@ -219,7 +219,7 @@ class Actions {
     public function setRedirectUrl($redirectUrl)
     {
         if(is_string($redirectUrl)) {
-            if($doc = Document::getByPath($redirectUrl)) {
+            if($doc = Model\Document::getByPath($redirectUrl)) {
                 $redirectUrl = $doc->getId();
             }
         }


### PR DESCRIPTION
Global targeting rules couldn't save because of this.
Error:
```
Warning: include_once(Pimcore/Model/Tool/Targeting/Rule/Document.php): failed to open stream: No such file or directory in
```