### PR TITLE
CSS Styles of class layout component are ignored.

### DIFF
--- a/web/pimcore/static6/js/pimcore/object/helpers/edit.js
+++ b/web/pimcore/static6/js/pimcore/object/helpers/edit.js
@@ -178,7 +178,7 @@ pimcore.object.helpers.edit = {
                 }
             }
 
-            newConfig = Object.extend(newConfig, xTypeLayoutMapping[l.fieldtype]);
+            newConfig = Object.extend(xTypeLayoutMapping[l.fieldtype], newConfig);
             if (typeof newConfig.labelWidth != "undefined") {
                 newConfig = Ext.applyIf(newConfig, {
                     defaults: {


### PR DESCRIPTION
newConfig's properties have to overwrite xTypeLayoutMapping's properties to take in account the configuration of class layouts. (web/pimcore/static6/js/pimcore/object/helpers/edit.js)
  
## Fixes Issue #1635