### PR TITLE
Fixes bug when block names are modified by non-existing or disabled brick

### DIFF
--- a/pimcore/models/Document/Tag/Area.php
+++ b/pimcore/models/Document/Tag/Area.php
@@ -83,20 +83,20 @@ class Area extends Model\Document\Tag {
     public function frontend() {
 
         $count = 0;
+        $options = $this->getOptions();
+        // don't show disabled bricks
+        if(!ExtensionManager::isEnabled("brick", $options["type"]) && $options['dontCheckEnabled'] != true) {
+            return;
+        }
 
         $this->setupStaticEnvironment();
         $suffixes = \Zend_Registry::get("pimcore_tag_block_current");
         $suffixes[] = $this->getName();
         \Zend_Registry::set("pimcore_tag_block_current", $suffixes);
 
-        $options = $this->getOptions();
 
         $this->current = $count;
 
-        // don't show disabled bricks
-        if(!ExtensionManager::isEnabled("brick", $options["type"]) && $options['dontCheckEnabled'] != true) {
-            return;
-        }
 
         // create info object and assign it to the view
         $info = null;


### PR DESCRIPTION
This may be potencially problematic fix as it may change block ID's. However without this fix everytime we enable or disable brick it changes other blocks ID's and page content disapear. Problem is in order when condition test for enabled brick was made after "pimcore_tag_block_current" in Zend registry has been modified and if brick doesn't exist or is disabled it finishes without removing changes already made to "pimcore_tag_block_current" I have just moved the test if brick is enabled to happen before any changes to "pimcore_tag_block_current" is made.