### PR TITLE
Fix areabrick template autodiscovery for bundles installed via composer 

### DIFF
--- a/pimcore/lib/Pimcore/HttpKernel/BundleLocator/BundleLocatorInterface.php
+++ b/pimcore/lib/Pimcore/HttpKernel/BundleLocator/BundleLocatorInterface.php
@@ -21,19 +21,29 @@ interface BundleLocatorInterface
     /**
      * Loads bundle for a class name. Returns the AppBundle for AppBundle\Controller\FooController
      *
-     * @param string $className
+     * @param string|object $class
      *
      * @return BundleInterface
+     *
+     * @throws NotFoundException
      */
-    public function getBundle($className);
+    public function getBundle($class): BundleInterface;
 
     /**
      * Resolves bundle directory from a class name.
+     *
      * AppBundle\Controller\FooController returns src/AppBundle
      *
-     * @param string $className
+     * @param string|object $class
      *
      * @return string
+     *
+     * @throws NotFoundException
      */
-    public function resolveBundlePath($className);
+    public function getBundlePath($class): string;
+
+    /**
+     * @deprecated Use getBundlePath instead
+     */
+    public function resolveBundlePath($class);
 }


### PR DESCRIPTION
Areabrick template autodiscovery failed when the bundle was not situated in a directory ending in `Bundle`, e.g. when a bundle is installed via composer. This reuses the same logic as the TemplateGuesser in SensioFrameworkExtraBundle to look up a bundle dir.