### PR TITLE
[PIMCORE4] Credis 1.8 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     "sabre/dav": "~3.1",
     "pear/net_url2": "~2.2",
     "ramsey/uuid": "~3",
-    "colinmollenhour/credis": "~1",
+    "colinmollenhour/credis": "1.8.*",
     "endroid/qrcode": "~2.2",
     "mpratt/embera": "~1",
     "defuse/php-encryption": "~2",


### PR DESCRIPTION
See #2026 for Pimcore 5 version. Won't fix in Pimcore 4 - just keep using 1.8.x here.