### PR TITLE
Bugfix for named params in "addConditionParam"

### DIFF
--- a/pimcore/lib/Pimcore/Model/Listing/AbstractListing.php
+++ b/pimcore/lib/Pimcore/Model/Listing/AbstractListing.php
@@ -257,8 +257,9 @@ abstract class AbstractListing extends AbstractModel
                 // If there is not a placeholder, ignore value!
                 if (!$value['ignore-value']) {
                     if (is_array($value['value'])) {
-                        foreach ($value['value'] as $v) {
-                            $params[] = $v;
+                        foreach ($value['value'] as $k => $v) {
+                            //$k is for named params the key
+                            $params[ $k ] = $v;
                         }
                     } else {
                         $params[] = $value['value'];


### PR DESCRIPTION
Please read our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR. 

Fixes # 

## Changes in this pull request  

## Additional info  


addConditionParam( 'name LIKE :param', [ 'param' => 'name' ] );

Param is now set as key for the 'ConditionVariables'