### PR TITLE
convert invalid menu id prefix backslash to dash.

### DIFF
--- a/pimcore/lib/Pimcore/Navigation/Renderer/AbstractRenderer.php
+++ b/pimcore/lib/Pimcore/Navigation/Renderer/AbstractRenderer.php
@@ -203,9 +203,9 @@ abstract class AbstractRenderer implements RendererInterface
     {
         if (null === $this->_prefixForId) {
             $prefix             = get_class($this);
-            $this->_prefixForId = strtolower(
+            $this->_prefixForId = str_replace('\\', '-', strtolower(
                     trim(substr($prefix, strrpos($prefix, '_')), '_')
-                ) . '-';
+                )) . '-';
         }
 
         return $this->_prefixForId;


### PR DESCRIPTION
instead of `<a id="pimcore\navigation\renderer\menu-23">` => `<a id="pimcore-navigation-renderer-menu-23">`

