### PR TITLE
[PIMCORE5] Expose website settings in controllers and views

### DIFF
--- a/doc/Development_Documentation/18_Tools_and_Features/27_Website_Settings.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/27_Website_Settings.md
@@ -3,7 +3,8 @@
 The `Website Settings` give you the possibility to configure website-specific settings, which you can 
 access in every controller and view.
 
-Examples
+Examples:
+
 * ReCAPTCHA public & private key
 * Locale settings
 * Google Maps API key
@@ -11,38 +12,74 @@ Examples
 * ....
 
 ### Access the Settings
-You can access the settings in every controller and view with `$this->config`. This variable contains 
-a `Zend_Config` object containing your settings.
 
-If you're not in a view or controller you can use `Pimcore\Tool\Frontend::getWebsiteConfig();` to 
-retrieve the configuration.
+In controllers and views, you can use view helpers or argument resolves to access the config. If you're not in a view or
+controller you can use `Pimcore\Tool\Frontend::getWebsiteConfig();` to retrieve the configuration.
+
+The returned configuration is a `Pimcore\Config\Config` object containing your settings.
 
 
 ### Example Configuration
 ![Website Setting Config](../img/website-settings.png)
 
-### Example in a View
+### Example in a PHP template
+
 ```php 
-<script type="text/javascript" src="http://www.google.com/jsapi?autoload=%7B%22modules%22%3A%5B%7B%22name%22%3A%22maps%22%2C%22version%22%3A%222%22%7D%5D%7D&amp;key=<?= $this->config->googleMapsKey ?>"></script>
+<?php
+// access the whole configuration
+$this->websiteConfig();
+
+// or only a single value
+$this->websiteConfig('googleMapsKey');
+
+// you can pass a default value in case the value is not configured
+$this->websiteConfig('googleMapsKey', 'NOT SET');
+?>
+```
+
+### Example in a Twig template
+
+```twig
+{# access the whole configuration #}
+{{ pimcore_website_config() }}
+
+{# or only a single value #}
+{{ pimcore_website_config('googleMapsKey') }}
+
+{# you can pass a default value in case the value is not configured #}
+{{ pimcore_website_config('googleMapsKey', 'NOT SET') }}
 ```
 
 ### Example in a Controller
+
 ```php
-public function testAction () {
-    $recaptchaKeyPublic = $this->config->recaptchaPublic;
+<?php
+class TestController
+{
+    public function testAction(\Pimcore\Config\Config $websiteConfig)
+    {
+        $recaptchaKeyPublic = $websiteConfig->get('recaptchaPublic');
+    }    
 }
 ```
 
 ### Manipulate the values in a Controller
+
 If you want to change the value of a website setting from your PHP script, for example from a controller, you can use this code.
+
 ```php
-public function testAction () {
-    $somesetting = \Pimcore\Model\WebsiteSetting::getByName('somenumber');
-    $currentnumber = $somesetting->getData();
-    //Now do something with the data or set new data
-    //Count up in this case
-    $newnumber = $currentnumber + 1;
-    $somesetting->setData($newnumber);
-    $somesetting->save();
+<?php
+class TestController
+{
+    public function testAction()
+    {
+        $somesetting = \Pimcore\Model\WebsiteSetting::getByName('somenumber');
+        $currentnumber = $somesetting->getData();
+        //Now do something with the data or set new data
+        //Count up in this case
+        $newnumber = $currentnumber + 1;
+        $somesetting->setData($newnumber);
+        $somesetting->save();
+    }
 }
 ```

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
@@ -254,6 +254,11 @@ services:
         tags:
             - { name: controller.argument_value_resolver }
 
+    Pimcore\Controller\ArgumentValueResolver\WebsiteConfigValueResolver:
+        public: false
+        tags:
+            - { name: controller.argument_value_resolver }
+
     #
     # EXTENSIONS
     #

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating_php.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating_php.yml
@@ -156,3 +156,6 @@ services:
       tags:
           - { name: templating.helper, alias: navigation }
 
+    Pimcore\Templating\Helper\WebsiteConfig:
+        tags:
+            - { name: templating.helper, alias: websiteConfig }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating_twig.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating_twig.yml
@@ -51,6 +51,11 @@ services:
         tags:
             - { name: twig.extension }
 
+    Pimcore\Twig\Extension\WebsiteConfigExtension:
+        public: false
+        tags:
+            - { name: twig.extension }
+
     # the deferred extension is needed for placeholder helpers to work
     # as otherwise the placeholder block would be rendered before any
     # content was added (e.g. headTitle)

--- a/pimcore/lib/Pimcore/Config.php
+++ b/pimcore/lib/Pimcore/Config.php
@@ -226,6 +226,24 @@ class Config
     }
 
     /**
+     * Returns whole website config or only a given setting for the current site
+     *
+     * @param null|mixed $key       Config key to directly load. If null, the whole config will be returned
+     * @param null|mixed $default   Default value to use if the key is not set
+     *
+     * @return Config\Config|mixed
+     */
+    public static function getWebsiteConfigValue($key = null, $default = null)
+    {
+        $config = self::getWebsiteConfig();
+        if (null !== $key) {
+            return $config->get($key, $default);
+        }
+
+        return $config;
+    }
+
+    /**
      * @static
      *
      * @return \Pimcore\Config\Config

--- a/pimcore/lib/Pimcore/Controller/ArgumentValueResolver/WebsiteConfigValueResolver.php
+++ b/pimcore/lib/Pimcore/Controller/ArgumentValueResolver/WebsiteConfigValueResolver.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Controller\ArgumentValueResolver;
+
+use Pimcore\Config;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+class WebsiteConfigValueResolver implements ArgumentValueResolverInterface
+{
+    public function supports(Request $request, ArgumentMetadata $argument)
+    {
+        return $argument->getType() === Config\Config::class && $argument->getName() === 'websiteConfig';
+    }
+
+    public function resolve(Request $request, ArgumentMetadata $argument)
+    {
+        yield Config::getWebsiteConfig();
+    }
+}

--- a/pimcore/lib/Pimcore/Templating/Helper/WebsiteConfig.php
+++ b/pimcore/lib/Pimcore/Templating/Helper/WebsiteConfig.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Templating\Helper;
+
+use Pimcore\Config;
+use Symfony\Component\Templating\Helper\Helper;
+
+class WebsiteConfig extends Helper
+{
+    public function getName()
+    {
+        return 'websiteConfig';
+    }
+
+    public function __invoke($key = null, $default = null)
+    {
+        return Config::getWebsiteConfigValue($key, $default);
+    }
+}

--- a/pimcore/lib/Pimcore/Templating/PhpEngine.php
+++ b/pimcore/lib/Pimcore/Templating/PhpEngine.php
@@ -14,6 +14,7 @@
 
 namespace Pimcore\Templating;
 
+use Pimcore\Config\Config;
 use Pimcore\Model\Document;
 use Pimcore\Model\Document\Tag;
 use Pimcore\Templating\Helper\Cache;
@@ -90,6 +91,7 @@ use Symfony\Component\Templating\Storage\Storage;
  * @method string inc($include, array $params = [], $cacheEnabled = true, $editmode = null)
  * @method InlineScript inlineScript($mode = HeadScript::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
  * @method Navigation navigation()
+ * @method Config|mixed websiteConfig($key = null, $default = null)
  * @method string pimcoreUrl(array $urlOptions = [], $name = null, $reset = false, $encode = true, $relative = false)
  * @method string translate($key, $parameters = [], $domain = null, $locale = null)
  *

--- a/pimcore/lib/Pimcore/Twig/Extension/WebsiteConfigExtension.php
+++ b/pimcore/lib/Pimcore/Twig/Extension/WebsiteConfigExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Twig\Extension;
+
+use Pimcore\Config;
+
+class WebsiteConfigExtension extends \Twig_Extension
+{
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction('pimcore_website_config', [$this, 'getWebsiteConfig']),
+        ];
+    }
+
+    /**
+     * Returns website config for the current site
+     *
+     * @param null|mixed $key       Config key to directly load. If null, the whole config will be returned
+     * @param null|mixed $default   Default value to use if the key is not set
+     *
+     * @return Config\Config|mixed
+     */
+    public function getWebsiteConfig($key = null, $default = null)
+    {
+        return Config::getWebsiteConfigValue($key, $default);
+    }
+}


### PR DESCRIPTION
* PHP templating view helper `$this->websiteConfig()` or `$this->websiteConfig('foobar')`
* Twig helper `{{ pimcore_website_config() }}` or `{{ pimcore_website_config('foobar') }}`
* Argument resolver `fooAction(\Pimcore\Config\Config $websiteConfig) {}`

Resolves #1835 