### PR TITLE
Fixed potential issue with loading tags for an element

### DIFF
--- a/pimcore/models/Element/Tag/Dao.php
+++ b/pimcore/models/Element/Tag/Dao.php
@@ -120,7 +120,7 @@ class Dao extends Model\Dao\AbstractDao
             $tags[] = Model\Element\Tag::getById($tagId);
         }
 
-        array_filter($tags);
+        $tags = array_filter($tags);
         @usort($tags, function ($left, $right) {
             return strcmp($left->getNamePath(), $right->getNamePath());
         });


### PR DESCRIPTION
A variable assignment was missing in the getTagsForElement function which can lead to an exception in the compare function.