### PR TITLE
allow backend ui to trigger preSaveObject & postSaveObject

### DIFF
--- a/pimcore/static6/js/pimcore/helpers.js
+++ b/pimcore/static6/js/pimcore/helpers.js
@@ -969,6 +969,9 @@ pimcore.helpers.deleteDocumentCheckDependencyComplete = function (id, callback, 
 pimcore.helpers.deleteDocumentFromServer = function (id, r, callback, button) {
 
     if (button == "ok" && r.deletejobs) {
+
+        pimcore.plugin.broker.fireEvent("preDeleteDocument", id);
+
         var tree = pimcore.globalmanager.get("layout_document_tree").tree;
         var view = tree.getView();
         var store = tree.getStore();
@@ -1011,6 +1014,8 @@ pimcore.helpers.deleteDocumentFromServer = function (id, r, callback, button) {
 
         var pj = new pimcore.tool.paralleljobs({
             success: function (id, callback) {
+
+                pimcore.plugin.broker.fireEvent("postDeleteDocument", id);
 
                 //var node = pimcore.globalmanager.get("layout_document_tree").tree.getNodeById(id);
                 try {
@@ -1108,6 +1113,8 @@ pimcore.helpers.deleteObjectFromServer = function (id, r, callback, button) {
 
     if (button == "ok" && r.deletejobs) {
 
+        pimcore.plugin.broker.fireEvent("preDeleteObject", id);
+
         var tree = pimcore.globalmanager.get("layout_object_tree").tree;
         var view = tree.getView();
         var store = tree.getStore();
@@ -1149,6 +1156,8 @@ pimcore.helpers.deleteObjectFromServer = function (id, r, callback, button) {
 
         var pj = new pimcore.tool.paralleljobs({
             success: function (id, callback) {
+
+                pimcore.plugin.broker.fireEvent("postDeleteObject", id);
 
                 //var node = pimcore.globalmanager.get("layout_object_tree").tree.getNodeById(id);
                 try {

--- a/pimcore/static6/js/pimcore/object/object.js
+++ b/pimcore/static6/js/pimcore/object/object.js
@@ -682,48 +682,51 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                 }
             }
 
+            pimcore.plugin.broker.fireEvent("preSaveObject", this, task, only);
+
             Ext.Ajax.request({
                 url: '/admin/object/save/task/' + task,
                 method: "post",
                 params: saveData,
                 success: function (response) {
-                        if (task != "session") {
-                            try {
-                                var rdata = Ext.decode(response.responseText);
-                                if (rdata && rdata.success) {
-                                    pimcore.helpers.showNotification(t("success"), t("your_object_has_been_saved"),
-                                        "success");
-                                    this.resetChanges();
-                                    Ext.apply(this.data.general,rdata.general);
+                    if (task != "session") {
+                        try {
+                            var rdata = Ext.decode(response.responseText);
+                            if (rdata && rdata.success) {
+                                pimcore.helpers.showNotification(t("success"), t("your_object_has_been_saved"),
+                                    "success");
+                                this.resetChanges();
+                                Ext.apply(this.data.general,rdata.general);
 
-                                    pimcore.helpers.updateObjectQTip(this.id, rdata.treeData);
-                                }
-                                else {
-                                    pimcore.helpers.showPrettyError(rdata.type, t("error"), t("error_saving_object"),
-                                        rdata.message, rdata.stack, rdata.code);
-                                }
-                            } catch (e) {
-                                pimcore.helpers.showNotification(t("error"), t("error_saving_object"), "error");
+                                pimcore.helpers.updateObjectQTip(this.id, rdata.treeData);
+                                pimcore.plugin.broker.fireEvent("postSaveObject", this, task, only);
                             }
-                            // reload versions
-                            if (this.isAllowed("versions")) {
-                                if (typeof this.versions.reload == "function") {
-                                    try {
-                                        //TODO remove this as soon as it works
-                                        this.versions.reload();
-                                    } catch (e) {
-                                        console.log(e);
-                                    }
+                            else {
+                                pimcore.helpers.showPrettyError(rdata.type, t("error"), t("error_saving_object"),
+                                    rdata.message, rdata.stack, rdata.code);
+                            }
+                        } catch (e) {
+                            pimcore.helpers.showNotification(t("error"), t("error_saving_object"), "error");
+                        }
+                        // reload versions
+                        if (this.isAllowed("versions")) {
+                            if (typeof this.versions.reload == "function") {
+                                try {
+                                    //TODO remove this as soon as it works
+                                    this.versions.reload();
+                                } catch (e) {
+                                    console.log(e);
                                 }
                             }
                         }
+                    }
 
 
                     this.tab.unmask();
 
-                        if (typeof callback == "function") {
-                            callback();
-                        }
+                    if (typeof callback == "function") {
+                        callback();
+                    }
 
                 }.bind(this),
                 failure: function (response) {


### PR DESCRIPTION
adds `preSaveObject` and `postSaveObject` events, to allow plugins interacting with object saving state.


