### PR TITLE
PIMCORE-2466 Change order of the system language

### DIFF
--- a/pimcore/config/texts/en.csv
+++ b/pimcore/config/texts/en.csv
@@ -98,6 +98,7 @@
 "fallback_languages","Fallback Languages (CSV eg. de_CH,de)"
 "languages","Languages"
 "add_language","Add Language"
+"default_language", "Default language"
 "localization_and_internationalization","Localization &amp; Internationalization"
 "contact_email","Contact E-Mail"
 "password_was_not_changed","Password wasn't changed because it isn't secure enough"

--- a/pimcore/lib/Pimcore/Tool.php
+++ b/pimcore/lib/Pimcore/Tool.php
@@ -113,9 +113,10 @@ class Tool {
         if (!empty($languages) && in_array($defaultLanguage, $languages)) {
             return $defaultLanguage;
         }
-        else {
+        else if (!empty($languages)) {
             return $languages[0];
         }
+
         return null;
     }
 

--- a/pimcore/lib/Pimcore/Tool.php
+++ b/pimcore/lib/Pimcore/Tool.php
@@ -106,8 +106,14 @@ class Tool {
      * @return null
      */
     public static function getDefaultLanguage() {
+        $config = Config::getSystemConfig();
+        $defaultLanguage = $config->general->defaultLanguage;
         $languages = self::getValidLanguages();
-        if(!empty($languages)) {
+
+        if (!empty($languages) && in_array($defaultLanguage, $languages)) {
+            return $defaultLanguage;
+        }
+        else {
             return $languages[0];
         }
         return null;

--- a/pimcore/modules/admin/controllers/SettingsController.php
+++ b/pimcore/modules/admin/controllers/SettingsController.php
@@ -358,6 +358,7 @@ class Admin_SettingsController extends \Pimcore\Controller\Action\Admin {
                 "language" => $values["general.language"],
                 "validLanguages" => implode(",", $filteredLanguages),
                 "fallbackLanguages" => $fallbackLanguages,
+                "defaultLanguage" => $values["general.defaultLanguage"],
                 "theme" => $values["general.theme"],
                 "contactemail" => $values["general.contactemail"],
                 "loginscreencustomimage" => $values["general.loginscreencustomimage"],

--- a/pimcore/static/js/pimcore/settings/system.js
+++ b/pimcore/static/js/pimcore/settings/system.js
@@ -292,7 +292,7 @@ pimcore.settings.system = Class.create({
                                 xtype: "container",
                                 width: 450,
                                 style: "margin-top: 20px;",
-                                id: "system.settings.general.languageConainer",
+                                id: "system.settings.general.languageContainer",
                                 items: [],
                                 listeners: {
                                     beforerender: function () {
@@ -1596,7 +1596,7 @@ pimcore.settings.system = Class.create({
             }
 
             // add the language to the container, so that further settings for the language can be set (eg. fallback, ...)
-            var container = Ext.getCmp("system.settings.general.languageConainer");
+            var container = Ext.getCmp("system.settings.general.languageContainer");
             var lang = container.getComponent(language);
             if(lang) {
                 return;
@@ -1657,7 +1657,7 @@ pimcore.settings.system = Class.create({
         }
 
         // remove the language from the container
-        var container = Ext.getCmp("system.settings.general.languageConainer");
+        var container = Ext.getCmp("system.settings.general.languageContainer");
         var lang = container.getComponent(language);
         if(lang) {
             container.remove(lang);

--- a/pimcore/static/js/pimcore/settings/system.js
+++ b/pimcore/static/js/pimcore/settings/system.js
@@ -1619,8 +1619,6 @@ pimcore.settings.system = Class.create({
                     xtype: "radio",
                     name: "general.defaultLanguageRadio",
                     fieldLabel: t("default_language"),
-                    boxLabel: t("default"),
-                    inputValue: language,
                     checked: this.getValue("general.defaultLanguage") == language || (!this.getValue("general.defaultLanguage") && container.items.length == 0 ),
                     listeners: {
                         check: function (el, checked) {

--- a/pimcore/static/js/pimcore/settings/system.js
+++ b/pimcore/static/js/pimcore/settings/system.js
@@ -284,6 +284,11 @@ pimcore.settings.system = Class.create({
                                 name: 'general.validLanguages',
                                 value: this.getValue("general.validLanguages")
                             }, {
+                                xtype: "hidden",
+                                id: "system.settings.general.defaultLanguage",
+                                name: "general.defaultLanguage",
+                                value: this.getValue("general.defaultLanguage")
+                            }, {
                                 xtype: "container",
                                 width: 450,
                                 style: "margin-top: 20px;",
@@ -1611,6 +1616,21 @@ pimcore.settings.system = Class.create({
                     name: "general.fallbackLanguages." + language,
                     value: this.getValue("general.fallbackLanguages." + language)
                 },{
+                    xtype: "radio",
+                    name: "general.defaultLanguageRadio",
+                    fieldLabel: t("default_language"),
+                    boxLabel: t("default"),
+                    inputValue: language,
+                    checked: this.getValue("general.defaultLanguage") == language || (!this.getValue("general.defaultLanguage") && container.items.length == 0 ),
+                    listeners: {
+                        check: function (el, checked) {
+                            if (checked) {
+                                var defaultLanguageField = Ext.getCmp("system.settings.general.defaultLanguage");
+                                defaultLanguageField.setValue(language);
+                            }
+                        }.bind(this)
+                    }
+                },{
                     xtype: "button",
                     title: t("delete"),
                     iconCls: "pimcore_icon_delete",
@@ -1630,6 +1650,12 @@ pimcore.settings.system = Class.create({
         if(in_array(language, addedLanguages)) {
             addedLanguages.splice(array_search(language, addedLanguages),1);
             languageField.setValue(addedLanguages.join(","));
+        }
+
+        // remove the default language from hidden field
+        var defaultLanguageField = Ext.getCmp("system.settings.general.defaultLanguage");
+        if (defaultLanguageField.getValue() == language) {
+            defaultLanguageField.setValue("");
         }
 
         // remove the language from the container


### PR DESCRIPTION
Reordering is still not possible but each language-container has a "mark as default" option