### PR TITLE
Classification store: Fixed PHPDoc type in class definition

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data/Classificationstore.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Classificationstore.php
@@ -36,7 +36,7 @@ class Classificationstore extends Model\Object\ClassDefinition\Data
      *
      * @var string
      */
-    public $phpdocType = "\\Pimcore\\Model\\Object\\Data\\ClassificationStore";
+    public $phpdocType = "\\Pimcore\\Model\\Object\\Classificationstore";
 
     /**
      * @var array


### PR DESCRIPTION
With b0053fa "new datatype - calculated values" this PHPDoc type was set. However, for this classname there's no data class for the classification store.

