### PR TITLE
Update AbstractObject.php

### DIFF
--- a/pimcore/models/Object/AbstractObject.php
+++ b/pimcore/models/Object/AbstractObject.php
@@ -236,7 +236,8 @@ class AbstractObject extends Model\Element\AbstractElement
         $cacheKey = "object_" . $id;
 
         try {
-            $object = \Zend_Registry::get($cacheKey);
+            // we need to have new instance of model, in other case it will be a reference
+            $object = clone \Zend_Registry::get($cacheKey);
             if (!$object) {
                 throw new \Exception("Object\\AbstractObject: object in registry is null");
             }


### PR DESCRIPTION
Model from cache are passing by reference it cause problems when you need to use same model twice.

Anyway each model should be separated from others.


