### PR TITLE
Fix "Limit reached" bug in objectbricks.js

### DIFF
--- a/web/pimcore/static6/js/pimcore/object/tags/objectbricks.js
+++ b/web/pimcore/static6/js/pimcore/object/tags/objectbricks.js
@@ -203,6 +203,20 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
     },
 
 
+    getCurrentElementsCount: function() {
+        var i = 0;
+        var types = Object.keys(this.currentElements);
+        for(var t=0; t < types.length; t++) {
+            if (this.currentElements[types[t]]) {
+                var element = this.currentElements[types[t]];
+                if (element.action != "deleted") {
+                    i++;
+                }
+            }
+        }
+        return i;
+    },
+
     addBlockElement: function (index, type, blockData, ignoreChange) {
         if(!type){
             return;
@@ -210,7 +224,7 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
         if(!this.layoutDefinitions[type]) {
             return;
         }
-        if (this.fieldConfig.maxItems && Object.keys(this.currentElements).length >= this.fieldConfig.maxItems) {
+        if (this.fieldConfig.maxItems && this.getCurrentElementsCount() >= this.fieldConfig.maxItems) {
             Ext.Msg.alert(t("error"),t("limit_reached"));
             return;
         }


### PR DESCRIPTION
How to reproduce this bug?

1. Add objectbricks field in some class, set limit e.g. to 1.
2. Create new object.
3. Press green (+) button in object brick field.
4. After new element is added, press red (x) button to remove it.
5. Try go to step 3, but you'll get error message "Limited reached".


