### PR TITLE
thumbnail configuration: use di to get config class

### DIFF
--- a/pimcore/config/di.php
+++ b/pimcore/config/di.php
@@ -8,4 +8,6 @@ return [
     'Pimcore\Model\Object\*' => DI\object('Pimcore\Model\Object\*'),
 
     \Pimcore\Image\Adapter::class => DI\factory([\Pimcore\Image::class, 'create']),
+	'Pimcore\Model\Asset\Image\Thumbnail\Config' => DI\object('Pimcore\Model\Asset\Image\Thumbnail\Config'),
+	'Pimcore\Model\Asset\Video\Thumbnail\Config' => DI\object('Pimcore\Model\Asset\Video\Thumbnail\Config'),
 ];

--- a/pimcore/lib/Pimcore/Console/Command/ThumbnailsImageCommand.php
+++ b/pimcore/lib/Pimcore/Console/Command/ThumbnailsImageCommand.php
@@ -98,7 +98,8 @@ class ThumbnailsImageCommand extends AbstractCommand
                 }
 
                 if ($input->getOption("system")) {
-                    $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig();
+                    $thumbnail = \Pimcore::getDiContainer()->get('Pimcore\Model\Asset\Image\Thumbnail\Config');
+                    $thumbnail = $thumbnail::getPreviewConfig();
                     if ($input->getOption("force")) {
                         $image->clearThumbnail($thumbnail->getName());
                     }

--- a/pimcore/lib/Pimcore/Console/Command/ThumbnailsVideoCommand.php
+++ b/pimcore/lib/Pimcore/Console/Command/ThumbnailsVideoCommand.php
@@ -100,7 +100,8 @@ class ThumbnailsVideoCommand extends AbstractCommand
 
                 if ($input->getOption("system")) {
                     $this->output->writeln("generating thumbnail for video: " . $video->getRealFullPath() . " | " . $video->getId() . " | Thumbnail: System Preview : " . formatBytes(memory_get_usage()));
-                    $thumbnail = Asset\Video\Thumbnail\Config::getPreviewConfig();
+                    $thumbnail = \Pimcore::getDiContainer()->get('Pimcore\Model\Asset\Video\Thumbnail\Config');
+                    $thumbnail = $thumbnail::getPreviewConfig();
                     $video->getThumbnail($thumbnail);
                     $this->waitTillFinished($video->getId(), $thumbnail);
                 }

--- a/pimcore/models/Asset/Image.php
+++ b/pimcore/models/Asset/Image.php
@@ -63,7 +63,8 @@ class Image extends Model\Asset
         // now directly create "system" thumbnails (eg. for the tree, ...)
         if ($this->getDataChanged()) {
             try {
-                $path = $this->getThumbnail(Image\Thumbnail\Config::getPreviewConfig())->getFileSystemPath();
+                $config = \Pimcore::getDiContainer()->get('Pimcore\Model\Asset\Image\Thumbnail\Config');
+                $path = $this->getThumbnail($config::getPreviewConfig())->getFileSystemPath();
 
                 // set the modification time of the thumbnail to the same time from the asset
                 // so that the thumbnail check doesn't fail in Asset\Image\Thumbnail\Processor::process();

--- a/pimcore/modules/admin/controllers/AssetController.php
+++ b/pimcore/modules/admin/controllers/AssetController.php
@@ -889,7 +889,8 @@ class Admin_AssetController extends \Pimcore\Controller\Action\Admin\Element
         }
 
         if ($this->getParam("treepreview")) {
-            $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig();
+            $thumbnail = \Pimcore::getDiContainer()->get('Pimcore\Model\Asset\Image\Thumbnail\Config');
+            $thumbnail = $thumbnail::getPreviewConfig();
         }
 
         if ($this->getParam("cropPercent")) {
@@ -947,7 +948,8 @@ class Admin_AssetController extends \Pimcore\Controller\Action\Admin\Element
         $thumbnail = $this->getAllParams();
 
         if ($this->getParam("treepreview")) {
-            $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig();
+            $thumbnail = \Pimcore::getDiContainer()->get('Pimcore\Model\Asset\Image\Thumbnail\Config');
+            $thumbnail = $thumbnail::getPreviewConfig();
         }
 
         $time = null;
@@ -995,7 +997,8 @@ class Admin_AssetController extends \Pimcore\Controller\Action\Admin\Element
         }
 
         if ($this->getParam("treepreview")) {
-            $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig();
+            $thumbnail = \Pimcore::getDiContainer()->get('Pimcore\Model\Asset\Image\Thumbnail\Config');
+            $thumbnail = $thumbnail::getPreviewConfig();
         }
 
         $page = 1;
@@ -1043,7 +1046,8 @@ class Admin_AssetController extends \Pimcore\Controller\Action\Admin\Element
 
         $this->view->asset = $asset;
 
-        $config = Asset\Video\Thumbnail\Config::getPreviewConfig();
+        $config = \Pimcore::getDiContainer()->get('Pimcore\Model\Asset\Video\Thumbnail\Config');
+        $config = $config::getPreviewConfig();
 
         $thumbnail = $asset->getThumbnail($config, ["mp4"]);
 


### PR DESCRIPTION
## Changes in this pull request  
Use DI for the image and video thumbnail configurations, so that you can overwrite it.

## Additional info  
I included the full class name into di.php to prevent Pimcore\Model\Asset\* from interfering and Pimcore\Model\Asset\Image\Thumbnail\* would be more of a burden than of help.

Thanks for implementing DI 👍 