### PR TITLE
CLI commands for definition imports

### DIFF
--- a/pimcore/lib/Pimcore/Console/Command/Definition/Import/AbstractStructureImportCommand.php
+++ b/pimcore/lib/Pimcore/Console/Command/Definition/Import/AbstractStructureImportCommand.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2009-2016 pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace Pimcore\Console\Command\Definition\Import;
+
+use Pimcore\Console\AbstractCommand;
+use Pimcore\Console\Traits\DryRun;
+use Pimcore\Model\AbstractModel;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+abstract class AbstractStructureImportCommand extends AbstractCommand
+{
+    use DryRun;
+
+    protected function configure()
+    {
+        $type = $this->getType();
+
+        $this
+            ->setName(sprintf('definition:import:%s', strtolower($type)))
+            ->setDescription(sprintf('Import %s definition from a JSON export', $type))
+            ->addArgument(
+                'path', InputArgument::REQUIRED,
+                sprintf('Path to %s JSON export file', $type)
+            )
+            ->addOption(
+                'force', 'f', InputOption::VALUE_NONE,
+                sprintf('Force import (do not ask for confirmation when %s already exists)', $type)
+            );
+
+        $this->configureDryRunOption();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $path = $this->getPath();
+        $type = $this->getType();
+
+        $name = $this->getDefinitionName(basename($path));
+        if (null === $name) {
+            throw new \InvalidArgumentException('File name does not match expected format');
+        }
+
+        $json  = $this->getJson($path);
+        $force = $this->input->getOption('force');
+
+        $logName = sprintf('(%s) <comment>%s</comment>', $type, $name);
+
+        $definition = $this->loadDefinition($name);
+        if (null !== $definition) {
+            if ($force) {
+                $this->output->writeln(sprintf('%s already exists', $logName));
+            } else {
+                if (!$this->askConfirmation($name)) {
+                    return 0;
+                }
+            }
+        } else {
+            $this->output->writeln(sprintf('%s was not found', $logName));
+
+            if ($this->isDryRun()) {
+                $this->output->writeln($this->prefixDryRun(sprintf('Skipping creation of %s', $logName)));
+            } else {
+                $this->output->writeln(sprintf('Creating %s', $logName));
+                $definition = $this->createDefinition($name);
+            }
+        }
+
+        $result = false;
+        if ($this->isDryRun()) {
+            $this->output->writeln($this->prefixDryRun(sprintf('Skipping import of %s from %s', $logName, $path)));
+            $result = true;
+        } else {
+            $this->output->writeln(sprintf('Importing %s from %s', $logName, $path));
+            $result = $this->import($definition, $json);
+        }
+
+        if ($result) {
+            $this->output->writeln(sprintf('Successfully imported %s', $logName));
+            return 0;
+        } else {
+            $this->output->writeln(sprintf('<error>ERROR:</error> Failed to import %s', $logName));
+            return 1;
+        }
+    }
+
+    /**
+     * Validate and return path to JSON file
+     *
+     * @return string
+     */
+    protected function getPath()
+    {
+        $path = $this->input->getArgument('path');
+        if (!file_exists($path) || !is_readable($path)) {
+            throw new \InvalidArgumentException('File does not exist');
+        }
+
+        return $path;
+    }
+
+    /**
+     * Load JSON data from file
+     *
+     * @param $path
+     * @return mixed
+     */
+    protected function getJson($path)
+    {
+        $content = file_get_contents($path);
+
+        // try to decode json here as we want to fail early if file is no valid JSON
+        $json = json_decode($content);
+        if (null === $json) {
+            throw new \InvalidArgumentException('JSON could not be decoded');
+        }
+
+        // return string content as service import
+        // methods decode JSON by their own
+        return $content;
+    }
+
+    /**
+     * Ask for confirmation before overwriting
+     *
+     * @param $name
+     * @return bool
+     */
+    protected function askConfirmation($name)
+    {
+        /** @var QuestionHelper $helper */
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion(
+            sprintf('(%s) <comment>%s</comment> already exists. Overwrite? [y/N] ', $this->getType(), $name),
+            false
+        );
+
+        if ($helper->ask($this->input, $this->output, $question)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get type
+     *
+     * @return string
+     */
+    abstract protected function getType();
+
+    /**
+     * Get definition name from filename (e.g. class_Customer_export.json -> Customer)
+     *
+     * @param string $filename
+     * @return string
+     */
+    abstract protected function getDefinitionName($filename);
+
+    /**
+     * Try to load definition by name
+     *
+     * @param $name
+     * @return AbstractModel|null
+     */
+    abstract protected function loadDefinition($name);
+
+    /**
+     * Create a new definition
+     *
+     * @param $name
+     * @return AbstractModel
+     */
+    abstract protected function createDefinition($name);
+
+    /**
+     * Process import
+     *
+     * @param AbstractModel $definition
+     * @param string $json
+     * @return bool
+     */
+    abstract protected function import(AbstractModel $definition, $json);
+}

--- a/pimcore/lib/Pimcore/Console/Command/Definition/Import/ClassCommand.php
+++ b/pimcore/lib/Pimcore/Console/Command/Definition/Import/ClassCommand.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2009-2016 pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace Pimcore\Console\Command\Definition\Import;
+
+use Pimcore\Model\AbstractModel;
+use Pimcore\Model\Object\ClassDefinition;
+use Pimcore\Model\Object\ClassDefinition\Service;
+
+class ClassCommand extends AbstractStructureImportCommand
+{
+    /**
+     * Get type
+     *
+     * @return string
+     */
+    protected function getType()
+    {
+        return 'Class';
+    }
+
+    /**
+     * Get definition name from filename (e.g. class_Customer_export.json -> Customer)
+     *
+     * @param string $filename
+     * @return string
+     */
+    protected function getDefinitionName($filename)
+    {
+        $parts = [];
+        if (1 === preg_match('/^class_(.*)_export\.json$/', $filename, $parts)) {
+            return $parts[1];
+        }
+    }
+
+    /**
+     * Try to load definition by name
+     *
+     * @param $name
+     * @return AbstractModel|null
+     */
+    protected function loadDefinition($name)
+    {
+        return ClassDefinition::getByName($name);
+    }
+
+    /**
+     * Create a new definition
+     *
+     * @param $name
+     * @return AbstractModel
+     */
+    protected function createDefinition($name)
+    {
+        $class = new ClassDefinition();
+        $class->setName($name);
+
+        return $class;
+    }
+
+    /**
+     * Process import
+     *
+     * @param AbstractModel $definition
+     * @param string $json
+     * @return bool
+     */
+    protected function import(AbstractModel $definition, $json)
+    {
+        return Service::importClassDefinitionFromJson($definition, $json);
+    }
+}

--- a/pimcore/lib/Pimcore/Console/Command/Definition/Import/FieldCollectionCommand.php
+++ b/pimcore/lib/Pimcore/Console/Command/Definition/Import/FieldCollectionCommand.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2009-2016 pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace Pimcore\Console\Command\Definition\Import;
+
+use Pimcore\Model\AbstractModel;
+use Pimcore\Model\Object\ClassDefinition;
+use Pimcore\Model\Object\ClassDefinition\Service;
+use Pimcore\Model\Object\Fieldcollection\Definition;
+
+class FieldCollectionCommand extends AbstractStructureImportCommand
+{
+    /**
+     * Get type
+     *
+     * @return string
+     */
+    protected function getType()
+    {
+        return 'FieldCollection';
+    }
+
+    /**
+     * Get definition name from filename (e.g. class_Customer_export.json -> Customer)
+     *
+     * @param string $filename
+     * @return string
+     */
+    protected function getDefinitionName($filename)
+    {
+        $parts = [];
+        if (1 === preg_match('/^fieldcollection_(.*)_export\.json$/', $filename, $parts)) {
+            return $parts[1];
+        }
+    }
+
+    /**
+     * Try to load definition by name
+     *
+     * @param $name
+     * @return AbstractModel|null
+     */
+    protected function loadDefinition($name)
+    {
+        try {
+            return Definition::getByKey($name);
+        } catch (\Exception $e) {
+            // noop
+        }
+    }
+
+    /**
+     * Create a new definition
+     *
+     * @param $name
+     * @return AbstractModel
+     */
+    protected function createDefinition($name)
+    {
+        $definition = new Definition();
+        $definition->setKey($name);
+
+        return $definition;
+    }
+
+    /**
+     * Process import
+     *
+     * @param AbstractModel $definition
+     * @param string $json
+     * @return bool
+     */
+    protected function import(AbstractModel $definition, $json)
+    {
+        return Service::importFieldCollectionFromJson($definition, $json);
+    }
+}

--- a/pimcore/lib/Pimcore/Console/Command/Definition/Import/ObjectBrickCommand.php
+++ b/pimcore/lib/Pimcore/Console/Command/Definition/Import/ObjectBrickCommand.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2009-2016 pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace Pimcore\Console\Command\Definition\Import;
+
+use Pimcore\Model\AbstractModel;
+use Pimcore\Model\Object\ClassDefinition;
+use Pimcore\Model\Object\ClassDefinition\Service;
+use Pimcore\Model\Object\Objectbrick\Definition;
+
+class ObjectBrickCommand extends AbstractStructureImportCommand
+{
+    /**
+     * Get type
+     *
+     * @return string
+     */
+    protected function getType()
+    {
+        return 'ObjectBrick';
+    }
+
+    /**
+     * Get definition name from filename (e.g. class_Customer_export.json -> Customer)
+     *
+     * @param string $filename
+     * @return string
+     */
+    protected function getDefinitionName($filename)
+    {
+        $parts = [];
+        if (1 === preg_match('/^objectbrick_(.*)_export\.json$/', $filename, $parts)) {
+            return $parts[1];
+        }
+    }
+
+    /**
+     * Try to load definition by name
+     *
+     * @param $name
+     * @return AbstractModel|null
+     */
+    protected function loadDefinition($name)
+    {
+        try {
+            return Definition::getByKey($name);
+        } catch (\Exception $e) {
+            // noop
+        }
+    }
+
+    /**
+     * Create a new definition
+     *
+     * @param $name
+     * @return AbstractModel
+     */
+    protected function createDefinition($name)
+    {
+        $definition = new Definition();
+        $definition->setKey($name);
+
+        return $definition;
+    }
+
+    /**
+     * Process import
+     *
+     * @param AbstractModel $definition
+     * @param string $json
+     * @return bool
+     */
+    protected function import(AbstractModel $definition, $json)
+    {
+        return Service::importObjectBrickFromJson($definition, $json);
+    }
+}

--- a/pimcore/lib/Pimcore/Console/Traits/DryRun.php
+++ b/pimcore/lib/Pimcore/Console/Traits/DryRun.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2009-2016 pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace Pimcore\Console\Traits;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\Input;
+use Symfony\Component\Console\Input\InputOption;
+
+trait DryRun
+{
+    /**
+     * Configure --dry-run
+     *
+     * @param null $description
+     * @return $this
+     */
+    protected function configureDryRunOption($description = null)
+    {
+        /** @var Command $command */
+        $command = $this;
+
+        if (null === $description) {
+            $description = 'Simulate only (do not change anything)';
+        }
+
+        $command->addOption(
+            'dry-run', 'N', InputOption::VALUE_NONE,
+            $description
+        );
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isDryRun()
+    {
+        /** @var Input $input */
+        $input = $this->input;
+
+        return (bool) $input->getOption('dry-run');
+    }
+
+    /**
+     * Prefix message with DRY-RUN
+     *
+     * @param $message
+     * @return string
+     */
+    protected function prefixDryRun($message, $prefix = 'DRY-RUN')
+    {
+        return sprintf(
+            '<bg=cyan;fg=white>%s</> %s',
+            $prefix,
+            $message
+        );
+    }
+}


### PR DESCRIPTION
Adds CLI commands to import JSON export files for classes, objectbricks and fieldcollections

```
$ php pimcore/cli/console.php definition:import:class class_Customer_export.json
$ php pimcore/cli/console.php definition:import:objectbrick objectbrick_FooBar_export.json
$ php pimcore/cli/console.php definition:import:fieldcollection fieldcollection_Bazinga_export.json
```
