### PR TITLE
Wait 1 sec after gziping

### DIFF
--- a/pimcore/models/Version.php
+++ b/pimcore/models/Version.php
@@ -590,13 +590,10 @@ class Version extends AbstractModel
                     $alreadyCompressedCounter = 0;
 
                     Logger::debug("version compressed:" . $version->getFilePath());
+                    Logger::debug("Waiting 1 sec to not kill the server...");
+                    sleep(1);
                 } else {
                     $alreadyCompressedCounter++;
-                }
-
-                if ($overallCounter % 10 == 0) {
-                    Logger::debug("Waiting 5 secs to not kill the server...");
-                    sleep(5);
                 }
             }
 


### PR DESCRIPTION
The current maintenance script will wait 5 seconds each iteration regardless of the need for version gzipping. In this case we'll just wait 1 sec after gzipping to reduce total load. Currently the script always sleeps about 50 seconds on many of our sites even if nothing has to be done.