### PR TITLE
Use youtube-nocookie.com to comply with EU cookie guidelines

### DIFF
--- a/pimcore/models/Document/Tag/Video.php
+++ b/pimcore/models/Document/Tag/Video.php
@@ -507,7 +507,7 @@ class Video extends Model\Document\Tag
         }
 
         $code .= '<div id="pimcore_video_' . $this->getName() . '" class="pimcore_tag_video">
-            <iframe width="' . $width . '" height="' . $height . '" src="//www.youtube.com/embed/' . $youtubeId . '?wmode=transparent' . $additional_params .'" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
+            <iframe width="' . $width . '" height="' . $height . '" src="//www.youtube-nocookie.com/embed/' . $youtubeId . '?wmode=transparent' . $additional_params .'" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
         </div>';
 
         return $code;


### PR DESCRIPTION
## Additional info  

This change will display youtube videos using the URL youtube-nocookie.com which does not set cookies for visitors to comply with EU cookie guidelines.

A setting in ACP might be useful for this feature in case somebody does like youtube cookies.