### PR TITLE
models MySQL 5.7 fixes

### DIFF
--- a/pimcore/models/Object/Fieldcollection/Definition/Dao.php
+++ b/pimcore/models/Object/Fieldcollection/Definition/Dao.php
@@ -5,7 +5,7 @@
  * This source file is available under two different licenses:
  * - GNU General Public License version 3 (GPLv3)
  * - Pimcore Enterprise License (PEL)
- * Full copyright and license information is available in 
+ * Full copyright and license information is available in
  * LICENSE.md which is distributed with this source code.
  *
  * @category   Pimcore
@@ -56,7 +56,7 @@ class Dao extends Model\Dao\AbstractDao
         $this->db->query("CREATE TABLE IF NOT EXISTS `" . $table . "` (
 		  `o_id` int(11) NOT NULL default '0',
 		  `index` int(11) default '0',
-          `fieldname` varchar(255) default NULL,
+          `fieldname` varchar(255) default '',
           PRIMARY KEY (`o_id`,`index`,`fieldname`(255)),
           INDEX `o_id` (`o_id`),
           INDEX `index` (`index`),

--- a/pimcore/models/Object/Objectbrick/Definition/Dao.php
+++ b/pimcore/models/Object/Objectbrick/Definition/Dao.php
@@ -5,7 +5,7 @@
  * This source file is available under two different licenses:
  * - GNU General Public License version 3 (GPLv3)
  * - Pimcore Enterprise License (PEL)
- * Full copyright and license information is available in 
+ * Full copyright and license information is available in
  * LICENSE.md which is distributed with this source code.
  *
  * @category   Pimcore
@@ -58,7 +58,7 @@ class Dao extends Model\Object\Fieldcollection\Definition\Dao
 
         $this->db->query("CREATE TABLE IF NOT EXISTS `" . $tableStore . "` (
 		  `o_id` int(11) NOT NULL default '0',
-          `fieldname` varchar(255) default NULL,
+          `fieldname` varchar(255) default '',
           PRIMARY KEY (`o_id`,`fieldname`),
           INDEX `o_id` (`o_id`),
           INDEX `fieldname` (`fieldname`)
@@ -66,7 +66,7 @@ class Dao extends Model\Object\Fieldcollection\Definition\Dao
 
         $this->db->query("CREATE TABLE IF NOT EXISTS `" . $tableQuery . "` (
 		  `o_id` int(11) NOT NULL default '0',
-          `fieldname` varchar(255) default NULL,
+          `fieldname` varchar(255) default '',
           PRIMARY KEY (`o_id`,`fieldname`),
           INDEX `o_id` (`o_id`),
           INDEX `fieldname` (`fieldname`)


### PR DESCRIPTION
# Bug Report

### Expected behavior 
  Import all classes via bulk import
### Actual behavior  
  Bulk import throws and exception with MySQL version 5.7

```
2016-04-06T15:48:41+02:00 EMERG (0):   7 MB | () [23]: [Exception] with message: Mysqli statement execute error : All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead
In file: /var/www/pimcore/lib/Zend/Db/Statement/Mysqli.php on line 214
#0 /var/www/pimcore/lib/Zend/Db/Statement.php(303): Zend_Db_Statement_Mysqli->_execute(Array)
#1 /var/www/pimcore/lib/Zend/Db/Adapter/Abstract.php(480): Zend_Db_Statement->execute(Array)
#2 [internal function]: Zend_Db_Adapter_Abstract->query('CREATE TABLE IF...')
#3 /var/www/pimcore/lib/Pimcore/Resource/Wrapper.php(263): call_user_func_array(Array, Array)
#4 /var/www/pimcore/lib/Pimcore/Resource/Wrapper.php(233): Pimcore\Resource\Wrapper->callResourceMethod('query', Array)
#5 /var/www/pimcore/models/Object/Fieldcollection/Definition/Resource.php(62): Pimcore\Resource\Wrapper->__call('query', Array)
#6 /var/www/pimcore/models/Object/Fieldcollection/Definition.php(286): Pimcore\Model\Object\Fieldcollection\Definition\Resource->createUpdateTable(Object(Pimcore\Model\Object\ClassDefinition))
#7 /var/www/pimcore/models/Object/ClassDefinition/Service.php(115): Pimcore\Model\Object\Fieldcollection\Definition->save()
#8 /var/www/pimcore/modules/admin/controllers/ClassController.php(989): Pimcore\Model\Object\ClassDefinition\Service::importFieldCollectionFromJson(Object(Pimcore\Model\Object\Fieldcollection\Definition), '{"parentClass":...', true)
#9 /var/www/pimcore/lib/Zend/Controller/Action.php(516): Admin_ClassController->bulkCommitAction()
#10 /var/www/pimcore/lib/Zend/Controller/Dispatcher/Standard.php(308): Zend_Controller_Action->dispatch('bulkCommitActio...')
#11 /var/www/pimcore/lib/Zend/Controller/Front.php(954): Zend_Controller_Dispatcher_Standard->dispatch(Object(Zend_Controller_Request_Http), Object(Zend_Controller_Response_Http))
#12 /var/www/pimcore/lib/Pimcore.php(276): Zend_Controller_Front->dispatch()
#13 /var/www/index.php(18): Pimcore::run()
#14 {main}
```

### Steps to reproduce  
  Execute this
```
CREATE TABLE IF NOT EXISTS `foo` (
		  `o_id` int(11) NOT NULL default '0',
          `fieldname` varchar(255) default NULL,
          PRIMARY KEY (`o_id`,`fieldname`),
          INDEX `o_id` (`o_id`),
          INDEX `fieldname` (`fieldname`)
		) DEFAULT CHARSET=utf8;
```
fieldname has to be not null
```
CREATE TABLE IF NOT EXISTS `foo` (
		  `o_id` int(11) NOT NULL default '0',
          `fieldname` varchar(255) default '',
          PRIMARY KEY (`o_id`,`fieldname`),
          INDEX `o_id` (`o_id`),
          INDEX `fieldname` (`fieldname`)
		) DEFAULT CHARSET=utf8;
```

This code (`fieldname` varchar(255) default) is used 3 different model classes