### PR TITLE
checks if pimcore_tag_block_current is in registry

### DIFF
--- a/pimcore/lib/Pimcore/Controller/Action/Frontend.php
+++ b/pimcore/lib/Pimcore/Controller/Action/Frontend.php
@@ -507,11 +507,18 @@ abstract class Frontend extends Action
         // this is for $this->action() in templates when they are inside a block element
         try {
             if (!$this->getParam("disableBlockClearing")) {
-                $this->parentBlockCurrent = \Zend_Registry::get("pimcore_tag_block_current");
-                $this->parentBlockNumeration = \Zend_Registry::get("pimcore_tag_block_numeration");
+                $this->parentBlockCurrent = [];
+                if (\Zend_Registry::isRegistered('pimcore_tag_block_current')) {
+                    $this->parentBlockCurrent = \Zend_Registry::get("pimcore_tag_block_current");
+                }
 
-                \Zend_Registry::set("pimcore_tag_block_current", null);
-                \Zend_Registry::set("pimcore_tag_block_numeration", null);
+                $this->parentBlockNumeration = [];
+                if (\Zend_Registry::isRegistered('pimcore_tag_block_numeration')) {
+                    $this->parentBlockNumeration = \Zend_Registry::get("pimcore_tag_block_numeration");
+                }
+
+                \Zend_Registry::set("pimcore_tag_block_current", []);
+                \Zend_Registry::set("pimcore_tag_block_numeration", []);
             }
         } catch (\Exception $e) {
             Logger::debug($e);

--- a/pimcore/models/Document/Tag/Area.php
+++ b/pimcore/models/Document/Tag/Area.php
@@ -102,7 +102,10 @@ class Area extends Model\Document\Tag
         }
 
         $this->setupStaticEnvironment();
-        $suffixes = \Zend_Registry::get("pimcore_tag_block_current");
+        $suffixes = [];
+        if (\Zend_Registry::isRegistered('pimcore_tag_block_current')) {
+            $suffixes = \Zend_Registry::get("pimcore_tag_block_current");
+        }
         $suffixes[] = $this->getName();
         \Zend_Registry::set("pimcore_tag_block_current", $suffixes);
 
@@ -238,12 +241,18 @@ class Area extends Model\Document\Tag
         }
 
 
-        $suffixes = \Zend_Registry::get("pimcore_tag_block_numeration");
-        array_pop($suffixes);
+        $suffixes = [];
+        if (\Zend_Registry::isRegistered('pimcore_tag_block_numeration')) {
+            $suffixes = \Zend_Registry::get("pimcore_tag_block_numeration");
+            array_pop($suffixes);
+        }
         \Zend_Registry::set("pimcore_tag_block_numeration", $suffixes);
 
-        $suffixes = \Zend_Registry::get("pimcore_tag_block_current");
-        array_pop($suffixes);
+        $suffixes = [];
+        if (\Zend_Registry::isRegistered('pimcore_tag_block_current')) {
+            $suffixes = \Zend_Registry::get("pimcore_tag_block_current");
+            array_pop($suffixes);
+        }
         \Zend_Registry::set("pimcore_tag_block_current", $suffixes);
     }
 

--- a/pimcore/models/Document/Tag/Areablock.php
+++ b/pimcore/models/Document/Tag/Areablock.php
@@ -405,7 +405,10 @@ class Areablock extends Model\Document\Tag
         ');
 
         // set name suffix for the whole block element, this will be addet to all child elements of the block
-        $suffixes = \Zend_Registry::get("pimcore_tag_block_current");
+        $suffixes = [];
+        if (\Zend_Registry::isRegistered('pimcore_tag_block_current')) {
+            $suffixes = \Zend_Registry::get("pimcore_tag_block_current");
+        }
         $suffixes[] = $this->getName();
         \Zend_Registry::set("pimcore_tag_block_current", $suffixes);
 
@@ -429,8 +432,11 @@ class Areablock extends Model\Document\Tag
         $this->current = 0;
 
         // remove the suffix which was set by self::start()
-        $suffixes = \Zend_Registry::get("pimcore_tag_block_current");
-        array_pop($suffixes);
+        $suffixes = [];
+        if (\Zend_Registry::isRegistered('pimcore_tag_block_current')) {
+            $suffixes = \Zend_Registry::get("pimcore_tag_block_current");
+            array_pop($suffixes);
+        }
         \Zend_Registry::set("pimcore_tag_block_current", $suffixes);
 
         $this->outputEditmode("</div>");

--- a/pimcore/models/Document/Tag/Block.php
+++ b/pimcore/models/Document/Tag/Block.php
@@ -201,7 +201,10 @@ class Block extends Model\Document\Tag
         ');
 
         // set name suffix for the whole block element, this will be addet to all child elements of the block
-        $suffixes = \Zend_Registry::get("pimcore_tag_block_current");
+        $suffixes = [];
+        if (\Zend_Registry::isRegistered('pimcore_tag_block_current')) {
+            $suffixes = \Zend_Registry::get("pimcore_tag_block_current");
+        }
         $suffixes[] = $this->getName();
         \Zend_Registry::set("pimcore_tag_block_current", $suffixes);
 
@@ -225,8 +228,11 @@ class Block extends Model\Document\Tag
         $this->current = 0;
 
         // remove the suffix which was set by self::start()
-        $suffixes = \Zend_Registry::get("pimcore_tag_block_current");
-        array_pop($suffixes);
+        $suffixes = [];
+        if (\Zend_Registry::isRegistered('pimcore_tag_block_current')) {
+            $suffixes = \Zend_Registry::get("pimcore_tag_block_current");
+            array_pop($suffixes);
+        }
         \Zend_Registry::set("pimcore_tag_block_current", $suffixes);
 
         $this->outputEditmode("</div>");


### PR DESCRIPTION
Before using pimcore_tag_block_current we must check if it is set in the
registry. Also made the variable consistent to an array since at some
places there is a check if the content is not an array and chages it to
an array.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>

