### PR TITLE
New object methods for select and multiselect object fields

### DIFF
--- a/pimcore/models/Object/AbstractObject.php
+++ b/pimcore/models/Object/AbstractObject.php
@@ -1026,8 +1026,30 @@ class AbstractObject extends Model\Element\AbstractElement {
      * @param $fieldname
      * @return array
      */
-    public static function getOptionsForMultiSelectField($fieldname) {
+    public function getOptionsForMultiSelectField($fieldname) {
         return $this->getOptionsForSelectField($fieldname);
+    }
+
+    /**
+     * @param $fieldname
+     * @return string
+     */
+    public function getDisplayNameForSelectField($fieldname) {
+        $value = $this->{"get" . ucfirst($fieldname)}();
+        return $this->getOptionsForSelectField($fieldname)[$value];
+    }
+
+    /**
+     * @param $fieldname
+     * @return array
+     */
+    public function getDisplayNameForMultiSelectField($fieldname) {
+        $values = $this->{"get" . ucfirst($fieldname)}();
+        $displayNames = [];
+        foreach ($values as $value) {
+            $displayNames[] = $this->getOptionsForMultiSelectField($fieldname)[$value];
+        }
+        return $displayNames;
     }
 
     /**

--- a/pimcore/models/Object/AbstractObject.php
+++ b/pimcore/models/Object/AbstractObject.php
@@ -1014,6 +1014,23 @@ class AbstractObject extends Model\Element\AbstractElement {
     }
 
     /**
+     * @param $fieldname
+     * @return array
+     */
+    public function getOptionsForSelectField($fieldname) {
+        return Service::getOptionsForSelectField($this, $fieldname);
+    }
+
+    /**
+     * alias of getOptionsForSelectField
+     * @param $fieldname
+     * @return array
+     */
+    public static function getOptionsForMultiSelectField($fieldname) {
+        return $this->getOptionsForSelectField($fieldname);
+    }
+
+    /**
      * @return Model\Element\AdminStyle
      */
     public function getElementAdminStyle() {


### PR DESCRIPTION
This add four new methods to object:

- getOptionsForSelectField and getOptionsForMultiSelectField : same as Service but can be directly called from the object, more easy to remember and can be know from autocompletion IDE.

- getDisplayNameForSelectField and getDisplayNameForMultiSelectField : for easier display on the views (creation select, print display names, ...)

With those we can do:

````html
<select>
<?php foreach ($obj->getOptionsForMultiSelectField("mymultiselect") as $key => $value): ?>
	<option value="<?= $key ?>"><?php $value ?></option>
<?php endforeach; ?>
</select>
<br>Current choices: <?= implode(", ", $obj->getDisplayNameForMultiSelectField("mymultiselect")) ?>
````

Instead of:
````html
<select>
<?php foreach (Object_Service::getOptionsForMultiSelectField($obj, "mymultiselect") as $key => $value): ?>
	<option value="<?= $key ?>"><?php $value ?></option>
<?php endforeach; ?>
</select>
<?php
	$displayNames = array();
	foreach ($obj->getMymultiselect() as $value) $displayNames[] = Object_Service::getOptionsForMultiSelectField($obj, "mymultiselect")[$value];
?>
<br>Current choice: <?= implode(", ", $displayNames) ?>
````

Displaying name will be easier, as we don't need to call Service directly anymore, and work as a getter from the object (like to get the value).