### PR TITLE
Option to limit the number of objectbricks which could be added

### DIFF
--- a/pimcore/config/texts/en.json
+++ b/pimcore/config/texts/en.json
@@ -6279,5 +6279,13 @@
     {
         "term": "site_ids_tooltip",
         "definition": "Provide a comma-seperated list of site IDs"
+    },
+    {
+        "term": "limit_to_one_objectbrick",
+        "definition": "Limit to one objectbrick"
+    },
+    {
+        "term": "only_one_objectbrick_can_be_added",
+        "definition": "Only one objectbrick can be added"
     }
 ]

--- a/pimcore/config/texts/en.json
+++ b/pimcore/config/texts/en.json
@@ -6279,13 +6279,5 @@
     {
         "term": "site_ids_tooltip",
         "definition": "Provide a comma-seperated list of site IDs"
-    },
-    {
-        "term": "limit_to_one_objectbrick",
-        "definition": "Limit to one objectbrick"
-    },
-    {
-        "term": "only_one_objectbrick_can_be_added",
-        "definition": "Only one objectbrick can be added"
     }
 ]

--- a/pimcore/models/Object/ClassDefinition/Data/Objectbricks.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Objectbricks.php
@@ -45,27 +45,27 @@ class Objectbricks extends Model\Object\ClassDefinition\Data
     public $allowedTypes = [];
 
     /**
-     * @var boolean
+     * @var int
      */
-    public $limitToOne;
+    public $maxItems;
 
     /**
-     * @return boolean
+     * @param $maxItems
+     * @return $this
      */
-    public function getLimitToOne()
+    public function setMaxItems($maxItems)
     {
-        return $this->limitToOne;
+        $this->maxItems = $this->getAsIntegerCast($maxItems);
+
+        return $this;
     }
 
     /**
-     * @param boolean $limitToOne
-     * @return void
+     * @return int
      */
-    public function setLimitToOne($limitToOne)
+    public function getMaxItems()
     {
-        $this->limitToOne = (bool) $limitToOne;
-
-        return $this;
+        return $this->maxItems;
     }
 
     /**
@@ -930,7 +930,7 @@ class Objectbricks extends Model\Object\ClassDefinition\Data
     public function synchronizeWithMasterDefinition(Object\ClassDefinition\Data $masterDefinition)
     {
         $this->allowedTypes = $masterDefinition->allowedTypes;
-        $this->limitToOne = $masterDefinition->limitToOne;
+        $this->maxItems = $masterDefinition->maxItems;
     }
 
     /**

--- a/pimcore/models/Object/ClassDefinition/Data/Objectbricks.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Objectbricks.php
@@ -45,6 +45,30 @@ class Objectbricks extends Model\Object\ClassDefinition\Data
     public $allowedTypes = [];
 
     /**
+     * @var boolean
+     */
+    public $limitToOne;
+
+    /**
+     * @return boolean
+     */
+    public function getLimitToOne()
+    {
+        return $this->limitToOne;
+    }
+
+    /**
+     * @param boolean $limitToOne
+     * @return void
+     */
+    public function setLimitToOne($limitToOne)
+    {
+        $this->limitToOne = (bool) $limitToOne;
+
+        return $this;
+    }
+
+    /**
      * @see Object\ClassDefinition\Data::getDataForEditmode
      * @param string $data
      * @param null|Model\Object\AbstractObject $object
@@ -906,6 +930,7 @@ class Objectbricks extends Model\Object\ClassDefinition\Data
     public function synchronizeWithMasterDefinition(Object\ClassDefinition\Data $masterDefinition)
     {
         $this->allowedTypes = $masterDefinition->allowedTypes;
+        $this->limitToOne = $masterDefinition->limitToOne;
     }
 
     /**

--- a/pimcore/static6/js/pimcore/object/classes/data/objectbricks.js
+++ b/pimcore/static6/js/pimcore/object/classes/data/objectbricks.js
@@ -55,10 +55,11 @@ pimcore.object.classes.data.objectbricks = Class.create(pimcore.object.classes.d
         this.specificPanel.removeAll();
         this.specificPanel.add([
             {
-                xtype: "checkbox",
-                fieldLabel: t("limit_to_one_objectbrick"),
-                name: "limitToOne",
-                checked: this.datax.limitToOne
+                xtype: "numberfield",
+                fieldLabel: t("maximum_items"),
+                name: "maxItems",
+                value: this.datax.maxItems,
+                minValue: 0
             }
         ]);
         
@@ -90,7 +91,7 @@ pimcore.object.classes.data.objectbricks = Class.create(pimcore.object.classes.d
             Ext.apply(this.datax,
                 {
                     allowedTypes: source.datax.allowedTypes,
-                    limitToOne: source.datax.limitToOne
+                    maxItems: source.datax.maxItems
                 });
         }
     }

--- a/pimcore/static6/js/pimcore/object/classes/data/objectbricks.js
+++ b/pimcore/static6/js/pimcore/object/classes/data/objectbricks.js
@@ -53,7 +53,15 @@ pimcore.object.classes.data.objectbricks = Class.create(pimcore.object.classes.d
         $super();
         
         this.specificPanel.removeAll();
-
+        this.specificPanel.add([
+            {
+                xtype: "checkbox",
+                fieldLabel: t("limit_to_one_objectbrick"),
+                name: "limitToOne",
+                checked: this.datax.limitToOne
+            }
+        ]);
+        
         return this.layout;
     },
 
@@ -81,7 +89,8 @@ pimcore.object.classes.data.objectbricks = Class.create(pimcore.object.classes.d
             }
             Ext.apply(this.datax,
                 {
-                    allowedTypes: source.datax.allowedTypes
+                    allowedTypes: source.datax.allowedTypes,
+                    limitToOne: source.datax.limitToOne
                 });
         }
     }

--- a/pimcore/static6/js/pimcore/object/tags/objectbricks.js
+++ b/pimcore/static6/js/pimcore/object/tags/objectbricks.js
@@ -88,9 +88,6 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
         if(this.fieldConfig.title) {
             panelConf.title = this.fieldConfig.title;
         }
-        if (this.fieldConfig.limitToOne) {
-            panelConf.limitToOne = true;
-        }
         this.component = new Ext.Panel(panelConf);
 
         return this.component;
@@ -212,8 +209,8 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
         if(!this.layoutDefinitions[type]) {
             return;
         }
-        if (this.fieldConfig.limitToOne && Object.keys(this.currentElements).length >= 1) {
-            Ext.MessageBox.alert(t("warning"), t("only_one_objectbrick_can_be_added"));
+        if (this.fieldConfig.maxItems && Object.keys(this.currentElements).length >= this.fieldConfig.maxItems) {
+            Ext.Msg.alert(t("error"),t("limit_reached"));
             return;
         }
         

--- a/pimcore/static6/js/pimcore/object/tags/objectbricks.js
+++ b/pimcore/static6/js/pimcore/object/tags/objectbricks.js
@@ -88,6 +88,9 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
         if(this.fieldConfig.title) {
             panelConf.title = this.fieldConfig.title;
         }
+        if (this.fieldConfig.limitToOne) {
+            panelConf.limitToOne = true;
+        }
         this.component = new Ext.Panel(panelConf);
 
         return this.component;
@@ -209,7 +212,11 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
         if(!this.layoutDefinitions[type]) {
             return;
         }
-
+        if (this.fieldConfig.limitToOne && Object.keys(this.currentElements).length >= 1) {
+            Ext.MessageBox.alert(t("warning"), t("only_one_objectbrick_can_be_added"));
+            return;
+        }
+        
         this.dataFields = [];
         this.currentData = {};
         this.currentMetaData = {};
@@ -228,7 +235,7 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
                 ownerName: this.fieldConfig.name
             }
         ).items;
-
+        
         if(this.fieldConfig.noteditable && items) {
             items.forEach(function (record) {
                 record.disabled = true;


### PR DESCRIPTION
This is pull request for : https://github.com/pimcore/pimcore/issues/999

Objectbricks can be limit to one, so only a single objectbrick could be added for the related field in an object.
Purpose of this is for instance, sometimes you model a generic object and want to add some specific fields depending the object type. Object brick is great for it but user could not be limited to the number of them he can add. This PR give the option to prevent the user to be able to add several objectbrick.

A use case could be modeling a generic "product" classe having an objectbrick field called "Type of product".
The generic classe will have price, name, weight, ...
The objectbricks could be: tv, bycicle, book... which will bring additionnal specific field to the product. Only one of those must be added to the product, no more.
Limiting the objectbrick field to one will permit this way of making product model.