### PR TITLE
notes user and date search

### DIFF
--- a/pimcore/modules/admin/controllers/ElementController.php
+++ b/pimcore/modules/admin/controllers/ElementController.php
@@ -107,7 +107,13 @@ class Admin_ElementController extends \Pimcore\Controller\Action\Admin
 
         $conditions = [];
         if ($this->getParam("filter")) {
-            $conditions[] = "(`title` LIKE " . $list->quote("%".$this->getParam("filter")."%") . " OR `description` LIKE " . $list->quote("%".$this->getParam("filter")."%") . " OR `type` LIKE " . $list->quote("%".$this->getParam("filter")."%") . ")";
+            $conditions[] = "("
+                . "`title` LIKE " . $list->quote("%".$this->getParam("filter")."%")
+                . " OR `description` LIKE " . $list->quote("%".$this->getParam("filter")."%")
+                . " OR `type` LIKE " . $list->quote("%".$this->getParam("filter")."%")
+                . " OR `user` IN (SELECT `id` FROM `users` WHERE `name` LIKE " . $list->quote("%".$this->getParam("filter")."%") . ")"
+                . " OR DATE_FORMAT(FROM_UNIXTIME(`date`), '%Y-%m-%d') LIKE " . $list->quote("%".$this->getParam("filter")."%")
+                . ")";
         }
 
         if ($this->getParam("cid") && $this->getParam("ctype")) {


### PR DESCRIPTION
This pull request is for: https://github.com/pimcore/pimcore/issues/1244
As there is already a global filter for type, title and description, I just added support for this global search for user and date.

I think it is more simple than adding filter grid wich will be make things complicated because of the generic actual common filter.
User can search a specific user or specific date even a month (searching for "2017-01" for instance).