### PR TITLE
MultiRelation path formatter bugfix: inheritance indicator didn't work when a path formatter was used

### DIFF
--- a/web/pimcore/static6/js/pimcore/helpers.js
+++ b/web/pimcore/static6/js/pimcore/helpers.js
@@ -2895,6 +2895,7 @@ pimcore.helpers.getNicePathHandlerStore = function(store, config, gridView, resp
         pathProperty: "path"
     });
 
+    store.ignoreDataChanged = true;
     store.each(function (record, id) {
         var recordId = record.data[config.idProperty];
         if (typeof responseData[recordId] != "undefined") {
@@ -2907,6 +2908,7 @@ pimcore.helpers.getNicePathHandlerStore = function(store, config, gridView, resp
             }
         }
     }, this);
+    store.ignoreDataChanged = false;
 
     gridView.updateLayout();
 

--- a/web/pimcore/static6/js/pimcore/object/tags/multihrefMetadata.js
+++ b/web/pimcore/static6/js/pimcore/object/tags/multihrefMetadata.js
@@ -65,6 +65,9 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                     this.dataChanged = true;
                 }.bind(this),
                 update: function(store) {
+                    if(store.ignoreDataChanged) {
+                        return;
+                    }
                     this.dataChanged = true;
                 }.bind(this)
             },

--- a/web/pimcore/static6/js/pimcore/object/tags/objectsMetadata.js
+++ b/web/pimcore/static6/js/pimcore/object/tags/objectsMetadata.js
@@ -65,6 +65,9 @@ pimcore.object.tags.objectsMetadata = Class.create(pimcore.object.tags.objects, 
                     this.dataChanged = true;
                 }.bind(this),
                 update: function(store) {
+                    if(store.ignoreDataChanged) {
+                        return;
+                    }
                     this.dataChanged = true;
                 }.bind(this)
             },


### PR DESCRIPTION
This pull request fixes the inheritance indicator when a multirelation path formatter is used in objects with metadata or multihref with metadata (other relation types are not effected).

We tried several different solutions but unfortunately it's not possible to solve it differently without doing some refactorings.