### PR TITLE
PIMCORE 2688 - Placeholder option for input editable

### DIFF
--- a/pimcore/static/css/editmode.css
+++ b/pimcore/static/css/editmode.css
@@ -333,11 +333,16 @@
 }
 
 .pimcore_tag_input[contenteditable=true]:empty:before{
-    /* PIMCORE-2688 */
+    cursor: text; /* For chrome */
     content: attr(data-placeholder);
     display: block; /* For Firefox */
     color:#BABABA;
 }
+
+.pimcore_tag_input[contenteditable=true]:empty:focus:before{
+    display: none; /* For Firefox */
+}
+
 
 .pimcore_tag_textarea {
     white-space: pre-line;

--- a/pimcore/static/css/editmode.css
+++ b/pimcore/static/css/editmode.css
@@ -332,6 +332,13 @@
     box-shadow: none;
 }
 
+.pimcore_tag_input[contenteditable=true]:empty:before{
+    /* PIMCORE-2688 */
+    content: attr(data-placeholder);
+    display: block; /* For Firefox */
+    color:#BABABA;
+}
+
 .pimcore_tag_textarea {
     white-space: pre-line;
     width: 100%;

--- a/pimcore/static/js/pimcore/document/tags/input.js
+++ b/pimcore/static/js/pimcore/document/tags/input.js
@@ -86,6 +86,10 @@ pimcore.document.tags.input = Class.create(pimcore.document.tag, {
         if(options["class"]) {
             this.element.addClass(options["class"]);
         }
+
+        if (options["placeholder"]) {
+            this.element.dom.setAttribute('data-placeholder', options["placeholder"]);
+        }
     },
 
     checkValue: function () {


### PR DESCRIPTION
Usage: $this->input('field', ['placeholder' => 'placeholder text']);

Before I forget, is /static5/.../input.js in use?