### PR TITLE
Fix areablock import from webservice

### DIFF
--- a/pimcore/models/Document/Tag/Areablock.php
+++ b/pimcore/models/Document/Tag/Areablock.php
@@ -716,7 +716,7 @@ class Areablock extends Model\Document\Tag
         $data = $wsElement->value;
         if (($data->indices === null or is_array($data->indices)) and ($data->current==null or is_numeric($data->current))
             and ($data->currentIndex==null or is_numeric($data->currentIndex))) {
-            $indices = $data["indices"];
+            $indices = $data->indices;
             if ($indices instanceof \stdclass) {
                 $indices = (array) $indices;
             }


### PR DESCRIPTION
When importing from webservice, the $data variable is a stdClass object, not an array. This throws an error.