### PR TITLE
fix missing video target when deleting video link

### DIFF
--- a/pimcore/models/Document/Tag/Video.php
+++ b/pimcore/models/Document/Tag/Video.php
@@ -384,6 +384,8 @@ class Video extends Model\Document\Tag
             } else {
                 return $this->getErrorCode("The given thumbnail doesn't exist: '" . $options["thumbnail"] . "'");
             }
+        } else {
+            return $this->getEmptyCode();
         }
     }
 


### PR DESCRIPTION
- add video to a target (in a snippet for example)
- delete video from assets.
- try to add a vide in snippet again: the target video is gone.

this pr should fix this. 