### PR TITLE
Change navigation helper to use a renderer locator instead of the whole container

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Compiler/NavigationRendererPass.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Compiler/NavigationRendererPass.php
@@ -20,6 +20,7 @@ namespace Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Adds tagged navigation renderers to navigation helper
@@ -48,15 +49,11 @@ class NavigationRendererPass implements CompilerPassInterface
                     ));
                 }
 
-                $map[$alias] = $id;
+                $map[$alias] = new Reference($id);
             }
         }
 
-        if (count($map) === 0) {
-            return;
-        }
-
-        $helperDefinition = $container->findDefinition('pimcore.templating.view_helper.navigation');
-        $helperDefinition->setArgument('$rendererMap', $map);
+        $locatorDefinition = $container->findDefinition('pimcore.templating.navigation.renderer_locator');
+        $locatorDefinition->setArgument(0, $map);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating.yml
@@ -18,6 +18,12 @@ services:
 
     # NAVIGATION
 
+    # renderer locator collecting all registered renderers
+    pimcore.templating.navigation.renderer_locator:
+        class: Symfony\Component\DependencyInjection\ServiceLocator
+        tags: ['container.service_locator']
+        arguments: [[]]
+
     pimcore.navigation.builder:
         class: Pimcore\Navigation\Builder
         arguments: ['@pimcore.http.request_helper']

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating_php.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating_php.yml
@@ -151,7 +151,7 @@ services:
 
     pimcore.templating.view_helper.navigation:
       class: Pimcore\Templating\Helper\Navigation
-      arguments: ['@service_container', '@pimcore.navigation.builder', '@?']
+      arguments: ['@pimcore.navigation.builder', '@pimcore.templating.navigation.renderer_locator']
       lazy: true
       tags:
           - { name: templating.helper, alias: navigation }

--- a/pimcore/lib/Pimcore/Templating/Helper/Navigation.php
+++ b/pimcore/lib/Pimcore/Templating/Helper/Navigation.php
@@ -36,35 +36,23 @@ use Symfony\Component\Templating\Helper\Helper;
 class Navigation extends Helper
 {
     /**
-     * @var ContainerInterface
-     */
-    private $container;
-
-    /**
      * @var Builder
      */
     private $builder;
 
     /**
-     * @var array
+     * @var ContainerInterface
      */
-    private $rendererMap;
+    private $rendererLocator;
 
     /**
-     * @var RendererInterface[]
-     */
-    private $renderers = [];
-
-    /**
-     * @param ContainerInterface $container
      * @param Builder $builder
-     * @param array $rendererMap    Map with alias => id mapping for registered renderers
+     * @param ContainerInterface $rendererLocator
      */
-    public function __construct(ContainerInterface $container, Builder $builder, array $rendererMap)
+    public function __construct(Builder $builder, ContainerInterface $rendererLocator)
     {
-        $this->container   = $container;
-        $this->builder     = $builder;
-        $this->rendererMap = $rendererMap;
+        $this->builder         = $builder;
+        $this->rendererLocator = $rendererLocator;
     }
 
     /**
@@ -111,23 +99,17 @@ class Navigation extends Helper
      */
     public function getRenderer(string $alias): RendererInterface
     {
-        if (isset($this->renderers[$alias])) {
-            return $this->renderers[$alias];
-        }
-
-        if (isset($this->rendererMap[$alias])) {
-            $renderer = $this->container->get($this->rendererMap[$alias]);
-
-            if (!$renderer instanceof RendererInterface) {
-                throw InvalidRendererException::create($alias, $renderer);
-            }
-
-            $this->renderers[$alias] = $renderer;
-
-            return $renderer;
-        } else {
+        if (!$this->rendererLocator->has($alias)) {
             throw RendererNotFoundException::create($alias);
         }
+
+        $renderer = $this->rendererLocator->get($alias);
+
+        if (!$renderer instanceof RendererInterface) {
+            throw InvalidRendererException::create($alias, $renderer);
+        }
+
+        return $renderer;
     }
 
     /**


### PR DESCRIPTION
Preparation for #1629. Use a renderer locator to lazy load renderers.