### PR TITLE
Delete dialog: show key of element

### DIFF
--- a/pimcore/modules/admin/controllers/AssetController.php
+++ b/pimcore/modules/admin/controllers/AssetController.php
@@ -472,12 +472,19 @@ class Admin_AssetController extends \Pimcore\Controller\Action\Admin\Element
             }
         }
 
+        // get the element key in case of just one
+        $elementKey = false;
+        if (count($ids) === 1) {
+            $elementKey = Asset::getById($id)->getKey();
+        }
+
         $deleteJobs = array_merge($recycleJobs, $deleteJobs);
         $this->_helper->json([
             "hasDependencies" => $hasDependency,
             "childs" => $totalChilds,
             "deletejobs" => $deleteJobs,
-            "batchDelete" => count($ids) > 1
+            "batchDelete" => count($ids) > 1,
+            "elementKey" => $elementKey
         ]);
     }
 

--- a/pimcore/modules/admin/controllers/DocumentController.php
+++ b/pimcore/modules/admin/controllers/DocumentController.php
@@ -361,10 +361,14 @@ class Admin_DocumentController extends \Pimcore\Controller\Action\Admin\Element
             ]];
         }
 
+        // get the element key
+        $elementKey = $document->getKey();
+
         $this->_helper->json([
             "hasDependencies" => $hasDependency,
             "childs" => $childs,
-            "deletejobs" => $deleteJobs
+            "deletejobs" => $deleteJobs,
+            "elementKey" => $elementKey
         ]);
     }
 

--- a/pimcore/modules/admin/controllers/ObjectController.php
+++ b/pimcore/modules/admin/controllers/ObjectController.php
@@ -895,12 +895,19 @@ class Admin_ObjectController extends \Pimcore\Controller\Action\Admin\Element
             }
         }
 
+        // get the element key in case of just one
+        $elementKey = false;
+        if (count($ids) === 1) {
+            $elementKey = Object::getById($id)->getKey();
+        }
+
         $deleteJobs = array_merge($recycleJobs, $deleteJobs);
         $this->_helper->json([
             "hasDependencies" => $hasDependency,
             "childs" => $totalChilds,
             "deletejobs" => $deleteJobs,
-            "batchDelete" => count($ids) > 1
+            "batchDelete" => count($ids) > 1,
+            "elementKey" => $elementKey
         ]);
     }
 

--- a/pimcore/static6/js/pimcore/elementservice.js
+++ b/pimcore/static6/js/pimcore/elementservice.js
@@ -29,6 +29,9 @@ pimcore.elementservice.deleteElementCheckDependencyComplete = function (options,
     try {
         var res = Ext.decode(response.responseText);
         var message = res.batchDelete ? t('delete_message_batch') : t('delete_message');
+        if (res.elementKey) {
+            message += "<br />\" " + res.elementKey + " \"";
+        }
         if (res.hasDependencies) {
             message += "<br />" + t('delete_message_dependencies');
         }


### PR DESCRIPTION
This pull request is for https://github.com/pimcore/pimcore/issues/844

It add the key of the element (document/asset/object) in the popin when clic on delete in the main element tree. So enduser can be more confident when he delete element without asking himself if he has done the right click on the right element ; )

Here is an example of the result:
![delete-popin](https://cloud.githubusercontent.com/assets/9025839/18185622/da6a0d70-709e-11e6-9d99-6f9cfaab949a.png)


