### PR TITLE
Move the user-image path to a constant

### DIFF
--- a/pimcore/config/startup.php
+++ b/pimcore/config/startup.php
@@ -109,6 +109,9 @@ if (!defined("PIMCORE_SYSTEM_TEMP_DIRECTORY")) {
 if (!defined("PIMCORE_LOG_MAIL_PERMANENT")) {
     define("PIMCORE_LOG_MAIL_PERMANENT", PIMCORE_WEBSITE_VAR . "/email");
 }
+if (!defined("PIMCORE_USERIMAGE_DIRECTORY")) {
+    define("PIMCORE_USERIMAGE_DIRECTORY", PIMCORE_WEBSITE_VAR . "/user-image");
+}
 
 
 // setup include paths

--- a/pimcore/models/User.php
+++ b/pimcore/models/User.php
@@ -500,12 +500,11 @@ class User extends User\UserRole
      */
     public function setImage($path)
     {
-        $userImageDir = PIMCORE_WEBSITE_VAR . "/user-image";
-        if (!is_dir($userImageDir)) {
-            File::mkdir($userImageDir);
+        if (!is_dir(PIMCORE_USERIMAGE_DIRECTORY)) {
+            File::mkdir(PIMCORE_USERIMAGE_DIRECTORY);
         }
 
-        $destFile = $userImageDir . "/user-" . $this->getId() . ".png";
+        $destFile = PIMCORE_USERIMAGE_DIRECTORY . "/user-" . $this->getId() . ".png";
         $thumb = PIMCORE_SYSTEM_TEMP_DIRECTORY . "/user-thumbnail-" . $this->getId() . ".png";
         @unlink($destFile);
         @unlink($thumb);
@@ -528,7 +527,7 @@ class User extends User\UserRole
         }
 
         $id = $this->getId();
-        $user = PIMCORE_WEBSITE_VAR . "/user-image/user-" . $id . ".png";
+        $user = PIMCORE_USERIMAGE_DIRECTORY . "/user-" . $id . ".png";
         if (file_exists($user)) {
             $thumb = PIMCORE_SYSTEM_TEMP_DIRECTORY . "/user-thumbnail-" . $id . ".png";
             if (!file_exists($thumb)) {


### PR DESCRIPTION
Define the `user-image` directory once at startup. It allows to override this path (to move it to S3 for example)