### PR TITLE
Add windows support for localisation and Carbon

### DIFF
--- a/pimcore/lib/Pimcore/Controller/Action/Frontend.php
+++ b/pimcore/lib/Pimcore/Controller/Action/Frontend.php
@@ -344,10 +344,17 @@ abstract class Frontend extends Action
                 }
             }
 
+            // windows system doesn't support utf8, we add same list without utf8
+            $localeList = array_merge($localeList, str_replace(".utf8", "", $localeList));
+            
             // currently we have to exclude LC_MONETARY from being set, because of issues in combination with
             // Zend_Currency -> see also https://github.com/zendframework/zf1/issues/706
             // once this is resolved we can safely set the locale for LC_MONETARY as well.
             setlocale(LC_ALL & ~LC_MONETARY, $localeList);
+
+            // reconfigure Carbon date
+            \Carbon\Carbon::setLocale($locale->getLanguage());
+            \Carbon\CarbonInterval::setLocale($locale->getLanguage());
 
             // reconfigure translation management
             if (\Zend_Registry::isRegistered("Zend_Translate")) {


### PR DESCRIPTION
This pull request add localisation support for Windows.
On windows ".utf8" is not supported, so PHP localisation fall in "C", preventing using date or other function depending of it.

It add too the configuration for carbon so something like that will be ready to work natively on the same language than document:
`echo \Carbon\Carbon::now()->subDays(5)->diffForHumans();`