### PR TITLE
Catch Exceptions when Sending the newsletter to one recipient fails.

### DIFF
--- a/pimcore/lib/Pimcore/Console/Command/InternalNewsletterDocumentSendCommand.php
+++ b/pimcore/lib/Pimcore/Console/Command/InternalNewsletterDocumentSendCommand.php
@@ -114,7 +114,11 @@ class InternalNewsletterDocumentSendCommand extends AbstractCommand
                 \Pimcore::collectGarbage();
             }
 
-            \Pimcore\Tool\Newsletter::sendNewsletterDocumentBasedMail($mail, $sendingParamContainer);
+            try {
+                \Pimcore\Tool\Newsletter::sendNewsletterDocumentBasedMail($mail, $sendingParamContainer);
+            } catch( \Exception $e) {
+                Logger::err( 'Exception while sending newsletter: '.$e->getMessage());
+            }
 
             $currentCount++;
         }
@@ -149,8 +153,12 @@ class InternalNewsletterDocumentSendCommand extends AbstractCommand
 
             $sendingParamContainers = $addressAdapter->getParamsForSingleSending($limit, $offset);
             foreach ($sendingParamContainers as $sendingParamContainer) {
-                $mail = \Pimcore\Tool\Newsletter::prepareMail($document, $sendingParamContainer, $hostUrl);
-                \Pimcore\Tool\Newsletter::sendNewsletterDocumentBasedMail($mail, $sendingParamContainer);
+                try {
+                    $mail = \Pimcore\Tool\Newsletter::prepareMail($document, $sendingParamContainer, $hostUrl);
+                    \Pimcore\Tool\Newsletter::sendNewsletterDocumentBasedMail($mail, $sendingParamContainer);
+                } catch( \Exception $e) {
+                    Logger::err( 'Exception while sending newsletter: '.$e->getMessage());
+                }
 
 
                 if (empty($tmpStore)) {


### PR DESCRIPTION
Fixes #1345

## Changes in this pull request  
Add try/catch around one newsletter sendout to not abort the whole process for the remaining recipients.