### PR TITLE
fix nearest document by path matches

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
@@ -117,7 +117,7 @@ class DocumentFallbackListener extends AbstractFrontendListener implements Event
         // this is only done on the master request as a sub-request's pathInfo is _fragment when
         // rendered via actions helper
         if ($event->isMasterRequest()) {
-            $document = $this->documentService->getNearestDocumentByPath($request);
+            $document = $this->documentService->getNearestDocumentByPath($request->getPathInfo());
             if ($document) {
                 $this->documentResolver->setDocument($request, $document);
             }

--- a/pimcore/lib/Pimcore/Routing/Dynamic/DocumentRouteHandler.php
+++ b/pimcore/lib/Pimcore/Routing/Dynamic/DocumentRouteHandler.php
@@ -145,9 +145,11 @@ class DocumentRouteHandler implements DynamicRouteHandlerInterface
 
         // check for a parent hardlink with childs
         if (!$document instanceof Document) {
-            $hardlinkedParentDocument = $this->documentService->getNearestDocumentByPath($context->getPath(), true);
-            if ($hardlinkedParentDocument instanceof Document\Hardlink) {
-                if ($hardLinkedDocument = Document\Hardlink\Service::getChildByPath($hardlinkedParentDocument, $context->getPath())) {
+            $parentDocument = $this->documentService->getNearestDocumentByPath($context->getPath(), true);
+            if ($parentDocument instanceof Document) {
+                $document = $parentDocument;
+            } else if ($parentDocument instanceof Document\Hardlink) {
+                if ($hardLinkedDocument = Document\Hardlink\Service::getChildByPath($parentDocument, $context->getPath())) {
                     $document = $hardLinkedDocument;
                 }
             }


### PR DESCRIPTION
some explanation:

1.) https://github.com/pimcore/pimcore/compare/master...solverat:fixNearestDocumentPath?expand=1#diff-1570666f8a7cd8c0e8886d72b4134db1R120

This is weird anyway but i just fixed the passing argument (not the whole request, just the path info)

2.) https://github.com/pimcore/pimcore/compare/master...solverat:fixNearestDocumentPath?expand=1#diff-dd59407f672dfbb4c15d1ec7801489abR148

To reproduce this little (but nasty)  error:

![bildschirmfoto 2017-07-03 um 21 09 52](https://user-images.githubusercontent.com/700119/27805277-156ac2e0-6034-11e7-9ad5-ec0ebdb7ab93.png)

- create a static route "news_detail" (/de/news/news-1)
- create a site (see screenshot)
- open url (/de/news/news-1)
- debug `getNearestDocumentByPath()`
- it returns the ID `1` -> the root page, which is wrong, the nearest page is `/de/` or even `/pimcore5.dev` 

Since this method only checks hardlink parents it will never get to the next closest document.

