### PR TITLE
case-insensitive preg_match patterns

### DIFF
--- a/pimcore/lib/Pimcore/Document/Adapter/LibreOffice.php
+++ b/pimcore/lib/Pimcore/Document/Adapter/LibreOffice.php
@@ -53,7 +53,7 @@ class LibreOffice extends Ghostscript
     {
 
         // it's also possible to pass a path or filename
-        if (preg_match("/\.?(pdf|doc|docx|odt|xls|xlsx|ods|ppt|pptx|odp)$/", $fileType)) {
+        if (preg_match("/\.?(pdf|doc|docx|odt|xls|xlsx|ods|ppt|pptx|odp)$/i", $fileType)) {
             return true;
         }
 
@@ -91,8 +91,8 @@ class LibreOffice extends Ghostscript
         }
 
         // first we have to create a pdf out of the document (if it isn't already one), so that we can pass it to ghostscript
-        // unfortunately there isn't an other way at the moment
-        if (!preg_match("/\.?pdf$/", $path)) {
+        // unfortunately there isn't any other way at the moment
+        if (!preg_match("/\.?pdf$/i", $path)) {
             if (!parent::isFileTypeSupported($path)) {
                 $this->path = $this->getPdf($path);
             }


### PR DESCRIPTION
case-insensitive preg_match patterns for file extensions since upper/mixed case is valid (see commit #1798 on master branch)


## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
  
  
## Fixes Issue #

## Changes in this pull request  

## Additional info  

