### PR TITLE
Options precision and max-min for quantity value

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data/QuantityValue.php
+++ b/pimcore/models/Object/ClassDefinition/Data/QuantityValue.php
@@ -76,6 +76,31 @@ class QuantityValue extends Model\Object\ClassDefinition\Data
     public $phpdocType = "Pimcore\\Model\\Object\\Data\\QuantityValue";
 
     /**
+     * @var bool
+     */
+    public $integer = false;
+
+    /**
+     * @var bool
+     */
+    public $unsigned = false;
+
+    /**
+     * @var float
+     */
+    public $minValue;
+
+    /**
+     * @var float
+     */
+    public $maxValue;
+
+    /**
+     * @var int
+     */
+    public $decimalPrecision;
+
+    /**
      * @return integer
      */
     public function getWidth()
@@ -98,7 +123,7 @@ class QuantityValue extends Model\Object\ClassDefinition\Data
     public function getDefaultValue()
     {
         if ($this->defaultValue !== null) {
-            return (double) $this->defaultValue;
+            return $this->toNumeric($this->defaultValue);
         }
     }
 
@@ -111,6 +136,131 @@ class QuantityValue extends Model\Object\ClassDefinition\Data
         if (strlen(strval($defaultValue)) > 0) {
             $this->defaultValue = $defaultValue;
         }
+    }
+
+    /**
+     * @param boolean $integer
+     */
+    public function setInteger($integer)
+    {
+        $this->integer = $integer;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getInteger()
+    {
+        return $this->integer;
+    }
+
+    /**
+     * @param float $maxValue
+     */
+    public function setMaxValue($maxValue)
+    {
+        $this->maxValue = $maxValue;
+    }
+
+    /**
+     * @return float
+     */
+    public function getMaxValue()
+    {
+        return $this->maxValue;
+    }
+
+    /**
+     * @param float $minValue
+     */
+    public function setMinValue($minValue)
+    {
+        $this->minValue = $minValue;
+    }
+
+    /**
+     * @return float
+     */
+    public function getMinValue()
+    {
+        return $this->minValue;
+    }
+
+    /**
+     * @param boolean $unsigned
+     */
+    public function setUnsigned($unsigned)
+    {
+        $this->unsigned = $unsigned;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getUnsigned()
+    {
+        return $this->unsigned;
+    }
+
+    /**
+     * @param int $decimalPrecision
+     */
+    public function setDecimalPrecision($decimalPrecision)
+    {
+        $this->decimalPrecision = $decimalPrecision;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDecimalPrecision()
+    {
+        return $this->decimalPrecision;
+    }
+
+    /**
+     * @return string
+     */
+    public function getColumnType()
+    {
+        if ($this->getInteger()) {
+            return [
+                "value" => "bigint(20)",
+                "unit" => "bigint(20)"
+            ];
+        }
+
+        if ($this->getDecimalPrecision()) {
+            return [
+                "value" => "decimal(64, " . intval($this->getDecimalPrecision()) . ")",
+                "unit" => "bigint(20)"
+            ];
+        }
+
+        return parent::getColumnType();
+    }
+
+    /**
+     * @return string
+     */
+    public function getQueryColumnType()
+    {
+        if ($this->getInteger()) {
+
+            return [
+                "value" => "bigint(20)",
+                "unit" => "bigint(20)"
+            ];
+        }
+
+        if ($this->getDecimalPrecision()) {
+            return [
+                "value" => "decimal(64, " . intval($this->getDecimalPrecision()) . ")",
+                "unit" => "bigint(20)"
+            ];
+        }
+
+        return parent::getQueryColumnType();
     }
 
     /**
@@ -181,7 +331,12 @@ class QuantityValue extends Model\Object\ClassDefinition\Data
     public function getDataFromResource($data, $object = null, $params = [])
     {
         if ($data[$this->getName() . "__value"] || $data[$this->getName() . "__unit"]) {
-            return new  \Pimcore\Model\Object\Data\QuantityValue($data[$this->getName() . "__value"], $data[$this->getName() . "__unit"]);
+            if (is_numeric($data[$this->getName() . "__value"])) {
+                $number = $this->toNumeric($data[$this->getName() . "__value"]);
+            } else {
+                $number = $data[$this->getName() . "__value"];
+            }
+            return new  \Pimcore\Model\Object\Data\QuantityValue($number, $data[$this->getName() . "__unit"]);
         }
 
         return;
@@ -267,15 +422,43 @@ class QuantityValue extends Model\Object\ClassDefinition\Data
      */
     public function checkValidity($data, $omitMandatoryCheck = false)
     {
-        if (!$omitMandatoryCheck && $this->getMandatory() &&
+        if (!$omitMandatoryCheck && $this->getMandatory() && $this->isEmpty($data->getValue()) &&
            ($data === null || $data->getValue() === null || $data->getUnitId() === null)) {
             throw new Model\Element\ValidationException("Empty mandatory field [ ".$this->getName()." ]");
+        }
+
+        if (!$this->isEmpty($data->getValue()) && !is_numeric($data->getValue())) {
+            throw new Model\Element\ValidationException("invalid numeric data [" . $data->getValue() . "]");
         }
 
         if (!empty($data)) {
             $value = $data->getValue();
             if ((!empty($value) && !is_numeric($data->getValue())) || !($data->getUnitId())) {
                 throw new Model\Element\ValidationException("Invalid dimension unit data");
+            }
+        }
+
+        if (!$this->isEmpty($data->getValue()) && !$omitMandatoryCheck) {
+            $value = $this->toNumeric($data->getValue());
+
+            if ($value >= PHP_INT_MAX) {
+                throw new Model\Element\ValidationException("Value exceeds PHP_INT_MAX please use an input data type instead of numeric!");
+            }
+
+            if ($this->getInteger() && strpos((string) $value, ".") !== false) {
+                throw new Model\Element\ValidationException("Value in field [ ".$this->getName()." ] is not an integer");
+            }
+
+            if (strlen($this->getMinValue()) && $this->getMinValue() > $value) {
+                throw new Model\Element\ValidationException("Value in field [ ".$this->getName()." ] is not at least " . $this->getMinValue());
+            }
+
+            if (strlen($this->getMaxValue()) && $value > $this->getMaxValue()) {
+                throw new Model\Element\ValidationException("Value in field [ ".$this->getName()." ] is bigger than " . $this->getMaxValue());
+            }
+
+            if ($this->getUnsigned() && $value < 0) {
+                throw new Model\Element\ValidationException("Value in field [ ".$this->getName()." ] is not unsigned (bigger than 0)");
             }
         }
     }
@@ -312,7 +495,7 @@ class QuantityValue extends Model\Object\ClassDefinition\Data
 
         $value = null;
         if ($values[0] && $values[1]) {
-            $number = (double) str_replace(",", ".", $values[0]);
+            $number = $this->toNumeric(str_replace(",", ".", $values[0]));
             $value = new  \Pimcore\Model\Object\Data\QuantityValue($number, $values[1]);
         }
 
@@ -446,5 +629,27 @@ class QuantityValue extends Model\Object\ClassDefinition\Data
     public function __wakeup()
     {
         $this->configureOptions();
+    }
+
+    /**
+     * @param $data
+     * @return bool
+     */
+    public function isEmpty($data)
+    {
+        return (strlen($data) < 1);
+    }
+
+    /**
+     * @param $value
+     * @return double|int
+     */
+    protected function toNumeric($value)
+    {
+        if (strpos((string) $value, ".") === false) {
+            return (int) $value;
+        }
+
+        return (double) $value;
     }
 }

--- a/pimcore/static6/js/pimcore/object/classes/data/quantityValue.js
+++ b/pimcore/static6/js/pimcore/object/classes/data/quantityValue.js
@@ -89,6 +89,61 @@ pimcore.object.classes.data.quantityValue = Class.create(pimcore.object.classes.
             }
         ]);
 
+        if (!this.isInCustomLayoutEditor()) {
+            this.specificPanel.add([
+                {
+                    xtype: "numberfield",
+                    fieldLabel: t("decimal_precision"),
+                    name: "decimalPrecision",
+                    maxValue: 65,
+                    value: this.datax.decimalPrecision
+                }, {
+                    xtype: "panel",
+                    bodyStyle: "padding-top: 3px",
+                    style: "margin-bottom: 10px",
+                    html: t('if_specified_decimal_mysql_type_is_used_automatically')
+                }, {
+                    xtype: "checkbox",
+                    fieldLabel: t("integer"),
+                    name: "integer",
+                    checked: this.datax.integer
+                }, {
+                    xtype: "checkbox",
+                    fieldLabel: t("only_unsigned"),
+                    name: "unsigned",
+                    checked: this.datax["unsigned"]
+                }, {
+                    xtype: "numberfield",
+                    fieldLabel: t("min_value"),
+                    name: "minValue",
+                    value: this.datax.minValue
+                },{
+                    xtype: "numberfield",
+                    fieldLabel: t("max_value"),
+                    name: "maxValue",
+                    value: this.datax.maxValue
+                }
+            ]);
+        }
+
         return this.layout;
+    },
+    
+    applySpecialData: function(source) {
+        if (source.datax) {
+            if (!this.datax) {
+                this.datax =  {};
+            }
+            Ext.apply(this.datax,
+                {
+                    width: source.datax.width,
+                    defaultValue: source.datax.defaultValue,
+                    integer: source.datax.integer,
+                    unsigned: source.datax.unsigned,
+                    minValue: source.datax.minValue,
+                    maxValue: source.datax.maxValue,
+                    decimalPrecision: source.datax.decimalPrecision
+                });
+        }
     }
 });

--- a/pimcore/static6/js/pimcore/object/tags/quantityValue.js
+++ b/pimcore/static6/js/pimcore/object/tags/quantityValue.js
@@ -70,6 +70,26 @@ pimcore.object.tags.quantityValue = Class.create(pimcore.object.tags.abstract, {
             input.labelWidth = this.fieldConfig.labelWidth;
         }
 
+        if (this.fieldConfig["unsigned"]) {
+            input.minValue = 0;
+        }
+
+        if (is_numeric(this.fieldConfig["minValue"])) {
+            input.minValue = this.fieldConfig.minValue;
+        }
+
+        if (is_numeric(this.fieldConfig["maxValue"])) {
+            input.maxValue = this.fieldConfig.maxValue;
+        }
+
+        if (this.fieldConfig["integer"]) {
+            input.decimalPrecision = 0;
+        } else if (this.fieldConfig["decimalPrecision"]) {
+            input.decimalPrecision = this.fieldConfig["decimalPrecision"];
+        } else {
+            input.decimalPrecision = 20;
+        }
+        
         var options = {
             width: 100,
             triggerAction: "all",


### PR DESCRIPTION
This pull request is for https://github.com/pimcore/pimcore/issues/522

Using quantity value could be improved by having the possibility to definit limits (max/min) and the type (integer, decimal). This way it is like numeric and can be greatly personnalized to different use case.

One of the case is to use it for multi-currency (where currency are units of quantity value), and where the value need to be accurate and so use decimal in database.
Other use case is forcing integer so user can only fill integer (plain quantity), for instance for stock left depending of different parameters (wich will be the 'units' in this case).

Code of this PR is greatly copied from numeric field. I made some extending testing and seems to work great!
