### PR TITLE
Allow the onlyDirectChildren flag to be set to false from a custom gr…

### DIFF
--- a/pimcore/static6/js/pimcore/object/folder/search.js
+++ b/pimcore/static6/js/pimcore/object/folder/search.js
@@ -146,9 +146,7 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
             fields = response.availableFields;
             this.gridLanguage = response.language;
             this.sortinfo = response.sortinfo;
-            if (response.onlyDirectChildren) {
-                this.onlyDirectChildren = response.onlyDirectChildren;
-            }
+            this.onlyDirectChildren = response.onlyDirectChildren === true;
         } else {
             fields = response;
         }


### PR DESCRIPTION
In an object's children grid, the "onlyDirectChildren" flag can be set to true by default in [/pimcore/static6/js/pimcore/object/object.js#L279](https://github.com/pimcore/pimcore/blob/7fd56888e21accbe42c684ce9525daeea507daf0/pimcore/static6/js/pimcore/object/object.js#L279). This prevents the flag from being reset to false from a users custom grid config. This change fixes the issue.