### PR TITLE
Add ExtJs "fieldcontainer" and "splitter" to pimcore ClassDefinition

### DIFF
--- a/pimcore/config/texts/en.json
+++ b/pimcore/config/texts/en.json
@@ -6738,6 +6738,14 @@
     {
         "term": "object_search",
         "definition": "Search Objects"
+    },
+    {
+        "term" : "splitter",
+        "definition": "Splitter"
+    },
+    {
+        "term" : "fieldcontainer",
+        "definition": "Field Container"
     }
 
 

--- a/pimcore/models/Object/ClassDefinition/Layout/Fieldcontainer.php
+++ b/pimcore/models/Object/ClassDefinition/Layout/Fieldcontainer.php
@@ -1,0 +1,101 @@
+<?php 
+/**
+ * Pimcore
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @category   Pimcore
+ * @package    Object|Class
+ * @copyright  Copyright (c) 2009-2016 pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace Pimcore\Model\Object\ClassDefinition\Layout;
+
+use Pimcore\Model;
+
+class Fieldcontainer extends Model\Object\ClassDefinition\Layout
+{
+
+    /**
+     * Static type of this element
+     *
+     * @var string
+     */
+    public $fieldtype = "fieldcontainer";
+
+
+    /**
+     * Width of input field labels
+     * @var int
+     */
+    public $labelWidth = 100;
+
+    /**
+     * @var string
+     */
+    public $layout;
+
+    /**
+     * @var string
+     */
+    public $fieldLabel;
+
+    /**
+     * @param $labelWidth
+     * @return $this
+     */
+    public function setLabelWidth($labelWidth)
+    {
+        if (!empty($labelWidth)) {
+            $this->labelWidth = intval($labelWidth);
+        }
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLabelWidth()
+    {
+        return $this->labelWidth;
+    }
+
+    /**
+     * @param $layout
+     * @return $this
+     */
+    public function setLayout($layout)
+    {
+        $this->layout = $layout;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLayout()
+    {
+        return $this->layout;
+    }
+
+    /**
+     * @param $fieldLabel
+     * @return $this
+     */
+    public function setFieldLabel($fieldLabel)
+    {
+        $this->fieldLabel = $fieldLabel;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFieldLabel()
+    {
+        return $this->fieldLabel;
+    }
+}

--- a/pimcore/models/Object/ClassDefinition/Layout/Splitter.php
+++ b/pimcore/models/Object/ClassDefinition/Layout/Splitter.php
@@ -1,0 +1,28 @@
+<?php 
+/**
+ * Pimcore
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @category   Pimcore
+ * @package    Object|Class
+ * @copyright  Copyright (c) 2009-2016 pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace Pimcore\Model\Object\ClassDefinition\Layout;
+
+use Pimcore\Model;
+
+class Splitter extends Model\Object\ClassDefinition\Layout
+{
+
+    /**
+     * Static type of this element
+     *
+     * @var string
+     */
+    public $fieldtype = "splitter";
+}

--- a/pimcore/modules/admin/views/scripts/index/index6.php
+++ b/pimcore/modules/admin/views/scripts/index/index6.php
@@ -369,6 +369,8 @@ $scripts = array(
     "pimcore/object/classes/layout/layout.js",
     "pimcore/object/classes/layout/accordion.js",
     "pimcore/object/classes/layout/fieldset.js",
+    "pimcore/object/classes/layout/fieldcontainer.js",
+    "pimcore/object/classes/layout/splitter.js",
     "pimcore/object/classes/layout/panel.js",
     "pimcore/object/classes/layout/region.js",
     "pimcore/object/classes/layout/tabpanel.js",

--- a/pimcore/static6/css/icons.css
+++ b/pimcore/static6/css/icons.css
@@ -352,6 +352,14 @@
     background: url(/pimcore/static6/img/flat-color-icons/fieldset.svg) center center no-repeat !important;
 }
 
+.pimcore_icon_fieldcontainer {
+    background: url(/pimcore/static6/img/flat-color-icons/row.svg) center center no-repeat !important;
+}
+
+.pimcore_icon_splitter {
+    background: url(/pimcore/static6/img/flat-color-icons/rectangle.svg) center center no-repeat !important;
+}
+
 .pimcore_icon_panel {
     background: url(/pimcore/static6/img/flat-color-icons/panel.svg) center center no-repeat !important;
 }

--- a/pimcore/static6/js/pimcore/object/classes/class.js
+++ b/pimcore/static6/js/pimcore/object/classes/class.js
@@ -346,7 +346,7 @@ pimcore.object.classes.klass = Class.create({
         var menu = new Ext.menu.Menu();
 
         //get all allowed data types for localized fields
-        var lftypes = ["panel","tabpanel","accordion","fieldset","text","region","button"];
+        var lftypes = ["panel","tabpanel","accordion","fieldset", "fieldcontainer", "text","region","button"];
         var dataComps = Object.keys(pimcore.object.classes.data);
 
         for (var i = 0; i < dataComps.length; i++) {
@@ -363,11 +363,13 @@ pimcore.object.classes.klass = Class.create({
         var allowedTypes = {
             accordion: ["panel","region","tabpanel","text"],
             fieldset: ["data","text"],
-            panel: ["data","region","tabpanel","button","accordion","fieldset","panel","text","html"],
+            fieldcontainer: ["data","text","splitter"],
+            panel: ["data","region","tabpanel","button","accordion","fieldset", "fieldcontainer","panel","text","html"],
             region: ["panel","accordion","tabpanel","text","localizedfields"],
             tabpanel: ["panel", "region", "accordion","text","localizedfields"],
             button: [],
             text: [],
+            splitter: [],
             root: ["panel","region","tabpanel","accordion","text"],
             localizedfields: lftypes
         };

--- a/pimcore/static6/js/pimcore/object/classes/layout/fieldcontainer.js
+++ b/pimcore/static6/js/pimcore/object/classes/layout/fieldcontainer.js
@@ -1,0 +1,79 @@
+/**
+ * Pimcore
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2009-2016 pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+pimcore.registerNS("pimcore.object.classes.layout.fieldcontainer");
+pimcore.object.classes.layout.fieldcontainer = Class.create(pimcore.object.classes.layout.layout, {
+
+    type: "fieldcontainer",
+
+    initialize: function (treeNode, initData) {
+        this.type = "fieldcontainer";
+
+        this.initData(initData);
+        this.datax.name = t("fieldcontainer");
+
+        this.treeNode = treeNode;
+    },
+
+    getTypeName: function () {
+        return t("fieldcontainer");
+    },
+
+    getIconClass: function () {
+        return "pimcore_icon_fieldcontainer";
+    },
+
+    getLayout: function ($super) {
+        $super();
+
+        var layouts = Ext.create('Ext.data.Store', {
+            fields: ['abbr', 'name'],
+            data: [
+                {"abbr": "", "name": "vbox"},
+                {"abbr": "hbox", "name": "hbox"}
+            ]
+        });
+
+        this.layout.add({
+            xtype: "form",
+            bodyStyle: "padding: 10px;",
+            style: "margin: 10px 0 10px 0",
+            items: [
+                {
+                    xtype: "textfield",
+                    name: "fieldLabel",
+                    fieldLabel: t("label"),
+                    value: this.datax.fieldLabel
+                },
+                {
+                    xtype: "numberfield",
+                    name: "labelWidth",
+                    fieldLabel: t("label_width"),
+                    value: this.datax.labelWidth
+                },
+                {
+                    xtype: "combo",
+                    fieldLabel: t("layout"),
+                    name: "layout",
+                    value: this.datax.layout,
+                    store: layouts,
+                    triggerAction: 'all',
+                    editable: false,
+                    displayField: 'name',
+                    valueField: 'abbr',
+                }
+            ]
+        });
+
+        return this.layout;
+    }
+
+});

--- a/pimcore/static6/js/pimcore/object/classes/layout/splitter.js
+++ b/pimcore/static6/js/pimcore/object/classes/layout/splitter.js
@@ -1,0 +1,39 @@
+/**
+ * Pimcore
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2009-2016 pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+pimcore.registerNS("pimcore.object.classes.layout.splitter");
+pimcore.object.classes.layout.splitter = Class.create(pimcore.object.classes.layout.layout, {
+
+    type: "splitter",
+
+    initialize: function (treeNode, initData) {
+        this.type = "splitter";
+
+        this.initData(initData);
+        this.datax.name = t("splitter");
+
+        this.treeNode = treeNode;
+    },
+
+    getTypeName: function () {
+        return t("splitter");
+    },
+
+    getIconClass: function () {
+        return "pimcore_icon_splitter";
+    },
+
+    getLayout: function ($super) {
+        $super();
+        return this.layout;
+    }
+
+});

--- a/pimcore/static6/js/pimcore/object/helpers/customLayoutEditor.js
+++ b/pimcore/static6/js/pimcore/object/helpers/customLayoutEditor.js
@@ -371,11 +371,13 @@ pimcore.object.helpers.customLayoutEditor = Class.create({
         var allowedTypes = {
             accordion: ["panel","region","tabpanel","text"],
             fieldset: ["data","text"],
+            fieldcontainer: ["data","text","splitter"],
             panel: ["data","region","tabpanel","button","accordion","fieldset","panel","text","html"],
             region: ["panel","accordion","tabpanel","text","localizedfields"],
             tabpanel: ["panel", "region", "accordion","text","localizedfields"],
             button: [],
             text: [],
+            splitter: [],
             root: ["panel","region","tabpanel","accordion","text"],
             localizedfields: ["panel","tabpanel","accordion","fieldset","text","region","button"]
         };

--- a/pimcore/static6/js/pimcore/object/helpers/edit.js
+++ b/pimcore/static6/js/pimcore/object/helpers/edit.js
@@ -58,6 +58,16 @@ pimcore.object.helpers.edit = {
                 hideMode: "offsets",
                 listeners: panelListenerConfig
             },
+            fieldcontainer: {
+                xtype: "fieldcontainer",
+                autoScroll: true,
+                forceLayout: true,
+                hideMode: "offsets",
+                listeners: panelListenerConfig
+            },
+            splitter: {
+                xtype: "splitter"
+            },
             panel: {
                 xtype: "panel",
                 autoScroll: true,
@@ -106,7 +116,7 @@ pimcore.object.helpers.edit = {
         };
 
         var validKeys = ["xtype","title","layout","icon","items","region","width","height","name","text","html","handler",
-            "labelWidth","collapsible","collapsed","bodyStyle"];
+            "labelWidth", "fieldLabel", "collapsible","collapsed","bodyStyle"];
 
         var tmpItems;
 
@@ -124,6 +134,10 @@ pimcore.object.helpers.edit = {
                         var childConfig = l.childs[i];
                         if (typeof childConfig.labelWidth == "undefined" && l.labelWidth != "undefined") {
                             childConfig.labelWidth = l.labelWidth;
+                        }
+
+                        if (typeof childConfig.fieldLabel == "undefined" && l.fieldLabel != "undefined") {
+                            childConfig.fieldLabel = l.fieldLabel;
                         }
 
                         tmpItems = this.getRecursiveLayout(childConfig, noteditable);


### PR DESCRIPTION
# Description
Our goal was to build better looking, more complex forms to increase the editors user experience.

Basic implementation of ExtJS FieldContainer (http://docs.sencha.com/extjs/6.0/6.0.1-classic/#!/api/Ext.form.FieldContainer) and Splitter (http://docs.sencha.com/extjs/6.0/6.0.1-classic/#!/api/Ext.resizer.Splitter) as Pimcore ClassDefinition layout elements.

We've tested the implementation against import, export and the rest api.

# Features
- hbox/vbox layout for fieldcontainer
- custom fieldcontainer label (to allow single labled form rows/fieldcontainers – see examples address row)
- splitter to add additional spacing between form field and the ability to allow user resizable inputs

# Example

Dummy ClassDefinition Export:
https://gist.github.com/joramhoefs/cb68f8f480635d87e787

ClassDefinition:
<img src="http://i.imgur.com/8x0KboB.png" title="source: imgur.com" />

Object usage:
<img src="http://i.imgur.com/4StnVfT.png" title="source: imgur.com" />