### PR TITLE
make object grid cell editing work again in pimcore 5

### DIFF
--- a/web/pimcore/static6/js/pimcore/object/helpers/grid.js
+++ b/web/pimcore/static6/js/pimcore/object/helpers/grid.js
@@ -84,10 +84,10 @@ pimcore.object.helpers.grid = Class.create({
                 rootProperty: 'data'
             },
             api: {
-                create  : this.url + "?xaction=create",
-                read    : this.url + "?xaction=read",
-                update  : this.url + "?xaction=update",
-                destroy : this.url + "?xaction=destroy"
+                create  : this.url + "&xaction=create",
+                read    : this.url + "&xaction=read",
+                update  : this.url + "&xaction=update",
+                destroy : this.url + "&xaction=destroy"
             },
             actionMethods: {
                 create : 'POST',


### PR DESCRIPTION
Object grid cell editing didn't work anymore because the routing/url structure changed in pimcore 5.