### PR TITLE
Fixed handling of empty-check on field

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data.php
+++ b/pimcore/models/Object/ClassDefinition/Data.php
@@ -960,11 +960,7 @@ abstract class Data
      */
     public function isEmpty($data)
     {
-        if (empty($data)) {
-            return true;
-        }
-
-        return false;
+        return empty($data) && !is_numeric($data) && !is_bool($data);
     }
 
     /** True if change is allowed in edit mode.


### PR DESCRIPTION
`empty()` doesn't work on on fields that can store values that trigger this, like `0`, "0" or `false`.

This is especially the case when setting checkboxes to `false`; with activated inheritance the Object Class returns the parent's value:

`if(Object_Abstract::doGetInheritedValues() && $this->getClass()->getFieldDefinition("NAME")->isEmpty($data)) { return $this->getValueFromParent("NAME");}`

The handling of `empty()` seems to be a consistent problem in Pimcore...