### PR TITLE
Fixing problem with hanging soffice locks

### DIFF
--- a/pimcore/lib/Pimcore/Document/Adapter/LibreOffice.php
+++ b/pimcore/lib/Pimcore/Document/Adapter/LibreOffice.php
@@ -148,12 +148,13 @@ class LibreOffice extends Ghostscript {
 
         if(!file_exists($pdfFile)) {
 
-            Model\Tool\Lock::acquire($lockKey); // avoid parallel conversions of the same document
-
             // a list of all available filters is here:
             // http://cgit.freedesktop.org/libreoffice/core/tree/filter/source/config/fragments/filters
             $cmd = self::getLibreOfficeCli() . " --headless --nologo --nofirststartwizard --norestore --convert-to pdf:writer_web_pdf_Export --outdir " . PIMCORE_TEMPORARY_DIRECTORY . " " . $path;
+
+            Model\Tool\Lock::acquire($lockKey); // avoid parallel conversions
             $out = Console::exec($cmd, PIMCORE_LOG_DIRECTORY . "/libreoffice-pdf-convert.log", 240);
+            Model\Tool\Lock::release($lockKey);
 
             \Logger::debug("LibreOffice Output was: " . $out);
 
@@ -167,7 +168,7 @@ class LibreOffice extends Ghostscript {
                 throw new \Exception($message);
             }
 
-            Model\Tool\Lock::release($lockKey);
+
         } else {
             $pdfPath = $pdfFile;
         }


### PR DESCRIPTION
Locks should be released as soon as possible - in this case, when somehow libreoffice failed to convert file, the lock wasn't released at all - exception was thrown without releasing lock. It caused next php processes to hang. In worst case scenario - it can deplete server's php processes pool.