### PR TITLE
Explicitly set file mode for optimized images

### DIFF
--- a/pimcore/lib/Pimcore/Image/Optimizer.php
+++ b/pimcore/lib/Pimcore/Image/Optimizer.php
@@ -12,6 +12,7 @@
 
 namespace Pimcore\Image;
 
+use Pimcore\File;
 use Pimcore\Tool\Console;
 use Pimcore\Config;
 
@@ -52,6 +53,7 @@ class Optimizer
                         if (file_exists($newFile)) {
                             unlink($path);
                             rename($newFile, $path);
+                            @chmod($path, File::getDefaultMode());
                         }
                     }
                 }
@@ -64,6 +66,7 @@ class Optimizer
                         if (file_exists($newFile)) {
                             unlink($path);
                             rename($newFile, $path);
+                            @chmod($path, File::getDefaultMode());
                         }
                     } elseif ($optimizer["type"] == "jpegoptim") {
                         $additionalParams = "";
@@ -71,6 +74,7 @@ class Optimizer
                             $additionalParams = " --all-progressive";
                         }
                         Console::exec($optimizer["path"] . $additionalParams . " -o --strip-all --max=85 " . $path, null, 60);
+                        @chmod($path, File::getDefaultMode());
                     }
                 }
             }


### PR DESCRIPTION
For me, jpegoptim set the file mode of optimized images to 0600 which made them unreadable for our webserver process. I've added chmods in the same way it is done for "regular" thumbnails to prevent this from happening. Though i have not tested the other optimizers i suspect the same problem might occur, so i added chmods for them as wenn, just in case.