### PR TITLE
Added a try/catch to catch exceptions from document adapters

### DIFF
--- a/pimcore/models/Search/Backend/Data.php
+++ b/pimcore/models/Search/Backend/Data.php
@@ -399,10 +399,14 @@ class Data extends \Pimcore\Model\AbstractModel
 
             if ($element instanceof Asset\Document && \Pimcore\Document::isAvailable()) {
                 if (\Pimcore\Document::isFileTypeSupported($element->getFilename())) {
-                    $contentText = $element->getText();
-                    $contentText = str_replace(["\r\n", "\r", "\n", "\t", "\f"], " ", $contentText);
-                    $contentText = preg_replace("/[ ]+/", " ", $contentText);
-                    $this->data .= " " . $contentText;
+                    try {
+                      $contentText = $element->getText();
+                      $contentText = str_replace(["\r\n", "\r", "\n", "\t", "\f"], " ", $contentText);
+                      $contentText = preg_replace("/[ ]+/", " ", $contentText);
+                      $this->data .= " " . $contentText;
+                    } catch (\Exception $e) {
+                      \Logger::error($e);
+                    }  
                 }
             }
 


### PR DESCRIPTION
The Pimcore\Document\Adapter throws an Exception in getPdf() if something's wrong, which is caught e.g. in Pimcore\Models\Asset\Document::readPageCount(), but not in this class.

If you, for example, in a plugin create a xls and store it in an asset, the error creating the thumbnail is correctly caught, but the exception that then is thrown when generating the search data is uncaught.

For your convenience here's the stacktrace:
[stacktrace.txt](https://github.com/pimcore/pimcore/files/214688/stacktrace.txt)
