### PR TITLE
[ROUTING] Add a list of parameters which are mapped to _locale attribute if not set

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -67,6 +67,7 @@ class Configuration implements ConfigurationInterface
         $this->addDocumentsNode($rootNode);
         $this->addModelsNode($rootNode);
 
+        $this->addRoutingNode($rootNode);
         $this->addCacheNode($rootNode);
         $this->addContextNode($rootNode);
         $this->addAdminNode($rootNode);
@@ -84,12 +85,11 @@ class Configuration implements ConfigurationInterface
     {
         $rootNode
             ->children()
-            ->arrayNode('models')
-            ->addDefaultsIfNotSet()
-                ->children()
-                ->arrayNode('class_overrides')
-                ->prototype('scalar')
-                ->end();
+                ->arrayNode('models')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('class_overrides')
+                            ->prototype('scalar');
     }
 
     /**
@@ -174,6 +174,27 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end();
+    }
+
+    private function addRoutingNode(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('routing')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('static')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->arrayNode('locale_params')
+                                    ->info('Route params from this list will be mapped to _locale if _locale is not set explicitely')
+                                    ->prototype('scalar')
+                                    ->defaultValue([])
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end();
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -82,6 +82,7 @@ class PimcoreCoreExtension extends Extension implements PrependExtensionInterfac
         $this->configureImplementationLoaders($container, $config);
         $this->configureModelFactory($container, $config);
         $this->configureDocumentEditableNamingStrategy($container, $config);
+        $this->configureRouting($container, $config['routing']);
         $this->configureCache($container, $loader, $config);
         $this->configurePasswordEncoders($container, $config);
 
@@ -179,6 +180,14 @@ class PimcoreCoreExtension extends Extension implements PrependExtensionInterfac
             $service = $container->getDefinition($serviceId);
             $service->setArguments([$loaders]);
         }
+    }
+
+    private function configureRouting(ContainerBuilder $container, array $config)
+    {
+        $container->setParameter(
+            'pimcore.routing.static.locale_params',
+            $config['static']['locale_params']
+        );
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
@@ -34,8 +34,11 @@ services:
     # dedicated router for static routes
     pimcore.routing.router.staticroute:
         class: Pimcore\Routing\Staticroute\Router
-        arguments: ['@router.request_context', '@pimcore.controller.config.config_normalizer']
+        arguments:
+            - '@router.request_context'
+            - '@pimcore.controller.config.config_normalizer'
         calls:
+            - [setLocaleParams, ['%pimcore.routing.static.locale_params%']]
             - [setLogger, ['@logger']]
         tags:
             - { name: router, priority: 100 }

--- a/pimcore/lib/Pimcore/Routing/Staticroute/Router.php
+++ b/pimcore/lib/Pimcore/Routing/Staticroute/Router.php
@@ -58,9 +58,11 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
     protected $supportedNames;
 
     /**
-     * @param RequestContext $context
-     * @param ConfigNormalizer $configNormalizer
+     * Params which are treated as _locale if no _locale attribute is set
+     * @var array
      */
+    protected $localeParams = [];
+
     public function __construct(RequestContext $context, ConfigNormalizer $configNormalizer)
     {
         $this->context          = $context;
@@ -81,6 +83,16 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
     public function getContext()
     {
         return $this->context;
+    }
+
+    public function getLocaleParams(): array
+    {
+        return $this->localeParams;
+    }
+
+    public function setLocaleParams(array $localeParams)
+    {
+        $this->localeParams = $localeParams;
     }
 
     /**
@@ -248,6 +260,16 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
         );
 
         $routeParams['_controller'] = $controller;
+
+        // map common language properties (e.g. language) to _locale if not set
+        if (!isset($routeParams['_locale'])) {
+            foreach ($this->localeParams as $localeParam) {
+                if (isset($routeParams[$localeParam])) {
+                    $routeParams['_locale'] = $routeParams[$localeParam];
+                    break;
+                }
+            }
+        }
 
         return $routeParams;
     }


### PR DESCRIPTION
Many older projects use parameters like `language` to define a language in the URL. As this is now handled by Symfony's default `_locale` parameter, all existing static routes and code relying on their params needs to be updated. This PR adds a mapping to resolve existing params like `language` to the `_locale` attribute. The mapping is only used if no explicit `_locale` parameter is set. 

Valid params can be set via config:

```yaml
# will map a static route parameter language to _locale
pimcore:
    routing:
        static:
            locale_params:
                - language
```