### PR TITLE
Check for DateTimeInterface instead of just DateTime

### DIFF
--- a/pimcore/models/Document/Tag/Date.php
+++ b/pimcore/models/Document/Tag/Date.php
@@ -76,7 +76,7 @@ class Date extends Model\Document\Tag
 
         if ($this->date instanceof \Zend_Date) {
             return $this->date->toString($this->options["format"], "php");
-        } elseif ($this->date instanceof \DateTime) {
+        } elseif ($this->date instanceof \DateTimeInterface) {
             return $this->date->formatLocalized($this->options["format"]);
         }
     }

--- a/pimcore/models/Element/Note/Dao.php
+++ b/pimcore/models/Element/Note/Dao.php
@@ -122,7 +122,7 @@ class Dao extends Model\Dao\AbstractDao
                     $data = $data->getId();
                 }
             } elseif ($type == "date") {
-                if ($data instanceof \DateTime) {
+                if ($data instanceof \DateTimeInterface) {
                     $data = $data->getTimestamp();
                 }
             } elseif ($type == "bool") {

--- a/pimcore/models/Object/ClassDefinition/Data/Date.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Date.php
@@ -178,7 +178,7 @@ class Date extends Model\Object\ClassDefinition\Data
     {
         if ($data instanceof \Zend_Date) {
             return $data->get(\Zend_Date::DATE_MEDIUM);
-        } elseif ($data instanceof \DateTime) {
+        } elseif ($data instanceof \DateTimeInterface) {
             return $data->format("Y-m-d");
         }
     }
@@ -226,7 +226,7 @@ class Date extends Model\Object\ClassDefinition\Data
         $data = $this->getDataFromObjectParam($object, $params);
         if ($data instanceof \Zend_Date) {
             return $data->toString("Y-m-d", "php");
-        } elseif ($data instanceof \DateTime) {
+        } elseif ($data instanceof \DateTimeInterface) {
             return $data->format("Y-m-d");
         }
 

--- a/pimcore/models/Object/ClassDefinition/Data/Datetime.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Datetime.php
@@ -176,7 +176,7 @@ class Datetime extends Model\Object\ClassDefinition\Data
     {
         if ($data instanceof \Zend_Date) {
             return $data->toString("Y-m-d H:i", "php");
-        } elseif ($data instanceof \DateTime) {
+        } elseif ($data instanceof \DateTimeInterface) {
             return $data->format("Y-m-d H:i");
         }
     }
@@ -194,7 +194,7 @@ class Datetime extends Model\Object\ClassDefinition\Data
         $data = $this->getDataFromObjectParam($object, $params);
         if ($data instanceof \Zend_Date) {
             return $data->toString("Y-m-d H:i", "php");
-        } elseif ($data instanceof \DateTime) {
+        } elseif ($data instanceof \DateTimeInterface) {
             return $data->format("Y-m-d H:i");
         }
 

--- a/pimcore/models/Tool/Email/Log/Dao.php
+++ b/pimcore/models/Tool/Email/Log/Dao.php
@@ -159,7 +159,7 @@ class Dao extends Model\Dao\AbstractDao
         if (is_string($value) || is_int($value) || is_null($value)) {
             $class->data = ['type' => 'simple',
                 'value' => $value];
-        } elseif ($value instanceof \DateTime) {
+        } elseif ($value instanceof \DateTimeInterface) {
             $class->data = ['type' => 'simple',
                 'value' => $value->format("Y-m-d H:i")];
         } elseif (is_object($value) && method_exists($value, 'getId')) {

--- a/pimcore/models/Webservice/Data/Mapper.php
+++ b/pimcore/models/Webservice/Data/Mapper.php
@@ -80,7 +80,7 @@ abstract class Mapper
      */
     public static function map($object, $apiclass, $type, $options = null)
     {
-        if ($object instanceof \Zend_Date || $object instanceof \DateTime) {
+        if ($object instanceof \Zend_Date || $object instanceof \DateTimeInterface) {
             $object = $object->getTimestamp();
         } elseif (is_object($object)) {
             if (Tool::classExists($apiclass)) {

--- a/tests/lib/Test/Tool.php
+++ b/tests/lib/Test/Tool.php
@@ -57,7 +57,7 @@ class Test_Tool
                         $propertiesStringArray["property_" . $key . "_" . $value->type] = "property_" . $key . "_" . $value->type . ": null";
                     }
                 } elseif ($value->type == 'date') {
-                    if ($value->data instanceof \DateTime) {
+                    if ($value->data instanceof \DateTimeInterface) {
                         $propertiesStringArray["property_" . $key . "_" . $value->type] = "property_" . $key . "_" . $value->type . ":" . $value->data->getTimestamp();
                     }
                 } elseif ($value->type == "bool") {


### PR DESCRIPTION
In PHP we can use DateTime or DateTimeImmutable, both use the same
interface so can be used interchangeably as DateTime objects.
To make sure DateTimeImmutable and DateTime can be used the instanceof
checks must check for DateTimeInterface instead of only DateTime.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>