### PR TITLE
Viewport tree expand/collapse fix

### DIFF
--- a/pimcore/static6/css/ext-modifications.css
+++ b/pimcore/static6/css/ext-modifications.css
@@ -94,6 +94,7 @@
 
 .x-panel-header-default {
     background-color: #ececec;
+    border: none;
 }
 
 .x-panel-header-title-default {

--- a/pimcore/static6/js/pimcore/startup.js
+++ b/pimcore/static6/js/pimcore/startup.js
@@ -523,6 +523,7 @@ Ext.onReady(function () {
                                 height: 300,
                                 minSize:175,
                                 collapsible:true,
+                                collapseMode: 'header',
                                 animCollapse:false,
                                 layout:'accordion',
                                 layoutConfig:{
@@ -561,6 +562,7 @@ Ext.onReady(function () {
                             width:250,
                             minSize:175,
                             collapsible:true,
+                            collapseMode: 'header',
                             collapsed:false,
                             animCollapse:false,
                             layout:'accordion',


### PR DESCRIPTION
I've added collapseMode to the west/east region panels as this was causing a rendering issue as can be seen here in Chrome

![ezgif-3754161084](https://cloud.githubusercontent.com/assets/1098498/11685954/ce67febc-9e74-11e5-869e-4526dc496110.gif)
