### PR TITLE
Fix Pimcore::inDebugMode() returning false if debug mode is configured to IP

### DIFF
--- a/pimcore/config/bootstrap.php
+++ b/pimcore/config/bootstrap.php
@@ -12,10 +12,13 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-// set up constants and autoloading
-require_once  __DIR__ . '/bootstrap.php';
+error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);
 
-// load kernel
-$kernel = require_once  __DIR__ . '/kernel.php';
+require_once __DIR__ . '/constants.php';
+require_once __DIR__ . '/autoload.php';
 
-return $kernel;
+$phpLog = PIMCORE_LOG_DIRECTORY . '/php.log';
+if (is_writable(PIMCORE_LOG_DIRECTORY)) {
+    ini_set('error_log', $phpLog);
+    ini_set('log_errors', '1');
+}

--- a/pimcore/lib/Pimcore/Tool.php
+++ b/pimcore/lib/Pimcore/Tool.php
@@ -21,6 +21,14 @@ use Symfony\Component\HttpFoundation\Request;
 class Tool
 {
     /**
+     * Sets the current request to use when resolving request at early
+     * stages (before container is loaded)
+     *
+     * @var Request
+     */
+    private static $currentRequest;
+
+    /**
      * @var array
      */
     protected static $notFoundClassNames = [];
@@ -34,6 +42,16 @@ class Tool
      * @var null
      */
     protected static $isFrontend = null;
+
+    /**
+     * Sets the current request to operate on
+     *
+     * @param Request|null $request
+     */
+    public static function setCurrentRequest(Request $request = null)
+    {
+        self::$currentRequest = $request;
+    }
 
     /**
      * returns a valid cache key/tag string
@@ -305,6 +323,10 @@ class Tool
             // do an extra check for the container as we might be in a state where no container is set yet
             if (\Pimcore::hasContainer()) {
                 $request = \Pimcore::getContainer()->get('request_stack')->getMasterRequest();
+            } else {
+                if (null !== self::$currentRequest) {
+                    return self::$currentRequest;
+                }
             }
         }
 

--- a/web/app.php
+++ b/web/app.php
@@ -12,12 +12,23 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
+use Pimcore\Tool;
 use Symfony\Component\HttpFoundation\Request;
 
-/** @var \Pimcore\Kernel $kernel */
-$kernel = require_once __DIR__ . '/../pimcore/config/startup.php';
+require_once __DIR__ . '/../pimcore/config/bootstrap.php';
 
-$request  = Request::createFromGlobals();
+$request = Request::createFromGlobals();
+
+// set current request as property on tool as there's no
+// request stack available yet
+Tool::setCurrentRequest($request);
+
+/** @var \Pimcore\Kernel $kernel */
+$kernel = require_once __DIR__ . '/../pimcore/config/kernel.php';
+
+// reset current request - will be read from request stack from now on
+Tool::setCurrentRequest(null);
+
 $response = $kernel->handle($request);
 $response->send();
 


### PR DESCRIPTION
Tool::getClientIp() does not have access to a request at the time the kernel is built. Now the request is set as static property on Tool until the kernel is built. To make this possbile, initialization logic needs to be split up into bootstrapping (autoloader, constants) and building the kernel.