### PR TITLE
Unifiy sub-request rendering

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/PimcoreHeaderListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/PimcoreHeaderListener.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+class PimcoreHeaderListener
+{
+    /**
+     * @param FilterResponseEvent $event
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if ($event->isMasterRequest()) {
+            $response = $event->getResponse();
+            $response->headers->set('X-Powered-By', 'pimcore', true);
+        }
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/event_listeners.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/event_listeners.yml
@@ -31,6 +31,11 @@ services:
       tags:
         - { name: kernel.event_subscriber }
 
+    pimcore.event_listener.pimcore_header:
+        class: Pimcore\Bundle\CoreBundle\EventListener\PimcoreHeaderListener
+        tags:
+            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
+
     #
     # PIMCORE OBJECTS/PARAMS LOGIC
     #


### PR DESCRIPTION
* support `attributes`, `query` and `options` everywhere
* define an interface for `DocumentRenderer` and implement it in new and legacy document renderer