### PR TITLE
[NAVIGATION][TEMPLATING] Refactor navigation to be independent from navigation helper

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/01_Upgrade_from_4_to_5/04_Migrate_to_Symfony_Stack.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/01_Upgrade_from_4_to_5/04_Migrate_to_Symfony_Stack.md
@@ -102,10 +102,11 @@ This will result in data loss!
      as attributes in sub request then. 
 
   - Navigation Changes
-     - Replace `$this->pimcoreNavigation` with `$this->navigation`. 
+     - Replace `$this->pimcoreNavigation` with `$this->navigation`.
+     - The navigation helper is now handles building and rendering a navigation without an own internal state. Please see
+       the [navigation documentation](../../../03_Documents/03_Navigation.md) for details.
      - In your navigation partial scripts, use `$this->pages` instead of `$this->container` (reserved for DI-container)
      - Replace `Pimcore\Navigation\Page\Uri` with `Pimcore\Navigation\Page\Document`. 
-     - Every thing else should remain the same. 
 
    - Replace all `$this->url()` with `$this->pimcoreUrl()`, parameters and behaviour stay the same. 
    You also could use Symfony standard helpers `$this->path()` and `$this->url()`, but there you also 

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5.md
@@ -1,5 +1,23 @@
 # Upgrade Notes for Upgrades within Pimcore 5
 
+## Build 60 (2017-05-31)
+
+The navigation view helper signature has changed and now uses a different syntax to render navigations. In short,
+building the navigation container and rendering the navigation is now split up into 2 distinct calls and needs to be adapted
+in templates:
+
+```php
+<?php
+// previously
+echo $this->navigation($this->document, $navStartNode)->menu()->renderMenu(null, ['maxDepth' => 1]);
+
+// now
+$nav = $this->navigation()->buildNavigation($this->document, $navStartNode);
+echo $this->navigation()->menu()->renderMenu($nav, ['maxDepth' => 1]);
+```
+
+See the [navigation documentation](./../../03_Documents/03_Navigation.md) for details.
+
 ## Build 54 (2017-05-16)
 
 Added new nested naming scheme for document editables, which allows reliable copy/paste in nested block elements. Pimcore

--- a/install-profiles/demo-cms/app/Resources/views/layout.html.php
+++ b/install-profiles/demo-cms/app/Resources/views/layout.html.php
@@ -104,8 +104,9 @@ use Pimcore\Model\Document\Page;
                 </div>
                 <div class="navbar-collapse collapse">
                     <?php
-                    $mainNavigation = $this->navigation($document, $mainNavStartNode);
-                    echo $mainNavigation->menu()->renderMenu(null, [
+                    $mainNavigation = $this->navigation()->buildNavigation($document, $mainNavStartNode);
+
+                    echo $this->navigation()->render($mainNavigation, 'menu', 'renderMenu', [
                         'maxDepth' => 1,
                         'ulClass'  => 'nav navbar-nav'
                     ]);
@@ -142,7 +143,14 @@ use Pimcore\Model\Document\Page;
             <?php if ($showBreadcrumbs): ?>
                 <div>
                     <a href="/"><?= $this->translate('Home'); ?></a> &gt;
-                    <?= $mainNavigation->breadcrumbs()->setMinDepth(null); ?>
+
+                    <?php
+                    /** @var \Pimcore\Navigation\Renderer\Breadcrumbs $breadcrumbsRenderer */
+                    $breadcrumbsRenderer = $this->navigation()->getRenderer('breadcrumbs');
+                    $breadcrumbsRenderer->setMinDepth(null);
+
+                    echo $breadcrumbsRenderer->render($mainNavigation);
+                    ?>
                 </div>
             <?php endif; ?>
         </div>
@@ -151,17 +159,19 @@ use Pimcore\Model\Document\Page;
             <div class="col-md-3 col-md-pull-9 sidebar">
                 <div class="bs-sidebar hidden-print affix-top" role="complementary">
                     <?php
-                    $startNode = $document->getProperty('leftNavStartNode');
-                    if (!$startNode) {
-                        $startNode = $mainNavStartNode;
+                    $leftNavStartNode = $document->getProperty('leftNavStartNode');
+                    if (!$leftNavStartNode) {
+                        $leftNavStartNode = $mainNavStartNode;
                     }
+
+                    $leftNav = $this->navigation()->buildNavigation($document, $leftNavStartNode);
                     ?>
 
-                    <h3><?= $startNode->getProperty('navigation_name'); ?></h3>
-                    <?= $this->navigation($document, $startNode)->menu()->renderMenu(null, [
+                    <h3><?= $leftNavStartNode->getProperty('navigation_name'); ?></h3>
+                    <?= $this->navigation()->render($leftNav, 'menu', 'renderMenu', [
                         'ulClass'                          => 'nav bs-sidenav',
                         'expandSiblingNodesOfActiveBranch' => true
-                    ]); ?>
+                    ]) ?>
                 </div>
                 <?= $this->inc($document->getProperty('sidebar')); ?>
             </div>

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Compiler/NavigationRendererPass.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Compiler/NavigationRendererPass.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Adds tagged navigation renderers to navigation helper
+ */
+class NavigationRendererPass implements CompilerPassInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $taggedServices = $container->findTaggedServiceIds('pimcore.navigation.renderer');
+
+        $map = [];
+        foreach ($taggedServices as $id => $tags) {
+            foreach ($tags as $tag) {
+                $alias = null;
+                if (isset($tag['alias']) && !empty($tag['alias'])) {
+                    $alias = (string)$tag['alias'];
+                }
+
+                if (!$alias) {
+                    throw new InvalidConfigurationException(sprintf(
+                        'Missing "alias" attribute on navigtion renderer tag for service "%s"',
+                        $id
+                    ));
+                }
+
+                $map[$alias] = $id;
+            }
+        }
+
+        if (count($map) === 0) {
+            return;
+        }
+
+        $helperDefinition = $container->findDefinition('pimcore.templating.view_helper.navigation');
+        $helperDefinition->setArgument('$rendererMap', $map);
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/PimcoreCoreBundle.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/PimcoreCoreBundle.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\CoreBundle;
 
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\AreabrickPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\CacheCollectorPass;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\NavigationRendererPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\PhpTemplatingPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\PimcoreContextResolverAwarePass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\PimcoreGlobalTemplatingVariablesPass;
@@ -57,6 +58,7 @@ class PimcoreCoreBundle extends Bundle
         $container->addCompilerPass(new PimcoreContextResolverAwarePass());
         $container->addCompilerPass(new PhpTemplatingPass());
         $container->addCompilerPass(new AreabrickPass());
+        $container->addCompilerPass(new NavigationRendererPass());
         $container->addCompilerPass(new CacheCollectorPass());
         $container->addCompilerPass(new PimcoreGlobalTemplatingVariablesPass());
         $container->addCompilerPass(new TemplateVarsProviderPass());

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating.yml
@@ -14,3 +14,27 @@ services:
             - '@pimcore.service.request.editmode_resolver'
         calls:
             - [setLogger, ['@logger']]
+
+
+    # NAVIGATION
+
+    pimcore.navigation.builder:
+        class: Pimcore\Navigation\Builder
+        arguments: ['@pimcore.http.request_helper']
+        public: false
+
+    pimcore.navigation.base_renderer:
+        abstract: true
+        arguments: ['@templating.engine.delegating']
+
+    pimcore.navigation.renderer.menu:
+        class: Pimcore\Navigation\Renderer\Menu
+        parent: pimcore.navigation.base_renderer
+        tags:
+            - { name: pimcore.navigation.renderer, alias: menu }
+
+    pimcore.navigation.renderer.breadcrumbs:
+        class: Pimcore\Navigation\Renderer\Breadcrumbs
+        parent: pimcore.navigation.base_renderer
+        tags:
+            - { name: pimcore.navigation.renderer, alias: breadcrumbs }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating_php.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating_php.yml
@@ -149,6 +149,8 @@ services:
 
     pimcore.templating.view_helper.navigation:
       class: Pimcore\Templating\Helper\Navigation
+      arguments: ['@service_container', '@pimcore.navigation.builder', '@?']
+      lazy: true
       tags:
           - { name: templating.helper, alias: navigation }
 

--- a/pimcore/lib/Pimcore/Navigation/Renderer/AbstractRenderer.php
+++ b/pimcore/lib/Pimcore/Navigation/Renderer/AbstractRenderer.php
@@ -35,18 +35,18 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Pimcore\Templating\Helper\Navigation\Renderer;
+namespace Pimcore\Navigation\Renderer;
 
 use Pimcore\Navigation\Container;
 use Pimcore\Navigation\Page;
-use Pimcore\Templating\Helper\Navigation;
+use Symfony\Component\Templating\EngineInterface;
 
-abstract class AbstractHelper implements HelperInterface
+abstract class AbstractRenderer implements RendererInterface
 {
     /**
-     * @var Navigation
+     * @var EngineInterface
      */
-    protected $helper = null;
+    protected $templatingEngine;
 
     /**
      * The minimum depth a page must have to be included when rendering
@@ -90,37 +90,15 @@ abstract class AbstractHelper implements HelperInterface
      */
     protected $_renderInvisible = false;
 
+    /**
+     * @param EngineInterface $templatingEngine
+     */
+    public function __construct(EngineInterface $templatingEngine)
+    {
+        $this->templatingEngine = $templatingEngine;
+    }
+
     // Accessors:
-
-    /**
-     * @return Container  navigation container
-     */
-    public function getContainer()
-    {
-        $container = $this->getHelper()->getContainer();
-
-        if (null === $container) {
-            $container = new Container();
-        }
-
-        return $container;
-    }
-
-    /**
-     * @return Navigation
-     */
-    public function getHelper()
-    {
-        return $this->helper;
-    }
-
-    /**
-     * @param Navigation $helper
-     */
-    public function setHelper($helper)
-    {
-        $this->helper = $helper;
-    }
 
     /**
      * Sets the minimum depth a page must have to be included when rendering
@@ -258,50 +236,11 @@ abstract class AbstractHelper implements HelperInterface
      *
      * @return $this
      */
-    public function setRenderInvisible($renderInvisible = true)
+    public function setRenderInvisible(bool $renderInvisible = true)
     {
         $this->_renderInvisible = (bool) $renderInvisible;
 
         return $this;
-    }
-
-    // Magic overloads:
-
-    /**
-     * Magic overload: Proxy calls to the navigation container
-     *
-     * @param  string $method             method name in container
-     * @param  array  $arguments          [optional] arguments to pass
-     *
-     * @return mixed                      returns what the container returns
-     *
-     * @throws \Exception  if method does not exist in container
-     */
-    public function __call($method, array $arguments = [])
-    {
-        return call_user_func_array(
-                [$this->getContainer(), $method],
-                $arguments);
-    }
-
-    /**
-     * Magic overload: Proxy to {@link render()}.
-     *
-     * This method will trigger an E_USER_ERROR if rendering the helper causes
-     * an exception to be thrown.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        try {
-            return $this->render();
-        } catch (\Exception $e) {
-            $msg = get_class($e) . ': ' . $e->getMessage();
-            trigger_error($msg, E_USER_ERROR);
-
-            return '';
-        }
     }
 
     // Public methods:
@@ -361,14 +300,6 @@ abstract class AbstractHelper implements HelperInterface
         } else {
             return [];
         }
-    }
-
-    /**
-     * @return bool  whether the helper has a container or not
-     */
-    public function hasContainer()
-    {
-        return null !== $this->_container;
     }
 
     /**
@@ -533,13 +464,5 @@ abstract class AbstractHelper implements HelperInterface
         }
 
         return $value;
-    }
-
-    /**
-     * @return \Pimcore\Templating\PhpEngine
-     */
-    protected function getTemplatingEngine()
-    {
-        return $this->getHelper()->getTemplatingEngine();
     }
 }

--- a/pimcore/lib/Pimcore/Navigation/Renderer/Breadcrumbs.php
+++ b/pimcore/lib/Pimcore/Navigation/Renderer/Breadcrumbs.php
@@ -35,12 +35,12 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Pimcore\Templating\Helper\Navigation\Renderer;
+namespace Pimcore\Navigation\Renderer;
 
 use Pimcore\Navigation\Container;
 use Pimcore\Navigation\Page;
 
-class Breadcrumbs extends AbstractHelper
+class Breadcrumbs extends AbstractRenderer
 {
     /**
      * Breadcrumbs separator string
@@ -69,20 +69,6 @@ class Breadcrumbs extends AbstractHelper
      * @var string|array
      */
     protected $_template;
-
-    /**
-     * @param Container|null $container
-     *
-     * @return $this
-     */
-    public function breadcrumbs(Container $container = null)
-    {
-        if (null !== $container) {
-            $this->setContainer($container);
-        }
-
-        return $this;
-    }
 
     // Accessors:
 
@@ -182,17 +168,14 @@ class Breadcrumbs extends AbstractHelper
      *
      * @return string
      */
-    public function renderStraight(Container $container = null)
+    public function renderStraight(Container $container)
     {
-        if (null === $container) {
-            $container = $this->getContainer();
-        }
-
         // find deepest active
         if (!$active = $this->findActive($container)) {
             return '';
         }
 
+        /** @var Page $active */
         $active = $active['page'];
 
         // put the deepest active page last in breadcrumbs
@@ -224,19 +207,15 @@ class Breadcrumbs extends AbstractHelper
     }
 
     /**
-     * @param Container|null $container
-     * @param string $partial
+     * @param Container $container
+     * @param string|null $partial
      *
      * @return mixed
      *
      * @throws \Exception
      */
-    public function renderTemplate(Container $container = null, $partial = null)
+    public function renderTemplate(Container $container, string $partial = null)
     {
-        if (null === $container) {
-            $container = $this->getContainer();
-        }
-
         if (null === $partial) {
             $partial = $this->getTemplate();
         }
@@ -248,8 +227,10 @@ class Breadcrumbs extends AbstractHelper
         // put breadcrumb pages in model
         $model = ['pages' => []];
         if ($active = $this->findActive($container)) {
+            /** @var Page $active */
             $active = $active['page'];
             $model['pages'][] = $active;
+
             while ($parent = $active->getParent()) {
                 if ($parent instanceof Page) {
                     $model['pages'][] = $parent;
@@ -267,28 +248,28 @@ class Breadcrumbs extends AbstractHelper
             $model['pages'] = array_reverse($model['pages']);
         }
 
-        return $this->getTemplatingEngine()->render($partial, $model);
+        return $this->templatingEngine->render($partial, $model);
     }
 
     /**
      * Alias of renderTemplate() for ZF1 backward compatibility
      *
      * @param Container|null $container
-     * @param null $partial
+     * @param string|null $partial
      *
      * @return mixed
      */
-    public function renderPartial(Container $container = null, $partial = null)
+    public function renderPartial(Container $container, string $partial = null)
     {
         return $this->renderTemplate($container, $partial);
     }
 
     /**
-     * @param Container|null $container
+     * @param Container $container
      *
      * @return string
      */
-    public function render(Container $container = null)
+    public function render(Container $container)
     {
         if ($partial = $this->getTemplate()) {
             return $this->renderPartial($container, $partial);

--- a/pimcore/lib/Pimcore/Navigation/Renderer/Menu.php
+++ b/pimcore/lib/Pimcore/Navigation/Renderer/Menu.php
@@ -35,12 +35,12 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Pimcore\Templating\Helper\Navigation\Renderer;
+namespace Pimcore\Navigation\Renderer;
 
 use Pimcore\Navigation\Container;
 use Pimcore\Navigation\Page;
 
-class Menu extends AbstractHelper
+class Menu extends AbstractRenderer
 {
     /**
      * CSS class to use for the ul element
@@ -118,25 +118,6 @@ class Menu extends AbstractHelper
      * @var string
      */
     protected $_innerIndent = '    ';
-
-    /**
-     * View helper entry point:
-     * Retrieves helper and optionally sets container to operate on
-     *
-     * @param  Container $container  [optional] container to
-     *                                               operate on
-     *
-     * @return self      fluent interface,
-     *                                               returns self
-     */
-    public function menu(Container $container = null)
-    {
-        if (null !== $container) {
-            $this->setContainer($container);
-        }
-
-        return $this;
-    }
 
     // Accessors:
 
@@ -446,7 +427,7 @@ class Menu extends AbstractHelper
      * @param  string|int $indent                          indentation string or
      *                                                     number of spaces
      *
-     * @return AbstractHelper  fluent interface,
+     * @return AbstractRenderer  fluent interface,
      *                                                     returns self
      */
     public function setInnerIndent($indent)
@@ -682,6 +663,7 @@ class Menu extends AbstractHelper
         // Reset prefix for IDs
         $this->_skipPrefixForId = $skipValue;
 
+        /** @var Page $subPage */
         foreach ($active['page'] as $subPage) {
             if (!$this->accept($subPage)) {
                 continue;
@@ -734,19 +716,21 @@ class Menu extends AbstractHelper
      *
      * @return string                                       rendered menu (HTML)
      */
-    protected function _renderMenu(Container $container,
-                                   $ulClass,
-                                   $indent,
-                                   $innerIndent,
-                                   $minDepth,
-                                   $maxDepth,
-                                   $onlyActive,
-                                   $expandSibs,
-                                   $ulId,
-                                   $addPageClassToLi,
-                                   $activeClass,
-                                   $parentClass,
-                                   $renderParentClass)
+    protected function _renderMenu(
+        Container $container,
+        $ulClass,
+        $indent,
+        $innerIndent,
+        $minDepth,
+        $maxDepth,
+        $onlyActive,
+        $expandSibs,
+        $ulId,
+        $addPageClassToLi,
+        $activeClass,
+        $parentClass,
+        $renderParentClass
+    )
     {
         $html = '';
 
@@ -903,24 +887,13 @@ class Menu extends AbstractHelper
      *
      * Available $options:
      *
+     * @param  Container $container
+     * @param  array $options    [optional] options for controlling rendering
      *
-     * @param  Container $container  [optional] container to
-     *                                               create menu from. Default
-     *                                               is to use the container
-     *                                               retrieved from
-     *                                               {@link getContainer()}.
-     * @param  array                     $options    [optional] options for
-     *                                               controlling rendering
-     *
-     * @return string                                rendered menu
+     * @return string rendered menu
      */
-    public function renderMenu(Container $container = null,
-                               array $options = [])
+    public function renderMenu(Container $container, array $options = [])
     {
-        if (null === $container) {
-            $container = $this->getContainer();
-        }
-
         $options = $this->_normalizeOptions($options);
 
         if ($options['onlyActiveBranch'] && !$options['renderParents']) {
@@ -973,10 +946,7 @@ class Menu extends AbstractHelper
      * ));
      * </code>
      *
-     * @param  Container $container  [optional] container to
-     *                                               render. Default is to render
-     *                                               the container registered in
-     *                                               the helper.
+     * @param  Container $container
      * @param  string|null               $ulClass    [optional] CSS class to
      *                                               use for UL element. Default
      *                                               is to use the value from
@@ -998,12 +968,14 @@ class Menu extends AbstractHelper
      *
      * @return string                                   rendered content
      */
-    public function renderSubMenu(Container $container = null,
-                                  $ulClass = null,
-                                  $indent = null,
-                                  $ulId   = null,
-                                  $addPageClassToLi = false,
-                                  $innerIndent = null)
+    public function renderSubMenu(
+        Container $container,
+        $ulClass = null,
+        $indent = null,
+        $ulId   = null,
+        $addPageClassToLi = false,
+        $innerIndent = null
+    )
     {
         return $this->renderMenu($container, [
             'indent'           => $indent,
@@ -1025,10 +997,7 @@ class Menu extends AbstractHelper
      * as-is, and will be available in the partial script as 'container', e.g.
      * <code>echo 'Number of pages: ', count($this->container);</code>.
      *
-     * @param  Container $container  [optional] container to
-     *                                               pass to view script. Default
-     *                                               is to use the container
-     *                                               registered in the helper.
+     * @param  Container $container
      * @param  string|array             $partial     [optional] partial view
      *                                               script to use. Default is to
      *                                               use the partial registered
@@ -1043,12 +1012,8 @@ class Menu extends AbstractHelper
      *
      * @throws \Exception   When no partial script is set
      */
-    public function renderTemplate(Container $container = null, $partial = null)
+    public function renderTemplate(Container $container, $partial = null)
     {
-        if (null === $container) {
-            $container = $this->getContainer();
-        }
-
         if (null === $partial) {
             $partial = $this->getTemplate();
         }
@@ -1062,28 +1027,24 @@ class Menu extends AbstractHelper
             'pages' => $container, // we can't use `container` as index name, since this is used by the DI-container
         ];
 
-        return $this->getTemplatingEngine()->render($partial, $model);
+        return $this->templatingEngine->render($partial, $model);
     }
 
     /**
      * Alias of renderTemplate()
      *
-     * @param Container|null $container
+     * @param Container $container
      * @param null $partial
      *
      * @return string
      */
-    public function renderPartial(Container $container = null, $partial = null)
+    public function renderPartial(Container $container, $partial = null)
     {
         return $this->renderTemplate($container, $partial);
     }
 
-    // Zend_View_Helper_Navigation_Helper:
-
     /**
      * Renders menu
-     *
-     * Implements {@link Zend_View_Helper_Navigation_Helper::render()}.
      *
      * If a partial view is registered in the helper, the menu will be rendered
      * using the given partial script. If no partial is registered, the menu
@@ -1092,14 +1053,11 @@ class Menu extends AbstractHelper
      * @see renderTemplate()
      * @see renderMenu()
      *
-     * @param  Container $container  [optional] container to
-     *                                               render. Default is to
-     *                                               render the container
-     *                                               registered in the helper.
+     * @param  Container $container
      *
-     * @return string                                helper output
+     * @return string
      */
-    public function render(Container $container = null)
+    public function render(Container $container)
     {
         if ($partial = $this->getTemplate()) {
             return $this->renderTemplate($container, $partial);

--- a/pimcore/lib/Pimcore/Navigation/Renderer/RendererInterface.php
+++ b/pimcore/lib/Pimcore/Navigation/Renderer/RendererInterface.php
@@ -35,17 +35,12 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 
-namespace Pimcore\Templating\Helper\Navigation\Renderer;
+namespace Pimcore\Navigation\Renderer;
 
 use Pimcore\Navigation\Container;
 
-interface HelperInterface
+interface RendererInterface
 {
-    /**
-     * @return mixed
-     */
-    public function getContainer();
-
     /**
      * @return bool
      */
@@ -54,26 +49,16 @@ interface HelperInterface
     /**
      * @param  bool
      *
-     * @return AbstractHelper
+     * @return AbstractRenderer
      */
-    public function setRenderInvisible($renderInvisible = true);
+    public function setRenderInvisible(bool $renderInvisible = true);
 
     /**
-     * @return bool
-     */
-    public function hasContainer();
-
-    /**
-     * @return string
-     */
-    public function __toString();
-
-    /**
-     * @param  Container $container
+     * @param Container $container
      *
      * @return string
      *
      * @throws \Exception
      */
-    public function render(Container $container = null);
+    public function render(Container $container);
 }

--- a/pimcore/lib/Pimcore/Templating/Helper/Navigation.php
+++ b/pimcore/lib/Pimcore/Templating/Helper/Navigation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Pimcore
  *
@@ -14,42 +17,55 @@
 
 namespace Pimcore\Templating\Helper;
 
+use Pimcore\Model\Document;
 use Pimcore\Navigation\Builder;
 use Pimcore\Navigation\Container;
-use Pimcore\Templating\Helper\Navigation\Renderer\Breadcrumbs;
-use Pimcore\Templating\Helper\Navigation\Renderer\Menu;
-use Pimcore\Templating\Helper\Navigation\Renderer\Menu as MenuRenderer;
-use Pimcore\Templating\Helper\Traits\TemplatingEngineAwareHelperTrait;
-use Pimcore\Templating\PhpEngine;
+use Pimcore\Navigation\Renderer\Breadcrumbs;
+use Pimcore\Navigation\Renderer\Menu;
+use Pimcore\Navigation\Renderer\Menu as MenuRenderer;
+use Pimcore\Navigation\Renderer\RendererInterface;
+use Pimcore\Templating\Helper\Navigation\Exception\InvalidRendererException;
+use Pimcore\Templating\Helper\Navigation\Exception\RendererNotFoundException;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Templating\Helper\Helper;
 
 /**
  * @method MenuRenderer menu()
  * @method Breadcrumbs breadcrumbs()
  */
-class Navigation extends Helper implements TemplatingEngineAwareHelperInterface
+class Navigation extends Helper
 {
-    use TemplatingEngineAwareHelperTrait;
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
 
     /**
      * @var Builder
      */
-    protected $builder;
-
-    /**
-     * @var Container
-     */
-    protected $container;
-
-    /**
-     * @var string
-     */
-    protected $defaultRenderer = 'menu';
+    private $builder;
 
     /**
      * @var array
      */
-    protected $renderer = [];
+    private $rendererMap;
+
+    /**
+     * @var RendererInterface[]
+     */
+    private $renderers = [];
+
+    /**
+     * @param ContainerInterface $container
+     * @param Builder $builder
+     * @param array $rendererMap    Map with alias => id mapping for registered renderers
+     */
+    public function __construct(ContainerInterface $container, Builder $builder, array $rendererMap)
+    {
+        $this->container   = $container;
+        $this->builder     = $builder;
+        $this->rendererMap = $rendererMap;
+    }
 
     /**
      * @inheritDoc
@@ -60,107 +76,99 @@ class Navigation extends Helper implements TemplatingEngineAwareHelperInterface
     }
 
     /**
-     * @return Builder
-     */
-    protected function getBuilder()
-    {
-        if (!$this->builder) {
-            $this->builder = new Builder();
-        }
-
-        return $this->builder;
-    }
-
-    /**
-     * @param null $activeDocument
-     * @param null $navigationRootDocument
-     * @param null $htmlMenuIdPrefix
-     * @param null $pageCallback
-     * @param bool $cache
+     * Builds a navigation container
      *
-     * @return $this
-     */
-    public function __invoke($activeDocument = null, $navigationRootDocument = null, $htmlMenuIdPrefix = null, $pageCallback = null, $cache = true)
-    {
-        if ($activeDocument) {
-            // this is the new more convenient way of creating a navigation
-            $navContainer = $this->getBuilder()->getNavigation($activeDocument, $navigationRootDocument, $htmlMenuIdPrefix, $pageCallback, $cache);
-            $this->setContainer($navContainer);
-        }
-
-        return $this;
-    }
-
-    /**
-     * @param $name
+     * @param Document $activeDocument
+     * @param Document|null $navigationRootDocument
+     * @param string|null $htmlMenuPrefix
+     * @param callable|null $pageCallback
+     * @param bool|string $cache
      *
-     * @return mixed
-     */
-    public function getRenderer($name)
-    {
-        if (!isset($this->renderer[$name])) {
-            $renderClass = 'Pimcore\Templating\Helper\Navigation\Renderer\\' . ucfirst($name);
-            if (class_exists($renderClass)) {
-                $this->renderer[$name] = new $renderClass;
-                $this->renderer[$name]->setHelper($this);
-            } else {
-                $this->renderer[$name] = false;
-            }
-        }
-
-        return $this->renderer[$name];
-    }
-
-    /**
-     * @param Container|null $container
-     *
-     * @return mixed
-     */
-    public function render(Container $container = null)
-    {
-        $helper = $this->getRenderer($this->defaultRenderer);
-
-        return $helper->render($container);
-    }
-
-    /**
      * @return Container
      */
-    public function getContainer()
+    public function buildNavigation(
+        Document $activeDocument,
+        Document $navigationRootDocument = null,
+        string $htmlMenuPrefix = null,
+        callable $pageCallback = null,
+        $cache = true
+    ): Container
     {
-        return $this->container;
+        return $this->builder->getNavigation(
+            $activeDocument,
+            $navigationRootDocument,
+            $htmlMenuPrefix,
+            $pageCallback,
+            $cache
+        );
     }
 
     /**
-     * @param Container $container
-     */
-    public function setContainer($container)
-    {
-        $this->container = $container;
-    }
-
-    /**
-     * @return PhpEngine
-     */
-    public function getTemplatingEngine()
-    {
-        return $this->templatingEngine;
-    }
-
-    /**
-     * @param $method
-     * @param array $arguments
+     * Get a named renderer
      *
-     * @return mixed
+     * @param string $alias
+     *
+     * @return RendererInterface
      */
-    public function __call($method, array $arguments = [])
+    public function getRenderer(string $alias): RendererInterface
     {
-        // check if call should proxy to another helper
-        if ($helper = $this->getRenderer($method)) {
-            return call_user_func_array([$helper, $method], $arguments);
+        if (isset($this->renderers[$alias])) {
+            return $this->renderers[$alias];
         }
 
-        // default behaviour: proxy call to container
-        return call_user_func_array([$this->getContainer(), $method], $arguments);
+        if (isset($this->rendererMap[$alias])) {
+            $renderer = $this->container->get($this->rendererMap[$alias]);
+
+            if (!$renderer instanceof RendererInterface) {
+                throw InvalidRendererException::create($alias, $renderer);
+            }
+
+            $this->renderers[$alias] = $renderer;
+
+            return $renderer;
+        } else {
+            throw RendererNotFoundException::create($alias);
+        }
+    }
+
+    /**
+     * Renders a navigation with the given renderer
+     *
+     * @param Container $container
+     * @param string $rendererName
+     * @param string|null $renderMethod     Optional render method to use (e.g. menu -> renderMenu)
+     * @param array $rendererArguments      Option arguments to pass to the render method after the container
+     *
+     * @return string
+     */
+    public function render(
+        Container $container,
+        string $rendererName = 'menu',
+        string $renderMethod = 'render',
+        ...$rendererArguments
+    )
+    {
+        $renderer = $this->getRenderer($rendererName);
+
+        if (!method_exists($renderer, $renderMethod)) {
+            throw new \InvalidArgumentException(sprintf('Method "%s" does not exist on renderer "%s"', $renderMethod, $rendererName));
+        }
+
+        $args = array_merge([$container], array_values($rendererArguments));
+
+        return call_user_func_array([$renderer, $renderMethod], $args);
+    }
+
+    /**
+     * Magic overload is an alias to getRenderer()
+     *
+     * @param string $method
+     * @param array $arguments
+     *
+     * @return RendererInterface
+     */
+    public function __call($method, array $arguments = []): RendererInterface
+    {
+        return $this->getRenderer($method);
     }
 }

--- a/pimcore/lib/Pimcore/Templating/Helper/Navigation/Exception/InvalidRendererException.php
+++ b/pimcore/lib/Pimcore/Templating/Helper/Navigation/Exception/InvalidRendererException.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Templating\Helper\Navigation\Exception;
+
+use Pimcore\Navigation\Renderer\RendererInterface;
+
+class InvalidRendererException extends \LogicException
+{
+    /**
+     * @param string $id
+     * @param mixed $renderer
+     *
+     * @return self
+     */
+    public static function create(string $name, $renderer): self
+    {
+        $type = is_object($renderer) ? get_class($renderer) : gettype($renderer);
+
+        return new static(sprintf(
+            'Renderer for name "%s" was expected to implement interface "%s", "%s" given.',
+            $name,
+            RendererInterface::class,
+            $type
+        ));
+    }
+}

--- a/pimcore/lib/Pimcore/Templating/Helper/Navigation/Exception/RendererNotFoundException.php
+++ b/pimcore/lib/Pimcore/Templating/Helper/Navigation/Exception/RendererNotFoundException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Templating\Helper\Navigation\Exception;
+
+class RendererNotFoundException extends \InvalidArgumentException
+{
+    public static function create(string $name): self
+    {
+        return new static(sprintf('The navigation renderer "%s" was not found', $name));
+    }
+}

--- a/pimcore/lib/Pimcore/Templating/PhpEngine.php
+++ b/pimcore/lib/Pimcore/Templating/PhpEngine.php
@@ -89,7 +89,7 @@ use Symfony\Component\Templating\Storage\Storage;
  * @method HeadTitle headTitle($title = null, $setType = null)
  * @method string inc($include, array $params = [], $cacheEnabled = true, $editmode = null)
  * @method InlineScript inlineScript($mode = HeadScript::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
- * @method Navigation navigation($activeDocument = null, $navigationRootDocument = null, $htmlMenuIdPrefix = null, $pageCallback = null, $cache = true)
+ * @method Navigation navigation()
  * @method string pimcoreUrl(array $urlOptions = [], $name = null, $reset = false, $encode = true, $relative = false)
  * @method string translate($key, $parameters = [], $domain = null, $locale = null)
  *

--- a/pimcore/models/Object/ClassDefinition.php
+++ b/pimcore/models/Object/ClassDefinition.php
@@ -749,7 +749,7 @@ class ClassDefinition extends Model\AbstractModel
      */
     public function getFieldDefinitions($context = array())
     {
-        if ($context["suppressEnrichment"]) {
+        if (isset($context["suppressEnrichment"]) && $context["suppressEnrichment"]) {
             return $this->fieldDefinitions;
         }
 
@@ -814,7 +814,7 @@ class ClassDefinition extends Model\AbstractModel
     public function getFieldDefinition($key, $context = array())
     {
         if (array_key_exists($key, $this->fieldDefinitions)) {
-            if ($context["suppressEnrichment"]) {
+            if (isset($context["suppressEnrichment"]) && $context["suppressEnrichment"]) {
                 return $this->fieldDefinitions[$key];
             }
             $fieldDefinition = $this->doEnrichFieldDefinition($this->fieldDefinitions[$key], $context);

--- a/pimcore/models/Object/ClassDefinition/Data/Block.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Block.php
@@ -558,7 +558,7 @@ class Block extends Model\Object\ClassDefinition\Data
             $this->fieldDefinitionsCache = $definitions;
         }
 
-        if ($context["suppressEnrichment"]) {
+        if (isset($context["suppressEnrichment"]) && $context["suppressEnrichment"]) {
             return $this->fieldDefinitionsCache;
         }
 
@@ -582,7 +582,7 @@ class Block extends Model\Object\ClassDefinition\Data
     {
         $fds = $this->getFieldDefinitions();
         if (isset($fds[$name])) {
-            if ($context["suppressEnrichment"]) {
+            if (isset($context["suppressEnrichment"]) && $context["suppressEnrichment"]) {
                 return $fds[$name];
             }
             $fieldDefinition = $this->doEnrichFieldDefinition($fds[$name], $context);

--- a/pimcore/models/Object/ClassDefinition/Data/Localizedfields.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Localizedfields.php
@@ -723,7 +723,7 @@ class Localizedfields extends Model\Object\ClassDefinition\Data
         $fds = $this->getFieldDefinitions($context);
         if (isset($fds[$name])) {
             $fieldDefinition = $fds[$name];
-            if ($context["suppressEnrichment"]) {
+            if (isset($context["suppressEnrichment"]) && $context["suppressEnrichment"]) {
                 return $fieldDefinition;
             }
 
@@ -751,7 +751,7 @@ class Localizedfields extends Model\Object\ClassDefinition\Data
             $this->fieldDefinitionsCache = $definitions;
         }
 
-        if ($context["suppressEnrichment"]) {
+        if (isset($context["suppressEnrichment"]) && $context["suppressEnrichment"]) {
             return $this->fieldDefinitionsCache;
         }
 

--- a/pimcore/models/Object/Fieldcollection/Definition.php
+++ b/pimcore/models/Object/Fieldcollection/Definition.php
@@ -112,7 +112,7 @@ class Definition extends Model\AbstractModel
      */
     public function getFieldDefinitions($context = array())
     {
-        if ($context["suppressEnrichment"]) {
+        if (isset($context["suppressEnrichment"]) && $context["suppressEnrichment"]) {
             return $this->fieldDefinitions;
         }
 
@@ -160,7 +160,7 @@ class Definition extends Model\AbstractModel
     public function getFieldDefinition($key, $context = array())
     {
         if (array_key_exists($key, $this->fieldDefinitions)) {
-            if ($context["suppressEnrichment"]) {
+            if (isset($context["suppressEnrichment"]) && $context["suppressEnrichment"]) {
                 return $this->fieldDefinitions[$key];
             }
 

--- a/update-scripts/60/postupdate.php
+++ b/update-scripts/60/postupdate.php
@@ -1,0 +1,9 @@
+<?php
+
+$message = <<<EOF
+The navigation view helper signature changed with build 60 and now handles building and rendering the navigation
+in 2 distinct steps. If you use the navigation view helper, please update your views accordingly. Plase have a look
+at the <a href="https://www.pimcore.org/docs/5.0.0/Documents/Navigation.html">navigation docs</a> for details.
+EOF;
+
+echo sprintf('<p> %s</p>' . PHP_EOL, $message);


### PR DESCRIPTION
Renderers have no connection to the Helper anymore and require the navigation container as mandatory argument in all `render*` methods. They now hold an instance of the delegating rendering engine, effectively supporting any kind of template. Additional helpers can be added to the helper by tagging them with the `pimcore.navigation.renderer` DI tag.

The helper itself does not have any state anymore but just exposes methods to build and render navigations. This has 2 main advantages:

* Navigation state is predictable as every call requires the container. No nav containers will be cached on the helper level (helper is stateless)
* The navigation can be rendered from everywhere (Twig, PHP, ...) and the helper reused from other templating engines (as preparation for Twig support)

The navigation rendering in a template is now split up into 2 distinct steps:

1. Build the navigation
2. Render the navigation container through the renderer

Magic `__call()` and `__toString()` calls were removed as render methods need to access the container, however 2 calls exist which should cover most use cases:

```php
// menu() will call getRenderer('menu') and return the menu renderer
echo $this->navigation()->menu()->renderMenu($nav);

// shorthand call to $this->navigation()->getRenderer('menu')->renderMenu($nav, ['foo' => 'bar']);
echo $this->navigation()->render($nav, 'menu', 'renderMenu', ['foo', 'bar']);
```

Documentation was updated to reflect the changes in this PR.