### PR TITLE
Improve classes-rebuild command

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/ClassesRebuildCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/ClassesRebuildCommand.php
@@ -96,7 +96,7 @@ class ClassesRebuildCommand extends AbstractCommand
                 $output->writeln($brickDefinition->getKey() . ' saved');
             }
 
-            $brickDefinition->save();
+            $brickDefinition->save(false);
         }
 
         if ($output->isVerbose()) {
@@ -110,7 +110,7 @@ class ClassesRebuildCommand extends AbstractCommand
                 $output->writeln($fc->getKey() . ' saved');
             }
 
-            $fc->save();
+            $fc->save(false);
         }
     }
 }

--- a/pimcore/models/DataObject/Fieldcollection/Definition.php
+++ b/pimcore/models/DataObject/Fieldcollection/Definition.php
@@ -247,7 +247,7 @@ class Definition extends Model\AbstractModel
     /**
      * @throws \Exception
      */
-    public function save()
+    public function save($saveDefinitionFile = true)
     {
         if (!$this->getKey()) {
             throw new \Exception('A field-collection needs a key to be saved!');
@@ -261,16 +261,18 @@ class Definition extends Model\AbstractModel
         $clone->setDao(null);
         unset($clone->fieldDefinitions);
 
-        $exportedClass = var_export($clone, true);
+        if ($saveDefinitionFile) {
+            $exportedClass = var_export($clone, true);
 
-        $data = '<?php ';
-        $data .= "\n\n";
-        $data .= $infoDocBlock;
-        $data .= "\n\n";
+            $data = '<?php ';
+            $data .= "\n\n";
+            $data .= $infoDocBlock;
+            $data .= "\n\n";
 
-        $data .= "\nreturn " . $exportedClass . ";\n";
+            $data .= "\nreturn " . $exportedClass . ";\n";
 
-        \Pimcore\File::put($definitionFile, $data);
+            \Pimcore\File::put($definitionFile, $data);
+        }
 
         $extendClass = 'DataObject\\Fieldcollection\\Data\\AbstractData';
         if ($this->getParentClass()) {

--- a/pimcore/models/DataObject/Objectbrick/Definition.php
+++ b/pimcore/models/DataObject/Objectbrick/Definition.php
@@ -97,7 +97,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
     /**
      * @throws \Exception
      */
-    public function save()
+    public function save($saveDefinitionFile = true)
     {
         if (!$this->getKey()) {
             throw new \Exception('A object-brick needs a key to be saved!');
@@ -127,16 +127,18 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
         unset($clone->oldClassDefinitions);
         unset($clone->fieldDefinitions);
 
-        $exportedClass = var_export($clone, true);
+        if ($saveDefinitionFile) {
+            $exportedClass = var_export($clone, true);
 
-        $data = '<?php ';
-        $data .= "\n\n";
-        $data .= $infoDocBlock;
-        $data .= "\n\n";
+            $data = '<?php ';
+            $data .= "\n\n";
+            $data .= $infoDocBlock;
+            $data .= "\n\n";
 
-        $data .= "\nreturn " . $exportedClass . ";\n";
+            $data .= "\nreturn " . $exportedClass . ";\n";
 
-        \Pimcore\File::put($definitionFile, $data);
+            \Pimcore\File::put($definitionFile, $data);
+        }
 
         $extendClass = 'DataObject\\Objectbrick\\Data\\AbstractData';
         if ($this->getParentClass()) {


### PR DESCRIPTION
Do not dump definition file for object bricks and field collections when
running bin/console classes-rebuild, mimic what is done for classes
