### PR TITLE
[AdminBundle] better handling of Object and Object\Folder not found

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ObjectController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ObjectController.php
@@ -313,7 +313,7 @@ class ObjectController extends ElementControllerBase implements EventedControlle
 
         $object = Object::getById(intval($request->get('id')));
 
-        if ($object instanceof Object) {
+        if (!$object instanceof Object) {
             return $this->json([
                 'success' => false,
                 'message' => 'element_not_found'

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ObjectController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ObjectController.php
@@ -312,6 +312,14 @@ class ObjectController extends ElementControllerBase implements EventedControlle
         Element\Editlock::lock($request->get('id'), 'object');
 
         $object = Object::getById(intval($request->get('id')));
+
+        if ($object instanceof Object) {
+            return $this->json([
+                'success' => false,
+                'message' => 'element_not_found'
+            ]);
+        }
+
         $object = clone $object;
 
         // set the latest available version for editmode
@@ -717,6 +725,14 @@ class ObjectController extends ElementControllerBase implements EventedControlle
         Element\Editlock::lock($request->get('id'), 'object');
 
         $object = Object::getById(intval($request->get('id')));
+
+        if (!$object instanceof Object\Folder) {
+            return $this->json([
+                'success' => false,
+                'message' => 'element_not_found'
+            ]);
+        }
+
         if ($object->isAllowed('view')) {
             $objectData = [];
 

--- a/web/pimcore/static6/js/pimcore/object/folder.js
+++ b/web/pimcore/static6/js/pimcore/object/folder.js
@@ -61,6 +61,12 @@ pimcore.object.folder = Class.create(pimcore.object.abstract, {
                 throw "object is locked";
             }
 
+            if (this.data.hasOwnProperty('success') && !this.data.success) {
+                Ext.MessageBox.alert(t(this.data.message), t(this.data.message));
+
+                throw this.data.message;
+            }
+
             this.init();
             this.addTab();
             this.startChangeDetector();

--- a/web/pimcore/static6/js/pimcore/object/object.js
+++ b/web/pimcore/static6/js/pimcore/object/object.js
@@ -73,6 +73,12 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                 throw "object is locked";
             }
 
+            if (this.data.hasOwnProperty('success') && !this.data.success) {
+                Ext.MessageBox.alert(t(this.data.message), t(this.data.message));
+
+                throw this.data.message;
+            }
+
             this.addTab();
 
             this.startChangeDetector();


### PR DESCRIPTION
This PR adds some better handling for Objects and Object\Folders which don't exist anymore. Actually, for Folders this should never happen, but since Objects are remembered in local storage, this causes an exception very often. Therefore I created this PR to solve this issue. It checks instanceof Object (or Folder), if good, same behaviour as before, if not: Respond with success: false and a translateable message to the client "element_not_found". The client checks for the success-property and shows a message-box if not found. Cause of this behaviour, the remembered tab gets removed as well.