### PR TITLE
phpdoc of magic method mustn't contain static keyword

### DIFF
--- a/pimcore/models/Object/ClassDefinition.php
+++ b/pimcore/models/Object/ClassDefinition.php
@@ -312,9 +312,9 @@ class ClassDefinition extends Model\AbstractModel
             foreach ($this->getFieldDefinitions() as $key => $def) {
                 if (!(method_exists($def, "isRemoteOwner") and $def->isRemoteOwner())) {
                     if ($def instanceof Object\ClassDefinition\Data\Localizedfields) {
-                        $cd .= "* @method static \\Pimcore\\Model\\Object\\" . ucfirst($this->getName()) . '\Listing getBy' . ucfirst($def->getName()) . ' ($field, $value, $locale = null, $limit = 0) ' . "\n";
+                        $cd .= "* @method \\Pimcore\\Model\\Object\\" . ucfirst($this->getName()) . '\Listing getBy' . ucfirst($def->getName()) . ' ($field, $value, $locale = null, $limit = 0) ' . "\n";
                     } else {
-                        $cd .= "* @method static \\Pimcore\\Model\\Object\\" . ucfirst($this->getName()) . '\Listing getBy' . ucfirst($def->getName()) . ' ($value, $limit = 0) ' . "\n";
+                        $cd .= "* @method \\Pimcore\\Model\\Object\\" . ucfirst($this->getName()) . '\Listing getBy' . ucfirst($def->getName()) . ' ($value, $limit = 0) ' . "\n";
                     }
                 }
             }


### PR DESCRIPTION
phpdoc for magic Listing methods is generated with static keyword
However the phpdoc standard doesn't allow this.

Syntax for @method from phpdoc:
@method [return type] [name]([[type] [parameter]<, ...>]) [<description>]

reference:
https://phpdoc.org/docs/latest/references/phpdoc/tags/method.html

I experienced problems in NetBeans as magic methods generated by Pimcore like
`* @method static \Pimcore\Model\Object\Account\Listing getByAccount_type ($value, $limit = 0)`
annoy the code indexer. The indexer takes `static` as type and `Listing` as method name which appears as many times as we have magic methods. Thus it displays "duplicate method" errors.
