### PR TITLE
Mark non-static methods as static

### DIFF
--- a/pimcore/models/Object/ClassDefinition.php
+++ b/pimcore/models/Object/ClassDefinition.php
@@ -344,7 +344,7 @@ class ClassDefinition extends Model\AbstractModel
                                 $def->getName()
                             ).' ($field, $value, $locale = null, $limit = 0) '."\n";
                     } else {
-                        $cd .= '* @method \\Pimcore\\Model\\Object\\'.ucfirst(
+                        $cd .= '* @method static \\Pimcore\\Model\\Object\\'.ucfirst(
                                 $this->getName()
                             ).'\Listing getBy'.ucfirst($def->getName()).' ($value, $limit = 0) '."\n";
                     }


### PR DESCRIPTION
## Fixes Issue #
1. IDEs aren't able to autocomplete static getBy-calls on an object. 
2. If you extend a class and a getBy method call should be overridden, the IDE will throw an error like 'Cannot make non-static method ... static"

## Changes in this pull request  
- marked non-static method calls in doc-block as static methods.

## Additional info  
All 'getBy' calls are realized by "__callStatic" in Pimcore\Model\Object\Concrete. So methods should be marked as static.
