### PR TITLE
Fixed error with fieldcollections containing metadata fields

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data/MultihrefMetadata.php
+++ b/pimcore/models/Object/ClassDefinition/Data/MultihrefMetadata.php
@@ -562,6 +562,10 @@ class MultihrefMetadata extends Model\Object\ClassDefinition\Data\Multihref
         } else {
             $sql = $db->quoteInto("o_id = ?", $objectId) . " AND " . $db->quoteInto("fieldname = ?", $this->getName())
                 . " AND " . $db->quoteInto("position = ?", $position);
+
+            if ($params && $params["context"] && $params["context"]["fieldname"]) {
+                $sql .= " AND " . $db->quoteInto("ownername = ?", $params["context"]["fieldname"]);
+            }
         }
 
         $db->delete($table, $sql);
@@ -645,7 +649,13 @@ class MultihrefMetadata extends Model\Object\ClassDefinition\Data\Multihref
                 . " AND " . $db->quoteInto("fieldname = ?", $this->getName())
             );
         } else {
-            $db->delete("object_metadata_" . $object->getClassId(), $db->quoteInto("o_id = ?", $object->getId()) . " AND " . $db->quoteInto("fieldname = ?", $this->getName()));
+            $condition = $db->quoteInto("o_id = ?", $object->getId()) . " AND " . $db->quoteInto("fieldname = ?", $this->getName());
+
+            if ($params && $params["context"] && $params["context"]["fieldname"]) {
+                $condition .= " AND " . $db->quoteInto("ownername = ?", $params["context"]["fieldname"]);
+            }
+
+            $db->delete("object_metadata_" . $object->getClassId(), $condition);
         }
     }
 


### PR DESCRIPTION
## Problem encountered
I created a class with to fieldcollection fields, both allowing the same fieldcollection. That fieldcollection contains a "Multihref with metadata" attribute. After adding the fieldcollections and filling in some data for additional columns in the metadata field, only the metadata for one field will be saved.

## Cause
From what i can tell, the problem lies in the `delete` and `save` methods of `pimcore/models/Object/ClassDefinition/Data/MultihrefMetadata.php`
There, the owner name is not included in the delete-statement (for unlocalized fields at least) when the old metadata is removed. This means that all metadata gets deleted, regardless of the fieldcollection they belong to. If multiple metadata fields with the same name are present in the fieldcollections ob an object, only the values from last one will be preserved, as everything that was added earlier is deleted again.


## Steps to reproduce
* Create a fieldcollection containing a field of type "Multihref with metadata"
* Add a column of type "text"
* Allow any of the element types to be added
* Create a class containing _two_ distinct fieldcollection fields, both allowing the same field collection to be added
* Create an object of that class
* Add a fieldcollection to both fields, add elements to both, and fill in all metadata fields with any value
* Save, reload

The metadata from one the fieldcollections will be gone.

## Solution
I have added the `ownername` to the delete statement if it is present in the `$params` array. This solves the problem for me and i _think_ it should not interfere with anything else.

Best regards,
Dennis