### PR TITLE
setting layoutid to null if it is specified as an empty parameter

### DIFF
--- a/pimcore/modules/admin/controllers/ObjectController.php
+++ b/pimcore/modules/admin/controllers/ObjectController.php
@@ -343,8 +343,8 @@ class Admin_ObjectController extends \Pimcore\Controller\Action\Admin\Element
             $objectData["childdata"]["id"] = $object->getId();
             $objectData["childdata"]["data"]["classes"] = $object->getResource()->getClasses();
 
-            $currentLayoutId = $this->getParam("layoutId");
-
+            $currentLayoutId = $this->getParam("layoutId", null);
+            
             $validLayouts = Object\Service::getValidLayouts($object);
 
             //master layout has id 0 so we check for is_null()


### PR DESCRIPTION
Related to: https://github.com/pimcore/pimcore/issues/286

For competeness, I saw that  
https://github.com/pimcore/pimcore/blob/master/pimcore/static6/js/pimcore/object/object.js#L38
checks for options but doesn't check for null. I have left this line unedited for future 'option' considerations.
