### PR TITLE
Ignore alt+s combination for saving

### DIFF
--- a/pimcore/static6/js/pimcore/helpers.js
+++ b/pimcore/static6/js/pimcore/helpers.js
@@ -25,6 +25,7 @@ pimcore.helpers.registerKeyBindings = function (bindEl, ExtJS) {
             key: "s",
             ctrl: true,
             shift: false,
+            alt: false,
             fn: top.pimcore.helpers.handleCtrlS
         }, {
             key:116,


### PR DESCRIPTION
A simple fix for the bug which allows to save a document with Alt+S key combination (occurs only on Windows for some reason). In the Polish keyboard layout "Alt+s" is used to type "ś" character so the bug makes entering text by my fellows a little problematic.