### PR TITLE
Skip locked jobs at execution time

### DIFF
--- a/pimcore/models/Schedule/Manager/Procedural.php
+++ b/pimcore/models/Schedule/Manager/Procedural.php
@@ -97,6 +97,11 @@ class Procedural
         $this->setLastExecution();
 
         foreach ($this->jobs as $job) {
+            if ($job->isLocked() && !$this->getForce()) {
+                Logger::info("Skipped job with ID: " . $job->getId() . " because it already being executed.");
+                continue;
+            }
+
             $job->lock();
             Logger::info("Executing job with ID: " . $job->getId());
             try {


### PR DESCRIPTION
## Changes in this pull request  
Skip maintenance jobs that have a lock at execution time, unless we are running in a forced mode.

## Additional info  
In cluster environment, where the database and the `var` folder are shared across instances, running the jobs in parallel on several machines might lead to several issues. 
The current lock process check the state of jobs at initialization time, but assumes this state won't change before actually start processing the job. We should check whether the job is currently locked or not just before executing it.