### PR TITLE
Added getOwnerClassId function to Nonownerobjects.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@
 .idea
 # NetBeans
 nbproject
-phpmyadmin

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 .idea
 # NetBeans
 nbproject
+phpmyadmin

--- a/pimcore/models/Object/ClassDefinition/Data/Nonownerobjects.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Nonownerobjects.php
@@ -39,7 +39,11 @@ class Nonownerobjects extends Model\Object\ClassDefinition\Data\Objects
      */
     public $ownerClassName;
 
-
+    /**
+     * @var number
+     */
+    public $ownerClassId;
+    
     /**
      * @var string
      */
@@ -107,6 +111,23 @@ class Nonownerobjects extends Model\Object\ClassDefinition\Data\Objects
             }
         }
         return $this->ownerClassName;
+    }
+    
+    /**
+     * @return number
+     */
+    public function getOwnerClassId()
+    {
+   
+        if (empty($this->ownerClassId)) {
+            try {
+                $class = Object\ClassDefinition::getByName($this->ownerClassName);
+                $this->ownerClassId =  $class->getId();
+            } catch (\Exception $e) {
+                \Logger::error($e->getMessage());
+            }
+        }
+        return $this->ownerClassId;
     }
 
     /**


### PR DESCRIPTION

In the documentation of the Nonowner objects is a example code:

`
$def = $object->getClass()->getFieldDefinition("myNonOwnerObjectField");
$refKey = $def->getOwnerFieldName();
$refId = $def->getOwnerClassId();
$nonOwnerRelations = $object->getRelationData($refKey,false,$refId);`

[https://www.pimcore.org/wiki/display/PIMCORE3/Non-Owner+Objects](url)

But $def->getOwnerClassId(); dosn't exists. 

Fixes # 

Added getOwnerClassId function to Nonownerobjects.php


