### PR TITLE
composer: add path-based repository for local packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,10 @@
           "reference": "master"
         }
       }
+    },
+    "plugins": {
+      "type": "path",
+      "url": "./local-packages/*"
     }
   },
   "require": {


### PR DESCRIPTION
## Introduction

Currently, developing a software layer on top of Pimcore is a PITA: custom dependencies and autoloader parameters are likely to be added directly to Pimcore's `composer.json` file.  Pimcore upgrades are then painful as my custom module is tightly coupled with Pimcore.

## Changes in this pull request  

Adds a path-based composer repository to introduce a convention: all directories found under the `local-packages` dir are supposed to be composer packages, with specific `composer.json` and source code.

## Additional info  

See composer documentation at https://getcomposer.org/doc/05-repositories.md#path

If this change is likely to be accepted, I'd be willing to write the corresponding documentation in the `doc` dir.