### PR TITLE
Sent email enhanced log fix

### DIFF
--- a/pimcore/modules/admin/controllers/EmailController.php
+++ b/pimcore/modules/admin/controllers/EmailController.php
@@ -232,9 +232,9 @@ class Admin_EmailController extends \Pimcore\Controller\Action\Admin\Document
      */
     protected function enhanceLoggingData(&$data, &$fullEntry = null)
     {
-        if ($data['objectId']) {
-            if (is_subclass_of($class, "\\Pimcore\\Model\\Element\\ElementInterface")) {
-                $class = "\\" . ltrim($data['objectClass'], "\\");
+        if (!empty($data['objectClass'])) {
+            $class = "\\" . ltrim($data['objectClass'], "\\");
+            if (!empty($data['objectId']) && is_subclass_of($class, "\\Pimcore\\Model\\Element\\ElementInterface")) {
                 $obj = $class::getById($data['objectId']);
                 if (is_null($obj)) {
                     $data['objectPath'] = '';

--- a/pimcore/modules/admin/controllers/EmailController.php
+++ b/pimcore/modules/admin/controllers/EmailController.php
@@ -241,7 +241,13 @@ class Admin_EmailController extends \Pimcore\Controller\Action\Admin\Document
                 } else {
                     $data['objectPath'] = $obj->getRealFullPath();
                 }
-                $niceClassName = str_replace("\\Pimcore\\Model\\", "", $data['objectClass']);
+                //check for classmapping
+                if (stristr($class, "\\Pimcore\\Model") === false) {
+                    $niceClassName = "\\" . ltrim(get_parent_class($class), "\\");
+                } else {
+                    $niceClassName = $class;
+                }
+                $niceClassName = str_replace("\\Pimcore\\Model\\", "", $niceClassName);
                 $niceClassName = str_replace("_", "\\", $niceClassName);
 
                 $tmp = explode("\\", $niceClassName);


### PR DESCRIPTION
Hi,

this is a small fix for the dynamic parameters popup in sent e-mails log. Any asset/document/object parameter is now always marked as deleted. This PR should fix that and also ads a check for classmapping when determinig the pimcore element type.

Before PR:
![before](https://cloud.githubusercontent.com/assets/2148902/17803895/6dadd234-65f9-11e6-84fd-6e0ea6b38629.png)

After PR:
![after](https://cloud.githubusercontent.com/assets/2148902/17803947/b01c96a0-65f9-11e6-987b-dda21f1ae4f0.png)

M.
