### PR TITLE
Backport ZF2+ pwnscriptum handling to Pimcore\Mail #1165

### DIFF
--- a/pimcore/lib/Pimcore/Mail.php
+++ b/pimcore/lib/Pimcore/Mail.php
@@ -601,6 +601,12 @@ class Mail extends \Zend_Mail
      */
     public function setFrom($email, $name = null)
     {
+        // mitigate "pwnscriptum" attack
+        // see https://framework.zend.com/security/advisory/ZF2016-04 for ZF2+ fix
+        if (preg_match('/\\\"/', $email)) {
+            throw new \RuntimeException("Potential code injection in From header");
+        }
+
         $this->_from = null;
         $this->clearHeader("From");
 

--- a/tests/AllTests.php
+++ b/tests/AllTests.php
@@ -10,6 +10,7 @@ class AllTests extends Test_SuiteBase
         $suite->addTest(TestSuite_Inheritance_AllTests::suite());
         $suite->addTest(TestSuite_Rest_AllTests::suite());
         $suite->addTest(TestSuite_Classificationstore_AllTests::suite());
+        $suite->addTest(TestSuite_Pimcore_AllTests::suite());
 
         return $suite;
     }

--- a/tests/TestSuite/Pimcore/AllTests.php
+++ b/tests/TestSuite/Pimcore/AllTests.php
@@ -1,0 +1,21 @@
+<?php
+//require_once 'PHPUnit/Framework.php';
+
+class TestSuite_Pimcore_AllTests extends Test_SuiteBase
+{
+    public static function suite()
+    {
+        $suite = new TestSuite_Basics_AllTests('Pimcore');
+
+        $tests = [
+            \TestSuite\Pimcore\MailTest::class
+        ];
+
+        foreach ($tests as $test) {
+            print("    - " . $test . "\n");
+            $suite->addTestSuite($test);
+        }
+
+        return $suite;
+    }
+}

--- a/tests/TestSuite/Pimcore/AllTests.php
+++ b/tests/TestSuite/Pimcore/AllTests.php
@@ -5,7 +5,7 @@ class TestSuite_Pimcore_AllTests extends Test_SuiteBase
 {
     public static function suite()
     {
-        $suite = new TestSuite_Basics_AllTests('Pimcore');
+        $suite = new static();
 
         $tests = [
             \TestSuite\Pimcore\MailTest::class

--- a/tests/TestSuite/Pimcore/MailTest.php
+++ b/tests/TestSuite/Pimcore/MailTest.php
@@ -17,16 +17,6 @@ class MailTest extends TestCase
         $this->assertEquals($email, $mail->getFrom());
     }
 
-    public function testLocalFrom()
-    {
-        $email = '"foo-bar"@domain';
-
-        $mail = new Mail();
-        $mail->setFrom($email, 'Sender\'s name');
-
-        $this->assertEquals($email, $mail->getFrom());
-    }
-
     /**
      * See issue #1165 ("pwnscriptum")
      *

--- a/tests/TestSuite/Pimcore/MailTest.php
+++ b/tests/TestSuite/Pimcore/MailTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace TestSuite\Pimcore;
+
+use PHPUnit\Framework\TestCase;
+use Pimcore\Mail;
+
+class MailTest extends TestCase
+{
+    public function testNormalFrom()
+    {
+        $email = 'foo@example.com';
+
+        $mail = new Mail();
+        $mail->setFrom($email, 'Sender\'s name');
+
+        $this->assertEquals($email, $mail->getFrom());
+    }
+
+    public function testLocalFrom()
+    {
+        $email = '"foo-bar"@domain';
+
+        $mail = new Mail();
+        $mail->setFrom($email, 'Sender\'s name');
+
+        $this->assertEquals($email, $mail->getFrom());
+    }
+
+    /**
+     * See issue #1165 ("pwnscriptum")
+     *
+     * @expectedException \RuntimeException
+     */
+    public function testMailFromInjectionMitigation()
+    {
+        $mail = new Mail();
+        $mail->setFrom('"AAA\" code injection"@domain', 'Sender\'s name');
+    }
+}


### PR DESCRIPTION
Applies https://framework.zend.com/security/advisory/ZF2016-04 fix to `Pimcore\Mail`

Fixes #1165 
