### PR TITLE
fix WorkflowController::submitWorkflowTransitionAction json return

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/WorkflowController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/WorkflowController.php
@@ -176,7 +176,7 @@ class WorkflowController extends AdminController implements EventedControllerInt
             ];
         }
 
-        return $this->json($data, true);
+        return $this->json($data);
     }
 
     /**


### PR DESCRIPTION
WorkflowController::submitWorkflowTransitionAction has a second parameter to $this->json, which is a boolean, but json expects it to be a http-header-code, therefore it throws an error with invalid http-code 1. this pr fixes that