### PR TITLE
added filter for allowed predefined document types

### DIFF
--- a/pimcore/static6/js/pimcore/document/tree.js
+++ b/pimcore/static6/js/pimcore/document/tree.js
@@ -785,11 +785,16 @@ pimcore.document.tree = Class.create({
 
     populatePredefinedDocumentTypes: function(documentMenu, tree, record) {
         var document_types = pimcore.globalmanager.get("document_types_store");
+        var perspectiveCfg = this.perspectiveCfg;
 
         document_types.sort([{property: 'priority', direction: 'DESC'},
             {property: 'name', direction: 'ASC'}]);
 
         document_types.each(function (documentMenu, typeRecord) {
+            if (perspectiveCfg["allowed_predefined_" + typeRecord.get("type")] && !in_array(typeRecord.get("name"), perspectiveCfg["allowed_predefined_" + typeRecord.get("type")])) {
+                return;
+            }
+
             if (typeRecord.get("type") == "page") {
                 documentMenu.page.push({
                     text: ts(typeRecord.get("name")),


### PR DESCRIPTION
## Changes in this pull request  
Allowes developers to define whitelist for predefined document types in perspectives.

## Additional info  
use "allowed_predefined_page" => ["My Page", "Special Page"] or "allowed_predefined_email" and so on in perspectives.php inside the customview.