### PR TITLE
added defaultEditorConfig for documents and documentation is updated

### DIFF
--- a/docs/Development_Documentation/03_Documents/01_Editables/40_WYSIWYG.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/40_WYSIWYG.md
@@ -79,6 +79,19 @@ There is also an additional way to specify the configuration by adding `customCo
 </section>
 ```
 
+##### Global Configuration
+You can add a Global Configuration for all WYSIWYG Editors for all documents by setting ```pimcore.document.tags.wysiwyg.defaultEditorConfig```
+
+For this purpose, you can create a plugin and add the configuration in the new created file `/plugins/MyPlugin/static/js/startup.js` like this:
+
+```
+pimcoreReady: function (params,broker){
+
+    pimcore.document.tags.wysiwyg.defaultEditorConfig.allowedContent = true;
+
+}
+```
+
 ### Text Output in Editmode
 
 With the following code you can get the text even in editmode:

--- a/docs/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/01_Text_Types.md
+++ b/docs/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/01_Text_Types.md
@@ -76,6 +76,16 @@ More examples and config options for the toolbar and toolbarGroups can be found 
 Please refer to the [CKeditor 4.0 Documentation](http://docs.ckeditor.com/).
   
 ##### Global Configuration
-You can add a Global Configuration for all WYSIWYG Editors by setting ```pimcore.object.tags.wysiwyg.defaultEditorConfig```
+You can add a Global Configuration for all WYSIWYG Editors for all objects by setting ```pimcore.object.tags.wysiwyg.defaultEditorConfig```
+
+For this purpose, you can create a plugin and add the configuration in the new created file `/plugins/MyPlugin/static/js/startup.js` like this:
+
+```
+pimcoreReady: function (params,broker){
+
+    pimcore.object.tags.wysiwyg.defaultEditorConfig.allowedContent = true;
+
+}
+```
 
 

--- a/pimcore/static/js/pimcore/document/tags/wysiwyg.js
+++ b/pimcore/static/js/pimcore/document/tags/wysiwyg.js
@@ -102,6 +102,10 @@ pimcore.document.tags.wysiwyg = Class.create(pimcore.document.tag, {
             eConfig.entities_latin = false;
             eConfig.allowedContent = true; // disables CKEditor ACF (will remove pimcore_* attributes from links, etc.)
 
+            if(typeof(pimcore.document.tags.wysiwyg.defaultEditorConfig) == 'object'){
+                eConfig = mergeObject(pimcore.document.tags.wysiwyg.defaultEditorConfig,eConfig);
+            }
+            
             this.ckeditor = CKEDITOR.inline(this.textarea, eConfig);
 
             this.ckeditor.on('focus', function () {

--- a/pimcore/static6/js/pimcore/document/tags/wysiwyg.js
+++ b/pimcore/static6/js/pimcore/document/tags/wysiwyg.js
@@ -107,6 +107,10 @@ pimcore.document.tags.wysiwyg = Class.create(pimcore.document.tag, {
             eConfig.entities_latin = false;
             eConfig.extraAllowedContent = "*[pimcore_type,pimcore_id]";
 
+            if(typeof(pimcore.document.tags.wysiwyg.defaultEditorConfig) == 'object'){
+                eConfig = mergeObject(pimcore.document.tags.wysiwyg.defaultEditorConfig,eConfig);
+            }
+        
             this.ckeditor = CKEDITOR.inline(this.textarea, eConfig);
 
             this.ckeditor.on('focus', function () {


### PR DESCRIPTION
This is the pull request for issue https://github.com/pimcore/pimcore/issues/1160.

With this, it is now possible to globally change in just one place document editable wysiwyg configuration.

Thanks!