### PR TITLE
Password field password_hash

### DIFF
--- a/pimcore/modules/admin/controllers/SettingsController.php
+++ b/pimcore/modules/admin/controllers/SettingsController.php
@@ -1414,7 +1414,12 @@ class Admin_SettingsController extends \Pimcore\Controller\Action\Admin
 
     public function getAvailableAlgorithmsAction()
     {
-        $options = array();
+        $options = array(
+            array(
+                'key'   => 'password_hash',
+                'value' => 'password_hash',
+            )
+        );
 
         $algorithms = hash_algos();
         foreach ($algorithms as $algorithm) {


### PR DESCRIPTION
Enhances password field with support for [`password_hash`](http://php.net/manual/de/function.password-hash.php). Salt and salt location params will be ignored when in `password_hash` mode (maybe there's a way to disable/hide them when `password_hash` is selected?) and `password_hash` will be called with PHP's defaults for algorithm, parameters (e.g. cost) and salt handling.

In addition, a verify method on the password definition takes care of validating a password: 

```php
<?php
/* @var Pimcore\Model\Object\ClassDefinition\Data\Password $passwordField */
$passwordField = $customer->getClass()->getFieldDefinition('password');

// verify password against value stored in object, optionally take care of updating the hash if it is outdated
$result = $passwordField->verifyPassword($password, $customer, true);
```