### PR TITLE
bugfix: importer mapping + minor improvements

### DIFF
--- a/pimcore/static6/js/pimcore/object/importer.js
+++ b/pimcore/static6/js/pimcore/object/importer.js
@@ -183,16 +183,15 @@ pimcore.object.importer = Class.create({
                     }.bind(this),
                     flex: 1
                 },
-                {header: t("target"),sortable: false, dataIndex: "target", editor: new Ext.form.ComboBox({
+                {header: t("target"), sortable: false, dataIndex: "target", flex: 1, editor: new Ext.form.ComboBox({
                     store: targetFields,
                     mode: "local",
                     triggerAction: "all",
-                    flex: 1
+                    valueField: 'value',
+                    displayField: 'text',
                 })}
             ],
-            viewConfig: {
-                forceFit: true
-            }
+            forceFit: true
         });
 
         var filenameMappingStore = sourceFields;
@@ -220,6 +219,8 @@ pimcore.object.importer = Class.create({
                 {
                     xtype: "checkbox",
                     name: "overwrite",
+                    inputValue: "true",
+                    uncheckedValue: "false",
                     fieldLabel: t("overwrite_object_with_same_key")
                 },
                 {
@@ -307,10 +308,9 @@ pimcore.object.importer = Class.create({
             parentId: this.parentId
         };
 
-        this.jobRequest = mergeObject(this.jobRequest, this.settingsForm.getForm().getFieldValues());
+        this.jobRequest = mergeObject(this.jobRequest, this.settingsForm.getForm().getValues());
 
         this.dataWin.close();
-
 
         this.importProgressBar = new Ext.ProgressBar({
             text: t('Initializing'),


### PR DESCRIPTION
I've fixed combobox using displayfield as value in mapping fieldname(type_ was being sent instead of the fieldname.

![capture](https://cloud.githubusercontent.com/assets/1098498/10818484/e28e32b8-7e39-11e5-826c-35903e1c6b9d.JPG)


Also improved the layout of mapping grid & prevented displayfields from being submitted in every request in the import process.