### PR TITLE
ClassDefinition DateTime: Use Carbon for PHPdoc as well

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data/Datetime.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Datetime.php
@@ -47,7 +47,7 @@ class Datetime extends Model\Object\ClassDefinition\Data
      *
      * @var string
      */
-    public $phpdocType = "\\Pimcore\\Date";
+    public $phpdocType = "\\Carbon\\Carbon";
 
 
     /**


### PR DESCRIPTION
When not using the compat-layer (useZendDate) Date and DateTime hold an instance of Carbon. The auto-generated class files for DateTime still used the PHPdoc for \Pimcore\Date.
