### PR TITLE
Set SQL SECURITY INVOKER on VIEWs

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Dao.php
+++ b/pimcore/models/Object/ClassDefinition/Dao.php
@@ -206,7 +206,7 @@ class Dao extends Model\Dao\AbstractDao
         // create view
         try {
             //$this->db->query('CREATE OR REPLACE VIEW `' . $objectView . '` AS SELECT * FROM `objects` left JOIN `' . $objectTable . '` ON `objects`.`o_id` = `' . $objectTable . '`.`oo_id` WHERE `objects`.`o_classId` = ' . $this->model->getId() . ';');
-            $this->db->query('CREATE OR REPLACE VIEW `' . $objectView . '` AS SELECT * FROM `' . $objectTable . '` JOIN `objects` ON `objects`.`o_id` = `' . $objectTable . '`.`oo_id`;');
+            $this->db->query('CREATE OR REPLACE SQL SECURITY INVOKER VIEW `' . $objectView . '` AS SELECT * FROM `' . $objectTable . '` JOIN `objects` ON `objects`.`o_id` = `' . $objectTable . '`.`oo_id`;');
         } catch (\Exception $e) {
             Logger::debug($e);
         }

--- a/pimcore/models/Object/Localizedfield/Dao.php
+++ b/pimcore/models/Object/Localizedfield/Dao.php
@@ -474,7 +474,7 @@ class Dao extends Model\Dao\AbstractDao
 
                 // create view
                 $viewQuery = <<<QUERY
-CREATE OR REPLACE VIEW `object_localized_{$this->model->getClass()->getId()}_{$language}` AS
+CREATE OR REPLACE SQL SECURITY INVOKER VIEW `object_localized_{$this->model->getClass()->getId()}_{$language}` AS
 
 SELECT {$selectViewFields}
 FROM `{$defaultTable}`

--- a/pimcore/modules/install/controllers/CheckController.php
+++ b/pimcore/modules/install/controllers/CheckController.php
@@ -346,7 +346,7 @@ class Install_CheckController extends \Pimcore\Controller\Action
             // create view
             $queryCheck = true;
             try {
-                $db->query("CREATE OR REPLACE VIEW __pimcore_req_check_view AS SELECT * FROM __pimcore_req_check");
+                $db->query("CREATE OR REPLACE SQL SECURITY INVOKER VIEW __pimcore_req_check_view AS SELECT * FROM __pimcore_req_check");
             } catch (\Exception $e) {
                 $queryCheck = false;
             }


### PR DESCRIPTION
This greatly simplifies moving Pimcore Databases around, without (in this case) reducing security, since there's no need anymore to keep the Users in sync - which is even impossible, when IP's/Hostnames change and requires to recreate all VIEWS after a database transfer (or patch the export SQL-file).

Drawback: This is a extension to the SQL Standard.
See [MySQL Docs](https://dev.mysql.com/doc/refman/5.7/en/stored-programs-security.html)


