### PR TITLE
Application logger: Fix for unsetting filter "Component"

### DIFF
--- a/pimcore/modules/admin/controllers/LogController.php
+++ b/pimcore/modules/admin/controllers/LogController.php
@@ -131,7 +131,7 @@ class Admin_LogController extends \Pimcore\Controller\Action\Admin
 
     public function componentJsonAction()
     {
-        $components[] = ["key" => "-", "value" => ""];
+        $components[] = ["key" => "", "value" => "-"];
         foreach (ApplicationLoggerDb::getComponents() as $p) {
             $components[] = ["key" => $p, "value" => $p];
         }


### PR DESCRIPTION
Once the filter component has been set it couldn't be unset anymore (besides button "reset").