### PR TITLE
save tag: fix exception when tag does not yet exist

### DIFF
--- a/pimcore/models/Element/Tag/Dao.php
+++ b/pimcore/models/Element/Tag/Dao.php
@@ -54,7 +54,10 @@ class Dao extends Model\Dao\AbstractDao
         try {
             $dataAttributes = get_object_vars($this->model);
 
-            $originalIdPath = $this->db->fetchOne('SELECT idPath FROM tags WHERE id = ?', $this->model->getId());
+            $originalIdPath = null;
+            if ( $this->model->getId() ){
+                $originalIdPath = $this->db->fetchOne('SELECT idPath FROM tags WHERE id = ?', $this->model->getId());
+            }
 
             $data = [];
             foreach ($dataAttributes as $key => $value) {


### PR DESCRIPTION
## Fixes Issue #1705 

## Changes in this pull request  

When saving a tag, only attempt to get idPath of existing tag when tag has an ID (i.e. when the tag already exists). 

## Additional info  
To reproduce bug (before fix):
Try creating a new tag, either through "Tag Configuration" or via the Tags tab on an asset.


