### PR TITLE
Workflowmanagement - Added support for "user" fieldType in actions

### DIFF
--- a/pimcore/lib/Pimcore/WorkflowManagement/Workflow/Manager.php
+++ b/pimcore/lib/Pimcore/WorkflowManagement/Workflow/Manager.php
@@ -17,7 +17,6 @@ namespace Pimcore\WorkflowManagement\Workflow;
 use Pimcore\Model\Element\AbstractElement;
 use Pimcore\Model\Element\Service;
 use Pimcore\Model\Element\WorkflowState;
-use Pimcore\Model\Object\ClassDefinition;
 use Pimcore\Model\Object\Concrete as ConcreteObject;
 use Pimcore\Model\Document;
 use Pimcore\Model\Asset;
@@ -353,7 +352,17 @@ class Manager
      */
     public function getAdditionalFieldsForAction($actionName)
     {
-        return $this->getWorkflow()->getAdditionalFieldsForAction($actionName, $this->getElementStatus());
+        $additionalFields = $this->getWorkflow()->getAdditionalFieldsForAction($actionName, $this->getElementStatus());
+
+        foreach($additionalFields as &$field) {
+            if ($field['fieldType'] === 'user') {
+                $userdata = new \Pimcore\Model\Object\ClassDefinition\Data\User();
+                $userdata->configureOptions();
+                $field['options'] = $userdata->getOptions();
+            }
+        }
+
+        return $additionalFields;
     }
 
 

--- a/pimcore/static6/js/pimcore/workflowmanagement/actionPanel.js
+++ b/pimcore/static6/js/pimcore/workflowmanagement/actionPanel.js
@@ -420,7 +420,7 @@ pimcore.workflowmanagement.actionPanel = Class.create({
         Ext.each(additional, function(c) {
             //add a new field
             var field = {};
-            var supportedTags = ['input', 'textarea', 'select', 'datetime', 'date'];
+            var supportedTags = ['input', 'textarea', 'select', 'datetime', 'date', 'user'];
 
             if (in_array(c.fieldType, supportedTags)) {
 


### PR DESCRIPTION
## Changes in this pull request  

## Additional info  
example action configuration:

```
[
    "name" => "create_task",
    "label" => "Create Task",
    "additionalFields"=>[
        [
            "name" => "assignee",
            "fieldType"=> "user"
        ]
    ],
    "notes" => [
        "required" => false
    ]
],
```


