### PR TITLE
[BugFix] Don't create translations for empty strings

### DIFF
--- a/pimcore/lib/Pimcore/Translate.php
+++ b/pimcore/lib/Pimcore/Translate.php
@@ -234,7 +234,7 @@ class Translate extends \Zend_Translate_Adapter
         $messageId = trim($messageId);
 
         // don't create translation if it's just empty
-        if (array_key_exists($messageId, $this->_translate[$locale])) {
+        if (empty($messageId) || array_key_exists($messageId, $this->_translate[$locale])) {
             return;
         }
 


### PR DESCRIPTION
Trimmed $messageId's that return empty string translations appear to be saved.

