### PR TITLE
added a description column on document properties

### DIFF
--- a/pimcore/static6/js/pimcore/element/properties.js
+++ b/pimcore/static6/js/pimcore/element/properties.js
@@ -125,7 +125,7 @@ pimcore.element.properties = Class.create({
                         rootProperty: 'properties'
                     }
                 },
-                fields: ['name','type',{name: "data", type: "string", convert: function (v, rec) {
+                fields: ['name','description', 'type',{name: "data", type: "string", convert: function (v, rec) {
                     if (rec.data.type == "document" || rec.data.type == "asset" || rec.data.type == "object") {
                         var type = rec.data.type;
                         if (type == "document") {
@@ -157,6 +157,19 @@ pimcore.element.properties = Class.create({
                         return true;
                     }.bind(this)
                 ]
+            });
+
+            predefinedPropertiesStore.load({
+                callback: function(records, operation, success) {
+                    $.each(records, function(index, item) {
+                        var key = item.data.key;
+                        var desc = item.data.name;
+                        var record = store.findRecord('name', key);
+                        if (record) {
+                            record.set("description", desc);
+                        }
+                    });
+                }
             });
 
             var checkColumn = Ext.create('Ext.grid.column.Check', {
@@ -251,6 +264,13 @@ pimcore.element.properties = Class.create({
                                 allowBlank: false
                             });
                         },
+                        sortable: true,
+                        width: 230
+                    },
+                    {
+                        header: t("description"),
+                        dataIndex: 'description',
+                        editable: false,
                         sortable: true,
                         width: 230
                     },


### PR DESCRIPTION
## Changes in this pull request
Properties are often added using the "predefined properties". The Dropdown shows the Description which is not shown in the grid. So you add something and sometimes you are not sure what you added, because it may not have the same name. Therefore i added a new column which is filled with the description from the predefined property, if there is one with the same key.

![screenshot from 2016-10-24 11-07-23](https://cloud.githubusercontent.com/assets/11159008/19639788/222540f8-99da-11e6-914d-1a8db8edb549.png)

