### PR TITLE
Pimcore User Role Update Bug: Call to undefined method setAdmin in class Pimcore\Model\User\Role

### DIFF
--- a/pimcore/lib/Pimcore/View/Helper/PimcoreNavigation.php
+++ b/pimcore/lib/Pimcore/View/Helper/PimcoreNavigation.php
@@ -307,7 +307,7 @@ class PimcoreNavigationController
                     }
 
                     if ($child->hasChilds()) {
-                        $childPages = $this->buildNextLevel($child, false);
+                        $childPages = $this->buildNextLevel($child, false, $pageCallback);
                         $page->setPages($childPages);
                     }
 

--- a/pimcore/modules/admin/controllers/UserController.php
+++ b/pimcore/modules/admin/controllers/UserController.php
@@ -242,7 +242,7 @@ class Admin_UserController extends \Pimcore\Controller\Action\Admin {
 
             // only admins are allowed to create admin users
             // if the logged in user isn't an admin, set admin always to false
-            if(!$this->getUser()->isAdmin()) {
+            if(!$this->getUser()->isAdmin() && $user instanceof User) {
                 $user->setAdmin(false);
             }
 


### PR DESCRIPTION
Reproduce steps:
Create user which has permission to edit user/roles but is NOT admin.
Log in with that user and create User Role, than try to update it.
By updating it you will get [Exception] with message: Call to undefined method setAdmin in class Pimcore\Model\User\Role

The reason is that in method Admin_UserController::updateAction there is this code:

```
// only admins are allowed to create admin users
// if the logged in user isn't an admin, set admin always to false
if(!$this->getUser()->isAdmin()) {
    $user->setAdmin(false);
}
```

And the case is that !$this->getUser()->isAdmin() is TRUE but the $user is not User instance but UserRole which has no method setAdmin.