### PR TITLE
Added object close confirmation when element isDirty

### DIFF
--- a/pimcore/static6/js/pimcore/element/abstract.js
+++ b/pimcore/static6/js/pimcore/element/abstract.js
@@ -96,7 +96,7 @@ pimcore.element.abstract = Class.create({
         return this.addToHistory;
     },
 
-    confirmCloseDirty: function(callback) {
+    confirmCloseDirty: function() {
         Ext.MessageBox.confirm(
             t("element_has_unsaved_changes"), t("element_unsaved_changes_message"),
             function (buttonValue) {

--- a/pimcore/static6/js/pimcore/element/abstract.js
+++ b/pimcore/static6/js/pimcore/element/abstract.js
@@ -16,6 +16,8 @@ pimcore.element.abstract = Class.create({
 
     addToHistory: true,
 
+    confirmedClose: false,
+
     // startup / opening functions
     addLoadingPanel : function () {
         var type = pimcore.helpers.getElementTypeByObject(this);
@@ -92,5 +94,19 @@ pimcore.element.abstract = Class.create({
 
     getAddToHistory: function() {
         return this.addToHistory;
+    },
+
+    confirmCloseDirty: function(callback) {
+        Ext.MessageBox.confirm(
+            t("element_has_unsaved_changes"), t("element_unsaved_changes_message"),
+            function (buttonValue) {
+                if (buttonValue === "yes") {
+                    this.confirmedClose = true;
+                    var tabPanel = Ext.getCmp("pimcore_panel_tabs");
+                    tabPanel.remove(this.tab);
+                }
+            }.bind(this)
+        );
     }
+
 });

--- a/pimcore/static6/js/pimcore/object/object.js
+++ b/pimcore/static6/js/pimcore/object/object.js
@@ -157,13 +157,18 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
         }.bind(this));
 
         this.tab.on("beforedestroy", function () {
-            Ext.Ajax.request({
-                url: "/admin/element/unlock-element",
-                params: {
-                    id: this.id,
-                    type: "object"
-                }
-            });
+            if (!this.confirmedClose && this.isAllowed("save") && this.isDirty) {
+                this.confirmCloseDirty();
+                return false;
+            } else {
+                Ext.Ajax.request({
+                    url: "/admin/element/unlock-element",
+                    params: {
+                        id: this.id,
+                        type: "object"
+                    }
+                });
+            }
         }.bind(this));
 
         // remove this instance when the panel is closed

--- a/pimcore/static6/js/pimcore/object/object.js
+++ b/pimcore/static6/js/pimcore/object/object.js
@@ -156,19 +156,22 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
             pimcore.layout.refresh();
         }.bind(this));
 
-        this.tab.on("beforedestroy", function () {
-            if (!this.confirmedClose && this.isAllowed("save") && this.isDirty) {
+        this.tab.on("beforeclose", function () {
+            if (!this.confirmedClose && this.isAllowed("save") && this.isDirty()) {
                 this.confirmCloseDirty();
                 return false;
-            } else {
-                Ext.Ajax.request({
-                    url: "/admin/element/unlock-element",
-                    params: {
-                        id: this.id,
-                        type: "object"
-                    }
-                });
             }
+            return true;
+        }.bind(this));
+
+        this.tab.on("beforedestroy", function () {
+            Ext.Ajax.request({
+                url: "/admin/element/unlock-element",
+                params: {
+                    id: this.id,
+                    type: "object"
+                }
+            });
         }.bind(this));
 
         // remove this instance when the panel is closed
@@ -726,6 +729,8 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
     reload: function (layoutId) {
         var options = {};
         options.layoutId = layoutId;
+        //automatically confirm to close the object
+        this.confirmedClose = true;
         window.setTimeout(function (id) {
             pimcore.helpers.openObject(id, "object", options);
         }.bind(window, this.id), 500);


### PR DESCRIPTION
One of our clients asked for a close confirmation on objects when they are dirty, so I've added the functionality like below. this could easily be extended to check documents too.

There's a couple of language keys needed to make this work, which I have left out since the translations seem to change frequently.

Additionally, I can see that this may be a feature some users would want to turn on and off, perhaps an user or system setting?

Let me know :)