### PR TITLE
Pimcore Staticroute Improvements

### DIFF
--- a/pimcore/models/Staticroute.php
+++ b/pimcore/models/Staticroute.php
@@ -526,7 +526,7 @@ class Staticroute extends AbstractModel
 
             // merge route params from static routes here
             $request = \Pimcore::getContainer()->get('request_stack')->getCurrentRequest();
-            if ($request->attributes->get('_route_params')) {
+            if (null !== $request && $request->attributes->get('_route_params')) {
                 $requestParameters = array_merge($requestParameters, $request->attributes->get('_route_params'));
             }
 


### PR DESCRIPTION
* Fixes `Staticroute::assemble()` when no request is available (CLI)
* Adds support for URL reference types for Pimcore's static routes (fixes #1902)