### PR TITLE
XLIFF export: Handle selfclosing tags

### DIFF
--- a/pimcore/modules/admin/controllers/TranslationController.php
+++ b/pimcore/modules/admin/controllers/TranslationController.php
@@ -23,6 +23,8 @@ use Pimcore\Logger;
 
 class Admin_TranslationController extends \Pimcore\Controller\Action\Admin
 {
+    const SELFCLOSING_TAGS = ['area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input', 'keygen', 'link', 'meta', 'param', 'source', 'track', 'wbr'];
+
     public function importAction()
     {
         $this->checkPermission("translations");
@@ -944,7 +946,7 @@ class Admin_TranslationController extends \Pimcore\Controller\Action\Admin
         if (preg_match("/<\/?(bpt|ept)/", $content)) {
             $xml = str_get_html($content);
             if ($xml) {
-                $els = $xml->find("bpt,ept");
+                $els = $xml->find("bpt,ept,ph");
                 foreach ($els as $el) {
                     $content = html_entity_decode($el->innertext, null, "UTF-8");
                     $el->outertext = $content;
@@ -987,8 +989,12 @@ class Admin_TranslationController extends \Pimcore\Controller\Action\Admin
                     if (preg_match("/<([a-z0-9\/]+)/", $part, $tag)) {
                         $tagName = str_replace("/", "", $tag[1]);
                         if (strpos($tag[1], "/") === false) {
-                            $openTags[$count] = ["tag" => $tagName, "id" => $count];
-                            $part = '<bpt id="' . $count . '"><![CDATA[' . $part . ']]></bpt>';
+                            if (in_array($tagName, self::SELFCLOSING_TAGS)) {
+                                $part = '<ph id="' . $count . '"><![CDATA[' . $part . ']]></ph>';
+                            } else {
+                                $openTags[$count] = ["tag" => $tagName, "id" => $count];
+                                $part = '<bpt id="' . $count . '"><![CDATA[' . $part . ']]></bpt>';
+                            }
 
                             $count++;
                         } else {

--- a/pimcore/modules/admin/controllers/TranslationController.php
+++ b/pimcore/modules/admin/controllers/TranslationController.php
@@ -988,13 +988,13 @@ class Admin_TranslationController extends \Pimcore\Controller\Action\Admin
                 if (!empty($part)) {
                     if (preg_match("/<([a-z0-9\/]+)/", $part, $tag)) {
                         $tagName = str_replace("/", "", $tag[1]);
-                        if (strpos($tag[1], "/") === false) {
-                            if (in_array($tagName, self::SELFCLOSING_TAGS)) {
-                                $part = '<ph id="' . $count . '"><![CDATA[' . $part . ']]></ph>';
-                            } else {
-                                $openTags[$count] = ["tag" => $tagName, "id" => $count];
-                                $part = '<bpt id="' . $count . '"><![CDATA[' . $part . ']]></bpt>';
-                            }
+                        if (in_array($tagName, self::SELFCLOSING_TAGS)) {
+                            $part = '<ph id="' . $count . '"><![CDATA[' . $part . ']]></ph>';
+
+                            $count++;
+                        } else if (strpos($tag[1], "/") === false) {
+                            $openTags[$count] = ["tag" => $tagName, "id" => $count];
+                            $part = '<bpt id="' . $count . '"><![CDATA[' . $part . ']]></bpt>';
 
                             $count++;
                         } else {


### PR DESCRIPTION
## Changes in this pull request  

Extra-check on the tag name to handle self-closing tags (do not use `<bpt>`/`<ept>` logic but the `<ph>` instead).

## Additional info  
About the `<ph>` element :
> The <ph> element is used to delimit a sequence of native standalone codes in the translation unit
> http://www.maxprograms.com/articles/xliff.html#Table2

This case happens on WYSIWYG inputs with the `enterMode` parameter to 2.

The modifications handle the following cases:
- `<br>` (HTML 5)
- `<br />` (XHTML syntax, valid in HTML5 as well)
- `<br></br>` (XHTML syntax)