### PR TITLE
[BUNDLES] Run assets:install and cache:clear after pimcore:bundle:ena…

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/DisableCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/DisableCommand.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\CoreBundle\Command\Bundle;
 
+use Pimcore\Bundle\CoreBundle\Command\Bundle\Helper\PostStateChange;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -30,6 +31,8 @@ class DisableCommand extends AbstractBundleCommand
             ->configureDescriptionAndHelp('Disables a bundle')
             ->addArgument('bundle', InputArgument::REQUIRED, 'The bundle to disable')
             ->configureFailWithoutErrorOption();
+
+        PostStateChange::configureStateChangeCommandOptions($this);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -43,6 +46,11 @@ class DisableCommand extends AbstractBundleCommand
             $this->io->success(sprintf('Bundle "%s" was successfully disabled', $bundle->getName()));
         } catch (\Exception $e) {
             $this->handlePrerequisiteError($e->getMessage());
+
+            return;
         }
+
+        $postStateChange = new PostStateChange($this->getApplication());
+        $postStateChange->runPostStateChangeCommands($this->io);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/EnableCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/EnableCommand.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\CoreBundle\Command\Bundle;
 
+use Pimcore\Bundle\CoreBundle\Command\Bundle\Helper\PostStateChange;
 use Pimcore\Extension\Bundle\PimcoreBundleManager;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -50,8 +51,9 @@ class EnableCommand extends AbstractBundleCommand
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'If defined, the bundle will be configured to only be loaded in the specified environments'
             )
-            ->configureFailWithoutErrorOption()
-        ;
+            ->configureFailWithoutErrorOption();
+
+        PostStateChange::configureStateChangeCommandOptions($this);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -73,7 +75,12 @@ class EnableCommand extends AbstractBundleCommand
             $this->io->success(sprintf('Bundle "%s" was successfully enabled', $bundleClass));
         } catch (\Exception $e) {
             $this->handlePrerequisiteError($e->getMessage());
+
+            return;
         }
+
+        $postStateChange = new PostStateChange($this->getApplication());
+        $postStateChange->runPostStateChangeCommands($this->io);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/Helper/PostStateChange.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/Helper/PostStateChange.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Command\Bundle\Helper;
+
+use Pimcore\Console\Application;
+use Pimcore\Console\Style\PimcoreStyle;
+use Pimcore\Tool\AssetsInstaller;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputOption;
+
+class PostStateChange
+{
+    /**
+     * @var Application
+     */
+    private $application;
+
+    public function __construct(Application $application)
+    {
+        $this->application = $application;
+    }
+
+    public static function configureStateChangeCommandOptions(Command $command)
+    {
+        $command->addOption(
+            'no-post-change-commands',
+            null,
+            InputOption::VALUE_NONE,
+            'Do not run any post change commands (<comment>assets:install</comment>, <comment>cache:clear</comment>) after successful state change'
+        );
+
+        $command->addOption(
+            'no-assets-install',
+            null,
+            InputOption::VALUE_NONE,
+            'Do not run <comment>assets:install</comment> command after successful state change'
+        );
+
+        $command->addOption(
+            'no-cache-clear',
+            null,
+            InputOption::VALUE_NONE,
+            'Do not run <comment>cache:clear</comment> command after successful state change'
+        );
+    }
+
+    public function runPostStateChangeCommands(PimcoreStyle $io)
+    {
+        $input = $io->getInput();
+
+        if ($input->getOption('no-post-change-commands')) {
+            return;
+        }
+
+        $runAssetsInstall = $input->getOption('no-assets-install') ? false : true;
+        $runCacheClear    = $input->getOption('no-cache-clear') ? false : true;
+
+        $commands = [];
+
+        if ($runAssetsInstall) {
+            $commands[] = ['assets:install', $this->resolveAssetsInstallOptions()];
+        }
+
+        if ($runCacheClear) {
+            $commands[] = ['cache:clear'];
+        }
+
+        if (empty($commands)) {
+            return;
+        }
+
+        $io->newLine();
+        $io->section('Running post state change commands');
+
+        foreach ($commands as $command) {
+            $this->runCommand($io, $command[0], $command[1] ?? []);
+        }
+    }
+
+    private function runCommand(PimcoreStyle $io, string $command, array $arguments = [])
+    {
+        $this->writeCommandInfo($io, $command, $arguments);
+
+        $command   = $this->application->find($command);
+        $arguments = array_merge(['command' => $command], $arguments);
+
+        $code = $command->run(new ArrayInput($arguments), $io);
+        if ($code > 0) {
+            throw new \RuntimeException(sprintf('Command "%s" failed', $command));
+        }
+    }
+
+    private function resolveAssetsInstallOptions(): array
+    {
+        $assetsInstaller = $this->application->getKernel()->getContainer()->get(AssetsInstaller::class);
+
+        $assetsOptions = [];
+        foreach ($assetsInstaller->resolveOptions(['ansi' => true]) as $option => $value) {
+            // do not set ansi option again for our subcommand
+            if ('ansi' === $option) {
+                continue;
+            }
+
+            $assetsOptions['--' . $option] = $value;
+        }
+
+        return $assetsOptions;
+    }
+
+    /**
+     * Prints information about the command about to be run
+     *
+     * @param string $command
+     * @param array $arguments
+     */
+    private function writeCommandInfo(PimcoreStyle $io, string $command, array $arguments)
+    {
+        $argumentsInfo = [];
+        foreach ($arguments as $key => $value) {
+            if (0 === strpos($key, '--')) {
+                // --option
+                $option = $key;
+
+                if (is_bool($value)) {
+                    if (!$value) {
+                        $option .= '=0';
+                    }
+                } else {
+                    $option .= sprintf('="%s"', $value);
+                }
+
+                $argumentsInfo[] = $option;
+            } else {
+                // arguments just add the value
+                $argumentsInfo[] = sprintf('"%s"', $value);
+            }
+        }
+
+        $commandInfo = $command;
+        if (!empty($argumentsInfo)) {
+            $commandInfo .= ' ' . implode(' ', $argumentsInfo);
+        }
+
+        $io->comment(sprintf('Running command %s', $commandInfo));
+    }
+}

--- a/pimcore/lib/Pimcore/Tool/AssetsInstaller.php
+++ b/pimcore/lib/Pimcore/Tool/AssetsInstaller.php
@@ -84,10 +84,7 @@ class AssetsInstaller
      */
     public function buildProcess(array $options = []): Process
     {
-        $resolver = new OptionsResolver();
-        $this->configureOptions($resolver);
-
-        $options = $resolver->resolve($options);
+        $options = $this->resolveOptions($options);
 
         $builder = new ProcessBuilder([
             'assets:install',
@@ -114,6 +111,22 @@ class AssetsInstaller
         }
 
         return $builder->getProcess();
+    }
+
+    /**
+     * Takes a set of options as defined in configureOptions and validates and merges them
+     * with values from composer.json
+     *
+     * @param array $options
+     *
+     * @return array
+     */
+    public function resolveOptions(array $options = [])
+    {
+        $resolver = new OptionsResolver();
+        $this->configureOptions($resolver);
+
+        return $resolver->resolve($options);
     }
 
     private function configureOptions(OptionsResolver $resolver)


### PR DESCRIPTION
Resolves #1962: runs `assets:install` and `cache:clear` after `pimcore:bundle:enable/disable` commands. Running those post install scripts can be influcenced by options (see `--help`).