### PR TITLE
Fixes bug that corrupts cache

### DIFF
--- a/pimcore/lib/Pimcore/Cache.php
+++ b/pimcore/lib/Pimcore/Cache.php
@@ -342,6 +342,9 @@ class Cache
      */
     public static function save($data, $key, $tags = [], $lifetime = null, $priority = 0, $force = false)
     {
+        if(is_object($data)){
+            $data = clone $data;
+        }
         if (self::getForceImmediateWrite() || $force) {
             if (self::hasWriteLock()) {
                 return;


### PR DESCRIPTION
Please read our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR. 

Fixes # 

## Changes in this pull request  

## Additional info  


This code fixes a nasty bug that corrupts pimcore cached objects.

To reproduce the bug:

- Create class with DateTime field (startdate).
- Clear the cache
- In code do this:
- $object = Object::getById(666);  // just an example
- $dt = $object->getStartdate();  // get get a REFERENCE to the startdate here
- $dt->add(new \DateInterval('P1D'));  // we change the startdate of the object because we chage the reference
- // we never save the changed object
- Now the object with the altered (but not saved!) start date gets cached!