### PR TITLE
Symptomatically fixes 1095. In case removing the Alpha-Channel fails,…

### DIFF
--- a/pimcore/lib/Pimcore/Image/Adapter/Imagick.php
+++ b/pimcore/lib/Pimcore/Image/Adapter/Imagick.php
@@ -175,15 +175,19 @@ class Imagick extends Adapter
         if (in_array($format, ["jpeg", "pjpeg", "jpg"]) && $this->isAlphaPossible) {
             // set white background for transparent pixels
             $i->setImageBackgroundColor("#ffffff");
-
-            // Imagick version compatibility
-            $alphaChannel = 11; // This works at least as far back as version 3.1.0~rc1-1
-            if (defined("Imagick::ALPHACHANNEL_REMOVE")) {
-                // Imagick::ALPHACHANNEL_REMOVE has been added in 3.2.0b2
-                $alphaChannel = \Imagick::ALPHACHANNEL_REMOVE;
+            
+            try {
+                // Imagick version compatibility
+                $alphaChannel = 11; // This works at least as far back as version 3.1.0~rc1-1
+                if (defined("Imagick::ALPHACHANNEL_REMOVE")) {
+                    // Imagick::ALPHACHANNEL_REMOVE has been added in 3.2.0b2
+                    $alphaChannel = \Imagick::ALPHACHANNEL_REMOVE;
+                }
+                $i->setImageAlphaChannel($alphaChannel); 
+            } catch(\ImagickException $e) {
+               Logger::warn("Failed to remove Alpha Channel for image: " . $path);
             }
-
-            $i->setImageAlphaChannel($alphaChannel);
+            
             $i->mergeImageLayers(\Imagick::LAYERMETHOD_FLATTEN);
         }
 


### PR DESCRIPTION
… the Image is written with Alpha-Channel.

Fixes #1095 

## Changes in this pull request  
wrap `Imagick::setImageAlphaChannel();` in a try/catch Block and write a Warning to log if ImagickException is thrown.

**Note:** Just fixes the Symptom (no Image created), not the cause.