### PR TITLE
add PIMCORE_PROJECT_ROOT to internal php commands and processes

### DIFF
--- a/pimcore/lib/Pimcore/Tool/AssetsInstaller.php
+++ b/pimcore/lib/Pimcore/Tool/AssetsInstaller.php
@@ -96,6 +96,7 @@ class AssetsInstaller
         ]);
 
         $builder
+            ->addEnvironmentVariables(['PIMCORE_PROJECT_ROOT' => PIMCORE_PROJECT_ROOT])
             ->setWorkingDirectory(PIMCORE_PROJECT_ROOT)
             ->setPrefix('bin/console');
 

--- a/pimcore/lib/Pimcore/Tool/Console.php
+++ b/pimcore/lib/Pimcore/Tool/Console.php
@@ -246,7 +246,7 @@ class Console
     {
         $phpCli = self::getPhpCli();
 
-        $cmd = $phpCli . ' ' . $script;
+        $cmd = 'PIMCORE_PROJECT_ROOT=' . PIMCORE_PROJECT_ROOT . ' ' . $phpCli . ' ' . $script;
 
         if (Config::getEnvironment()) {
             $cmd .= ' --env=' . Config::getEnvironment();

--- a/pimcore/lib/Pimcore/Web2Print/Processor.php
+++ b/pimcore/lib/Pimcore/Web2Print/Processor.php
@@ -72,7 +72,9 @@ abstract class Processor
             $args[] = '--env=' . $env;
         }
 
-        $cmd = Tool\Console::getPhpCli() . ' ' . realpath(PIMCORE_PROJECT_ROOT . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'console'). ' web2print:pdf-creation ' . implode(' ', $args);
+        $phpCli = Tool\Console::getPhpCli();
+        $cmd = 'PIMCORE_PROJECT_ROOT=' . PIMCORE_PROJECT_ROOT . ' ' . $phpCli . ' ';
+        $cmd .= realpath(PIMCORE_PROJECT_ROOT . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'console'). ' web2print:pdf-creation ' . implode(' ', $args);
 
         Logger::info($cmd);
 


### PR DESCRIPTION
This PR will resolve #1681 without any "hacking". Adding `PIMCORE_PROJECT_ROOT` to the pimcore processes and commands will solve conflicts when overriding the `PIMCORE_PROJECT_ROOT` constant since this path gets lost after execution. 