### PR TITLE
[ECOMMERCE] Default legacy mapping to false

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
@@ -117,7 +117,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('use_legacy_class_mapping')
                     ->info('If true, the bundle will alias legacy class names (OnlineShop\Framework\*) to the new namespace')
-                    ->defaultTrue()
+                    ->defaultFalse()
                 ->end()
                ->integerNode('decimal_scale')
                     ->info('Default scale used for Decimal objects')

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PimcoreEcommerceFrameworkBundle.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PimcoreEcommerceFrameworkBundle.php
@@ -83,7 +83,7 @@ class PimcoreEcommerceFrameworkBundle extends AbstractPimcoreBundle
         Decimal::setDefaultScale($container->getParameter('pimcore_ecommerce.decimal_scale'));
 
         // use legacy class mapping if configured
-        if ($container->getParameter('pimcore_ecommerce.use_legacy_class_mapping') && $this->getInstaller()->isInstalled()) {
+        if ($container->getParameter('pimcore_ecommerce.use_legacy_class_mapping')) {
             //load legacy class mapping only when ecommerce framework bundle is installed.
             LegacyClassMappingTool::loadMapping();
         }

--- a/update-scripts/134/preupdate.php
+++ b/update-scripts/134/preupdate.php
@@ -1,0 +1,38 @@
+<?php
+
+use Pimcore\Bundle\EcommerceFrameworkBundle\PimcoreEcommerceFrameworkBundle;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Yaml;
+
+// only add mapping if the ecommerce framework bundle is enabled
+if (!PimcoreEcommerceFrameworkBundle::isEnabled()) {
+    return;
+}
+
+$configFile = PIMCORE_APP_ROOT . '/config/local/update_134_ecommerce_legacy_mapping.yml';
+
+$configData = [
+    'pimcore_ecommerce_framework' => [
+        'use_legacy_class_mapping' => true
+    ]
+];
+
+$fs = new Filesystem();
+$relativeConfigFile = $fs->makePathRelative($configFile, PIMCORE_PROJECT_ROOT);
+
+try {
+    $yaml = Yaml::dump($configData, 100);
+    $yaml = '# created by build 134 - you can safely remove this if you don\'t need any legacy class mapping' . "\n" . $yaml;
+
+    $fs->dumpFile($configFile, $yaml);
+} catch (Exception $e) {
+    echo sprintf(PHP_EOL . '<p><strong style="color: red">ERROR:</strong> Failed to write YML config to <code>%s</code>: %s</p>' . PHP_EOL, $configFile, $e->getMessage());
+    echo <<<EOF
+<p>Please add the following configuration manually:<br>
+<pre>
+pimcore_ecommerce_framework:
+    use_legacy_class_mapping: true
+</pre>
+</p>
+EOF;
+}


### PR DESCRIPTION
Partially fixes #2004 

* Disables legacy mapping by default. If a project already has the framework enabled, an update script will take care of creating a local config file enabling the mapping.
* Does not check for `isInstalled()` when applying legacy mapping as it is a performance hit which runs on every request and shouldn't be necessary for static class mapping.