### PR TITLE
[Pimcore 5] [Ecommerce] - make form-attributes in Ecommerce-Payments expandable

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PaymentManager/Payment/Datatrans.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PaymentManager/Payment/Datatrans.php
@@ -144,6 +144,17 @@ class Datatrans implements IPayment
     }
 
     /**
+     * @param array $formAttributes
+     * @param IPrice $price
+     * @param array $config
+     * @return array
+     */
+    protected function extendFormAttributes(array $formAttributes, IPrice $price, array $config) : array
+    {
+        return $formAttributes;
+    }
+
+    /**
      * start payment
      *
      * @param IPrice $price
@@ -159,15 +170,7 @@ class Datatrans implements IPayment
     public function initPayment(IPrice $price, array $config)
     {
         // check params
-        $required = [
-            'successUrl' => null,
-            'errorUrl'   => null,
-            'cancelUrl'  => null,
-            'refno'      => null,
-            'useAlias'   => null,
-            'reqtype'    => null,
-            'language'   => null
-        ];
+        $required = $this->getRequiredRequestFields();
 
         $config = array_intersect_key($config, $required);
 
@@ -216,6 +219,8 @@ class Datatrans implements IPayment
         }
 
         $formAttributes['id'] = 'paymentForm';
+
+        $formAttributes = $this->extendFormAttributes($formAttributes, $price, $config);
 
         // create form
         //form name needs to be null in order to make sure the element names are correct - and not FORMNAME[ELEMENTNAME]
@@ -337,6 +342,22 @@ class Datatrans implements IPayment
                 'datatrans_response'             => $response
             ]
         );
+    }
+
+    /**
+     * @return array
+     */
+    protected function getRequiredRequestFields() : array
+    {
+        return [
+            'successUrl' => null,
+            'errorUrl'   => null,
+            'cancelUrl'  => null,
+            'refno'      => null,
+            'useAlias'   => null,
+            'reqtype'    => null,
+            'language'   => null,
+        ];
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PaymentManager/Payment/QPay.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PaymentManager/Payment/QPay.php
@@ -163,6 +163,17 @@ class QPay implements IPayment
     }
 
     /**
+     * @param array $formAttributes
+     * @param IPrice $price
+     * @param array $config
+     * @return array
+     */
+    protected function extendFormAttributes(array $formAttributes, IPrice $price, array $config) : array
+    {
+        return $formAttributes;
+    }
+
+    /**
      * Start payment
      *
      * @param IPrice $price
@@ -175,15 +186,7 @@ class QPay implements IPayment
     public function initPayment(IPrice $price, array $config)
     {
         // check params
-        $required = [
-            'successURL'       => null,
-            'cancelURL'        => null,
-            'failureURL'       => null,
-            'serviceURL'       => null,
-            'orderDescription' => null,
-            'orderIdent'       => null,
-            'language'         => null
-        ];
+        $required = $this->getRequiredRequestFields();
 
         $check = array_intersect_key($config, $required);
         if (count($required) != count($check)) {
@@ -220,10 +223,15 @@ class QPay implements IPayment
 
         // create form
         $formData = [];
+        $formAttributes = [];
+
+        $formAttributes['id'] = 'paymentForm';
+
+        $formAttributes = $this->extendFormAttributes(['id' => 'paymentForm'], $price, $config);
 
         //form name needs to be null in order to make sure the element names are correct - and not FORMNAME[ELEMENTNAME]
         $form = $this->formFactory->createNamedBuilder(null, FormType::class, [], [
-            'attr' => ['id' => 'paymentForm']
+            'attr' => $formAttributes
         ]);
 
         $form->setAction('https://www.qenta.com/qpay/init.php');
@@ -329,6 +337,22 @@ class QPay implements IPayment
                 'qpay_response'     => $response
             ]
         );
+    }
+
+    /**
+     * @return array
+     */
+    protected function getRequiredRequestFields() : array
+    {
+        return [
+            'successURL'       => null,
+            'cancelURL'        => null,
+            'failureURL'       => null,
+            'serviceURL'       => null,
+            'orderDescription' => null,
+            'orderIdent'       => null,
+            'language'         => null,
+        ];
     }
 
     /**


### PR DESCRIPTION
## Fixes Issue 
This PR makes form-attributes in the Ecommerce-Payments expandable. In some cases it might be necessary to set additional form html properties (e.g. <form ... data-paymentmethod='methods'>...</form>). By providing an formAttributes property additional form-attributes, other than those set by the EcommerceFramework, can be defined

## Changes in this pull request  

- added an array-property which will be used in order to create the Symfony-FormBuilder.


