### PR TITLE
Custom Templating Helper Link fix

### DIFF
--- a/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/README.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/README.md
@@ -52,7 +52,7 @@ All helpers are described below in detail, the following tables give just a shor
 
 
 You can also create your own custom templating helpers to make certain functionalities available to your views.  
-Here you can find an example how to [create](https://github.com/pimcore/pimcore/blob/master/install-profiles/demo-basic/src/AppBundle/Templating/Example.php) 
+Here you can find an example how to [create](https://github.com/pimcore/pimcore/blob/master/install-profiles/demo-basic/src/AppBundle/Templating/Helper/Example.php) 
 and [register](https://github.com/pimcore/pimcore/blob/master/app/config/services.yml) your own templating helper. 
 
 ### `$this->action()`


### PR DESCRIPTION
Link to example file for creating custom templating helpers was not reachable, now updated to correct url.

From 
https://github.com/pimcore/pimcore/blob/master/install-profiles/demo-basic/src/AppBundle/Templating/Example.php
to
https://github.com/pimcore/pimcore/blob/master/install-profiles/demo-basic/src/AppBundle/Templating/Helper/Example.php