### PR TITLE
FIX: Icon for variants not displayed in the object tree

### DIFF
--- a/pimcore/modules/admin/controllers/ObjectController.php
+++ b/pimcore/modules/admin/controllers/ObjectController.php
@@ -187,7 +187,7 @@ class Admin_ObjectController extends \Pimcore\Controller\Action\Admin\Element
             $tmpObject["allowVariants"] = $child->getClass()->getAllowVariants();
         }
         if ($tmpObject["type"] == "variant") {
-            $tmpObject["iconCls"] = "pimcore_icon_tree_variant";
+            $tmpObject["iconCls"] = "pimcore_icon_variant";
         } else {
             if ($child->getElementAdminStyle()->getElementIcon()) {
                 $tmpObject["icon"] = $child->getElementAdminStyle()->getElementIcon();


### PR DESCRIPTION
The icon for variants was not displayed in object tree. This pull request breaks the icon for the Ext.js 3.4 (a placeholder icon is still displayed). But I guess the focus is on ExtJs 6, right?

