### PR TITLE
Refactor the URL cleanup logic to avoid chained redirects

### DIFF
--- a/pimcore/lib/Pimcore/Controller/Router/Route/Frontend.php
+++ b/pimcore/lib/Pimcore/Controller/Router/Route/Frontend.php
@@ -244,6 +244,8 @@ class Frontend extends \Zend_Controller_Router_Route_Abstract
                     if (in_array($document->getType(), self::getDirectRouteDocumentTypes())) {
                         if (Tool::isFrontentRequestByAdmin() || $document->isPublished()) {
 
+                            $finalUrl = $originalPath;
+
                             // check for a pretty url, and if the document is called by that, otherwise redirect to pretty url
                             if ($document instanceof Document\Page
                                 && !($document instanceof Document\Hardlink\Wrapper\WrapperInterface)
@@ -251,12 +253,7 @@ class Frontend extends \Zend_Controller_Router_Route_Abstract
                                 && !Tool::isFrontentRequestByAdmin()
                             ) {
                                 if (rtrim(strtolower($document->getPrettyUrl()), " /") != rtrim(strtolower($originalPath), "/")) {
-                                    $redirectUrl = $document->getPrettyUrl();
-                                    if ($_SERVER["QUERY_STRING"]) {
-                                        $redirectUrl .= "?" . $_SERVER["QUERY_STRING"];
-                                    }
-                                    header("Location: " . $redirectUrl, true, 301);
-                                    exit;
+                                    $finalUrl = $document->getPrettyUrl();
                                 }
                             }
 
@@ -279,29 +276,27 @@ class Frontend extends \Zend_Controller_Router_Route_Abstract
                             if (strtolower($_SERVER["REQUEST_METHOD"]) == "get") {
                                 if ($config->documents->allowtrailingslash) {
                                     if ($config->documents->allowtrailingslash == "no") {
-                                        if (substr($originalPath, strlen($originalPath)-1, 1) == "/" && $originalPath != "/") {
-                                            $redirectUrl = rtrim($originalPath, "/");
-                                            if ($_SERVER["QUERY_STRING"]) {
-                                                $redirectUrl .= "?" . $_SERVER["QUERY_STRING"];
-                                            }
-                                            header("Location: " . $redirectUrl, true, 301);
-                                            exit;
+                                        if (substr($finalUrl, strlen($finalUrl) - 1, 1) == "/" && $finalUrl != "/") {
+                                            $finalUrl = rtrim($finalUrl, "/");
                                         }
                                     }
                                 }
 
                                 if ($config->documents->allowcapitals) {
                                     if ($config->documents->allowcapitals == "no") {
-                                        if (strtolower($originalPath) != $originalPath) {
-                                            $redirectUrl = strtolower($originalPath);
-                                            if ($_SERVER["QUERY_STRING"]) {
-                                                $redirectUrl .= "?" . $_SERVER["QUERY_STRING"];
-                                            }
-                                            header("Location: " . $redirectUrl, true, 301);
-                                            exit;
+                                        if (strtolower($finalUrl) != $finalUrl) {
+                                            $finalUrl = strtolower($finalUrl);
                                         }
                                     }
                                 }
+                            }
+
+                            if ($finalUrl !== $originalPath) {
+                                if ($_SERVER["QUERY_STRING"]) {
+                                    $finalUrl .= "?" . $_SERVER["QUERY_STRING"];
+                                }
+                                header("Location: " . $finalUrl, true, 301);
+                                exit;
                             }
 
                             $matchFound = true;


### PR DESCRIPTION
Chaining 301 redirects is bad for user experience (more delay), for SEO, and for performance. We should clean the URL once, instead of redirecting the user at every step of the process.
![screen shot 2016-08-29 at 18 44 34](https://cloud.githubusercontent.com/assets/1093360/18059342/d72c7fae-6e18-11e6-89ff-ac5f357b5bd6.png)

## Changes in this pull request  
- Creating a `$finalUrl` variable in Frontend router used along the url cleaning process ;
- Remove 3 identical blocks of code and run this code only at the end of the cleaning process, only if the `$finalUrl` is different than the `$originalPath`.