### PR TITLE
Call update video panel in another way - see #1121

### DIFF
--- a/pimcore/static6/js/pimcore/object/tags/video.js
+++ b/pimcore/static6/js/pimcore/object/tags/video.js
@@ -189,7 +189,8 @@ pimcore.object.tags.video = Class.create(pimcore.object.tags.abstract, {
             content = '<iframe src="//www.dailymotion.com/embed/video/' + this.data.data + '" width="' + width + '" height="' + height + '" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>';
         }
 
-        this.getBody().update(content);
+        this.component.update(content);
+        
     },
 
     getBody: function () {


### PR DESCRIPTION
Fixes #1121 

`this.getBody().update(content);`
seemed to mess up the dom. It removed the inner div's of the classes 'x-autocontainer-outerCt' and 'x-autocontainer-innerCt', which caused Ext.js to crash.
If you update the html of the video panel component like this:
`this.component.update(content);`
It will keep the dom elements in place.

I am not sure if this.getBody() returns the right object, but it is certainly related.

