### PR TITLE
custom report adapter for newsletter

### DIFF
--- a/pimcore/lib/Pimcore/Document/Newsletter/AddressSourceAdapter/ReportAdapter.php
+++ b/pimcore/lib/Pimcore/Document/Newsletter/AddressSourceAdapter/ReportAdapter.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2009-2016 pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Document\Newsletter\AddressSourceAdapter;
+
+use Pimcore\Document\Newsletter\AddressSourceAdapterInterface;
+use Pimcore\Document\Newsletter\SendingParamContainer;
+use Pimcore\Model\Object\ClassDefinition;
+use Pimcore\Model\Object\Listing;
+
+class ReportAdapter implements AddressSourceAdapterInterface
+{
+
+    /**
+     * @var int
+     */
+    protected $reportId;
+
+    /**
+     * @var string[]
+     */
+    protected $emailFieldName;
+
+    /**
+     * @var string[]
+     */
+    protected $emailAddresses;
+
+    /**
+     * @var int
+     */
+    protected $elementsTotal;
+
+    /**
+     * @var Listing
+     */
+    protected $list;
+
+    /**
+     * IAddressSourceAdapter constructor.
+     * @param $params
+     */
+    public function __construct($params)
+    {
+        $this->reportId = $params['reportId'];
+        $this->emailFieldName = $params['emailFieldName'];
+    }
+
+    /**
+     * @return Listing
+     */
+    protected function getListing()
+    {
+        $config = \Pimcore\Model\Tool\CustomReport\Config::getByName($this->reportId);
+        $configuration = $config->getDataSourceConfig();
+        $adapter = \Pimcore\Model\Tool\CustomReport\Config::getAdapter($configuration, $config);
+        $result = $adapter->getData(null, $this->emailFieldName, 'ASC', null, null);
+
+        $this->list = $result['data'];
+        $this->elementsTotal = intval($result["total"]);
+
+        $this->emailAddresses = [];
+        foreach ($this->list as $row) {
+            if (isset($row[$this->emailFieldName])) $this->emailAddresses[] = $row[$this->emailFieldName];
+        }
+
+        return $this->list;
+    }
+
+    /**
+     * returns array of email addresses for batch sending
+     *
+     * @return SendingParamContainer[]
+     */
+    public function getMailAddressesForBatchSending()
+    {
+        if (!$this->list) $this->getListing();
+
+        $containers = [];
+        foreach ($this->emailAddresses as $address) {
+            $containers[] = new SendingParamContainer($address, ['emailAddress' => $address]);
+        }
+
+        return $containers;
+    }
+
+    /**
+     * returns params to be set on mail for test sending
+     *
+     * @param string $emailAddress
+     * @return SendingParamContainer
+     */
+    public function getParamsForTestSending($emailAddress)
+    {
+        if (!$this->list) $this->getListing();
+
+        return new SendingParamContainer($emailAddress, current($this->list));
+    }
+
+    /**
+     * returns total number of newsletter recipients
+     *
+     * @return int
+     */
+    public function getTotalRecordCount()
+    {
+        if (!$this->list) $this->getListing();
+
+        return $this->elementsTotal;
+    }
+
+    /**
+     * returns array of params to be set on mail for single sending
+     *
+     * @param $limit
+     * @param $offset
+     * @return SendingParamContainer[]
+     */
+    public function getParamsForSingleSending($limit, $offset)
+    {
+        if (!$this->list) $this->getListing();
+
+        $listing = $this->list;
+
+        $containers = [];
+
+        for ($i = $offset; $i <= $limit; $i++) {
+            if (isset($listing[$i][$this->emailFieldName])) {
+                // as $listing is array type we can send all so every column can be used as placeholder in email
+                $containers[] = new SendingParamContainer($listing[$i][$this->emailFieldName], $listing[$i]);
+            }
+        }
+
+        return $containers;
+    }
+}

--- a/pimcore/modules/admin/controllers/NewsletterController.php
+++ b/pimcore/modules/admin/controllers/NewsletterController.php
@@ -180,6 +180,36 @@ class Admin_NewsletterController extends \Pimcore\Controller\Action\Admin\Docume
         $this->_helper->json(['data' => $availableClasses]);
     }
 
+    public function getAvailableReportsAction()
+    {
+        $task = $this->getParam("task");
+
+        if ($task === 'list') {
+
+            $reportList = \Pimcore\Model\Tool\CustomReport\Config::getReportsList();
+
+            $availableReports = [];
+            foreach ($reportList as $report) {
+                $availableReports[] = ['id' => $report['id'], 'text' => $report['text']];
+            }
+
+            $this->_helper->json(['data' => $availableReports]);
+
+        } else if ($task === 'fieldNames') {
+
+            $reportId = $this->getParam("reportId");
+            $report = \Pimcore\Model\Tool\CustomReport\Config::getByName($reportId);
+            $columnConfiguration = $report->getColumnConfiguration();
+
+            $availableColumns = [];
+            foreach ($columnConfiguration as $column) {
+                if ($column['display']) $availableColumns[] = ['name' => $column['name']];
+            }
+
+            $this->_helper->json(['data' => $availableColumns]);
+
+        }
+    }
 
     public function getSendStatusAction()
     {

--- a/pimcore/modules/admin/views/scripts/index/index6.php
+++ b/pimcore/modules/admin/views/scripts/index/index6.php
@@ -316,6 +316,7 @@ $scripts = array(
     "pimcore/document/newsletters/sendingPanel.js",
     "pimcore/document/newsletters/addressSourceAdapters/default.js",
     "pimcore/document/newsletters/addressSourceAdapters/csvList.js",
+    "pimcore/document/newsletters/addressSourceAdapters/report.js",
     "pimcore/document/link.js",
     "pimcore/document/hardlink.js",
     "pimcore/document/folder.js",

--- a/pimcore/static6/js/pimcore/document/newsletters/addressSourceAdapters/report.js
+++ b/pimcore/static6/js/pimcore/document/newsletters/addressSourceAdapters/report.js
@@ -1,0 +1,119 @@
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2009-2016 pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+pimcore.registerNS("pimcore.document.newsletters.addressSourceAdapters.report");
+pimcore.document.newsletters.addressSourceAdapters.report = Class.create({
+
+    initialize: function(document, data) {
+        this.document = document;
+    },
+
+    /**
+     * returns name of corresponding php implementation class
+     *
+     * @returns {string}
+     */
+    getName: function() {
+        return "reportAdapter";
+    },
+
+    /**
+     * returns layout for sending panel
+     *
+     * @returns {Ext.form.Panel|*}
+     */
+    getLayout: function () {
+
+        if (this.layout == null) {
+
+            this.layout = Ext.create('Ext.form.Panel', {
+                border: false,
+                autoScroll: true,
+                defaults: {labelWidth: 200},
+                items: [
+                    {
+                        xtype: "combo",
+                        name: "reportId",
+                        fieldLabel: t("report"),
+                        triggerAction: 'all',
+                        editable: false,
+                        store: new Ext.data.Store({
+                            autoDestroy: true,
+                            proxy: {
+                                type: 'ajax',
+                                url: "/admin/newsletter/get-available-reports?task=list",
+                                reader: {
+                                    type: 'json',
+                                    rootProperty: 'data'
+                                }
+                            },
+                            fields: ["id", "text"]
+                        }),
+                        id: "pimcore_newsletter_send_report_" + this.document.id,
+                        width: 600,
+                        displayField: 'text',
+                        valueField: 'id'
+                    },{
+                        xtype:'combo',
+                        name: "emailFieldName",
+                        fieldLabel: t('email_field_name'),
+                        triggerAction: "all",
+                        editable: false,
+                        store: new Ext.data.JsonStore({
+                            autoDestroy: true,
+                            proxy: {
+                                type: 'ajax',
+                                url: "/admin/newsletter/get-available-reports?task=fieldNames",
+                                reader: {
+                                    type: 'json',
+                                    rootProperty: 'data'
+                                }
+                            },
+                            fields: ["name"]
+                        }),
+                        width: 600,
+                        displayField: 'name',
+                        valueField: 'name',
+                        listeners: {
+                            "focus": function (el) {
+                                el.getStore().reload({
+                                    params: {
+                                        reportId: Ext.getCmp("pimcore_newsletter_send_report_"
+                                            + this.document.id).getValue()
+                                    }
+                                });
+                            }.bind(this)
+                        }
+                    }
+                ]
+            });
+        }
+
+        return this.layout;
+    },
+
+    /**
+     * returns values for sending process
+     *
+     * @returns {*|Object}
+     */
+    getValues: function () {
+
+        if (!this.layout.rendered) {
+            throw "settings not available";
+        }
+
+        return this.getLayout().getForm().getFieldValues();
+    }
+
+});


### PR DESCRIPTION
This is a pull request for https://github.com/pimcore/pimcore/issues/788

I think it could be a great addition to Pimcore so custom reports and newsletter can be played together. I know the new newsletter as been thinked as extendable so not to added to the core, but i think this adapter will bring really strength to newsletter if it is added to core. And like asked in https://github.com/pimcore/pimcore/issues/788, flashxp said it is a good idea and so i can make a PR on this.

All columns of the report can be used as placeholder in email (like for Default Object List adapter). So it can be very powerfull to send newsletter based on custom report with some column of it used for placeholder in the email (single email sending).

After choosing the "Report adapter" for newsletter, two combobox are provided. Frist one to choose the custom report to use, and the second (it refresh depending of the choosen custom report) to choose the fieldname use as email.

Here are some screenshot:

![newsletter_newtype](https://cloud.githubusercontent.com/assets/9025839/18216353/7a1d58e2-7156-11e6-81b2-6778668d0050.png)

![newsletter_report](https://cloud.githubusercontent.com/assets/9025839/18216346/718a293a-7156-11e6-988f-a315accab281.png)

![newsletter_fieldname](https://cloud.githubusercontent.com/assets/9025839/18216358/81aba2bc-7156-11e6-9387-e3b0c995b135.png)
