### PR TITLE
custom adapter for custom reports

### DIFF
--- a/pimcore/models/Tool/CustomReport/Config.php
+++ b/pimcore/models/Tool/CustomReport/Config.php
@@ -150,7 +150,23 @@ class Config extends Model\AbstractModel
     public static function getAdapter($configuration, $fullConfig = null)
     {
         $type = $configuration->type ? ucfirst($configuration->type) : 'Sql';
-        $adapter = "\\Pimcore\\Model\\Tool\\CustomReport\\Adapter\\{$type}";
+        if ($type === 'Custom') {
+            if (@\class_exists($configuration->className, true)) { // can need autoloader, can send warning and break json response so we use @
+                $adapter = $configuration->className;
+                $adpaterInstance = new $adapter($configuration, $fullConfig);
+                // we make some check for security reason (because className can be choosen at the GUI level)
+                if (get_parent_class($adpaterInstance) !== 'Pimcore\\Model\\Tool\\CustomReport\\Adapter\\AbstractAdapter') {
+                    throw new \Exception("Class" . $configuration->className ." doesn't extend AbstractAdapter");
+                }
+                if ((!method_exists($adpaterInstance, 'getData')) || (!method_exists($adpaterInstance, 'getColumns')) || (!method_exists($adpaterInstance, 'getAvailableOptions'))) {
+                    throw new \Exception("Class" . $configuration->className ." must implement methods getData, getColumns and getAvailableOptions");
+                }
+            } else {
+                throw new \Exception("Class" . $configuration->className ." doesn't exist");
+            }
+        } else {
+            $adapter = "\\Pimcore\\Model\\Tool\\CustomReport\\Adapter\\{$type}";
+        }
 
         return new $adapter($configuration, $fullConfig);
     }

--- a/pimcore/modules/admin/views/scripts/index/index6.php
+++ b/pimcore/modules/admin/views/scripts/index/index6.php
@@ -501,6 +501,7 @@ $scripts = array(
     "pimcore/report/custom/report.js",
     "pimcore/report/custom/definitions/sql.js",
     "pimcore/report/custom/definitions/analytics.js",
+    "pimcore/report/custom/definitions/custom.js",
 
     "pimcore/settings/tagmanagement/panel.js",
     "pimcore/settings/tagmanagement/item.js",

--- a/pimcore/static6/js/pimcore/report/custom/definitions/custom.js
+++ b/pimcore/static6/js/pimcore/report/custom/definitions/custom.js
@@ -1,0 +1,88 @@
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2009-2016 pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+pimcore.registerNS("pimcore.report.custom.definition.custom");
+pimcore.report.custom.definition.custom = Class.create({
+
+    element: null,
+    sourceDefinitionData: null,
+    columnSettingsCallback: null,
+
+    initialize: function (sourceDefinitionData, key, deleteControl, columnSettingsCallback) {
+        this.sourceDefinitionData = sourceDefinitionData;
+        this.columnSettingsCallback = columnSettingsCallback;
+        this.groupByStore = new Ext.data.ArrayStore({
+            fields: ['text'],
+            data: [],
+            expandData: true
+        });
+
+        this.element = new Ext.form.FormPanel({
+            key: key,
+            bodyStyle: "padding:10px;",
+            autoHeight: true,
+            border: false,
+            tbar: deleteControl,
+            listeners: {
+                afterrender: function() {
+                    this.updateGroupByMultiSelectStore(true);
+                }.bind(this)
+            },
+            items: [
+                {
+                    xtype: "textfield",
+                    name: "className",
+                    fieldLabel: "Class name",
+                    value: (sourceDefinitionData ? sourceDefinitionData.className : ""),
+                    width: 500,
+                    //height: 150,
+                    enableKeyEvents: true,
+                    listeners: {
+                        keyup: this.onCustomEditorKeyup.bind(this)
+                    }
+                }
+            ]
+        });
+
+        this.customText = new Ext.form.DisplayField({
+            name: "customText",
+            style: "color: blue;",
+            value: "Adapter class name must be fully qualified<br /><small>(eg. \\Website\\MyReportAdapter)</small>"
+        });
+        this.element.add(this.customText);
+        this.element.updateLayout();
+    },
+
+    getElement: function() {
+        return this.element;
+    },
+
+    getValues: function() {
+        var values = this.element.getForm().getFieldValues();
+        values.type = "custom";
+        return values;
+    },
+
+    onCustomEditorKeyup: function() {
+        clearTimeout(this._keyupTimout);
+
+        var self = this;
+        this._keyupTimout = setTimeout(function() {
+            self.updateGroupByMultiSelectStore(false);
+        }, 500);
+    },
+
+    updateGroupByMultiSelectStore: function(addItem) {
+        this.columnSettingsCallback();
+    }
+});

--- a/pimcore/static6/js/pimcore/report/custom/item.js
+++ b/pimcore/static6/js/pimcore/report/custom/item.js
@@ -591,6 +591,12 @@ pimcore.report.custom.item = Class.create({
                 handler: this.addSourceDefinition.bind(this, {type: 'analytics'}),
                 iconCls: "pimcore_icon_objectbricks"
             });
+            
+            classMenu.push({
+                text: t("custom_report_adapter_custom"),
+                handler: this.addSourceDefinition.bind(this, {type: 'custom'}),
+                iconCls: "pimcore_icon_objectbricks"
+            });
         }
 
         var items = [];


### PR DESCRIPTION
This is a pull request for https://github.com/pimcore/pimcore/issues/618

Actually custom report can only be SQL request (context independant, so we cannot fetch object of connected user on Pimcore for instance) or Analytics. And extending custom reports seems not possible at the moment.
Purpose is like new reports for newsletter to be able to create custom class adapter for custom reports.
It can be used for parsing CSV, fetch external data on webservices, request database depending connected user on Pimcore, ...
**With this PR administrator can use the powerfull custom reports feature of Pimcore like a generic tool to draw datas coming from various sources.** I think it is a great addition.

Side note:
one translation need to be added: see t("custom_report_adapter_custom"). Some other text are hardcoded for this PR (to be more comprehensive), but should be dynamic.

You can test it with this custom adapter: 
[MyReportAdapter.zip](https://github.com/pimcore/pimcore/files/452361/MyReportAdapter.zip)

Screenshots:

Selector:
![custom_new](https://cloud.githubusercontent.com/assets/9025839/18209232/301d7e8e-7133-11e6-8a9d-2d9038332df0.png)

Configured with results:
![custom_with_result](https://cloud.githubusercontent.com/assets/9025839/18209242/3ea96936-7133-11e6-9029-60871a1ed190.png)

Comprehensive errors for users:
![custom_error1](https://cloud.githubusercontent.com/assets/9025839/18209256/47eae8b2-7133-11e6-9253-4b5a5518a46b.png)

![custom_error2](https://cloud.githubusercontent.com/assets/9025839/18209258/4a85c3c6-7133-11e6-91aa-f3595a737b24.png)

![custom_error3](https://cloud.githubusercontent.com/assets/9025839/18209261/4d5c7144-7133-11e6-8990-a8ea16b38d6a.png)
