### PR TITLE
Workflowmanagement - Refresh of formData after the preAction event

### DIFF
--- a/pimcore/lib/Pimcore/WorkflowManagement/Workflow/Manager.php
+++ b/pimcore/lib/Pimcore/WorkflowManagement/Workflow/Manager.php
@@ -466,6 +466,9 @@ class Manager
         \Pimcore::getEventManager()->trigger("workflowmanagement.preAction", $this, [
             'actionName' => $actionName
         ]);
+        
+        //refresh the local copy after the event
+        $formData = $this->getActionData();
 
         $actionConfig = $this->workflow->getActionConfig($actionName, $this->getElementStatus());
         $additional = $formData['additional'];


### PR DESCRIPTION
## Changes in this pull request  

This small adjustment should make it possible to change the formData entirely within the preAction event. I came across this requirement when migrating a client. We have scenarios where we need to override the state / status of an action based on certain element information.