### PR TITLE
add customviews to runtime perspective config

### DIFF
--- a/pimcore/lib/Pimcore/Config.php
+++ b/pimcore/lib/Pimcore/Config.php
@@ -509,6 +509,7 @@ class Config
                     $tmpData["showroot"] = (bool)$tmpData["showroot"];
                     $customViewId = $tmpData["id"];
                     $cfConfigMapping[$customViewId]= $tmpData;
+                    $tmpResult[] = $tmpData;
                 }
             }
         }


### PR DESCRIPTION
Hi, custom runtime perspectives are missing customviews trees, because their configs are not added to the elementTree configuration.