### PR TITLE
Calculated Value object field icon style

### DIFF
--- a/pimcore/static6/js/pimcore/object/tags/calculatedValue.js
+++ b/pimcore/static6/js/pimcore/object/tags/calculatedValue.js
@@ -24,7 +24,7 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
     getLayoutEdit: function () {
 
         var input = {
-            fieldLabel: '<img src="/pimcore/static6/img/flat-color-icons/calculator.svg"/>'  +this.fieldConfig.title,
+            fieldLabel: '<img src="/pimcore/static6/img/flat-color-icons/calculator.svg" style="height: 1.8em; display: inline-block; vertical-align: middle;"/>' + this.fieldConfig.title,
             componentCls: "object_field",
             labelWidth: 100,
             disabled: true


### PR DESCRIPTION
Hi, the Calculated value icon is too big on objects. This should fix it.

Current style:
![image](https://cloud.githubusercontent.com/assets/2148902/14019631/12fa1404-f1d4-11e5-874d-22235f9b1770.png)

New style:
![image](https://cloud.githubusercontent.com/assets/2148902/14019652/2ec25c82-f1d4-11e5-99f0-e05a79441872.png)



