### PR TITLE
EmailLog / buildArray returns invalid recipients when $data is NULL

### DIFF
--- a/pimcore/models/Tool/Email/Log.php
+++ b/pimcore/models/Tool/Email/Log.php
@@ -600,6 +600,10 @@ class Log extends Model\AbstractModel
      */
     protected function buildArray($data)
     {
+        if (is_null($data)) {
+            return [];
+        }
+        
         $dataArray = [];
         $tmp = explode(',', trim($data));
 


### PR DESCRIPTION
See here: https://3v4l.org/hrFVT

This causes errors resending mail when CC and Bcc are not set