### PR TITLE
do not show frontend http auth in backend

### DIFF
--- a/pimcore/lib/Pimcore/Controller/Router/Route/Frontend.php
+++ b/pimcore/lib/Pimcore/Controller/Router/Route/Frontend.php
@@ -109,7 +109,7 @@ class Frontend extends \Zend_Controller_Router_Route_Abstract
         if ($config->general->http_auth) {
             $username = $config->general->http_auth->username;
             $password = $config->general->http_auth->password;
-            if ($username && $password) {
+            if ($username && $password && (!Tool::isFrontentRequestByAdmin() || !Tool\Authentication::authenticateSession())) {
                 $adapter = new \Zend_Auth_Adapter_Http([
                     "accept_schemes" => "basic",
                     "realm" => Tool::getHostname()


### PR DESCRIPTION
Hi, imho it's a bit annoying that the frontend http authentication configurable in system settings pops also on documents in backend (editmode and preview). So maybe we could suppress it on frontend requests by admin? Here is a PR if you agree :).