### PR TITLE
Unused variable $sql

### DIFF
--- a/pimcore/models/Tool/Setup/Dao.php
+++ b/pimcore/models/Tool/Setup/Dao.php
@@ -42,7 +42,7 @@ class Dao extends Model\Dao\AbstractDao
             $sql = trim($m);
             if (strlen($sql) > 0) {
                 $sql .= ";";
-                $this->db->query($m);
+                $this->db->query($sql);
             }
         }
 


### PR DESCRIPTION
I think is better to use the sql variable, since we apply trim on $m and we append ';'
