### PR TITLE
[AdminBundle] fix translations export Content-Type

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TranslationController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TranslationController.php
@@ -212,7 +212,7 @@ class TranslationController extends AdminController
         $suffix = $admin ? 'admin' : 'website';
         $response = new Response("\xEF\xBB\xBF" . $csv);
         $response->headers->set('Content-Encoding', 'UTF-8');
-        $response->headers->set('Content-type:', 'text/csv; charset=UTF-8');
+        $response->headers->set('Content-Type', 'text/csv; charset=UTF-8');
         $response->headers->set('Content-Disposition', 'attachment; filename="export_ ' . $suffix . '_translations.csv"');
         ini_set('display_errors', false); //to prevent warning messages in csv
         return $response;


### PR DESCRIPTION
Content-Type is set with a ending ':', therefore fastcgi reports duplicate-header exception.