### PR TITLE
[TEMPLATING] Set PHP engine when building a TemplatingEngineAwareHelper

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Compiler/TemplatingEngineAwareHelperPass.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Compiler/TemplatingEngineAwareHelperPass.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Pimcore\Templating\Helper\TemplatingEngineAwareHelperInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Adds a call to set the PHP templating engine to all helpers implementing TemplatingEngineAwareHelperInterface
+ */
+class TemplatingEngineAwareHelperPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->findTaggedServiceIds('templating.helper') as $id => $tags) {
+            $definition = $container->getDefinition($id);
+
+            $reflector = new \ReflectionClass($definition->getClass());
+            if ($reflector->implementsInterface(TemplatingEngineAwareHelperInterface::class)) {
+                $definition->addMethodCall('setTemplatingEngine', [new Reference('pimcore.templating.engine.php')]);
+            }
+        }
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/PimcoreCoreBundle.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/PimcoreCoreBundle.php
@@ -24,6 +24,7 @@ use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\PimcoreGlobalTemplati
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\ServiceControllersPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\SessionConfiguratorPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\TemplateVarsProviderPass;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\TemplatingEngineAwareHelperPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\WebDebugToolbarListenerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
@@ -63,6 +64,7 @@ class PimcoreCoreBundle extends Bundle
         $container->addCompilerPass(new NavigationRendererPass());
         $container->addCompilerPass(new CacheCollectorPass());
         $container->addCompilerPass(new PimcoreGlobalTemplatingVariablesPass());
+        $container->addCompilerPass(new TemplatingEngineAwareHelperPass());
         $container->addCompilerPass(new TemplateVarsProviderPass());
         $container->addCompilerPass(new ServiceControllersPass());
         $container->addCompilerPass(new SessionConfiguratorPass());

--- a/pimcore/lib/Pimcore/Templating/Helper/Traits/TemplatingEngineAwareHelperTrait.php
+++ b/pimcore/lib/Pimcore/Templating/Helper/Traits/TemplatingEngineAwareHelperTrait.php
@@ -29,5 +29,7 @@ trait TemplatingEngineAwareHelperTrait
     public function setTemplatingEngine(PhpEngine $engine)
     {
         $this->templatingEngine = $engine;
+
+        $this->setCharset($engine->getCharset());
     }
 }

--- a/pimcore/lib/Pimcore/Templating/PhpEngine.php
+++ b/pimcore/lib/Pimcore/Templating/PhpEngine.php
@@ -145,19 +145,6 @@ class PhpEngine extends BasePhpEngine
     }
 
     /**
-     * @inheritDoc
-     */
-    public function get($name)
-    {
-        $helper = parent::get($name);
-        if ($helper instanceof TemplatingEngineAwareHelperInterface) {
-            $helper->setTemplatingEngine($this);
-        }
-
-        return $helper;
-    }
-
-    /**
      * In addition to the core method, this keeps parameters in a ViewModel instance which is accessible from
      * view helpers and via $this->$variable.
      *


### PR DESCRIPTION
Currently a view helper implementing `TemplatingEngineAwareHelper` needs to be fetched through the PHP engine as the setter is called by the engine after loading the helper. This shifts the call to a compiler pass setting the engine as soon as the helper is built.