### PR TITLE
Removed padding from portlet base class

### DIFF
--- a/pimcore/static6/js/lib/ext-plugins/portlet/Portlet.js
+++ b/pimcore/static6/js/lib/ext-plugins/portlet/Portlet.js
@@ -9,7 +9,6 @@ Ext.define('Portal.view.Portlet', {
     layout: 'fit',
     anchor: '100%',
     frame: true,
-    padding: '8 8 0 0',
     closable: true,
     collapsible: true,
     animCollapse: true,


### PR DESCRIPTION
This is very minor. The padding here is producing a gap inside each portlet. Is there a reason why its set as 8 8 0 0? Removing it appears to remove the gap.

Sorry for the aweful branch name :-( I'm never editing directly in github again!

Thanks,