### PR TITLE
ExtJS6 Fix notification icons & window width behaviour

### DIFF
--- a/pimcore/static6/css/icons.css
+++ b/pimcore/static6/css/icons.css
@@ -536,8 +536,8 @@
 .pimcore_icon_restore {
     background: url(/pimcore/static6/img/flat-color-icons/redo.svg) center center no-repeat !important;
 }
-
-.pimcore_icon_apply {
+/* to keep compatibility with icon_notification_success - pimcore.helpers.showNotification */
+.pimcore_icon_apply, .pimcore_icon_success {
     background: url(/pimcore/static6/img/flat-color-icons/ok.svg) center center no-repeat !important;
 }
 

--- a/pimcore/static6/js/pimcore/helpers.js
+++ b/pimcore/static6/js/pimcore/helpers.js
@@ -605,10 +605,13 @@ pimcore.helpers.showNotification = function (title, text, type, errorText, hideD
         errWin.show();
     } else {
         var notification = Ext.create('Ext.window.Toast', {
-            iconCls: 'icon_notification_' + type,
+            iconCls: 'pimcore_icon_' + type,
             title: title,
             html: text,
-            autoShow: true
+            autoShow: true,
+            width: 'auto',
+            maxWidth: 350,
+            closeable: true
             //autoDestroy: true
             //,
             //hideDelay:  hideDelay | 1000


### PR DESCRIPTION
Notifications except "success" type wont' show icon because in ext6 css there's no icon_notification_* classes, so I added pimcore_icon_success also set window max width and made it closable.