### PR TITLE
Fix document render errors from admin context

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TranslationController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TranslationController.php
@@ -1281,6 +1281,8 @@ class TranslationController extends AdminController
             } catch (\Exception $e) {
                 Logger::error('Word Export: ' . $e->getMessage());
                 Logger::error($e);
+
+                throw $e;
             }
         }
 

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TranslationController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TranslationController.php
@@ -1154,12 +1154,7 @@ class TranslationController extends AdminController
                     }
 
                     // we need to set the parameter "pimcore_admin" here to be able to render unpublished documents
-                    $reqBak = $_REQUEST;
-                    $_REQUEST['pimcore_admin'] = true;
-
-                    $html = Document\Service::render($element, [], false);
-
-                    $_REQUEST = $reqBak; // set the request back to original
+                    $html = Document\Service::render($element, [], false, ['pimcore_admin' => true]);
 
                     $html = preg_replace('@</?(img|meta|div|section|aside|article|body|bdi|bdo|canvas|embed|footer|head|header|html)([^>]+)?>@', '', $html);
                     $html = preg_replace('/<!--(.*)-->/Uis', '', $html);

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -261,7 +261,7 @@ class PimcoreCoreExtension extends Extension implements PrependExtensionInterfac
      */
     protected function addContextRoutes(ContainerBuilder $container, array $config)
     {
-        $guesser = $container->getDefinition('pimcore.service.request.pimcore_context_resolver');
+        $guesser = $container->getDefinition('pimcore.service.context.pimcore_context_guesser');
 
         foreach ($config as $context => $contextConfig) {
             $guesser->addMethodCall('addContextRoutes', [$context, $contextConfig['routes']]);

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
@@ -88,14 +88,27 @@ class DocumentFallbackListener extends AbstractFrontendListener implements Event
             return;
         } else {
             // if we're in a sub request and no explicit document is set - try to load document from
-            // master request and set it on our sub-request
+            // parent and/or master request and set it on our sub-request
             if (!$event->isMasterRequest()) {
+                $parentRequest = $this->requestStack->getParentRequest();
                 $masterRequest = $this->requestStack->getMasterRequest();
 
-                if ($document = $this->documentResolver->getDocument($masterRequest)) {
-                    $this->documentResolver->setDocument($request, $document);
+                $eligibleRequests = [];
 
-                    return;
+                if (null !== $parentRequest) {
+                    $eligibleRequests[] = $parentRequest;
+                }
+
+                if ($masterRequest !== $parentRequest) {
+                    $eligibleRequests[] = $masterRequest;
+                }
+
+                foreach ($eligibleRequests as $eligibleRequest) {
+                    if ($document = $this->documentResolver->getDocument($eligibleRequest)) {
+                        $this->documentResolver->setDocument($request, $document);
+
+                        return;
+                    }
                 }
             }
         }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/ElementListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/ElementListener.php
@@ -101,7 +101,9 @@ class ElementListener extends AbstractFrontendListener implements EventSubscribe
             return;
         }
 
-        $adminRequest = $this->requestHelper->isFrontendRequestByAdmin($this->requestHelper->getMasterRequest());
+        $adminRequest =
+            $this->requestHelper->isFrontendRequestByAdmin($request) ||
+            $this->requestHelper->isFrontendRequestByAdmin($this->requestHelper->getMasterRequest());
 
         $user = null;
         if ($adminRequest) {

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
@@ -149,6 +149,10 @@ services:
     pimcore.service.request_matcher_factory:
         class: Pimcore\Service\RequestMatcherFactory
 
+    pimcore.service.context.pimcore_context_guesser:
+        class: Pimcore\Service\Context\PimcoreContextGuesser
+        arguments: ['@pimcore.service.request_matcher_factory']
+
     #
     # REQUEST RESOLVERS
     #
@@ -157,7 +161,7 @@ services:
 
     pimcore.service.request.pimcore_context_resolver:
         class: Pimcore\Service\Request\PimcoreContextResolver
-        arguments: ['@request_stack', '@pimcore.service.request_matcher_factory']
+        arguments: ['@request_stack', '@pimcore.service.context.pimcore_context_guesser']
 
     pimcore.service.request.site_resolver:
         class: Pimcore\Service\Request\SiteResolver

--- a/pimcore/lib/Pimcore/Service/Context/PimcoreContextGuesser.php
+++ b/pimcore/lib/Pimcore/Service/Context/PimcoreContextGuesser.php
@@ -14,15 +14,82 @@
 
 namespace Pimcore\Service\Context;
 
+use Pimcore\Service\Request\PimcoreContextResolver;
 use Pimcore\Service\RequestMatcherFactory;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 
 class PimcoreContextGuesser
 {
+    /**
+     * @var array
+     */
+    private $routes = [];
+
+    /**
+     * @var RequestMatcherInterface[]
+     */
+    private $matchers;
+
+    /**
+     * @var RequestMatcherFactory
+     */
+    private $requestMatcherFactory;
+
     /**
      * @param RequestMatcherFactory $factory
      */
     public function __construct(RequestMatcherFactory $factory)
     {
         $this->requestMatcherFactory = $factory;
+    }
+
+    /**
+     * Add context specific routes
+     *
+     * @param string $context
+     * @param array $routes
+     */
+    public function addContextRoutes(string $context, array $routes)
+    {
+        $this->routes[$context] = $routes;
+    }
+
+    /**
+     * Guess the pimcore context
+     *
+     * @param Request $request
+     * @param string $default
+     *
+     * @return string
+     */
+    public function guess(Request $request, string $default): string
+    {
+        /** @var RequestMatcherInterface[] $matchers */
+        foreach ($this->getMatchers() as $context => $matchers) {
+            foreach ($matchers as $matcher) {
+                if ($matcher->matches($request)) {
+                    return $context;
+                }
+            }
+        }
+
+        return $default;
+    }
+
+    /**
+     * Get request matchers to query admin pimcore context from
+     *
+     * @return RequestMatcherInterface[]
+     */
+    private function getMatchers(): array
+    {
+        if (null === $this->matchers) {
+            foreach ($this->routes as $context => $routes) {
+                $this->matchers[$context] = $this->requestMatcherFactory->buildRequestMatchers($routes);
+            }
+        }
+
+        return $this->matchers;
     }
 }

--- a/pimcore/lib/Pimcore/Templating/Renderer/ActionRenderer.php
+++ b/pimcore/lib/Pimcore/Templating/Renderer/ActionRenderer.php
@@ -16,6 +16,7 @@ namespace Pimcore\Templating\Renderer;
 
 use Pimcore\Model\Document;
 use Pimcore\Service\MvcConfigNormalizer;
+use Pimcore\Service\Request\PimcoreContextResolver;
 use Symfony\Bundle\FrameworkBundle\Templating\Helper\ActionsHelper;
 use Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
@@ -110,11 +111,18 @@ class ActionRenderer
      *
      * @param Document\PageSnippet $document
      * @param array $attributes
+     * @param string|null $context
      *
      * @return array
      */
-    public function addDocumentAttributes(Document\PageSnippet $document, array $attributes = [])
+    public function addDocumentAttributes(Document\PageSnippet $document, array $attributes = [], string $context = PimcoreContextResolver::CONTEXT_DEFAULT)
     {
+        if (null !== $context) {
+            // document needs to be rendered with default context as the context guesser can't resolve the
+            // context from a fragment route
+            $attributes[PimcoreContextResolver::ATTRIBUTE_PIMCORE_CONTEXT] = $context;
+        }
+
         // The CMF dynamic router sets the 2 attributes contentDocument and contentTemplate to set
         // a route's document and template. Those attributes are later used by controller listeners to
         // determine what to render. By injecting those attributes into the sub-request we can rely on

--- a/pimcore/models/Document/Service.php
+++ b/pimcore/models/Document/Service.php
@@ -93,9 +93,7 @@ class Service extends Model\Element\Service
         }
 
         // keep useLayout compatibility
-        if ($useLayout) {
-            $attributes['_useLayout'] = $useLayout;
-        }
+        $attributes['_useLayout'] = $useLayout;
 
         return $renderer->render($document, $attributes, $query, $options);
     }


### PR DESCRIPTION
Fixes issue #1441

Pimcore context needs to be resolved for every request, not globally as otherwise Documents rendered from admin (e.g. `DocumentRenderer::render()` will end up without a document).