### PR TITLE
[ECOMMERCE] Check if bundle is enabled before trying to fetch installer in IndexFieldSelectionCombo

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionCombo.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionCombo.php
@@ -16,8 +16,7 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\CoreExtensions\ClassDefinition
 
 use Pimcore\Bundle\EcommerceFrameworkBundle\Factory;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\ProductList\IProductList;
-use Pimcore\Bundle\EcommerceFrameworkBundle\Tools\Installer;
-use Pimcore\Logger;
+use Pimcore\Bundle\EcommerceFrameworkBundle\PimcoreEcommerceFrameworkBundle;
 use Pimcore\Model\Object\ClassDefinition\Data\Select;
 
 class IndexFieldSelectionCombo extends Select
@@ -35,34 +34,35 @@ class IndexFieldSelectionCombo extends Select
 
     public function __construct()
     {
-        $installer = \Pimcore::getContainer()->get('pimcore.ecommerceframework.installer');
-        if ($installer->isInstalled()) {
-            $indexColumns = [];
-            try {
-                $indexService = Factory::getInstance()->getIndexService();
-                $indexColumns = $indexService->getIndexAttributes(true);
-            } catch (\Exception $e) {
-                Logger::err($e);
-            }
+        $this->setOptions($this->buildOptions());
+    }
 
-            $options = [];
-
-            foreach ($indexColumns as $c) {
-                $options[] = [
-                    'key' => $c,
-                    'value' => $c
-                ];
-            }
-
-            if ($this->getSpecificPriceField()) {
-                $options[] = [
-                    'key' => IProductList::ORDERKEY_PRICE,
-                    'value' => IProductList::ORDERKEY_PRICE
-                ];
-            }
-
-            $this->setOptions($options);
+    protected function buildOptions(): array
+    {
+        if (!PimcoreEcommerceFrameworkBundle::isInstalled()) {
+            return [];
         }
+
+        $indexService = Factory::getInstance()->getIndexService();
+        $indexColumns = $indexService->getIndexAttributes(true);
+
+        $options = [];
+
+        foreach ($indexColumns as $c) {
+            $options[] = [
+                'key' => $c,
+                'value' => $c
+            ];
+        }
+
+        if ($this->getSpecificPriceField()) {
+            $options[] = [
+                'key' => IProductList::ORDERKEY_PRICE,
+                'value' => IProductList::ORDERKEY_PRICE
+            ];
+        }
+
+        return $options;
     }
 
     public function setSpecificPriceField($specificPriceField)

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PimcoreEcommerceFrameworkBundle.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PimcoreEcommerceFrameworkBundle.php
@@ -19,10 +19,13 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Legacy\LegacyClassMappingTool;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Tools\Installer;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Type\Decimal;
 use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
+use Pimcore\Extension\Bundle\Traits\StateHelperTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class PimcoreEcommerceFrameworkBundle extends AbstractPimcoreBundle
 {
+    use StateHelperTrait;
+
     /**
      * @inheritDoc
      */

--- a/pimcore/lib/Pimcore/Extension/Bundle/PimcoreBundleManager.php
+++ b/pimcore/lib/Pimcore/Extension/Bundle/PimcoreBundleManager.php
@@ -153,6 +153,20 @@ class PimcoreBundleManager
     }
 
     /**
+     * Determines if a bundle exists (is enabled or can be enabled)
+     *
+     * @param string|PimcoreBundleInterface $bundle
+     *
+     * @return bool
+     */
+    public function exists($bundle): bool
+    {
+        $identifier = $this->getBundleIdentifier($bundle);
+
+        return $this->isValidBundleIdentifier($identifier);
+    }
+
+    /**
      * @param string|PimcoreBundleInterface $bundle
      *
      * @return string
@@ -168,19 +182,29 @@ class PimcoreBundleManager
     }
 
     /**
-     * Validates bundle name against list if available and active bundles
+     * @param string $identifier
      *
-     * @param string $bundle
+     * @return bool
      */
-    protected function validateBundleIdentifier(string $bundle)
+    protected function isValidBundleIdentifier(string $identifier): bool
     {
         $validNames = array_merge(
             array_keys($this->getActiveBundles(false)),
             $this->getAvailableBundles()
         );
 
-        if (!in_array($bundle, $validNames)) {
-            throw new BundleNotFoundException(sprintf('Bundle %s is no valid bundle identifier', $bundle));
+        return in_array($identifier, $validNames);
+    }
+
+    /**
+     * Validates bundle name against list if available and active bundles
+     *
+     * @param string $identifier
+     */
+    protected function validateBundleIdentifier(string $identifier)
+    {
+        if (!$this->isValidBundleIdentifier($identifier)) {
+            throw new BundleNotFoundException(sprintf('Bundle "%s" is no valid bundle identifier', $identifier));
         }
     }
 

--- a/pimcore/lib/Pimcore/Extension/Bundle/Traits/StateHelperTrait.php
+++ b/pimcore/lib/Pimcore/Extension/Bundle/Traits/StateHelperTrait.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Extension\Bundle\Traits;
+
+/**
+ * Helper trait exposing static isEnabled() and isInstalled() methods for bundles which can be used
+ * to check bundle state from non-service definitions (e.g. class definitions).
+ */
+trait StateHelperTrait
+{
+    /**
+     * Helper method to check enabled state from class definitions/non-service instances
+     *
+     * @return bool
+     */
+    public static function isEnabled(): bool
+    {
+        $bundleManager = \Pimcore::getContainer()->get('pimcore.extension.bundle_manager');
+
+        if (!$bundleManager->exists(__CLASS__)) {
+            return false;
+        }
+
+        if (!$bundleManager->isEnabled(__CLASS__)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Helper method to check installed state from class definitions/non-service instances
+     *
+     * @return bool
+     */
+    public static function isInstalled(): bool
+    {
+        if (!static::isEnabled()) {
+            return false;
+        }
+
+        $bundleManager = \Pimcore::getContainer()->get('pimcore.extension.bundle_manager');
+
+        $bundle = $bundleManager->getActiveBundle(__CLASS__);
+        if (!$bundleManager->isInstalled($bundle)) {
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
After uninstalling or disabling the ecommerce framework, the Fieldcollections extending from `IndexFieldSelectionCombo` which are not deleted on uninstall still try to fetch the installer which is not available anymore. This adds a check if the bundle is enabled and installed before trying to fetch options from the factory.