### PR TITLE
Action to unlink document translation

### DIFF
--- a/docs/Development_Documentation/06_Multi_Language_i18n/02_Localize_your_Documents.md
+++ b/docs/Development_Documentation/06_Multi_Language_i18n/02_Localize_your_Documents.md
@@ -64,8 +64,26 @@ The localization tool for Pimcore documents is a comfort tool which supports cre
 Following features are supported: 
 * **Creating new documents** for another language - either an empty document or and document using content inheritance (see below)
 * **Link existing documents** in order to have the language link between documents
+* **Unlink existing documents** in order to remove the language link between documents
 * **Open Translation** to quickly navigate to the corresponing document in another language. 
 
+ ```php
+ $service = new \Pimcore\Model\Document\Service();
+ $translations = $service->getTranslations($document); // return an array of all linked languages with associated document ID: Array ( [en] => 2 [fr] => 7 )
+ ```
+  
+ // in your view
+ $language = $this->document->getProperty("language");
+  
+  
+ // any document
+ $doc = \Pimcore\Model\Document::getById(234);
+ $language = $doc->getProperty("language");
+  
+  
+ // accessing anywhere in your code using the registry (the common ZF way)
+ $language = \Zend_Registry::get("Zend_Locale");
+ ```
 
 ### Content Inheritance
 Content inheritance is a Pimcore feature to save duplicate data maintenance within documents. This feature is quite handy

--- a/pimcore/config/texts/en.json
+++ b/pimcore/config/texts/en.json
@@ -5641,6 +5641,10 @@
         "definition": "Link existing Document"
     },
     {
+        "term": "unlink_existing_document",
+        "definition": "Unlink existing Document"
+    },
+    {
         "term": "using_inheritance",
         "definition": "Using Inheritance"
     },

--- a/pimcore/models/Document/Service/Dao.php
+++ b/pimcore/models/Document/Service/Dao.php
@@ -102,11 +102,26 @@ class Dao extends Model\Dao\AbstractDao
             $language = $translation->getProperty("language");
         }
 
+        // Prevent self link and link loop (self link can happen if document translation is added when the reverse logic is already added between the two documents)
+        if ($translation->getId() === $sourceId) return;
+
         $this->db->insertOrUpdate("documents_translations", [
             "id" => $translation->getId(),
             "sourceId" => $sourceId,
             "language" => $language
         ]);
+    }
+
+    /**
+     * @param Document $document
+     * @param Document $translation
+     * @param $language
+     */
+    public function deleteTranslation(Document $sourceDocument, Document $targetDocument)
+    {
+        // Remove in both way
+        $this->db->delete("documents_translations", "id = " . $sourceDocument->getId() . " AND sourceId = ". $targetDocument->getId());
+        $this->db->delete("documents_translations", "id = " . $targetDocument->getId() . " AND sourceId = ". $sourceDocument->getId());
     }
 
     /**

--- a/pimcore/modules/admin/controllers/DocumentController.php
+++ b/pimcore/modules/admin/controllers/DocumentController.php
@@ -1112,6 +1112,21 @@ class Admin_DocumentController extends \Pimcore\Controller\Action\Admin\Element
         ]);
     }
 
+    public function translationDeleteAction()
+    {
+        $sourceDocument = Document::getById($this->getParam("sourceId"));
+        $targetDocument = Document::getById($this->getParam("targetId"));
+
+        if ($sourceDocument && $targetDocument) {
+            $service = new Document\Service;
+            $service->deleteTranslation($sourceDocument, $targetDocument);
+        }
+        
+        $this->_helper->json([
+            "success" => true
+        ]);
+    }
+
     public function translationCheckLanguageAction()
     {
         $success = false;

--- a/pimcore/static6/js/pimcore/document/document.js
+++ b/pimcore/static6/js/pimcore/document/document.js
@@ -511,6 +511,29 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
             });
         }
 
+        var unlinkTranslationsMenu = [];
+        if(this.data["translations"]) {
+            var me = this;
+            Ext.iterate(this.data["translations"], function (language, documentId, myself) {
+                unlinkTranslationsMenu.push({
+                    text: pimcore.available_languages[language] + " [" + language + "]",
+                    iconCls: "pimcore_icon_language_" + language,
+                    handler: function () {
+                        Ext.Ajax.request({
+                            url: "/admin/document/translation-delete",
+                            params: {
+                                sourceId: me.id,
+                                targetId: documentId
+                            },
+                            success: function (response) {
+                                me.reload();
+                            }.bind(this)
+                        });
+                    }.bind(this)
+                });
+            });
+        }
+        
         return {
             tooltip: t("translation"),
             iconCls: "pimcore_icon_translations",
@@ -533,6 +556,11 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
                 text: t("link_existing_document"),
                 handler: this.linkTranslation.bind(this),
                 iconCls: "pimcore_icon_page pimcore_icon_overlay_reading"
+            }, {
+                text: t("unlink_existing_document"),
+                menu: unlinkTranslationsMenu,
+                hidden: !unlinkTranslationsMenu.length,
+                iconCls: "pimcore_icon_page pimcore_icon_overlay_delete"
             }, {
                 text: t("open_translation"),
                 menu: translationsMenu,


### PR DESCRIPTION
This pull request is for : https://github.com/pimcore/pimcore/issues/1079

It adds the missing unlink feature.

Documentation is updated with this feature (maybe you will want to update the Localization Tool image illustration, it is not in this PR).
I added some code to show how to get the linked translations for documents using API.

And I added a patch, because there was a bug in the current Pimcore release when two document was already linked and if you make the same link (from the other document), it was strangely added in documents_translations table with same id and sourceId. To prevent this i have added `if ($translation->getId() === $sourceId) return;` in the addTranslation method of the DAO.

I hope all is ok in this PR : )
Thanks!