### PR TITLE
pimcore5 | Nonowner fields | bug | extjs

### DIFF
--- a/web/pimcore/static6/js/pimcore/object/tags/nonownerobjects.js
+++ b/web/pimcore/static6/js/pimcore/object/tags/nonownerobjects.js
@@ -85,7 +85,7 @@ pimcore.object.tags.nonownerobjects = Class.create(pimcore.object.tags.objects, 
         var cls = 'object_field';
 
         var classStore = pimcore.globalmanager.get("object_types_store");
-        var record = classStore.getAt(classStore.find('text', this.fieldConfig.ownerClassName));
+        var record = classStore.getAt(classStore.findExact('text', this.fieldConfig.ownerClassName));
 
         // no class for nonowner is specified
         if(!record) {
@@ -279,7 +279,7 @@ pimcore.object.tags.nonownerobjects = Class.create(pimcore.object.tags.objects, 
         var classname = data.className;
 
         var classStore = pimcore.globalmanager.get("object_types_store");
-        var record = classStore.getAt(classStore.find('text', classname));
+        var record = classStore.getAt(classStore.findExact('text', classname));
         var name = record.data.text;
 
         if (this.fieldConfig.ownerClassName == name) {
@@ -292,7 +292,7 @@ pimcore.object.tags.nonownerobjects = Class.create(pimcore.object.tags.objects, 
     openSearchEditor: function () {
         var allowedClasses = [];
         var classStore = pimcore.globalmanager.get("object_types_store");
-        var record = classStore.getAt(classStore.find('text', this.fieldConfig.ownerClassName));
+        var record = classStore.getAt(classStore.findExact('text', this.fieldConfig.ownerClassName));
         allowedClasses.push(record.data.text);
 
 


### PR DESCRIPTION
Drag&Drop of non owner fields did not work reliably, because find() method did not determine the class name exactly. For instance if there existed "ShopProduct" and "ShopProductMaterial" classes then "ShopProductMaterial" was matching incorrectly.