### PR TITLE
show path of link if no linktext is set instead of not_set message

### DIFF
--- a/pimcore/static/js/pimcore/document/tags/link.js
+++ b/pimcore/static/js/pimcore/document/tags/link.js
@@ -74,6 +74,8 @@ pimcore.document.tags.link = Class.create(pimcore.document.tag, {
         var text = "[" + t("not_set") + "]";
         if (this.data.text) {
             text = this.data.text;
+        } else if (this.data.path) {
+            text = this.data.path;
         }
         if (this.data.path) {
             return '<a href="' + this.data.path + '" class="' + this.options["class"] + ' ' + this.data["class"] + '">' + text + '</a>';

--- a/pimcore/static6/js/pimcore/document/tags/link.js
+++ b/pimcore/static6/js/pimcore/document/tags/link.js
@@ -74,6 +74,8 @@ pimcore.document.tags.link = Class.create(pimcore.document.tag, {
         var text = "[" + t("not_set") + "]";
         if (this.data.text) {
             text = this.data.text;
+        } else if (this.data.path) {
+            text = this.data.path;
         }
         if (this.data.path) {
             return '<a href="' + this.data.path + '" class="' + this.options["class"] + ' ' + this.data["class"] + '">' + text + '</a>';


### PR DESCRIPTION
## Changes in this pull request

Sometimes i use the link editable to be more flexible for links, for example if the target has to be a document or also an external link. But the text part has to be more flexible (for example an wysiwyg or even more). So i don't use the text field of the link. In this case it shows the "Not set" message in the editmode, altough the link is actually set. This is a bit confusing, therefore is suggest to show the path of the link if it is set.