### PR TITLE
Added CLI utility to reset password

### DIFF
--- a/pimcore/cli/reset-password.php
+++ b/pimcore/cli/reset-password.php
@@ -22,17 +22,29 @@ use Pimcore\Model\User;
 echo "\n";
 
 function prompt_silent($prompt = "Enter new password:") {
+  if (preg_match('/^win/i', PHP_OS)) {
+    $vbscript = sys_get_temp_dir() . 'prompt_password.vbs';
+    file_put_contents(
+      $vbscript, 'wscript.echo(InputBox("'
+      . addslashes($prompt)
+      . '", "", "password here"))');
+    $command = "cscript //nologo " . escapeshellarg($vbscript);
+    $password = rtrim(shell_exec($command));
+    unlink($vbscript);
+    return $password;
+  } else {
     $command = "/usr/bin/env bash -c 'echo OK'";
     if (rtrim(shell_exec($command)) !== 'OK') {
-        trigger_error("Can't invoke bash");
-        return false;
+      trigger_error("Can't invoke bash");
+      return;
     }
     $command = "/usr/bin/env bash -c 'read -s -p \""
-        . addslashes($prompt)
-        . "\" mypassword && echo \$mypassword'";
+      . addslashes($prompt)
+      . "\" mypassword && echo \$mypassword'";
     $password = rtrim(shell_exec($command));
     echo "\n";
     return $password;
+  }
 }
 
 if ($argc <= 1) { // if no arguments


### PR DESCRIPTION
In case you're interested. This might be useful to other users and to e.g. automate installation under certain use-cases. 

Usage:
```bash
php pimcore/cli/reset-password.php id/username
```

The utility will prompt for the new password and update the record in the database automatically.