### PR TITLE
Minor fix: staticroutes filter function uses only scalar values

### DIFF
--- a/pimcore/modules/admin/controllers/SettingsController.php
+++ b/pimcore/modules/admin/controllers/SettingsController.php
@@ -694,8 +694,11 @@ class Admin_SettingsController extends \Pimcore\Controller\Action\Admin
                 $filter = $this->getParam("filter");
                 $list->setFilter(function ($row) use ($filter) {
                     foreach ($row as $value) {
-                        if (strpos($value, $filter) !== false) {
-                            return true;
+	                    if ( ! is_scalar($value)) {
+		                    continue;
+	                    }
+	                    if (strpos((string)$value, $filter) !== false) {
+		                    return true;
                         }
                     }
 


### PR DESCRIPTION
This fix prevents PHP from warning 'strpos() expects parameter 1 to be string, array given' when filtering. Site ids are stored as an array in config/staticroutes.php since bac7b39
