### PR TITLE
[ECOMMERCE] Only check isInstalled() once

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Tools/Installer.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Tools/Installer.php
@@ -164,6 +164,9 @@ class Installer extends AbstractInstaller
 
         $this->addPermissions();
 
+        // reset installed state
+        $this->installed = null;
+
         return true;
     }
 
@@ -483,6 +486,9 @@ class Installer extends AbstractInstaller
 
         $key = 'bundle_ecommerce_back-office_order';
         $db->deleteWhere('users_permission_definitions', '`key` = ' . $db->quote($key));
+
+        // reset installed state
+        $this->installed = null;
 
         return true;
     }

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Tools/Installer.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Tools/Installer.php
@@ -37,6 +37,11 @@ class Installer extends AbstractInstaller
     private $installSourcesPath;
 
     /**
+     * @var bool
+     */
+    private $installed;
+
+    /**
      * @var array - contains all tables that need to be created
      */
     private $tables = [
@@ -498,6 +503,10 @@ class Installer extends AbstractInstaller
      */
     public function isInstalled()
     {
+        if (null !== $this->installed) {
+            return $this->installed;
+        }
+
         $result = null;
         try {
             if (Config::getSystemConfig()) {
@@ -507,6 +516,8 @@ class Installer extends AbstractInstaller
             $this->logger->error($e);
         }
 
-        return !empty($result);
+        $this->installed = !empty($result);
+
+        return $this->installed;
     }
 }


### PR DESCRIPTION
Partially fixes #2004. Avoids doing multiple lookups on `isInstalled()`