### PR TITLE
Fix admin translations not being loaded in Safari

### DIFF
--- a/web/pimcore/static6/js/pimcore/overrides.js
+++ b/web/pimcore/static6/js/pimcore/overrides.js
@@ -13,7 +13,7 @@
 
 if(typeof window['t'] !== 'function') {
     // for compatibility reasons
-    function t(v) {return v;};
+    window.t = function(v) { return v; };
 }
 
 Ext.override(Ext.dd.DragDropMgr, {


### PR DESCRIPTION
The t() function fallback which was added in #1811 seems to be declared
even if the surrounding if() block does not resolve to true, resulting
in t() always being the fallback method instead of the real translator.
By setting it as function expression on the window object the fallback
should work properly without overwriting the actual t() function.

Fixes #1997

