### PR TITLE
Obj events

### DIFF
--- a/docs/Development_Documentation/10_Extending_Pimcore/11_Event_API_and_Event_Manager.md
+++ b/docs/Development_Documentation/10_Extending_Pimcore/11_Event_API_and_Event_Manager.md
@@ -146,6 +146,7 @@ attach multiple events
 | `object.preUpdate`    | `Pimcore\Model\Object\AbstractObject`   | (bool) saveVersionOnly                             | saveVersionOnly is set if method saveVersion() was called instead of save()   |
 | `object.postCopy`     | `Pimcore\Model\Object\AbstractObject`   | `Pimcore\Model\Object\AbstractObject base_element` | base_element contains the base object used in copying process                 |
 
+*in preAdd and preUpdate can give object 'saveActionExtraJSONdata' member to append data to JSON response to browser.
 
 ### Asset
 

--- a/docs/Development_Documentation/10_Extending_Pimcore/13_Plugin_Developers_Guide/05_Plugin_Backend_UI.md
+++ b/docs/Development_Documentation/10_Extending_Pimcore/13_Plugin_Developers_Guide/05_Plugin_Backend_UI.md
@@ -52,6 +52,7 @@ corresponding method to the javascript plugin class.
 | postOpenDocument | after document is opened, document and type are passed as parameters |
 | preOpenObject | before object is opened, object and type are passed as parameters |
 | postOpenObject | after object is opened, object and type are passed as parameters |
+| postSaveObject | after object is saved, object and request data are passed as parameters |
 | prepareAssetTreeContextMenu | before context menu is opened, menu, tree class and asset record are passed as parameters |
 | prepareObjectTreeContextMenu | before context menu is opened, menu, tree class and object record are passed as parameters |
 | prepareDocumentTreeContextMenu | before context menu is opened, menu, tree and document record are passed as parameters |

--- a/pimcore/modules/admin/controllers/ObjectController.php
+++ b/pimcore/modules/admin/controllers/ObjectController.php
@@ -1103,10 +1103,19 @@ class Admin_ObjectController extends \Pimcore\Controller\Action\Admin\Element
                 $object->save();
                 $treeData = $this->getTreeNodeConfig($object);
 
-                $this->_helper->json([
+				$json_data = [
                     "success" => true,
                     "general" => ["o_modificationDate" => $object->getModificationDate()],
-                    "treeData" => $treeData]);
+                    "treeData" => $treeData];
+				
+				
+                if(isset($object->saveActionExtraJSONdata) && is_array($object->saveActionExtraJSONdata)){
+                	$json_data = array_merge($json_data,$object->saveActionExtraJSONdata); 
+					unset($object->saveActionExtraJSONdata);
+                }                 
+				
+				
+                $this->_helper->json($json_data);
             } elseif ($this->getParam("task") == "session") {
 
                 //$object->_fulldump = true; // not working yet, donno why

--- a/pimcore/static6/js/pimcore/object/object.js
+++ b/pimcore/static6/js/pimcore/object/object.js
@@ -672,7 +672,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                                     Ext.apply(this.data.general,rdata.general);
 
                                     pimcore.helpers.updateObjectStyle(this.id, rdata.treeData);
-                                    pimcore.plugin.broker.fireEvent("postSaveObject", this);
+                                    pimcore.plugin.broker.fireEvent("postSaveObject", this, rdata);
                                 }
                                 else {
                                     pimcore.helpers.showPrettyError(rdata.type, t("error"), t("error_saving_object"),


### PR DESCRIPTION
Please read our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR. 


Fixes # 

more control over js request, server response. Specifically for Objects [events *for plugins]. 
i.e. increased programmability of object events in plugins

## Changes in this pull request  

2 Object event modifications:

1) modules/admin/controllers/ObjectController.php: saveAction( checks for member variable 'saveActionExtraJSONdata' and appends it to the response JSON, then unsets it if it exists
2) static6/js/pimcore/object/object.js: save:function( ... now passes rdata[response data] to:
    fireEvent("postSaveObject"

And documentation.
## Additional info  

I needed a way to get more specific result information on the client side. 
e.g. request an object save with js[from browser], then look for certain values in the response.
Previously the response was pretty generic and un-editable.  
