### PR TITLE
REST Service: use class mapping in object creation

### DIFF
--- a/pimcore/models/Webservice/Service.php
+++ b/pimcore/models/Webservice/Service.php
@@ -634,7 +634,7 @@ class Service
     {
         try {
             if ($wsDocument instanceof Webservice\Data\Object\Concrete\In) {
-                $classname = "\\Pimcore\\Model\\Object\\" . ucfirst($wsDocument->className);
+                $classname = Tool::getModelClassMapping("\\Pimcore\\Model\\Object\\" . ucfirst($wsDocument->className));
                 if (Tool::classExists($classname)) {
                     $object = new $classname();
 


### PR DESCRIPTION
REST Service use class mapping only in update mode with Object::getById() method.
Now, with this fix, also in add mode.