### PR TITLE
Add `class` configuration to all editables

### DIFF
--- a/pimcore/models/Document/Tag.php
+++ b/pimcore/models/Document/Tag.php
@@ -134,7 +134,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
             <script type="text/javascript">
                 editableConfigurations.push(' . $options . ');
             </script>
-            <div id="pimcore_editable_' . $this->getName() . '" class="pimcore_editable pimcore_tag_' . $this->getType() . '"></div>
+            <div id="pimcore_editable_' . $this->getName() . '" class="pimcore_editable pimcore_tag_' . $this->getType() . ' '.$this->getOptions()['class'].'"></div>
         ';
     }
 


### PR DESCRIPTION
## Additional info  

Adding class to input, textarea and other document editables via JS does not seem to work properly (FF latest, Pimcore 4.3.1) and causes issues with external script interaction.
Might be better to inject it directly?