### PR TITLE
Add a maximum selected items for multiselect object field

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data/Multiselect.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Multiselect.php
@@ -47,6 +47,11 @@ class Multiselect extends Model\Object\ClassDefinition\Data
     public $height;
 
     /**
+     * @var int
+     */
+    public $maxItems;
+
+    /**
      * Type for the column to query
      *
      * @var string
@@ -122,6 +127,25 @@ class Multiselect extends Model\Object\ClassDefinition\Data
         $this->height = $this->getAsIntegerCast($height);
 
         return $this;
+    }
+
+    /**
+     * @param $maxItems
+     * @return $this
+     */
+    public function setMaxItems($maxItems)
+    {
+        $this->maxItems = $this->getAsIntegerCast($maxItems);
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxItems()
+    {
+        return $this->maxItems;
     }
 
     /**
@@ -344,6 +368,7 @@ class Multiselect extends Model\Object\ClassDefinition\Data
      */
     public function synchronizeWithMasterDefinition(Object\ClassDefinition\Data $masterDefinition)
     {
+        $this->maxItems = $masterDefinition->maxItems;
         $this->options = $masterDefinition->options;
     }
 }

--- a/pimcore/static/js/pimcore/object/classes/data/multiselect.js
+++ b/pimcore/static/js/pimcore/object/classes/data/multiselect.js
@@ -203,7 +203,14 @@ pimcore.object.classes.data.multiselect = Class.create(pimcore.object.classes.da
                 fieldLabel: t("height"),
                 name: "height",
                 value: this.datax.height
-            },this.valueGrid
+            },
+            {
+                xtype: "spinnerfield",
+                fieldLabel: t("maximum_items"),
+                name: "maxItems",
+                value: this.datax.maxItems
+            },
+            this.valueGrid
         ]);
 
         return this.layout;
@@ -235,7 +242,8 @@ pimcore.object.classes.data.multiselect = Class.create(pimcore.object.classes.da
                 {
                     options: source.datax.options,
                     width: source.datax.width,
-                    height: source.datax.height
+                    height: source.datax.height,
+                    maxItems: source.datax.maxItems
                 });
         }
     },

--- a/pimcore/static/js/pimcore/object/tags/multiselect.js
+++ b/pimcore/static/js/pimcore/object/tags/multiselect.js
@@ -81,7 +81,20 @@ pimcore.object.tags.multiselect = Class.create(pimcore.object.tags.abstract, {
             editable: false,
             fieldLabel: this.fieldConfig.title,
             store: store,
-            itemCls: "object_field"
+            itemCls: "object_field",
+            listeners: {
+                change : function  ( multiselect , newValue , oldValue , eOpts ) {
+                    if (parseInt(this.maxSelections) > 0 && this.getValue().length > this.maxSelections) {
+                        // we need to set a timeout so setValue is applied when change event is totally finished
+                        // without this, multiselect wont be updated visually with oldValue (but internal value will be oldValue)
+                        setTimeout(function(multiselect, oldValue){
+                            multiselect.setValue(oldValue);
+                        }, 100, multiselect, oldValue);
+                        Ext.Msg.alert(t("error"),t("limit_reached"));
+                    }
+                    return true;
+                }
+            }
         };
 
         if (this.fieldConfig.width) {
@@ -90,7 +103,10 @@ pimcore.object.tags.multiselect = Class.create(pimcore.object.tags.abstract, {
         if (this.fieldConfig.height) {
             options.height = this.fieldConfig.height;
         }
-
+        if (parseInt(this.fieldConfig.maxItems) > 0) {
+            options.maxSelections = parseInt(this.fieldConfig.maxItems);
+        }
+        
         if (typeof this.data == "string" || typeof this.data == "number") {
             options.value = this.data;
         }

--- a/pimcore/static6/js/pimcore/object/classes/data/multiselect.js
+++ b/pimcore/static6/js/pimcore/object/classes/data/multiselect.js
@@ -217,7 +217,15 @@ pimcore.object.classes.data.multiselect = Class.create(pimcore.object.classes.da
                 fieldLabel: t("height"),
                 name: "height",
                 value: this.datax.height
-            },this.valueGrid
+            },
+            {
+                xtype: "numberfield",
+                fieldLabel: t("maximum_items"),
+                name: "maxItems",
+                value: this.datax.maxItems,
+                minValue: 0
+            },
+            this.valueGrid
         ]);
 
         return this.layout;
@@ -249,7 +257,8 @@ pimcore.object.classes.data.multiselect = Class.create(pimcore.object.classes.da
                 {
                     options: source.datax.options,
                     width: source.datax.width,
-                    height: source.datax.height
+                    height: source.datax.height,
+                    maxItems: source.datax.maxItems
                 });
         }
     },

--- a/pimcore/static6/js/pimcore/object/tags/multiselect.js
+++ b/pimcore/static6/js/pimcore/object/tags/multiselect.js
@@ -95,7 +95,20 @@ pimcore.object.tags.multiselect = Class.create(pimcore.object.tags.abstract, {
             componentCls: "object_field",
             height: 100,
             valueField: 'id',
-            labelWidth: this.fieldConfig.labelWidth ? this.fieldConfig.labelWidth : 100
+            labelWidth: this.fieldConfig.labelWidth ? this.fieldConfig.labelWidth : 100,
+            listeners: {
+                change : function  ( multiselect , newValue , oldValue , eOpts ) {
+                    if (parseInt(this.maxSelections) > 0 && this.getValue().length > this.maxSelections) {
+                        // we need to set a timeout so setValue is applied when change event is totally finished
+                        // without this, multiselect wont be updated visually with oldValue (but internal value will be oldValue)
+                        setTimeout(function(multiselect, oldValue){
+                            multiselect.setValue(oldValue);
+                        }, 100, multiselect, oldValue);
+                        Ext.Msg.alert(t("error"),t("limit_reached"));
+                    }
+                    return true;
+                }
+            }
         };
 
         if (this.fieldConfig.width) {
@@ -108,6 +121,10 @@ pimcore.object.tags.multiselect = Class.create(pimcore.object.tags.abstract, {
 
         if (this.fieldConfig.height) {
             options.height = this.fieldConfig.height;
+        }
+
+        if (parseInt(this.fieldConfig.maxItems) > 0) {
+            options.maxSelections = parseInt(this.fieldConfig.maxItems);
         }
 
         if (typeof this.data == "string" || typeof this.data == "number") {


### PR DESCRIPTION
This is a pull request for https://github.com/pimcore/pimcore/issues/734

This add max. items options for "multiselect" field data type object, like multihref for instance (same position and name in GUI). Like multihref, validation is only done at GUI level (not in checkValidity php method, so direct API call can bypass this).

As a side use case, now multiselect can be used as color selector (as it accept HTML value) for choosing a single color by limit it to 1 max. items (like you did on the e-commerce Pimcore demo but for multiple color choice).

_Side note:
Validating the max items limit was a bit tricky. First i try using combination of "maxSelections", "validateOnChange: true" and "validitychange (combo, isValid, eOpts)" event, but it is not possible to restore previous value or abort change by returning false... so i opted for the "change" event. I had to add a slight timeout so restoring value are visualy done (see code comment)._

_The "maxSelections" config too (line 127 of pimcore\static6\js\pimcore\object\tags\multiselect.js) provide a visual warning on mouseover if more than maximum items is selected (shoud not happen as change event limit it on GUI level, but could be an visuel indicator if API was used to create/update object with more than maxSelections number of items)._
