### PR TITLE
fix preview of object versions

### DIFF
--- a/pimcore/static6/js/pimcore/object/versions.js
+++ b/pimcore/static6/js/pimcore/object/versions.js
@@ -150,10 +150,10 @@ pimcore.object.versions = Class.create({
         }
 
         if (selModel.getCount() > 1) {
-            this.compareVersions(grid, rowIndex, event);
+            this.compareVersions(grid, rowIndex, e);
         }
         else {
-            this.showVersionPreview(grid, rowIndex, event);
+            this.showVersionPreview(grid, rowIndex, e);
         }
     },
 


### PR DESCRIPTION
# Bug Report
### Behavior and steps to reproduce
With the exctjs6 config enabled, clicking on an object version throw an JS error and does not open the preview
```js
ReferenceError: event is not defined
this.showVersionPreview(grid, rowIndex, event)
```

### Code
pimcore/static6/js/pimcore/object/versions.js
```js
    onRowClick: function(grid, record, tr, rowIndex, e, eOpts ) {
        var selModel = grid.getSelectionModel();
        if (selModel.getCount() > 2) {
            selModel.select(record);
        }

        if (selModel.getCount() > 1) {
            this.compareVersions(grid, rowIndex, event);
        }
        else {
            this.showVersionPreview(grid, rowIndex, event);
        }
    },
```
### Fix
either change function variable name
```js
onRowClick: function(grid, record, tr, rowIndex, e, eOpts ) {
```
in pimcore/static6/js/pimcore/asset/versions.js
and pimcore/static6/js/pimcore/object/versions.js

or change variable name like in the pull request
