### PR TITLE
update child paths also if parent has only variants as childs

### DIFF
--- a/pimcore/models/Object/AbstractObject/Dao.php
+++ b/pimcore/models/Object/AbstractObject/Dao.php
@@ -154,7 +154,7 @@ class Dao extends Model\Element\Dao
      */
     public function updateChildsPaths($oldPath)
     {
-        if ($this->hasChilds()) {
+        if ($this->hasChilds([Object::OBJECT_TYPE_OBJECT, Object::OBJECT_TYPE_FOLDER, Object::OBJECT_TYPE_VARIANT])) {
             //get objects to empty their cache
             $objects = $this->db->fetchCol("SELECT o_id FROM objects WHERE o_path LIKE ?", $oldPath . "%");
 


### PR DESCRIPTION
# Bug Report with solution
If rename an object which has variant-childs, their o_path does not change, because the object only updates if it has either at least a folder or an object child. This makes the database inconsistent as the variant childs have a path which does not exist. The solution is the check for variant childs in the updateChildPaths method of the Dao.