### PR TITLE
Allow empty units in quantity value field

### DIFF
--- a/pimcore/static6/js/pimcore/object/tags/quantityValue.js
+++ b/pimcore/static6/js/pimcore/object/tags/quantityValue.js
@@ -77,7 +77,7 @@ pimcore.object.tags.quantityValue = Class.create(pimcore.object.tags.abstract, {
             editable: true,
             selectOnFocus: true,
             allowBlank: true,
-            forceSelection: true,
+            forceSelection: false,
             store: this.store,
             valueField: 'id',
             displayField: 'abbreviation',


### PR DESCRIPTION
This allows for quantity values to be empty. This is important for inheritance - in case the user changes the value in an inherited object or variant, the user can't revert back to inherited state since he cannot set the unit to empty, which is required in order for inheritance to kick back in.

I tested it and didn't notice any unwanted behaviour caused by this change.
