### PR TITLE
Hardcoded mapping in lib/Pimcore/Model/AbstractModel.php

### DIFF
--- a/pimcore/lib/Pimcore/Model/AbstractModel.php
+++ b/pimcore/lib/Pimcore/Model/AbstractModel.php
@@ -93,12 +93,7 @@ abstract class AbstractModel
             self::$daoClassMap = include(PIMCORE_PATH . '/config/dao-classmap.php');
         }
 
-        // we have 2 static mappings for objects for performance reasons
-        if ($this instanceof DataObject\Concrete) {
-            $dao = 'Pimcore\Model\DataObject\Concrete\Dao';
-        } elseif ($this instanceof DataObject\Listing\Concrete) {
-            $dao = 'Pimcore\Model\DataObject\Listing\Concrete\Dao';
-        } elseif (!$forceDetection && array_key_exists($cacheKey, self::$daoClassCache)) {
+        if (!$forceDetection && array_key_exists($cacheKey, self::$daoClassCache)) {
             $dao = self::$daoClassCache[$cacheKey];
         } elseif (!$key || $forceDetection) {
             if (isset(self::$daoClassMap[$myClass])) {


### PR DESCRIPTION
fixed issue #2000 

You had flexibility issue. Architecturally low level models should not care about performance. It's mostly task for server cache. I removed static mapping for several models for further easy overriding these models.