### PR TITLE
Composer file path

### DIFF
--- a/pimcore/config/constants.php
+++ b/pimcore/config/constants.php
@@ -30,6 +30,10 @@ if (!defined('PIMCORE_COMPOSER_PATH')) {
     define('PIMCORE_COMPOSER_PATH', PIMCORE_PROJECT_ROOT . '/vendor');
 }
 
+if (!defined('PIMCORE_COMPOSER_FILE_PATH')) {
+    define('PIMCORE_COMPOSER_FILE_PATH', realpath(__DIR__ . '/../../'));
+}
+
 if (!defined('PIMCORE_APP_ROOT')) {
     define('PIMCORE_APP_ROOT', PIMCORE_PROJECT_ROOT . '/app');
 }

--- a/pimcore/lib/Pimcore/Update.php
+++ b/pimcore/lib/Pimcore/Update.php
@@ -446,7 +446,7 @@ class Update
 
         try {
             $composerPath = \Pimcore\Tool\Console::getExecutable('composer');
-            $process = new Process($composerPath . ' dumpautoload -d ' . PIMCORE_PROJECT_ROOT);
+            $process = new Process($composerPath . ' dumpautoload -d ' . PIMCORE_COMPOSER_FILE_PATH);
             $process->setTimeout(300);
             $process->mustRun();
         } catch (\Exception $e) {

--- a/pimcore/lib/Pimcore/Update.php
+++ b/pimcore/lib/Pimcore/Update.php
@@ -293,7 +293,7 @@ class Update
                 if (!self::$dryRun) {
                     if ($file['path'] == '/composer.json') {
                         // composer.json needs some special processing
-                        self::installComposerJson($srcFile, $destFile);
+                        self::installComposerJson($srcFile, PIMCORE_COMPOSER_FILE_PATH . $file['path']);
                     } else {
                         copy($srcFile, $destFile);
                     }
@@ -411,7 +411,7 @@ class Update
      */
     public static function composerUpdate($options = [])
     {
-        $composerLock = PIMCORE_PROJECT_ROOT . '/composer.lock';
+        $composerLock = PIMCORE_COMPOSER_FILE_PATH . '/composer.lock';
         if (file_exists($composerLock)) {
             @unlink($composerLock);
         }
@@ -423,7 +423,7 @@ class Update
 
             $composerOptions = array_merge(['-n'], $options);
 
-            $process = new Process($composerPath . ' update ' . implode(' ', $composerOptions) . ' -d ' . PIMCORE_PROJECT_ROOT);
+            $process = new Process($composerPath . ' update ' . implode(' ', $composerOptions) . ' -d ' . PIMCORE_COMPOSER_FILE_PATH);
             $process->setTimeout(900);
             $process->mustRun();
         } catch (\Exception $e) {


### PR DESCRIPTION
## tltr;
- `composerUpdate()`: only update the real pimcore `composer.json`
- `installData()`: move `composer.json` to the real pimcore directory
- `composerDumpAutoload()`: `dump-autoload` only in real pimcore directory

## About this PR
This PR will force pimcore to use the real pimcore `composer.json` file, since the `PIMCORE_PROJECT_ROOT` could lead to a different path and a thereby to a different `composer.json`.
