### PR TITLE
add text asset to search data

### DIFF
--- a/pimcore/models/Asset/Text.php
+++ b/pimcore/models/Asset/Text.php
@@ -16,7 +16,9 @@
 
 namespace Pimcore\Model\Asset;
 
+use Pimcore\Cache;
 use Pimcore\Model;
+use Pimcore\Logger;
 
 class Text extends Model\Asset
 {
@@ -25,4 +27,22 @@ class Text extends Model\Asset
      * @var string
      */
     public $type = "text";
+
+    public function getText($page = null)
+    {
+        if (preg_match("/\.?(txt|csv|xml)$/", $this->getFilename())) {
+            $cacheKey = "asset_text_text_" . $this->getId() . "_" . ($page ? $page : "all");
+
+            if (!$text = Cache::load($cacheKey)) {
+                $text = file_get_contents($this->getFileSystemPath());
+                Cache::save($text, $cacheKey, $this->getCacheTags(), null, 99, true); // force cache write
+            }
+
+            return $text;
+        } else {
+            Logger::error("Couldn't get text out of text asset " . $this->getRealFullPath() . " not supported extension");
+        }
+
+        return null;
+    }
 }

--- a/pimcore/models/Search/Backend/Data.php
+++ b/pimcore/models/Search/Backend/Data.php
@@ -410,6 +410,15 @@ class Data extends \Pimcore\Model\AbstractModel
                 }
             }
 
+            if ($element instanceof Asset\Text) {
+                try {
+                    $contentText = $element->getText();
+                    if ($contentText) $this->data .= " " . $contentText;
+                } catch (\Exception $e) {
+                    Logger::error($e);
+                }
+            }
+
             if ($element instanceof Asset\Document && \Pimcore\Document::isAvailable()) {
                 if (\Pimcore\Document::isFileTypeSupported($element->getFilename())) {
                     try {


### PR DESCRIPTION
This pull request is for https://github.com/pimcore/pimcore/issues/180

It add text content in search data for asset of type "text" having extension txt, csv or xml.