### PR TITLE
[Pimcore4] Problems with IE company wide compatibly settings

### DIFF
--- a/pimcore/modules/admin/views/scripts/index/index6.php
+++ b/pimcore/modules/admin/views/scripts/index/index6.php
@@ -4,6 +4,7 @@
 
     <meta charset="utf-8">
     <meta name="robots" content="noindex, nofollow" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/pimcore/modules/admin/views/scripts/login/index.php
+++ b/pimcore/modules/admin/views/scripts/login/index.php
@@ -6,6 +6,7 @@
 
     <meta charset="UTF-8">
     <meta name="robots" content="noindex, follow" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     <link rel="icon" type="image/png" href="/pimcore/static6/img/favicon/favicon-32x32.png" />
 


### PR DESCRIPTION
## Fixes Issue #
When a customer has in there company has a compatibility rule (All websites) in IE, force the browser to take the latest render version. This to prevent that the admin of Pimcore be rendered with old IE render engine.

## Changes in this pull request  
Changes in the admin layout and the login page

