### PR TITLE
Add event admin.document.get.preSendData to PrintPages

### DIFF
--- a/pimcore/lib/Pimcore/Controller/Action/Admin/Printpage.php
+++ b/pimcore/lib/Pimcore/Controller/Action/Admin/Printpage.php
@@ -54,9 +54,17 @@ class Printpage extends \Pimcore\Controller\Action\Admin\Document
 
         // cleanup properties
         $this->minimizeProperties($page);
+        
+        //Hook for modifying return value - e.g. for changing permissions based on object data
+        //data need to wrapped into a container in order to pass parameter to event listeners by reference so that they can change the values
+        $returnValueContainer = new \Pimcore\Model\Tool\Admin\EventDataContainer(object2array($page));
+        \Pimcore::getEventManager()->trigger("admin.document.get.preSendData", $this, [
+            "document" => $page,
+            "returnValueContainer" => $returnValueContainer
+        ]);
 
         if ($page->isAllowed("view")) {
-            $this->_helper->json($page);
+            $this->_helper->json($returnValueContainer->getData());
         }
 
         $this->_helper->json(false);


### PR DESCRIPTION
The workflow component uses the "admin.document.get.preSendData" event to add data about the workflow. Currently the Printpage overrides the getDataByIdAction action and does not add this event.

This PR adds that functionality. It is already tested and worklow component does work on print pages after this change.