### PR TITLE
Class definition js fix

### DIFF
--- a/pimcore/static6/js/pimcore/object/objectbricks/field.js
+++ b/pimcore/static6/js/pimcore/object/objectbricks/field.js
@@ -263,7 +263,7 @@ pimcore.object.objectbricks.field = Class.create(pimcore.object.classes.klass, {
 
         this.baseStore[classDefinitionData.classname] = this.availableClasses[classDefinitionData.classname];
 
-        this.classDefinitionsItems.remove(this.classDefinitionsItems.items.get(0));
+        this.classDefinitionsItems.remove(this.classDefinitionsItems.get(0));
         this.classDefinitionsItems.insert(0, this.getAddControl());
         this.classDefinitionsItems.updateLayout();
 

--- a/pimcore/static6/js/pimcore/object/objectbricks/field.js
+++ b/pimcore/static6/js/pimcore/object/objectbricks/field.js
@@ -263,7 +263,7 @@ pimcore.object.objectbricks.field = Class.create(pimcore.object.classes.klass, {
 
         this.baseStore[classDefinitionData.classname] = this.availableClasses[classDefinitionData.classname];
 
-        this.classDefinitionsItems.remove(this.classDefinitionsItems.get(0));
+        this.classDefinitionsItems.remove(this.classDefinitionsItems.items.get(0));
         this.classDefinitionsItems.insert(0, this.getAddControl());
         this.classDefinitionsItems.updateLayout();
 


### PR DESCRIPTION
when adding a class definition in object bricks ext will throw an error: `this.classDefinitionsItems.get is not a function`