### PR TITLE
Refinements to bundle/controller selection

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/MiscController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/MiscController.php
@@ -65,12 +65,8 @@ class MiscController extends AdminController
     {
         $provider = $this->get('pimcore.controller.config.controller_data_provider');
 
-        $bundle = $request->get('moduleName');
-        if (empty($bundle)) {
-            $bundle = 'AppBundle';
-        }
-
-        $controllers = $provider->getControllers($bundle);
+        $bundle      = $request->get('moduleName');
+        $controllers = $provider->getControllers($bundle, 'AppBundle');
 
         $result = array_map(function ($controller) {
             return [

--- a/pimcore/lib/Pimcore/Controller/Config/ControllerDataProvider.php
+++ b/pimcore/lib/Pimcore/Controller/Config/ControllerDataProvider.php
@@ -152,6 +152,8 @@ class ControllerDataProvider
             $classNames[]  = $className;
         }
 
+        sort($controllers);
+
         if (null === $bundle) {
             // if set, use default bundle to resolve controllers which are not defined as service
             if (null !== $defaultBundleName) {
@@ -163,7 +165,8 @@ class ControllerDataProvider
             }
         }
 
-        $bundleControllers = $this->findBundleControllers($bundle);
+        $bundleControllers     = $this->findBundleControllers($bundle);
+        $bundleControllerNames = [];
 
         /** @var \ReflectionClass $controllerReflector */
         foreach ($bundleControllers as $controllerName => $controllerReflector) {
@@ -172,8 +175,12 @@ class ControllerDataProvider
                 continue;
             }
 
-            $controllers[] = $controllerName;
+            $bundleControllerNames[] = $controllerName;
         }
+
+        sort($bundleControllerNames);
+
+        $controllers = array_merge($bundleControllerNames, $controllers);
 
         return $controllers;
     }

--- a/pimcore/lib/Pimcore/Controller/Config/ControllerDataProvider.php
+++ b/pimcore/lib/Pimcore/Controller/Config/ControllerDataProvider.php
@@ -114,13 +114,17 @@ class ControllerDataProvider
     }
 
     /**
-     * Returns all service controllers and all controllers matching the selected bundle
+     * Returns all service controllers and all controllers matching the selected bundle. The bundleName will be used
+     * to filter service and non-service controllers (thus, only service controllers defined in the selected bundle
+     * will be used. If no bundleName is passed, all service controllers will be returned and the defaultBundleName will
+     * be used to resolve controllers not defined as service.
      *
      * @param string|null $bundleName
+     * @param string|null $defaultBundleName
      *
      * @return array
      */
-    public function getControllers(string $bundleName = null): array
+    public function getControllers(string $bundleName = null, string $defaultBundleName = null): array
     {
         $controllers = [];
         $classNames  = [];
@@ -149,7 +153,14 @@ class ControllerDataProvider
         }
 
         if (null === $bundle) {
-            return $controllers;
+            // if set, use default bundle to resolve controllers which are not defined as service
+            if (null !== $defaultBundleName) {
+                $bundle = $this->getBundle($defaultBundleName);
+            }
+
+            if (null === $bundle) {
+                return $controllers;
+            }
         }
 
         $bundleControllers = $this->findBundleControllers($bundle);

--- a/web/pimcore/static6/js/pimcore/settings/staticroutes.js
+++ b/web/pimcore/static6/js/pimcore/settings/staticroutes.js
@@ -110,8 +110,25 @@ pimcore.settings.staticroutes = Class.create({
                 editor:new Ext.form.TextField({})},
             {header:t("reverse"), flex:100, sortable:true, dataIndex:'reverse',
                 editor:new Ext.form.TextField({})},
-            {header:t("bundle_optional"), flex:50, sortable:false, dataIndex:'module',
-                editor:new Ext.form.TextField({})},
+            {
+                header: t("bundle_optional"), flex: 50, sortable: false, dataIndex: 'module',
+                editor: new Ext.form.ComboBox({
+                    store: new Ext.data.JsonStore({
+                        autoDestroy: true,
+                        proxy: {
+                            type: 'ajax',
+                            url: "/admin/misc/get-available-modules",
+                            reader: {
+                                type: 'json',
+                                rootProperty: 'data'
+                            }
+                        },
+                        fields: ["name"]
+                    }),
+                    triggerAction: "all",
+                    displayField: 'name'
+                })
+            },
             {header:t("controller"), flex:50, sortable:false, dataIndex:'controller',
                 editor:new Ext.form.ComboBox({
                     store:new Ext.data.JsonStore({


### PR DESCRIPTION
* Add module AJAX select to static routes editor
* Changes to bundle selection logic in document/static route
  - If no bundle is selected, all controllers defined as service will be returned.
    Additionally, all controllers which are no service and which are defined in the
    defaultBundle (AppBundle) will be included. This allows us to leave
    the module select empty while still getting results which make sense
    in most cases.
 
  - If a bundle is selected both controllers which are services and normal
    controllers will be filtered to those which are defined in the bundle.