### PR TITLE
[Admin] refactor TokenStorageUserResolver to get rid of Container dependency

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/config/services.yml
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/config/services.yml
@@ -109,7 +109,7 @@ services:
 
     pimcore_admin.security.token_storage_user_resolver:
         class: Pimcore\Bundle\AdminBundle\Security\User\TokenStorageUserResolver
-        arguments: ['@service_container']
+        arguments: ['@security.token_storage']
 
     pimcore_admin.security.user_loader:
         class: Pimcore\Bundle\AdminBundle\Security\User\UserLoader

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Security/User/TokenStorageUserResolver.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Security/User/TokenStorageUserResolver.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\AdminBundle\Security\User;
 use Pimcore\Bundle\AdminBundle\Security\User\User as UserProxy;
 use Pimcore\Model\User;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Resolves the current pimcore user from the token storage.
@@ -24,16 +25,16 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class TokenStorageUserResolver
 {
     /**
-     * @var ContainerInterface
+     * @var TokenStorageInterface
      */
-    protected $container;
+    protected $tokenStorage;
 
     /**
-     * @param ContainerInterface $container
+     * @param TokenStorageInterface $tokenStorage
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(TokenStorageInterface $tokenStorage)
     {
-        $this->container = $container;
+        $this->tokenStorage = $tokenStorage;
     }
 
     /**
@@ -44,6 +45,8 @@ class TokenStorageUserResolver
         if ($proxy = $this->getUserProxy()) {
             return $proxy->getUser();
         }
+
+        return null;
     }
 
     /**
@@ -55,11 +58,7 @@ class TokenStorageUserResolver
      */
     public function getUserProxy()
     {
-        if (!$this->container->has('security.token_storage')) {
-            throw new \LogicException('The SecurityBundle is not registered in your application.');
-        }
-
-        if (null === $token = $this->container->get('security.token_storage')->getToken()) {
+        if (null === $token = $this->tokenStorage->getToken()) {
             return null;
         }
 
@@ -71,5 +70,7 @@ class TokenStorageUserResolver
         if ($user instanceof UserProxy) {
             return $user;
         }
+
+        return null;
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Security/User/TokenStorageUserResolver.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Security/User/TokenStorageUserResolver.php
@@ -45,8 +45,6 @@ class TokenStorageUserResolver
         if ($proxy = $this->getUserProxy()) {
             return $proxy->getUser();
         }
-
-        return null;
     }
 
     /**
@@ -70,7 +68,5 @@ class TokenStorageUserResolver
         if ($user instanceof UserProxy) {
             return $user;
         }
-
-        return null;
     }
 }


### PR DESCRIPTION
Is it really necessary to have a Container dependency inside the TokenResolver? Shouldn't this (PR) be enough? I mean, if the security.token_storage service is missing (eg. SecurityBundle is missing as well), something is wrong anyway.