### PR TITLE
Fix StructuredTable definition

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data/StructuredTable.php
+++ b/pimcore/models/Object/ClassDefinition/Data/StructuredTable.php
@@ -80,7 +80,7 @@ class StructuredTable extends Model\Object\ClassDefinition\Data
      *
      * @var string
      */
-    public $phpdocType = "array";
+    public $phpdocType = "Data\StructuredTable";
 
     /**
      * @return integer


### PR DESCRIPTION
## Changes in this pull request  
Change the `phpdocType` from `array` to `Data\StructuredTable` in the StructuredTable ClassDefinition. Providing an array to the get functions generated for attributes of type StructuredTable results in error.

```
// Correct according to generated phpdoc, but doesn't work
$object->setMyAttribute(new StructuredTable($array));
// Wrong according to phpdocs, but seems to be the right way to initiate a StructuredTable attribute
$object->setMyAttribute(new StructuredTable($array));
```

## Additional info  
- An alternative fix would be to modify the getter to automatically convert arrays in StructuredTables if needed.
- Initialisation of StructuredTable attribute could be more detailled within the documentation
- I also have the feeling than many phpDoc elements in [Data/StructuredTable.php ](pimcore/models/Object/ClassDefinition/Data/StructuredTable.php) do not reflect the way the class works.