### PR TITLE
bugfix, prevent rename of home folders

### DIFF
--- a/pimcore/static6/js/pimcore/asset/tree.js
+++ b/pimcore/static6/js/pimcore/asset/tree.js
@@ -474,7 +474,7 @@ pimcore.asset.tree = Class.create({
             }
         }
 
-        if (record.data.permissions.rename && this.id != 1 && !record.data.locked) {
+        if (record.data.permissions.rename && record.data.id != 1 && !record.data.locked) {
             menu.add(new Ext.menu.Item({
                 text: t('edit_filename'),
                 iconCls: "pimcore_icon_key pimcore_icon_overlay_go",

--- a/pimcore/static6/js/pimcore/object/tree.js
+++ b/pimcore/static6/js/pimcore/object/tree.js
@@ -610,7 +610,7 @@ pimcore.object.tree = Class.create({
             }));
         }
 
-        if (record.data.permissions.rename && this.id != 1 && !record.data.locked) {
+        if (record.data.permissions.rename && record.data.id != 1 && !record.data.locked) {
             menu.add(new Ext.menu.Item({
                 text: t('rename'),
                 iconCls: "pimcore_icon_key pimcore_icon_overlay_go",


### PR DESCRIPTION
Please read our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR. 

## Changes in this pull request  
Corrects the reference to the asset and object id in the tree so that the user cannot edit the filename of the home folders




