### PR TITLE
[Twig] add pimcore_site function

### DIFF
--- a/pimcore/lib/Pimcore/Twig/Extension/PimcoreObjectExtension.php
+++ b/pimcore/lib/Pimcore/Twig/Extension/PimcoreObjectExtension.php
@@ -20,6 +20,7 @@ namespace Pimcore\Twig\Extension;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Document;
+use Pimcore\Model\Site;
 
 class PimcoreObjectExtension extends \Twig_Extension
 {
@@ -28,6 +29,7 @@ class PimcoreObjectExtension extends \Twig_Extension
         // simple object access functions in case documents/assets/objects need to be loaded directly in the template
         return [
             new \Twig_Function('pimcore_document', [Document::class, 'getById']),
+            new \Twig_Function('pimcore_site', [Site::class, 'getById']),
             new \Twig_Function('pimcore_asset', [Asset::class, 'getById']),
             new \Twig_Function('pimcore_object', [DataObject\AbstractObject::class, 'getById']),
             new \Twig_Function('pimcore_document_wrap_hardlink', [Document\Hardlink\Service::class, 'wrap']),


### PR DESCRIPTION
Kinda messed up the merge for PR #1878, so here is a new one.

In Multi-Site context, its often necessary to get the site to get its root-document and for example include snippets from its root document.