### PR TITLE
Added HTTPResponseCode to error document cachekey

### DIFF
--- a/pimcore/lib/Pimcore/Controller/Action/Frontend.php
+++ b/pimcore/lib/Pimcore/Controller/Action/Frontend.php
@@ -532,7 +532,8 @@ abstract class Frontend extends Action
                 try {
                     // check if we have the error page already in the cache
                     // the cache is written in Pimcore\Controller\Plugin\HttpErrorLog::dispatchLoopShutdown()
-                    $cacheKey = "error_page_response_" . \Pimcore\Tool\Frontend::getSiteKey();
+                    $responseCode = $this->getResponse()->getHttpResponseCode();
+                    $cacheKey = "error_page_response_" . $responseCode . "_" . \Pimcore\Tool\Frontend::getSiteKey();
                     if ($responseBody = \Pimcore\Cache::load($cacheKey)) {
                         $this->getResponse()->setBody($responseBody);
                         $this->getResponse()->sendResponse();


### PR DESCRIPTION
Please read our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR. 

## Changes in this pull request  
This PR adds the httpResponseCode into the cacheKey of an error document. I noticed that the error document is cached and therefore if you were to have a site which used an error document to return both 404 and server 500 errors it would not be possible to customise the response per error code.

## Additional info  
Example of a document that could now be created (assuming you set the $code in the controller action)

```
<?php if ($this->editmode || $this->code == 404) : ?>
    <h1><?= $this->input('error_code_404_h1', [ 'placeholder' => 'Not Found' ]); ?></h1>
    <p><?= $this->wysiwyg('error_code_404'); ?></p>
    <p><?= $this->getSuggestedContent(); ?></p>
<?php endif; ?>

<?php if ($this->editmode || $this->code >= 500) : ?>
    <h1><?= $this->input('error_code_500_h1', [ 'placeholder' => 'Server Error' ]); ?></h1>
    <p><?= $this->wysiwyg('error_code_500'); ?></p>
<?php endif; ?>

`



