### PR TITLE
Allow for resizing of details panel in Notes & Events view.

### DIFF
--- a/pimcore/static6/js/pimcore/element/notes.js
+++ b/pimcore/static6/js/pimcore/element/notes.js
@@ -195,7 +195,8 @@ pimcore.element.notes = Class.create({
 
             this.detailView = new Ext.Panel({
                 region: "east",
-                width: 350,
+                minWidth: 350,
+                split: true,
                 layout: "fit"
             });
 


### PR DESCRIPTION
## Fixes Issue #
Details panel in Notes & Events view isn't resizable which makes it hardly usable for one of our use-cases. This pull requst keeps the same default size, but allows for resizing.

I will provide additional Pull Request for Pimcore 5 if this one gets accepted. 