### PR TITLE
added missing/correcting processor items parameters

### DIFF
--- a/pimcore/models/Asset/Image/Thumbnail/Processor.php
+++ b/pimcore/models/Asset/Image/Thumbnail/Processor.php
@@ -26,8 +26,8 @@ class Processor
 {
     protected static $argumentMapping = [
         "resize" => ["width", "height"],
-        "scaleByWidth" => ["width"],
-        "scaleByHeight" => ["height"],
+        "scaleByWidth" => ["width", "forceResize"],
+        "scaleByHeight" => ["height", "forceResize"],
         "contain" => ["width", "height"],
         "cover" => ["width", "height", "positioning", "doNotScaleUp"],
         "frame" => ["width", "height"],
@@ -35,7 +35,7 @@ class Processor
         "rotate" => ["angle"],
         "crop" => ["x", "y", "width", "height"],
         "setBackgroundColor" => ["color"],
-        "roundCorners" => ["width", "height"],
+        "roundCorners" => ["x", "y"],
         "setBackgroundImage" => ["path"],
         "addOverlay" => ["path", "x", "y", "alpha", "composite", "origin"],
         "addOverlayFit" => ["path", "composite"],


### PR DESCRIPTION
Here you will find some small fixes to thumbnail processor (wrong name of parameters for roundCorner and missing parameters for scaleBy).

Merging this pull request will solve https://github.com/pimcore/pimcore/issues/783 (i have updated some days ago with a real use case with zip exemple, where this missing paramters is needed - extending/DI thumbnail image and using items pipeline).

By the way can i prepare a pull request for https://github.com/pimcore/pimcore/issues/786 ? (i ask here at it is on the same thema).

Thanks.

