### PR TITLE
[SESSION][ADMIN] Add support for a mockable admin session

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/config/services.yml
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/config/services.yml
@@ -27,7 +27,7 @@ services:
         arguments: ['@pimcore_admin.session.storage']
 
     pimcore_admin.session.handler:
-        class: Pimcore\Bundle\AdminBundle\Session\AdminSessionHandler
+        class: Pimcore\Bundle\AdminBundle\Session\Handler\AdminSessionHandler
         arguments: ['@pimcore_admin.session', '@pimcore_admin.session.storage', '@pimcore_admin.session.storage_factory']
         calls:
             - [setLogger, ['@logger']]

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Session/Handler/AbstractAdminSessionHandler.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Session/Handler/AbstractAdminSessionHandler.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\AdminBundle\Session\Handler;
+
+use Pimcore\Session\Attribute\LockableAttributeBagInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+abstract class AbstractAdminSessionHandler implements AdminSessionHandlerInterface
+{
+    /**
+     * @var SessionInterface
+     */
+    protected $session;
+
+    /**
+     * @inheritdoc
+     */
+    public function getSessionId()
+    {
+        return $this->useSession(function (SessionInterface $session) {
+            return $session->getId();
+        });
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function useSession(callable $callable)
+    {
+        $session = $this->loadSession();
+
+        $result = call_user_func_array($callable, [$session]);
+
+        $this->writeClose();
+
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function useSessionAttributeBag(callable $callable, $name = 'pimcore_admin')
+    {
+        $session      = $this->loadSession();
+        $attributeBag = $this->loadAttributeBag($name, $session);
+
+        $result = call_user_func_array($callable, [$attributeBag, $session]);
+
+        $this->writeClose();
+
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getReadOnlyAttributeBag(string $name = 'pimcore_admin'): AttributeBagInterface
+    {
+        $bag = $this->useSessionAttributeBag(function (AttributeBagInterface $bag) {
+            if ($bag instanceof LockableAttributeBagInterface) {
+                $bag->lock();
+            }
+
+            return $bag;
+        }, $name);
+
+        return $bag;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function invalidate(int $lifetime = null): bool
+    {
+        return $this->session->invalidate($lifetime);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function regenerateId(): bool
+    {
+        return $this->useSession(function (SessionInterface $session) {
+            return $session->migrate(true);
+        });
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function loadAttributeBag(string $name, SessionInterface $session = null): SessionBagInterface
+    {
+        if (null === $session) {
+            $session = $this->loadSession();
+        }
+
+        $attributeBag = $session->getBag($name);
+        if ($attributeBag instanceof LockableAttributeBagInterface) {
+            $attributeBag->unlock();
+        }
+
+        return $attributeBag;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function requestHasSessionId(Request $request, bool $checkRequestParams = false): bool
+    {
+        $sessionName = $this->getSessionName();
+
+        $properties = ['cookies'];
+
+        if ($checkRequestParams) {
+            $properties[] = 'request';
+            $properties[] = 'query';
+        }
+
+        foreach ($properties as $property) {
+            if ($request->$property->has($sessionName) && !empty($request->$property->get($sessionName))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSessionIdFromRequest(Request $request, bool $checkRequestParams = false): string
+    {
+        if (static::requestHasSessionId($request, $checkRequestParams)) {
+            $sessionName = static::getSessionName();
+
+            if ($sessionId = $request->cookies->get($sessionName)) {
+                return $sessionId;
+            }
+
+            if ($checkRequestParams) {
+                if ($sessionId = $request->request->get($sessionName)) {
+                    return $sessionId;
+                }
+
+                if ($sessionId = $request->query->get($sessionName)) {
+                    return $sessionId;
+                }
+            }
+        }
+
+        throw new \RuntimeException('Failed to get session ID from request');
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Session/Handler/AdminSessionHandlerInterface.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Session/Handler/AdminSessionHandlerInterface.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\AdminBundle\Session\Handler;
+
+use Pimcore\Session\Attribute\LockableAttributeBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+interface AdminSessionHandlerInterface
+{
+    /**
+     * @param string $name
+     *
+     * @return mixed|null
+     */
+    public function getOption(string $name);
+
+    /**
+     * @return string
+     */
+    public function getSessionName(): string;
+
+    /**
+     * Returns the session ID
+     *
+     * @see SessionInterface::getId()
+     *
+     * @return string
+     */
+    public function getSessionId();
+
+    /**
+     * Use the admin session and immediately close it after usage. The callable gets the session as its first argument.
+     *
+     * @param callable $callable
+     *
+     * @return mixed
+     */
+    public function useSession(callable $callable);
+
+    /**
+     * Use an attribute bag and close the session immediately after usage. The callable gets the attribute bag and the
+     * session as arguments.
+     *
+     * @param callable $callable
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function useSessionAttributeBag(callable $callable, $name = 'pimcore_admin');
+
+    /**
+     * Loads an attribute bag, optionally lock it if supported and close the session.
+     *
+     * @param string $name
+     *
+     * @return AttributeBagInterface
+     */
+    public function getReadOnlyAttributeBag(string $name = 'pimcore_admin'): AttributeBagInterface;
+
+    /**
+     * @param int|null $lifetime
+     *
+     * @return bool
+     */
+    public function invalidate(int $lifetime = null);
+
+    /**
+     * Regenerates the session ID
+     *
+     * @see SessionInterface::migrate()
+     *
+     * @return bool
+     */
+    public function regenerateId(): bool;
+
+    /**
+     * Loads the admin session and backs up a currently open foreign session. You MUST call writeClose() after usage
+     * to make sure the admin session is written and foreign sessions are restored.
+     *
+     * @return SessionInterface
+     */
+    public function loadSession(): SessionInterface;
+
+    /**
+     * Directly loads an attribute bag from the session. You MUST call writeClose() after usage
+     * to make sure the admin session is written and foreign sessions are restored.
+     *
+     * @param string $name
+     * @param SessionInterface|null $session
+     *
+     * @return AttributeBagInterface|LockableAttributeBag|SessionBagInterface
+     */
+    public function loadAttributeBag(string $name, SessionInterface $session = null): SessionBagInterface;
+
+    /**
+     * Saves the session if it is the last admin session which was opened and restore a foreign session if there is one
+     * available.
+     */
+    public function writeClose();
+
+    /**
+     * Check if the request has a cookie or a param matching the session name.
+     *
+     * @param Request $request
+     * @param bool $checkRequestParams
+     *
+     * @return bool
+     */
+    public function requestHasSessionId(Request $request, bool $checkRequestParams = false): bool;
+
+    /**
+     * Get session ID from request cookie/param
+     *
+     * @param Request $request
+     * @param bool $checkRequestParams
+     *
+     * @return string
+     */
+    public function getSessionIdFromRequest(Request $request, bool $checkRequestParams = false): string;
+}

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Session/Handler/SimpleAdminSessionHandler.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Session/Handler/SimpleAdminSessionHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\AdminBundle\Session\Handler;
+
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class SimpleAdminSessionHandler extends AbstractAdminSessionHandler
+{
+    public function __construct(SessionInterface $session)
+    {
+        $this->session = $session;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getOption(string $name)
+    {
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSessionName(): string
+    {
+        return $this->session->getName();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function loadSession(): SessionInterface
+    {
+        return $this->session;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function writeClose()
+    {
+        $this->session->save();
+    }
+}

--- a/pimcore/lib/Pimcore/Tool/Session.php
+++ b/pimcore/lib/Pimcore/Tool/Session.php
@@ -14,27 +14,29 @@
 
 namespace Pimcore\Tool;
 
-use Pimcore\Bundle\AdminBundle\Session\AdminSessionHandler;
+use Pimcore\Bundle\AdminBundle\Session\Handler\AdminSessionHandlerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 
 class Session
 {
     /**
-     * @var AdminSessionHandler
+     * @var AdminSessionHandlerInterface
      */
     private static $handler;
 
-    /**
-     * @return AdminSessionHandler
-     */
-    public static function getHandler()
+    public static function getHandler(): AdminSessionHandlerInterface
     {
         if (null === static::$handler) {
             static::$handler = \Pimcore::getContainer()->get('pimcore_admin.session.handler');
         }
 
         return static::$handler;
+    }
+
+    public static function setHandler(AdminSessionHandlerInterface $handler)
+    {
+        static::$handler = $handler;
     }
 
     /**


### PR DESCRIPTION
As preparation for #1525: in certain cases (e.g. the naming migration or testing) it's necessary to set the admin session to a dummy/in-memory session which does not open/close foreign session and which does not rely on a real session storage. This change defines a common interface an `AdminSessionHandler` needs to implement and allows to set a custom admin session handler on `Pimcore\Tool\Session` if needed.