### PR TITLE
FIX - nonsortable columns in search should not have the sorting optio…

### DIFF
--- a/pimcore/static6/js/pimcore/element/selector/object.js
+++ b/pimcore/static6/js/pimcore/element/selector/object.js
@@ -261,7 +261,7 @@ pimcore.element.selector.object = Class.create(pimcore.element.selector.abstract
             fields = response;
         }
 
-        var gridHelper = new pimcore.object.helpers.grid(selectedClass, fields, "/admin/search/search/find");
+        var gridHelper = new pimcore.object.helpers.grid(selectedClass, fields, "/admin/search/search/find", null, true);
         this.store = gridHelper.getStore();
         this.store.setPageSize(50);
         var gridColumns = gridHelper.getGridColumns();

--- a/pimcore/static6/js/pimcore/object/helpers/grid.js
+++ b/pimcore/static6/js/pimcore/object/helpers/grid.js
@@ -214,6 +214,10 @@ pimcore.object.helpers.grid = Class.create({
                     fc.filter = gridFilters[field.key];
                 }
 
+                if (this.isSearch) {
+                    fc.sortable = false;
+                }
+
                 gridColumns.push(fc);
                 gridColumns[gridColumns.length-1].hidden = false;
                 gridColumns[gridColumns.length-1].layout = fields[i];


### PR DESCRIPTION
FIX - nonsortable columns (object fields) in search should not have the sorting option available - as the sort will not function anyway since the search_backend_data table is used. This pull request removes the sorting option from the UI for those columns. 