### PR TITLE
Add module's selector in document's setting tab.

### DIFF
--- a/pimcore/static6/js/pimcore/document/pages/settings.js
+++ b/pimcore/static6/js/pimcore/document/pages/settings.js
@@ -401,9 +401,33 @@ pimcore.document.pages.settings = Class.create({
                                 }
                             },
                             {
+                                xtype:'combo',
                                 fieldLabel: t('module_optional'),
-                                name: 'module',
-                                value: this.page.data.module
+                                displayField: 'name',
+                                valueField: 'name',
+                                name: "module",
+                                disableKeyFilter: true,
+                                store: new Ext.data.Store({
+                                    autoDestroy: true,
+                                    proxy: {
+                                        type: 'ajax',
+                                        url: "/admin/misc/get-available-modules",
+                                        reader: {
+                                            type: 'json',
+                                            rootProperty: 'data'
+                                        }
+                                    },
+                                    fields: ["name"]
+                                }),
+                                triggerAction: "all",
+                                mode: "local",
+                                id: "pimcore_document_settings_module_" + this.page.id,
+                                value: this.page.data.module,
+                                listeners: {
+                                    afterrender: function (el) {
+                                        el.getStore().load();
+                                    }
+                                }
                             },
                             {
                                 xtype:'combo',
@@ -429,9 +453,17 @@ pimcore.document.pages.settings = Class.create({
                                 id: "pimcore_document_settings_controller_" + this.page.id,
                                 value: this.page.data.controller,
                                 listeners: {
-                                    afterrender: function (el) {
-                                        el.getStore().load();
-                                    }
+                                    "focus": function (el) {
+                                        el.getStore().reload({
+                                            params: {
+                                                moduleName: Ext.getCmp("pimcore_document_settings_module_"
+                                                    + this.page.id).getValue()
+                                            },
+                                            callback: function() {
+                                                el.expand();
+                                            }
+                                        });
+                                    }.bind(this),
                                 }
                             },
                             {
@@ -460,6 +492,8 @@ pimcore.document.pages.settings = Class.create({
                                     "focus": function (el) {
                                         el.getStore().reload({
                                             params: {
+                                                moduleName: Ext.getCmp("pimcore_document_settings_module_"
+                                                    + this.page.id).getValue(),
                                                 controllerName: Ext.getCmp("pimcore_document_settings_controller_"
                                                                                     + this.page.id).getValue()
                                             },


### PR DESCRIPTION
I found that it's not possible to use controllers from plugin's `controllers` dir in the document's settings. Controller for listing all possible values is already there `/admin/misc/get-available-modules` so I just have created JS code that uses it.