### PR TITLE
Bugfix: Inputfield for traits was missing

### DIFF
--- a/pimcore/static6/js/pimcore/object/classes/class.js
+++ b/pimcore/static6/js/pimcore/object/classes/class.js
@@ -716,6 +716,13 @@ pimcore.object.classes.klass = Class.create({
                 },
                 {
                     xtype: "textfield",
+                    fieldLabel: t("use_traits"),
+                    name: "useTraits",
+                    width: 600,
+                    value: this.data.useTraits
+                },
+                {
+                    xtype: "textfield",
                     fieldLabel: t("icon"),
                     name: "icon",
                     width: 600,


### PR DESCRIPTION
The input field for traits in the new Extjs6 surface of class definitions was gone missing.
This fix adds it again.