### PR TITLE
save toolbar position in localstorage

### DIFF
--- a/pimcore/static6/js/pimcore/document/tags/areablock.js
+++ b/pimcore/static6/js/pimcore/document/tags/areablock.js
@@ -782,6 +782,28 @@ pimcore.document.tags.areablock = Class.create(pimcore.document.tag, {
                 x = Ext.getBody().getWidth()-areaBlockToolbarSettings["x"]-areaBlockToolbarSettings["width"];
             }
 
+            var tbId = this.toolbarGlobalVar,
+                toolbarPosition = localStorage.getItem("pimcore_toolbar_position");
+
+            if(!toolbarPosition) {
+                toolbarPosition = {};
+            } else {
+                toolbarPosition = JSON.parse(toolbarPosition);
+            }
+
+            if( !toolbarPosition[tbId] ) {
+                toolbarPosition[tbId] = { x : x, y : areaBlockToolbarSettings["y"], closed : false }
+            }
+
+            //now check if xPos is not out of view.
+            if( toolbarPosition[tbId].x > Ext.getBody().getWidth() ) {
+                toolbarPosition[tbId].x =  Ext.getBody().getWidth()-areaBlockToolbarSettings["width"] - 20
+            }
+
+            var storeToolbarState = function() {
+                localStorage.setItem("pimcore_toolbar_position", JSON.stringify(toolbarPosition));
+            };
+
             var toolbar = new Ext.Window({
                 title: areaBlockToolbarSettings.title,
                 width: areaBlockToolbarSettings.width,
@@ -791,12 +813,31 @@ pimcore.document.tags.areablock = Class.create(pimcore.document.tag, {
                 autoHeight: true,
                 style: "position:fixed;",
                 collapsible: true,
+                expandOnShow : !toolbarPosition[tbId].closed,
+                collapsed: toolbarPosition[tbId].closed,
                 cls: "pimcore_areablock_toolbar",
                 closable: false,
-                x: x,
-                y: areaBlockToolbarSettings["y"],
-                items: buttons
+                x: toolbarPosition[tbId].x,
+                y: toolbarPosition[tbId].y,
+                items: buttons,
+                listeners: {
+                    collapse: function(p, eOpts) {
+                        toolbarPosition[tbId].closed = true;
+                        storeToolbarState();
+                    },
+                    expand: function(p, eOpts) {
+                        toolbarPosition[tbId].closed = false;
+                        storeToolbarState();
+                    },
+                    move: function (win, x, y) {
+                        toolbarPosition[tbId].x = Math.max( 20, x );
+                        toolbarPosition[tbId].y = Math.max( 20, y );
+                        storeToolbarState();
+                    }
+                }
             });
+
+            storeToolbarState();
 
             toolbar.show();
 


### PR DESCRIPTION
Sometimes the position of the toolbar can be very annoying. 

![bildschirmfoto 2016-04-14 um 11 19 02](https://cloud.githubusercontent.com/assets/700119/14523271/16e5ed1c-0233-11e6-8f74-d6c4fbdb8158.png)

especially when the toolbar has been repositioned and after a reload the position is the initial again. this PR will take care about that.

**what it does**
- Check if toolbar position exists in localstorage. If so, use that information.
- If the window size has been changed so that the toolbar would be out of view, update the toolbar position.
- Also checks and stores the toggle state.