### PR TITLE
Newsletter: Fix tracking params in urls containing a hash

### DIFF
--- a/pimcore/lib/Pimcore/Tool/Newsletter.php
+++ b/pimcore/lib/Pimcore/Tool/Newsletter.php
@@ -69,18 +69,22 @@ class Newsletter
                 if ($html) {
                     $links = $html->find("a");
                     foreach ($links as $link) {
-                        if (preg_match("/^(mailto)/", trim(strtolower($link->href)))) {
+                        if (preg_match("/^(mailto|#)/", trim(strtolower($link->href)))) {
+                            // No tracking for mailto and hash only links
                             continue;
                         }
-
+                        $urlParts = parse_url( $link->href);
                         $glue = "?";
-                        if (strpos($link->href, "?")) {
+                        $params = "utm_source=" . $newsletterDocument->getTrackingParameterSource() .
+                                    "&utm_medium=" . $newsletterDocument->getTrackingParameterMedium() .
+                                    "&utm_campaign=" . $newsletterDocument->getTrackingParameterName();
+                        if( isset( $urlParts['query'])) {
                             $glue = "&";
                         }
-                        $link->href = $link->href . $glue .
-                            "utm_source=" . $newsletterDocument->getTrackingParameterSource() .
-                            "&utm_medium=" . $newsletterDocument->getTrackingParameterMedium() .
-                            "&utm_campaign=" . $newsletterDocument->getTrackingParameterName();
+                        $link->href = preg_replace( '/[#].+$/', '', $link->href).$glue.$params;
+                        if( isset( $urlParts['fragment'])) {
+                            $link->href .= '#'.$urlParts['fragment'];
+                        }
                     }
 
                     $contentHTML = $html->save();


### PR DESCRIPTION
Newsletter tracking currently breaks hashes in links.
This patch changes Newsletter::prepareMail to properly detect hashes in links to appending the tracking parameters before the hash.

Fixes #1324 
