### PR TITLE
add proper namespace in QuantityValue phpdocType

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data/QuantityValue.php
+++ b/pimcore/models/Object/ClassDefinition/Data/QuantityValue.php
@@ -73,7 +73,7 @@ class QuantityValue extends Model\Object\ClassDefinition\Data
      *
      * @var string
      */
-    public $phpdocType = 'Pimcore\\Model\\Object\\Data\\QuantityValue';
+    public $phpdocType = '\\Pimcore\\Model\\Object\\Data\\QuantityValue';
 
     /**
      * @return int


### PR DESCRIPTION
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
  
  
## Fixes Issue #

Wrong phpdoc types for QuantityValue

## Changes in this pull request  

Fix the namespace in the classdefinition of QuantityValue

## Additional info  

