### PR TITLE
QuantityValue getFromWebserviceImport bugfix

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data/QuantityValue.php
+++ b/pimcore/models/Object/ClassDefinition/Data/QuantityValue.php
@@ -412,21 +412,22 @@ class QuantityValue extends Model\Object\ClassDefinition\Data
             return null;
         } else {
             $value = (array) $value;
-            if ($value['value'] !== null && $value['unit'] !== null && $value['unitAbbreviation'] !== null) {
-                $unitId = $value['unit'];
-
+            if (array_key_exists("value", $value) && array_key_exists("unit", $value) && array_key_exists("unitAbbreviation", $value)) {
+                $unitId = $value["unit"];
                 if ($idMapper) {
-                    $unitId = $idMapper->getMappedId('unit', $unitId);
+                    $unitId = $idMapper->getMappedId("unit", $unitId);
                 }
 
                 $unit = Model\Object\QuantityValue\Unit::getById($unitId);
-                if ($unit && $unit->getAbbreviation() == $value['unitAbbreviation']) {
-                    return new \Pimcore\Model\Object\Data\QuantityValue($value['value'], $unitId);
+                if ($unit && $unit->getAbbreviation() == $value["unitAbbreviation"]) {
+                    return new \Pimcore\Model\Object\Data\QuantityValue($value["value"], $unitId);
+                } elseif(!$unit && is_null($value['unit'])) {
+                    return new \Pimcore\Model\Object\Data\QuantityValue($value["value"]);
                 } else {
-                    throw new \Exception(get_class($this).': cannot get values from web service import - unit id and unit abbreviation do not match with local database');
+                    throw new \Exception(get_class($this).": cannot get values from web service import - unit id and unit abbreviation do not match with local database");
                 }
             } else {
-                throw new \Exception(get_class($this).': cannot get values from web service import - invalid data');
+                throw new \Exception(get_class($this).": cannot get values from web service import - invalid data");
             }
         }
     }


### PR DESCRIPTION
The getFromWebserviceImport method of the QuantityValue data type should not throw an exception if only parts of the field (only value or only unit) are filled. 
It should be a valid counterpart to the getForWebserviceImport method in order to make it possible to transfer the data from one pimcore instance to another one correctly via the REST webservice.

This pull request applies to Pimcore 5 - should I create the same one for Pimcore 4? It should be fixed there too!
