### PR TITLE
Bundle initialization priority

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -11,29 +11,28 @@
  * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
+
+use Pimcore\HttpKernel\BundleCollection\BundleCollection;
 use Pimcore\Kernel;
-use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 class AppKernel extends Kernel
 {
     /**
-     * Returns an array of bundles to register.
+     * Adds bundles to register to the bundle collection. The collection is able
+     * to handle priorities and environment specific bundles.
      *
-     * @return BundleInterface[] An array of bundle instances
+     * @param BundleCollection $collection
      */
-    public function registerBundles()
+    protected function buildBundleCollection(BundleCollection $collection)
     {
-        // pimcore bundles
-        $bundles = parent::registerBundles();
+        parent::buildBundleCollection($collection);
 
         if (class_exists('\\AppBundle\\AppBundle')) {
-            $bundles[] = new \AppBundle\AppBundle;
+            $collection->addBundle(new \AppBundle\AppBundle);
         }
 
         if (class_exists('\Pimcore\Bundle\LegacyBundle\PimcoreLegacyBundle')) {
-            $bundles[] = new \Pimcore\Bundle\LegacyBundle\PimcoreLegacyBundle;
+            $collection->addBundle(new \Pimcore\Bundle\LegacyBundle\PimcoreLegacyBundle);
         }
-
-        return $bundles;
     }
 }

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -23,10 +23,8 @@ class AppKernel extends Kernel
      *
      * @param BundleCollection $collection
      */
-    protected function buildBundleCollection(BundleCollection $collection)
+    public function registerBundlesToCollection(BundleCollection $collection)
     {
-        parent::buildBundleCollection($collection);
-
         if (class_exists('\\AppBundle\\AppBundle')) {
             $collection->addBundle(new \AppBundle\AppBundle);
         }

--- a/doc/Development_Documentation/20_Extending_Pimcore/01_Add_Your_Own_Dependencies_and_Packages.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/01_Add_Your_Own_Dependencies_and_Packages.md
@@ -9,6 +9,59 @@ Use composer in your project root directory, eg.
 composer require mtdowling/cron-expression
 ```
 
+## Third party bundles
+
+You can install third party bundles via composer as shown above (as Pimcore is a standard Symfony application, you should
+be able to use any third-party Symfony bundle).
+
+To load a bundle with the application, it must first be registered on the kernel (see [bundles documentation](http://symfony.com/doc/current/bundles.html)).
+By default there's a `registerBundles` method on the `AppKernel` which is expected to return a list of bundles to load. As
+Pimcore defines a list of default bundles in its base kernel and priority can be important for config auto loading, the
+Pimcore Kernel exposes a `registerBundlesToCollection`  method which allows to add bundles to a `BundleCollection` with
+an optional priority (higher priority is loaded first) and a list of environments to handle (e.g. load only in `dev`
+environment).
+
+> Bundles without a priority are registered with a default priority of 0. You can a priority lower than default by using 
+  a negative value.
+
+As an example, register a third party bundle on the collection:
+
+```php
+<?php
+
+use Pimcore\HttpKernel\BundleCollection\BundleCollection;
+use Pimcore\Kernel;
+
+class AppKernel extends Kernel
+{
+    /**
+     * Adds bundles to register to the bundle collection. The collection is able
+     * to handle priorities and environment specific bundles.
+     *
+     * @param BundleCollection $collection
+     */
+    public function registerBundlesToCollection(BundleCollection $collection)
+    {
+        if (class_exists('\\AppBundle\\AppBundle')) {
+            $collection->addBundle(new \AppBundle\AppBundle);
+        }
+
+        // add a custom third-party bundle here with a high priority and only for dev environment
+        $collection->addBundle(new Third\Party\PartyBundle, 10, ['dev']);
+    }
+}
+```
+
+ Internally, the `BundleCollection` will be ordered by priority, filtered by environment and returned as plain array in
+`registerBundles`. If you need full control over the registered bundles, you can override `registerBundles` and add your
+customizations on the resulting array.
+
+### Pimcore Bundles
+
+For more information see [Pimcore Bundles](./13_Bundle_Developers_Guide/05_Pimcore_Bundles.md).
+
+Pimcore bundles can be registered on the kernel by enabling them in the extension manager. The extension manager also allows
+you to set a priority and environments to handle (as comma-separated string).
 
 ## Version Checking
 To avoid compatibility problems with plugins or custom components, that are compatible with a special Pimcore version only, Pimcore

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
@@ -114,7 +114,7 @@ class ExtensionManagerController extends AdminController implements EventedContr
         $message = null;
 
         if ($type === 'bundle') {
-            $this->bundleManager->setState($id, $enable);
+            $this->bundleManager->setState($id, ['enabled' => $enable]);
             $reload = true;
 
             if ($enable) {
@@ -302,7 +302,7 @@ class ExtensionManagerController extends AdminController implements EventedContr
         $bm = $this->bundleManager;
 
         $results = [];
-        foreach ($bm->getEnabledBundles() as $className) {
+        foreach ($bm->getEnabledBundleNames() as $className) {
             $bundle = $bm->getActiveBundle($className, false);
 
             $results[$bm->getBundleIdentifier($bundle)] = $this->buildBundleInfo($bundle, true, $bm->isInstalled($bundle));

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
@@ -355,6 +355,8 @@ class ExtensionManagerController extends AdminController implements EventedContr
     {
         $bm = $this->bundleManager;
 
+        $state = $bm->getState($bundle);
+
         $info = [
             'id'            => $bm->getBundleIdentifier($bundle),
             'type'          => 'bundle',
@@ -366,7 +368,9 @@ class ExtensionManagerController extends AdminController implements EventedContr
             'updateable'    => false,
             'installed'     => $installed,
             'configuration' => $this->getIframePath($bundle),
-            'version'       => $bundle->getVersion()
+            'version'       => $bundle->getVersion(),
+            'priority'      => $state['priority'],
+            'environments'  => implode(', ', $state['environments'])
         ];
 
         // only check for installation specifics if the bundle is enabled

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
@@ -249,10 +249,14 @@ services:
             - '%pimcore.extensions.bundles.search_paths%'
             - '%pimcore.extensions.bundles.handle_composer%'
 
+    pimcore.extension.bundle.state_config:
+        class: Pimcore\Extension\Bundle\Config\StateConfig
+        arguments: ['@pimcore.extension.config']
+
     pimcore.extension.bundle_manager:
         class: Pimcore\Extension\Bundle\PimcoreBundleManager
         arguments:
-            - '@pimcore.extension.config'
+            - '@pimcore.extension.bundle.state_config'
             - '@pimcore.extension.bundle_locator'
             - '@kernel'
             - '@event_dispatcher'

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/translations/en.json
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/translations/en.json
@@ -6,6 +6,7 @@
     "addoverlay_fit": "Add Overlay Fit",
     "upload_failed_files": "Unable to upload the following files",
     "environment": "Environment",
+    "environments": "Environments",
     "test": "Test",
     "local": "Local",
     "show_cookie_notice": "Show Cookie Notice (EU Policy)",

--- a/pimcore/lib/Pimcore/Extension/Bundle/Config/StateConfig.php
+++ b/pimcore/lib/Pimcore/Extension/Bundle/Config/StateConfig.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Extension\Bundle\Config;
+
+use Pimcore\Config as PimcoreConfig;
+use Pimcore\Extension\Config;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class StateConfig
+{
+    /**
+     * @var OptionsResolver
+     */
+    private static $optionsResolver;
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @param Config $config
+     */
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Sets the normalized bundle state on the extension manager config
+     *
+     * @param string $bundle
+     * @param array $options
+     */
+    public function setState(string $bundle, array $options)
+    {
+        $config = $this->config->loadConfig();
+        if (!isset($config->bundle)) {
+            $config->bundle = new PimcoreConfig\Config([], true);
+        }
+
+        $entry = [];
+        if (isset($config->bundle->$bundle)) {
+            $entry = $config->bundle->$bundle;
+        }
+
+        $entry = array_merge($entry, $options);
+        $entry = self::normalizeOptions($entry);
+
+        $config->bundle->$bundle = $entry;
+
+        $this->config->saveConfig($config);
+    }
+
+    /**
+     * Lists enabled bundles from config
+     *
+     * @return array
+     */
+    public function getEnabledBundles(): array
+    {
+        $result  = [];
+        $bundles = $this->getBundlesFromConfig();
+
+        foreach ($bundles as $bundleName => $options) {
+            if ($options['enabled']) {
+                $result[$bundleName] = $options;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Lists enabled bundle names from config
+     *
+     * @return array
+     */
+    public function getEnabledBundleNames(): array
+    {
+        return array_keys($this->getEnabledBundles());
+    }
+
+    /**
+     * Loads bundles which are defined in configuration
+     *
+     * @return array
+     */
+    private function getBundlesFromConfig(): array
+    {
+        $config = $this->config->loadConfig();
+        if (!isset($config->bundle)) {
+            return [];
+        }
+
+        $bundles = $config->bundle->toArray();
+
+        $result = [];
+        foreach ($bundles as $bundleName => $options) {
+            $result[$bundleName] = self::normalizeOptions($options);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Normalizes options array as expected in extension manager config
+     *
+     * @param array|bool $options
+     *
+     * @return array
+     */
+    final public static function normalizeOptions($options): array
+    {
+        if (is_bool($options)) {
+            $options = ['enabled' => $options];
+        } elseif (!is_array($options)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Expected options as bool or as array, but got %s',
+                is_object($options) ? get_class($options) : gettype($options)
+            ));
+        }
+
+        $resolver = self::getOptionsResolver();
+        $options  = $resolver->resolve($options);
+
+        return $options;
+    }
+
+    private static function getOptionsResolver(): OptionsResolver
+    {
+        if (null !== self::$optionsResolver) {
+            return self::$optionsResolver;
+        }
+
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'enabled'      => false,
+            'priority'     => 0,
+            'environments' => []
+        ]);
+
+        $resolver->setRequired(['enabled', 'priority', 'environments']);
+
+        $resolver->setAllowedTypes('enabled', 'bool');
+        $resolver->setAllowedTypes('priority', 'int');
+        $resolver->setAllowedTypes('environments', 'array');
+
+        $resolver->setNormalizer('environments', function (Options $options, $value) {
+            return array_map(function ($item) {
+                return (string)$item;
+            }, $value);
+        });
+
+        self::$optionsResolver = $resolver;
+
+        return self::$optionsResolver;
+    }
+}

--- a/pimcore/lib/Pimcore/Extension/Bundle/Config/StateConfig.php
+++ b/pimcore/lib/Pimcore/Extension/Bundle/Config/StateConfig.php
@@ -156,15 +156,20 @@ final class StateConfig
             $config->bundle = new PimcoreConfig\Config([], true);
         }
 
-        $entry = [];
+        $state = [];
         if (isset($config->bundle->$bundle)) {
-            $entry = $this->normalizeOptions($config->bundle->$bundle->toArray());
+            $currentState = $config->bundle->$bundle;
+            if ($currentState instanceof PimcoreConfig\Config) {
+                $currentState = $currentState->toArray();
+            }
+
+            $state = $this->normalizeOptions($currentState);
         }
 
-        $entry = array_merge($entry, $options);
-        $entry = $this->prepareWriteOptions($entry);
+        $state = array_merge($state, $options);
+        $state = $this->prepareWriteOptions($state);
 
-        $config->bundle->$bundle = $entry;
+        $config->bundle->$bundle = $state;
     }
 
     /**

--- a/pimcore/lib/Pimcore/Extension/Bundle/PimcoreBundleManager.php
+++ b/pimcore/lib/Pimcore/Extension/Bundle/PimcoreBundleManager.php
@@ -186,6 +186,22 @@ class PimcoreBundleManager
     }
 
     /**
+     * Reads bundle state from config
+     *
+     * @param $bundle
+     *
+     * @return array
+     */
+    public function getState($bundle): array
+    {
+        $identifier = $this->getBundleIdentifier($bundle);
+
+        $this->validateBundleIdentifier($identifier);
+
+        return $this->stateConfig->getState($identifier);
+    }
+
+    /**
      * Updates state for a bundle and writes it to config
      *
      * @param string|PimcoreBundleInterface $bundle
@@ -198,6 +214,25 @@ class PimcoreBundleManager
         $this->validateBundleIdentifier($identifier);
 
         $this->stateConfig->setState($identifier, $options);
+    }
+
+    /**
+     * Batch updates bundle states
+     *
+     * @param array $states
+     */
+    public function setStates(array $states)
+    {
+        $updates = [];
+
+        foreach ($states as $bundle => $options) {
+            $identifier = $this->getBundleIdentifier($bundle);
+            $this->validateBundleIdentifier($identifier);
+
+            $updates[$identifier] = $options;
+        }
+
+        $this->stateConfig->setStates($updates);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Extension/Config.php
+++ b/pimcore/lib/Pimcore/Extension/Config.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Pimcore
  *
@@ -32,7 +35,7 @@ class Config
     /**
      * @return PimcoreConfig\Config
      */
-    public function loadConfig()
+    public function loadConfig(): PimcoreConfig\Config
     {
         if (!$this->config) {
             if ($this->configFileExists()) {
@@ -61,9 +64,9 @@ class Config
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function locateConfigFile()
+    public function locateConfigFile(): string
     {
         if (null === $this->file) {
             $this->file = PimcoreConfig::locateConfigFile('extensions.php');
@@ -75,7 +78,7 @@ class Config
     /**
      * @return bool
      */
-    public function configFileExists()
+    public function configFileExists(): bool
     {
         if (null !== $file = $this->locateConfigFile()) {
             return file_exists($file);

--- a/pimcore/lib/Pimcore/HttpKernel/BundleCollection/BundleCollection.php
+++ b/pimcore/lib/Pimcore/HttpKernel/BundleCollection/BundleCollection.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\HttpKernel\BundleCollection;
+
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+class BundleCollection
+{
+    /**
+     * @var Item[]
+     */
+    private $items = [];
+
+    /**
+     * @var array
+     */
+    private $names = [];
+
+    /**
+     * Adds a collection item
+     *
+     * @param Item $item
+     *
+     * @return self
+     */
+    public function add(Item $item): self
+    {
+        $name = $item->getBundle()->getName();
+        if (in_array($name, $this->names)) {
+            throw new \LogicException(sprintf('Trying to register two bundles with the same name "%s"', $name));
+        }
+
+        $this->names[] = $name;
+        $this->items[$item->getPriority()][] = $item;
+
+        return $this;
+    }
+
+    /**
+     * Adds a bundle
+     *
+     * @param BundleInterface $bundle
+     * @param int $priority
+     * @param array $environments
+     *
+     * @return self
+     */
+    public function addBundle(BundleInterface $bundle, int $priority = 0, array $environments = []): self
+    {
+        return $this->add(new Item($bundle, $priority, $environments));
+    }
+
+    /**
+     * Adds a collection of bundles with the same priority and environments
+     *
+     * @param BundleInterface[] $bundles
+     * @param int $priority
+     * @param array $environments
+     *
+     * @return BundleCollection
+     */
+    public function addBundles(array $bundles, int $priority = 0, array $environments = []): self
+    {
+        foreach ($bundles as $bundle) {
+            $this->addBundle($bundle, $priority, $environments);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get bundles matching environment ordered by priority
+     *
+     * @param string $environment
+     *
+     * @return BundleInterface[]
+     */
+    public function getBundles(string $environment): array
+    {
+        $priorities = array_keys($this->items);
+        rsort($priorities); // highest priority first
+
+        $bundles = [];
+        foreach ($priorities as $priority) {
+
+            /** @var Item $item */
+            foreach ($this->items[$priority] as $item) {
+                if ($item->matchesEnvironment($environment)) {
+                    $bundles[] = $item->getBundle();
+                }
+            }
+        }
+
+        return $bundles;
+    }
+}

--- a/pimcore/lib/Pimcore/HttpKernel/BundleCollection/Item.php
+++ b/pimcore/lib/Pimcore/HttpKernel/BundleCollection/Item.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\HttpKernel\BundleCollection;
+
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+class Item
+{
+    /**
+     * @var BundleInterface
+     */
+    private $bundle;
+
+    /**
+     * @var int
+     */
+    private $priority;
+
+    /**
+     * @var array
+     */
+    private $environments = [];
+
+    /**
+     * @param BundleInterface $bundle
+     * @param int $priority
+     * @param array $environments
+     */
+    public function __construct(BundleInterface $bundle, int $priority = 0, array $environments = [])
+    {
+        $this->bundle       = $bundle;
+        $this->priority     = $priority;
+        $this->environments = $environments;
+    }
+
+    public function getBundle(): BundleInterface
+    {
+        return $this->bundle;
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+
+    public function getEnvironments(): array
+    {
+        return $this->environments;
+    }
+
+    public function matchesEnvironment(string $environment): bool
+    {
+        if (empty($this->environments)) {
+            return true;
+        }
+
+        return in_array($environment, $this->environments, true);
+    }
+}

--- a/pimcore/lib/Pimcore/Kernel.php
+++ b/pimcore/lib/Pimcore/Kernel.php
@@ -149,6 +149,11 @@ abstract class Kernel extends SymfonyKernel
         return $bundles;
     }
 
+    /**
+     * Registers "core" bundles
+     *
+     * @param BundleCollection $collection
+     */
     protected function registerCoreBundlesToCollection(BundleCollection $collection)
     {
         $collection->addBundles([
@@ -171,14 +176,11 @@ abstract class Kernel extends SymfonyKernel
             80, ['dev']
         );
 
-        $collection->addBundles(
-            [
-                new DebugBundle(),
-                new WebProfilerBundle(),
-                new SensioDistributionBundle()
-            ],
-            80, ['dev', 'test']
-        );
+        $collection->addBundles([
+            new DebugBundle(),
+            new WebProfilerBundle(),
+            new SensioDistributionBundle()
+        ], 80, ['dev', 'test']);
 
         // pimcore bundles
         $collection->addBundles([

--- a/pimcore/lib/Pimcore/Kernel.php
+++ b/pimcore/lib/Pimcore/Kernel.php
@@ -19,6 +19,7 @@ use Pimcore\Bundle\AdminBundle\PimcoreAdminBundle;
 use Pimcore\Bundle\CoreBundle\PimcoreCoreBundle;
 use Pimcore\Config\BundleConfigLocator;
 use Pimcore\Event\SystemEvents;
+use Pimcore\Extension\Bundle\Config\StateConfig;
 use Pimcore\HttpKernel\BundleCollection\BundleCollection;
 use Pimcore\HttpKernel\Config\SystemConfigParamResource;
 use Sensio\Bundle\DistributionBundle\SensioDistributionBundle;
@@ -193,41 +194,14 @@ abstract class Kernel extends SymfonyKernel
      */
     protected function registerExtensionManagerBundles(BundleCollection $collection)
     {
-        $config = $this->extensionConfig->loadConfig();
-        if (isset($config->bundle)) {
-            foreach ($config->bundle->toArray() as $className => $config) {
-                if (!class_exists($className)) {
-                    continue;
-                }
+        $stateConfig = new StateConfig($this->extensionConfig);
 
-                $priority     = 0;
-                $environments = [];
-
-                if (is_bool($config)) {
-                    if (!$config) {
-                        continue;
-                    }
-                } elseif (is_array($config)) {
-                    $enabled = isset($config['enabled']) && (bool)$config['enabled'];
-                    if (!$enabled) {
-                        continue;
-                    }
-
-                    if (isset($config['priority'])) {
-                        $priority = (int)$config['priority'];
-                    }
-
-                    if (isset($config['environments'])) {
-                        if (is_array($config['environments'])) {
-                            $environments = $config['environments'];
-                        }
-                    }
-                } else {
-                    continue;
-                }
-
-                $collection->addBundle(new $className, $priority, $environments);
+        foreach ($stateConfig->getEnabledBundles() as $className => $options) {
+            if (!class_exists($className)) {
+                continue;
             }
+
+            $collection->addBundle(new $className, $options['priority'], $options['environments']);
         }
     }
 

--- a/pimcore/lib/Pimcore/Kernel.php
+++ b/pimcore/lib/Pimcore/Kernel.php
@@ -134,18 +134,21 @@ abstract class Kernel extends SymfonyKernel
     {
         $collection = new BundleCollection();
 
-        $this->buildBundleCollection($collection);
+        // core bundles (Symfony, Pimcore)
+        $this->registerCoreBundlesToCollection($collection);
 
-        return $collection->getBundles($this->getEnvironment());
+        // bundles registered in extensions.php
+        $this->registerExtensionManagerBundles($collection);
+
+        // custom bundles
+        $this->registerBundlesToCollection($collection);
+
+        $bundles = $collection->getBundles($this->getEnvironment());
+
+        return $bundles;
     }
 
-    /**
-     * Adds bundles to register to the bundle collection. The collection is able
-     * to handle priorities and environment specific bundles.
-     *
-     * @param BundleCollection $collection
-     */
-    protected function buildBundleCollection(BundleCollection $collection)
+    protected function registerCoreBundlesToCollection(BundleCollection $collection)
     {
         $collection->addBundles([
             // symfony "core"/standard
@@ -181,9 +184,6 @@ abstract class Kernel extends SymfonyKernel
             new PimcoreCoreBundle(),
             new PimcoreAdminBundle(),
         ], 60);
-
-        // bundles registered in extensions.php
-        $this->registerExtensionManagerBundles($collection);
     }
 
     /**
@@ -229,6 +229,18 @@ abstract class Kernel extends SymfonyKernel
                 $collection->addBundle(new $className, $priority, $environments);
             }
         }
+    }
+
+    /**
+     * Adds bundles to register to the bundle collection. The collection is able
+     * to handle priorities and environment specific bundles.
+     *
+     * To be implemented in child classes
+     *
+     * @param BundleCollection $collection
+     */
+    public function registerBundlesToCollection(BundleCollection $collection)
+    {
     }
 
     /**

--- a/pimcore/tests/unit/HttpKernel/BundleCollection/BundleCollectionTest.php
+++ b/pimcore/tests/unit/HttpKernel/BundleCollection/BundleCollectionTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Tests\Unit\HttpKernel\BundleCollection;
+
+use Pimcore\HttpKernel\BundleCollection\BundleCollection;
+use Pimcore\HttpKernel\BundleCollection\Item;
+use Pimcore\Tests\Test\TestCase;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+class BundleCollectionTest extends TestCase
+{
+    /**
+     * @var BundleCollection
+     */
+    private $collection;
+
+    /**
+     * @var BundleInterface[]
+     */
+    private $bundles;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->collection = new BundleCollection();
+
+        $this->bundles = [
+            new BundleA,
+            new BundleB,
+            new BundleC,
+            new BundleD
+        ];
+    }
+
+    public function testAddBundle()
+    {
+        foreach ($this->bundles as $bundle) {
+            $this->collection->addBundle($bundle);
+        }
+
+        $this->assertEquals($this->bundles, $this->collection->getBundles('prod'));
+    }
+
+    public function testAddBundles()
+    {
+        $this->collection->addBundles($this->bundles);
+
+        $this->assertEquals($this->bundles, $this->collection->getBundles('prod'));
+    }
+
+    public function testAddItem()
+    {
+        foreach ($this->bundles as $bundle) {
+            $this->collection->add(new Item($bundle));
+        }
+
+        $this->assertEquals($this->bundles, $this->collection->getBundles('prod'));
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Trying to register two bundles with the same name "BundleA"
+     */
+    public function testExceptionOnDoubleBundle()
+    {
+        $this->collection->addBundle($this->bundles[0]);
+        $this->collection->addBundle($this->bundles[0]);
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Trying to register two bundles with the same name "BundleA"
+     */
+    public function testExceptionOnDoubleBundleWithDifferentInstance()
+    {
+        $this->collection->addBundle(new BundleA);
+        $this->collection->addBundle(new BundleA);
+    }
+
+    public function testBundlesAreOrderedByPriority()
+    {
+        $collection = $this->collection;
+        $bundles    = $this->bundles;
+
+        $collection->addBundle($bundles[0], 10);
+        $collection->addBundle($bundles[1], 5);
+        $collection->addBundle($bundles[2], -10);
+        $collection->addBundle($bundles[3], 50);
+
+        $result = $collection->getBundles('prod');
+
+        $this->assertEquals($bundles[3], $result[0]);
+        $this->assertEquals($bundles[0], $result[1]);
+        $this->assertEquals($bundles[1], $result[2]);
+        $this->assertEquals($bundles[2], $result[3]);
+    }
+
+    public function testBundlesAreFilteredByEnvironment()
+    {
+        $collection = $this->collection;
+
+        $bundles   = $this->bundles;
+        $bundles[] = new BundleD;
+
+        $collection->addBundle($bundles[0]); // this will always be loaded
+        $collection->addBundle($bundles[1], 0, ['dev']);
+        $collection->addBundle($bundles[2], 0, ['dev', 'test']);
+        $collection->addBundle($bundles[3], 0, ['test']);
+
+        // dev and test will be excluded
+        $this->assertEquals([
+            $bundles[0],
+        ], $collection->getBundles('prod'));
+
+        // dev environment excludes the test-only bundle
+        $this->assertEquals([
+            $bundles[0],
+            $bundles[1],
+            $bundles[2]
+        ], $collection->getBundles('dev'));
+
+        // test environment excludes the dev-only bundle
+        $this->assertEquals([
+            $bundles[0],
+            $bundles[2],
+            $bundles[3]
+        ], $collection->getBundles('test'));
+
+    }
+}
+
+class BundleA extends Bundle
+{
+}
+
+class BundleB extends Bundle
+{
+}
+
+class BundleC extends Bundle
+{
+}
+
+class BundleD extends Bundle
+{
+}

--- a/pimcore/tests/unit/HttpKernel/BundleCollection/ItemTest.php
+++ b/pimcore/tests/unit/HttpKernel/BundleCollection/ItemTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Tests\Unit\HttpKernel\BundleCollection;
+
+use Pimcore\HttpKernel\BundleCollection\Item;
+use Pimcore\Tests\Test\TestCase;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class ItemTest extends TestCase
+{
+    public function testEmptyEnvironmentsMatchesAnyEnvironment()
+    {
+        $item = new Item(new ItemTestBundle(), 0, []);
+        foreach (['prod', 'dev', 'test'] as $environment) {
+            $this->assertTrue($item->matchesEnvironment($environment));
+        }
+    }
+
+    public function testItemMatchesEnvironment()
+    {
+        $item = new Item(new ItemTestBundle(), 0, ['dev']);
+
+        $this->assertTrue($item->matchesEnvironment('dev'));
+        $this->assertFalse($item->matchesEnvironment('prod'));
+        $this->assertFalse($item->matchesEnvironment('test'));
+    }
+
+    public function testItemWithMultipleEnvironments()
+    {
+        $item = new Item(new ItemTestBundle(), 0, ['dev', 'test']);
+
+        $this->assertTrue($item->matchesEnvironment('dev'));
+        $this->assertTrue($item->matchesEnvironment('test'));
+        $this->assertFalse($item->matchesEnvironment('prod'));
+    }
+}
+
+class ItemTestBundle extends Bundle
+{
+}
+

--- a/web/pimcore/static6/js/pimcore/extensionmanager/admin.js
+++ b/web/pimcore/static6/js/pimcore/extensionmanager/admin.js
@@ -106,7 +106,16 @@ pimcore.extensionmanager.admin = Class.create({
 
         this.store = new Ext.data.Store({
             model: 'pimcore.model.extensions.admin',
-            autoSync: false
+            autoSync: true,
+            listeners: {
+                beforesync: function () {
+                    self.panel.setLoading(true);
+                },
+
+                update: function () {
+                    self.panel.setLoading(false);
+                }
+            }
         });
 
         this.store.load();
@@ -121,19 +130,6 @@ pimcore.extensionmanager.admin = Class.create({
                 },
                 '->',
                 '<b id="ext-manager-reload-info" style="visibility: hidden">' + t("please_dont_forget_to_reload_pimcore_after_modifications") + '!</b>',
-                {
-                    text: t("apply"),
-                    iconCls: "pimcore_icon_apply",
-                    handler: function() {
-                        self.panel.setLoading(true);
-                        self.store.sync({
-                            callback: function() {
-                                self.panel.setLoading(false);
-                                console.log('CB', arguments);
-                            }
-                        });
-                    }.bind(this)
-                },
                 {
                     text: t("clear_cache_and_reload"),
                     iconCls: "pimcore_icon_clear_cache",
@@ -413,6 +409,7 @@ pimcore.extensionmanager.admin = Class.create({
             {
                 header: t("priority"),
                 width: 80,
+                align: 'right',
                 sortable: true,
                 dataIndex: 'priority',
                 editor: new Ext.form.Number({})
@@ -438,7 +435,15 @@ pimcore.extensionmanager.admin = Class.create({
             },
             plugins: [
                 Ext.create('Ext.grid.plugin.CellEditing', {
-                    clicksToEdit: 1
+                    clicksToEdit: 1,
+                    listeners: {
+                        beforeedit: function (editor, context, eOpts) {
+                            // only allow editing for bundles
+                            if (context.record.data.type !== 'bundle') {
+                                return false;
+                            }
+                        }
+                    }
                 })
             ],
             trackMouseOver: true,

--- a/web/pimcore/static6/js/pimcore/extensionmanager/admin.js
+++ b/web/pimcore/static6/js/pimcore/extensionmanager/admin.js
@@ -82,21 +82,31 @@ pimcore.extensionmanager.admin = Class.create({
                 extend: 'Ext.data.Model',
                 fields: [
                     "id", "extensionId", "type", "name", "description", "installed", "installable", "uninstallable", "active",
-                    "configuration", "updateable", "xmlEditorFile", "version"
+                    "configuration", "updateable", "xmlEditorFile", "version", "priority", "environments"
                 ],
                 proxy: {
                     type: 'ajax',
-                    url: '/admin/extensionmanager/admin/get-extensions',
+                    url: '/admin/extensionmanager/admin/extensions',
                     reader: {
                         type: 'json',
-                        rootProperty: "extensions"
+                        rootProperty: 'extensions'
+                    },
+                    writer: {
+                        type: 'json',
+                        rootProperty: 'extensions',
+                        allowSingle: false
+                    },
+                    actionMethods: {
+                        read: 'GET',
+                        update: 'PUT'
                     }
                 }
             });
         }
 
         this.store = new Ext.data.Store({
-            model: 'pimcore.model.extensions.admin'
+            model: 'pimcore.model.extensions.admin',
+            autoSync: false
         });
 
         this.store.load();
@@ -111,6 +121,19 @@ pimcore.extensionmanager.admin = Class.create({
                 },
                 '->',
                 '<b id="ext-manager-reload-info" style="visibility: hidden">' + t("please_dont_forget_to_reload_pimcore_after_modifications") + '!</b>',
+                {
+                    text: t("apply"),
+                    iconCls: "pimcore_icon_apply",
+                    handler: function() {
+                        self.panel.setLoading(true);
+                        self.store.sync({
+                            callback: function() {
+                                self.panel.setLoading(false);
+                                console.log('CB', arguments);
+                            }
+                        });
+                    }.bind(this)
+                },
                 {
                     text: t("clear_cache_and_reload"),
                     iconCls: "pimcore_icon_clear_cache",
@@ -386,6 +409,20 @@ pimcore.extensionmanager.admin = Class.create({
                 dataIndex: 'xmlEditorFile',
                 hidden: true,
                 hideable: false
+            },
+            {
+                header: t("priority"),
+                width: 80,
+                sortable: true,
+                dataIndex: 'priority',
+                editor: new Ext.form.Number({})
+            },
+            {
+                header: t("environments"),
+                width: 100,
+                sortable: false,
+                dataIndex: 'environments',
+                editor: new Ext.form.TextField({})
             }
         ];
 
@@ -399,6 +436,11 @@ pimcore.extensionmanager.admin = Class.create({
                     flex: 0
                 }
             },
+            plugins: [
+                Ext.create('Ext.grid.plugin.CellEditing', {
+                    clicksToEdit: 1
+                })
+            ],
             trackMouseOver: true,
             columnLines: true,
             stripeRows: true,


### PR DESCRIPTION
Fixes Issue #1455

* Bundles are registered on the `AppKernel` via `registerBundlesToCollection`. A `BundleCollection` handles bundle priority and filters by environment
* Bundle state (enabled, priority, environments) is written to config file in a normalized manner, supporting both boolean and array entries through a `StateConfig` class
* Extension manager exposes priority and environments in editable grid cells