### PR TITLE
Add dailymotion as video source (like youtube or vimeo)

### DIFF
--- a/pimcore/static/js/pimcore/helpers.js
+++ b/pimcore/static/js/pimcore/helpers.js
@@ -2006,6 +2006,8 @@ pimcore.helpers.editmode.openVideoEditPanel = function (data, callback) {
                     form.getComponent("type").setValue("youtube");
                 } else if (el.getValue().indexOf("vim") >= 0 && el.getValue().indexOf("http") >= 0) {
                     form.getComponent("type").setValue("vimeo");
+                } else if (el.getValue().indexOf("dai") >= 0 && el.getValue().indexOf("http") >= 0) {
+                    form.getComponent("type").setValue("dailymotion");
                 }
             }.bind(this)
         }
@@ -2103,11 +2105,15 @@ pimcore.helpers.editmode.openVideoEditPanel = function (data, callback) {
         }
 
         if(type == "youtube") {
-            labelEl.update("URL / ID");
+            labelEl.update("ID");
         }
 
         if(type == "vimeo") {
-            labelEl.update("URL");
+            labelEl.update("ID");
+        }
+        
+        if(type == "dailymotion") {
+            labelEl.update("ID");
         }
     };
 
@@ -2122,7 +2128,7 @@ pimcore.helpers.editmode.openVideoEditPanel = function (data, callback) {
             triggerAction: 'all',
             editable: true,
             mode: "local",
-            store: ["asset","youtube","vimeo"],
+            store: ["asset","youtube","vimeo","dailymotion"],
             value: data.type,
             listeners: {
                 select: function (combo) {

--- a/pimcore/static/js/pimcore/object/tags/video.js
+++ b/pimcore/static/js/pimcore/object/tags/video.js
@@ -234,7 +234,7 @@ pimcore.object.tags.video = Class.create(pimcore.object.tags.abstract, {
                 triggerAction: 'all',
                 editable: true,
                 mode: "local",
-                store: ["asset","youtube","vimeo"],
+                store: ["asset","youtube","vimeo","dailymotion"],
                 value: this.data.type,
                 listeners: {
                     select: function (combo) {
@@ -356,10 +356,13 @@ pimcore.object.tags.video = Class.create(pimcore.object.tags.abstract, {
             this.searchButton.disable();
         }
         if(type == "youtube") {
-            labelEl.update("URL / ID");
+            labelEl.update("ID");
         }
         if(type == "vimeo") {
-            labelEl.update("URL / ID");
+            labelEl.update("ID");
+        }
+        if(type == "dailymotion") {
+            labelEl.update("ID");
         }
     },
 
@@ -387,8 +390,10 @@ pimcore.object.tags.video = Class.create(pimcore.object.tags.abstract, {
             content = '<iframe width="' + width + '" height="' + height + '" src="//www.youtube.com/embed/' + this.data.data + '" frameborder="0" allowfullscreen></iframe>';
         } else if (this.data.type == "vimeo") {
             content = '<iframe src="//player.vimeo.com/video/' + this.data.data + '?title=0&amp;byline=0&amp;portrait=0" width="' + width + '" height="' + height + '" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>';
+        } else if (this.data.type == "dailymotion") {
+            content = '<iframe src="//www.dailymotion.com/embed/video/' + this.data.data + '" width="' + width + '" height="' + height + '" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>';
         }
-
+        
         this.getBody().update(content);
     },
 

--- a/pimcore/static6/js/pimcore/helpers.js
+++ b/pimcore/static6/js/pimcore/helpers.js
@@ -1822,6 +1822,8 @@ pimcore.helpers.editmode.openVideoEditPanel = function (data, callback) {
                     form.getComponent("type").setValue("youtube");
                 } else if (el.getValue().indexOf("vim") >= 0 && el.getValue().indexOf("http") >= 0) {
                     form.getComponent("type").setValue("vimeo");
+                } else if (el.getValue().indexOf("dai") >= 0 && el.getValue().indexOf("http") >= 0) {
+                    form.getComponent("type").setValue("dailymotion");
                 }
             }.bind(this)
         }
@@ -1929,11 +1931,15 @@ pimcore.helpers.editmode.openVideoEditPanel = function (data, callback) {
         }
 
         if(type == "youtube") {
-            labelEl.update("URL / ID");
+            labelEl.update("ID");
         }
 
         if(type == "vimeo") {
-            labelEl.update("URL");
+            labelEl.update("ID");
+        }
+        
+        if(type == "dailymotion") {
+            labelEl.update("ID");
         }
     };
 
@@ -1949,7 +1955,7 @@ pimcore.helpers.editmode.openVideoEditPanel = function (data, callback) {
             editable: false,
             width: 270,
             mode: "local",
-            store: ["asset","youtube","vimeo"],
+            store: ["asset","youtube","vimeo","dailymotion"],
             value: data.type,
             listeners: {
                 select: function (combo) {

--- a/pimcore/static6/js/pimcore/object/tags/video.js
+++ b/pimcore/static6/js/pimcore/object/tags/video.js
@@ -162,6 +162,8 @@ pimcore.object.tags.video = Class.create(pimcore.object.tags.abstract, {
             content = '<iframe width="' + width + '" height="' + height + '" src="//www.youtube.com/embed/' + this.data.data + '" frameborder="0" allowfullscreen></iframe>';
         } else if (this.data.type == "vimeo") {
             content = '<iframe src="//player.vimeo.com/video/' + this.data.data + '?title=0&amp;byline=0&amp;portrait=0" width="' + width + '" height="' + height + '" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>';
+        } else if (this.data.type == "dailymotion") {
+            content = '<iframe src="//www.dailymotion.com/embed/video/' + this.data.data + '" width="' + width + '" height="' + height + '" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>';
         }
 
         this.getBody().update(content);


### PR DESCRIPTION
This is a pull request for https://github.com/pimcore/pimcore/issues/696
It adds Dailymotion for video element. Now the 3 main video providers can be choose (YouTube, Vimeo and Dailymotion).

_Side note:
When making this pull request i find some incoherence betweens extjs4 and extjs6 in the videos.js tags. For extjs6 it seems to miss the URL converter to ID but not sure... So i touched nothing : )
Actually if copying youtube/vimeo URL (not ID), it seems to not work (video doesn't preview in the backend). So **I relabeled "ID" instead "URL" or "URL / ID" the input field**, as directly pasting URL seems broken. Maybe it could be abandonned (code to be cleaned) or corrected in another issue ?_
