### PR TITLE
Workflowmanagement - Updated References in Decorator for notes

### DIFF
--- a/pimcore/lib/Pimcore/WorkflowManagement/Workflow/Decorator.php
+++ b/pimcore/lib/Pimcore/WorkflowManagement/Workflow/Decorator.php
@@ -114,8 +114,8 @@ class Decorator
     public function getNoteType($actionName, $formData)
     {
         $config = $this->workflow->getActionConfig($actionName);
-        if (!empty($config['note_type'])) {
-            return $config['note_type'];
+        if (!empty($config['noteType'])) {
+            return $config['noteType'];
         }
 
         if ($this->workflow->isGlobalAction($actionName)) {
@@ -129,8 +129,8 @@ class Decorator
     public function getNoteTitle($actionName, $formData)
     {
         $config = $this->workflow->getActionConfig($actionName);
-        if (!empty($config['note_title'])) {
-            return $config['note_title'];
+        if (!empty($config['noteTitle'])) {
+            return $config['noteTitle'];
         }
 
         if ($this->workflow->isGlobalAction($actionName) || $formData['oldStatus'] === $formData['newStatus']) {


### PR DESCRIPTION
Sicking with convention, the note_title and note_type configs which are used for customising the type and title of the notes created during an action have been updated to camelCase