### PR TITLE
Prevents warning it iptcparse fails

### DIFF
--- a/pimcore/models/Asset/Image.php
+++ b/pimcore/models/Asset/Image.php
@@ -373,15 +373,17 @@ class Image extends Model\Asset
 
                 if ($info && isset($info['APP13'])) {
                     $iptcRaw = iptcparse($info['APP13']);
-                    foreach ($iptcRaw as $key => $value) {
-                        if (is_array($value) && count($value) === 1) {
-                            $value = $value[0];
-                        }
+	                if (is_array($iptcRaw)) {
+		                foreach ($iptcRaw as $key => $value) {
+	                        if (is_array($value) && count($value) === 1) {
+	                            $value = $value[0];
+	                        }
 
-                        if (isset($mapping[$key])) {
-                            $data[$mapping[$key]] = \ForceUTF8\Encoding::toUTF8($value);
-                        }
-                    }
+	                        if (isset($mapping[$key])) {
+	                            $data[$mapping[$key]] = \ForceUTF8\Encoding::toUTF8($value);
+	                        }
+	                    }
+	                }
                 }
             }
         }


### PR DESCRIPTION
## Changes in this pull request  

This change prevents a warning if `iptcparse` should fail and return `false`.

## Additional info  

I encountered a JPEG image with the value `Photoshop 3.0 8BIM%                     ` in the IPTC field "APP13". The special characters are an EOT (0x04) and a DLE (0x10).

For some reason this lets iptcparse return `false` and PHP throws a `Warning: Invalid argument supplied for foreach()`.
