### PR TITLE
ExtJS 6 icons: using text icon for rtf files

### DIFF
--- a/pimcore/static6/css/icons.css
+++ b/pimcore/static6/css/icons.css
@@ -235,7 +235,7 @@
     background: url(/pimcore/static6/img/flat-color-icons/powerpoint.svg) center center no-repeat !important;
 }
 
-.pimcore_icon_txt, .pimcore_icon_log, .pimcore_icon_css {
+.pimcore_icon_txt, .pimcore_icon_log, .pimcore_icon_css, .pimcore_icon_rtf {
     background: url(/pimcore/static6/img/flat-color-icons/text.svg) center center no-repeat !important;
 }
 


### PR DESCRIPTION
This PR makes Pimcore display text.svg as icon for RTF-files in the asset tree view instead of none.