### PR TITLE
Static routes inside a site do not resolve nearest document properly

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
@@ -132,7 +132,7 @@ class DocumentFallbackListener extends AbstractFrontendListener implements Event
                 $path = urldecode($request->getPathInfo());
             }
 
-            $document = $this->documentService->getNearestDocumentByPath($path);
+            $document = $this->documentService->getNearestDocumentByPath($path, false, ['page', 'snippet', 'hardlink']);
             if ($document) {
                 $this->documentResolver->setDocument($request, $document);
             }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
@@ -15,8 +15,10 @@
 namespace Pimcore\Bundle\CoreBundle\EventListener\Frontend;
 
 use Pimcore\Model\Document;
+use Pimcore\Model\Site;
 use Pimcore\Service\Request\DocumentResolver;
 use Pimcore\Service\Request\PimcoreContextResolver;
+use Pimcore\Service\Request\SiteResolver;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -32,9 +34,9 @@ use Symfony\Component\HttpKernel\KernelEvents;
 class DocumentFallbackListener extends AbstractFrontendListener implements EventSubscriberInterface
 {
     /**
-     * @var Document\Service
+     * @var RequestStack
      */
-    protected $documentService;
+    protected $requestStack;
 
     /**
      * @var DocumentResolver
@@ -42,20 +44,26 @@ class DocumentFallbackListener extends AbstractFrontendListener implements Event
     protected $documentResolver;
 
     /**
-     * @var RequestStack
+     * @var SiteResolver
      */
-    protected $requestStack;
+    protected $siteResolver;
 
     /**
-     * @param Document\Service $documentService
-     * @param DocumentResolver $documentResolver
-     * @param RequestStack $requestStack
+     * @var Document\Service
      */
-    public function __construct(Document\Service $documentService, DocumentResolver $documentResolver, RequestStack $requestStack)
+    protected $documentService;
+
+    public function __construct(
+        RequestStack $requestStack,
+        DocumentResolver $documentResolver,
+        SiteResolver $siteResolver,
+        Document\Service $documentService
+    )
     {
-        $this->documentService  = $documentService;
-        $this->documentResolver = $documentResolver;
         $this->requestStack     = $requestStack;
+        $this->documentResolver = $documentResolver;
+        $this->siteResolver     = $siteResolver;
+        $this->documentService  = $documentService;
     }
 
     /**
@@ -72,7 +80,7 @@ class DocumentFallbackListener extends AbstractFrontendListener implements Event
     }
 
     /**
-     * Finds the nearest document for the current request if the routing/document router didn't (e.g. static routes)
+     * Finds the nearest document for the current request if the routing/document router didn't find one (e.g. static routes)
      *
      * @param GetResponseEvent $event
      */
@@ -117,7 +125,14 @@ class DocumentFallbackListener extends AbstractFrontendListener implements Event
         // this is only done on the master request as a sub-request's pathInfo is _fragment when
         // rendered via actions helper
         if ($event->isMasterRequest()) {
-            $document = $this->documentService->getNearestDocumentByPath($request);
+            $path = null;
+            if ($this->siteResolver->isSiteRequest($request)) {
+                $path = $this->siteResolver->getSitePath($request);
+            } else {
+                $path = urldecode($request->getPathInfo());
+            }
+
+            $document = $this->documentService->getNearestDocumentByPath($path);
             if ($document) {
                 $this->documentResolver->setDocument($request, $document);
             }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/event_listeners.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/event_listeners.yml
@@ -22,7 +22,11 @@ services:
 
     pimcore.event_listener.frontend.document_fallback:
         class: Pimcore\Bundle\CoreBundle\EventListener\Frontend\DocumentFallbackListener
-        arguments: ['@pimcore.document_service', '@pimcore.service.request.document_resolver', '@request_stack']
+        arguments:
+            - '@request_stack'
+            - '@pimcore.service.request.document_resolver'
+            - '@pimcore.service.request.site_resolver'
+            - '@pimcore.document_service'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/pimcore/lib/Pimcore/Routing/Staticroute/Router.php
+++ b/pimcore/lib/Pimcore/Routing/Staticroute/Router.php
@@ -210,8 +210,6 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
 
         foreach ($this->getStaticRoutes() as $route) {
             if ($routeParams = $route->match($pathinfo, $params)) {
-                // TODO nearest document
-
                 Staticroute::setCurrentRoute($route);
 
                 // add the route object also as parameter to the request object, this is needed in


### PR DESCRIPTION
When loading a static route inside a site, the nearest document isn't properly resolved as it does not take the site into account. 