### PR TITLE
Add missing print.css in demo-basic-twig installation profile

### DIFF
--- a/install-profiles/demo-basic-twig/web/static/css/print.css
+++ b/install-profiles/demo-basic-twig/web/static/css/print.css
@@ -1,0 +1,11 @@
+.navbar-wrapper, .sidebar, .filters, .pagination, .breadcrumb-footer , footer {
+    display: none;
+}
+a {
+    color: #337ab7;
+}
+body {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.42857143;
+}


### PR DESCRIPTION
In the layout of the demo-basic-twig installation profile is a print.css included:
https://github.com/pimcore/pimcore/blob/master/install-profiles/demo-basic-twig/app/Resources/views/layout.html.twig#L18

But this file is missing. A add the one from the demo-basic installation profile.