### PR TITLE
placeholder-extjs6

### DIFF
--- a/pimcore/static6/css/editmode.css
+++ b/pimcore/static6/css/editmode.css
@@ -344,6 +344,20 @@
     display: inline-block;
 }
 
+/* support for placeholders as in EXTJS3,4 */
+.pimcore_tag_input[contenteditable=true]:empty:before,
+.pimcore_tag_textarea[contenteditable=true]:empty:before,
+.pimcore_wysiwyg.empty[contenteditable=true]:before {
+    cursor: text; /* For chrome */
+    content: attr(data-placeholder);
+    display: block; /* For firefox */
+    color:#BABABA;
+}
+
+.pimcore_wysiwyg.empty[contenteditable=true]:before {
+    height: 0; /* For firefox and Edge */
+}
+
 /* text fields: hover, focus, ... states */
 .pimcore_tag_input, .pimcore_tag_wysiwyg, .pimcore_tag_textarea, .pimcore_tag_textarea:focus .pimcore_wysiwyg:focus {
     outline:0 auto;

--- a/pimcore/static6/js/pimcore/document/tags/input.js
+++ b/pimcore/static6/js/pimcore/document/tags/input.js
@@ -78,6 +78,9 @@ pimcore.document.tags.input = Class.create(pimcore.document.tag, {
                 overflow: "auto"
             });
         }
+        if (options["placeholder"]) {
+            this.element.dom.setAttribute('data-placeholder', options["placeholder"]);
+        }
     },
 
     checkValue: function () {

--- a/pimcore/static6/js/pimcore/document/tags/textarea.js
+++ b/pimcore/static6/js/pimcore/document/tags/textarea.js
@@ -97,6 +97,9 @@ pimcore.document.tags.textarea = Class.create(pimcore.document.tag, {
                 height: options["height"] + "px"
             })
         }
+        if (options["placeholder"]) {
+            this.element.dom.setAttribute('data-placeholder', options["placeholder"]);
+        }
     },
 
     checkValue: function () {

--- a/pimcore/static6/js/pimcore/document/tags/wysiwyg.js
+++ b/pimcore/static6/js/pimcore/document/tags/wysiwyg.js
@@ -44,6 +44,9 @@ pimcore.document.tags.wysiwyg = Class.create(pimcore.document.tag, {
         if (options.height) {
             textareaHeight = options.height;
         }
+        if (options.placeholder) {
+            this.textarea.setAttribute('data-placeholder', options["placeholder"]);
+        }
 
         var inactiveContainerWidth = options.width + "px";
         if (typeof options.width == "string" && options.width.indexOf("%") >= 0) {


### PR DESCRIPTION
Re-introduce the placeholder functionality for input, textarea and wysiwyg editables, as it used to exist in ExtJS 3,4.