### PR TITLE
Skip the copy step if the target path already exists.

### DIFF
--- a/pimcore/lib/Pimcore/Install/Installer.php
+++ b/pimcore/lib/Pimcore/Install/Installer.php
@@ -256,6 +256,9 @@ class Installer
                         ]);
 
                         $fs->remove($target);
+                    } else {
+                        $this->logger->info('Skipping ' . $logAction . ' {source} to {target}. The target path already exists.');
+                        continue;
                     }
                 }
 


### PR DESCRIPTION
In our deployment process the installation overwrites existing files although we are using the no-overwrite option.

This is the scenario:
* we check out our code
* we run the deployment script
* deployment script downloads the setup files (they now have newer timestamp)
* the copy process will overwrite all older existing files - it won't preserve the existing files since they have older timestamp

This fix will stop the copy process for the whole folder, but I guess this should be fine. Otherwise we should maybe replace the Symfony's copy/mirror function with something else that doesn't overwrite existing files. 