### PR TITLE
Fix file uploads due to musl libc iconv error (alpine linux)

### DIFF
--- a/pimcore/lib/Pimcore/Tool/Transliteration.php
+++ b/pimcore/lib/Pimcore/Tool/Transliteration.php
@@ -41,8 +41,13 @@ class Transliteration
         $value = self::_transliterationProcess($value, "~", $language);
         
         // then use iconv
-        $value = trim(iconv("utf-8", "ASCII//IGNORE//TRANSLIT", $value));
-        
+        $iconvValue = trim(iconv("utf-8", "ASCII//IGNORE//TRANSLIT", $value));
+
+        // iconv translit returns an empty value in alpine linux (musl libc)
+        if (!empty($iconvValue)) {
+            $value = $iconvValue;
+        }
+
         return $value;
     }
 


### PR DESCRIPTION
## Fixes
Fix file uploads on alpine linux (musl libc)

## Changes in this pull request  
If the filename is empty the upload will not work. Therefore use the iconv result only when it is not empty. 

## Additional info  
This is not an ideal fix but at least file uploads work again.