### PR TITLE
Escaped wildcards in MySQL LIKE Statements.

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Dao.php
+++ b/pimcore/models/Object/ClassDefinition/Dao.php
@@ -252,29 +252,29 @@ class Dao extends Model\Dao\AbstractDao
         $this->db->delete("objects", $this->db->quoteInto("o_classId = ?", $this->model->getId()));
 
         // remove fieldcollection tables
-        $allTables = $this->db->fetchAll("SHOW TABLES LIKE 'object_collection_%_" . $this->model->getId() . "'");
+        $allTables = $this->db->fetchAll("SHOW TABLES LIKE 'object\_collection\_%\_" . $this->model->getId() . "'");
         foreach ($allTables as $table) {
             $collectionTable = current($table);
             $this->db->query("DROP TABLE IF EXISTS `".$collectionTable."`");
         }
 
         // remove localized fields tables and views
-        $allViews = $this->db->fetchAll("SHOW TABLES LIKE 'object_localized_" . $this->model->getId() . "_%'");
+        $allViews = $this->db->fetchAll("SHOW TABLES LIKE 'object\_localized\_" . $this->model->getId() . "_%'");
         foreach ($allViews as $view) {
             $localizedView = current($view);
             $this->db->query("DROP VIEW IF EXISTS `".$localizedView."`");
         }
 
-        $allTables = $this->db->fetchAll("SHOW TABLES LIKE 'object_localized_query_" . $this->model->getId() . "_%'");
+        $allTables = $this->db->fetchAll("SHOW TABLES LIKE 'object\_localized\_query\_" . $this->model->getId() . "_%'");
         foreach ($allTables as $table) {
             $queryTable = current($table);
             $this->db->query("DROP TABLE IF EXISTS `".$queryTable."`");
         }
 
-        $this->db->query("DROP TABLE IF EXISTS object_localized_data_" . $this->model->getId());
+        $this->db->query("DROP TABLE IF EXISTS object\_localized\_data\_" . $this->model->getId());
 
         // objectbrick tables
-        $allTables = $this->db->fetchAll("SHOW TABLES LIKE 'object_brick_%_" . $this->model->getId() . "'");
+        $allTables = $this->db->fetchAll("SHOW TABLES LIKE 'object\_brick\_%\_" . $this->model->getId() . "'");
         foreach ($allTables as $table) {
             $brickTable = current($table);
             $this->db->query("DROP TABLE `".$brickTable."`");

--- a/pimcore/models/Object/ClassDefinition/Dao.php
+++ b/pimcore/models/Object/ClassDefinition/Dao.php
@@ -259,13 +259,13 @@ class Dao extends Model\Dao\AbstractDao
         }
 
         // remove localized fields tables and views
-        $allViews = $this->db->fetchAll("SHOW TABLES LIKE 'object\_localized\_" . $this->model->getId() . "_%'");
+        $allViews = $this->db->fetchAll("SHOW TABLES LIKE 'object\_localized\_" . $this->model->getId() . "\_%'");
         foreach ($allViews as $view) {
             $localizedView = current($view);
             $this->db->query("DROP VIEW IF EXISTS `".$localizedView."`");
         }
 
-        $allTables = $this->db->fetchAll("SHOW TABLES LIKE 'object\_localized\_query\_" . $this->model->getId() . "_%'");
+        $allTables = $this->db->fetchAll("SHOW TABLES LIKE 'object\_localized\_query\_" . $this->model->getId() . "\_%'");
         foreach ($allTables as $table) {
             $queryTable = current($table);
             $this->db->query("DROP TABLE IF EXISTS `".$queryTable."`");

--- a/pimcore/models/Object/ClassDefinition/Dao.php
+++ b/pimcore/models/Object/ClassDefinition/Dao.php
@@ -271,7 +271,7 @@ class Dao extends Model\Dao\AbstractDao
             $this->db->query("DROP TABLE IF EXISTS `".$queryTable."`");
         }
 
-        $this->db->query("DROP TABLE IF EXISTS object\_localized\_data\_" . $this->model->getId());
+        $this->db->query("DROP TABLE IF EXISTS object_localized_data_" . $this->model->getId());
 
         // objectbrick tables
         $allTables = $this->db->fetchAll("SHOW TABLES LIKE 'object\_brick\_%\_" . $this->model->getId() . "'");


### PR DESCRIPTION
Wildcards in MySQL LIKE Statements must be escaped. Otherwise wrong classes will be deleted. Unfortunately happened in our PROD environment today.

Eg:
- Delete the class with object Id 6
- The previous LIKE Statement object_collection_%_" . $this->model->getId() . " will also delete the following collection: object_collection_whatever_26
- The _ matches exactly one character in MySQL LIKE Statements. So the _ in the example above will be matched with the %, the non-escaped _ will match the value 2 and the model-Id is 6
