### PR TITLE
[BUNDLES] Expose extension manager functionality as CLI commands

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/AbstractBundleCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/AbstractBundleCommand.php
@@ -105,4 +105,15 @@ abstract class AbstractBundleCommand extends AbstractCommand
     {
         return str_replace('/', '\\', $bundleIdentifier);
     }
+
+    protected function getShortClassName(string $className)
+    {
+        if (!class_exists($className)) {
+            throw new \InvalidArgumentException(sprintf('Class "%s" does not exist', $className));
+        }
+
+        $parts = explode('\\', $className);
+
+        return array_pop($parts);
+    }
 }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/AbstractBundleCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/AbstractBundleCommand.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Command\Bundle;
+
+use Pimcore\Console\AbstractCommand;
+use Pimcore\Extension\Bundle\PimcoreBundleInterface;
+use Pimcore\Extension\Bundle\PimcoreBundleManager;
+use Symfony\Component\Console\Input\InputOption;
+
+abstract class AbstractBundleCommand extends AbstractCommand
+{
+    protected function configureDescriptionAndHelp(string $description, string $help = null): self
+    {
+        if (null === $help) {
+            $help = 'Bundle can be passed as fully qualified class name or as bundle short name (e.g. <comment>PimcoreEcommerceFrameworkBundle</comment>).';
+        }
+
+        $this
+            ->setDescription($description)
+            ->setHelp(sprintf('%s. %s', $description, $help));
+
+        return $this;
+    }
+
+    protected function configureFailWithoutErrorOption(): self
+    {
+        $this->addOption(
+            'fail-without-error', 'f',
+            InputOption::VALUE_NONE,
+            'Just output a warning but do not return an error code if the command can\'t be executed'
+        );
+
+        return $this;
+    }
+
+    protected function buildName(string $name)
+    {
+        return sprintf('pimcore:bundle:%s', $name);
+    }
+
+    protected function handlePrerequisiteError(string $message): int
+    {
+        if ($this->io->getInput()->getOption('fail-without-error')) {
+            $this->io->warning($message);
+
+            return 0;
+        } else {
+            $this->io->error($message);
+
+            return 1;
+        }
+    }
+
+    protected function getBundleManager(): PimcoreBundleManager
+    {
+        return $this->getContainer()->get('pimcore.extension.bundle_manager');
+    }
+
+    protected function getBundle(): PimcoreBundleInterface
+    {
+        $bundleId = $this->io->getInput()->getArgument('bundle');
+        $bundleId = $this->normalizeBundleIdentifier($bundleId);
+
+        $bundleManager = $this->getBundleManager();
+        $activeBundles = $bundleManager->getActiveBundles(false);
+
+        $bundle = null;
+
+        if (isset($activeBundles[$bundleId])) {
+            // try to load bundle via fully qualified class name first
+            $bundle = $activeBundles[$bundleId];
+        } else {
+            // fall back to fetching bundle from kernel with its logical name
+            $kernel = $this->getApplication()->getKernel();
+            $bundle = $kernel->getBundle($bundleId);
+        }
+
+        if (!$bundle instanceof PimcoreBundleInterface) {
+            throw new \InvalidArgumentException(sprintf(
+                'Bundle "%s" does not implement %s',
+                $bundle->getName(),
+                PimcoreBundleInterface::class
+            ));
+        }
+
+        return $bundle;
+    }
+
+    protected function normalizeBundleIdentifier(string $bundleIdentifier): string
+    {
+        return str_replace('/', '\\', $bundleIdentifier);
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/DisableCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/DisableCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Command\Bundle;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DisableCommand extends AbstractBundleCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName($this->buildName('disable'))
+            ->configureDescriptionAndHelp('Disables a bundle')
+            ->addArgument('bundle', InputArgument::REQUIRED, 'The bundle to disable');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $bm     = $this->getBundleManager();
+        $bundle = $this->getBundle();
+
+        try {
+            $bm->disable($bundle);
+
+            $this->io->success(sprintf('Bundle "%s" was successfully disabled', $bundle->getName()));
+        } catch (\Exception $e) {
+            $this->handlePrerequisiteError($e->getMessage());
+        }
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/EnableCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/EnableCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Command\Bundle;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class EnableCommand extends AbstractBundleCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName($this->buildName('enable'))
+            ->configureDescriptionAndHelp(
+                'Enables a bundle',
+                'The class name can also be specified with slashes for easier handling on the command line. (e.g. <comment>Pimcore/Bundle/EcommerceFramework/PimcoreEcommerceFrameworkBundle</comment>)'
+            )
+            ->addArgument(
+                'bundle-class',
+                InputArgument::REQUIRED,
+                'The bundle to enable as fully qualified class name'
+            )
+            ->addOption(
+                'priority', 'p',
+                InputOption::VALUE_REQUIRED,
+                'Optional priority to configure'
+            )
+            ->addOption(
+                'environments', 'E',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'If defined, the bundle will be configured to only be loaded in the specified environments'
+            )
+            ->configureFailWithoutErrorOption()
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $state = $this->resolveState($input);
+
+        $bundleClass = $this->normalizeBundleIdentifier($input->getArgument('bundle-class'));
+
+        $bm = $this->getBundleManager();
+
+        try {
+            $bm->enable($bundleClass, $state);
+
+            $this->io->success(sprintf('Bundle "%s" was successfully enabled', $bundleClass));
+        } catch (\Exception $e) {
+            $this->handlePrerequisiteError($e->getMessage());
+        }
+    }
+
+    private function resolveState(InputInterface $input): array
+    {
+        $state = [];
+
+        $priority = $input->getOption('priority');
+        if (null !== $priority) {
+            $state['priority'] = (int)$priority;
+        }
+
+        $environments = $input->getOption('environments');
+        if (!empty($environments)) {
+            $state['environments'] = $environments;
+        }
+
+        return $state;
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/InstallCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/InstallCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Command\Bundle;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class InstallCommand extends AbstractBundleCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName($this->buildName('install'))
+            ->configureDescriptionAndHelp('Installs a bundle')
+            ->addArgument('bundle', InputArgument::REQUIRED, 'The bundle to install')
+            ->configureFailWithoutErrorOption()
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $bm     = $this->getBundleManager();
+        $bundle = $this->getBundle();
+
+        try {
+            $bm->install($bundle);
+
+            $this->io->success(sprintf('Bundle "%s" was successfully installed', $bundle->getName()));
+        } catch (\Exception $e) {
+            return $this->handlePrerequisiteError($e->getMessage());
+        }
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/ListCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/ListCommand.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Command\Bundle;
+
+use Pimcore\Extension\Bundle\PimcoreBundleInterface;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableCell;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListCommand extends AbstractBundleCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName($this->buildName('list'))
+            ->setDescription('Lists all pimcore bundles and their enabled/installed state')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $table = new Table($output);
+        $table->setHeaders([
+            'Bundle',
+            'Enabled',
+            'Installed',
+            'I?',
+            'UI?',
+            'UP?',
+        ]);
+
+        $bm = $this->getBundleManager();
+        foreach ($bm->getAvailableBundles() as $bundleClass) {
+            $enabled = $bm->isEnabled($bundleClass);
+
+            /** @var PimcoreBundleInterface $bundle */
+            $bundle = null;
+            if ($enabled) {
+                $bundle = $bm->getActiveBundle($bundleClass, false);
+            }
+
+            $row = [
+                $bundleClass
+            ];
+
+            $row[] = $this->formatBool($enabled);
+
+            if ($enabled) {
+                $row[] = $this->formatBool($bm->isInstalled($bundle));
+                $row[] = $this->formatBool($bm->canBeInstalled($bundle));
+                $row[] = $this->formatBool($bm->canBeUninstalled($bundle));
+                $row[] = $this->formatBool($bm->canBeUpdated($bundle));
+            } else {
+                $row[] = $this->formatBool(false);
+                $row[] = $this->formatBool(false);
+                $row[] = $this->formatBool(false);
+                $row[] = $this->formatBool(false);
+            }
+
+            $table->addRow($row);
+        }
+
+        $table->render();
+
+        $this->io->newLine();
+        $this->io->writeln(implode(' ', [
+            'Legend:',
+            '<comment>I?</comment>: Can be installed?',
+            '<comment>UI?</comment>: Can be uninstalled?',
+            '<comment>UP?</comment>: Can be updated?',
+        ]));
+    }
+
+    private function formatBool($state): string
+    {
+        $decorated = $this->io->getOutput()->isDecorated();
+
+        if ($state) {
+            return sprintf(
+                '<fg=green>%s</>',
+                $decorated ? "\xE2\x9C\x94" : 'yes'
+            );
+        } else {
+            return sprintf(
+                '<fg=red>%s</>',
+                $decorated ? "\xE2\x9D\x8C" : 'no'
+            );
+        }
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/ListCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/ListCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableCell;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends AbstractBundleCommand
@@ -31,6 +32,11 @@ class ListCommand extends AbstractBundleCommand
         $this
             ->setName($this->buildName('list'))
             ->setDescription('Lists all pimcore bundles and their enabled/installed state')
+            ->addOption(
+                'fully-qualified-classnames', 'f',
+                InputOption::VALUE_NONE,
+                'Show fully qualified class names instead of short names'
+            )
         ;
     }
 
@@ -56,9 +62,13 @@ class ListCommand extends AbstractBundleCommand
                 $bundle = $bm->getActiveBundle($bundleClass, false);
             }
 
-            $row = [
-                $bundleClass
-            ];
+            $row = [];
+
+            if ($input->getOption('fully-qualified-classnames')) {
+                $row[] = $bundleClass;
+            } else {
+                $row[] = $this->getShortClassName($bundleClass);
+            }
 
             $row[] = $this->formatBool($enabled);
 

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/UninstallCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/UninstallCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Command\Bundle;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UninstallCommand extends AbstractBundleCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName($this->buildName('uninstall'))
+            ->configureDescriptionAndHelp('Uninstalls a bundle')
+            ->addArgument('bundle', InputArgument::REQUIRED, 'The bundle to uninstall')
+            ->configureFailWithoutErrorOption();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $bm     = $this->getBundleManager();
+        $bundle = $this->getBundle();
+
+        try {
+            $bm->uninstall($bundle);
+
+            $this->io->success(sprintf('Bundle "%s" was successfully uninstalled', $bundle->getName()));
+        } catch (\Exception $e) {
+            return $this->handlePrerequisiteError($e->getMessage());
+        }
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/UpdateCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/UpdateCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Command\Bundle;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UpdateCommand extends AbstractBundleCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName($this->buildName('update'))
+            ->configureDescriptionAndHelp('Updates a bundle')
+            ->addArgument('bundle', InputArgument::REQUIRED, 'The bundle to update')
+            ->configureFailWithoutErrorOption();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $bm     = $this->getBundleManager();
+        $bundle = $this->getBundle();
+
+        try {
+            $bm->update($bundle);
+
+            $this->io->success(sprintf('Bundle "%s" was successfully updated', $bundle->getName()));
+        } catch (\Exception $e) {
+            return $this->handlePrerequisiteError($e->getMessage());
+        }
+    }
+}

--- a/pimcore/lib/Pimcore/Extension/Bundle/PimcoreBundleManager.php
+++ b/pimcore/lib/Pimcore/Extension/Bundle/PimcoreBundleManager.php
@@ -211,7 +211,7 @@ class PimcoreBundleManager
     /**
      * Reads bundle state from config
      *
-     * @param $bundle
+     * @param string|PimcoreBundleInterface $bundle
      *
      * @return array
      */
@@ -262,10 +262,15 @@ class PimcoreBundleManager
      * Enables a bundle
      *
      * @param string|PimcoreBundleInterface $bundle
+     * @param array $state Optional additional state config (see StateConfig)
      */
-    public function enable($bundle)
+    public function enable($bundle, array $state = [])
     {
-        $this->setState($bundle, ['enabled' => true]);
+        $state = array_merge($state, [
+            'enabled' => true
+        ]);
+
+        $this->setState($bundle, $state);
     }
 
     /**


### PR DESCRIPTION
As preparation for #1847. Exposes all methods provided by the extension manager as CLI commands. #1847 will implement a return channel from installers to the CLI allowing to output information from your installer to the CLI command.

* `pimcore:bundle:disable`
* `pimcore:bundle:enable`
* `pimcore:bundle:install`
* `pimcore:bundle:list`
* `pimcore:bundle:uninstall`
* `pimcore:bundle:update`