### PR TITLE
default module for empty page in subsite

### DIFF
--- a/pimcore/modules/admin/controllers/DocumentController.php
+++ b/pimcore/modules/admin/controllers/DocumentController.php
@@ -161,6 +161,16 @@ class Admin_DocumentController extends \Pimcore\Controller\Action\Admin\Element
                 } elseif ($this->getParam("type") == "page" || $this->getParam("type") == "snippet" || $this->getParam("type") == "email") {
                     $createValues["controller"] = Config::getSystemConfig()->documents->default_controller;
                     $createValues["action"] = Config::getSystemConfig()->documents->default_action;
+                    // we look for sites, so same default module is used than the rootDocument
+                    $sitesList = new Site\Listing();
+                    $sitesObjects = $sitesList->load();
+                    foreach ($sitesObjects as $sitesObject) {
+                        if (strpos($intendedPath, $sitesObject->getRootDocument()->getRealFullPath()) === 0) {
+                            $module = $sitesObject->getRootDocument()->getModule();
+                            if ($module) $createValues["module"] = $module;
+                            break;
+                        }
+                    }
                 }
 
                 if ($this->getParam("inheritanceSource")) {


### PR DESCRIPTION
This is a pull request for https://github.com/pimcore/pimcore/issues/640

In multisite, when creating an empty page under a subsite, the module of the rootDocument will be used instead of website module. So empty page can be managed by module for multisite. Often each subsite is asociated to on module having his own logic/template. So creating empty page will no more break this logic.
