### PR TITLE
Fix language fallback for localized field value.

### DIFF
--- a/pimcore/models/Object/Localizedfield.php
+++ b/pimcore/models/Object/Localizedfield.php
@@ -271,7 +271,9 @@ class Localizedfield extends Model\AbstractModel
             foreach (Tool::getFallbackLanguagesFor($language) as $l) {
                 if ($this->languageExists($l)) {
                     if (array_key_exists($name, $this->items[$l])) {
-                        $data = $this->getLocalizedValue($name, $l);
+                        if($data = $this->getLocalizedValue($name, $l)) {
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
For now it returns the latest localized version from fallback list regardless of value.

Example: For now, if I have object with localized field "text", and three locales specified in System Settings: en_US, de_DE and en_150. Fallback specified for de_DE is en_150, en_US.
$obj->text:en_US = "Some text for US"
$obj->text:en_150 = "Some text for EU"
$obj->text:de_DE = ""

$obj->localizedfields->getLocalizedValue('text', 'de_DE') will always return "Some text for US" if de_DE value not specified.

After fix it will return first not empty value from fallback list.

