### PR TITLE
cast mandatory to bool in KeyConfig

### DIFF
--- a/pimcore/models/Object/KeyValue/KeyConfig.php
+++ b/pimcore/models/Object/KeyValue/KeyConfig.php
@@ -369,7 +369,7 @@ class KeyConfig extends Model\AbstractModel {
      */
     public function setMandatory($mandatory)
     {
-        $this->mandatory = $mandatory;
+        $this->mandatory = (bool)$mandatory;
     }
 
     /**


### PR DESCRIPTION
once set, then unset, this function would return `"0"`, which is true as it's a string