### PR TITLE
Fixes to Areabrick edit templates

### DIFF
--- a/pimcore/lib/Pimcore/Document/Tag/TagHandler.php
+++ b/pimcore/lib/Pimcore/Document/Tag/TagHandler.php
@@ -223,7 +223,7 @@ class TagHandler implements TagHandlerInterface, LoggerAwareInterface
         echo $brick->getHtmlTagOpen($info);
 
         if ($brick->hasEditTemplate() && $editmode) {
-            echo '<div class="pimcore_area_edit_button_' . $tag->getName() . ' pimcore_area_edit_button" data-name="' . $tag->getName() . '"></div>';
+            echo '<div class="pimcore_area_edit_button" data-name="' . $tag->getName() . '" data-real-name="' . $tag->getRealName() . '"></div>';
 
             // forces the editmode in view independent if there's an edit or not
             if (!array_key_exists('forceEditInView', $params) || !$params['forceEditInView']) {

--- a/pimcore/lib/Pimcore/Templating/HelperBroker/DocumentTag.php
+++ b/pimcore/lib/Pimcore/Templating/HelperBroker/DocumentTag.php
@@ -51,6 +51,12 @@ class DocumentTag implements HelperBrokerInterface
     {
         $document = $engine->getViewParameter('document');
 
+        // if editmode is set as parameter override the editmode resolver value
+        $editmode = $engine->getViewParameter('editmode');
+        if (null !== $editmode) {
+            $editmode = (bool)$editmode;
+        }
+
         if (null === $document) {
             throw new \RuntimeException(sprintf('Trying to render the tag "%s", but no document was found', $method));
         }
@@ -64,6 +70,6 @@ class DocumentTag implements HelperBrokerInterface
             $arguments[1] = [];
         }
 
-        return $this->tagRenderer->render($document, $method, $arguments[0], $arguments[1]);
+        return $this->tagRenderer->render($document, $method, $arguments[0], $arguments[1], $editmode);
     }
 }

--- a/pimcore/lib/Pimcore/Templating/Renderer/TagRenderer.php
+++ b/pimcore/lib/Pimcore/Templating/Renderer/TagRenderer.php
@@ -63,17 +63,18 @@ class TagRenderer implements LoggerAwareInterface
      * @param $type
      * @param $inputName
      * @param array $options
+     * @param bool|null $editmode
      *
      * @return Tag|null
-     *
-     * @see \Pimcore\View::tag
      */
-    public function getTag(PageSnippet $document, $type, $inputName, array $options = [])
+    public function getTag(PageSnippet $document, $type, $inputName, array $options = [], bool $editmode = null)
     {
         $type = strtolower($type);
         $name = Tag::buildTagName($type, $inputName, $document);
 
-        $editmode = $this->editmodeResolver->isEditmode();
+        if (null === $editmode) {
+            $editmode = $this->editmodeResolver->isEditmode();
+        }
 
         try {
             $tag = null;
@@ -116,12 +117,13 @@ class TagRenderer implements LoggerAwareInterface
      * @param $type
      * @param $inputName
      * @param array $options
+     * @param bool|null $editmode
      *
-     * @return Tag|string|null
+     * @return Tag|string
      */
-    public function render(PageSnippet $document, $type, $inputName, array $options = [])
+    public function render(PageSnippet $document, $type, $inputName, array $options = [], bool $editmode = null)
     {
-        $tag = $this->getTag($document, $type, $inputName, $options);
+        $tag = $this->getTag($document, $type, $inputName, $options, $editmode);
 
         if ($tag) {
             return $tag;


### PR DESCRIPTION
Follow up to #1598. Further normalizes/fixes areabrick edit template markup and fixes editmode not being handled properly in edit templates as the editmode parameter was not honored while rendering document tags.