### PR TITLE
static create asset fix (remote stream)

### DIFF
--- a/pimcore/models/Asset.php
+++ b/pimcore/models/Asset.php
@@ -1181,8 +1181,8 @@ class Asset extends Element\AbstractElement
      */
     public function getStream()
     {
-        $streamMeta = stream_get_meta_data($this->stream);
         if ($this->stream) {
+            $streamMeta = stream_get_meta_data($this->stream);
             if (!@rewind($this->stream) && $streamMeta['stream_type'] === 'STDIO') {
                 $this->stream = null;
             }

--- a/pimcore/models/Asset.php
+++ b/pimcore/models/Asset.php
@@ -303,7 +303,7 @@ class Asset extends Element\AbstractElement
         // create already the real class for the asset type, this is especially for images, because a system-thumbnail
         // (tree) is generated immediately after creating an image
         $class = "Asset";
-        if (array_key_exists("filename", $data) && array_key_exists("sourcePath", $data) ) {
+        if (isset($data["filename"]) && isset($data["sourcePath"]) ) {
             $mimeType = Mime::detect($data["sourcePath"], $data["filename"]);
             if (is_file($data["sourcePath"])) {
                 $data["stream"] = fopen($data["sourcePath"], "r+", false, File::getContext());
@@ -313,7 +313,7 @@ class Asset extends Element\AbstractElement
 
             $type = self::getTypeFromMimeMapping($mimeType, $data["filename"]);
             $class = "\\Pimcore\\Model\\Asset\\" . ucfirst($type);
-            if (array_key_exists("type", $data)) {
+            if (isset($data["type"])) {
                 unset($data["type"]);
             }
         }


### PR DESCRIPTION
If you try to static create an asset from a non-local stream it will just create an empty file. That's because the $tmpFile is unlinked (line 326) right after stream_copy_to_stream in line 321. Later in the getStream method of the Asset class $this->stream is set to null, because a non-local stream is (always) not rewindable.

Fixes # 

1) getStream just sets the stream to null if a LOCAL stream is not rewindable. So the remote stream can be copied to local filesystem in the update method in line 624.

2) Line 307 - 333 is unnecessary, because all these I/O Actions like line 311 are performed twice in the setData method.

## Changes in this pull request  
- Removed line 307 - 333
- Don't set a non-local stream to null if it's not rewindable
- Changed some array_key_exists calls to isset

### Steps to reproduce:
`$imgUrl = "https://www.arvato.com/content/dam/arvato/images/campaign-material/logimat/Arvato_IT_LogiMAT2017_2880x1800.adaptive.400.jpg";`
`$filename = array_pop(explode("/", $imgUrl));`
`$fp = fopen($imgUrl, 'r');`
`@\Pimcore\Model\Asset\Image::create(1, array('stream' => $fp, 'filename' => $filename));`
