### PR TITLE
Better description of "classes" attribute in customviews sample

### DIFF
--- a/website_demo/config/customviews.example.php
+++ b/website_demo/config/customviews.example.php
@@ -10,7 +10,7 @@ return [
             "id" => 1,                                                          // unique (!!!) custom view ID
             "rootfolder" => "/blog",                                            // root node
             "showroot" => false,                                                // show root node or just children?
-            "classes" => "",                                                    // allowed classes to add
+            "classes" => "",                                                    // allowed classes to add; use class ids; comma-separated
             "position" => "right",                                              // left or right accordion
             "sort" => "1",                                                      // sort priority. lower values are shown first (prio for standard trees is -3 docs,-2 assets,-1 objects)
             "expanded" => true,                                                 // tree is expanded by default (there can be only one expanded tree on each side)


### PR DESCRIPTION
## Fixes Issue
Unclear instruction how to use the "classes" attribute

## Changes in this pull request 
Extended description so it's clear it expects a comma-separated list of class ids (not class names)