### PR TITLE
[Pimcore 5] Adding Marketing settings to documentation

### DIFF
--- a/doc/Development_Documentation/18_Tools_and_Features/28_Marketing_Settings.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/28_Marketing_Settings.md
@@ -10,11 +10,9 @@ The `Marketing Settings` give you the possibility to configure marketing-specifi
 Google Analytics code is automaticaly injected during rendering the page.
 This behaviour can be disabled using:
 
-```
+```php
 <?php
-// either
+// fetch the listener through container or (better) inject it as dependency into your code
 $gaListener = $container->get(\Pimcore\Bundle\CoreBundle\EventListener\Frontend\GoogleAnalyticsCodeListener::class);
-// or
-$gaListener = $container->get('Pimcore\\Bundle\\CoreBundle\\EventListener\\Frontend\\GoogleAnalyticsCodeListener');
 $gaListener->disable();
 ```

--- a/doc/Development_Documentation/18_Tools_and_Features/28_Marketing_Settings.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/28_Marketing_Settings.md
@@ -11,6 +11,10 @@ Google Analytics code is automaticaly injected during rendering the page.
 This behaviour can be disabled using:
 
 ```
-$gaListener = $container->get('pimcore.event_listener.frontend.google_analytics_code');
+<?php
+// either
+$gaListener = $container->get(\Pimcore\Bundle\CoreBundle\EventListener\Frontend\GoogleAnalyticsCodeListener::class);
+// or
+$gaListener = $container->get('Pimcore\\Bundle\\CoreBundle\\EventListener\\Frontend\\GoogleAnalyticsCodeListener');
 $gaListener->disable();
 ```

--- a/doc/Development_Documentation/18_Tools_and_Features/28_Marketing_Settings.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/28_Marketing_Settings.md
@@ -1,0 +1,16 @@
+# Marketing Settings
+
+The `Marketing Settings` give you the possibility to configure marketing-specific settings, which are:
+- Google Analytics
+- Google Search Console
+- Google Tag Manager
+
+
+### Google Analytics
+Google Analytics code is automaticaly injected during rendering the page.
+This behaviour can be disabled using:
+
+```
+$gaListener = $container->get('pimcore.event_listener.frontend.google_analytics_code');
+$gaListener->disable();
+```


### PR DESCRIPTION
This is the pull request for Pimcore 5 for https://github.com/pimcore/pimcore/issues/1882.
As there is no Marketing settings page in documentation I added one here, with a note about desactivate automatic Google Analytics code injection as it can be needed sometimes (to be able to layer some custom debugging code for instance wich need to inject custom code).

This page can be enriched later if neccessary for other marketing settings (they are self explanotory in the GUI for now).