### PR TITLE
classes-rebuild command: Added option for rebuilding only modified classes

### DIFF
--- a/pimcore/lib/Pimcore/Console/Command/ClassesRebuildCommand.php
+++ b/pimcore/lib/Pimcore/Console/Command/ClassesRebuildCommand.php
@@ -34,6 +34,10 @@ class ClassesRebuildCommand extends AbstractCommand
                 InputOption::VALUE_NONE,
                 "Create missing Classes (Classes that exists in website/var/classes but not in the database)"
             )
+            ->addOption(
+                'modified-only', 'm',
+                InputOption::VALUE_NONE, 'Only rebuild if generation date of definition and php class file differs'
+            )
         ;
     }
 
@@ -63,6 +67,13 @@ class ClassesRebuildCommand extends AbstractCommand
                     $existingClass = ClassDefinition::getByName($class->getName());
 
                     if ($existingClass instanceof ClassDefinition) {
+                        if ($input->getOption('modified-only') && $existingClass->checkDefinitionFileAndPhpClassFileGenerationDate()) {
+                            if ($output->isVeryVerbose()) {
+                                $output->writeln($existingClass->getName() . " is up-to-date, skipped");
+                            }
+                            continue;
+                        }
+
                         if ($output->isVerbose()) {
                             $output->writeln($class->getName() . " [" . $class->getId() . "] saved");
                         }
@@ -79,6 +90,14 @@ class ClassesRebuildCommand extends AbstractCommand
             }
         } else {
             foreach ($list->getClasses() as $class) {
+                /** @var ClassDefinition $class */
+                if ($input->getOption('modified-only') && $class->checkDefinitionFileAndPhpClassFileGenerationDate()) {
+                    if ($output->isVeryVerbose()) {
+                        $output->writeln($class->getName() . " is up-to-date, skipped");
+                    }
+                    continue;
+                }
+
                 if ($output->isVerbose()) {
                     $output->writeln($class->getName() . " [" . $class->getId() . "] saved");
                 }
@@ -94,6 +113,14 @@ class ClassesRebuildCommand extends AbstractCommand
         $list = new Object\Objectbrick\Definition\Listing();
         $list = $list->load();
         foreach ($list as $brickDefinition) {
+            /** @var Object\Objectbrick\Definition $brickDefinition */
+            if ($input->getOption('modified-only') && $brickDefinition->checkDefinitionFileAndPhpClassFileGenerationDate()) {
+                if ($output->isVeryVerbose()) {
+                    $output->writeln($brickDefinition->getKey() . " is up-to-date, skipped");
+                }
+                continue;
+            }
+
             if ($output->isVerbose()) {
                 $output->writeln($brickDefinition->getKey() . " saved");
             }
@@ -109,6 +136,14 @@ class ClassesRebuildCommand extends AbstractCommand
         $list = new Object\Fieldcollection\Definition\Listing();
         $list = $list->load();
         foreach ($list as $fc) {
+            /** @var Object\Fieldcollection\Definition $fc */
+            if ($input->getOption('modified-only') && $fc->checkDefinitionFileAndPhpClassFileGenerationDate()) {
+                if ($output->isVeryVerbose()) {
+                    $output->writeln($fc->getKey() . " is up-to-date, skipped");
+                }
+                continue;
+            }
+
             if ($output->isVerbose()) {
                 $output->writeln($fc->getKey() . " saved");
             }

--- a/pimcore/models/Object/ClassDefinition.php
+++ b/pimcore/models/Object/ClassDefinition.php
@@ -441,6 +441,28 @@ class ClassDefinition extends Model\AbstractModel
     }
 
     /**
+     * Checks whether generation date (info block) of definition file and php class file is identical
+     *
+     * @return bool true if generation date is identical
+     */
+    public function checkDefinitionFileAndPhpClassFileGenerationDate()
+    {
+        $definitionFile = $this->getDefinitionFile();
+        $phpClassFile = PIMCORE_CLASS_DIRECTORY . "/Object/" . ucfirst($this->getName()) . ".php";
+
+        if (!is_readable($definitionFile) || !is_readable($phpClassFile)) {
+            return false;
+        }
+
+        $patternGenerationDate = '/^\\* Generated at: /';
+
+        $generationDateDefinition = current(preg_grep($patternGenerationDate, file($definitionFile)));
+        $generationDatePhpClass = current(preg_grep($patternGenerationDate, file($phpClassFile)));
+
+        return ($generationDateDefinition === $generationDatePhpClass);
+    }
+
+    /**
      * @return string
      */
     protected function getInfoDocBlock()

--- a/pimcore/models/Object/Fieldcollection/Definition.php
+++ b/pimcore/models/Object/Fieldcollection/Definition.php
@@ -337,6 +337,28 @@ class Definition extends Model\AbstractModel
     }
 
     /**
+     * Checks whether generation date (info block) of definition file and php class file is identical
+     *
+     * @return bool true if generation date is identical
+     */
+    public function checkDefinitionFileAndPhpClassFileGenerationDate()
+    {
+        $definitionFile = $this->getDefinitionFile();
+        $phpClassFile = $this->getPhpClassFile();
+
+        if (!is_readable($definitionFile) || !is_readable($phpClassFile)) {
+            return false;
+        }
+
+        $patternGenerationDate = '/^\\* Generated at: /';
+
+        $generationDateDefinition = current(preg_grep($patternGenerationDate, file($definitionFile)));
+        $generationDatePhpClass = current(preg_grep($patternGenerationDate, file($phpClassFile)));
+
+        return ($generationDateDefinition === $generationDatePhpClass);
+    }
+
+    /**
      * @return string
      */
     protected function getDefinitionFile()


### PR DESCRIPTION
If the option --modified-only (or -m) is given, classes-rebuild will only rebuild classes where the generation date of the definition file and the php class file differs. If the generation dates are identical, the rebuild for this class is skipped entirely (no update of definition, php class file or database).

This feature improves working collaboratively on projects under SCM. Before deployment:classes-rebuild was giving the developer a hard time figuring out whether the file changes were only differences resulting from the rebuild process.