### PR TITLE
No-interact mode support for pimcore:update command

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/UpdateCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/UpdateCommand.php
@@ -130,7 +130,7 @@ class UpdateCommand extends AbstractCommand
             $helper = $this->getHelper('question');
             $question = new ConfirmationQuestion("You are going to update to build $build! Continue with this action? (y/n)", false);
 
-            if (!$helper->ask($input, $output, $question)) {
+            if (!$helper->ask($input, $output, $question) && !$input->getOption('no-interaction')) {
                 return;
             }
 


### PR DESCRIPTION
When pimcore:update command is executed with -n switch (no-interaction) default the answer to yes