### PR TITLE
Localizedfields at a glance

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data/Localizedfields.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Localizedfields.php
@@ -88,6 +88,11 @@ class Localizedfields extends Model\Object\ClassDefinition\Data
     public $labelWidth;
 
     /**
+     * @var bool
+     */
+    public $atAGlance;
+
+    /**
      * contains further localized field definitions if there are more than one localized fields in on class
      * @var array
      */
@@ -914,6 +919,25 @@ class Localizedfields extends Model\Object\ClassDefinition\Data
     public function getWidth()
     {
         return $this->width;
+    }
+
+    /**
+     * @param $atAGlance
+     * @return $this
+     */
+    public function setAtAGlance($atAGlance)
+    {
+        $this->atAGlance = $atAGlance;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAtAGlance()
+    {
+        return $this->atAGlance;
     }
 
     /**

--- a/pimcore/static6/js/pimcore/object/classes/data/localizedfields.js
+++ b/pimcore/static6/js/pimcore/object/classes/data/localizedfields.js
@@ -137,6 +137,13 @@ pimcore.object.classes.data.localizedfields = Class.create(pimcore.object.classe
                     name: "labelWidth",
                     fieldLabel: t("label_width"),
                     value: this.datax.labelWidth
+                },
+                {
+                    xtype: "checkbox",
+                    fieldLabel: t("at_a_glance"),
+                    name: "atAGlance",
+                    itemId: "atAGlance",
+                    checked: this.datax.atAGlance
                 }
             ]
         });
@@ -167,7 +174,8 @@ pimcore.object.classes.data.localizedfields = Class.create(pimcore.object.classe
                     width: source.datax.width,
                     height: source.datax.height,
                     maxTabs: source.datax.maxTabs,
-                    labelWidth: source.datax.labelWidth
+                    labelWidth: source.datax.labelWidth,
+                    atAGlance: source.datax.atAGlance
                 });
         }
     }

--- a/pimcore/static6/js/pimcore/object/tags/localizedfields.js
+++ b/pimcore/static6/js/pimcore/object/tags/localizedfields.js
@@ -28,6 +28,7 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
         this.referencedFields = [];
         this.availablePanels = [];
         this.dropdownLayout = false;
+        this.atAGlance = false;
 
         if (pimcore.currentuser.admin || fieldConfig.permissionView === undefined) {
             this.frontendLanguages = pimcore.settings.websiteLanguages;
@@ -42,6 +43,14 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
 
         if (this.frontendLanguages.length > maxTabs) {
             this.dropdownLayout = true;
+        }
+
+        if(fieldConfig.atAGlance){
+            this.atAGlance = true;
+        }
+
+        if(fieldConfig.atAGlance){
+            this.atAGlance = true;
         }
 
         if (data) {
@@ -201,6 +210,67 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
                     text: t("language")
                 }), this.countrySelect];
             }
+        } else if (this.atAGlance){
+            
+            var glancePanelConf = {
+                items: [],
+                width: 'auto',
+                height: 'auto',
+                layout: {
+                    type: 'table',
+                    columns: nrOfLanguages
+                },
+                defaults: {
+                    border: true,
+                    bodyPadding: 10
+                }
+            };
+
+            if(this.fieldConfig.height) {
+                glancePanelConf.height = this.fieldConfig.height;
+                glancePanelConf.autoHeight = false;
+            }
+
+            for (var i = 0; i < nrOfLanguages; i++) {
+                this.currentLanguage = this.frontendLanguages[i];
+                this.languageElements[this.currentLanguage] = [];
+
+                var editable = (pimcore.currentuser.admin || this.fieldConfig.permissionEdit === undefined || this.fieldConfig.permissionEdit.length == 0 || in_array(this.currentLanguage, this.fieldConfig.permissionEdit));
+                var runtimeContext = Ext.clone(this.context);
+                runtimeContext.language = Ext.clone(this.currentLanguage);
+                
+                var items = this.getRecursiveLayout(this.fieldConfig, !editable, runtimeContext);
+                var item = {
+                    flex: 1,
+                    xtype: 'panel',
+                    autoScroll: true,
+                    padding: '0',
+                    margin: '10px',
+                    deferredRender: false,
+                    iconCls: "pimcore_icon_language_" + this.frontendLanguages[i].toLowerCase(),
+                    title: pimcore.available_languages[this.frontendLanguages[i]],
+                    items: items.items
+                };
+
+                if (this.fieldConfig.labelWidth) {
+                    item.labelWidth = this.fieldConfig.labelWidth;
+                }
+
+                glancePanelConf.items.push(item);
+            }
+
+
+            wrapperConfig.autoScroll = true;
+            wrapperConfig.layout = {
+                type: 'hbox',
+                pack: 'start',
+                align: 'stretchmax',
+                flex: 'all even'
+            };
+
+            var tablePanel = new Ext.Panel(glancePanelConf);
+            wrapperConfig.items = [tablePanel];
+
         } else {
             var panelConf = {
                 monitorResize: true,

--- a/pimcore/static6/js/pimcore/object/tags/localizedfields.js
+++ b/pimcore/static6/js/pimcore/object/tags/localizedfields.js
@@ -49,10 +49,6 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
             this.atAGlance = true;
         }
 
-        if(fieldConfig.atAGlance){
-            this.atAGlance = true;
-        }
-
         if (data) {
             if (data.data) {
                 this.data = data.data;

--- a/pimcore/static6/js/pimcore/object/tags/localizedfields.js
+++ b/pimcore/static6/js/pimcore/object/tags/localizedfields.js
@@ -44,11 +44,9 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
         if (this.frontendLanguages.length > maxTabs) {
             this.dropdownLayout = true;
         }
-
         if(fieldConfig.atAGlance){
             this.atAGlance = true;
         }
-
         if (data) {
             if (data.data) {
                 this.data = data.data;


### PR DESCRIPTION
# Feature Request 

Issue: https://github.com/pimcore/pimcore/issues/1279

## Feature description 

Added a new option to localizedfields data object definition. Now you can view mutliple language fields at a glance side by side. That's helpful to translate text. 
The Panel will scroll horizontially if the screen smaller than needed space for localized fields. 

![feat-glance-class](https://cloud.githubusercontent.com/assets/668703/22887114/17ac6e1a-f201-11e6-91a0-9de5ce8483da.png)
![feat-glance-object](https://cloud.githubusercontent.com/assets/668703/22887119/1ba2d216-f201-11e6-8bdc-4c6599d86f9d.png)

  