### PR TITLE
Bugfix: creating Objects, Assets and Folders with "0" as name

### DIFF
--- a/pimcore/models/Asset.php
+++ b/pimcore/models/Asset.php
@@ -605,7 +605,7 @@ class Asset extends Element\AbstractElement {
      */
     protected function update() {
 
-        if (!$this->getFilename() && $this->getId() != 1) {
+        if (!$this->getFilename() && !is_numeric($this->getFilename()) && $this->getId() != 1) {
             $this->setFilename("---no-valid-filename---" . $this->getId());
             throw new \Exception("Asset requires filename, generated filename automatically");
         }

--- a/pimcore/models/Object/AbstractObject/Resource.php
+++ b/pimcore/models/Object/AbstractObject/Resource.php
@@ -79,7 +79,7 @@ class Resource extends Model\Element\Resource
         ));
         $this->model->setId($this->db->lastInsertId());
 
-        if (!$this->model->getKey()) {
+        if (!$this->model->getKey() && !is_numeric($this->model->getKey())) {
             $this->model->setKey($this->db->lastInsertId());
         }
     }


### PR DESCRIPTION
Fixed a bug that prevented creating Objects, Assets and Folders with a name consisting of the single character "0"