### PR TITLE
Exclude jobs from maintenance

### DIFF
--- a/pimcore/lib/Pimcore/Console/Command/MaintenanceCommand.php
+++ b/pimcore/lib/Pimcore/Console/Command/MaintenanceCommand.php
@@ -34,6 +34,11 @@ class MaintenanceCommand extends AbstractCommand
                 'call just a specific job(s), use "," (comma) to execute more than one job (valid options: scheduledtasks, cleanupcache, logmaintenance, sanitycheck, cleanuplogfiles, versioncleanup, versioncompress, redirectcleanup, cleanupbrokenviews, usagestatistics, downloadmaxminddb, tmpstorecleanup, imageoptimize and plugin classes if you want to call a plugin maintenance)'
             )
             ->addOption(
+                'excludedJobs', 'ej',
+                InputOption::VALUE_OPTIONAL,
+                'exclude specific job(s), use "," (comma) to exclude more than one job (valid options: '.$validOptions.')'
+            )
+            ->addOption(
                 'force', 'f',
                 InputOption::VALUE_NONE,
                 "run the jobs, regardless if they're locked or not"
@@ -50,10 +55,16 @@ class MaintenanceCommand extends AbstractCommand
         if ($input->getOption("job")) {
             $validJobs = explode(",", $input->getOption("job"));
         }
+        
+        $excludedJobs =[];
+        if ($input->getOption('excludedJobs')) {
+            $excludedJobs = explode(",", $input->getOption("job"));
+        }
 
         // create manager
         $manager = Schedule\Manager\Factory::getManager("maintenance.pid");
         $manager->setValidJobs($validJobs);
+        $manager->setExcludedJobs($excludedJobs);
         $manager->setForce((bool) $input->getOption("force"));
 
         // register scheduled tasks


### PR DESCRIPTION
Exclude jobs via -ej option from maintenance script (such as cleaning up the cache).