### PR TITLE
Only try to remove AlphaChannel, if Image has an AlphaChannel

### DIFF
--- a/pimcore/lib/Pimcore/Image/Adapter/Imagick.php
+++ b/pimcore/lib/Pimcore/Image/Adapter/Imagick.php
@@ -176,14 +176,16 @@ class Imagick extends Adapter
             // set white background for transparent pixels
             $i->setImageBackgroundColor("#ffffff");
 
-            // Imagick version compatibility
-            $alphaChannel = 11; // This works at least as far back as version 3.1.0~rc1-1
-            if (defined("Imagick::ALPHACHANNEL_REMOVE")) {
-                // Imagick::ALPHACHANNEL_REMOVE has been added in 3.2.0b2
-                $alphaChannel = \Imagick::ALPHACHANNEL_REMOVE;
+            if ($i->getImageAlphaChannel() !== 0) { // Note: returns (int) 0 if there's no AlphaChannel, PHP Docs are wrong. See: https://www.imagemagick.org/api/channel.php
+                // Imagick version compatibility
+                $alphaChannel = 11; // This works at least as far back as version 3.1.0~rc1-1
+                if (defined("Imagick::ALPHACHANNEL_REMOVE")) {
+                    // Imagick::ALPHACHANNEL_REMOVE has been added in 3.2.0b2
+                    $alphaChannel = \Imagick::ALPHACHANNEL_REMOVE;
+                }
+                $i->setImageAlphaChannel($alphaChannel); 				
             }
 
-            $i->setImageAlphaChannel($alphaChannel);
             $i->mergeImageLayers(\Imagick::LAYERMETHOD_FLATTEN);
         }
 


### PR DESCRIPTION
Fixes #1095

## Changes in this pull request  
Check if there is an AlphaChannel before trying to remove it. Using `Imagick::getImageAlphaChannel()` which returns (int) 0 in PHP, if the Image has no AlphaChannel. 
This is needed for the Tree-Preview Thumbnails, which use `pimcore/static6/img/tree-preview-transparent-background.png` as Base/Background. 
And this image has no AlphaChannel, which can be checked in the Shell with this command:
`convert pimcore/static6/img/tree-preview-transparent-background.png -verbose info:`

