### PR TITLE
fixed on date filter for creation and modification date in shared translations

### DIFF
--- a/pimcore/modules/admin/controllers/TranslationController.php
+++ b/pimcore/modules/admin/controllers/TranslationController.php
@@ -444,13 +444,14 @@ class Admin_TranslationController extends \Pimcore\Controller\Action\Admin
                     $field = $fieldname;
                     $value = "%" . $filter["value"] . "%";
                 } elseif ($filter["type"] == "date" ||
-                    ($isExtJs6 && in_array($fieldname, ["modificationDate", "creationdate"]))) {
+                    ($isExtJs6 && in_array($fieldname, ["modificationDate", "creationDate"]))) {
                     if ($filter[$operatorField] == "lt") {
                         $operator = "<";
                     } elseif ($filter[$operatorField] == "gt") {
                         $operator = ">";
                     } elseif ($filter[$operatorField] == "eq") {
                         $operator = "=";
+                        $fieldname = "UNIX_TIMESTAMP(DATE(FROM_UNIXTIME({$fieldname})))";
                     }
                     $filter["value"] = strtotime($filter["value"]);
                     $field = $fieldname;


### PR DESCRIPTION
The "on" filter for creation and modification date was not working for shared translations due to comparison of timestamps instead of just dates. 
