### PR TITLE
doNotScaleUp for GUI, inline thumbnail and homogeneous

### DIFF
--- a/pimcore/lib/Pimcore/Image/Adapter.php
+++ b/pimcore/lib/Pimcore/Image/Adapter.php
@@ -137,9 +137,9 @@ abstract class Adapter
      * @param  $width
      * @return self
      */
-    public function scaleByWidth($width, $forceResize = false)
+    public function scaleByWidth($width, $doNotScaleUp = true)
     {
-        if ($forceResize || $width <= $this->getWidth() || $this->isVectorGraphic()) {
+        if ((!$doNotScaleUp) || $width <= $this->getWidth() || $this->isVectorGraphic()) {
             $height = round(($width / $this->getWidth()) * $this->getHeight(), 0);
             $this->resize(max(1, $width), max(1, $height));
         }
@@ -151,9 +151,9 @@ abstract class Adapter
      * @param  $height
      * @return self
      */
-    public function scaleByHeight($height, $forceResize = false)
+    public function scaleByHeight($height, $doNotScaleUp = true)
     {
-        if ($forceResize || $height < $this->getHeight() || $this->isVectorGraphic()) {
+        if ((!$doNotScaleUp) || $height < $this->getHeight() || $this->isVectorGraphic()) {
             $width = round(($height / $this->getHeight()) * $this->getWidth(), 0);
             $this->resize(max(1, $width), max(1, $height));
         }
@@ -164,18 +164,19 @@ abstract class Adapter
     /**
      * @param  $width
      * @param  $height
+     * @param  bool $doNotScaleUp
      * @return self
      */
-    public function contain($width, $height)
+    public function contain($width, $height, $doNotScaleUp = true)
     {
         $x = $this->getWidth() / $width;
         $y = $this->getHeight() / $height;
-        if ($x <= 1 && $y <= 1 && !$this->isVectorGraphic()) {
+        if ($doNotScaleUp && $x <= 1 && $y <= 1 && !$this->isVectorGraphic()) {
             return $this;
         } elseif ($x > $y) {
-            $this->scaleByWidth($width);
+            $this->scaleByWidth($width, $doNotScaleUp);
         } else {
-            $this->scaleByHeight($height);
+            $this->scaleByHeight($height, $doNotScaleUp);
         }
 
         return $this;
@@ -185,18 +186,18 @@ abstract class Adapter
      * @param  $width
      * @param  $height
      * @param string $orientation
+     * @param  bool $doNotScaleUp
      * @return self
      */
     public function cover($width, $height, $orientation = "center", $doNotScaleUp = true)
     {
-        $scaleUp = $doNotScaleUp ? false : true;
-
+        if (empty($orientation)) $orientation = "center"; // if not set (from GUI for instance) - default value in getByLegacyConfig method of Config object too
         $ratio = $this->getWidth() / $this->getHeight();
 
         if (($width / $height) > $ratio) {
-            $this->scaleByWidth($width, $scaleUp);
+            $this->scaleByWidth($width, $doNotScaleUp);
         } else {
-            $this->scaleByHeight($height, $scaleUp);
+            $this->scaleByHeight($height, $doNotScaleUp);
         }
 
         if ($orientation == "center") {
@@ -243,9 +244,10 @@ abstract class Adapter
     /**
      * @param $width
      * @param $height
+     * @param  bool $doNotScaleUp
      * @return $this
      */
-    public function frame($width, $height)
+    public function frame($width, $height, $doNotScaleUp = true)
     {
         return $this;
     }

--- a/pimcore/lib/Pimcore/Image/Adapter/GD.php
+++ b/pimcore/lib/Pimcore/Image/Adapter/GD.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Pimcore
  *
@@ -210,13 +210,14 @@ class GD extends Adapter
     /**
      * @param  $width
      * @param  $height
+     * @param  bool $doNotScaleUp
      * @return self
      */
-    public function frame($width, $height)
+    public function frame($width, $height, $doNotScaleUp = true)
     {
         $this->preModify();
 
-        $this->contain($width, $height);
+        $this->contain($width, $height, $doNotScaleUp);
 
         $x = ($width - $this->getWidth()) / 2;
         $y = ($height - $this->getHeight()) / 2;

--- a/pimcore/lib/Pimcore/Image/Adapter/Imagick.php
+++ b/pimcore/lib/Pimcore/Image/Adapter/Imagick.php
@@ -436,13 +436,14 @@ class Imagick extends Adapter
     /**
      * @param $width
      * @param $height
+     * @param  bool $doNotScaleUp
      * @return $this
      */
-    public function frame($width, $height)
+    public function frame($width, $height, $doNotScaleUp = true)
     {
         $this->preModify();
 
-        $this->contain($width, $height);
+        $this->contain($width, $height, $doNotScaleUp);
 
         $x = ($width - $this->getWidth()) / 2;
         $y = ($height - $this->getHeight()) / 2;

--- a/pimcore/models/Asset/Image/Thumbnail/Config.php
+++ b/pimcore/models/Asset/Image/Thumbnail/Config.php
@@ -466,41 +466,49 @@ class Config extends Model\AbstractModel
             $pipe->addItem("cover", [
                 "width" => $config["width"],
                 "height" => $config["height"],
-                "positioning" => "center"
+                "positioning" => ((isset($config["positioning"]) && !empty($config["positioning"])) ? (string)$config["positioning"] : "center"),
+                "doNotScaleUp" => (isset($config["doNotScaleUp"]) ? (bool)$config["doNotScaleUp"] : true)
             ]);
         } elseif (isset($config["contain"])) {
             $pipe->addItem("contain", [
                 "width" => $config["width"],
-                "height" => $config["height"]
+                "height" => $config["height"],
+                "doNotScaleUp" => (isset($config["doNotScaleUp"]) ? (bool)$config["doNotScaleUp"] : true)
             ]);
         } elseif (isset($config["frame"])) {
             $pipe->addItem("frame", [
                 "width" => $config["width"],
-                "height" => $config["height"]
+                "height" => $config["height"],
+                "doNotScaleUp" => (isset($config["doNotScaleUp"]) ? (bool)$config["doNotScaleUp"] : true)
             ]);
         } elseif (isset($config["aspectratio"]) && $config["aspectratio"]) {
             if (isset($config["height"]) && isset($config["width"]) && $config["height"] > 0 && $config["width"] > 0) {
                 $pipe->addItem("contain", [
                     "width" => $config["width"],
-                    "height" => $config["height"]
+                    "height" => $config["height"],
+                    "doNotScaleUp" => (isset($config["doNotScaleUp"]) ? (bool)$config["doNotScaleUp"] : true)
                 ]);
             } elseif (isset($config["height"]) && $config["height"] > 0) {
                 $pipe->addItem("scaleByHeight", [
-                    "height" => $config["height"]
+                    "height" => $config["height"],
+                    "doNotScaleUp" => (isset($config["doNotScaleUp"]) ? (bool)$config["doNotScaleUp"] : true)
                 ]);
             } else {
                 $pipe->addItem("scaleByWidth", [
-                    "width" => $config["width"]
+                    "width" => $config["width"],
+                    "doNotScaleUp" => (isset($config["doNotScaleUp"]) ? (bool)$config["doNotScaleUp"] : true)
                 ]);
             }
         } else {
             if (!isset($config["width"]) && isset($config["height"])) {
                 $pipe->addItem("scaleByHeight", [
-                    "height" => $config["height"]
+                    "height" => $config["height"],
+                    "doNotScaleUp" => (isset($config["doNotScaleUp"]) ? (bool)$config["doNotScaleUp"] : true)
                 ]);
             } elseif (isset($config["width"]) && !isset($config["height"])) {
                 $pipe->addItem("scaleByWidth", [
-                    "width" => $config["width"]
+                    "width" => $config["width"],
+                    "doNotScaleUp" => (isset($config["doNotScaleUp"]) ? (bool)$config["doNotScaleUp"] : true)
                 ]);
             } elseif (isset($config["width"]) && isset($config["height"])) {
                 $pipe->addItem("resize", [

--- a/pimcore/models/Asset/Image/Thumbnail/Processor.php
+++ b/pimcore/models/Asset/Image/Thumbnail/Processor.php
@@ -26,11 +26,11 @@ class Processor
 {
     protected static $argumentMapping = [
         "resize" => ["width", "height"],
-        "scaleByWidth" => ["width"],
-        "scaleByHeight" => ["height"],
-        "contain" => ["width", "height"],
+        "scaleByWidth" => ["width", "doNotScaleUp"],
+        "scaleByHeight" => ["height", "doNotScaleUp"],
+        "contain" => ["width", "height", "doNotScaleUp"],
         "cover" => ["width", "height", "positioning", "doNotScaleUp"],
-        "frame" => ["width", "height"],
+        "frame" => ["width", "height", "doNotScaleUp"],
         "trim" => ["tolerance"],
         "rotate" => ["angle"],
         "crop" => ["x", "y", "width", "height"],

--- a/pimcore/static/js/pimcore/settings/thumbnail/item.js
+++ b/pimcore/static/js/pimcore/settings/thumbnail/item.js
@@ -399,6 +399,11 @@ pimcore.settings.thumbnail.items = {
                 width: 60,
                 value: data.height
             },{
+                xtype: "checkbox",
+                name: "doNotScaleUp",
+                checked: data["doNotScaleUp"],
+                fieldLabel: t("do_not_scale_up")
+            },{
                 xtype: "hidden",
                 name: "type",
                 value: "scaleByHeight"
@@ -432,6 +437,11 @@ pimcore.settings.thumbnail.items = {
                 fieldLabel: t("width"),
                 width: 60,
                 value: data.width
+            },{
+                xtype: "checkbox",
+                name: "doNotScaleUp",
+                checked: data["doNotScaleUp"],
+                fieldLabel: t("do_not_scale_up")
             },{
                 xtype: "hidden",
                 name: "type",
@@ -476,6 +486,11 @@ pimcore.settings.thumbnail.items = {
                     width: 60,
                     value: data.height
                 }]
+            },{
+                xtype: "checkbox",
+                name: "doNotScaleUp",
+                checked: data["doNotScaleUp"],
+                fieldLabel: t("do_not_scale_up")
             },{
                 xtype: "hidden",
                 name: "type",
@@ -596,7 +611,7 @@ pimcore.settings.thumbnail.items = {
                 name: "doNotScaleUp",
                 checked: data["doNotScaleUp"],
                 fieldLabel: t("do_not_scale_up")
-            }, {
+            },{
                 xtype: "hidden",
                 name: "type",
                 value: "cover"
@@ -640,6 +655,11 @@ pimcore.settings.thumbnail.items = {
                     width: 60,
                     value: data.height
                 }]
+            },{
+                xtype: "checkbox",
+                name: "doNotScaleUp",
+                checked: data["doNotScaleUp"],
+                fieldLabel: t("do_not_scale_up")
             },{
                 xtype: "hidden",
                 name: "type",

--- a/pimcore/static6/js/pimcore/settings/thumbnail/item.js
+++ b/pimcore/static6/js/pimcore/settings/thumbnail/item.js
@@ -351,6 +351,11 @@ pimcore.settings.thumbnail.items = {
                 width: 210,
                 value: data.height
             },{
+                xtype: "checkbox",
+                name: "doNotScaleUp",
+                checked: data["doNotScaleUp"],
+                fieldLabel: t("do_not_scale_up")
+            },{
                 xtype: "hidden",
                 name: "type",
                 value: "scaleByHeight"
@@ -384,6 +389,11 @@ pimcore.settings.thumbnail.items = {
                 fieldLabel: t("width"),
                 width: 210,
                 value: data.width
+            },{
+                xtype: "checkbox",
+                name: "doNotScaleUp",
+                checked: data["doNotScaleUp"],
+                fieldLabel: t("do_not_scale_up")
             },{
                 xtype: "hidden",
                 name: "type",
@@ -433,6 +443,11 @@ pimcore.settings.thumbnail.items = {
                     width: 95,
                     value: data.height
                 }]
+            },{
+                xtype: "checkbox",
+                name: "doNotScaleUp",
+                checked: data["doNotScaleUp"],
+                fieldLabel: t("do_not_scale_up")
             },{
                 xtype: "hidden",
                 name: "type",
@@ -568,7 +583,7 @@ pimcore.settings.thumbnail.items = {
                 name: "doNotScaleUp",
                 checked: data["doNotScaleUp"],
                 fieldLabel: t("do_not_scale_up")
-            }, {
+            },{
                 xtype: "hidden",
                 name: "type",
                 value: "cover"
@@ -617,6 +632,11 @@ pimcore.settings.thumbnail.items = {
                     width: 95,
                     value: data.height
                 }]
+            },{
+                xtype: "checkbox",
+                name: "doNotScaleUp",
+                checked: data["doNotScaleUp"],
+                fieldLabel: t("do_not_scale_up")
             },{
                 xtype: "hidden",
                 name: "type",


### PR DESCRIPTION
Here is the pull request for https://github.com/pimcore/pimcore/issues/786

It includes:
- "forceResize" has been changed to "doNotScaleUp" for consistency accross the code. Backward compatibility is not broken as  forceResize was not publically available (doNotScaleUp was publicaly accesible so changing it will have break compatibility).
- Implemented for all resizing methods wich could need this: scaleByWidth, scaleByHeight, cover, contain and frame
- Could be used as inline thumbnail generation: $assetImage->getThumbnail(["frame" => true, "width" => 500, "height" => 300, "doNotScaleUp" => false]);
- GUI Thumbnail on Pimcore backend updated for extjs4 and extjs6 so it can be configured and used from herre
- Bug corrected for cover: in GUI by default "Positioning" is empty, so in the method "cover" of Adapter.php, "center" is set as default if empty (as it is done actually in getByLegacyConfig method of Config object)

Thanks!


