### PR TITLE
Add less map

### DIFF
--- a/pimcore/lib/Pimcore/Tool/Less.php
+++ b/pimcore/lib/Pimcore/Tool/Less.php
@@ -159,7 +159,15 @@ class Less
         // use php implementation of lessc if it doesn't work
         if (empty($compiledContent)) {
             $parser = new \Less_Parser();
-            $parser->parse(file_get_contents($path));
+            $sourceMapFile = PIMCORE_TEMPORARY_DIRECTORY . "/less___" . File::getValidFilename(str_replace(".less", "", $source)) . "-" . filemtime($path) . ".map";
+            $parser->SetOptions([
+                'sourceMap'         => true,
+                'sourceMapWriteTo'  => $sourceMapFile,
+                'sourceMapURL'      => str_replace(PIMCORE_DOCUMENT_ROOT, "", $sourceMapFile),
+                "sourceMapRootpath" => "/",
+                "sourceMapBasepath" => PIMCORE_DOCUMENT_ROOT
+            ]);
+            $parser->parseFile($path, ROOT_URL . dirname(str_replace(PIMCORE_DOCUMENT_ROOT, "", $path)) . "/");
             $compiledContent = $parser->getCss();
 
             // add a comment to the css so that we know it's compiled by lessphp


### PR DESCRIPTION
This pull request add less source map (to Less_Parser PHP processing only, not lessc binary as i don't use/know it and prefer to left this part to people being able to test it).
Using it make debuging a lot easier, so it will help developper life if this is merged.

A problem with Firefox dev tools using the sources map exists for domain with hyphen. For reference, the issue has been submitted to Firefox issue tracker:
https://bugzilla.mozilla.org/show_bug.cgi?id=1311424
So in case of test/using sources map better to go on Google Chrome for now ; )

Thanks.