### PR TITLE
[TRANSLATOR] Fix valid language check on adding new message for admin domain

### DIFF
--- a/pimcore/lib/Pimcore/Translation/Translator.php
+++ b/pimcore/lib/Pimcore/Translation/Translator.php
@@ -16,6 +16,7 @@ namespace Pimcore\Translation;
 
 use Pimcore\Cache;
 use Pimcore\Model\Translation\AbstractTranslation;
+use Pimcore\Model\Translation\TranslationInterface;
 use Pimcore\Tool;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
@@ -250,10 +251,11 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
                     throw new \Exception("Message ID's longer than 190 characters are invalid!");
                 }
 
+                /** @var TranslationInterface $class */
                 $class = '\\Pimcore\\Model\\Translation\\' . ucfirst($backend);
 
                 // no translation found create key
-                if (Tool::isValidLanguage($locale)) {
+                if ($class::isValidLanguage($locale)) {
                     try {
                         /**
                          * @var AbstractTranslation $t
@@ -269,7 +271,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
                         $t->setKey($id);
 
                         // add all available languages
-                        $availableLanguages = (array)Tool::getValidLanguages();
+                        $availableLanguages = (array)$class::getLanguages();
                         foreach ($availableLanguages as $language) {
                             $t->addTranslation($language, '');
                         }

--- a/pimcore/models/Translation/AbstractTranslation.php
+++ b/pimcore/models/Translation/AbstractTranslation.php
@@ -47,6 +47,14 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
     public $modificationDate;
 
     /**
+     * @inheritDoc
+     */
+    public static function isValidLanguage($locale): bool
+    {
+        return in_array($locale, (array)static::getLanguages());
+    }
+
+    /**
      * @return string
      */
     public function getKey()

--- a/pimcore/models/Translation/Admin.php
+++ b/pimcore/models/Translation/Admin.php
@@ -27,7 +27,7 @@ class Admin extends AbstractTranslation
     /**
      * @return array
      */
-    protected static function getLanguages()
+    public static function getLanguages(): array
     {
         return \Pimcore\Tool\Admin::getLanguages();
     }

--- a/pimcore/models/Translation/TranslationInterface.php
+++ b/pimcore/models/Translation/TranslationInterface.php
@@ -20,6 +20,22 @@ namespace Pimcore\Model\Translation;
 interface TranslationInterface
 {
     /**
+     * Returns a list of valid languages
+     *
+     * @return array
+     */
+    public static function getLanguages(): array;
+
+    /**
+     * Detemines if backend can handle the language
+     *
+     * @param $locale
+     *
+     * @return bool
+     */
+    public static function isValidLanguage($locale): bool;
+
+    /**
      * @param $id
      *
      * @return mixed

--- a/pimcore/models/Translation/Website.php
+++ b/pimcore/models/Translation/Website.php
@@ -25,7 +25,7 @@ class Website extends AbstractTranslation
     /**
      * @return array
      */
-    protected static function getLanguages()
+    public static function getLanguages(): array
     {
         return \Pimcore\Tool::getValidLanguages();
     }


### PR DESCRIPTION
Checks messages for admin domain against list of admin languages. Fixes #1842
