### PR TITLE
Color picker

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data/Input.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Input.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Pimcore
  *
@@ -47,13 +47,18 @@ class Input extends Model\Object\ClassDefinition\Data
      * @var string
      */
     public $columnType = "varchar";
-    
+
     /**
      * Column length
      *
      * @var integer
      */
     public $columnLength = 255;
+
+    /**
+     * @var bool
+     */
+    public $isColor = false;
 
     /**
      * Type for the generated phpdoc
@@ -145,7 +150,7 @@ class Input extends Model\Object\ClassDefinition\Data
     {
         return $this->getDataFromResource($data, $object, $params);
     }
-    
+
     /**
      * @return integer
      */
@@ -168,6 +173,22 @@ class Input extends Model\Object\ClassDefinition\Data
     }
 
     /**
+     * @param boolean $isColor
+     */
+    public function setIsColor($isColor)
+    {
+        $this->isColor = $isColor;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getIsColor()
+    {
+        return $this->isColor;
+    }
+
+    /**
      * @param string $regex
      */
     public function setRegex($regex)
@@ -182,7 +203,7 @@ class Input extends Model\Object\ClassDefinition\Data
     {
         return $this->regex;
     }
-    
+
     /**
      * @return string
      */
@@ -223,5 +244,6 @@ class Input extends Model\Object\ClassDefinition\Data
     public function synchronizeWithMasterDefinition(Model\Object\ClassDefinition\Data $masterDefinition)
     {
         $this->columnLength = $masterDefinition->columnLength;
+        $this->isColor = $masterDefinition->isColor;
     }
 }

--- a/pimcore/static/js/pimcore/object/classes/data/input.js
+++ b/pimcore/static/js/pimcore/object/classes/data/input.js
@@ -56,6 +56,11 @@ pimcore.object.classes.data.input = Class.create(pimcore.object.classes.data.dat
                 fieldLabel: t("width"),
                 name: "width",
                 value: this.datax.width
+            }, {
+                xtype: "checkbox",
+                fieldLabel: t("is_color"),
+                name: "isColor",
+                checked: this.datax.isColor
             }
         ]);
 
@@ -139,6 +144,7 @@ pimcore.object.classes.data.input = Class.create(pimcore.object.classes.data.dat
                 {
                     width: source.datax.width,
                     columnLength: source.datax.columnLength,
+                    isColor: source.datax.isColor,
                     regex: source.datax.regex
                 });
         }

--- a/pimcore/static/js/pimcore/object/tags/input.js
+++ b/pimcore/static/js/pimcore/object/tags/input.js
@@ -55,7 +55,14 @@ pimcore.object.tags.input = Class.create(pimcore.object.tags.abstract, {
         var input = {
             fieldLabel: this.fieldConfig.title,
             name: this.fieldConfig.name,
-            itemCls: "object_field"
+            itemCls: "object_field",
+            listeners: {
+                afterrender : function( input , eOpts ){
+                    if(this.fieldConfig.isColor) {
+                        jQuery(this.getEl().dom).find("input").attr("type", "color");
+                    }
+                }.bind(this)
+            }
         };
 
         if (this.data) {

--- a/pimcore/static6/js/pimcore/object/classes/data/input.js
+++ b/pimcore/static6/js/pimcore/object/classes/data/input.js
@@ -67,6 +67,11 @@ pimcore.object.classes.data.input = Class.create(pimcore.object.classes.data.dat
                     fieldLabel: t("columnlength"),
                     name: "columnLength",
                     value: this.datax.columnLength
+                }, {
+                    xtype: "checkbox",
+                    fieldLabel: t("is_color"),
+                    name: "isColor",
+                    checked: this.datax.isColor
                 }
             ]);
 
@@ -140,6 +145,7 @@ pimcore.object.classes.data.input = Class.create(pimcore.object.classes.data.dat
                 {
                     width: source.datax.width,
                     columnLength: source.datax.columnLength,
+                    isColor: source.datax.isColor,
                     regex: source.datax.regex
                 });
         }

--- a/pimcore/static6/js/pimcore/object/tags/input.js
+++ b/pimcore/static6/js/pimcore/object/tags/input.js
@@ -53,7 +53,14 @@ pimcore.object.tags.input = Class.create(pimcore.object.tags.abstract, {
             fieldLabel: this.fieldConfig.title,
             name: this.fieldConfig.name,
             componentCls: "object_field",
-            labelWidth: 100
+            labelWidth: 100,
+            listeners: {
+                afterrender : function( input , eOpts ){
+                    if(this.fieldConfig.isColor) {
+                        jQuery(this.getEl().dom).find("input").attr("type", "color");
+                    }
+                }.bind(this)
+            }
         };
 
         if (this.data) {
@@ -72,7 +79,8 @@ pimcore.object.tags.input = Class.create(pimcore.object.tags.abstract, {
         input.width += input.labelWidth;
 
         if(this.fieldConfig.columnLength) {
-            input.autoCreate = {tag: 'input', type: 'text', maxlength: this.fieldConfig.columnLength};
+            input.maxLength = this.fieldConfig.columnLength;
+            input.enforceMaxLength = true;
         }
 
         if(this.fieldConfig["regex"]) {


### PR DESCRIPTION
This is a pull request for https://github.com/pimcore/pimcore/issues/733.

It is very light implementation, based on html5 color input type. No external dependency, just a checkbox for input field "Is color" has been added. If checked, it change the type of input to "color" instead of "text" in the edit layout only.
So it doesn't introduce new datetype, just some small code changes, and provide just a great helper tool for color selection (for HTML5 compatible browser: http://caniuse.com/#feat=input-color , cover nearly 70%, and last chrome/firefox version, the more used by Pimcore administrator).

Sample:
![colorpicker](https://cloud.githubusercontent.com/assets/9025839/18170745/c765b254-705f-11e6-982a-bea08fbe6727.png)


