### PR TITLE
[Pimcore 5] Fixing annotation typo

### DIFF
--- a/pimcore/lib/Pimcore/Cache/Runtime.php
+++ b/pimcore/lib/Pimcore/Cache/Runtime.php
@@ -160,7 +160,7 @@ final class Runtime extends \ArrayObject
 
     /**
      * @param string $index
-     * @returns mixed
+     * @return mixed
      *
      * Workaround for http://bugs.php.net/bug.php?id=40442 (ZF-960).
      */


### PR DESCRIPTION
Incorrect annotation -` @returns` might cause AnnotationException