### PR TITLE
STYLING SUGGESTION: styling of tabs to improve contrast of UI

### DIFF
--- a/pimcore/static6/css/ext-modifications.css
+++ b/pimcore/static6/css/ext-modifications.css
@@ -28,9 +28,18 @@
 
 .x-tab-default-top {
     border-color: #3c3f41;
-    background-color: #f6f6f6;
+    background-color: #d1d6db;
     padding-top: 5px;
     padding-bottom: 5px;
+    -webkit-box-shadow: inset 0px -4px 5px -4px rgba(0,0,0,0.15);
+    -moz-box-shadow: inset 0px -4px 5px -4px rgba(0,0,0,0.15);
+    box-shadow: inset 0px -4px 5px -4px rgba(0,0,0,0.15);
+}
+
+.x-tab-default-top.x-tab-active {
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
 }
 
 .x-tab-over.x-tab-default.x-tab-over {


### PR DESCRIPTION
I like the new design and icons. But this one thing has bothered me from the beginning. The tabs are very hard to discern. It is difficult to see which tab is active and on some monitors this is actually completely impossible - all tabs seem to be the same shade of grey.

To some people it also wasn't immediately obvious that tabs are actually tabs, they thought those were just buttons on the top. Hopefully the small inset shadow on the bottom of inactive tabs should improve that. 

It is just a suggestion, but IMO it improves the UX of new UI.