### PR TITLE
Classification store: Allow setting value zero ("0")

### DIFF
--- a/pimcore/models/Object/Classificationstore.php
+++ b/pimcore/models/Object/Classificationstore.php
@@ -152,7 +152,10 @@ class Classificationstore extends Model\AbstractModel
     {
         $language  = $this->getLanguage($language);
 
-        if ($value) {
+        // treat value "0" nonempty
+        $nonEmpty = (is_string($value) || is_numeric($value)) && strlen($value) > 0;
+
+        if ($nonEmpty || $value) {
             $this->items[$groupId][$keyId][$language] = $value;
         } elseif (isset($this->items[$groupId][$keyId][$language])) {
             unset($this->items[$groupId][$keyId][$language]);


### PR DESCRIPTION
Value "0" evaluated to false in condition if($value) and thus not allow setting/saving this ordinary value.