### PR TITLE
Use Cache::save() instead of protected method Cache::storeToCache()

### DIFF
--- a/pimcore/lib/Pimcore/Cache/Tool/Warming.php
+++ b/pimcore/lib/Pimcore/Cache/Tool/Warming.php
@@ -100,7 +100,7 @@ class Warming
     public static function loadElementToCache($element)
     {
         $cacheKey = Element\Service::getElementType($element) . "_" . $element->getId();
-        Cache::storeToCache($element, $cacheKey, [], null, null, true);
+        Cache::save($element, $cacheKey, [], null, null, true);
     }
 
     /**


### PR DESCRIPTION
This commit fixes a fatal error during cache warming:

```
Fatal error: Call to protected method Pimcore\Cache::storeToCache() from context 'Pimcore\Cache\Tool\Warming' in /pimcore/lib/Pimcore/Cache/Tool/Warming.php
```

This fix uses Cache::save instead of Cache::saveToCache