### PR TITLE
Fix getChecksum bug in if logic

### DIFF
--- a/pimcore/models/Asset.php
+++ b/pimcore/models/Asset.php
@@ -1287,7 +1287,7 @@ class Asset extends Element\AbstractElement
         if (is_file($file)) {
             if ($type == 'md5') {
                 return md5_file($file);
-            } elseif ($type = 'sha1') {
+            } elseif ($type == 'sha1') {
                 return sha1_file($file);
             } else {
                 throw new \Exception("hashing algorithm '" . $type . "' isn't supported");

--- a/pimcore/models/Asset/Image/Thumbnail.php
+++ b/pimcore/models/Asset/Image/Thumbnail.php
@@ -583,7 +583,7 @@ class Thumbnail
         if (is_file($file)) {
             if ($type == 'md5') {
                 return md5_file($file);
-            } elseif ($type = 'sha1') {
+            } elseif ($type == 'sha1') {
                 return sha1_file($file);
             } else {
                 throw new \Exception("hashing algorithm '" . $type . "' isn't supported");


### PR DESCRIPTION
# Bug fix
When you want to get checksum other than md5 or sha1 instead of exception sha1 checksum is returned.
