### PR TITLE
Classificationstore groups not sorted

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data/Classificationstore.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Classificationstore.php
@@ -1196,7 +1196,7 @@ class Classificationstore extends Model\Object\ClassDefinition\Data
                 $s1 = $sorting[$a['id']] ? $sorting[$a['id']] : 0;
                 $s2 = $sorting[$b['id']] ? $sorting[$b['id']] : 0;
 
-                if ($s1 < $s2) {
+                if ($s1 > $s2) {
                     return 1;
                 } elseif ($s2 > $s1) {
                     return -1;


### PR DESCRIPTION
In admin mode, when editing an object, the classificationstore groups are not sorted correctly.
The sorter field is used, but there is a bug in the sort function.
The variables AND the comparaison sign are inverted at the same time.


## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
  
  
## Fixes Issue #

## Changes in this pull request  

## Additional info  

