### PR TITLE
Fix handling of Checkbox::isEmpty() check

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data/Checkbox.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Checkbox.php
@@ -275,4 +275,13 @@ class Checkbox extends Model\Object\ClassDefinition\Data
 
         return "IFNULL(" . $key . ", 0) = " . $value . " ";
     }
+    
+    /**
+     * @param Object_Concrete $data
+     * @return bool
+     */
+    public function isEmpty($data)
+    {
+        return empty($data) && !is_bool($data);
+    }
 }


### PR DESCRIPTION
Checkboxes store `true`/`false`, which in case of `false` wrongly triggers php's `empty()` function.