### PR TITLE
[fix] load geoip.js if Personas use Country as condition

### DIFF
--- a/pimcore/lib/Pimcore/Controller/Plugin/Targeting.php
+++ b/pimcore/lib/Pimcore/Controller/Plugin/Targeting.php
@@ -227,14 +227,14 @@ class Targeting extends \Zend_Controller_Plugin_Abstract
     {
         foreach ($personas as $persona) {
             foreach ($persona->getConditions() as $condition) {
-                if ($condition['type'] == "geopoint") {
+                if ($condition['type'] == "geopoint" || $condition['type'] == "country") {
                     return true;
                 }
             }
         }
         foreach ($targets as $target) {
             foreach ($target->getConditions() as $condition) {
-                if ($condition['type'] == "geopoint") {
+                if ($condition['type'] == "geopoint" || $condition['type'] == "country") {
                     return true;
                 }
             }


### PR DESCRIPTION
Fixes # 

## Changes in this pull request  
Fix the problem of missed location when Personas or List of Targets use Country as condition