### PR TITLE
[PIMCORE4] New feature: define di configs inside plugins.

### DIFF
--- a/docs/Development_Documentation/10_Extending_Pimcore/13_Plugin_Developers_Guide/01_Plugin_Anatomy.md
+++ b/docs/Development_Documentation/10_Extending_Pimcore/13_Plugin_Developers_Guide/01_Plugin_Anatomy.md
@@ -19,6 +19,8 @@ The folder structure of a plugin should look as follows:
 plugins
 └───ExtensionExample
     │
+    └───config (this is totally optional)
+    │   |   di.php
     ├───controllers
     │   │   IndexController.php
     │   │   ...
@@ -68,6 +70,7 @@ A plugin needs to be configured in the plugin.xml with the following parameters:
 * CSS file paths
 * Javascript paths for scripts which should be included in document editmode
 * CSS paths for stylesheets which should be included in document editmode
+* Dependency Injection config paths (optional, for more informations about DI look at here: [Dependency Injection](../03_Dependency_Injection.md))
 
 An example plugin.xml file looks like below:
 
@@ -104,6 +107,10 @@ An example plugin.xml file looks like below:
     <namespace>ExtensionExample</namespace>
     <namespace>Resource</namespace>
     </pluginNamespaces>
+    <!-- (optional) di config paths relative to plugin-directory -->
+    <pluginDependencyInjectionPaths>
+        <path>/ExtensionExample/config/di.php</path>
+    </pluginDependencyInjectionPaths>
     <!-- js files needed for Pimcore plugin (backend) with path relative to plugin-directory -->
     <pluginJsPaths>
         <path>/ExtensionExample/static/js/test.js</path>

--- a/pimcore/lib/Pimcore.php
+++ b/pimcore/lib/Pimcore.php
@@ -845,6 +845,10 @@ class Pimcore
 
             $builder->addDefinitions(PIMCORE_PATH . "/config/di.php");
 
+            foreach (ExtensionManager::getDiPaths() as $diPath) {
+                $builder->addDefinitions($diPath);
+            }
+
             $customFile = \Pimcore\Config::locateConfigFile("di.php");
             if (file_exists($customFile)) {
                 $builder->addDefinitions($customFile);

--- a/pimcore/lib/Pimcore/ExtensionManager.php
+++ b/pimcore/lib/Pimcore/ExtensionManager.php
@@ -129,6 +129,41 @@ class ExtensionManager
         }
     }
 
+    /**
+     * @return array
+     */
+    public static function getDiPaths()
+    {
+        $ret = [];
+        try {
+            $pluginConfigs = self::getPluginConfigs();
+            if (empty($pluginConfigs)) {
+                return $ret;
+            }
+            if (0 == count($pluginConfigs)) {
+                return $ret;
+            }
+            foreach ($pluginConfigs as $p) {
+                if (!self::isEnabled("plugin", $p["plugin"]["pluginName"])) {
+                    continue;
+                }
+
+                if (is_array($p['plugin']['pluginDependencyInjectionPaths']['path'])) {
+                    foreach ($p['plugin']['pluginDependencyInjectionPaths']['path'] as $path) {
+                        $ret[] = PIMCORE_PLUGINS_PATH . $path;
+                    }
+                } elseif ($p['plugin']['pluginDependencyInjectionPaths']['path'] != null) {
+                    $ret[] = PIMCORE_PLUGINS_PATH . $p['plugin']['pluginDependencyInjectionPaths']['path'];
+                }
+            }
+        } catch (\Exception $e) {
+            Logger::alert("there is a problem with the plugin configuration");
+            Logger::alert($e);
+        }
+        return $ret;
+    }
+
+
 
     /**
      * @return Array $pluginConfigs

--- a/pimcore/modules/extensionmanager/example-plugin/Example/plugin.xml
+++ b/pimcore/modules/extensionmanager/example-plugin/Example/plugin.xml
@@ -24,6 +24,11 @@
 				<path>/Example/lib</path>
 			</pluginIncludePaths>
 
+			<!-- di config paths relative to plugin-directory -->
+			<pluginDependencyInjectionPaths>
+				<path>/Example/config/di.php</path>
+			</pluginDependencyInjectionPaths>
+
 			<!-- namespaces to register with autoloader-->
 			<pluginNamespaces>
 				<namespace>Example</namespace>


### PR DESCRIPTION
From now you can define custom di configs inside plugins.

`Pimcore::initPluginsDi` runs before any `Plugin::init` because if you need there di container it must be completely built.

