### PR TITLE
Document editable tag name option

### DIFF
--- a/docs/Development_Documentation/03_Documents/01_Editables/08_Checkbox.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/08_Checkbox.md
@@ -2,11 +2,12 @@
 
 ## Configuration
 
-| Name     | Type    | Description                                                                        |
-|----------|---------|------------------------------------------------------------------------------------|
-| `reload` | boolean | Set to true to reload the page in editmode after changing the state.               |
-| `label`  | string  | a `<label>` which is added in the editmode                                         |
-| `class`  | string  | A CSS class that is added to the surrounding container of this element in editmode |
+| Name     | Type    | Description                                                                                                    |
+|----------|---------|----------------------------------------------------------------------------------------------------------------|
+| `reload` | boolean | Set to true to reload the page in editmode after changing the state.                                           |
+| `label`  | string  | a `<label>` which is added in the editmode                                                                     |
+| `class`  | string  | A CSS class that is added to the surrounding container of this element in editmode                             |
+| `tag`    | string  | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode |
 
 ## Methods
 

--- a/docs/Development_Documentation/03_Documents/01_Editables/10_Date.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/10_Date.md
@@ -2,10 +2,11 @@
 
 ### Configuration
 
-| Name     | Type   | Description                                                                        |
-|----------|--------|------------------------------------------------------------------------------------|
-| `format` | string | A string which describes how to output the date. (see below)                       |
-| `class`  | string | A CSS class that is added to the surrounding container of this element in editmode |
+| Name     | Type   | Description                                                                                                    |
+|----------|--------|----------------------------------------------------------------------------------------------------------------|
+| `format` | string | A string which describes how to output the date. (see below)                                                   |
+| `class`  | string | A CSS class that is added to the surrounding container of this element in editmode                             |
+| `tag`    | string | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode |
 
 ## Methods
 

--- a/docs/Development_Documentation/03_Documents/01_Editables/12_Href.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/12_Href.md
@@ -16,6 +16,7 @@ In frontend-mode the href returns the path of the linked element.
 | `width`      | int     | Width of the field in pixel.                                                                                                               |
 | `uploadPath` | string  | Target path for (inline) uploaded assets                                                                                                   |
 | `class`      | string  | A CSS class that is added to the surrounding container of this element in editmode                                                         |
+| `tag`        | string  | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode                             |
 
 ## Methods
 

--- a/docs/Development_Documentation/03_Documents/01_Editables/14_Image.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/14_Image.md
@@ -36,6 +36,7 @@ The biggest advantages of using that instead of (for example) the href editable:
 | `dropClass`                    | string  | This option can be used to add multiple alternative drop-targets and context menus on custom HTML elements in your code. <br /><br />Just add the class specified here also to custom HTML elements and they will get a drop target too. |
 | `deferred`                     | bool    | Set to false to disable deferred (on demand) thumbnail rendering                                                                                                                                                                         |
 | `class`                        | string  | A CSS class that is added to the surrounding container of this element in editmode                                                                                                                                                       |
+| `tag`                          | string  | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode                                                                                                                           |
 
 You can also pass every valid `<img>` tag attribute ([w3.org Image](http://www.w3.org/TR/html401/struct/objects.html#edef-IMG)), such as: `class`, `style`
 

--- a/docs/Development_Documentation/03_Documents/01_Editables/16_Input.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/16_Input.md
@@ -7,13 +7,14 @@ For a multi-line alternative have a look at the [textarea editable](./36_Textare
 
 ## Configuration
 
-| Name               | Type    | Configuration                                                                         |
-|--------------------|---------|---------------------------------------------------------------------------------------|
-| `width`            | integer | Width of the input in editmode (in pixels)                                            |
-| `htmlspecialchars` | boolean | Set to false to get the raw value without HTML special chars like & (default to true) |
-| `nowrap`           | boolean | set to false to disable the automatic line break                                      |
-| `class`            | string  | A CSS class that is added to the surrounding container of this element in editmode    |
-| `placeholder`      | string  | A placeholder that is displayed when the field is empty                               |
+| Name               | Type    | Configuration                                                                                                  |
+|--------------------|---------|----------------------------------------------------------------------------------------------------------------|
+| `width`            | integer | Width of the input in editmode (in pixels)                                                                     |
+| `htmlspecialchars` | boolean | Set to false to get the raw value without HTML special chars like & (default to true)                          |
+| `nowrap`           | boolean | set to false to disable the automatic line break                                                               |
+| `class`            | string  | A CSS class that is added to the surrounding container of this element in editmode                             |
+| `tag`              | string  | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode |
+| `placeholder`      | string  | A placeholder that is displayed when the field is empty                                                        |
 
 ## Methods
 

--- a/docs/Development_Documentation/03_Documents/01_Editables/18_Link.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/18_Link.md
@@ -9,9 +9,10 @@ The link editable is used for dynamic link creation in documents.
 You can pass every valid attribute an `<a>`-tag can have ([w3.org - Link](http://www.w3.org/TR/html401/struct/links.html#h-12.2)), 
 such as: `class`, `target`, `id`, `style`, `accesskey`, `name`, `title` and additionally the following: 
 
-| Name     | Type     | Description                                                             |
-|----------|----------|-------------------------------------------------------------------------|
-| `reload` | boolean  | Set to true to reload the page in editmode after changing the state.    |
+| Name     | Type     | Description                                                                                                    |
+|----------|----------|----------------------------------------------------------------------------------------------------------------|
+| `reload` | boolean  | Set to true to reload the page in editmode after changing the state.                                           |
+| `tag`    | string   | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode |
 
 ## Methods
 

--- a/docs/Development_Documentation/03_Documents/01_Editables/20_Multihref.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/20_Multihref.md
@@ -16,6 +16,7 @@ Multihref editable provides one to many relation to other Pimcore elements (docu
 | `subtypes`     | array     | Allowed subtypes grouped by type (folder, page, snippet, image, video, object, ...), if empty all subtypes are allowed (see example below)                      |
 | `classes`      | array     | Allowed object class names, if empty all classes are allowed                                                                                                    |
 | `class`        | string    | A CSS class that is added to the surrounding container of this element in editmode                                                                              |
+| `tag`          | string    | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode                                                  |
 
 ## Methods
 

--- a/docs/Development_Documentation/03_Documents/01_Editables/22_Multiselect.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/22_Multiselect.md
@@ -6,12 +6,13 @@ The Multiselect editable generates a **multiselect** box component in editmode.
 
 ## Configuration
 
-| Name     | Type    | Description                                                                        |
-|----------|---------|------------------------------------------------------------------------------------|
-| `store`  | array   | Key/Value pairs for the available options.                                         |
-| `width`  | integer | Width of a generated block in editmode                                             |
-| `height` | integer | Height of a generated block in editmode                                            |
-| `class`  | string  | A CSS class that is added to the surrounding container of this element in editmode |
+| Name     | Type    | Description                                                                                                    |
+|----------|---------|----------------------------------------------------------------------------------------------------------------|
+| `store`  | array   | Key/Value pairs for the available options.                                                                     |
+| `width`  | integer | Width of a generated block in editmode                                                                         |
+| `height` | integer | Height of a generated block in editmode                                                                        |
+| `class`  | string  | A CSS class that is added to the surrounding container of this element in editmode                             |
+| `tag`    | string  | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode |
 
 ## Methods
 

--- a/docs/Development_Documentation/03_Documents/01_Editables/24_Numeric.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/24_Numeric.md
@@ -5,12 +5,13 @@ The numeric editable is very similar to the [input editable](./16_Input.md), but
 
 ## Configuration
 
-| Name       | Type    | Description                                                                        |
-|------------|---------|------------------------------------------------------------------------------------|
-| `maxValue` | float   | Define a maximum value                                                             |
-| `minValue` | float   | Define a minimum value                                                             |
-| `width`    | integer | Width of the field in pixel                                                        |
-| `class`    | string  | A CSS class that is added to the surrounding container of this element in editmode |
+| Name       | Type    | Description                                                                                                    |
+|------------|---------|----------------------------------------------------------------------------------------------------------------|
+| `maxValue` | float   | Define a maximum value                                                                                         |
+| `minValue` | float   | Define a minimum value                                                                                         |
+| `width`    | integer | Width of the field in pixel                                                                                    |
+| `class`    | string  | A CSS class that is added to the surrounding container of this element in editmode                             |
+| `tag`      | string  | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode |
 
 ## Methods
 

--- a/docs/Development_Documentation/03_Documents/01_Editables/25_Embed.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/25_Embed.md
@@ -2,11 +2,12 @@
 
 ### Configuration
 
-| Name     | Type   | Description                                                                        |
-|----------|--------|------------------------------------------------------------------------------------|
-| `width`  | string | Width in the editmode                                                              |
-| `height` | string | Height in the editmode                                                             |
-| `class`  | string | A CSS class that is added to the surrounding container of this element in editmode |
+| Name     | Type   | Description                                                                                                    |
+|----------|--------|----------------------------------------------------------------------------------------------------------------|
+| `width`  | string | Width in the editmode                                                                                          |
+| `height` | string | Height in the editmode                                                                                         |
+| `class`  | string | A CSS class that is added to the surrounding container of this element in editmode                             |
+| `tag`    | string | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode |
 
 Additionally you can use any configuration option of https://github.com/mpratt/Embera
 

--- a/docs/Development_Documentation/03_Documents/01_Editables/26_PDF.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/26_PDF.md
@@ -9,13 +9,14 @@ The PDF editable allows you to embed asset documents (pdf, doc, xls, ...) into d
 
 ## Configuration
 
-| Name                | Type      | Description                                                                             |
-|---------------------|-----------|-----------------------------------------------------------------------------------------|
-| `width`             | integer   | Width of the viewer (default 100%)                                                      |
-| `height`            | integer   | Height of the viewerin pixel                                                            |
-| `fullscreen`        | bool      | Allow fullscreen or not                                                                 |
-| `hotspotCallback`   | closure   | Possibility to add custom attributes on hotspot `<div>` tags, ... see example below     |
-| `class`             | string    | A CSS class that is added to the surrounding container of this element in editmode      |
+| Name                | Type      | Description                                                                                                    |
+|---------------------|-----------|----------------------------------------------------------------------------------------------------------------|
+| `width`             | integer   | Width of the viewer (default 100%)                                                                             |
+| `height`            | integer   | Height of the viewerin pixel                                                                                   |
+| `fullscreen`        | bool      | Allow fullscreen or not                                                                                        |
+| `hotspotCallback`   | closure   | Possibility to add custom attributes on hotspot `<div>` tags, ... see example below                            |
+| `class`             | string    | A CSS class that is added to the surrounding container of this element in editmode                             |
+| `tag`               | string    | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode |
 
 ## Methods
 

--- a/docs/Development_Documentation/03_Documents/01_Editables/28_Renderlet.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/28_Renderlet.md
@@ -9,19 +9,20 @@ A typical use-case would be to render product objects within a document.
 
 ## Configuration
 
-| Name           | Type      | Description                                                                        | Mandatory   |
-|----------------|-----------|------------------------------------------------------------------------------------|-------------|
-| `action`       | string    | Specify action                                                                     | X           |
-| `className`    | string    | Specify class name (if type **object** chosen)                                     |             |
-| `controller`   | string    | Specify controller                                                                 | X           |
-| `height`       | integer   | Height of the renderlet in pixel                                                   |             |
-| `module`       | string    | Specify module (default: website)                                                  |             |
-| `reload`       | bool      | Reload document on change                                                          |             |
-| `template`     | string    | Specify template                                                                   |             |
-| `title`        | string    | Add a title to the box in editmode                                                 |             |
-| `type`         | string    | The type of the element assigned to the renderlet (document,asset,object)          |             |
-| `width`        | integer   | Width of the renderlet in pixel                                                    |             |
-| `class`        | string    | A CSS class that is added to the surrounding container of this element in editmode |             |
+| Name           | Type      | Description                                                                                                    | Mandatory   |
+|----------------|-----------|----------------------------------------------------------------------------------------------------------------|-------------|
+| `action`       | string    | Specify action                                                                                                 | X           |
+| `className`    | string    | Specify class name (if type **object** chosen)                                                                 |             |
+| `controller`   | string    | Specify controller                                                                                             | X           |
+| `height`       | integer   | Height of the renderlet in pixel                                                                               |             |
+| `module`       | string    | Specify module (default: website)                                                                              |             |
+| `reload`       | bool      | Reload document on change                                                                                      |             |
+| `template`     | string    | Specify template                                                                                               |             |
+| `title`        | string    | Add a title to the box in editmode                                                                             |             |
+| `type`         | string    | The type of the element assigned to the renderlet (document,asset,object)                                      |             |
+| `width`        | integer   | Width of the renderlet in pixel                                                                                |             |
+| `class`        | string    | A CSS class that is added to the surrounding container of this element in editmode                             |             |
+| `tag`          | string    | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode |             |
 
 Optionally you can pass every parameter (with a scalar data type) you like to the renderlet which can be accessed in 
 the configured controller with `$this->getParam("yourKey")`.

--- a/docs/Development_Documentation/03_Documents/01_Editables/30_Select.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/30_Select.md
@@ -6,12 +6,13 @@ The select editable generates select-box component in Editmode.
 
 ## Configuration
 
-| Name     | Type    | Description                                                                        |
-|----------|---------|------------------------------------------------------------------------------------|
-| `store`  | array   | Key/Value pairs for the available options.                                         |
-| `reload` | bool    | Set true to reload the page in editmode after selecting an item                    |
-| `width`  | integer | Width of the select box in pixel                                                   |
-| `class`  | string  | A CSS class that is added to the surrounding container of this element in editmode |
+| Name     | Type    | Description                                                                                                    |
+|----------|---------|----------------------------------------------------------------------------------------------------------------|
+| `store`  | array   | Key/Value pairs for the available options.                                                                     |
+| `reload` | bool    | Set true to reload the page in editmode after selecting an item                                                |
+| `width`  | integer | Width of the select box in pixel                                                                               |
+| `class`  | string  | A CSS class that is added to the surrounding container of this element in editmode                             |
+| `tag`    | string  | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode |
 
 ## Methods
 

--- a/docs/Development_Documentation/03_Documents/01_Editables/32_Snippet.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/32_Snippet.md
@@ -9,14 +9,15 @@ You have to create them the same way as other documents (pages).
 
 ## Configuration
 
-| Name            | Type    | Description                                                                        |
-|-----------------|---------|------------------------------------------------------------------------------------|
-| `defaultHeight` | integer | A default height if the element is empty                                           |
-| `height`        | integer | Height of the snippet in pixel                                                     |
-| `reload`        | bool    | Reload document on change                                                          |
-| `title`         | string  | You can give the element a title                                                   |
-| `width`         | integer | Width of the snippet in pixel                                                      |
-| `class`         | string  | A CSS class that is added to the surrounding container of this element in editmode |
+| Name            | Type    | Description                                                                                                    |
+|-----------------|---------|----------------------------------------------------------------------------------------------------------------|
+| `defaultHeight` | integer | A default height if the element is empty                                                                       |
+| `height`        | integer | Height of the snippet in pixel                                                                                 |
+| `reload`        | bool    | Reload document on change                                                                                      |
+| `title`         | string  | You can give the element a title                                                                               |
+| `width`         | integer | Width of the snippet in pixel                                                                                  |
+| `class`         | string  | A CSS class that is added to the surrounding container of this element in editmode                             |
+| `tag`           | string  | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode |
 
 ## Methods
 

--- a/docs/Development_Documentation/03_Documents/01_Editables/34_Table.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/34_Table.md
@@ -6,11 +6,12 @@ The table editable provides the ability to edit a table structure.
 
 ## Configuration
 
-| Name       | Type    | Description                                                                        |
-|------------|---------|------------------------------------------------------------------------------------|
-| `defaults` | array   | Array can have the following properties: rows, cols, data (see example)            |
-| `width`    | integer | Width of the field in pixel                                                        |
-| `class`    | string  | A CSS class that is added to the surrounding container of this element in editmode |
+| Name       | Type    | Description                                                                                                    |
+|------------|---------|----------------------------------------------------------------------------------------------------------------|
+| `defaults` | array   | Array can have the following properties: rows, cols, data (see example)                                        |
+| `width`    | integer | Width of the field in pixel                                                                                    |
+| `class`    | string  | A CSS class that is added to the surrounding container of this element in editmode                             |
+| `tag`      | string  | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode |
 
 ## Methods
 

--- a/docs/Development_Documentation/03_Documents/01_Editables/36_Textarea.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/36_Textarea.md
@@ -6,14 +6,15 @@ The textarea editable is very similar to the [Input](./16_Input.md) editable, th
 
 ## Configuration
 
-| Name               | Type    | Description                                                                           |
-|--------------------|---------|---------------------------------------------------------------------------------------|
-| `height`           | integer | Height of the textarea in pixel                                                       |
-| `htmlspecialchars` | boolean | Set to false to get the raw value without HTML special chars like & (default: `true`) |
-| `nl2br`            | boolean | Set to true to get also breaks in frontend                                            |
-| `placeholder`      | string  | A placeholder that is displayed when the field is empty                               |
-| `width`            | integer | Width of the textarea in pixel                                                        |
-| `class`            | string  | A CSS class that is added to the surrounding container of this element in editmode    |
+| Name               | Type    | Description                                                                                                    |
+|--------------------|---------|----------------------------------------------------------------------------------------------------------------|
+| `height`           | integer | Height of the textarea in pixel                                                                                |
+| `htmlspecialchars` | boolean | Set to false to get the raw value without HTML special chars like & (default: `true`)                          |
+| `nl2br`            | boolean | Set to true to get also breaks in frontend                                                                     |
+| `placeholder`      | string  | A placeholder that is displayed when the field is empty                                                        |
+| `width`            | integer | Width of the textarea in pixel                                                                                 |
+| `class`            | string  | A CSS class that is added to the surrounding container of this element in editmode                             |
+| `tag`              | string  | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode |
 
 ## Methods
 

--- a/docs/Development_Documentation/03_Documents/01_Editables/38_Video.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/38_Video.md
@@ -20,7 +20,8 @@ Local asset videos support the automatic generation and transcoding of videos us
 | `width`                   | integer   | Width of the video in pixel                                                                                                                                                                                             |
 | `youtube`                 | array     | Parameters for youtube integration. Possible parameters: [https://developers.google.com/youtube/player_parameters](https://developers.google.com/youtube/player_parameters) - only for type ***youtube***               |
 | `class`                   | string    | A CSS class that is added to the surrounding container of this element in editmode                                                                                                                                      |
-  
+| `tag`                     | string    | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode                                                                                                          |
+
 ## Methods
 
 | Name                       | Arguments            | Return                                                  | Description                                                                                   |

--- a/docs/Development_Documentation/03_Documents/01_Editables/40_WYSIWYG.md
+++ b/docs/Development_Documentation/03_Documents/01_Editables/40_WYSIWYG.md
@@ -6,14 +6,15 @@ Similar to Textarea and Input you can use the WYSIWYG editable in the templates 
  
 ## Configuration
 
-| Name            | Type    | Description                                                                        |
-|-----------------|---------|------------------------------------------------------------------------------------|
-| `customConfig`  | string  | Path to Javascript file with configuration for CKEditor                            |
-| `enterMode`     | integer | Set it to 2 if you don't want to add the P-tag                                     |
-| `height`        | integer | Minimum height of the field in pixels                                              |
-| `toolbarGroups` | string  | A toolbar config array (see below)                                                 |
-| `width`         | integer | Width of the field in pixels                                                       |
-| `class`         | string  | A CSS class that is added to the surrounding container of this element in editmode |
+| Name            | Type    | Description                                                                                                    |
+|-----------------|---------|----------------------------------------------------------------------------------------------------------------|
+| `customConfig`  | string  | Path to Javascript file with configuration for CKEditor                                                        |
+| `enterMode`     | integer | Set it to 2 if you don't want to add the P-tag                                                                 |
+| `height`        | integer | Minimum height of the field in pixels                                                                          |
+| `toolbarGroups` | string  | A toolbar config array (see below)                                                                             |
+| `width`         | integer | Width of the field in pixels                                                                                   |
+| `class`         | string  | A CSS class that is added to the surrounding container of this element in editmode                             |
+| `tag`           | string  | A tag name that is used instead of the default `div` for the surrounding container of this element in editmode |
 
 ## Methods
 

--- a/pimcore/models/Document/Tag.php
+++ b/pimcore/models/Document/Tag.php
@@ -138,11 +138,18 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
             $class .= (" " . $this->getOptions()["class"]);
         }
 
+        if (isset($this->getOptions()["tag"]) && $this->getOptions()["tag"]) {
+            $tag = $this->getOptions()["tag"];
+        }
+        else {
+            $tag = "div";
+        }
+
         return '
             <script type="text/javascript">
                 editableConfigurations.push(' . $options . ');
             </script>
-            <div id="pimcore_editable_' . $this->getName() . '" class="' . $class . '"></div>
+            <' . $tag . ' id="pimcore_editable_' . $this->getName() . '" class="' . $class . '"></' . $tag . '>
         ';
     }
 


### PR DESCRIPTION
This is a pull request for : https://github.com/pimcore/pimcore/issues/1006

It don't break anything as it is implemnted as an option (defaulted to "div" tag for sourrounding container).
Documentation has been updated (it was the long part of this PR ; ) )

With this, it is now possible to do (if forced the style inline for this exemple, but better in a css file for sure):
`<p style="background-color: red; font-size: 50px;"><?= $this->input("myinput", ["tag" => "span"])?></p>`
And the style in editmode won't be broken anymore and user can see as it will render in preview/real mode.
