### PR TITLE
XLIFF export: plain text / html 

### DIFF
--- a/pimcore/modules/admin/controllers/TranslationController.php
+++ b/pimcore/modules/admin/controllers/TranslationController.php
@@ -978,6 +978,10 @@ class Admin_TranslationController extends \Pimcore\Controller\Action\Admin
             return '<![CDATA[' . $content . ']]>';
         }
 
+        // Handle text before the first HTML tag
+        $firstTagPosition = strpos($content, '<');
+        $preText = ($firstTagPosition > 0) ? '<![CDATA[' . substr($content, 0, $firstTagPosition) . ']]>' : '';
+
         foreach ($matches[0] as $match) {
             $parts = explode(">", $match);
             $parts[0] .= ">";
@@ -1007,7 +1011,7 @@ class Admin_TranslationController extends \Pimcore\Controller\Action\Admin
             }
         }
 
-        $content = implode("", $final);
+        $content = $preText . implode("", $final);
 
         return $content;
     }


### PR DESCRIPTION
Export of WYSIWYG content in XLIFF is inconsistent: Text preceding the very first html tag is stripped.
e.g.: `My<strong>Test</strong>String` => `<strong>Test</strong>String`

## Changes in this pull request  
Preserve plain text before the first html tag by checking position of the first `<` character

## Additional info  
I chose not to modify the regex, since we are handling a fairly special case, that will happen only for the very first iteration of the loop. Let me know if you find a more sensible way to solve this issue!