### PR TITLE
fix checkbox selector and add it to extjs context

### DIFF
--- a/web/pimcore/static6/js/pimcore/document/tags/checkbox.js
+++ b/web/pimcore/static6/js/pimcore/document/tags/checkbox.js
@@ -10,44 +10,56 @@
  * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
-
 pimcore.registerNS("pimcore.document.tags.checkbox");
 pimcore.document.tags.checkbox = Class.create(pimcore.document.tag, {
 
-
     initialize: function(id, name, options, data, inherited) {
+
         this.id = id;
         this.name = name;
+        this.htmlId = this.id + "_editable";
+        this.element = null;
+
         this.setupWrapper();
-        options = this.parseOptions(options);
+
+        var checked = false,
+            domElement = Ext.query("#" + escapeSelector(id)),
+            options = this.parseOptions(options);
 
         if (!data) {
             data = false;
         }
 
-        this.htmlId = id + "_editable";
-        var checked = "";
         if(data) {
-            checked = ' checked="checked"';
+            checked = true;
         }
 
-        $("#" + id).append('<input name="' + this.htmlId + '" type="checkbox" value="true" id="' + this.htmlId + '" ' + checked + ' />');
-
-        if(options["label"]) {
-            $("#" + id).append('<label for="' + this.htmlId + '">' + options["label"] + '</label>');
+        if(domElement.length === 0) {
+            return false;
         }
 
-        // onchange event
-        if (options.onchange) {
-            $("#" + this.htmlId).change(eval(options.onchange));
-        }
-        if (options.reload) {
-            $("#" + this.htmlId).change(this.reloadDocument);
-        }
+        this.element = new Ext.form.field.Checkbox({
+            boxLabel: options["label"] ? options["label"] : "",
+            name: this.htmlId,
+            id: this.htmlId,
+            checked: checked,
+            handler: function(sender, checked) {
+                if (options.reload) {
+                    this.reloadDocument();
+                }
+                if (options.onchange) {
+                    //this is pure evil.
+                    eval(options.onchange);
+                }
+            }.bind(this)
+        });
+
+        this.element.render(domElement);
+
     },
 
     getValue: function () {
-        return ($("#" + this.htmlId + ":checked").val() == "true") ? true : false;
+        return this.element.getValue();
     },
 
     getType: function () {

--- a/web/pimcore/static6/js/pimcore/functions.js
+++ b/web/pimcore/static6/js/pimcore/functions.js
@@ -1760,4 +1760,6 @@ function array_merge_recursive (arr1, arr2){
     return arr1;
 }
 
-
+function escapeSelector (str) {
+    return str.replace(/[!"#$%&'()*+,./:;<=>?@\[\\\]^`{|}~]/g, "\\$&");
+}


### PR DESCRIPTION
- Move checkbox tag element to extjs instead of a jquery context
- Add escaped selector function to get elements with dots in id attribute

## Some general information
If you're using a checkbox inside a areabrick, the id gets transformed with some dots and colons in it (thats because of the new naming strategy). jQuery and also extjs will trigger some errors and no checkbox element gets rendered. Because not document tag is using jQuery i decided to move the checkbox tag to a extjs element.

![bildschirmfoto 2017-06-20 um 19 02 47](https://user-images.githubusercontent.com/700119/27345762-15f3cb60-55eb-11e7-955c-a0290257c4d8.png)
