### PR TITLE
[Pimcore 4] Update for webservices, cast array to object

### DIFF
--- a/pimcore/models/Document/Tag/Wysiwyg.php
+++ b/pimcore/models/Document/Tag/Wysiwyg.php
@@ -116,6 +116,9 @@ class Wysiwyg extends Model\Document\Tag
     public function getFromWebserviceImport($wsElement, $document = null, $params = [], $idMapper = null)
     {
         $data = $wsElement->value;
+        if (is_array($data)) {
+            $data =  (object) $data;
+        }
         if ($data->text === null or is_string($data->text)) {
             $this->text = $data->text;
         } else {


### PR DESCRIPTION
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
  
  
## Fixes Issue #

## Changes in this pull request  
Cast array to object for wysiwyg

## Additional info  
While testing with the api we discovered that the text from wysiwyg element isn't saved. $wsElement->value is an array and not an object.

## Steps to reproduce
- Create document with webservice api
- Expected result: text of wysiwyg is filled with "hoplaaa"
- Actual result: wysiwyg is empty

Data to test with:
`{
    "path": "\/",
    "userModification": 2,
    "childs": null,
    "controller": "Blog",
    "action": "default",
    "template": null,
    "elements": [
      {
        "type": "wysiwyg",
        "value": {
          "text": "hoplaaa",
          "options": null,
          "name": "richtexteditor",
          "realName": null,
          "inherited": false
        },
        "name": "richtexteditor"
      }
    ],
    "parentId": 1,
    "type": "snippet",
    "key": "test-api-user",
    "index": 2,
    "published": true,
    "userOwner": 2,
    "properties": null
}`