### PR TITLE
[INSTALLER] Fix installer sometimes relying on invalid container configuration

### DIFF
--- a/pimcore/lib/Pimcore/Config.php
+++ b/pimcore/lib/Pimcore/Config.php
@@ -705,11 +705,14 @@ class Config
     }
 
     /**
+     * @param bool $reset
+     * @param string|null $default
+     *
      * @return string
      */
-    public static function getEnvironment()
+    public static function getEnvironment(bool $reset = false, string $default = null)
     {
-        if (null === static::$environment) {
+        if (null === static::$environment || $reset) {
             $environment = false;
 
             // check env vars - fall back to default (prod)
@@ -736,10 +739,14 @@ class Config
             }
 
             if (!$environment) {
-                if (\Pimcore::inDebugMode()) {
-                    $environment = 'dev';
+                if (null !== $default) {
+                    $environment = $default;
                 } else {
-                    $environment = static::DEFAULT_ENVIRONMENT;
+                    if (\Pimcore::inDebugMode()) {
+                        $environment = 'dev';
+                    } else {
+                        $environment = static::DEFAULT_ENVIRONMENT;
+                    }
                 }
             }
 

--- a/pimcore/lib/Pimcore/Install/SystemConfig/ConfigWriter.php
+++ b/pimcore/lib/Pimcore/Install/SystemConfig/ConfigWriter.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Install\SystemConfig;
+
+use Pimcore\File;
+
+class ConfigWriter
+{
+    /**
+     * @var array
+     */
+    private $defaultConfig = [
+        'general' => [
+            'timezone' => 'Europe/Berlin',
+            'language' => 'en',
+            'validLanguages' => 'en',
+        ],
+        'database' => [
+            'params' => [
+                'username' => 'root',
+                'password' => '',
+                'dbname' => '',
+            ]
+        ],
+        'documents' => [
+            'versions' => [
+                'steps' => '10'
+            ],
+            'default_controller' => 'default',
+            'default_action' => 'default',
+            'error_pages' => [
+                'default' => '/'
+            ],
+            'createredirectwhenmoved' => '',
+            'allowtrailingslash' => 'no',
+            'generatepreview' => '1'
+        ],
+        'objects' => [
+            'versions' => [
+                'steps' => '10'
+            ]
+        ],
+        'assets' => [
+            'versions' => [
+                'steps' => '10'
+            ]
+        ],
+        'services' => [],
+        'cache' => [
+            'excludeCookie' => ''
+        ],
+        'httpclient' => [
+            'adapter' => 'Socket'
+        ],
+        'email' => [
+            'sender' => [
+                'name' => '',
+                'email' => ''
+            ],
+            'return' => [
+                'name' => '',
+                'email' => ''
+            ],
+            'method' => 'mail',
+            'smtp' => [
+                'host' => '',
+                'port' => '',
+                'ssl' => null,
+                'name' => '',
+                'auth' => [
+                    'method' => null,
+                    'username' => '',
+                    'password' => ''
+                ]
+            ],
+            'debug' => [
+                'emailaddresses' => ''
+            ]
+        ],
+        'newsletter' => [
+            'sender' => [
+                'name' => '',
+                'email' => ''
+            ],
+            'return' => [
+                'name' => '',
+                'email' => ''
+            ],
+            'method' => 'mail',
+            'smtp' => [
+                'host' => '',
+                'port' => '',
+                'ssl' => null,
+                'name' => '',
+                'auth' => [
+                    'method' => null,
+                    'username' => '',
+                    'password' => ''
+                ]
+            ],
+            'usespecific' => ''
+        ]
+    ];
+
+    public function __construct(array $defaultConfig = null)
+    {
+        if (null !== $defaultConfig) {
+            $this->defaultConfig = $defaultConfig;
+        }
+    }
+
+    public function writeSystemConfig(array $config = [])
+    {
+        $settings = null;
+
+        // check for an initial configuration template
+        // used eg. by the demo installer
+        $configTemplatePaths = [
+            PIMCORE_CONFIGURATION_DIRECTORY . '/system.php',
+            PIMCORE_CONFIGURATION_DIRECTORY . '/system.template.php'
+        ];
+
+        foreach ($configTemplatePaths as $configTemplatePath) {
+            if (!file_exists($configTemplatePath)) {
+                continue;
+            }
+
+            try {
+                $configTemplateArray = include($configTemplatePath);
+
+                if (!is_array($configTemplateArray)) {
+                    continue;
+                }
+
+                $configTemplate = new \Pimcore\Config\Config($configTemplateArray);
+                if ($configTemplate->general) { // check if the template contains a valid configuration
+                    $settings = $configTemplate->toArray();
+
+                    // unset database configuration
+                    unset($settings['database']['params']['host']);
+                    unset($settings['database']['params']['port']);
+
+                    break;
+                }
+            } catch (\Exception $e) {
+            }
+        }
+
+        // set default configuration if no template is present
+        if (!$settings) {
+            // write configuration file
+            $settings = $this->defaultConfig;
+        }
+
+        $settings = array_replace_recursive($settings, $config);
+
+        $configFile = \Pimcore\Config::locateConfigFile('system.php');
+        File::putPhpFile($configFile, to_php_data_file_format($settings));
+    }
+
+    public function writeDebugModeConfig($ip = '')
+    {
+        File::putPhpFile(PIMCORE_CONFIGURATION_DIRECTORY . '/debug-mode.php', to_php_data_file_format([
+            'active' => true,
+            'ip' => '',
+        ]));
+    }
+
+    public function generateParametersFile(string $secret = null)
+    {
+        if (null === $secret) {
+            $secret = generateRandomSymfonySecret();
+        }
+
+        // generate parameters.yml
+        $parametersFilePath = PIMCORE_APP_ROOT . '/config/parameters.yml';
+        if (!file_exists($parametersFilePath)) {
+            return;
+        }
+
+        $parameters = file_get_contents(PIMCORE_APP_ROOT . '/config/parameters.example.yml');
+        $parameters = str_replace('ThisTokenIsNotSoSecretChangeIt', $secret, $parameters);
+
+        File::put($parametersFilePath, $parameters);
+    }
+}

--- a/pimcore/lib/Pimcore/Tool.php
+++ b/pimcore/lib/Pimcore/Tool.php
@@ -660,9 +660,7 @@ class Tool
             $realCacheDir = PIMCORE_PRIVATE_VAR . '/cache';
         }
 
-        // the old cache dir name must not be longer than the real one to avoid exceeding
-        // the maximum length of a directory or file path within it (esp. Windows MAX_PATH)
-        $oldCacheDir = substr($realCacheDir, 0, -1).('~' === substr($realCacheDir, -1) ? '+' : '~');
+        $oldCacheDir = self::getSymfonyCacheDirRemoveTempLocation($realCacheDir);
         $filesystem = $container->get('filesystem');
         if ($filesystem->exists($oldCacheDir)) {
             $filesystem->remove($oldCacheDir);
@@ -674,6 +672,13 @@ class Tool
 
         $filesystem->rename($realCacheDir, $oldCacheDir);
         $filesystem->remove($oldCacheDir);
+    }
+
+    public static function getSymfonyCacheDirRemoveTempLocation(string $realCacheDir): string
+    {
+        // the temp cache dir name must not be longer than the real one to avoid exceeding
+        // the maximum length of a directory or file path within it (esp. Windows MAX_PATH)
+        return substr($realCacheDir, 0, -1) . ('~' === substr($realCacheDir, -1) ? '+' : '~');
     }
 
     /**

--- a/web/app.php
+++ b/web/app.php
@@ -13,6 +13,7 @@
  */
 
 use Pimcore\Tool;
+use Symfony\Component\Debug\Debug;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -34,9 +35,6 @@ $request = Request::createFromGlobals();
 // request stack available yet
 Tool::setCurrentRequest($request);
 
-/** @var \Pimcore\Kernel $kernel */
-$kernel = require_once PIMCORE_PROJECT_ROOT . '/pimcore/config/kernel.php';
-
 // redirect to installer if pimcore is not installed
 if (!is_file(\Pimcore\Config::locateConfigFile('system.php'))) {
     if (file_exists(__DIR__ . '/install.php')) {
@@ -44,8 +42,12 @@ if (!is_file(\Pimcore\Config::locateConfigFile('system.php'))) {
         return;
     }
 
+    Debug::enable(E_ALL, true);
     throw new RuntimeException('Pimcore is not installed and the installer is not available. Please add the installer or install via command line.');
 }
+
+/** @var \Pimcore\Kernel $kernel */
+$kernel = require_once PIMCORE_PROJECT_ROOT . '/pimcore/config/kernel.php';
 
 // reset current request - will be read from request stack from now on
 Tool::setCurrentRequest(null);


### PR DESCRIPTION
When the installer tries to build the container for the first time, it can happen that there's already built container in place (e.g. because of CLI scripts). Under certain circumstances (probably timing issues), it can happen that the kernel does not rebuild the container from the newly created config, but keeps using that cached container, resulting in errors (e.g. using root as DB user as it is in the default config). This makes sure:

* the cache dir is cleared before the application kernel is built
* `app.php` does not even try to build a kernel if no `system.php` is found (prevents building an invalid kernel)
* the `Setup` model is not loaded before building the kernel. The method writing config files was moved to an extra class
* the new kernel is always booted in dev mode (as we set the debug to true in installer). The only exception to this rule is a setup where the environment was forced by setting the `PIMCORE_ENVIRONMENT` env var
* the error thrown in `app.php` when no `system.php` and no `install.php` are present is now rendered through Symfony's debug handler to get a nicer error output
