### PR TITLE
updated Pimcore::shutdown

### DIFF
--- a/pimcore/lib/Pimcore.php
+++ b/pimcore/lib/Pimcore.php
@@ -1002,7 +1002,9 @@ class Pimcore
         self::$inShutdown = true;
 
         // flush all custom output buffers
-        while (@ob_end_flush());
+        while (count(ob_get_status(true)) > 1) {
+            ob_end_flush();
+        }
 
         // flush everything
         flush();


### PR DESCRIPTION
the problem with current shutdown buffer cleaning is that calling ob_end_clean() while no buffers available yields an error (e_warning I presume though not 100% sure) and then when calling error_get_last() or debug_backtrace() will result into not actual fatal error data retrieved, but rather "ob_end_flush(): failed to delete and flush buffer. No buffer to delete or flush" error.

while you have @ operator, which doesn't allow error to pop, last error is still overriden

proposed way to handle buffer will not lead to such problem