### PR TITLE
Fixed double scroll on object search grid

### DIFF
--- a/pimcore/static6/js/pimcore/object/folder/search.js
+++ b/pimcore/static6/js/pimcore/object/folder/search.js
@@ -329,7 +329,6 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
             this.editor = new Ext.Panel({
                 layout: "border",
                 items: [new Ext.Panel({
-                    autoScroll: true,
                     items: [this.grid],
                     region: "center",
                     layout: "fit",


### PR DESCRIPTION
Both the search grid and outer panel had scroll enabled, which led to a double scroll. I have removed autoScroll from the outer panel.