### PR TITLE
Fixing object preview for ExtJS 6

### DIFF
--- a/pimcore/static6/js/pimcore/object/preview.js
+++ b/pimcore/static6/js/pimcore/object/preview.js
@@ -24,7 +24,7 @@ pimcore.object.preview = Class.create({
             var iframeOnLoad = "pimcore.globalmanager.get('object_"
                                         + this.object.data.general.o_id + "').preview.iFrameLoaded()";
 
-            this.layout = Ext.create('Ext.tab.Tab', {
+            this.layout = Ext.create('Ext.panel.Panel', {
                 title: t('preview'),
                 border: false,
                 autoScroll: true,


### PR DESCRIPTION
One line that fixes Object preview functionality in Pimcore 4