### PR TITLE
[CustomReportAdapter] make them available via service-locator

### DIFF
--- a/doc/Development_Documentation/18_Tools_and_Features/29_Custom_Reports.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/29_Custom_Reports.md
@@ -22,3 +22,26 @@ the namespace `pimcore.report.custom.definition`, named like the adapter (e.g. `
 the options, columns and data. It has to be located in the namespace `Pimcore\Model\Tool\CustomReport\Adapter`, named like
 the adapter (e.g. `MySource`) and extend the abstract class `Pimcore\Model\Tool\CustomReport\Adapter\AbstractAdapter`. As sample see
  [analytics adapter](https://github.com/pimcore/pimcore/blob/master/pimcore/models/Tool/CustomReport/Adapter/Analytics.php). 
+
+- PHP Class: This class is the server side implementation of the adapter. It is responsible for retrieving and preparing
+the options, columns and data. It needs to implement the interface `Pimcore\Model\Tool\CustomReport\Adapter\CustomReportAdapterInterface`. As sample see
+ [Sql](https://github.com/pimcore/pimcore/blob/master/pimcore/models/Tool/CustomReport/Adapter/Sql.php).
+- Register your Adapter Factory as Service. If you are using a very simple Adapter Source, you can use the DefaultCustomReportAdapterFactory
+  ```yml
+  app.custom_report.adapter.factory.custom:
+      class: Pimcore\Model\Tool\CustomReport\Adapter\DefaultCustomReportAdapterFactory
+      arguments:
+        - 'App\CustomReport\Adapter\Custom'
+  ```
+- If you are using a more complex Adapter, you can create your own Factory by implementing the interface `Pimcore\Model\Tool\CustomReport\Adapter\CustomReportAdapterFactoryInterface`
+- Add your Adapter Factory to the configuration:
+
+```yml
+pimcore:
+    custom_report:
+        adapters:
+            myAdapter: app.custom_report.adapter.factory.custom
+
+````
+
+

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/02_V4_to_V5.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/02_V4_to_V5.md
@@ -316,3 +316,26 @@ pimcore:
     newsletter:
         source_adapters:
             myAdapter: app.document.newsletter.factory.myAdapter
+```
+
+## Custom Report Adapter
+
+Custom Report Adapter implementation has been changed to be able to register them using configuration. It is very easy to migrate your Adapter to Pimcore 5.
+Since nothing really changed, you only need to create a factory service that creates your CustomReportAdapterInterface
+ - If you are using a very simple Adapter Source, you can use the DefaultFactory
+  ```yml
+  app.custom_report.adapter.factory.custom:
+      class: Pimcore\Model\Tool\CustomReport\Adapter\DefaultCustomReportAdapterFactory
+      arguments:
+        - 'App\CustomReport\Adapter\Custom'
+  ```
+- If you are using a more complex Adapter, you can create your own Factory by implementing the interface `Pimcore\Model\Tool\CustomReport\Adapter\CustomReportAdapterFactoryInterface`
+- Add your Adapter Factory to the configuration:
+
+```yml
+pimcore:
+    custom_report:
+        adapters:
+            myAdapter: app.custom_report.adapter.factory.custom
+
+```

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/CustomReportController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/CustomReportController.php
@@ -187,7 +187,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
         $result = [];
 
         try {
-            $adapter = $this->getReportAdapter($configuration->type, $configuration);
+            $adapter = CustomReport\Config::getAdapter($configuration);
             $columns = $adapter->getColumns($configuration);
             if (!is_array($columns)) {
                 $columns = [];
@@ -273,7 +273,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
         $config = CustomReport\Config::getByName($request->get('name'));
         $configuration = $config->getDataSourceConfig();
 
-        $adapter = $this->getReportAdapter($configuration->type, $configuration, $config);
+        $adapter = CustomReport\Config::getAdapter($configuration, $config);
 
         $result = $adapter->getData($filters, $sort, $dir, $offset, $limit, null, $drillDownFilters, $config);
 
@@ -300,7 +300,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
         $config = CustomReport\Config::getByName($request->get('name'));
         $configuration = $config->getDataSourceConfig();
 
-        $adapter = $this->getReportAdapter($configuration->type, $configuration, $config);
+        $adapter = CustomReport\Config::getAdapter($configuration, $config);
         $result = $adapter->getAvailableOptions($filters, $field, $drillDownFilters);
 
         return $this->json([
@@ -327,7 +327,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
 
         $configuration = $config->getDataSourceConfig();
 
-        $adapter = $this->getReportAdapter($configuration->type, $configuration, $config);
+        $adapter = CustomReport\Config::getAdapter($configuration, $config);
         $result = $adapter->getData($filters, $sort, $dir, null, null, null, $drillDownFilters);
 
         return $this->json([
@@ -370,7 +370,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
             ? $configuration[0]
             : $configuration;
 
-        $adapter = $this->getReportAdapter($configuration->type, $configuration, $config);
+        $adapter = CustomReport\Config::getAdapter($configuration, $config);
         $result = $adapter->getData($filters, $sort, $dir, null, null, $fields, $drillDownFilters);
 
         $exportFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/report-export-' . uniqid() . '.csv';
@@ -394,29 +394,6 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
         $response->deleteFileAfterSend(true);
 
         return $response;
-    }
-
-    /**
-     * Creates an instanceof CustomReportAdapterInterface based on $type
-     *
-     * @param $type
-     * @param $configuration
-     * @param null $fullConfig
-     * @return CustomReport\Adapter\CustomReportAdapterInterface
-     */
-    private function getReportAdapter($type, $configuration, $fullConfig = null) {
-        $serviceLocator = $this->get('pimcore.custom_report.adapter.factories');
-
-        if (!$serviceLocator->has($type)) {
-            throw new \RuntimeException(sprintf("Could not find Custom Report Adapter with type %s", $type));
-        }
-
-        /**
-         * @var $factory CustomReport\Adapter\CustomReportAdapterFactoryInterface
-         */
-        $factory = $serviceLocator->get($type);
-
-        return $factory->create($configuration, $fullConfig);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/CustomReportController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/CustomReportController.php
@@ -187,7 +187,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
         $result = [];
 
         try {
-            $adapter = CustomReport\Config::getAdapter($configuration);
+            $adapter = $this->getReportAdapter($configuration->type, $configuration);
             $columns = $adapter->getColumns($configuration);
             if (!is_array($columns)) {
                 $columns = [];
@@ -273,7 +273,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
         $config = CustomReport\Config::getByName($request->get('name'));
         $configuration = $config->getDataSourceConfig();
 
-        $adapter = CustomReport\Config::getAdapter($configuration, $config);
+        $adapter = $this->getReportAdapter($configuration->type, $configuration, $config);
 
         $result = $adapter->getData($filters, $sort, $dir, $offset, $limit, null, $drillDownFilters, $config);
 
@@ -300,7 +300,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
         $config = CustomReport\Config::getByName($request->get('name'));
         $configuration = $config->getDataSourceConfig();
 
-        $adapter = CustomReport\Config::getAdapter($configuration, $config);
+        $adapter = $this->getReportAdapter($configuration->type, $configuration, $config);
         $result = $adapter->getAvailableOptions($filters, $field, $drillDownFilters);
 
         return $this->json([
@@ -327,8 +327,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
 
         $configuration = $config->getDataSourceConfig();
 
-        $adapter = CustomReport\Config::getAdapter($configuration, $config);
-
+        $adapter = $this->getReportAdapter($configuration->type, $configuration, $config);
         $result = $adapter->getData($filters, $sort, $dir, null, null, null, $drillDownFilters);
 
         return $this->json([
@@ -371,8 +370,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
             ? $configuration[0]
             : $configuration;
 
-        $adapter = CustomReport\Config::getAdapter($configuration, $config);
-
+        $adapter = $this->getReportAdapter($configuration->type, $configuration, $config);
         $result = $adapter->getData($filters, $sort, $dir, null, null, $fields, $drillDownFilters);
 
         $exportFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/report-export-' . uniqid() . '.csv';
@@ -396,6 +394,29 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
         $response->deleteFileAfterSend(true);
 
         return $response;
+    }
+
+    /**
+     * Creates an instanceof CustomReportAdapterInterface based on $type
+     *
+     * @param $type
+     * @param $configuration
+     * @param null $fullConfig
+     * @return CustomReport\Adapter\CustomReportAdapterInterface
+     */
+    private function getReportAdapter($type, $configuration, $fullConfig = null) {
+        $serviceLocator = $this->get('pimcore.custom_report.adapter.factories');
+
+        if (!$serviceLocator->has($type)) {
+            throw new \RuntimeException(sprintf("Could not find Custom Report Adapter with type %s", $type));
+        }
+
+        /**
+         * @var $factory CustomReport\Adapter\CustomReportAdapterFactoryInterface
+         */
+        $factory = $serviceLocator->get($type);
+
+        return $factory->create($configuration, $fullConfig);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -88,6 +88,7 @@ class Configuration implements ConfigurationInterface
         $this->addWebProfilerNode($rootNode);
         $this->addSecurityNode($rootNode);
         $this->addNewsletterNode($rootNode);
+        $this->addCustomReportsNode($rootNode);
 
         return $treeBuilder;
     }
@@ -534,6 +535,27 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->arrayNode('source_adapters')
+                            ->useAttributeAsKey('name')
+                                ->prototype('scalar')
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * Adds configuration tree for custom report adapters
+     *
+     * @param ArrayNodeDefinition $rootNode
+     */
+    private function addCustomReportsNode(ArrayNodeDefinition $rootNode) {
+        $rootNode
+            ->children()
+                ->arrayNode('custom_report')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('adapters')
                             ->useAttributeAsKey('name')
                                 ->prototype('scalar')
                             ->end()

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -98,7 +98,8 @@ class PimcoreCoreExtension extends Extension implements PrependExtensionInterfac
         $this->configureCache($container, $loader, $config);
         $this->configureTranslations($container, $config['translations']);
         $this->configurePasswordEncoders($container, $config);
-        $this->configureNewsletterAdapterFactories($container, $config['newsletter']['source_adapters']);
+        $this->configureAdapterFactories($container, $config['newsletter']['source_adapters'], 'pimcore.newsletter.address_source_adapter.factories', 'Newsletter Address Source Adapter Factory');
+        $this->configureAdapterFactories($container, $config['custom_report']['adapters'], 'pimcore.custom_report.adapter.factories', 'Custom Report Adapter Factory');
 
         // load engine specific configuration only if engine is active
         $configuredEngines = ['twig', 'php'];
@@ -387,22 +388,24 @@ class PimcoreCoreExtension extends Extension implements PrependExtensionInterfac
     }
 
     /**
-     * Configure Container for Newsletter Source Adapters
+     * Configure Adapter Factories
      *
      * @param ContainerBuilder $container
-     * @param $adapters
+     * @param $factories
+     * @param $serviceLocatorId
+     * @param $type
      */
-    private function configureNewsletterAdapterFactories(ContainerBuilder $container, $adapters)
+    private function configureAdapterFactories(ContainerBuilder $container, $factories, $serviceLocatorId, $type)
     {
-        $serviceLocator = $container->getDefinition('pimcore.newsletter.address_source_adapter.factories');
+        $serviceLocator = $container->getDefinition($serviceLocatorId);
         $arguments = [];
 
-        foreach ($adapters as $key => $serviceId) {
+        foreach ($factories as $key => $serviceId) {
             if (!$container->has($serviceId)) {
                 throw new RuntimeException(sprintf(
-                'The Service with id %s as Newsletter Address Source Adapter Factory could not be found',
-                $serviceId
-            ));
+                    'The Service with id %s as %s could not be found',
+                    $serviceId, $type
+                ));
             }
 
             $arguments[$key] = new Reference($serviceId);

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/config.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/config.yml
@@ -156,6 +156,11 @@ pimcore:
             csvList: pimcore.document.newsletter.factory.csv
             reportAdapter: pimcore.document.newsletter.factory.report
 
+    custom_report:
+        adapters:
+            sql: pimcore.custom_report.adapter.factory.sql
+            analytics: pimcore.custom_report.adapter.factory.analytics
+
     # the routes below are used to determine the request context in PimcoreContextGuesser
     context:
         profiler:

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
@@ -110,10 +110,26 @@ services:
         - 'Pimcore\Document\Newsletter\AddressSourceAdapter\CsvList'
 
     pimcore.document.newsletter.factory.report:
-      class: Pimcore\Document\Newsletter\DefaultAddressSourceAdapterFactory
+      class: Pimcore\Document\Newsletter\ReportAddressSourceAdapterFactory
       arguments:
-        - 'Pimcore\Document\Newsletter\AddressSourceAdapter\ReportAdapter'
+        - '@pimcore.custom_report.adapter.factories'
 
     pimcore.newsletter.address_source_adapter.factories:
+        class: Symfony\Component\DependencyInjection\ServiceLocator
+        tags: ['container.service_locator']
+
+
+    # CustomReport Adapter
+    pimcore.custom_report.adapter.factory.sql:
+      class: Pimcore\Model\Tool\CustomReport\Adapter\DefaultCustomReportAdapterFactory
+      arguments:
+        - 'Pimcore\Model\Tool\CustomReport\Adapter\Sql'
+
+    pimcore.custom_report.adapter.factory.analytics:
+      class: Pimcore\Model\Tool\CustomReport\Adapter\DefaultCustomReportAdapterFactory
+      arguments:
+        - 'Pimcore\Model\Tool\CustomReport\Adapter\Analytics'
+
+    pimcore.custom_report.adapter.factories:
         class: Symfony\Component\DependencyInjection\ServiceLocator
         tags: ['container.service_locator']

--- a/pimcore/lib/Pimcore/Document/Newsletter/AddressSourceAdapter/ReportAdapter.php
+++ b/pimcore/lib/Pimcore/Document/Newsletter/AddressSourceAdapter/ReportAdapter.php
@@ -17,18 +17,19 @@ namespace Pimcore\Document\Newsletter\AddressSourceAdapter;
 use Pimcore\Document\Newsletter\AddressSourceAdapterInterface;
 use Pimcore\Document\Newsletter\SendingParamContainer;
 use Pimcore\Model\DataObject\Listing;
+use Pimcore\Model\Tool\CustomReport\Adapter\CustomReportAdapterInterface;
 
 class ReportAdapter implements AddressSourceAdapterInterface
 {
     /**
-     * @var int
-     */
-    protected $reportId;
-
-    /**
      * @var string[]
      */
     protected $emailFieldName;
+
+    /**
+     * @var CustomReportAdapterInterface
+     */
+    protected $reportAdapter;
 
     /**
      * @var string[]
@@ -46,14 +47,13 @@ class ReportAdapter implements AddressSourceAdapterInterface
     protected $list;
 
     /**
-     * IAddressSourceAdapter constructor.
-     *
-     * @param $params
+     * @param $emailFieldName
+     * @param CustomReportAdapterInterface $reportAdapter
      */
-    public function __construct($params)
+    public function __construct($emailFieldName, CustomReportAdapterInterface $reportAdapter)
     {
-        $this->reportId = $params['reportId'];
-        $this->emailFieldName = $params['emailFieldName'];
+        $this->emailFieldName = $emailFieldName;
+        $this->reportAdapter = $reportAdapter;
     }
 
     /**
@@ -61,10 +61,7 @@ class ReportAdapter implements AddressSourceAdapterInterface
      */
     protected function getListing()
     {
-        $config = \Pimcore\Model\Tool\CustomReport\Config::getByName($this->reportId);
-        $configuration = $config->getDataSourceConfig();
-        $adapter = \Pimcore\Model\Tool\CustomReport\Config::getAdapter($configuration, $config);
-        $result = $adapter->getData(null, $this->emailFieldName, 'ASC', null, null);
+        $result = $this->reportAdapter->getData(null, $this->emailFieldName, 'ASC', null, null);
 
         $this->list = $result['data'];
         $this->elementsTotal = intval($result['total']);

--- a/pimcore/lib/Pimcore/Document/Newsletter/ReportAddressSourceAdapterFactory.php
+++ b/pimcore/lib/Pimcore/Document/Newsletter/ReportAddressSourceAdapterFactory.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Document\Newsletter;
+
+use Pimcore\Document\Newsletter\AddressSourceAdapter\ReportAdapter;
+use Pimcore\Model\Tool\CustomReport\Adapter\CustomReportAdapterFactoryInterface;
+use Pimcore\Model\Tool\CustomReport\Config;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+class ReportAddressSourceAdapterFactory implements AddressSourceAdapterFactoryInterface
+{
+    /**
+     * @var ServiceLocator
+     */
+    private $reportAdapterServiceLocator;
+
+    /**
+     * @param ServiceLocator $reportAdapterServiceLocator
+     */
+    public function __construct(ServiceLocator $reportAdapterServiceLocator)
+    {
+        $this->reportAdapterServiceLocator = $reportAdapterServiceLocator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($params)
+    {
+        $config = Config::getByName($params['reportId']);
+        $configuration = $config->getDataSourceConfig();
+
+        $reportAdapterType = $configuration->type;
+
+        if (!$this->reportAdapterServiceLocator->has($reportAdapterType)) {
+            throw new \RuntimeException(sprintf("Could not find Custom Report Adapter with type %s", $reportAdapterType));
+        }
+
+        /**
+         * @var $adapterFactory CustomReportAdapterFactoryInterface
+         */
+        $adapterFactory = $this->reportAdapterServiceLocator->get($reportAdapterType);
+        $adapter = $adapterFactory->create($configuration, $config);
+
+        return new ReportAdapter($params['emailFieldName'], $adapter);
+    }
+}

--- a/pimcore/models/Tool/CustomReport/Adapter/CustomReportAdapterFactoryInterface.php
+++ b/pimcore/models/Tool/CustomReport/Adapter/CustomReportAdapterFactoryInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @category   Pimcore
+ * @package    Pimcore
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Model\Tool\CustomReport\Adapter;
+
+interface CustomReportAdapterFactoryInterface
+{
+    /**
+     * Create a CustomReport Adapter
+     *
+     * @param $config
+     * @param $fullConfig
+     * @return CustomReportAdapterInterface
+     */
+    public function create($config, $fullConfig = null);
+}

--- a/pimcore/models/Tool/CustomReport/Adapter/CustomReportAdapterInterface.php
+++ b/pimcore/models/Tool/CustomReport/Adapter/CustomReportAdapterInterface.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @category   Pimcore
+ * @package    Pimcore
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Model\Tool\CustomReport\Adapter;
+
+interface CustomReportAdapterInterface
+{
+    /**
+     * returns data for given parameters
+     *
+     * @param $filters
+     * @param $sort
+     * @param $dir
+     * @param $offset
+     * @param $limit
+     * @param null $fields - if set, only in fields specified columns are returned
+     * @param null $drillDownFilters - if set, additional filters are set
+     *
+     * @return array
+     */
+    public function getData($filters, $sort, $dir, $offset, $limit, $fields = null, $drillDownFilters = null);
+
+    /**
+     * returns available columns for given configuration
+     *
+     * @param $configuration
+     *
+     * @return mixed
+     */
+    public function getColumns($configuration);
+
+    /**
+     * returns all available values for given field with given filters and drillDownFilters
+     *
+     * @param $filters
+     * @param $field
+     * @param $drillDownFilters
+     *
+     * @return mixed
+     */
+    public function getAvailableOptions($filters, $field, $drillDownFilters);
+}

--- a/pimcore/models/Tool/CustomReport/Adapter/DefaultCustomReportAdapterFactory.php
+++ b/pimcore/models/Tool/CustomReport/Adapter/DefaultCustomReportAdapterFactory.php
@@ -17,30 +17,26 @@
 
 namespace Pimcore\Model\Tool\CustomReport\Adapter;
 
-abstract class AbstractAdapter implements CustomReportAdapterInterface
+class DefaultCustomReportAdapterFactory implements CustomReportAdapterFactoryInterface
 {
     /**
-     * @param $config
-     * @param null $fullConfig
+     * @var string
      */
-    public function __construct($config, $fullConfig = null)
+    private $className;
+
+    /**
+     * @param string $className
+     */
+    public function __construct($className)
     {
-        $this->config = $config;
-        $this->fullConfig = $fullConfig;
+        $this->className = $className;
     }
 
     /**
      * {@inheritdoc}
      */
-    abstract public function getData($filters, $sort, $dir, $offset, $limit, $fields = null, $drillDownFilters = null);
-
-    /**
-     * {@inheritdoc}
-     */
-    abstract public function getColumns($configuration);
-
-    /**
-     * {@inheritdoc}
-     */
-    abstract public function getAvailableOptions($filters, $field, $drillDownFilters);
+    public function create($config, $fullConfig = null)
+    {
+        return new $this->className($config, $fullConfig);
+    }
 }

--- a/pimcore/models/Tool/CustomReport/Config.php
+++ b/pimcore/models/Tool/CustomReport/Config.php
@@ -155,10 +155,19 @@ class Config extends Model\AbstractModel
      */
     public static function getAdapter($configuration, $fullConfig = null)
     {
-        $type = $configuration->type ? ucfirst($configuration->type) : 'Sql';
-        $adapter = "\\Pimcore\\Model\\Tool\\CustomReport\\Adapter\\{$type}";
+        $type = $configuration->type ? $configuration->type : 'Sql';
+        $serviceLocator = \Pimcore::getContainer()->get('pimcore.custom_report.adapter.factories');
 
-        return new $adapter($configuration, $fullConfig);
+        if (!$serviceLocator->has($type)) {
+            throw new \RuntimeException(sprintf("Could not find Custom Report Adapter with type %s", $type));
+        }
+
+        /**
+         * @var $factory Model\Tool\CustomReport\Adapter\CustomReportAdapterFactoryInterface
+         */
+        $factory = $serviceLocator->get($type);
+
+        return $factory->create($configuration, $fullConfig);
     }
 
     /**

--- a/pimcore/models/Tool/CustomReport/Config.php
+++ b/pimcore/models/Tool/CustomReport/Config.php
@@ -149,8 +149,9 @@ class Config extends Model\AbstractModel
     /**
      * @param $configuration
      * @param null $fullConfig
+     * @deprecated Use ServiceLocator with id 'pimcore.custom_report.adapter.factories' to determine the factory for the adapter instead
      *
-     * @return mixed
+     * @return Model\Tool\CustomReport\Adapter\CustomReportAdapterInterface
      */
     public static function getAdapter($configuration, $fullConfig = null)
     {

--- a/web/pimcore/static6/js/pimcore/report/custom/settings.js
+++ b/web/pimcore/static6/js/pimcore/report/custom/settings.js
@@ -32,7 +32,6 @@ pimcore.report.custom.settings = Class.create({
                 id: "pimcore_custom_reports_settings",
                 title: t("custom_reports"),
                 iconCls: "pimcore_icon_reports",
-                bodyStyle: "padding: 10px;",
                 layout: "fit",
                 closable:true,
                 items: [editor.getTabPanel()]


### PR DESCRIPTION
related to #1399 

Adds the possibility to load CustomReport Adapters via configuration:

```yml
pimcore:
    custom_report:
        adapters:
            identifier: service_name
```

This PR also creates a Factory class For ReportAddressSourceAdapterFactory to take advantage of DI for Newsletter Address Sources as well.

pimcore/models/Tool/CustomReport/Config.php::156 (getAdapter) is now deprecated, but still works for maybe BC reasons?

There is also a small change in ExtJS for CustomReports, they used to have a body-padding of 10px inside of Pimcore, which is very unusual. Nothing inside the main-tab-panel has a padding of 10px.