### PR TITLE
[ECOMMERCE] Fix payment issues with Decimal

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/OrderManager/Order/Agent.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/OrderManager/Order/Agent.php
@@ -26,6 +26,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\IOrderAgent;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PaymentManager\IPaymentManager;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PaymentManager\IStatus;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PaymentManager\Payment\IPayment;
+use Pimcore\Bundle\EcommerceFrameworkBundle\Type\Decimal;
 use Pimcore\Logger;
 use Pimcore\Model\Element\Note;
 use Pimcore\Model\Element\Note\Listing as NoteListing;
@@ -410,7 +411,7 @@ class Agent implements IOrderAgent
     {
         $order = $this->getOrder();
         $fingerprintParts = [];
-        $fingerprintParts[] = $order->getTotalPrice();
+        $fingerprintParts[] = Decimal::create($order->getTotalPrice())->asString();
         $fingerprintParts[] = $order->getCreationDate();
         foreach ($order->getItems() as $item) {
             $fingerprintParts[] = $item->getProductNumber();

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PaymentManager/Payment/WirecardSeamless.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PaymentManager/Payment/WirecardSeamless.php
@@ -164,7 +164,7 @@ class WirecardSeamless implements IPayment
         $fields = [
             'customerId' => $this->settings->customerId,
             'shopId' => $this->settings->shopId,
-            'amount' => round($price->getAmount(), 2),
+            'amount' => round($price->getAmount()->asNumeric(), 2),
             'currency' => $price->getCurrency()->getShortName(),
             'paymentType' => $paymentType,
             'language' => $config['language'] ?: 'de',


### PR DESCRIPTION
* wirecardSeamless not converting Decimal to number before rounding
* agent not creating a reproducible fingerprint as string and float representations are mixed when loading from order object/from cart