### PR TITLE
Remove composer platform restriction to PHP 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,6 @@
     "docs": "https://www.pimcore.org/wiki/"
   },
   "config": {
-    "platform": {
-      "php": "7.0"
-    },
     "optimize-autoloader": true,
     "sort-packages": true
   },
@@ -71,7 +68,7 @@
     "composer/ca-bundle": "^1",
     "debril/rss-atom-bundle": "^3.0",
     "defuse/php-encryption": "~2",
-    "doctrine/doctrine-bundle": "1.6.*",
+    "doctrine/doctrine-bundle": "^1.6",
     "doctrine/doctrine-migrations-bundle": "^1.2",
     "egulias/email-validator": "*",
     "endroid/qrcode": "~1.5",


### PR DESCRIPTION
Restricting to a specific PHP platform will make updates to libraries specifying a certain minimum
PHP 7 version impossible. E.g. Symfony 3.3.8 requires PHP 7.0.8 which doesn't match with
PHP set to 7.0.