### PR TITLE
Workflowmanagement - Allow actions to dictate the date of notes

### DIFF
--- a/pimcore/lib/Pimcore/WorkflowManagement/Workflow/Service.php
+++ b/pimcore/lib/Pimcore/WorkflowManagement/Workflow/Service.php
@@ -109,7 +109,15 @@ class Service
 
         if (is_array($noteData)) {
             foreach ($noteData as $row) {
-                $note->addData($row['key'], $row['type'], $row['value']);
+                if ($row['key'] === 'noteDate' && $row['type'] === 'date') {
+                    /**
+                     * @var \Pimcore\Date $date
+                     */
+                    $date = $row['value'];
+                    $note->setDate($date->getTimestamp());
+                } else {
+                    $note->addData($row['key'], $row['type'], $row['value']);
+                }
             }
         }
 


### PR DESCRIPTION
When configuring an action you can now configure the date of the note

e.g.

```
"log_telephone_call" => [
            "label" => "Log Telephone Call",
            "transitionTo" => null,
            "notes" => [
                "required" => true,
            ],
            "additionalFields" => [
                [
                    "name"=> "noteDate",
                    "fieldType" => "datetime",
                    "title" => "Date of Conversation",
                    "required" => true
                ]
            ]
        ],
```

The note will automatically look for noteDate as a field in the actions additional fields
