### PR TITLE
Notice error ApplicationLoggerDb

### DIFF
--- a/pimcore/lib/Pimcore/Log/Handler/ApplicationLoggerDb.php
+++ b/pimcore/lib/Pimcore/Log/Handler/ApplicationLoggerDb.php
@@ -62,7 +62,7 @@ class ApplicationLoggerDb extends AbstractProcessingHandler
             'priority' => strtolower($record["level_name"]),
             'message' => $record["message"],
             'timestamp' => $record["datetime"]->format("Y-m-d H:i:s"),
-            'fileobject' => isset($record["context"]["fileObject"]) ? $record["context"]["fileObject"] : null,
+            'fileobject' => (array_key_exists('context', $record) && array_key_exists('fileObject', $record['context'])) ? $record["context"]["fileObject"] : null,
             'relatedobject' => isset($record["context"]["relatedObject"]) ? $record["context"]["relatedObject"] : null,
             'relatedobjecttype' => isset($record["context"]["relatedObjectType"]) ? $record["context"]["relatedObjectType"] : null,
             'component' => $record["context"]["component"],

--- a/pimcore/lib/Pimcore/Log/Handler/ApplicationLoggerDb.php
+++ b/pimcore/lib/Pimcore/Log/Handler/ApplicationLoggerDb.php
@@ -62,9 +62,9 @@ class ApplicationLoggerDb extends AbstractProcessingHandler
             'priority' => strtolower($record["level_name"]),
             'message' => $record["message"],
             'timestamp' => $record["datetime"]->format("Y-m-d H:i:s"),
-            'fileobject' => $record["context"]["fileObject"],
-            'relatedobject' => $record["context"]["relatedObject"],
-            'relatedobjecttype' => $record["context"]["relatedObjectType"],
+            'fileobject' => isset($record["context"]["fileObject"]) ? $record["context"]["fileObject"] : null,
+            'relatedobject' => isset($record["context"]["relatedObject"]) ? $record["context"]["relatedObject"] : null,
+            'relatedobjecttype' => isset($record["context"]["relatedObjectType"]) ? $record["context"]["relatedObjectType"] : null,
             'component' => $record["context"]["component"],
             'source' => $record["context"]["source"]
         ];


### PR DESCRIPTION
When making a simple log send:

```
$logger = \Pimcore\Log\ApplicationLogger::getInstance("My component", true);
$logger->log("info", "Test message");
```

A notice error is send (undefined index).

This pull request prevent this notice error when using ApplicationLoggerDb.

Thanks.