### PR TITLE
Event handler optimizations

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/EventListener/AdminExceptionListener.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/EventListener/AdminExceptionListener.php
@@ -18,19 +18,16 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\AdminBundle\EventListener;
 
 use Pimcore\Bundle\AdminBundle\HttpFoundation\JsonResponse;
-use Pimcore\Bundle\CoreBundle\EventListener\Traits\PimcoreContextAwareTrait;
+use Pimcore\Bundle\CoreBundle\EventListener\AbstractContextAwareListener;
 use Pimcore\Service\Request\PimcoreContextResolver;
-use Pimcore\Service\Request\PimcoreContextResolverAwareInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class AdminExceptionListener implements EventSubscriberInterface, PimcoreContextResolverAwareInterface
+class AdminExceptionListener extends AbstractContextAwareListener implements EventSubscriberInterface
 {
-    use PimcoreContextAwareTrait;
-
     /**
      * @inheritDoc
      */

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/EventListener/BruteforceProtectionListener.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/EventListener/BruteforceProtectionListener.php
@@ -17,7 +17,7 @@ namespace Pimcore\Bundle\AdminBundle\EventListener;
 use Pimcore\Bundle\AdminBundle\Controller\BruteforceProtectedControllerInterface;
 use Pimcore\Bundle\AdminBundle\Security\BruteforceProtectionHandler;
 use Pimcore\Bundle\AdminBundle\Security\Exception\BruteforceProtectionException;
-use Pimcore\Bundle\CoreBundle\EventListener\Traits\PimcoreContextAwareTrait;
+use Pimcore\Bundle\CoreBundle\EventListener\AbstractContextAwareListener;
 use Pimcore\Service\Request\PimcoreContextResolver;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,10 +25,8 @@ use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class BruteforceProtectionListener implements EventSubscriberInterface
+class BruteforceProtectionListener extends AbstractContextAwareListener implements EventSubscriberInterface
 {
-    use PimcoreContextAwareTrait;
-
     /**
      * @var BruteforceProtectionHandler
      */

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/EventListener/HttpCacheListener.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/EventListener/HttpCacheListener.php
@@ -14,7 +14,7 @@
 
 namespace Pimcore\Bundle\AdminBundle\EventListener;
 
-use Pimcore\Bundle\CoreBundle\EventListener\Traits\PimcoreContextAwareTrait;
+use Pimcore\Bundle\CoreBundle\EventListener\AbstractContextAwareListener;
 use Pimcore\Http\RequestHelper;
 use Pimcore\Http\ResponseHelper;
 use Pimcore\Service\Request\PimcoreContextResolver;
@@ -22,10 +22,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class HttpCacheListener implements EventSubscriberInterface
+class HttpCacheListener extends AbstractContextAwareListener implements EventSubscriberInterface
 {
-    use PimcoreContextAwareTrait;
-
     /**
      * @var RequestHelper
      */

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/EventListener/UsageStatisticsListener.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/EventListener/UsageStatisticsListener.php
@@ -15,7 +15,7 @@
 namespace Pimcore\Bundle\AdminBundle\EventListener;
 
 use Pimcore\Bundle\AdminBundle\Security\User\TokenStorageUserResolver;
-use Pimcore\Bundle\CoreBundle\EventListener\Traits\PimcoreContextAwareTrait;
+use Pimcore\Bundle\CoreBundle\EventListener\AbstractContextAwareListener;
 use Pimcore\Log\Simple;
 use Pimcore\Service\Request\PimcoreContextResolver;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -23,10 +23,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class UsageStatisticsListener implements EventSubscriberInterface
+class UsageStatisticsListener extends AbstractContextAwareListener implements EventSubscriberInterface
 {
-    use PimcoreContextAwareTrait;
-
     /**
      * @var TokenStorageUserResolver
      */

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/EventListener/UserPerspectiveListener.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/EventListener/UserPerspectiveListener.php
@@ -15,7 +15,7 @@
 namespace Pimcore\Bundle\AdminBundle\EventListener;
 
 use Pimcore\Bundle\AdminBundle\Security\User\TokenStorageUserResolver;
-use Pimcore\Bundle\CoreBundle\EventListener\Traits\PimcoreContextAwareTrait;
+use Pimcore\Bundle\CoreBundle\EventListener\AbstractContextAwareListener;
 use Pimcore\Config;
 use Pimcore\Model\User;
 use Pimcore\Service\Request\PimcoreContextResolver;
@@ -26,9 +26,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class UserPerspectiveListener implements EventSubscriberInterface, LoggerAwareInterface
+class UserPerspectiveListener extends AbstractContextAwareListener implements EventSubscriberInterface, LoggerAwareInterface
 {
-    use PimcoreContextAwareTrait;
     use LoggerAwareTrait;
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/config/event_listeners.yml
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/config/event_listeners.yml
@@ -6,8 +6,6 @@ services:
     pimcore_admin.event_listener.bruteforce_protection:
         class: Pimcore\Bundle\AdminBundle\EventListener\BruteforceProtectionListener
         arguments: ['@pimcore_admin.security.bruteforce_protection_handler']
-        calls:
-            - [setPimcoreContextResolver, ['@pimcore.service.request.pimcore_context_resolver']]
         tags:
             - { name: kernel.event_subscriber }
 
@@ -36,8 +34,6 @@ services:
     pimcore_admin.event_listener.http_cache:
         class: Pimcore\Bundle\AdminBundle\EventListener\HttpCacheListener
         arguments: ['@pimcore.http.request_helper', '@pimcore.http.response_helper']
-        calls:
-            - [setPimcoreContextResolver, ['@pimcore.service.request.pimcore_context_resolver']]
         tags:
             - { name: kernel.event_subscriber }
 
@@ -45,7 +41,6 @@ services:
         class: Pimcore\Bundle\AdminBundle\EventListener\UserPerspectiveListener
         arguments: ['@pimcore_admin.security.token_storage_user_resolver']
         calls:
-            - [setPimcoreContextResolver, ['@pimcore.service.request.pimcore_context_resolver']]
             - [setLogger, ['@logger']]
         tags:
             - { name: kernel.event_subscriber }
@@ -54,7 +49,5 @@ services:
     pimcore_admin.event_listener.usage_statistics:
         class: Pimcore\Bundle\AdminBundle\EventListener\UsageStatisticsListener
         arguments: ['@pimcore_admin.security.token_storage_user_resolver']
-        calls:
-            - [setPimcoreContextResolver, ['@pimcore.service.request.pimcore_context_resolver']]
         tags:
             - { name: kernel.event_subscriber }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/AbstractContextAwareListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/AbstractContextAwareListener.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Pimcore
  *
@@ -12,10 +15,12 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-namespace Pimcore\Bundle\CoreBundle\EventListener\Frontend;
+namespace Pimcore\Bundle\CoreBundle\EventListener;
 
-use Pimcore\Bundle\CoreBundle\EventListener\AbstractContextAwareListener;
+use Pimcore\Bundle\CoreBundle\EventListener\Traits\PimcoreContextAwareTrait;
+use Pimcore\Service\Request\PimcoreContextResolverAwareInterface;
 
-abstract class AbstractFrontendListener extends AbstractContextAwareListener
+abstract class AbstractContextAwareListener implements PimcoreContextResolverAwareInterface
 {
+    use PimcoreContextAwareTrait;
 }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/BlockStateListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/BlockStateListener.php
@@ -12,9 +12,10 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-namespace Pimcore\Bundle\CoreBundle\EventListener;
+namespace Pimcore\Bundle\CoreBundle\EventListener\Frontend;
 
 use Pimcore\Document\Tag\Block\BlockStateStack;
+use Pimcore\Service\Request\PimcoreContextResolver;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -25,7 +26,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 /**
  * Handles block state for sub requests (saves parent state and restores it after request completes)
  */
-class BlockStateListener implements EventSubscriberInterface, LoggerAwareInterface
+class BlockStateListener extends AbstractFrontendListener implements EventSubscriberInterface, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
@@ -58,7 +59,13 @@ class BlockStateListener implements EventSubscriberInterface, LoggerAwareInterfa
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
-        if ($event->getRequest()->get('disableBlockClearing')) {
+        $request = $event->getRequest();
+
+        if (!$this->matchesPimcoreContext($request, PimcoreContextResolver::CONTEXT_DEFAULT)) {
+            return;
+        }
+
+        if ($request->get('disableBlockClearing')) {
             return;
         }
 
@@ -77,7 +84,13 @@ class BlockStateListener implements EventSubscriberInterface, LoggerAwareInterfa
      */
     public function onKernelResponse(FilterResponseEvent $event)
     {
-        if ($event->getRequest()->get('disableBlockClearing')) {
+        $request = $event->getRequest();
+
+        if (!$this->matchesPimcoreContext($request, PimcoreContextResolver::CONTEXT_DEFAULT)) {
+            return;
+        }
+
+        if ($request->get('disableBlockClearing')) {
             return;
         }
 

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/ContentTemplateListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/ContentTemplateListener.php
@@ -12,8 +12,9 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-namespace Pimcore\Bundle\CoreBundle\EventListener;
+namespace Pimcore\Bundle\CoreBundle\EventListener\Frontend;
 
+use Pimcore\Service\Request\PimcoreContextResolver;
 use Pimcore\Service\Request\TemplateResolver;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -24,7 +25,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * If a contentTemplate attribute was set on the request (done by router when building a document route), extract the
  * value and set it on the Template annotation. This handles custom template files being configured on documents.
  */
-class ContentTemplateListener implements EventSubscriberInterface
+class ContentTemplateListener extends AbstractFrontendListener implements EventSubscriberInterface
 {
     /**
      * @var TemplateResolver
@@ -61,6 +62,11 @@ class ContentTemplateListener implements EventSubscriberInterface
     public function onKernelView(GetResponseForControllerResultEvent $event)
     {
         $request = $event->getRequest();
+
+        if (!$this->matchesPimcoreContext($request, PimcoreContextResolver::CONTEXT_DEFAULT)) {
+            return;
+        }
+
         $template = $request->attributes->get('_template');
 
         // no @Template present -> nothing to do

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
@@ -263,6 +263,10 @@ class FullPageCacheListener extends AbstractFrontendListener
             return false;
         }
 
+        if (!$this->matchesPimcoreContext($event->getRequest(), PimcoreContextResolver::CONTEXT_DEFAULT)) {
+            return false;
+        }
+
         $response = $event->getResponse();
 
         if (!$response) {

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/MaintenancePageListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/MaintenancePageListener.php
@@ -83,21 +83,23 @@ class MaintenancePageListener
         $maintenance = false;
         $file = \Pimcore\Tool\Admin::getMaintenanceModeFile();
 
-        if (is_file($file)) {
-            $conf = include($file);
-            if (isset($conf['sessionId'])) {
-                try {
-                    $requestSessionId = Session::getSessionIdFromRequest($event->getRequest());
-                } catch (\Exception $e) {
-                    $requestSessionId = null;
-                }
+        if (!is_file($file)) {
+            return;
+        }
 
-                if ($conf['sessionId'] != $requestSessionId) {
-                    $maintenance = true;
-                }
-            } else {
-                @unlink($file);
+        $conf = include($file);
+        if (isset($conf['sessionId'])) {
+            try {
+                $requestSessionId = Session::getSessionIdFromRequest($event->getRequest());
+            } catch (\Exception $e) {
+                $requestSessionId = null;
             }
+
+            if ($conf['sessionId'] != $requestSessionId) {
+                $maintenance = true;
+            }
+        } else {
+            @unlink($file);
         }
 
         // do not activate the maintenance for the server itself

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/ResponseExceptionListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/ResponseExceptionListener.php
@@ -14,13 +14,11 @@
 
 namespace Pimcore\Bundle\CoreBundle\EventListener;
 
-use Pimcore\Bundle\CoreBundle\EventListener\Traits\PimcoreContextAwareTrait;
 use Pimcore\Config;
 use Pimcore\Http\Exception\ResponseException;
 use Pimcore\Model\Document;
 use Pimcore\Model\Site;
 use Pimcore\Service\Request\PimcoreContextResolver;
-use Pimcore\Service\Request\PimcoreContextResolverAwareInterface;
 use Pimcore\Templating\Renderer\ActionRenderer;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,10 +26,8 @@ use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class ResponseExceptionListener implements EventSubscriberInterface, PimcoreContextResolverAwareInterface
+class ResponseExceptionListener extends AbstractContextAwareListener implements EventSubscriberInterface
 {
-    use PimcoreContextAwareTrait;
-
     /**
      * @var ActionRenderer
      */

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/event_listeners.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/event_listeners.yml
@@ -48,7 +48,6 @@ services:
             - '@pimcore.http.request_helper'
             - '@pimcore_admin.security.user_loader'
         calls:
-            - [setPimcoreContextResolver, ['@pimcore.service.request.pimcore_context_resolver']]
             - [setLogger, ['@logger']]
         tags:
             - { name: kernel.event_subscriber }
@@ -57,8 +56,6 @@ services:
     pimcore.event_listener.frontend.hardlink_canonical_listener:
         class: Pimcore\Bundle\CoreBundle\EventListener\Frontend\HardlinkCanonicalListener
         arguments: ['@pimcore.service.request.document_resolver']
-        calls:
-            - [setPimcoreContextResolver, ['@pimcore.service.request.pimcore_context_resolver']]
         tags:
             - { name: kernel.event_subscriber }
 
@@ -162,7 +159,6 @@ services:
             - '@pimcore_admin.security.user_loader'
             - '@pimcore.extension.bundle_manager'
         calls:
-            - [setPimcoreContextResolver, ['@pimcore.service.request.pimcore_context_resolver']]
             - [setLogger, ['@logger']]
         tags:
             - { name: kernel.event_subscriber }
@@ -174,8 +170,6 @@ services:
 
     pimcore.event_listener.frontend.google_analytics_code:
         class: Pimcore\Bundle\CoreBundle\EventListener\Frontend\GoogleAnalyticsCodeListener
-        calls:
-            - [setPimcoreContextResolver, ['@pimcore.service.request.pimcore_context_resolver']]
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: -110 }
 

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/event_listeners.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/event_listeners.yml
@@ -64,8 +64,8 @@ services:
     #
 
     # handles block state (current block, current index) for sub-requests
-    pimcore.event_listener.block_state:
-        class: Pimcore\Bundle\CoreBundle\EventListener\BlockStateListener
+    pimcore.event_listener.frontend.block_state:
+        class: Pimcore\Bundle\CoreBundle\EventListener\Frontend\BlockStateListener
         arguments: ['@pimcore.document.tag.block_state_stack']
         calls:
             - [setLogger, ['@logger']]
@@ -90,8 +90,8 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
-    pimcore.event_listener.content_template:
-        class: Pimcore\Bundle\CoreBundle\EventListener\ContentTemplateListener
+    pimcore.event_listener.frontend.content_template:
+        class: Pimcore\Bundle\CoreBundle\EventListener\Frontend\ContentTemplateListener
         arguments: ['@pimcore.service.request.template_resolver']
         tags:
             - { name: kernel.event_subscriber }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/config.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/config.yml
@@ -150,6 +150,9 @@ pimcore:
 
     # the routes below are used to determine the request context in PimcoreContextGuesser
     context:
+        profiler:
+            routes:
+                - { path: ^/_(_profiler|wdt) }
         admin:
             routes:
                 - { path: ^/admin }


### PR DESCRIPTION
* Add a `profiler` context to make sure context specific event handlers to not run on profiler requests
* Refine event handler definitions (user context resolver interface everywhere)
* Make sure BlockState, ContentTemplate and FullPageCache listeners run only in frontend context