### PR TITLE
Asset replace function: handle change of file types correctly

### DIFF
--- a/pimcore/config/texts/en.json
+++ b/pimcore/config/texts/en.json
@@ -6303,5 +6303,9 @@
     {
         "term": "predefined_hotspot_data_templates",
         "definition": "Predefined data templates"
+    },
+    {
+        "term": "asset_type_change_not_allowed",
+        "definition": "<strong>Only assets of same type are allowed here.</strong><br/>[ type of uploaded asset: \"%s\" | type of existing asset: \"%s\" ]"
     }
 ]

--- a/pimcore/models/Asset.php
+++ b/pimcore/models/Asset.php
@@ -663,7 +663,7 @@ class Asset extends Element\AbstractElement
 
                 // set mime type
 
-                $mimetype = Mime::detect($destinationPath);
+                $mimetype = Mime::detect($destinationPath, $this->getFilename());
                 $this->setMimetype($mimetype);
 
                 // set type

--- a/pimcore/static6/js/pimcore/asset/asset.js
+++ b/pimcore/static6/js/pimcore/asset/asset.js
@@ -381,8 +381,17 @@ pimcore.asset.asset = Class.create(pimcore.element.abstract, {
     upload: function () {
         pimcore.helpers.uploadDialog('/admin/asset/replace-asset/id/' + this.data.id, "Filedata", function() {
             this.reload();
-        }.bind(this), function () {
-            Ext.MessageBox.alert(t("error"), t("error"));
+        }.bind(this), function (res) {
+            var message = false;
+            try {
+                var response = Ext.util.JSON.decode(res.response.responseText);
+                if(response.message) {
+                    message = response.message;
+                }
+
+            } catch(e) {}
+
+            Ext.MessageBox.alert(t("error"), message || t("error"));
         });
     },
 


### PR DESCRIPTION
The upload function currently has a little bit strange behaviour:
![image](https://user-images.githubusercontent.com/4639428/29419116-8fb7998a-836e-11e7-8446-4703e80870d7.png)

Currently it just replaces the binary content of the asset.

This pull requests improves the behaviour as following:
- If the uploaded asset has the same type (for example Asset\Image) as the existing asset the filename and mime type will be updated (for example if a jpg gets replaced by a png).

- If the uploaded asset would change the type of the original asset an error message will be shown and the upload will be declined as such type changes could be quite dangerous when the asset is already used somewhere.

If the pull request gets accepted I will create one for Pimcore 5 too. Please let me know if I should update anything in the behaviour.