### PR TITLE
Decision dialog on closing dirty elements

### DIFF
--- a/pimcore/config/texts/en.json
+++ b/pimcore/config/texts/en.json
@@ -6003,5 +6003,17 @@
     {
         "term": "edit_block",
         "definition": "Edit Block"
+    },
+    {
+        "term": "allow_dirty_close",
+        "definition": "Disable unsaved content warning"
+    },
+    {
+        "term": "element_has_unsaved_changes",
+        "definition": "Element has unsaved changes"
+    },
+    {
+        "term": "element_unsaved_changes_message",
+        "definition": "All unsaved changes will be lost, are you really sure?"
     }
 ]

--- a/pimcore/models/User.php
+++ b/pimcore/models/User.php
@@ -76,11 +76,15 @@ class User extends User\UserRole
      */
     public $closeWarning = true;
 
-
     /**
      * @var bool
      */
     public $memorizeTabs = true;
+
+    /**
+     * @var bool
+     */
+    public $allowDirtyClose = false;
 
     /**
      * @var string|null
@@ -424,6 +428,25 @@ class User extends User\UserRole
     public function getMemorizeTabs()
     {
         return $this->memorizeTabs;
+    }
+
+    /**
+     * @param $allowDirtyClose
+     * @return $this
+     */
+    public function setAllowDirtyClose($allowDirtyClose)
+    {
+        $this->allowDirtyClose = (bool)$allowDirtyClose;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getAllowDirtyClose()
+    {
+        return $this->allowDirtyClose;
     }
 
     /**

--- a/pimcore/static6/js/pimcore/settings/user/user/settings.js
+++ b/pimcore/static6/js/pimcore/settings/user/user/settings.js
@@ -18,7 +18,6 @@ pimcore.settings.user.user.settings = Class.create({
     initialize:function (userPanel) {
         this.userPanel = userPanel;
 
-
         this.data = this.userPanel.data;
         this.currentUser = this.data.user;
         this.wsenabled = this.data.wsenabled;
@@ -117,7 +116,7 @@ pimcore.settings.user.user.settings = Class.create({
                             var cont = Ext.getCmp("pimcore_user_image_" + this.currentUser.id);
                             var date = new Date();
                             cont.update('<img src="/admin/user/get-image?id='
-                                                    + this.currentUser.id + '&_dc=' + date.getTime() + '" />');
+                                + this.currentUser.id + '&_dc=' + date.getTime() + '" />');
                         }.bind(this));
                 }.bind(this)
             }]
@@ -180,6 +179,13 @@ pimcore.settings.user.user.settings = Class.create({
             fieldLabel:t("memorize_tabs"),
             name:"memorizeTabs",
             checked:this.currentUser.memorizeTabs
+        });
+
+        generalItems.push({
+            xtype: "checkbox",
+            fieldLabel: t("allow_dirty_close"),
+            name: "allowDirtyClose",
+            checked: this.currentUser.allowDirtyClose
         });
 
         generalItems.push({
@@ -288,13 +294,13 @@ pimcore.settings.user.user.settings = Class.create({
                 },
                 items: [this.apiKeyField,
                     {
-                    xtype: "button",
-                    test: t("Generate"),
-                    iconCls: "pimcore_icon_clear_cache",
-                    handler: function (e) {
-                        this.apiKeyField.setValue(md5(uniqid()) + md5(uniqid()));
-                    }.bind(this)
-                }],
+                        xtype: "button",
+                        test: t("Generate"),
+                        iconCls: "pimcore_icon_clear_cache",
+                        handler: function (e) {
+                            this.apiKeyField.setValue(md5(uniqid()) + md5(uniqid()));
+                        }.bind(this)
+                    }],
                 hidden: !this.wsenabled
             });
 
@@ -325,7 +331,7 @@ pimcore.settings.user.user.settings = Class.create({
                         var res = Ext.decode(response.responseText);
                         if(res["link"]) {
                             Ext.MessageBox.alert("", t("login_as_this_user_description")
-                                            + ' <br /><br /><textarea style="width:100%;height:70px;">' + res["link"] + "</textarea>");
+                                + ' <br /><br /><textarea style="width:100%;height:70px;">' + res["link"] + "</textarea>");
                         }
                     }
                 });
@@ -364,27 +370,27 @@ pimcore.settings.user.user.settings = Class.create({
             title:t("allowed_types_to_create") + " (" + t("defaults_to_all") + ")",
             items:[
                 Ext.create('Ext.ux.form.MultiSelect', {
-                name: "docTypes",
-                triggerAction:"all",
-                editable:false,
-                fieldLabel:t("document_types"),
-                width:400,
-                displayField: "name",
-                valueField: "id",
-                store: pimcore.globalmanager.get("document_types_store"),
-                value: this.currentUser.docTypes
-            }),
+                    name: "docTypes",
+                    triggerAction:"all",
+                    editable:false,
+                    fieldLabel:t("document_types"),
+                    width:400,
+                    displayField: "name",
+                    valueField: "id",
+                    store: pimcore.globalmanager.get("document_types_store"),
+                    value: this.currentUser.docTypes
+                }),
                 Ext.create('Ext.ux.form.MultiSelect', {
-                name: "classes",
-                triggerAction:"all",
-                editable:false,
-                fieldLabel:t("classes"),
-                width:400,
-                displayField: "text",
-                valueField: "id",
-                store: pimcore.globalmanager.get("object_types_store"),
-                value: this.currentUser.classes
-            })],
+                    name: "classes",
+                    triggerAction:"all",
+                    editable:false,
+                    fieldLabel:t("classes"),
+                    width:400,
+                    displayField: "text",
+                    valueField: "id",
+                    store: pimcore.globalmanager.get("object_types_store"),
+                    value: this.currentUser.classes
+                })],
             hidden:this.currentUser.admin
         });
 


### PR DESCRIPTION
Extension to #397  

## Key Feature
Opens confirmation dialog when closing dirty elements (Document, Asset, Object). Can be enabled and disabled in the user settings as suggested in #397 .

### DB-Update
For this extension to work a small update script for the database is needed.

`ALTER TABLE users ADD COLUMN allowDirtyClose TINYINT(1) UNSIGNED NOT NULL DEFAULT 0`