### PR TITLE
Improvement: added length field for columns in StructuredTables

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data/StructuredTable.php
+++ b/pimcore/models/Object/ClassDefinition/Data/StructuredTable.php
@@ -497,7 +497,7 @@ class StructuredTable extends Model\Object\ClassDefinition\Data {
 
                 $col = new \stdClass();
                 $col->name = $name;
-                $col->type = $this->typeMapper($c['type']);
+                $col->type = $this->typeMapper($c['type'], $c['length']);
                 $dbCols[] = $col;
             }
         }
@@ -506,12 +506,13 @@ class StructuredTable extends Model\Object\ClassDefinition\Data {
     }
 
     /**
-     * @param $type
-     * @return mixed
+     * @param $type string text|number|bool
+     * @param $length int The length of the column, default is 255 for text
+     * @return string|null
      */
-    protected function typeMapper($type) {
+    protected function typeMapper($type, $length = null) {
         $mapper = array(
-            "text" => "varchar(255)",
+            "text" => "varchar(".($length > 0 ? $length : "255").")",
             "number" => "double",
             "bool" => "tinyint(1)"
         );

--- a/pimcore/static/js/pimcore/object/classes/data/structuredTable.js
+++ b/pimcore/static/js/pimcore/object/classes/data/structuredTable.js
@@ -99,6 +99,7 @@ pimcore.object.classes.data.structuredTable = Class.create(pimcore.object.classe
         
         if(hasType) {
             fields.push('type');
+            fields.push('length');
             fields.push('width');
         }
         
@@ -180,7 +181,10 @@ pimcore.object.classes.data.structuredTable = Class.create(pimcore.object.classe
                 return types[value];
             }});
 
-            typesColumns.push({header: t("width"), width: 10, sortable: true, dataIndex: 'width',
+            typesColumns.push({header: t("length"), width: 15, sortable: true, dataIndex: 'length',
+                                        editor: new Ext.form.NumberField({})});
+
+            typesColumns.push({header: t("width"), width: 15, sortable: true, dataIndex: 'width',
                                         editor: new Ext.form.NumberField({})});
 
         }


### PR DESCRIPTION
Added a field "length" for columns in StructuredTables to override the length of 255 for VARCHARS for text fields