### PR TITLE
Fixed a bug with immediate expiration in MySQL table cache

### DIFF
--- a/pimcore/lib/Pimcore/Cache/Backend/MysqlTable.php
+++ b/pimcore/lib/Pimcore/Cache/Backend/MysqlTable.php
@@ -76,6 +76,9 @@ class MysqlTable extends \Zend_Cache_Backend implements \Zend_Cache_Backend_Exte
     public function save($data, $id, $tags = array(), $specificLifetime = false)
     {
         $lifetime = $this->getLifetime($specificLifetime);
+        if (is_null($lifetime)) {
+          $lifetime = (86400*365);
+        }
 
         $this->getDb()->beginTransaction();
 


### PR DESCRIPTION
The API allowes the value `null` for `$specificLifetime` in the `save()` method, which is specified as infinite lifetime.

"expire" is stored in the database as `time() + $lifetime`, which in case of `null` results in immediate expiration instead of none at all.

Setting the expiration date to "1 year" in case of `null` should fix this.

I borrowed this piece of code from https://github.com/pimcore/pimcore/blob/master/pimcore/lib/Pimcore/Cache/Backend/Mongodb.php method `set()`