### PR TITLE
console: commands autoload on windows fix

### DIFF
--- a/pimcore/lib/Pimcore/Console/Application.php
+++ b/pimcore/lib/Pimcore/Console/Application.php
@@ -152,7 +152,7 @@ class Application extends \Symfony\Component\Console\Application
 
         /** @var SplFileInfo $file */
         foreach ($finder as $file) {
-            $subNamespace = trim(str_replace($directory, '', $file->getPath()), '/');
+            $subNamespace = trim(str_replace($directory, '', $file->getPath()), DIRECTORY_SEPARATOR);
             if (!empty($subNamespace)) {
                 $subNamespace = str_replace('/', '\\', $subNamespace);
                 $subNamespace = '\\' . $subNamespace;


### PR DESCRIPTION
Hi,

this fixes console commands autoloading on windows. There is a problem with different directory separator trimming which results in a fatal error when trying to use the console.

Regards,
Martin