### PR TITLE
[Pimcore 4] Adding Marketing settings to documentation

### DIFF
--- a/docs/Development_Documentation/08_Tools_and_Features/28_Marketing_Settings.md
+++ b/docs/Development_Documentation/08_Tools_and_Features/28_Marketing_Settings.md
@@ -1,0 +1,16 @@
+# Marketing Settings
+
+The `Marketing Settings` give you the possibility to configure marketing-specific settings, which are:
+- Google Analytics
+- Google Search Console
+- Google Tag Manager
+
+
+### Google Analytics
+Google Analytics code is automaticaly injected during rendering the page.
+This behaviour can be disabled using:
+
+```
+$front = \Zend_Controller_Front::getInstance();
+$front->unregisterPlugin('\Pimcore\Controller\Plugin\Analytics');
+```


### PR DESCRIPTION
This is the pull request for Pimcore 4 for #1882.
As there is no Marketing settings page in documentation I added one here, with a note about desactivate automatic Google Analytics code injection as it can be needed sometimes (to be able to layer some custom debugging code for instance wich need to inject custom code).

This page can be enriched later if neccessary for other marketing settings (they are self explanotory in the GUI for now).
