### PR TITLE
Converts mime encoded email subject before storing in database

### DIFF
--- a/pimcore/lib/Pimcore/Helper/Mail.php
+++ b/pimcore/lib/Pimcore/Helper/Mail.php
@@ -160,8 +160,16 @@ CSS;
 
         $emailLog->setRequestUri(htmlspecialchars($_SERVER['REQUEST_URI']));
         $emailLog->setParams($mail->getParams());
-        $emailLog->setSubject($mail->getSubject());
         $emailLog->setSentDate(time());
+
+        $subject = $mail->getSubjectRendered();
+        if (0 === strpos($subject, '=?')) {
+            $mbIntEnc = mb_internal_encoding();
+            mb_internal_encoding($mail->getCharset());
+            $subject = mb_decode_mimeheader($subject);
+            mb_internal_encoding($mbIntEnc);
+        }
+        $emailLog->setSubject($subject);
 
         $mailFrom = $mail->getFrom();
         if ($mailFrom) {


### PR DESCRIPTION
When Pimcore sends an email with non-ASCII characters in the subject, \Pimcore\Helper\Mail::logEmail() doesn't decode the UTF-8 mime encoded subject line, so a string like `=?UTF-8?Q?Hello=20=C3=B6=C3=A4=C3=BC=C3=9F?=` show up in the "Sent Email" grid in Pimcore's admin GUI.

## Changes in this pull request  

This fix uses `mb_decode_mimeheader()` to decode an encoded subject header before storing the log entry in table `email_log`.

## Additional info  

```
$template = \Pimcore\Model\Document\Email::getByPath('/path/to/email/template');
$email = new \Pimcore\Mail('UTF-8'); // tested with encodings UTF-8 and ISO-8859-1
$email->setDocument($template);
$email->clearSubject()->setSubject('Hello – 你好');
$email->send();
```

Result in db table `email_log` and "Sent Email" grid without fix:

`=?UTF-8?Q?Hello=20world=20=E2=80=93=20=E4=BD=A0=E5=A5=BD?=``

and with fix:

`Hello – 你好`

