### PR TITLE
Set credis dependency to 1.8.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     "ext-zlib": "*",
     "amnuts/opcache-gui": "~2",
     "cache/tag-interop": "^1",
-    "colinmollenhour/credis": "~1",
+    "colinmollenhour/credis": "1.8.*",
     "composer/ca-bundle": "^1",
     "debril/rss-atom-bundle": "^3.0",
     "defuse/php-encryption": "~2",


### PR DESCRIPTION
Credis introduced breaking changes in 1.9 which cause cache tests to fail. Until this is fixed, keep using 1.8.