### PR TITLE
replace deprecated php.ini # comments

### DIFF
--- a/build/travis/php.ini
+++ b/build/travis/php.ini
@@ -1,9 +1,9 @@
 
-# extensions
-#extension="redis.so"
-#extension="memcache.so"
-#extension="memcached.so"
+; extensions
+;extension="redis.so"
+;extension="memcache.so"
+;extension="memcached.so"
 
-# custom php settings
+; custom php settings
 memory_limit = 128M
 date.timezone = Europe/Berlin


### PR DESCRIPTION
php.ini comments starting with ``#`` are deprecated since PHP 5.3 (https://secure.php.net/manual/en/migration53.deprecated.php)

This patch prevents deprecation warnings like
```
PHP Deprecated:  Comments starting with '#' are deprecated in /home/travis/.phpenv/versions/5.5.21/etc/conf.d/php.ini on line 2 in Unknown on line 0

PHP Deprecated:  Comments starting with '#' are deprecated in /home/travis/.phpenv/versions/5.5.21/etc/conf.d/php.ini on line 3 in Unknown on line 0

PHP Deprecated:  Comments starting with '#' are deprecated in /home/travis/.phpenv/versions/5.5.21/etc/conf.d/php.ini on line 4 in Unknown on line 0

PHP Deprecated:  Comments starting with '#' are deprecated in /home/travis/.phpenv/versions/5.5.21/etc/conf.d/php.ini on line 5 in Unknown on line 0

PHP Deprecated:  Comments starting with '#' are deprecated in /home/travis/.phpenv/versions/5.5.21/etc/conf.d/php.ini on line 7 in Unknown on line 0
```