### PR TITLE
Nice path request via post

### DIFF
--- a/pimcore/static6/js/pimcore/helpers.js
+++ b/pimcore/static6/js/pimcore/helpers.js
@@ -2833,6 +2833,7 @@ pimcore.helpers.requestNicePathData = function(source, targets, config, fieldCon
     elementData = Ext.encode(elementData);
 
     Ext.Ajax.request({
+        method: 'POST',
         url: "/admin/element/get-nice-path",
         params: {
             source: Ext.encode(source),


### PR DESCRIPTION
I think is safer to use POST instead of default GET because if we have the scenario that an object is linked to many objects inside multi-object field then the request can exceed the maximum of ~ 2000 character url limit 

In my test scenario i got a url with +40000 characters  


