### PR TITLE
docs: Fix for example code in "Accessing Classification Store through code"

### DIFF
--- a/docs/Development_Documentation/05_Objects/01_Object_Classes/03_Structured_Data_Fields/08_Classification_Store.md
+++ b/docs/Development_Documentation/05_Objects/01_Object_Classes/03_Structured_Data_Fields/08_Classification_Store.md
@@ -111,7 +111,7 @@ $config = new \Pimcore\Model\Object\Classificationstore\KeyConfig();
 $config->setName($name);
 $config->setDescription($description);
 $config->setEnabled(true);
-$config->setType("text");
+$config->setType("input");
 $config->setDefinition(json_encode($definition)); // The definition is used in object editor to render fields
 $config->save();
   


### PR DESCRIPTION
Minor documentation fix for Classification store example code.