### PR TITLE
Site handling performance improvement

### DIFF
--- a/pimcore/models/Site.php
+++ b/pimcore/models/Site.php
@@ -16,6 +16,7 @@
 
 namespace Pimcore\Model;
 
+use Pimcore\Cache\Runtime;
 use Pimcore\Logger;
 
 /**
@@ -115,7 +116,10 @@ class Site extends AbstractModel
 
         // cached because this is called in the route (Pimcore_Controller_Router_Route_Frontend)
         $cacheKey = "site_domain_". md5($domain);
-        if (!$site = \Pimcore\Cache::load($cacheKey)) {
+
+        if(Runtime::isRegistered($cacheKey)) {
+            $site = Runtime::get($cacheKey);
+        } elseif (!$site = \Pimcore\Cache::load($cacheKey)) {
             $site = new self();
 
             try {
@@ -127,6 +131,8 @@ class Site extends AbstractModel
 
             \Pimcore\Cache::save($site, $cacheKey, ["system", "site"], null, 999);
         }
+
+        Runtime::set($cacheKey, $site);
 
         if ($site == "failed" || !$site) {
             $msg = "there is no site for the requested domain [" . $domain . "], content was [" . $site . "]";

--- a/pimcore/models/Staticroute.php
+++ b/pimcore/models/Staticroute.php
@@ -452,11 +452,14 @@ class Staticroute extends AbstractModel
         }
 
         foreach ($siteIds as $siteId) {
-            $site = null;
+            $siteId = (int)$siteId;
+            if($siteId < 1) {
+                continue;
+            }
             try {
                 $site = Site::getById($siteId);
                 if ($site) {
-                    $result[] = (int)$siteId;
+                    $result[] = $siteId;
                 }
             } catch (\Exception $e) {
                 // cleanup


### PR DESCRIPTION
I installed a fresh copy of the pimcore 5 demo website version.

For example at the portal page of the demo website I noticed in the symfony sql console that some unnecessary/multiple queries regarding sites were fired.

I've not installed a cache backend so the mysql cache is used.

The following query was executed 5 times:
![image](https://cloud.githubusercontent.com/assets/4639428/24931025/f0b71aa2-1f0b-11e7-9560-51a339e39798.png)

This happens because the Site::getByDomain() method is called multiple times with the same domain. Therefore I think it makes sense to store the result of Site::getByDomain() in the runtime cache in order to avoid multiple calls to the backend cache.

Additionally I noticed multiple completely useless calls like this:
![image](https://cloud.githubusercontent.com/assets/4639428/24931124/57e188a2-1f0c-11e7-9048-d739569b95a0.png)

I added a check to avoid this too into the Staticroutes model.