### PR TITLE
Run assets:install command after enabling bundle

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
@@ -120,6 +120,7 @@ class ExtensionManagerController extends AdminController implements EventedContr
             $message = $this->installAssets();
         } elseif ($type === 'areabrick') {
             $this->areabrickManager->setState($id, $enable);
+            $reload = true;
         }
 
         $data = [

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
@@ -30,6 +30,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 
 /**
  * Handles all "new" extensions as of pimcore 5 (bundles, new areabrick layout) and pipes legacy extension requests
@@ -108,19 +109,51 @@ class ExtensionManagerController extends AdminController implements EventedContr
         $type   = $request->get('type');
         $id     = $request->get('id');
         $enable = $request->get('method', 'enable') === 'enable' ? true : false;
-        $reload = false;
+
+        $reload  = false;
+        $message = null;
 
         if ($type === 'bundle') {
             $this->bundleManager->setState($id, $enable);
             $reload = true;
+
+            $message = $this->installAssets();
         } elseif ($type === 'areabrick') {
             $this->areabrickManager->setState($id, $enable);
         }
 
-        return $this->json([
+        $data = [
             'success' => true,
-            'reload'  => $reload
-        ]);
+            'reload'  => $reload,
+        ];
+
+        if ($message) {
+            $data['message'] = $message;
+        }
+
+        return $this->json($data);
+    }
+
+    /**
+     * Runs array:install command and returns its result as array (line-by-line)
+     *
+     * @return array
+     */
+    private function installAssets(): array
+    {
+        $assetsInstaller = $this->get('pimcore.tool.assets_installer');
+
+        try {
+            $installProcess = $assetsInstaller->install();
+
+            $message = str_replace("'", '', $installProcess->getCommandLine()) . PHP_EOL . $installProcess->getOutput();
+        } catch (ProcessFailedException $e) {
+            $message = 'Failed to run assets:install command. Please run command manually.' . PHP_EOL . PHP_EOL . $e->getMessage();
+        }
+
+        $message = explode(PHP_EOL, $message);
+
+        return $message;
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
@@ -117,7 +117,9 @@ class ExtensionManagerController extends AdminController implements EventedContr
             $this->bundleManager->setState($id, $enable);
             $reload = true;
 
-            $message = $this->installAssets();
+            if ($enable) {
+                $message = $this->installAssets();
+            }
         } elseif ($type === 'areabrick') {
             $this->areabrickManager->setState($id, $enable);
             $reload = true;

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
@@ -345,3 +345,7 @@ services:
     pimcore.rest_client:
         class: Pimcore\Tool\RestClient
         arguments: ['@pimcore.http_client']
+
+    pimcore.tool.assets_installer:
+        class: Pimcore\Tool\AssetsInstaller
+        arguments: ['@kernel', '@pimcore_admin.serializer']

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/translations/en.json
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/translations/en.json
@@ -444,6 +444,7 @@
     "files": "Files",
     "next": "Next",
     "please_dont_forget_to_reload_pimcore_after_modifications": "Please don't forget to reload pimcore after your modifications",
+    "clear_cache_and_reload": "Clear cache and reload",
     "enable": "Enable",
     "disable": "Disable",
     "configure": "Configure",

--- a/pimcore/lib/Pimcore/Tool/AssetsInstaller.php
+++ b/pimcore/lib/Pimcore/Tool/AssetsInstaller.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Tool;
+
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * Runs the assets:install command with the settings configured in composer.json
+ *
+ * @package Pimcore\Tool
+ */
+class AssetsInstaller
+{
+    /**
+     * @var KernelInterface
+     */
+    private $kernel;
+
+    /**
+     * @var Serializer
+     */
+    private $serializer;
+
+    /**
+     * @var string
+     */
+    private $composerJsonSetting;
+
+    /**
+     * @param KernelInterface $kernel
+     * @param Serializer $serializer
+     */
+    public function __construct(KernelInterface $kernel, Serializer $serializer)
+    {
+        $this->kernel     = $kernel;
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * Runs this assets:install command
+     *
+     * @param array $options
+     *
+     * @return Process
+     */
+    public function install(array $options = []): Process
+    {
+        $process = $this->buildProcess($options);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+
+        return $process;
+    }
+
+    /**
+     * Builds the process instance
+     *
+     * @param array $options
+     *
+     * @return Process
+     */
+    public function buildProcess(array $options = []): Process
+    {
+        $resolver = new OptionsResolver();
+        $this->configureOptions($resolver);
+
+        $options = $resolver->resolve($options);
+
+        $builder = new ProcessBuilder([
+            'assets:install',
+            'web',
+            '--env=' . $this->kernel->getEnvironment()
+        ]);
+
+        $builder
+            ->setWorkingDirectory(PIMCORE_PROJECT_ROOT)
+            ->setPrefix('bin/console');
+
+        if (!$options['ansi']) {
+            $builder->add('--no-ansi');
+        } else {
+            $builder->add('--ansi');
+        }
+
+        if ($options['symlink']) {
+            $builder->add('--symlink');
+        }
+
+        if ($options['relative']) {
+            $builder->add('--relative');
+        }
+
+        return $builder->getProcess();
+    }
+
+    private function configureOptions(OptionsResolver $resolver)
+    {
+        $defaults = [
+            'ansi'     => false,
+            'symlink'  => true,
+            'relative' => true
+        ];
+
+        $composerJsonSetting = $this->readComposerJsonSetting();
+        if (null !== $composerJsonSetting) {
+            if ('symlink' === $composerJsonSetting) {
+                $defaults = array_merge([
+                    'symlink'  => true,
+                    'relative' => false
+                ], $defaults);
+            } elseif ('relative' === $composerJsonSetting) {
+                $defaults = array_merge([
+                    'symlink'  => true,
+                    'relative' => true
+                ], $defaults);
+            }
+        }
+
+        $resolver->setDefaults($defaults);
+    }
+
+    /**
+     * @return string|null
+     */
+    private function readComposerJsonSetting()
+    {
+        if (null !== $this->composerJsonSetting) {
+            return $this->composerJsonSetting;
+        }
+
+        $json = [];
+        $file = PIMCORE_PROJECT_ROOT . DIRECTORY_SEPARATOR . 'composer.json';
+        if (file_exists($file)) {
+            $contents = file_get_contents($file);
+
+            if (!empty($contents)) {
+                try {
+                    $json = $this->serializer->decode($json, 'json', ['json_decode_associative' => true]);
+
+                    if ($json && isset($json['extra']) && isset($json['extra']['symfony-assets-install'])) {
+                        $this->composerJsonSetting = $json['extra']['symfony-assets-install'];
+                    }
+                } catch (\Exception $e) {
+                    // noop
+                }
+            }
+        }
+
+        return $this->composerJsonSetting;
+    }
+}

--- a/web/pimcore/static6/js/pimcore/extensionmanager/admin.js
+++ b/web/pimcore/static6/js/pimcore/extensionmanager/admin.js
@@ -101,6 +101,102 @@ pimcore.extensionmanager.admin = Class.create({
 
         this.store.load();
 
+        var toolbar = Ext.create('Ext.Toolbar', {
+            cls: 'main-toolbar',
+            items: [
+                {
+                    text: t("refresh"),
+                    iconCls: "pimcore_icon_reload",
+                    handler: this.reload.bind(this)
+                },
+                '->',
+                '<b id="ext-manager-reload-info" style="visibility: hidden">' + t("please_dont_forget_to_reload_pimcore_after_modifications") + '!</b>',
+                {
+                    text: t("clear_cache_and_reload"),
+                    iconCls: "pimcore_icon_clear_cache",
+                    handler: function() {
+                        Ext.Msg.confirm(t('warning'), t('system_performance_stability_warning'), function (btn) {
+                            if (btn === 'yes') {
+                                self.panel.setLoading(true);
+
+                                Ext.Ajax.request({
+                                    url: '/admin/settings/clear-cache',
+                                    params: {
+                                        only_symfony_cache: true
+                                    },
+                                    success: function () {
+                                        window.location.reload();
+                                    },
+                                    failure: function () {
+                                        self.panel.setLoading(false);
+                                    }
+                                });
+                            }
+                        });
+                    }.bind(this)
+                }
+            ]
+        });
+
+        var handleSuccess = function (transport) {
+            var res = Ext.decode(transport.responseText);
+
+            var message = '';
+            var showAsToast = true;
+
+            if (res.reload) {
+                message += t("please_dont_forget_to_reload_pimcore_after_modifications") + "!";
+
+                // show reload message
+                Ext.get('ext-manager-reload-info').show();
+                toolbar.updateLayout();
+            }
+
+            if (res.message) {
+                showAsToast = false;
+
+                if (message) {
+                    message = '<p style="text-align: center">' + message + '</p>';
+                    message += '<br /><hr />';
+                }
+
+                message += '<pre style="font-size:11px;word-wrap: break-word;margin-bottom: 0">';
+
+                if (Ext.isArray(res.message)) {
+                    Ext.Array.each(res.message, function(line) {
+                        if (message.length > 0) {
+                            message += "\n"
+                        }
+
+                        message += strip_tags(line);
+                    });
+                } else {
+                    if (message.length > 0) {
+                        message += "\n"
+                    }
+
+                    message += strip_tags(res.message);
+                }
+
+                message += '</pre>';
+            }
+
+            self.panel.setLoading(false);
+            this.reload();
+
+            if (!empty(message)) {
+                if (showAsToast) {
+                    pimcore.helpers.showNotification(t("success"), message, "success");
+                } else {
+                    self.showMessageWindow(t("success"), message, "success");
+                }
+            }
+        }.bind(this);
+
+        var handleFailure = function() {
+            this.panel.setLoading(false);
+        }.bind(this);
+
         var typesColumns = [
             {header: t("type"), width: 50, sortable: false, dataIndex: 'type', renderer:
             function (value, metaData, record, rowIndex, colIndex, store) {
@@ -145,46 +241,8 @@ pimcore.extensionmanager.admin = Class.create({
                                 type: rec.get("type"),
                                 extensionType: self.getExtensionType(rec)
                             },
-                            success: function (transport) {
-                                var res = Ext.decode(transport.responseText);
-
-                                var message = '';
-                                if (res.reload) {
-                                    message += '<p style="text-align: center">';
-                                    message += t("please_dont_forget_to_reload_pimcore_after_modifications");
-                                    message += '</p>';
-                                }
-
-                                if (res.message) {
-                                    message += '<br /><hr />';
-                                    message += '<pre style="font-size:11px;word-wrap: break-word;margin-bottom: 0">';
-
-                                    if (Ext.isArray(res.message)) {
-                                        Ext.Array.each(res.message, function(line) {
-                                            if (message.length > 0) {
-                                                message += "\n"
-                                            }
-
-                                            message += strip_tags(line);
-                                        });
-                                    } else {
-                                        if (message.length > 0) {
-                                            message += "\n"
-                                        }
-
-                                        message += strip_tags(res.message);
-                                    }
-
-                                    message += '</pre>';
-                                }
-
-                                if (!empty(message)) {
-                                    this.showMessageWindow(t("success"), message, "success");
-                                }
-
-                                this.panel.setLoading(false);
-                                this.reload();
-                            }.bind(this)
+                            success: handleSuccess,
+                            failure: handleFailure
                         });
                     }.bind(this)
                 }]
@@ -216,6 +274,8 @@ pimcore.extensionmanager.admin = Class.create({
                             return;
                         }
 
+                        this.panel.setLoading(true);
+
                         Ext.Ajax.request({
                             url: '/admin/extensionmanager/admin/' + method,
                             params: {
@@ -223,19 +283,8 @@ pimcore.extensionmanager.admin = Class.create({
                                 type: rec.get("type"),
                                 extensionType: self.getExtensionType(rec)
                             },
-                            success: function (transport) {
-                                var res = Ext.decode(transport.responseText);
-
-                                if(!empty(res.message)) {
-                                    Ext.Msg.alert(" ", res.message);
-                                }
-
-                                if(res.reload) {
-                                    window.location.reload();
-                                } else {
-                                    this.reload();
-                                }
-                            }.bind(this)
+                            success: handleSuccess,
+                            failure: handleFailure
                         });
                     }.bind(this)
                 }]
@@ -265,6 +314,8 @@ pimcore.extensionmanager.admin = Class.create({
                             return;
                         }
 
+                        this.panel.setLoading(true);
+
                         Ext.Ajax.request({
                             url: '/admin/extensionmanager/admin/update',
                             params: {
@@ -272,19 +323,8 @@ pimcore.extensionmanager.admin = Class.create({
                                 type: rec.get("type"),
                                 extensionType: self.getExtensionType(rec)
                             },
-                            success: function (transport) {
-                                var res = Ext.decode(transport.responseText);
-
-                                if(!empty(res.message)) {
-                                    Ext.Msg.alert(" ", res.message);
-                                }
-
-                                if(res.reload) {
-                                    window.location.reload();
-                                } else {
-                                    this.reload();
-                                }
-                            }.bind(this)
+                            success: handleSuccess,
+                            failure: handleFailure
                         });
                     }.bind(this)
                 }]
@@ -348,17 +388,6 @@ pimcore.extensionmanager.admin = Class.create({
                 hideable: false
             }
         ];
-
-        var toolbar = Ext.create('Ext.Toolbar', {
-            cls: 'main-toolbar',
-            items: [
-                {
-                    text: t("refresh"),
-                    iconCls: "pimcore_icon_reload",
-                    handler: this.reload.bind(this)
-                }, "->" , "<b>" + t("please_dont_forget_to_reload_pimcore_after_modifications") + "!</b>"
-            ]
-        });
 
         this.grid = Ext.create('Ext.grid.Panel', {
             frame: false,


### PR DESCRIPTION
Fixes Issue #1388 

* Runs `assets:install` command after enabling a bundle
* Shows a `Clear cache and reload` button on the extension grid
* Shows the "Please reload..." message only after changing an extension state