### PR TITLE
web2print - prePdfGeneration event to be able to add config options

### DIFF
--- a/docs/Development_Documentation/10_Extending_Pimcore/11_Event_API_and_Event_Manager.md
+++ b/docs/Development_Documentation/10_Extending_Pimcore/11_Event_API_and_Event_Manager.md
@@ -122,16 +122,17 @@ attach multiple events
 
 ### Document
 
-| Name                               | Target                   | Parameters                            | Description                                                                                              |
-|------------------------------------|--------------------------|---------------------------------------|----------------------------------------------------------------------------------------------------------|
-| `document.preAdd`                  | `Pimcore\Model\Document` | -                                     |                                                                                                          |
-| `document.postAdd`                 | `Pimcore\Model\Document` | -                                     |                                                                                                          |
-| `document.preUpdate`               | `Pimcore\Model\Document` | (bool) `saveVersionOnly`              | saveVersionOnly is set if method saveVersion() was called instead of save()                              |
-| `document.postUpdate`              | `Pimcore\Model\Document` | (bool) `saveVersionOnly`              | saveVersionOnly is set if method saveVersion() was called instead of save()                              |
-| `document.preDelete`               | `Pimcore\Model\Document` | -                                     |                                                                                                          |
-| `document.postDelete`              | `Pimcore\Model\Document` | -                                     |                                                                                                          |
-| `document.print.postPdfGeneration` | `Pimcore\Model\Document` | (string) `filename`, (string) `pdf`   | filename contains the filename of the generated pdf on filesystem, pdf contains generated pdf as string. |
-| `document.postCopy`                | `Pimcore\Model\Document` | `Pimcore\Model\Document base_element` | base_element contains the base document used in copying process                                          |
+| Name                               | Target                   | Parameters                                              | Description                                                                                             |
+|------------------------------------|--------------------------|---------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| `document.preAdd`                  | `Pimcore\Model\Document` | -                                                       |                                                                                                         |
+| `document.postAdd`                 | `Pimcore\Model\Document` | -                                                       |                                                                                                         |
+| `document.preUpdate`               | `Pimcore\Model\Document` | (bool) `saveVersionOnly`                                | saveVersionOnly is set if method saveVersion() was called instead of save()                             |
+| `document.postUpdate`              | `Pimcore\Model\Document` | (bool) `saveVersionOnly`                                | saveVersionOnly is set if method saveVersion() was called instead of save()                             |
+| `document.preDelete`               | `Pimcore\Model\Document` | -                                                       |                                                                                                         |
+| `document.postDelete`              | `Pimcore\Model\Document` | -                                                       |                                                                                                         |
+| `document.print.prePdfGeneration`  | `Pimcore\Model\Document` | `Pimcore\Web2Print\Processor\{ProcessorName} processor` | processor contains the processor object used to generate the PDF                                        |
+| `document.print.postPdfGeneration` | `Pimcore\Model\Document` | (string) `filename`, (string) `pdf`                     | filename contains the filename of the generated pdf on filesystem, pdf contains generated pdf as string |
+| `document.postCopy`                | `Pimcore\Model\Document` | `Pimcore\Model\Document base_element`                   | base_element contains the base document used in copying process                                         |
 
 ### Object
 

--- a/pimcore/lib/Pimcore/Web2Print/Processor.php
+++ b/pimcore/lib/Pimcore/Web2Print/Processor.php
@@ -93,6 +93,10 @@ abstract class Processor
         Model\Tool\Lock::acquire($document->getLockKey(), 0);
 
         try {
+            \Pimcore::getEventManager()->trigger("document.print.prePdfGeneration", $document, [
+                "processor" => $this // can be used to inject dynamicaly generation options for instance
+            ]);
+
             $pdf = $this->buildPdf($document, $jobConfigFile->config);
             file_put_contents($document->getPdfFileName(), $pdf);
 

--- a/pimcore/lib/Pimcore/Web2Print/Processor/WkHtmlToPdf.php
+++ b/pimcore/lib/Pimcore/Web2Print/Processor/WkHtmlToPdf.php
@@ -104,6 +104,22 @@ class WkHtmlToPdf extends Processor
         return [];
     }
 
+    /**
+     * @param string $options
+     * @return void
+     */
+    public function setOptions($options)
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
 
     /**
      * @param string $htmlString


### PR DESCRIPTION
This pull-request is to add an event before the pdf generation of web2print documents.
Puporse is to be able to inject dynamicaly options to wkhtml/pdfreactor depending of the document.

**One good usage may be the following one.**

Actually for wkhtml2pdf, you can only set page-size globaly. But some document could be A4 but other have another format (visit cards, small flyer, etc.).
So we could set an heritable property on document container like a property name "page-size" for instance.

Using this event hook, developper could grab the document properties and modify pdf generation option by setting $this->option on the "processor" object passed as argument in the event, and modify options as they want before rendering the PDF.

This way, we could have different format for instance without having to change the web2print global config each time we render some type of document having different page size parameters.
