### PR TITLE
Fix reload document behaviour - href tag

### DIFF
--- a/pimcore/static6/js/pimcore/document/tags/href.js
+++ b/pimcore/static6/js/pimcore/document/tags/href.js
@@ -301,6 +301,9 @@ pimcore.document.tags.href = Class.create(pimcore.document.tag, {
             this.data.path = item.fullpath;
 
             this.element.setValue(this.data.path);
+            if (this.options.reload) {
+                this.reloadDocument();
+            }
         }
     },
 


### PR DESCRIPTION
Currently reload document works only when you drag&drop object into field, but when you change field by search widget (context menu > search) it won't work.