### PR TITLE
Archiving usagelog.log

### DIFF
--- a/pimcore/lib/Pimcore/Log/Maintenance.php
+++ b/pimcore/lib/Pimcore/Log/Maintenance.php
@@ -101,8 +101,8 @@ class Maintenance
             $data = gzencode(file_get_contents($logFile));
             $response = Tool::getHttpData("https://www.pimcore.org/usage-statistics/", [], ["data" => $data]);
             if (strpos($response, "true") !== false) {
-                @unlink($logFile);
-                Logger::debug("Usage statistics are transmitted and logfile was cleaned");
+                rename($logFile, $logFile . "-archive-" . date("m-d-Y-H-i"));
+                Logger::debug("Usage statistics are transmitted and logfile was archived");
             } else {
                 Logger::debug("Unable to send usage statistics");
             }
@@ -122,6 +122,7 @@ class Maintenance
             PIMCORE_LOG_DIRECTORY . "/legacy-class-names.log",
             PIMCORE_LOG_DIRECTORY . "/legacy-class-names-admin.log",
             PIMCORE_LOG_DIRECTORY . "/libreoffice-pdf-convert.log",
+            PIMCORE_LOG_DIRECTORY . "/usagelog.log",
         ];
 
         foreach ($logs as $log) {


### PR DESCRIPTION
This pull request is for: https://github.com/pimcore/pimcore/issues/1128

Instead deleting it directly, the usagelog  is archived for 30 days, so administrator don't loose datas the day the limit size was reached. It will be keep 30 days in case of.
And this way, it is more working like the other logs.