### PR TITLE
added autocad file mime

### DIFF
--- a/pimcore/lib/Pimcore/Tool/Mime.php
+++ b/pimcore/lib/Pimcore/Tool/Mime.php
@@ -91,6 +91,7 @@ class Mime {
         'dcr'       => 'application/x-director',
         'dir'       => 'application/x-director',
         'dxr'       => 'application/x-director',
+	'dxf'       => 'application/x-autocad',
         'dvi'       => 'application/x-dvi',
         'spl'       => 'application/x-futuresplash',
         'tgz'       => 'application/x-gtar',


### PR DESCRIPTION
for autocad dxf files the mimetype from fileinfo gets text/plain and this makes it unable to open that asset in backend.