### PR TITLE
[Installer] improve installer when using deployer

### DIFF
--- a/pimcore/models/Tool/Setup.php
+++ b/pimcore/models/Tool/Setup.php
@@ -48,7 +48,13 @@ class Setup extends Model\AbstractModel
             }
 
             try {
-                $configTemplate = new \Pimcore\Config\Config(include($configTemplatePath));
+                $configTemplateArray = include($configTemplatePath);
+
+                if (!is_array($configTemplateArray)) {
+                    continue;
+                }
+
+                $configTemplate = new \Pimcore\Config\Config($configTemplateArray);
                 if ($configTemplate->general) { // check if the template contains a valid configuration
                     $settings = $configTemplate->toArray();
 


### PR DESCRIPTION
We are using Deployer for automated setup and deployments. We now run into the issue when installing Pimcore for the first time (eg. running setup).

We share our system.php thru all releases of your applications, when running deployment for the first time, there is no system.php available yet (cause the installer should create it). Therefore deployer creates a empty file (symlinked to the shared dir). Pimcore then fails installing cause it tries to parse the empty file and expects an array. With this PR, this is resolved and should work fine with deployer, automated setups, deployments and a shared system.php