### PR TITLE
MultiRelation path formatter layout bugfix

### DIFF
--- a/web/pimcore/static6/js/pimcore/helpers.js
+++ b/web/pimcore/static6/js/pimcore/helpers.js
@@ -2908,6 +2908,8 @@ pimcore.helpers.getNicePathHandlerStore = function(store, config, gridView, resp
         }
     }, this);
 
+    gridView.updateLayout();
+
 };
 
 pimcore.helpers.isValidPassword = function (pass) {


### PR DESCRIPTION
Grid layout needs to be refreshed after an update of the grid content occured otherwise strange things will happen if the new content's height is bigger then the original row height.
