### PR TITLE
Fixes MultihrefMetadata phpdoc (return type) generation.

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data/MultihrefMetadata.php
+++ b/pimcore/models/Object/ClassDefinition/Data/MultihrefMetadata.php
@@ -846,4 +846,12 @@ class MultihrefMetadata extends Model\Object\ClassDefinition\Data\Multihref
             return $result;
         }
     }
+
+    /**
+     * @return string
+     */
+    public function getPhpdocType()
+    {
+        return $this->phpdocType;
+    }
 }


### PR DESCRIPTION
Right now behaviour is like Multihref (objects, document or assets), but it should return 
```
\Pimcore\Model\Object\Data\ElemenentMetadata[]
```


