### PR TITLE
check REQUEST_URI if set before matching

### DIFF
--- a/pimcore/lib/Pimcore/Tool.php
+++ b/pimcore/lib/Pimcore/Tool.php
@@ -319,7 +319,7 @@ class Tool
             $isFrontend = false;
         }
 
-        if ($isFrontend) {
+        if ($isFrontend && isset($_SERVER["REQUEST_URI"])) {
             $excludePatterns = [
                 "/^\/admin.*/",
                 "/^\/install.*/",
@@ -345,7 +345,7 @@ class Tool
      */
     public static function isInstaller()
     {
-        if (preg_match("@^/install@", $_SERVER["REQUEST_URI"])) {
+        if (isset($_SERVER["REQUEST_URI"]) && preg_match("@^/install@", $_SERVER["REQUEST_URI"])) {
             return true;
         }
 
@@ -362,7 +362,7 @@ class Tool
             || array_key_exists("pimcore_admin", $_REQUEST)
             || array_key_exists("pimcore_object_preview", $_REQUEST)
             || array_key_exists("pimcore_version", $_REQUEST)
-            || preg_match("@^/pimcore_document_tag_renderlet@", $_SERVER["REQUEST_URI"])) {
+            || (isset($_SERVER["REQUEST_URI"]) && preg_match("@^/pimcore_document_tag_renderlet@", $_SERVER["REQUEST_URI"]))) {
             return true;
         }
 


### PR DESCRIPTION
This avoids notices when run from tests without request.

I experienced a notice with a test that loads `\Pimcore\Config::getWebsiteConfig()` in a utility class.
`\Pimcore\Config::getWebsiteConfig()` calls `\Pimcore\Tool::isFrontentRequestByAdmin()` which produces the notice by accessing `$_SERVER["REQUEST_URI"]` without checking if it is set.

My fix avoids this.


