### PR TITLE
Add Pimple PHP Dependency Injection Container http://pimple.sensiolab…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
         "mpratt/embera": "~1",
         "linfo/linfo": "~3",
         "amnuts/opcache-gui": "~2",
-        "vrana/adminer": "~4.2"
+        "vrana/adminer": "~4.2",
+        "pimple/pimple": "~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/pimcore/config/startup.php
+++ b/pimcore/config/startup.php
@@ -148,6 +148,10 @@ foreach ($autoloaderClassMapFiles as $autoloaderClassMapFile) {
     }
 }
 
+// add Pimple Dependency Injection Container
+\Zend_Controller_Front::getInstance()
+    ->setParam('container', new Pimple\Container());
+
 // generic pimcore startup
 \Pimcore::setSystemRequirements();
 \Pimcore::initAutoloader();

--- a/pimcore/lib/Pimcore.php
+++ b/pimcore/lib/Pimcore.php
@@ -279,6 +279,11 @@ class Pimcore
         // disable build-in error handler
         $front->setParam('noErrorHandler', true);
 
+        // add Pimple Dependency Injection Container if not set
+        if (null === $front->getParam('container')) {
+            $front->setParam('container', new \Pimple\Container());
+        }
+
         // for admin an other modules directly in the core
         $front->addModuleDirectory(PIMCORE_PATH . "/modules");
         // for plugins


### PR DESCRIPTION
Add Pimple PHP Dependency Injection Container for future usage

For example when pimcore will use DI for their core class then we can have posibility to override core class pretty nice way without hardcoding:

```php
<?php

// website/models/Website/User.php
namespace Website;

class User extends \Pimcore\Model\User {
    public function myCustomMethod () {
      return 'hello there!';
    }
}

// website/config/startup.php
$container = \Zend_Controller_Front::getInstance()->getParam('container');
$container['Pimcore\Model\User'] = $container->factory(function ($c) {
    return new \Website\User();
});

// DefaultController.php
use Website\Controller\Action;

class DefaultController extends Action
{
    public function indexAction()
    {
      $user = $this->getInvokeArg('container')['Pimcore\Model\User'] ;
      echo $user->myCustomMethod(); // prints hello there!
    }
}
```