### PR TITLE
[BUNDLES] Add possibility to return composer package version in getVersion()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,7 @@
     "myclabs/deep-copy": "~1.3",
     "neitanod/forceutf8": "~2",
     "nesbot/carbon": "~1",
+    "ocramius/package-versions": "^1.1",
     "ocramius/proxy-manager": "2.0.*",
     "oyejorge/less.php": "~1.7",
     "pear/net_url2": "~2.2",

--- a/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/05_Pimcore_Bundles/README.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/05_Pimcore_Bundles/README.md
@@ -74,7 +74,7 @@ version or read/write permissions on the filesystem.
 
 Read more in [Installers](./01_Installers.md).
 
-## Registration to ExtensionManager
+## Registration to extension manager
 
 To make use of the installer, a bundle needs to be managed through the extension manager and not manually registered on
 the `AppKernel` as normal bundles. As the extension manager needs to find the bundles it can manage, a Pimcore bundle needs
@@ -117,4 +117,36 @@ An example of a `composer.json` defining a Pimcore bundle:
 }
 ```
 
+#### Returning the composer package version in extension manager
 
+If you provide your bundle as composer package, you'll probably want to show the composer version of your bundle in the
+extension manager grid. As pimcore includes the [ocramius/package-versions](https://github.com/Ocramius/PackageVersions)
+library which generates a list of package versions installed via composer you can easily use that library to return the 
+installed version of your bundle.
+
+Pimcore provides a `Pimcore\Extension\Bundle\Traits\PackageVersionTrait` which you can include in your bundle. All you need
+to do is to implement a `getComposerPackageName` method returning the name of your composer package (e.g. `company/foo-bundle`):
+
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Company\FooBundle;
+
+use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
+use Pimcore\Extension\Bundle\Traits\PackageVersionTrait;
+
+class FooBundle extends AbstractPimcoreBundle
+{
+    use PackageVersionTrait;
+
+    protected function getComposerPackageName(): string
+    {
+        // getVersion() will use this name to read the version from
+        // PackageVersions and return a normalized value
+        return 'company/foo-bundle';
+    }
+}
+```

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PimcoreEcommerceFrameworkBundle.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PimcoreEcommerceFrameworkBundle.php
@@ -20,11 +20,20 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Tools\Installer;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Type\Decimal;
 use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
 use Pimcore\Extension\Bundle\Traits\StateHelperTrait;
+use Pimcore\Version;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class PimcoreEcommerceFrameworkBundle extends AbstractPimcoreBundle
 {
     use StateHelperTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function getVersion()
+    {
+        return sprintf('%s build %s', Version::getVersion(), Version::getRevision());
+    }
 
     /**
      * @inheritDoc

--- a/pimcore/lib/Pimcore/Extension/Bundle/Traits/PackageVersionTrait.php
+++ b/pimcore/lib/Pimcore/Extension/Bundle/Traits/PackageVersionTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Extension\Bundle\Traits;
+
+use PackageVersions\Versions;
+
+/**
+ * Exposes a simple getVersion() implementation by looking up the installed versions via ocramius/package-versions
+ * which is generated on composer install. This trait can be used by using it from a bundle class and implementing
+ * getComposerPackageName() to return the name of the composer package to lookup.
+ */
+trait PackageVersionTrait
+{
+    /**
+     * Returns the composer package name used to resolve the version
+     *
+     * @return string
+     */
+    abstract protected function getComposerPackageName(): string;
+
+    public function getVersion()
+    {
+        $version = Versions::getVersion($this->getComposerPackageName());
+
+        // normalizes v2.3.0@9e016f4898c464f5c895c17993416c551f1697d3 to 2.3.0
+        $version = preg_replace('/^v/', '', $version);
+        $version = preg_replace('/@(.+)$/', '', $version);
+
+        return $version;
+    }
+}


### PR DESCRIPTION
Resolves #1888

We already have an API for composer package versions through `ocramius/package-versions` which already is installed via `ocramius/proxy-manager`.  This adds a trait which can be used from bundles to read and return the package version from `getVersion()`. 