### PR TITLE
PIMCORE 2689 - LiveUpdate can fail because of libxml2 default parser lim...

### DIFF
--- a/pimcore/lib/Pimcore/Update.php
+++ b/pimcore/lib/Pimcore/Update.php
@@ -216,7 +216,8 @@ class Update {
         
         $xml = Tool::getHttpData($url);
         if($xml) {
-            $updateFiles = simplexml_load_string($xml, null, LIBXML_NOCDATA);
+            $parserOptions = LIBXML_VERSION >= 20900 ? LIBXML_NOCDATA | LIBXML_PARSEHUGE : LIBXML_NOCDATA;
+            $updateFiles = simplexml_load_string($xml, null, $parserOptions);
             
             foreach ($updateFiles->file as $file) {
                 


### PR DESCRIPTION
...its