### PR TITLE
Generate parameters.yml file only if it doesn't exist.

### DIFF
--- a/pimcore/models/Tool/Setup.php
+++ b/pimcore/models/Tool/Setup.php
@@ -160,9 +160,12 @@ class Setup extends Model\AbstractModel
         ]));
 
         // generate parameters.yml
-        $parameters = file_get_contents(PIMCORE_APP_ROOT . '/config/parameters.example.yml');
-        $parameters = str_replace('ThisTokenIsNotSoSecretChangeIt', generateRandomSymfonySecret(), $parameters);
-        File::put(PIMCORE_APP_ROOT . '/config/parameters.yml', $parameters);
+        $parametersFilePath = PIMCORE_APP_ROOT . '/config/parameters.yml';
+        if (!file_exists($parametersFilePath)) {
+            $parameters = file_get_contents(PIMCORE_APP_ROOT . '/config/parameters.example.yml');
+            $parameters = str_replace('ThisTokenIsNotSoSecretChangeIt', generateRandomSymfonySecret(), $parameters);
+            File::put($parametersFilePath, $parameters);
+        }
     }
 
     /**


### PR DESCRIPTION
We use a deployment system where we checkout the project (including parameters.yml) and then run Pimcore Installation and load data from Fixtures. This PR makes sure that the parameters.yml doesn't get overwritten or recreated with different 'secret' parameter which would stage a VCS change on the server after deployment. 