### PR TITLE
Add possibility to use property "leftNavHide" in twig basic demo.

### DIFF
--- a/install-profiles/demo-basic-twig/app/Resources/views/layout.html.twig
+++ b/install-profiles/demo-basic-twig/app/Resources/views/layout.html.twig
@@ -114,7 +114,7 @@
     {{ include('Includes/jumbotron.html.twig') }}
 
     <div id="content" class="container">
-        {% set hideLeftNav = false %}
+        {% set hideLeftNav = document.getProperty('leftNavHide') %}
         {% set showBreadcrumbs = true %}
         {% set mainColClass = hideLeftNav ? 'col-md-12': 'col-md-9 col-md-push-3' %}
 


### PR DESCRIPTION
Add possibility to use the predefined property "leftNavHide" within twig basic demo.
