### PR TITLE
ignore NetBean's 'nbproject' directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 
 # PhpStorm / IDEA
 .idea
+# NetBeans
+nbproject


### PR DESCRIPTION
NetBeans creates a ``nbproject`` directory in the project's root directory. For not having to exclude that in every commit, I added a .gitignore entry for that folder.