### PR TITLE
Prevent garbage collection of cell editors - bug of Ext.Js.

### DIFF
--- a/web/pimcore/static6/js/pimcore/document/tags/table.js
+++ b/web/pimcore/static6/js/pimcore/document/tags/table.js
@@ -177,6 +177,7 @@ pimcore.document.tags.table = Class.create(pimcore.document.tag, {
         var selected = this.grid.getSelectionModel();
         if (selected.selection) {
             this.store.remove(selected.selection.record);
+            this.grid.editingPlugin.view.refresh();  // Prevents the editor from being garbage collected
         }
     },
 

--- a/web/pimcore/static6/js/pimcore/object/tags/table.js
+++ b/web/pimcore/static6/js/pimcore/object/tags/table.js
@@ -253,6 +253,7 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
         var selected = this.grid.getSelectionModel();
         if (selected.selection) {
             this.store.remove(selected.selection.record);
+            this.grid.editingPlugin.view.refresh();  // Prevents the editor from being garbage collected
             this.dirty = true;
         }
     },


### PR DESCRIPTION
**Bug description:**
When using a cellediting plugin, the celleditor is always attached in DOM to the latest cell it was used in. If the row with that cell gets removed, the editor DOM node gets orphaned and removed by ExtJSs garbage collector (after 0-30s).

**Steps to reproduce:**
* add a table field to the object (or table editable to the document)
* add 2 additional rows to the table (there will be 3 rows now)
* put 'a', 'b' and 'c' into each of the rows respectively
* delete rows with 'c' and 'b'
* wait 30 seconds (default interval of the garbage collector)
* try editing the row by doubleclicking - it won't work and you will get errors in console

To make testing faster, you can change the garbage collector interval by issuing this command in console:
```
Ext.dom.GarbageCollector.interval = 5000; // 5 seconds
```

I hope this is the only case when the editor gets orphaned. 

**Fix**
After removing a table row, we explicitly call the refresh function of the celleditor, which makes sure that orphaned editor gets saved to the temporary DOM node (Ext.getDetachedBody().dom)

This is actually an ExtJS bug described here:
https://www.sencha.com/forum/showthread.php?330959-ExtJs-6-2-CellEditing-plugin-editor-el-dom-is-null/page2
The solution provided on the link above doesn't work as it is for the ExtJS 6.2. I couldn't achieve anything similar for ExtJS 6.0.0