### PR TITLE
[DB] Update Zend Compatibility Query Builder

### DIFF
--- a/pimcore/lib/Pimcore/Db.php
+++ b/pimcore/lib/Pimcore/Db.php
@@ -14,7 +14,7 @@
 
 namespace Pimcore;
 
-use Pimcore\Db\Wrapper;
+use Psr\Log\LoggerInterface;
 
 class Db
 {
@@ -49,6 +49,15 @@ class Db
         $db = \Pimcore::getContainer()->get("database_connection");
 
         return $db;
+    }
+
+    /**
+     * @static
+     * @return LoggerInterface
+     */
+    public static function getLogger()
+    {
+        return \Pimcore::getContainer()->get("monolog.logger.doctrine");
     }
 
     /**

--- a/pimcore/lib/Pimcore/Db/Connection.php
+++ b/pimcore/lib/Pimcore/Db/Connection.php
@@ -14,7 +14,6 @@
 
 namespace Pimcore\Db;
 
-use Closure;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Pimcore\Db;
 use Pimcore\Db\ZendCompatibility\Expression;
@@ -105,7 +104,8 @@ class Connection extends \Doctrine\DBAL\Connection
             $params = array_merge($qb->getParameters(), $params);
 
             Db::getLogger()->debug('QueryBuilder instance was normalized to string.', [
-                'query' => $query
+                'query'  => $query,
+                'params' => $params
             ]);
         }
 

--- a/pimcore/models/Asset/Listing/Dao.php
+++ b/pimcore/models/Asset/Listing/Dao.php
@@ -39,7 +39,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         $assets = [];
 
-        $select = (string) $this->getQuery(['id', "type"]);
+        $select = $this->getQuery(['id', "type"]);
         $assetsData = $this->db->fetchAll($select, $this->model->getConditionVariables());
 
         foreach ($assetsData as $assetData) {
@@ -85,7 +85,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function loadIdList()
     {
-        $select = (string) $this->getQuery(['id', "type"]);
+        $select = $this->getQuery(['id', "type"]);
         $assetIds = $this->db->fetchCol($select, $this->model->getConditionVariables());
 
         return $assetIds;
@@ -96,7 +96,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getCount()
     {
-        $select = (string) $this->getQuery([new Expression('COUNT(*)')]);
+        $select = $this->getQuery([new Expression('COUNT(*)')]);
         $amount = (int) $this->db->fetchOne($select, $this->model->getConditionVariables());
 
         return $amount;
@@ -110,7 +110,6 @@ class Dao extends Model\Listing\Dao\AbstractDao
         $select = $this->getQuery([new Expression('COUNT(*)')]);
         $select->reset(QueryBuilder::LIMIT_COUNT);
         $select->reset(QueryBuilder::LIMIT_OFFSET);
-        $select = (string) $select;
         $amount = (int) $this->db->fetchOne($select, $this->model->getConditionVariables());
 
         return $amount;

--- a/pimcore/models/Document/Dao.php
+++ b/pimcore/models/Document/Dao.php
@@ -16,9 +16,9 @@
 
 namespace Pimcore\Model\Document;
 
+use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Tool\Serialize;
-use Pimcore\Logger;
 
 /**
  * @property \Pimcore\Model\Document $model
@@ -63,7 +63,10 @@ class Dao extends Model\Element\Dao
         $_key = basename($path);
         $_path .= $_path != "/" ? "/" : "";
 
-        $data = $this->db->fetchRow("SELECT id FROM documents WHERE path = " . $this->db->quote($_path) . " and `key` = " . $this->db->quote($_key));
+        $data = $this->db->fetchRow("SELECT id FROM documents WHERE path = :path AND `key` = :key", [
+            'path' => $_path,
+            'key'  => $_key
+        ]);
 
         if ($data["id"]) {
             $this->assignVariablesToModel($data);

--- a/pimcore/models/Document/Listing/Dao.php
+++ b/pimcore/models/Document/Listing/Dao.php
@@ -38,7 +38,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function load()
     {
         $documents = [];
-        $select = (string) $this->getQuery(['id', "type"]);
+        $select = $this->getQuery(['id', "type"]);
 
         $documentsData = $this->db->fetchAll($select, $this->model->getConditionVariables());
 
@@ -85,7 +85,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function loadIdList()
     {
-        $select = (string) $this->getQuery(['id']);
+        $select = $this->getQuery(['id']);
         $documentIds = $this->db->fetchCol($select, $this->model->getConditionVariables());
 
         return $documentIds;
@@ -96,7 +96,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function loadIdPathList()
     {
-        $select = (string) $this->getQuery(['id', "CONCAT(path,`key`)"]);
+        $select = $this->getQuery(['id', "CONCAT(path,`key`)"]);
         $documentIds = $this->db->fetchAll($select, $this->model->getConditionVariables());
 
         return $documentIds;
@@ -120,7 +120,6 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         $select = $this->getQuery([new Expression('COUNT(*)')]);
         $select->reset(QueryBuilder::LIMIT_COUNT);
-        $select = (string) $select;
         $amount = (int) $this->db->fetchOne($select, $this->model->getConditionVariables());
 
         return $amount;

--- a/pimcore/models/Object/Listing/Dao.php
+++ b/pimcore/models/Object/Listing/Dao.php
@@ -20,7 +20,6 @@ use Pimcore\Db\ZendCompatibility\Expression;
 use Pimcore\Db\ZendCompatibility\QueryBuilder;
 use Pimcore\Model;
 use Pimcore\Model\Object;
-use Prophecy\Comparator\ClosureComparator;
 
 /**
  * @property \Pimcore\Model\Object\Listing $model


### PR DESCRIPTION
Fixes #1385. The following usage is now recommended as it passes parameters to Doctrine`s `executeQuery()` (internally building a prepared statement instead of quoting values into the query):

```php
/** @var Connection $db */
$db = $this->get('database_connection');

$qb = $db->select();
$qb
    ->from(['o' => 'objects'])
    ->where('o.o_id < :o_id')
    ->order('o.o_id ASC')
    ->setParameter('o_id', 10, \PDO::PARAM_INT);

$results = $qb->execute()->fetchAll();
```

Passing a QueryBuilder to `fetch*` also works. The QB will be transformed to a string and its parameters will be prepended to the list of passed params. The following calls are equal:

```php
/** @var Connection $db */
$db = $this->get('database_connection');

$qb1 = $db->select();
$qb1
    ->from(['o' => 'objects'])
    ->where('o.o_id < :o_id')
    ->order('o.o_id ASC')
    ->setParameter('o_id', 10, \PDO::PARAM_INT);

$results1 = $db->fetchAll($qb1);

$qb2 = $db->select();
$qb2
    ->from(['o' => 'objects'])
    ->where('o.o_id < :o_id')
    ->order('o.o_id ASC');

$results2 = $db->fetchAll($qb2, ['o_id' => 5], [\PDO::PARAM_INT]);
```

Passing parameter values directly to the `where()` method still works, but is discouraged as the value will be directly quoted into the SQL string instead of binding it to the prepared statement:

```php
/** @var Connection $db */
$db = $this->get('database_connection');

$qb = $db->select();
$qb
    ->from(['o' => 'objects'])
    ->where('o.o_id < ?', 10, \PDO::PARAM_INT)
    ->order('o.o_id ASC');

$results = $qb->execute()->fetchAll();
```