### PR TITLE
Split up initialization logic and accept optional request/response objects in Pimcore::run()

### DIFF
--- a/pimcore/lib/Pimcore.php
+++ b/pimcore/lib/Pimcore.php
@@ -51,14 +51,17 @@ class Pimcore
      */
     private static $globallyProtectedItems;
 
-
     /**
      * @static
-     * @throws Exception|\Zend_Controller_Router_Exception
+
      * @param bool $returnResponse
-     * @return \Zend_Controller_Response_Http|null
+     * @param Zend_Controller_Request_Abstract $request
+     * @param Zend_Controller_Response_Abstract $response
+     * @return null|Zend_Controller_Response_Http
+     * @throws Exception
+     * @throws Zend_Controller_Router_Exception
      */
-    public static function run($returnResponse = false)
+    public static function run($returnResponse = false, Zend_Controller_Request_Abstract $request = null, Zend_Controller_Response_Abstract $response = null)
     {
         $throwExceptions = false;
 
@@ -253,13 +256,13 @@ class Pimcore
                 @ini_set("display_errors", "Off");
                 @ini_set("display_startup_errors", "Off");
 
-                return $front->dispatch();
+                return $front->dispatch($request, $response);
             } else {
                 @ini_set("display_errors", "On");
                 @ini_set("display_startup_errors", "On");
 
                 $front->throwExceptions(true);
-                return $front->dispatch();
+                return $front->dispatch($request, $response);
             }
         } catch (\Zend_Controller_Router_Exception $e) {
             if (!headers_sent()) {

--- a/pimcore/lib/Pimcore.php
+++ b/pimcore/lib/Pimcore.php
@@ -68,8 +68,10 @@ class Pimcore
         // detect frontend (website)
         $frontend = Tool::isFrontend();
 
-        // enable the output-buffer, why? see in self::outputBufferStart()
-        self::outputBufferStart();
+        if (!$returnResponse) {
+            // enable the output-buffer, why? see in self::outputBufferStart()
+            self::outputBufferStart();
+        }
 
         // initialize cache
         Cache::init();

--- a/pimcore/lib/Pimcore.php
+++ b/pimcore/lib/Pimcore.php
@@ -55,8 +55,10 @@ class Pimcore
     /**
      * @static
      * @throws Exception|\Zend_Controller_Router_Exception
+     * @param bool $returnResponse
+     * @return \Zend_Controller_Response_Http|null
      */
-    public static function run()
+    public static function run($returnResponse = false)
     {
         $throwExceptions = false;
 
@@ -122,6 +124,10 @@ class Pimcore
         }
 
         self::initControllerFront($front);
+
+        if ($returnResponse) {
+            $front->returnResponse(true);
+        }
 
         // set router
         $router = $front->getRouter();
@@ -247,13 +253,13 @@ class Pimcore
                 @ini_set("display_errors", "Off");
                 @ini_set("display_startup_errors", "Off");
 
-                $front->dispatch();
+                return $front->dispatch();
             } else {
                 @ini_set("display_errors", "On");
                 @ini_set("display_startup_errors", "On");
 
                 $front->throwExceptions(true);
-                $front->dispatch();
+                return $front->dispatch();
             }
         } catch (\Zend_Controller_Router_Exception $e) {
             if (!headers_sent()) {


### PR DESCRIPTION
* Split up `Pimcore::run()` into multiple, smaller methods
* Accept `returnResponse` parameter in `Pimcore::run()` and return the response object instead of sending it to the client
* Accept optional request and response objects in `Pimcore::run()` which are passed to dispatcher