### PR TITLE
Missing icon for SQL query button

### DIFF
--- a/pimcore/static6/css/icons.css
+++ b/pimcore/static6/css/icons.css
@@ -960,3 +960,7 @@
 .pimcore_icon_pimcore {
     background: url(/pimcore/static6/img/flat-color-icons/pimcore-sign.svg) center center no-repeat !important;
 }
+
+.pimcore_icon_sql {
+    background: url(/pimcore/static6/img/flat-color-icons/database.svg) no-repeat !important;
+}


### PR DESCRIPTION
Missing icon for SQL query button in object grid view. Not sure if I chose the best icon, but it's better than empty button :)