### PR TITLE
Removed duplicate code for determining inheritable parent object

### DIFF
--- a/pimcore/models/Object/Concrete.php
+++ b/pimcore/models/Object/Concrete.php
@@ -523,8 +523,7 @@ class Concrete extends AbstractObject
 
 
     /**
-     * @return AbstractObject|void
-     * @return AbstractObject|void
+     * @return AbstractObject|null
      */
     public function getNextParentForInheritance()
     {
@@ -541,7 +540,7 @@ class Concrete extends AbstractObject
             }
         }
 
-        return;
+        return null;
     }
 
     /**

--- a/pimcore/models/Object/Service.php
+++ b/pimcore/models/Object/Service.php
@@ -526,24 +526,15 @@ class Service extends Model\Element\Service
 
     /**
      * @param Concrete $object
-     * @return AbstractObject
+     * @return AbstractObject|null
      */
     public static function hasInheritableParentObject(Concrete $object)
     {
         if ($object->getClass()->getAllowInherit()) {
-            if ($object->getParent() instanceof AbstractObject) {
-                $parent = $object->getParent();
-                while ($parent && $parent->getType() == "folder") {
-                    $parent = $parent->getParent();
-                }
-
-                if ($parent && ($parent->getType() == "object" || $parent->getType() == "variant")) {
-                    if ($parent->getClassId() == $object->getClassId()) {
-                        return $parent;
-                    }
-                }
-            }
+            return $object->getNextParentForInheritance();
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
This change removed duplicate code for determining whether an object has an inheritable parent object.

I noticed this duplication while trying to override `Object\Concrete::getNextParentForInheritance()` but having not the desired effect as `Object\Service::hasInheritableParentObject()` implemented it again.