### PR TITLE
Resolved Fullscreen problem on Internet Explorer

### DIFF
--- a/pimcore/static/js/frontend/pdfViewer/viewer.js
+++ b/pimcore/static/js/frontend/pdfViewer/viewer.js
@@ -268,9 +268,9 @@ pimcore.pdf.prototype.calculateDimensions = function () {
     this.pdfArrowLeft.style.marginLeft = Math.round(buttonWidth/3) + "px";
 
     // check fullscreen
-    if(document.mozFullScreenElement || document.webkitFullScreenElement || document.msFullScreenElement
+    if(document.mozFullScreenElement || document.webkitFullScreenElement || document.msFullscreenElement
         || document.fullScreenElement || document.webkitCurrentFullScreenElement || document.currentFullScreenElement
-        || document.mozCurrentFullScreenElement || document.msCurrentFullScreenElement) {
+        || document.mozCurrentFullScreenElement) {
 
     } else if(this.containerEl.classList && (this.containerEl.requestFullscreen
         || this.containerEl.mozRequestFullScreen || this.containerEl.webkitRequestFullscreen
@@ -364,8 +364,8 @@ pimcore.pdf.prototype.closeFullScreen = function (page) {
         document.mozCancelFullScreen();
     } else if (document.webkitCancelFullScreen) {
         document.webkitCancelFullScreen();
-    }  else if (document.msCancelFullScreen) {
-        document.msCancelFullScreen();
+    }  else if (document.msExitFullscreen) {
+        document.msExitFullscreen();
     }
 };
 

--- a/pimcore/static6/js/frontend/pdfViewer/viewer.js
+++ b/pimcore/static6/js/frontend/pdfViewer/viewer.js
@@ -268,9 +268,9 @@ pimcore.pdf.prototype.calculateDimensions = function () {
     this.pdfArrowLeft.style.marginLeft = Math.round(buttonWidth/3) + "px";
 
     // check fullscreen
-    if(document.mozFullScreenElement || document.webkitFullScreenElement || document.msFullScreenElement
+    if(document.mozFullScreenElement || document.webkitFullScreenElement || document.msFullscreenElement
         || document.fullScreenElement || document.webkitCurrentFullScreenElement || document.currentFullScreenElement
-        || document.mozCurrentFullScreenElement || document.msCurrentFullScreenElement) {
+        || document.mozCurrentFullScreenElement) {
 
     } else if(this.containerEl.classList && (this.containerEl.requestFullscreen
         || this.containerEl.mozRequestFullScreen || this.containerEl.webkitRequestFullscreen
@@ -364,8 +364,8 @@ pimcore.pdf.prototype.closeFullScreen = function (page) {
         document.mozCancelFullScreen();
     } else if (document.webkitCancelFullScreen) {
         document.webkitCancelFullScreen();
-    }  else if (document.msCancelFullScreen) {
-        document.msCancelFullScreen();
+    }  else if (document.msExitFullscreen) {
+        document.msExitFullscreen();
     }
 };
 


### PR DESCRIPTION
This PR fixes problem with removing pdfFullscreen class on Internet Explorer, which makes PDF Viewer unusable in fullscreen:
![721c1af9e88954a9d7cbc91d6adeb96b](https://cloud.githubusercontent.com/assets/7629808/14427979/57324dcc-fff7-11e5-972c-a297ddeaefc0.gif)

I've changed wrong names of Fullscreen API functions to correct ones
