### PR TITLE
Improvement: Make submodules selectable in document settings and static routes

### DIFF
--- a/pimcore/static/js/pimcore/document/pages/settings.js
+++ b/pimcore/static/js/pimcore/document/pages/settings.js
@@ -389,9 +389,28 @@ pimcore.document.pages.settings = Class.create({
                                 }
                             },
                             {
+                                xtype:'combo',
                                 fieldLabel: t('module_optional'),
+                                displayField: 'name',
+                                valueField: 'name',
                                 name: 'module',
-                                value: this.page.data.module
+                                disableKeyFilter: true,
+                                store: new Ext.data.JsonStore({
+                                    autoDestroy: true,
+                                    url: "/admin/misc/get-available-modules",
+                                    root: "data",
+                                    fields: ["name"]
+                                }),
+                                triggerAction: "all",
+                                mode: "local",
+                                id: "pimcore_document_settings_module_" + this.page.id,
+                                value: this.page.data.module,
+                                width: 250,
+                                listeners: {
+                                    afterrender: function (el) {
+                                        el.getStore().load();
+                                    }
+                                }
                             },
                             {
                                 xtype:'combo',
@@ -412,9 +431,14 @@ pimcore.document.pages.settings = Class.create({
                                 value: this.page.data.controller,
                                 width: 250,
                                 listeners: {
-                                    afterrender: function (el) {
-                                        el.getStore().load();
-                                    }
+                                    "focus": function (el) {
+                                        el.getStore().reload({
+                                            params: {
+                                                moduleName: Ext.getCmp("pimcore_document_settings_module_"
+                                                    + this.page.id).getValue()
+                                            }
+                                        });
+                                    }.bind(this)
                                 }
                             },
                             {
@@ -439,7 +463,9 @@ pimcore.document.pages.settings = Class.create({
                                         el.getStore().reload({
                                             params: {
                                                 controllerName: Ext.getCmp("pimcore_document_settings_controller_"
-                                                                                    + this.page.id).getValue()
+                                                                                    + this.page.id).getValue(),
+                                                moduleName: Ext.getCmp("pimcore_document_settings_module_"
+                                                    + this.page.id).getValue()
                                             }
                                         });
                                     }.bind(this)

--- a/pimcore/static/js/pimcore/settings/staticroutes.js
+++ b/pimcore/static/js/pimcore/settings/staticroutes.js
@@ -170,7 +170,17 @@ pimcore.settings.staticroutes = Class.create({
             {header:t("reverse"), width:100, sortable:true, dataIndex:'reverse',
                 editor:new Ext.form.TextField({})},
             {header:t("module_optional"), width:50, sortable:false, dataIndex:'module',
-                editor:new Ext.form.TextField({})},
+                editor:new Ext.form.ComboBox({
+                    store: new Ext.data.JsonStore({
+                        autoDestroy: true,
+                        url: "/admin/misc/get-available-modules",
+                        root: "data",
+                        fields: ["name"]
+                    }),
+                    triggerAction: "all",
+                    displayField: 'name',
+                    valueField: 'name'
+                })},
             {header:t("controller"), width:50, sortable:false, dataIndex:'controller',
                 editor:new Ext.form.ComboBox({
                     store:new Ext.data.JsonStore({
@@ -181,7 +191,17 @@ pimcore.settings.staticroutes = Class.create({
                     }),
                     triggerAction:"all",
                     displayField:'name',
-                    valueField:'name'
+                    valueField:'name',
+                    listeners:{
+                        "focus":function (el) {
+                            console.log();
+                            el.getStore().reload({
+                                params:{
+                                    moduleName:this.store.data.items[el.gridEditor.row].data.module
+                                }
+                            });
+                        }.bind(this)
+                    }
                 })},
             {header:t("action"), width:50, sortable:false, dataIndex:'action',
                 editor:new Ext.form.ComboBox({
@@ -199,6 +219,7 @@ pimcore.settings.staticroutes = Class.create({
                             console.log();
                             el.getStore().reload({
                                 params:{
+                                    moduleName:this.store.data.items[el.gridEditor.row].data.module,
                                     controllerName:this.store.data.items[el.gridEditor.row].data.controller
                                 }
                             });


### PR DESCRIPTION
Submodules, if present, can now be selected in document settings and static routes with a selectbox instead of entering the name by hand, additionally the controller select boxes are updated accordingly.