### PR TITLE
Update Editmode.php

### DIFF
--- a/pimcore/lib/Pimcore/Controller/Plugin/Frontend/Editmode.php
+++ b/pimcore/lib/Pimcore/Controller/Plugin/Frontend/Editmode.php
@@ -284,9 +284,9 @@ class Editmode extends \Zend_Controller_Plugin_Abstract
             $html = $this->getResponse()->getBody();
 
             if ($html) {
-                $htmlElement = preg_match("/<html[^a-zA-Z]?( [^>]+)?>/", $html);
-                $headElement = preg_match("/<head[^a-zA-Z]?( [^>]+)?>/", $html);
-                $bodyElement = preg_match("/<body[^a-zA-Z]?( [^>]+)?>/", $html);
+                $htmlElement = !!strpos( $html, '<html' );
+                $headElement = !!strpos( $html, '<head' );
+                $bodyElement = !!strpos( $html, '<body' );
 
                 $skipCheck = false;
 


### PR DESCRIPTION

Detection of body tag fails if you have some inline styles, for example:
<body style="height: 100%; width:100% !important; -webkit-text-size-adjust:100%; -ms-text-size-adjust:100%; margin:0; padding:0; background: #ffffff";">
And you need inline styles for html mails...