### PR TITLE
Bugfix for itemselector - elements per page

### DIFF
--- a/pimcore/static6/js/pimcore/element/selector/abstract.js
+++ b/pimcore/static6/js/pimcore/element/selector/abstract.js
@@ -158,6 +158,8 @@ pimcore.element.selector.abstract = Class.create({
                 select: function (box, rec, index) {
                     var store = this.pagingtoolbar.getStore();
                     store.setPageSize(intval(rec.data.field1));
+                    this.store.getProxy().extraParams.limit = intval(rec.data.field1);
+                    this.pagingtoolbar.pageSize = intval(rec.data.field1);
                     this.pagingtoolbar.moveFirst();
                 }.bind(this)
             }

--- a/pimcore/static6/js/pimcore/element/selector/object.js
+++ b/pimcore/static6/js/pimcore/element/selector/object.js
@@ -264,6 +264,7 @@ pimcore.element.selector.object = Class.create(pimcore.element.selector.abstract
         var gridHelper = new pimcore.object.helpers.grid(selectedClass, fields, "/admin/search/search/find");
         this.store = gridHelper.getStore();
         this.store.setPageSize(50);
+        this.store.getProxy().extraParams.limit = 50;
         var gridColumns = gridHelper.getGridColumns();
         var gridfilters = gridHelper.getGridFilters();
 


### PR DESCRIPTION
Fixes two problems:
- initially only 20 elements are loaded although 50 is preselected in combo box
- changing the value in "Elemente pro Seite" combo box doesn't work as expected - only 20 elements were loaded always