### PR TITLE
add myclabs/deep-copy to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
     "linfo/linfo": "~3",
     "monolog/monolog": "~1",
     "mpratt/embera": "~1",
+    "myclabs/deep-copy": "~1.3.0",
     "neitanod/forceutf8": "~2",
     "nesbot/carbon": "~1",
     "ocramius/proxy-manager": "2.0.*",

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     "linfo/linfo": "~3",
     "monolog/monolog": "~1",
     "mpratt/embera": "~1",
-    "myclabs/deep-copy": "~1.3.0",
+    "myclabs/deep-copy": "~1.3",
     "neitanod/forceutf8": "~2",
     "nesbot/carbon": "~1",
     "ocramius/proxy-manager": "2.0.*",


### PR DESCRIPTION
the "myclabs/deep-copy" package only gets installed in dev mode since the only dependency is in "phpunit/phpunit" - which is not available in `--no-dev` mode.