### PR TITLE
Area can't load action.php BUG

### DIFF
--- a/pimcore/models/Document/Tag/Area.php
+++ b/pimcore/models/Document/Tag/Area.php
@@ -150,7 +150,7 @@ class Area extends Model\Document\Tag
                     $replacement = str_replace(["-", "_"], "", $matches[0]);
 
                     return strtoupper($replacement);
-                }, ucfirst($this->currentIndex["type"]));
+                }, ucfirst($options["type"]));
 
                 $actionClassname = "\\Pimcore\\Model\\Document\\Tag\\Area\\" . $actionClass;
 


### PR DESCRIPTION
The Area load the action.php file but can't find the right classname.
There is no $this->currentIndex() so replace it with $options["type"]

Maybe a copy/paste error from the changes on May 21 :)
