### PR TITLE
Fix for the update command: --ignore-maintenance-mode

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/UpdateCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/UpdateCommand.php
@@ -164,7 +164,7 @@ class UpdateCommand extends AbstractCommand
                 }
 
                 $script = realpath(PIMCORE_PROJECT_ROOT . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'console');
-                $return = Console::runPhpScript($script, 'internal:update-processor ' . escapeshellarg(json_encode($job)));
+                $return = Console::runPhpScript($script, 'internal:update-processor --ignore-maintenance-mode ' . escapeshellarg(json_encode($job)));
 
                 $return = trim($return);
 


### PR DESCRIPTION
## Fixes Issue #
Update puts the system into maintenance mode, so the internal:update-process command should ignore maintenance mode when being run

## Changes in this pull request  
Adds --ignore-maintenance-mode flag to the call