### PR TITLE
Grid: Fix for displaying filter condition with operator ">"

### DIFF
--- a/pimcore/static6/js/pimcore/object/helpers/gridTabAbstract.js
+++ b/pimcore/static6/js/pimcore/object/helpers/gridTabAbstract.js
@@ -31,7 +31,7 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
                 if(operator == 'lt') {
                     operator = "&lt;";
                 } else if(operator == 'gt') {
-                    operator = "&lt;";
+                    operator = "&gt;";
                 } else if(operator == 'eq') {
                     operator = "=";
                 }


### PR DESCRIPTION
The filter condition was shown incorrectly when using the Greater-than-operator. Only ExtJS 6 (static6) is affected.
