### PR TITLE
Fix for text input with alt + shift

### DIFF
--- a/pimcore/static6/js/pimcore/helpers.js
+++ b/pimcore/static6/js/pimcore/helpers.js
@@ -36,12 +36,14 @@ pimcore.helpers.registerKeyBindings = function (bindEl, ExtJS) {
             key:"sa",
             fn: top.pimcore.helpers.openElementByIdDialog.bind(this, "asset"),
             ctrl:true,
-            shift:true
+            shift:true,
+            alt: false
         }, {
             key:"of",
             fn: top.pimcore.helpers.openElementByIdDialog.bind(this, "object"),
             ctrl:true,
-            shift:true
+            shift:true,
+            alt: false
         },  {
             key:"c",
             fn: top.pimcore.helpers.openClassEditor,


### PR DESCRIPTION
The same bug like here: https://github.com/pimcore/pimcore/pull/511

This is a fix for capital Polish special characters (Ś and Ó) because I forgot about them last time :)