### PR TITLE
Update 11_Event_API_and_Event_Manager.md

### DIFF
--- a/doc/Development_Documentation/20_Extending_Pimcore/11_Event_API_and_Event_Manager.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/11_Event_API_and_Event_Manager.md
@@ -48,7 +48,7 @@ services:
         tags:
             - { name: kernel.event_listener, event: pimcore.asset.preUpdate, method: onPreUpdate }
             - { name: kernel.event_listener, event: pimcore.document.preUpdate, method: onPreUpdate }
-            - { name: kernel.event_listener, event: pimcore.object.preUpdate, method: onPreUpdate }
+            - { name: kernel.event_listener, event: pimcore.dataobject.preUpdate, method: onPreUpdate }
 ```
 
 in your listener class `src/AppBundle/EventListener/TestListener`


### PR DESCRIPTION
Since Commit: 57044e5 it has to be 
- { name: kernel.event_listener, event: pimcore.dataobject.preUpdate, method: onPreUpdate }
instead of
- { name: kernel.event_listener, event: pimcore.object.preUpdate, method: onPreUpdate }