### PR TITLE
conditionally show a custom layout depending on object values

### DIFF
--- a/pimcore/modules/admin/controllers/ObjectController.php
+++ b/pimcore/modules/admin/controllers/ObjectController.php
@@ -358,7 +358,11 @@ class Admin_ObjectController extends \Pimcore\Controller\Action\Admin\Element
             //master layout has id 0 so we check for is_null()
             if (is_null($currentLayoutId) && !empty($validLayouts)) {
                 foreach ($validLayouts as $checkDefaultLayout) {
-                    if ($checkDefaultLayout->getDefault()) {
+                    $conditionalLayout = false;
+                    if (method_exists($object, "isDefaultConditionalLayout")) {
+                        $conditionalLayout = $object->isDefaultConditionalLayout($checkDefaultLayout);
+                    }
+                    if ($checkDefaultLayout->getDefault() || $conditionalLayout) {
                         $currentLayoutId = $checkDefaultLayout->getId();
                     }
                 }


### PR DESCRIPTION
## Changes in this pull request  
Conditionally show a custom layout of an object depending on a value. For instance show different default view of unpublished objects.

Steps to implement:
Create a parent class for your object and implement a method like this:

public function isDefaultConditionalLayout(ClassDefinition\CustomLayout $conditionalLayout) {
    if ($conditionalLayout->getName() == "inactive-user") {
        return !$this->getPublished();
    }
    return false;
}