### PR TITLE
Added default empty arrays to new variables in UserRole.php

### DIFF
--- a/pimcore/models/User/UserRole.php
+++ b/pimcore/models/User/UserRole.php
@@ -57,17 +57,17 @@ class UserRole extends AbstractUser
     /**
      * @var array
      */
-    public $perspectives;
+    public $perspectives = [];
 
     /**
      * @var array
      */
-    public $websiteTranslationLanguagesView;
+    public $websiteTranslationLanguagesView = [];
 
     /**
      * @var array
      */
-    public $websiteTranslationLanguagesEdit;
+    public $websiteTranslationLanguagesEdit = [];
 
     /**
      *


### PR DESCRIPTION
Added [] to new variables to prevent an error in pimcore/models/User.php getMergedWebsiteTranslationLanguagesEdit() function.
getWebsiteTranslationLanguagesEdit() will return null without empty array initialization, which will cause:
$this->mergedWebsiteTranslationLanguagesEdit = array_values($this->mergedWebsiteTranslationLanguagesEdit);
to crash.