### PR TITLE
#1139 Use ReflectionClass to list available actions

### DIFF
--- a/pimcore/modules/admin/controllers/MiscController.php
+++ b/pimcore/modules/admin/controllers/MiscController.php
@@ -501,7 +501,10 @@ class Admin_MiscController extends \Pimcore\Controller\Action\Admin
             });
             $actions = array_values(array_map(
                 function (\ReflectionMethod $method) {
-	                return ["name" => preg_replace('/Action$/', '', $method->getName())];
+	                $name = preg_replace('/Action$/', '', $method->getName());
+	                $filter = new \Zend_Filter_Word_CamelCaseToDash();
+	                $name = $filter->filter($name);
+	                return ["name" => $name];
                 }, $methods
             ));
         }

--- a/pimcore/modules/admin/controllers/MiscController.php
+++ b/pimcore/modules/admin/controllers/MiscController.php
@@ -501,7 +501,7 @@ class Admin_MiscController extends \Pimcore\Controller\Action\Admin
             });
             $actions = array_values(array_map(
                 function (\ReflectionMethod $method) {
-                    return ["name" => $method->getName()];
+	                return ["name" => preg_replace('/Action$/', '', $method->getName())];
                 }, $methods
             ));
         }

--- a/pimcore/modules/admin/controllers/MiscController.php
+++ b/pimcore/modules/admin/controllers/MiscController.php
@@ -484,6 +484,7 @@ class Admin_MiscController extends \Pimcore\Controller\Action\Admin
         $controller = $this->getParam("controllerName");
         $controllerClass = str_replace("-", " ", $controller);
         $controllerClass = str_replace(" ", "", ucwords($controllerClass));
+        $reflectionClass = "{$controllerClass}Controller";
         $controllerClass = preg_replace_callback("/([_])([a-z])/i", function ($matches) {
             return "/" . strtoupper($matches[2]);
         }, $controllerClass);
@@ -491,12 +492,18 @@ class Admin_MiscController extends \Pimcore\Controller\Action\Admin
         $controllerDir = $this->getControllerDir();
         $controllerFile = $controllerDir . $controllerClass . "Controller.php";
         if (is_file($controllerFile)) {
-            preg_match_all("/function[ ]+([a-zA-Z0-9]+)Action/i", file_get_contents($controllerFile), $matches);
-            foreach ($matches[1] as $match) {
-                $dat = [];
-                $dat["name"] = strtolower(preg_replace("/[A-Z]/", "-\\0", $match));
-                $actions[] = $dat;
-            }
+            require_once $controllerFile;
+            $oReflectionClass = new \ReflectionClass($reflectionClass);
+            $methods = $oReflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC);
+            $methods = array_filter(
+                $methods, function (\ReflectionMethod $method) {
+                return preg_match('/^([a-zA-Z0-9]+)Action$/', $method->getName());
+            });
+            $actions = array_values(array_map(
+                function (\ReflectionMethod $method) {
+                    return ["name" => $method->getName()];
+                }, $methods
+            ));
         }
 
         $this->_helper->json([


### PR DESCRIPTION
Fixes #1139 

## Changes in this pull request  

This commit uses PHPs built-in ReflectionClass to more reliably list a controllers available actions including inherited methods. Example:

```
// file /lib/Website/Controller/Action.php
namespace Website\Controller;
use Pimcore\Controller\Action\Frontend;

class Action extends Frontend {
    public function init() {}
}

// file /lib/Website/Controller/ContentController.php
namespace Website\Controller;
use Website\Controller\Action;

class ContentController extends Action {
    public function init() { parent::init(); }
    public function fooAction() {}
}

// file /website/controllers/ContentController.php
class ContentController extends Website\Controller\ContentController {
    // some comment: function doesntExistAction is shown if using regex
    public function barAction()
}
```

Current method with regex would list `doesnt-exist` and `bar`, while using ReflectionClass correctly lists `foo` and `bar`.
