### PR TITLE
Fixed PHP warning in Pimcore/Update

### DIFF
--- a/pimcore/lib/Pimcore/Update.php
+++ b/pimcore/lib/Pimcore/Update.php
@@ -320,8 +320,8 @@ class Update
 
         Cache::disable(); // it's important to disable the cache here eg. db-schemas, ...
 
+        $outputMessage = "";
         if (is_file($script)) {
-            $outputMessage = "";
             ob_start();
             try {
                 if (!self::$dryRun) {


### PR DESCRIPTION
Please read our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR. 

Fixes # 

## Changes in this pull request  

## Additional info  


If is_file is not true, you will get an e_notice in line 341, because $outputMessage is not set.
E_NOTICE: Undefined variable: outputMessage in /.../pimcore/lib/Pimcore/Update.php:334