### PR TITLE
Dashboard portlets reordering

### DIFF
--- a/pimcore/static6/js/pimcore/layout/portal.js
+++ b/pimcore/static6/js/pimcore/layout/portal.js
@@ -153,7 +153,7 @@ pimcore.layout.portal = Class.create({
                     }
                 });
 
-            });
+            }.bind(this));
 
             this.panel.on("destroy", function () {
                 pimcore.globalmanager.remove("layout_portal_" + this.key);


### PR DESCRIPTION
Hi, dashboard layout serialization fails on portlet reordering because of missing dashboard key in the request. This should fix it.