### PR TITLE
Fix handling of offset and limit

### DIFF
--- a/pimcore/lib/Pimcore/Document/Newsletter/AddressSourceAdapter/ReportAdapter.php
+++ b/pimcore/lib/Pimcore/Document/Newsletter/AddressSourceAdapter/ReportAdapter.php
@@ -145,7 +145,7 @@ class ReportAdapter implements AddressSourceAdapterInterface
 
         $containers = [];
 
-        for ($i = $offset; $i <= $limit; $i++) {
+        for ($i = $offset; $i < ($offset + $limit); $i++) {
             if (isset($listing[$i][$this->emailFieldName])) {
                 // as $listing is array type we can send all so every column can be used as placeholder in email
                 $containers[] = new SendingParamContainer($listing[$i][$this->emailFieldName], $listing[$i]);


### PR DESCRIPTION
Fix: Sending Newsletter through Report Adapter didn't work due to wrong handling of offset and limit.
