### PR TITLE
[BUNDLES] Support manually registered pimcore bundles

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
@@ -449,19 +449,20 @@ class ExtensionManagerController extends AdminController implements EventedContr
         $state = $bm->getState($bundle);
 
         $info = [
-            'id'            => $bm->getBundleIdentifier($bundle),
-            'type'          => 'bundle',
-            'name'          => !empty($bundle->getNiceName()) ? $bundle->getNiceName() : $bundle->getName(),
-            'description'   => $bundle->getDescription(),
-            'active'        => $enabled,
-            'installable'   => false,
-            'uninstallable' => false,
-            'updateable'    => false,
-            'installed'     => $installed,
-            'configuration' => $this->getIframePath($bundle),
-            'version'       => $bundle->getVersion(),
-            'priority'      => $state['priority'],
-            'environments'  => implode(', ', $state['environments'])
+            'id'             => $bm->getBundleIdentifier($bundle),
+            'type'           => 'bundle',
+            'name'           => !empty($bundle->getNiceName()) ? $bundle->getNiceName() : $bundle->getName(),
+            'description'    => $bundle->getDescription(),
+            'active'         => $enabled,
+            'installable'    => false,
+            'uninstallable'  => false,
+            'updateable'     => false,
+            'installed'      => $installed,
+            'canChangeState' => $bm->canChangeState($bundle),
+            'configuration'  => $this->getIframePath($bundle),
+            'version'        => $bundle->getVersion(),
+            'priority'       => $state['priority'],
+            'environments'   => implode(', ', $state['environments'])
         ];
 
         // only check for installation specifics if the bundle is enabled

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/translations/en.json
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/translations/en.json
@@ -449,6 +449,7 @@
   "next": "Next",
   "please_dont_forget_to_reload_pimcore_after_modifications": "Please don't forget to reload pimcore after your modifications",
   "clear_cache_and_reload": "Clear cache and reload",
+  "extension_manager_state_change_not_allowed": "State changes are not allowed for this extension.",
   "enable": "Enable",
   "disable": "Disable",
   "configure": "Configure",

--- a/pimcore/lib/Pimcore/Extension/Bundle/Config/StateConfig.php
+++ b/pimcore/lib/Pimcore/Extension/Bundle/Config/StateConfig.php
@@ -210,7 +210,7 @@ final class StateConfig
      *
      * @return array
      */
-    private function normalizeOptions($options): array
+    public function normalizeOptions($options): array
     {
         if (is_bool($options)) {
             $options = ['enabled' => $options];

--- a/pimcore/lib/Pimcore/HttpKernel/BundleCollection/AbstractItem.php
+++ b/pimcore/lib/Pimcore/HttpKernel/BundleCollection/AbstractItem.php
@@ -30,13 +30,15 @@ abstract class AbstractItem implements ItemInterface
     private $environments = [];
 
     /**
-     * @param int $priority
-     * @param array $environments
+     * @var string
      */
-    public function __construct(int $priority = 0, array $environments = [])
+    private $source;
+
+    public function __construct(int $priority = 0, array $environments = [], string $source = self::SOURCE_PROGRAMATICALLY)
     {
         $this->priority     = $priority;
         $this->environments = $environments;
+        $this->source       = $source;
     }
 
     public function getPriority(): int
@@ -56,5 +58,10 @@ abstract class AbstractItem implements ItemInterface
         }
 
         return in_array($environment, $this->environments, true);
+    }
+
+    public function getSource(): string
+    {
+        return $this->source;
     }
 }

--- a/pimcore/lib/Pimcore/HttpKernel/BundleCollection/Item.php
+++ b/pimcore/lib/Pimcore/HttpKernel/BundleCollection/Item.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\HttpKernel\BundleCollection;
 
+use Pimcore\Extension\Bundle\PimcoreBundleInterface;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 class Item extends AbstractItem
@@ -26,16 +27,16 @@ class Item extends AbstractItem
      */
     private $bundle;
 
-    /**
-     * @param BundleInterface $bundle
-     * @param int $priority
-     * @param array $environments
-     */
-    public function __construct(BundleInterface $bundle, int $priority = 0, array $environments = [])
+    public function __construct(
+        BundleInterface $bundle,
+        int $priority = 0,
+        array $environments = [],
+        string $source = self::SOURCE_PROGRAMATICALLY
+    )
     {
         $this->bundle = $bundle;
 
-        parent::__construct($priority, $environments);
+        parent::__construct($priority, $environments, $source);
     }
 
     public function getBundleIdentifier(): string
@@ -46,5 +47,10 @@ class Item extends AbstractItem
     public function getBundle(): BundleInterface
     {
         return $this->bundle;
+    }
+
+    public function isPimcoreBundle(): bool
+    {
+        return $this->bundle instanceof PimcoreBundleInterface;
     }
 }

--- a/pimcore/lib/Pimcore/HttpKernel/BundleCollection/ItemInterface.php
+++ b/pimcore/lib/Pimcore/HttpKernel/BundleCollection/ItemInterface.php
@@ -21,13 +21,20 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 interface ItemInterface
 {
+    const SOURCE_PROGRAMATICALLY          = 'programatically';
+    const SOURCE_EXTENSION_MANAGER_CONFIG = 'extension_manager_config';
+
     public function getBundleIdentifier(): string;
 
     public function getBundle(): BundleInterface;
+
+    public function isPimcoreBundle(): bool;
 
     public function getPriority(): int;
 
     public function getEnvironments(): array;
 
     public function matchesEnvironment(string $environment): bool;
+
+    public function getSource(): string;
 }

--- a/pimcore/lib/Pimcore/Kernel.php
+++ b/pimcore/lib/Pimcore/Kernel.php
@@ -23,6 +23,7 @@ use Pimcore\Config\BundleConfigLocator;
 use Pimcore\Event\SystemEvents;
 use Pimcore\Extension\Bundle\Config\StateConfig;
 use Pimcore\HttpKernel\BundleCollection\BundleCollection;
+use Pimcore\HttpKernel\BundleCollection\ItemInterface;
 use Pimcore\HttpKernel\BundleCollection\LazyLoadedItem;
 use Pimcore\HttpKernel\Config\SystemConfigParamResource;
 use Sensio\Bundle\DistributionBundle\SensioDistributionBundle;
@@ -228,7 +229,12 @@ abstract class Kernel extends SymfonyKernel
             }
 
             // use lazy loaded item to instantiate the bundle only if environment matches
-            $collection->add(new LazyLoadedItem($className, $options['priority'], $options['environments']));
+            $collection->add(new LazyLoadedItem(
+                $className,
+                $options['priority'],
+                $options['environments'],
+                ItemInterface::SOURCE_EXTENSION_MANAGER_CONFIG
+            ));
         }
     }
 

--- a/pimcore/lib/Pimcore/Kernel.php
+++ b/pimcore/lib/Pimcore/Kernel.php
@@ -144,11 +144,11 @@ abstract class Kernel extends SymfonyKernel
         // core bundles (Symfony, Pimcore)
         $this->registerCoreBundlesToCollection($collection);
 
-        // bundles registered in extensions.php
-        $this->registerExtensionManagerBundles($collection);
-
         // custom bundles
         $this->registerBundlesToCollection($collection);
+
+        // bundles registered in extensions.php
+        $this->registerExtensionManagerBundles($collection);
 
         $bundles = $collection->getBundles($this->getEnvironment());
 
@@ -219,6 +219,11 @@ abstract class Kernel extends SymfonyKernel
 
         foreach ($stateConfig->getEnabledBundles() as $className => $options) {
             if (!class_exists($className)) {
+                continue;
+            }
+
+            // do not register bundles twice - skip if it was already loaded manually
+            if ($collection->hasItem($className)) {
                 continue;
             }
 

--- a/pimcore/lib/Pimcore/Kernel.php
+++ b/pimcore/lib/Pimcore/Kernel.php
@@ -50,6 +50,11 @@ abstract class Kernel extends SymfonyKernel
     protected $extensionConfig;
 
     /**
+     * @var BundleCollection
+     */
+    private $bundleCollection;
+
+    /**
      * {@inheritdoc}
      */
     public function getRootDir()
@@ -153,7 +158,19 @@ abstract class Kernel extends SymfonyKernel
 
         $bundles = $collection->getBundles($this->getEnvironment());
 
+        $this->bundleCollection = $collection;
+
         return $bundles;
+    }
+
+    /**
+     * Returns the bundle collection which was used to build the set of used bundles
+     *
+     * @return BundleCollection
+     */
+    public function getBundleCollection(): BundleCollection
+    {
+        return $this->bundleCollection;
     }
 
     /**

--- a/pimcore/tests/unit/HttpKernel/BundleCollection/BundleCollectionTest.php
+++ b/pimcore/tests/unit/HttpKernel/BundleCollection/BundleCollectionTest.php
@@ -78,6 +78,43 @@ class BundleCollectionTest extends TestCase
         $this->assertEquals($this->bundles, $this->collection->getBundles('prod'));
     }
 
+    public function testHasItem()
+    {
+        foreach ($this->bundles as $bundle) {
+            $item = new Item($bundle);
+
+            $this->assertFalse($this->collection->hasItem($item->getBundleIdentifier()));
+            $this->collection->add($item);
+            $this->assertTrue($this->collection->hasItem($item->getBundleIdentifier()));
+        }
+    }
+
+    public function testGetItems()
+    {
+        $items = [];
+        foreach ($this->bundles as $bundle) {
+            $item = new Item($bundle);
+            $items[] = $item;
+
+            $this->collection->add($item);
+        }
+
+        $this->assertEquals($items, $this->collection->getItems());
+    }
+
+    public function testGetIdentifiers()
+    {
+        $identifiers = [];
+        foreach ($this->bundles as $bundle) {
+            $item = new Item($bundle);
+            $identifiers[] = $item->getBundleIdentifier();
+
+            $this->collection->add($item);
+        }
+
+        $this->assertEquals($identifiers, $this->collection->getIdentifiers());
+    }
+
     /**
      * @expectedException \LogicException
      * @expectedExceptionMessage Trying to register the bundle "Pimcore\Tests\Unit\HttpKernel\BundleCollection\BundleA" multiple times

--- a/pimcore/tests/unit/HttpKernel/BundleCollection/BundleCollectionTest.php
+++ b/pimcore/tests/unit/HttpKernel/BundleCollection/BundleCollectionTest.php
@@ -89,6 +89,28 @@ class BundleCollectionTest extends TestCase
         }
     }
 
+    public function testGetItem()
+    {
+        foreach ($this->bundles as $bundle) {
+            $item = new Item($bundle);
+
+            $this->collection->add($item);
+            $this->assertEquals($item, $this->collection->getItem($item->getBundleIdentifier()));
+        }
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Bundle "Pimcore\Tests\Unit\HttpKernel\BundleCollection\BundleA" is not registered
+     */
+    public function testGetItemThrowsException()
+    {
+        $item = new Item($this->bundles[0]);
+
+        $this->assertFalse($this->collection->hasItem($item->getBundleIdentifier()));
+        $this->collection->getItem($item->getBundleIdentifier());
+    }
+
     public function testGetItems()
     {
         $items = [];

--- a/pimcore/tests/unit/HttpKernel/BundleCollection/ItemTest.php
+++ b/pimcore/tests/unit/HttpKernel/BundleCollection/ItemTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Unit\HttpKernel\BundleCollection;
 
+use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
 use Pimcore\HttpKernel\BundleCollection\Item;
 use Pimcore\Tests\Test\TestCase;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -25,22 +26,22 @@ class ItemTest extends TestCase
 {
     public function testGetBundle()
     {
-        $bundle = new ItemTestBundle();
-        $item   = new Item(new ItemTestBundle());
+        $bundle = new ItemTestBundleA();
+        $item   = new Item(new ItemTestBundleA());
 
         $this->assertEquals($bundle, $item->getBundle());
     }
 
     public function testGetBundleIdentifier()
     {
-        $item = new Item(new ItemTestBundle());
+        $item = new Item(new ItemTestBundleA());
 
-        $this->assertEquals(ItemTestBundle::class, $item->getBundleIdentifier());
+        $this->assertEquals(ItemTestBundleA::class, $item->getBundleIdentifier());
     }
 
     public function testEmptyEnvironmentsMatchesAnyEnvironment()
     {
-        $item = new Item(new ItemTestBundle(), 0, []);
+        $item = new Item(new ItemTestBundleA(), 0, []);
         foreach (['prod', 'dev', 'test'] as $environment) {
             $this->assertTrue($item->matchesEnvironment($environment));
         }
@@ -48,7 +49,7 @@ class ItemTest extends TestCase
 
     public function testItemMatchesEnvironment()
     {
-        $item = new Item(new ItemTestBundle(), 0, ['dev']);
+        $item = new Item(new ItemTestBundleA(), 0, ['dev']);
 
         $this->assertTrue($item->matchesEnvironment('dev'));
         $this->assertFalse($item->matchesEnvironment('prod'));
@@ -57,14 +58,27 @@ class ItemTest extends TestCase
 
     public function testItemWithMultipleEnvironments()
     {
-        $item = new Item(new ItemTestBundle(), 0, ['dev', 'test']);
+        $item = new Item(new ItemTestBundleA(), 0, ['dev', 'test']);
 
         $this->assertTrue($item->matchesEnvironment('dev'));
         $this->assertTrue($item->matchesEnvironment('test'));
         $this->assertFalse($item->matchesEnvironment('prod'));
     }
+
+    public function testIsPimcoreBundle()
+    {
+        $itemA = new Item(new ItemTestBundleA());
+        $itemB = new Item(new ItemTestBundleB());
+
+        $this->assertFalse($itemA->isPimcoreBundle());
+        $this->assertTrue($itemB->isPimcoreBundle());
+    }
 }
 
-class ItemTestBundle extends Bundle
+class ItemTestBundleA extends Bundle
+{
+}
+
+class ItemTestBundleB extends AbstractPimcoreBundle
 {
 }


### PR DESCRIPTION
Resolves #1750

* Bundles from `addBundlesToCollection` are registered first
* Extension manager bundles will be loaded after the ones which are manually registered and will only be added if the bundle is not already registered. This allows to safely enable a bundle manually without running into duplicate bundle errors.
* The bundle collection is kept on the kernel and is used by the extension manager to distinguish manually added bundles from configured ones
* Manually added bundles can be installed/uninstalled and updated but not enabled/disabled and can't change priority or environments