### PR TITLE
check if plugin or website dir already exists. 

### DIFF
--- a/pimcore/lib/Pimcore/Composer.php
+++ b/pimcore/lib/Pimcore/Composer.php
@@ -26,8 +26,17 @@ class Composer
         // cleanup
         @unlink($rootPath . '/.travis.yml');
 
-        rename($rootPath . '/plugins_example', $rootPath . '/plugins');
-        rename($rootPath . '/website_example', $rootPath . '/website');
+        if( !is_dir(  $rootPath . '/plugins'  )) {
+
+            rename($rootPath . '/plugins_example', $rootPath . '/plugins');
+
+        }
+
+        if( !is_dir(  $rootPath . '/website'  )) {
+
+            rename($rootPath . '/website_example', $rootPath . '/website');
+
+        }
 
         $filesystem = new Filesystem();
         $filesystem->removeDirectory($rootPath . '/update');


### PR DESCRIPTION
otherwise the rename function in postCreateProject will throw an error.