### PR TITLE
allow getByLocalizedField on Objects.

### DIFF
--- a/pimcore/models/Object/ClassDefinition.php
+++ b/pimcore/models/Object/ClassDefinition.php
@@ -268,7 +268,12 @@ class ClassDefinition extends Model\AbstractModel
         if (is_array($this->getFieldDefinitions()) && count($this->getFieldDefinitions())) {
             foreach ($this->getFieldDefinitions() as $key => $def) {
                 if (!(method_exists($def, "isRemoteOwner") and $def->isRemoteOwner())) {
-                    $cd .= "* @method static \\Pimcore\\Model\\Object\\" . ucfirst($this->getName()) . '\Listing getBy' . ucfirst($def->getName()) . ' ($value, $limit = 0) ' ."\n";
+                    if($def instanceof Object\ClassDefinition\Data\Localizedfields) {
+                        $cd .= "* @method static \\Pimcore\\Model\\Object\\" . ucfirst($this->getName()) . '\Listing getBy' . ucfirst($def->getName()) . ' ($field, $value, $locale = null, $limit = 0) ' . "\n";
+                    }
+                    else {
+                        $cd .= "* @method static \\Pimcore\\Model\\Object\\" . ucfirst($this->getName()) . '\Listing getBy' . ucfirst($def->getName()) . ' ($value, $limit = 0) ' . "\n";
+                    }
                 }
             }
         }

--- a/pimcore/models/Object/Concrete.php
+++ b/pimcore/models/Object/Concrete.php
@@ -569,22 +569,49 @@ class Concrete extends AbstractObject
         $propertyName = implode("", preg_grep('/^' . preg_quote($propertyName, '/') . '$/i', $fieldnames));
 
         if (property_exists($tmpObj, $propertyName)) {
-
             // check if the given fieldtype is valid for this shorthand
-            $allowedDataTypes = array("input","numeric","checkbox","country","date","datetime","image","language","multihref","multiselect","select","slider","time","user","email","firstname","lastname");
+            $allowedDataTypes = array("input","numeric","checkbox","country","date","datetime","image","language","multihref","multiselect","select","slider","time","user","email","firstname","lastname","localizedfields");
 
             $field = $tmpObj->getClass()->getFieldDefinition($propertyName);
             if (!in_array($field->getFieldType(), $allowedDataTypes)) {
                 throw new \Exception("Static getter '::getBy".ucfirst($propertyName)."' is not allowed for fieldtype '" . $field->getFieldType() . "', it's only allowed for the following fieldtypes: " . implode(",", $allowedDataTypes));
             }
 
-            $arguments = array_pad($arguments, 3, 0);
-            list($value, $limit, $offset) = $arguments;
+            if($field instanceof Model\Object\ClassDefinition\Data\Localizedfields) {
+                $arguments = array_pad($arguments, 5, 0);
 
-            $defaultCondition = $propertyName . " = " . \Pimcore\Db::get()->quote($value) . " ";
-            $listConfig = array(
-                "condition" => $defaultCondition
-            );
+                list($localizedPropertyName, $value, $locale, $limit, $offset) = $arguments;
+
+                $localizedField = $field->getFielddefinition($localizedPropertyName);
+
+                if(!$localizedField instanceof Model\Object\ClassDefinition\Data) {
+                    \Logger::error("Class: Object\\Concrete => call to undefined static method " . $method);
+                    throw new \Exception("Call to undefined static method " . $method . " in class Object\\Concrete");
+                }
+
+                if(!in_array($localizedField->getFieldType(), $allowedDataTypes)) {
+                    throw new \Exception("Static getter '::getBy".ucfirst($propertyName)."' is not allowed for fieldtype '" . $localizedField->getFieldType() . "', it's only allowed for the following fieldtypes: " . implode(",", $allowedDataTypes));
+                }
+
+                $defaultCondition = $localizedPropertyName . " = " . \Pimcore\Db::get()->quote($value) . " ";
+                $listConfig = array(
+                    "condition" => $defaultCondition
+                );
+
+                if($locale) {
+                    $listConfig["locale"] = $locale;
+                }
+            }
+            else {
+
+                $arguments = array_pad($arguments, 3, 0);
+                list($value, $limit, $offset) = $arguments;
+
+                $defaultCondition = $propertyName . " = " . \Pimcore\Db::get()->quote($value) . " ";
+                $listConfig = array(
+                    "condition" => $defaultCondition
+                );
+            }
 
             if (!is_array($limit)) {
                 if ($limit) {


### PR DESCRIPTION
Allow to call static getByLocalizedfields($fieldName, $value, $locale, $limit | array("limit", "offset")) on Objects.

## Changes in this pull request  
 - Change static method "getByLocalizedfields" to accept new parameters in PHPDoc
 - Add feature to allow getByLocalizedfields


