### PR TITLE
Fix redis cache pool not working when redis extension is enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,20 @@ matrix:
       sudo: required
       php: 7
       env:
-          - PIMCORE_TEST_SUITE=rest PIMCORE_TEST_ENV=http
+          - PIMCORE_TEST_SUITE=rest
+          - PIMCORE_TEST_ENV=http
     - os: linux
       sudo: required
       php: 7.1
       env:
-          - PIMCORE_TEST_SUITE=rest PIMCORE_TEST_ENV=http
+          - PIMCORE_TEST_SUITE=rest
+          - PIMCORE_TEST_ENV=http
+    - os: linux
+      php: 7.1
+      env:
+          - PIMCORE_TEST_SUITE=cache
+          - PIMCORE_TEST_GROUP=cache.core.redis
+          - PIMCORE_TEST_SETUP_SKIP_PHP_REDIS_EXTENSION=true
 
 cache:
   directories:

--- a/.travis/php-redis.ini
+++ b/.travis/php-redis.ini
@@ -1,0 +1,1 @@
+extension="redis.so"

--- a/.travis/run-tests.sh
+++ b/.travis/run-tests.sh
@@ -9,6 +9,11 @@ if [[ -n "$PIMCORE_TEST_SUITE" ]]; then
     CMD="$CMD $PIMCORE_TEST_SUITE"
 fi
 
+# add test group if configured
+if [[ -n "$PIMCORE_TEST_GROUP" ]]; then
+    CMD="$CMD -g $PIMCORE_TEST_GROUP"
+fi
+
 # add env if configured
 if [[ -n "$PIMCORE_TEST_ENV" ]]; then
     CMD="$CMD --env $PIMCORE_TEST_ENV"

--- a/.travis/setup-php.sh
+++ b/.travis/setup-php.sh
@@ -3,3 +3,9 @@
 echo "Setting up PHP..."
 
 phpenv config-add .travis/php.ini
+
+if [[ "$PIMCORE_TEST_SETUP_SKIP_PHP_REDIS_EXTENSION" != "true" ]]
+then
+    echo "Enabling PHP Redis extension..."
+    phpenv config-add .travis/php-redis.ini
+fi

--- a/pimcore/lib/Pimcore/Cache/Pool/Redis/Connection.php
+++ b/pimcore/lib/Pimcore/Cache/Pool/Redis/Connection.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Cache\Pool\Redis;
+
+class Connection extends \Credis_Client
+{
+    public function isStandalone(): bool
+    {
+        return $this->standalone;
+    }
+}

--- a/pimcore/lib/Pimcore/Cache/Pool/Redis/ConnectionFactory.php
+++ b/pimcore/lib/Pimcore/Cache/Pool/Redis/ConnectionFactory.php
@@ -28,7 +28,7 @@ class ConnectionFactory
      *
      * @param array $options
      *
-     * @return \Credis_Client
+     * @return Connection
      *
      * @throws CacheException
      */
@@ -43,7 +43,7 @@ class ConnectionFactory
             throw new CacheException('Redis \'port\' not specified.');
         }
 
-        $redis = new \Credis_Client($options['server'], $options['port'], $options['timeout'], $options['persistent']);
+        $redis = new Connection($options['server'], $options['port'], $options['timeout'], $options['persistent']);
 
         if ($options['force_standalone']) {
             $redis->forceStandalone();


### PR DESCRIPTION
Resolves #1979 

Credis returns different responses when the redis extension is enabled leading to failures in the cache pool. This PR

* changes the cache pool behaviour to cope with different responses from credis
* updates travis config to enable redis extension by default and to run an extra environment with the extension disabled