### PR TITLE
[#1627] Adminer Integration: Styling Issues

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/External/AdminerController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/External/AdminerController.php
@@ -130,6 +130,7 @@ namespace Pimcore\Bundle\AdminBundle\Controller\Admin\External {
 
 namespace {
 
+    use Pimcore\Cache;
     use Pimcore\Tool\Session;
 
     if (!function_exists('adminer_object')) {
@@ -221,6 +222,24 @@ namespace {
                     $conf = \Pimcore\Config::getSystemConfig()->database->params;
                     // database name, will be escaped by Adminer
                     return $conf->dbname;
+                }
+
+                public function databases($flush = true)
+                {
+                    $cacheKey = 'pimcore_adminer_databases';
+
+                    if (!$return = Cache::load($cacheKey)) {
+                        $db = Pimcore\Db::get();
+                        $return = $db->fetchAll('SELECT SCHEMA_NAME FROM information_schema.SCHEMATA');
+
+                        foreach ($return as &$ret) {
+                            $ret = $ret['SCHEMA_NAME'];
+                        }
+
+                        Cache::save($return, $cacheKey);
+                    }
+
+                    return $return;
                 }
             }
 


### PR DESCRIPTION
Adminer behaves quite weird on first request. It loads all available database but flushes the output (https://github.com/vrana/adminer/blob/master/adminer/drivers/mysql.inc.php#L336 + https://github.com/vrana/adminer/blob/master/adminer/include/functions.inc.php#L1227). Not sure what the idea behind this is. This PR solves the issue and Adminer gets displayed properly. 