### PR TITLE
Fixed unnecessary class definition file rebuild during class rebuild command

### DIFF
--- a/pimcore/lib/Pimcore/Console/Command/ClassesRebuildCommand.php
+++ b/pimcore/lib/Pimcore/Console/Command/ClassesRebuildCommand.php
@@ -67,13 +67,13 @@ class ClassesRebuildCommand extends AbstractCommand
                             $output->writeln($class->getName() . " [" . $class->getId() . "] saved");
                         }
 
-                        $existingClass->save();
+                        $existingClass->save(false);
                     } else {
                         if ($output->isVerbose()) {
                             $output->writeln($class->getName() . " [" . $class->getId() . "] created");
                         }
 
-                        $class->save();
+                        $class->save(false);
                     }
                 }
             }
@@ -83,7 +83,7 @@ class ClassesRebuildCommand extends AbstractCommand
                     $output->writeln($class->getName() . " [" . $class->getId() . "] saved");
                 }
 
-                $class->save();
+                $class->save(false);
             }
         }
 

--- a/pimcore/models/Object/ClassDefinition.php
+++ b/pimcore/models/Object/ClassDefinition.php
@@ -245,9 +245,11 @@ class ClassDefinition extends Model\AbstractModel
     }
 
     /**
+     * @param bool $saveDefinitionFile
+     *
      * @throws \Exception
      */
-    public function save()
+    public function save($saveDefinitionFile = true)
     {
         $isUpdate = false;
         if ($this->getId()) {
@@ -278,17 +280,18 @@ class ClassDefinition extends Model\AbstractModel
         self::cleanupForExport($clone->layoutDefinitions);
 
 
-        $exportedClass = var_export($clone, true);
+        if ($saveDefinitionFile) {
+            $exportedClass = var_export($clone, true);
 
-        $data = '<?php ';
-        $data .= "\n\n";
-        $data .= $infoDocBlock;
-        $data .= "\n\n";
+            $data = '<?php ';
+            $data .= "\n\n";
+            $data .= $infoDocBlock;
+            $data .= "\n\n";
 
-        $data .= "\nreturn " . $exportedClass . ";\n";
+            $data .= "\nreturn " . $exportedClass . ";\n";
 
-        \Pimcore\File::put($definitionFile, $data);
-
+            \Pimcore\File::put($definitionFile, $data);
+        }
 
         // create class for object
         $extendClass = "Concrete";


### PR DESCRIPTION
During the `php pimcore/cli/console.php deployment:classes-rebuild` always are generated new timestamps in `definition_*` files, in my opinion it a bug, because it first load definition file saves it(why?) and then create/update models and database.