### PR TITLE
Implement an AdminUserTranslator which uses the user's language as default locale

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/config/services.yml
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/config/services.yml
@@ -36,3 +36,9 @@ services:
         resource: '../../Controller'
         public: true
         tags: ['controller.service_arguments']
+
+    #
+    # TRANSLATIONS
+    #
+
+    Pimcore\Bundle\AdminBundle\Translation\AdminUserTranslator: ~

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Translation/AdminUserTranslator.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Translation/AdminUserTranslator.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\AdminBundle\Translation;
+
+use Pimcore\Bundle\AdminBundle\Security\User\UserLoader;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class AdminUserTranslator implements TranslatorInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var UserLoader
+     */
+    private $userLoader;
+
+    public function __construct(TranslatorInterface $translator, UserLoader $userLoader)
+    {
+        $this->translator = $translator;
+        $this->userLoader = $userLoader;
+    }
+
+    private function getUserLocale()
+    {
+        if (null !== $user = $this->userLoader->getUser()) {
+            return $user->getLanguage();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function trans($id, array $parameters = [], $domain = null, $locale = null)
+    {
+        $domain = $domain ?? 'admin';
+        $locale = $locale ?? $this->getUserLocale();
+
+        return $this->translator->trans($id, $parameters, $domain, $locale);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
+    {
+        $domain = $domain ?? 'admin';
+        $locale = $locale ?? $this->getUserLocale();
+
+        return $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setLocale($locale)
+    {
+        $this->translator->setLocale($locale);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getLocale()
+    {
+        return $this->translator->getLocale();
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/documents.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/documents.yml
@@ -32,6 +32,7 @@ services:
         public: false
         arguments:
             $templating: '@templating'
+            $translator: '@Pimcore\Bundle\AdminBundle\Translation\AdminUserTranslator'
         calls:
             - [setLogger, ['@logger']]
         tags:

--- a/pimcore/lib/Pimcore/Document/Tag/TagHandler.php
+++ b/pimcore/lib/Pimcore/Document/Tag/TagHandler.php
@@ -167,8 +167,8 @@ class TagHandler implements TagHandlerInterface, LoggerAwareInterface
             }
 
             if ($view->editmode) {
-                $name = $this->translator->trans($name, [], 'admin');
-                $desc = $this->translator->trans($desc, [], 'admin');
+                $name = $this->translator->trans($name);
+                $desc = $this->translator->trans($desc);
             }
 
             $areas[$brick->getId()] = [


### PR DESCRIPTION
Needed when rendering admin elements outside of admin context (e.g.
areabrick toolbar in editmode). As the AdminUserTranslator implements
the TranslatorInterface, implementations can just use the new service
instead of the standard translator to get this behaviour.

Fixes #1857
