### PR TITLE
Web2Print Events - Add events to configure the processing options and the configuration for the adapters

### DIFF
--- a/pimcore/lib/Pimcore/Event/DocumentEvents.php
+++ b/pimcore/lib/Pimcore/Event/DocumentEvents.php
@@ -89,6 +89,40 @@ final class DocumentEvents
      */
     const PRINT_POST_PDF_GENERATION = 'pimcore.document.print.postPdfGeneration';
 
+
+    /**
+     * Modify the processing options (displayed in the pimcore admin interface)
+     *
+     * Arguments:
+     *  - options | array for configuration settings
+     *
+     * @Event("Pimcore\Event\Model\PrintConfigEvent")
+     *
+     * @var string
+     */
+    const PRINT_MODIFY_PROCESSING_OPTIONS = 'pimcore.document.print.processor.modifyProcessingOptions';
+
+    /**
+     * Modify the configuration for the processor (when the pdf gets created)
+     *
+     * Arguments:
+     * WkHtmlToPdfAdapter:
+     *  - wkhtmltopdfBin | path to wkhtmltopdf binary
+     *  - options | configuration options
+     *  - srcUrl | path tho source html file
+     *  - dstFile | path to the output pdf file
+     *  - config | configuration which is passed from the pimcore admin interface
+     *
+     * PDFReactor:
+     *  - config | configuration which is passed from the pimcore admin interface
+     *  - reactorConfig | configuration which is passed to PDFReactor
+     *
+     * @Event("Pimcore\Event\Model\DocumentEvent")
+     *
+     * @var string
+     */
+    const PRINT_MODIFY_PROCESSING_CONFIG = 'pimcore.document.print.processor.modifyConfig';
+
     /**
      * Arguments:
      *  - base_element | Pimcore\Model\Document | contains the base document used in copying process

--- a/pimcore/lib/Pimcore/Event/Model/PrintConfigEvent.php
+++ b/pimcore/lib/Pimcore/Event/Model/PrintConfigEvent.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Event\Model;
+
+use Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\Order\Listing\Filter\Product;
+use Pimcore\Event\Traits\ArgumentsAwareTrait;
+use Pimcore\Web2Print\Processor;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Process\Process;
+
+class PrintConfigEvent extends Event
+{
+    use ArgumentsAwareTrait;
+
+    /**
+     * @var Processor
+     */
+    protected $processor;
+
+    /**
+     * DocumentEvent constructor.
+     *
+     * @param Processor $processor
+     * @param array $arguments
+     */
+    public function __construct(Processor $processor, array $arguments = [])
+    {
+        $this->processor = $processor;
+        $this->arguments = $arguments;
+    }
+
+    /**
+     * @return Processor
+     */
+    public function getProcessor()
+    {
+        return $this->processor;
+    }
+
+    /**
+     * @param Processor $processor
+     * @return $this
+     */
+    public function setProcessor($processor)
+    {
+        $this->processor = $processor;
+        return $this;
+    }
+
+
+
+}

--- a/pimcore/lib/Pimcore/Web2Print/Processor/PdfReactor8.php
+++ b/pimcore/lib/Pimcore/Web2Print/Processor/PdfReactor8.php
@@ -18,6 +18,8 @@ use Pimcore\Config;
 use Pimcore\Logger;
 use Pimcore\Model\Document;
 use Pimcore\Web2Print\Processor;
+use Pimcore\Event\Model\PrintConfigEvent;
+use Pimcore\Event\DocumentEvents;
 
 class PdfReactor8 extends Processor
 {
@@ -135,6 +137,12 @@ class PdfReactor8 extends Processor
         $web2PrintConfig = Config::getWeb2PrintConfig();
         $reactorConfig['document'] = (string)$web2PrintConfig->pdfreactorBaseUrl . $filePath;
 
+
+        $event = new PrintConfigEvent($this, ['config' => $config, 'reactorConfig' => $reactorConfig]);
+        \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::PRINT_MODIFY_PROCESSING_CONFIG, $event);
+
+        $reactorConfig = $event->getArguments()['reactorConfig'];
+
         try {
             $progress = new \stdClass();
             $progress->finished = false;
@@ -211,6 +219,12 @@ class PdfReactor8 extends Processor
             'default' => \LogLevel::FATAL
         ];
 
-        return $options;
+        $event = new PrintConfigEvent($this, [
+            'options' => $options
+        ]);
+
+        \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::PRINT_MODIFY_PROCESSING_OPTIONS, $event);
+
+        return (array)$event->getArguments()['options'];
     }
 }


### PR DESCRIPTION
Added events:
 - pimcore.document.print.processor.modifyProcessingOptions
 - pimcore.document.print.processor.modifyConfig

to modify the processing behaviour of the Web2Print adapters.

Usage Example: 
Listener definition:
   app.event_listener.test:
        class: AppBundle\EventListener\TestListener
        tags:
            - { name: kernel.event_listener, event: pimcore.document.print.processor.modifyProcessingOptions, method: modifyProcessingOptions }
            - { name: kernel.event_listener, event: pimcore.document.print.processor.modifyConfig, method: modifyConfig }
			
			
Listener: 
<?php

namespace AppBundle\EventListener;

use Pimcore\Event\Model\ObjectEvent;

class TestListener
{
    public function modifyProcessingOptions(\Pimcore\Event\Model\PrintConfigEvent $event){

        $arguments = $event->getArguments();
        $options = $arguments['options'];

        $processor = $event->getProcessor();
        if($processor instanceof \Pimcore\Web2Print\Processor\WkHtmlToPdf){
            $options[] = ["name" => "title", "type" => "text", "default" => ""];
            $options[] = ["name" => "lowquality", "type" => "bool", "default" => ""];
            $options[] = ["name" => "grayscale", "type" => "bool", "default" => ""];
        }elseif($processor instanceof \Pimcore\Web2Print\Processor\PdfReactor8){
            $options[] = ['name' => 'appendLog', 'type' => 'bool', 'default' => false];
        }

        $arguments['options'] = $options;
        $event->setArguments($arguments);
    }

    public function modifyConfig(\Pimcore\Event\Model\PrintConfigEvent $event){

        $arguments = $event->getArguments();

        $processor = $event->getProcessor();
        if($processor instanceof \Pimcore\Web2Print\Processor\WkHtmlToPdf){
            if($arguments['config']->grayscale == 'true'){
                $arguments['options'].= ' --grayscale';
            }
        }elseif($processor instanceof \Pimcore\Web2Print\Processor\PdfReactor8){
            if($arguments['config']->appendLog == 'true'){
                $arguments['reactorConfig']['appendLog'] = true;
            }

            #$arguments['reactorConfig']['conformance'] = \Conformance::PDFX4;
            #$arguments['reactorConfig']["outputIntent"] = ['identifier' => "ISO Coated v2 300% (ECI)",'data' => base64_encode(file_get_contents('/path-to-color-profile/ISOcoated_v2_300_eci.icc'))];
        }

        $event->setArguments($arguments);
    }
}
