### PR TITLE
System Setting: Hide text edit panel for text assets

### DIFF
--- a/pimcore/config/texts/en.json
+++ b/pimcore/config/texts/en.json
@@ -5133,6 +5133,10 @@
         "definition": "Hide Edit Image Tab"
     },
     {
+        "term": "disable_text_edit_panel_tab",
+        "definition": "Disable Edit Tab for Text assets"
+    },
+    {
         "term": "merge_csv",
         "definition": "Import &amp; Merge CSV"
     },

--- a/pimcore/modules/admin/controllers/AssetController.php
+++ b/pimcore/modules/admin/controllers/AssetController.php
@@ -42,6 +42,7 @@ class Admin_AssetController extends \Pimcore\Controller\Action\Admin\Element
 
     public function getDataByIdAction()
     {
+        $systemConfig = \Pimcore\Config::getSystemConfig();
 
         // check for lock
         if (Element\Editlock::isLocked($this->getParam("id"), "asset")) {
@@ -67,7 +68,7 @@ class Admin_AssetController extends \Pimcore\Controller\Action\Admin\Element
         $asset->setLocked($asset->isLocked());
         $asset->setParent(null);
 
-        if ($asset instanceof Asset\Text) {
+        if ($asset instanceof Asset\Text && !$systemConfig->assets->disable_text_edit_panel_tab) {
             $asset->data =  \ForceUTF8\Encoding::toUTF8($asset->getData());
         }
 

--- a/pimcore/modules/admin/controllers/SettingsController.php
+++ b/pimcore/modules/admin/controllers/SettingsController.php
@@ -438,6 +438,7 @@ class Admin_SettingsController extends \Pimcore\Controller\Action\Admin
                 "icc_rgb_profile" => $values["assets.icc_rgb_profile"],
                 "icc_cmyk_profile" => $values["assets.icc_cmyk_profile"],
                 "hide_edit_image" => $values["assets.hide_edit_image"],
+                "disable_text_edit_panel_tab" => $values["assets.disable_text_edit_panel_tab"],
                 "disable_tree_preview" => $values["assets.disable_tree_preview"]
             ],
             "services" => [

--- a/pimcore/modules/admin/views/scripts/index/index6.php
+++ b/pimcore/modules/admin/views/scripts/index/index6.php
@@ -584,6 +584,7 @@ $googleMapsApiKey = $this->config->services->google->browserapikey;
         htmltoimage: <?= \Zend_Json::encode(\Pimcore\Image\HtmlToImage::isSupported()) ?>,
         videoconverter: <?= \Zend_Json::encode(\Pimcore\Video::isAvailable()) ?>,
         asset_hide_edit: <?= $this->config->assets->hide_edit_image ? "true" : "false" ?>,
+        disable_text_edit_panel_tab: <?= $this->config->assets->disable_text_edit_panel_tab ? "true" : "false" ?>,
         perspective: <?= \Zend_Json::encode($runtimePerspective) ?>,
         availablePerspectives: <?= \Zend_Json::encode(\Pimcore\Config::getAvailablePerspectives(\Pimcore\Tool\Admin::getCurrentUser())) ?>,
         customviews: <?= \Zend_Json::encode($this->customview_config) ?>,

--- a/pimcore/static6/js/pimcore/asset/text.js
+++ b/pimcore/static6/js/pimcore/asset/text.js
@@ -43,7 +43,9 @@ pimcore.asset.text = Class.create(pimcore.asset.asset, {
         var items = [];
         var user = pimcore.globalmanager.get("user");
 
-        items.push(this.getEditPanel());
+        if (!pimcore.settings.disable_text_edit_panel_tab) {
+            items.push(this.getEditPanel());
+        }
 
         if (this.isAllowed("publish")) {
             items.push(this.metadata.getLayout());
@@ -112,7 +114,9 @@ pimcore.asset.text = Class.create(pimcore.asset.asset, {
         var parameters = $super(only);
         
         if(!Ext.isString(only)) {
-            parameters.data = this.editArea.getValue();
+            if (this.editArea) {
+                parameters.data = this.editArea.getValue();
+            }
         }
         
         return parameters;

--- a/pimcore/static6/js/pimcore/settings/system.js
+++ b/pimcore/static6/js/pimcore/settings/system.js
@@ -1016,6 +1016,12 @@ pimcore.settings.system = Class.create({
                                 checked: this.getValue("assets.hide_edit_image")
                             },
                             {
+                                fieldLabel: t("disable_text_edit_panel_tab"),
+                                xtype: "checkbox",
+                                name: "assets.disable_text_edit_panel_tab",
+                                checked: this.getValue("assets.disable_text_edit_panel_tab")
+                            },
+                            {
                                 fieldLabel: t("disable_tree_preview"),
                                 xtype: "checkbox",
                                 name: "assets.disable_tree_preview",


### PR DESCRIPTION
Problem:
We are working with large XML assets in the Pimcore backend. In some cases the XML Assets are few 100MB big. This of course totally breaks Pimcore GUI and Browser as it is trying to load the whole data into a textarea in the editor. Additionally it will exhaust the PHP memory very quickly and further increasing memory doesn't seem like a good solution just for this case, as opening the XML asset will still take too long because the data is read from the disk. 

Solution:
Checkbox in the Assets section of System Settings to turn of the editor for Text Assets. 

I will of course provide a separate Pull Request for Pimcore 5 if needed.