### PR TITLE
Adds a method to retrieve elements that have a specific tag assigned

### DIFF
--- a/pimcore/models/Element/Tag.php
+++ b/pimcore/models/Element/Tag.php
@@ -133,6 +133,23 @@ class Tag extends Model\AbstractModel
         $tag->getDao()->batchAssignTagsToElement($cType, $cIds, $tagIds, $replace);
     }
 
+    /**
+     * Retrieves all elements that have a specific tag or one of its child tags assigned
+     *
+     * @param Tag    $tag               The tag to search for
+     * @param string $type              The type of elements to search for: 'document', 'asset' or 'object'
+     * @param array  $subtypes          Filter by subtypes, eg. page, object, email, folder etc.
+     * @param array  $classNames        For objects only: filter by classnames
+     * @param bool   $considerChildTags Look for elements having one of $tag's children assigned
+     *
+     * @return array
+     */
+    public static function getElementsForTag(
+        Tag $tag, $type, array $subtypes = [], $classNames = [], $considerChildTags = false
+    ) {
+        return $tag->getDao()->getElementsForTag($tag, $type, $subtypes, $classNames, $considerChildTags);
+    }
+
     public function save()
     {
         $this->correctPath();

--- a/pimcore/models/Element/Tag/Dao.php
+++ b/pimcore/models/Element/Tag/Dao.php
@@ -204,12 +204,16 @@ class Dao extends Model\Dao\AbstractDao
 
         $select = $this->db->select()
                            ->from('tags_assignment', array())
-                           ->where('tags_assignment.tagid = ?', $tag->getId())
                            ->where('tags_assignment.ctype = ?', $type);
 
-        if ($considerChildTags) {
+        if (true === $considerChildTags) {
             $select->joinInner('tags', 'tags.id = tags_assignment.tagid', array('tags_id' => 'id'));
-            $select->orWhere('tags.idPath LIKE ? ', $tag->getFullIdPath() . "%");
+            $select->where('(' .
+                $this->db->quoteInto('tags_assignment.tagid = ?', $tag->getId()) . ' OR ' .
+                $this->db->quoteInto('tags.idPath LIKE ?', $tag->getFullIdPath() . "%") . ')'
+            );
+        } else {
+            $select->where('tags_assignment.tagid = ?', $tag->getId());
         }
 
         $select->joinInner(

--- a/pimcore/models/Element/Tag/Dao.php
+++ b/pimcore/models/Element/Tag/Dao.php
@@ -217,11 +217,11 @@ class Dao extends Model\Dao\AbstractDao
             array('el_id' => $map[$type][1])
         );
 
-        if (is_array($subtypes) && ! empty($subtypes[0])) {
+        if (! empty($subtypes)) {
             $select->where($map[$type][2] . ' IN (?)', $subtypes);
         }
 
-        if ('object' === $type && is_array($classNames) && ! empty($classNames[0])) {
+        if ('object' === $type && ! empty($classNames)) {
             $select->where('o_className IN (?)', $classNames);
         }
 


### PR DESCRIPTION
## Changes in this pull request  

This change adds a method to retrieve elements (documents, assets, objects) that have a specific tag assigned.

Usage example:

```
$tag = \Pimcore\Model\Element\Tag::getById(1);

// retrieve all documents
$el = \Pimcore\Model\Element\Tag::getElementsForTag($tag, 'document');

// retrieve images from assets
$el = \Pimcore\Model\Element\Tag::getElementsForTag($tag, 'asset', ['image']);

// retrieve objects of class 'Test' and include child tags
$el = \Pimcore\Model\Element\Tag::getElementsForTag($tag, 'object', ['object'], ['Test'], true);
```
