### PR TITLE
MultiRelation path formatter bugfix: inheritance indicator didn't work when a path formatter was used (pimcore 4)

### DIFF
--- a/pimcore/static6/js/pimcore/helpers.js
+++ b/pimcore/static6/js/pimcore/helpers.js
@@ -2898,6 +2898,7 @@ pimcore.helpers.getNicePathHandlerStore = function(store, config, gridView, resp
         pathProperty: "path"
     });
 
+    store.ignoreDataChanged = true;
     store.each(function (record, id) {
         var recordId = record.data[config.idProperty];
         if (typeof responseData[recordId] != "undefined") {
@@ -2910,6 +2911,7 @@ pimcore.helpers.getNicePathHandlerStore = function(store, config, gridView, resp
             }
         }
     }, this);
+    store.ignoreDataChanged = false;
 
     gridView.updateLayout();
 };

--- a/pimcore/static6/js/pimcore/object/tags/multihrefMetadata.js
+++ b/pimcore/static6/js/pimcore/object/tags/multihrefMetadata.js
@@ -65,6 +65,9 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                     this.dataChanged = true;
                 }.bind(this),
                 update: function(store) {
+                    if(store.ignoreDataChanged) {
+                        return;
+                    }
                     this.dataChanged = true;
                 }.bind(this)
             },

--- a/pimcore/static6/js/pimcore/object/tags/objectsMetadata.js
+++ b/pimcore/static6/js/pimcore/object/tags/objectsMetadata.js
@@ -65,6 +65,9 @@ pimcore.object.tags.objectsMetadata = Class.create(pimcore.object.tags.objects, 
                     this.dataChanged = true;
                 }.bind(this),
                 update: function(store) {
+                    if(store.ignoreDataChanged) {
+                        return;
+                    }
                     this.dataChanged = true;
                 }.bind(this)
             },


### PR DESCRIPTION
same as #1482 for pimcore 4