### PR TITLE
[TRANSLATOR] Add a magic parameter to debug translation keys

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/15_Magic_Parameters.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/15_Magic_Parameters.md
@@ -23,3 +23,20 @@ This parameter only works if [`DEBUG MODE`](../18_Tools_and_Features/25_System_S
 ### pimcore_disable_host_redirect
 Disables the "redirect to main domain" feature. This is especially useful when using Pimcore behind 
 a reverse proxy. 
+
+### pimcore_debug_translations
+
+Configures the translator to return the given translation key instead of actually translating the message. This can be
+useful to debug translations or to get an overview over used translation keys. Example: http://www.example.com/my/page?pimcore_debug_translations=1
+
+This parameter is only available if activated via configuration and is enabled by default in the `dev` environment which
+is by default automatically chosen when debug mode is active:
+
+```yaml
+pimcore:
+    translations:
+        debugging:
+            enabled: true
+            # you could also change the parameter from pimcore_debug_translations to something else
+            parameter: my_custom_parameter
+```

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -59,20 +59,33 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('flags')
                     ->info('Generic map for feature flags, such as `zend_date`')
-                    ->prototype('scalar')
+                    ->prototype('scalar')->end()
+                ->end()
+                ->arrayNode('translations')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('debugging')
+                            ->info('If debugging is enabled, the translator will return the plain translation key instead of the translated message.')
+                            ->addDefaultsIfNotSet()
+                            ->canBeEnabled()
+                            ->children()
+                                ->scalarNode('parameter')
+                                    ->defaultValue('pimcore_debug_translations')
+                                ->end()
+                            ->end()
+                        ->end()
                     ->end()
+                ->end()
             ->end();
 
         $this->addObjectsNode($rootNode);
         $this->addDocumentsNode($rootNode);
         $this->addModelsNode($rootNode);
-
         $this->addRoutingNode($rootNode);
         $this->addCacheNode($rootNode);
         $this->addContextNode($rootNode);
         $this->addAdminNode($rootNode);
         $this->addWebProfilerNode($rootNode);
-
         $this->addSecurityNode($rootNode);
 
         return $treeBuilder;

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -14,6 +14,7 @@
 
 namespace Pimcore\Bundle\CoreBundle\DependencyInjection;
 
+use Pimcore\Bundle\CoreBundle\EventListener\TranslationDebugListener;
 use Pimcore\Http\Context\PimcoreContextGuesser;
 use Pimcore\Loader\ImplementationLoader\ClassMapLoader;
 use Pimcore\Loader\ImplementationLoader\PrefixLoader;
@@ -95,6 +96,7 @@ class PimcoreCoreExtension extends Extension implements PrependExtensionInterfac
         $this->configureDocumentEditableNamingStrategy($container, $config);
         $this->configureRouting($container, $config['routing']);
         $this->configureCache($container, $loader, $config);
+        $this->configureTranslations($container, $config['translations']);
         $this->configurePasswordEncoders($container, $config);
 
         // load engine specific configuration only if engine is active
@@ -264,6 +266,19 @@ class PimcoreCoreExtension extends Extension implements PrependExtensionInterfac
 
         // set core cache pool alias
         $container->setAlias('pimcore.cache.core.pool', $coreCachePool);
+    }
+
+    private function configureTranslations(ContainerBuilder $container, array $config)
+    {
+        $parameter = $config['debugging']['parameter'];
+
+        // remove the listener as it isn't needed at all if it is disabled or the parameter is empty
+        if (!$config['debugging']['enabled'] || empty($parameter)) {
+            $container->removeDefinition(TranslationDebugListener::class);
+        } else {
+            $definition = $container->getDefinition(TranslationDebugListener::class);
+            $definition->setArgument('$parameterName', $parameter);
+        }
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/TranslationDebugListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/TranslationDebugListener.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\EventListener;
+
+use Pimcore\Translation\Translator;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class TranslationDebugListener implements EventSubscriberInterface
+{
+    /**
+     * @var Translator
+     */
+    private $translator;
+
+    /**
+     * @var string
+     */
+    private $parameterName;
+
+    public function __construct(
+        Translator $translator,
+        string $parameterName
+    )
+    {
+        $this->translator    = $translator;
+        $this->parameterName = $parameterName;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => 'onKernelRequest'
+        ];
+    }
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        if (empty($this->parameterName)) {
+            return;
+        }
+
+        if ((bool)$event->getRequest()->query->get($this->parameterName, false)) {
+            $this->translator->setDisableTranslations(true);
+        }
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/event_listeners.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/event_listeners.yml
@@ -16,10 +16,17 @@ services:
 
     Pimcore\Bundle\CoreBundle\EventListener\Frontend\DocumentFallbackListener: ~
 
-    Pimcore\Bundle\CoreBundle\EventListener\Frontend\LocaleListener: ~
-
     Pimcore\Bundle\CoreBundle\EventListener\PimcoreHeaderListener: ~
 
+    #
+    # TRANSLATIONS/LOCALE
+    #
+
+    Pimcore\Bundle\CoreBundle\EventListener\Frontend\LocaleListener: ~
+
+    Pimcore\Bundle\CoreBundle\EventListener\TranslationDebugListener:
+        arguments:
+            $translator: '@pimcore.translator'
 
     #
     # PIMCORE OBJECTS/PARAMS LOGIC

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/config_dev.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/config_dev.yml
@@ -29,3 +29,9 @@ pimcore:
     web_profiler:
         toolbar:
             excluded_routes: ~
+
+    translations:
+        # enables support for the pimcore_debug_translations magic parameter
+        # see https://www.pimcore.org/docs/5.0.0/Development_Tools_and_Details/Magic_Parameters.html
+        debugging:
+            enabled: true

--- a/pimcore/lib/Pimcore/Translation/Translator.php
+++ b/pimcore/lib/Pimcore/Translation/Translator.php
@@ -47,6 +47,15 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
     protected $adminPath = '';
 
     /**
+     * If true, the translator will just return the translation key instead of actually translating
+     * the message. Can be useful for debugging and to get an overview over used translation keys on
+     * a page.
+     *
+     * @var bool
+     */
+    protected $disableTranslations = false;
+
+    /**
      * @var Kernel
      */
     protected $kernel;
@@ -69,6 +78,10 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
      */
     public function trans($id, array $parameters = [], $domain = null, $locale = null)
     {
+        if ($this->disableTranslations) {
+            return $id;
+        }
+
         if (null === $domain) {
             $domain = 'messages';
         }
@@ -94,6 +107,10 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
      */
     public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
     {
+        if ($this->disableTranslations) {
+            return $id;
+        }
+
         $parameters = array_merge([
             '%count%' => $number,
         ], $parameters);
@@ -341,6 +358,16 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
     public function setKernel($kernel)
     {
         $this->kernel = $kernel;
+    }
+
+    public function getDisableTranslations(): bool
+    {
+        return $this->disableTranslations;
+    }
+
+    public function setDisableTranslations(bool $disableTranslations)
+    {
+        $this->disableTranslations = $disableTranslations;
     }
 
     /**


### PR DESCRIPTION
Resolves #1850 

This adds a flag to the translator which allows to set it into debug mode (translator will just return the given message id instead of actually translating the message). An event listener listens on a
configurable parameter and sets the flag on the translator.

Example: http://foo.bar/en?pimcore_debug_translations=1

Debugging can be disabled completely via config (enabled by default in dev).