### PR TITLE
Removed unnecessary if-condition in Frontend Router

### DIFF
--- a/pimcore/lib/Pimcore/Controller/Router/Route/Frontend.php
+++ b/pimcore/lib/Pimcore/Controller/Router/Route/Frontend.php
@@ -145,9 +145,7 @@ class Frontend extends \Zend_Controller_Router_Route_Abstract
 
 
         // test if there is a suitable redirect with override = all (=> priority = 99)
-        if (!$matchFound) {
-            $this->checkForRedirect($originalPath, true);
-        }
+        $this->checkForRedirect($originalPath, true);
 
         // do not allow requests including /index.php/ => SEO
         // this is after the first redirect check, to allow redirects in index.php?xxx


### PR DESCRIPTION
## Changes in this pull request  
- Removed a not needed if condition in Frontend Router

## Additional info  
In Line 94 $matchFound is set to false and until line 148 it can't be set to another value. checkForRedirect will be always executed. So the if condition is not necessarily.
