### PR TITLE
Added call to admin translation function for labels in multiselect fields

### DIFF
--- a/pimcore/static6/js/pimcore/object/tags/multiselect.js
+++ b/pimcore/static6/js/pimcore/object/tags/multiselect.js
@@ -75,7 +75,7 @@ pimcore.object.tags.multiselect = Class.create(pimcore.object.tags.abstract, {
                     }
                 }
 
-                storeData.push([value, this.fieldConfig.options[i].key]);
+                storeData.push([value, ts(this.fieldConfig.options[i].key)]);
                 validValues.push(value);
             }
         }


### PR DESCRIPTION
Admin translations for multiselect fields in object were not available as this call to the translation function seemed to be missing.