### PR TITLE
Homogenize the way we retrieve thumbnails in Image Tag

### DIFF
--- a/pimcore/models/Document/Tag/Image.php
+++ b/pimcore/models/Document/Tag/Image.php
@@ -225,7 +225,7 @@ class Image extends Model\Document\Tag
                 $thumbnail = $image->getThumbnail($thumbConfig, $deferred);
             } else {
                 // we're using the thumbnail class only to generate the HTML
-                $thumbnail = new Asset\Image\Thumbnail($image);
+                $thumbnail = $image->getThumbnail();
             }
 
             $attributes = array_merge($this->options, [


### PR DESCRIPTION
I experienced a weird behaviour with DI on Images and Thumbnails: when defining custom classes in my `di.php` file, the custom Thumbnail class was being used only when a specific thumbnail config was defined in the Tag.

It apparently lies on both image thumbnails not being retrieved the same way. Getting a thumbnail with `new Asset\Image\Thumbnail($image);` seems to ignore the defined overwrite rules (I am not so sure to understand why though).

### Questions/Remarks
- Why is the DI class not being called in this case?
- Deferred option: I let it to its default value, not so sure what would be the best option here