### PR TITLE
The same file can't be uploaded twice, since the on-change event isn'…

### DIFF
--- a/pimcore/static6/js/pimcore/asset/tree.js
+++ b/pimcore/static6/js/pimcore/asset/tree.js
@@ -890,6 +890,8 @@ pimcore.asset.tree = Class.create({
             jQuery("body").append('<input type="file" name="multiUploadField" id="multiUploadField" multiple>');
         }
 
+        jQuery("#multiUploadField").val("");
+
         // this is the tree node
         jQuery("#multiUploadField").unbind("change");
         jQuery("#multiUploadField").on("change", function (e) {


### PR DESCRIPTION
The same file can't be uploaded twice, since the on-change event isn't triggered the second time.

To reproduce:
- upload a file
- delete it
- reupload the same file and nothing will happen

I will provide a Pull Request for Pimcore 5 if this one gets accepted.

