### PR TITLE
Make CSV Import compatible with PHP 7

### DIFF
--- a/pimcore/lib/Csv/Reader/String.php
+++ b/pimcore/lib/Csv/Reader/String.php
@@ -30,7 +30,7 @@ class Csv_Reader_String extends Csv_Reader {
     
     }
 	
-	protected function initStream($string) {
+	protected function initStream($string = '') {
 	
         $this->handle = fopen("php://memory", 'w+'); // not sure if I should use php://memory or php://temp here
         fwrite($this->handle, $string);


### PR DESCRIPTION
PHP 7 writes this warning when trying to import objects using CSV Import:

`Declaration of Csv_Reader_String::initStream($string) should be compatible with Csv_Reader::initStream() in [...]\pimcore\lib\Csv\Reader\String.php on line 13`

This ist just a warning by PHP 7; however, pimcore just closes the import window.

The solution to this is actually quite simple, see my proposed changes.