### PR TITLE
[MIGRATIONS] Configurable Sets

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -93,6 +93,7 @@ class Configuration implements ConfigurationInterface
         $this->addSecurityNode($rootNode);
         $this->addNewsletterNode($rootNode);
         $this->addCustomReportsNode($rootNode);
+        $this->addMigrationsNode($rootNode);
 
         return $treeBuilder;
     }
@@ -564,6 +565,54 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('adapters')
                             ->useAttributeAsKey('name')
                                 ->prototype('scalar')
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * Adds configuration tree node for migrations
+     *
+     * @param ArrayNodeDefinition $rootNode
+     */
+    private function addMigrationsNode(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('migrations')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('sets')
+                            ->useAttributeAsKey('identifier')
+                            ->defaultValue([])
+                            ->info('Migration sets which can be used apart from bundle migrations. Use the -s option in migration commands to select a specific set.')
+                            ->example([
+                                [
+                                    'custom_set' => [
+                                        'name'       => 'Custom Migrations',
+                                        'namespace'  => 'App\\Migrations\\Custom',
+                                        'directory'  => 'src/App/Migrations/Custom'
+                                    ]
+                                ]
+                            ])
+                            ->prototype('array')
+                                ->children()
+                                    ->scalarNode('identifier')->end()
+                                    ->scalarNode('name')
+                                        ->isRequired()
+                                        ->cannotBeEmpty()
+                                    ->end()
+                                    ->scalarNode('namespace')
+                                        ->isRequired()
+                                        ->cannotBeEmpty()
+                                    ->end()
+                                    ->scalarNode('directory')
+                                        ->isRequired()
+                                        ->cannotBeEmpty()
+                                    ->end()
+                                ->end()
                             ->end()
                         ->end()
                     ->end()

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -594,7 +594,13 @@ class Configuration implements ConfigurationInterface
                                         'name'       => 'Custom Migrations',
                                         'namespace'  => 'App\\Migrations\\Custom',
                                         'directory'  => 'src/App/Migrations/Custom'
-                                    ]
+                                    ],
+                                    'custom_set_2' => [
+                                        'name'       => 'Custom Migrations 2',
+                                        'namespace'  => 'App\\Migrations\\Custom2',
+                                        'directory'  => 'src/App/Migrations/Custom2',
+                                        'connection' => 'custom_connection'
+                                    ],
                                 ]
                             ])
                             ->prototype('array')
@@ -611,6 +617,18 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('directory')
                                         ->isRequired()
                                         ->cannotBeEmpty()
+                                    ->end()
+                                    ->scalarNode('connection')
+                                        ->info('If defined, the DBAL connection defined here will be used')
+                                        ->defaultNull()
+                                        ->beforeNormalization()
+                                            ->ifTrue(function ($v) {
+                                                return empty(trim($v));
+                                            })
+                                            ->then(function() {
+                                                return null;
+                                            })
+                                        ->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -18,6 +18,7 @@ use Pimcore\Bundle\CoreBundle\EventListener\TranslationDebugListener;
 use Pimcore\Http\Context\PimcoreContextGuesser;
 use Pimcore\Loader\ImplementationLoader\ClassMapLoader;
 use Pimcore\Loader\ImplementationLoader\PrefixLoader;
+use Pimcore\Migrations\Configuration\ConfigurationFactory;
 use Pimcore\Model\Document\Tag\Loader\PrefixLoader as DocumentTagPrefixLoader;
 use Pimcore\Model\Factory;
 use Pimcore\Routing\Loader\AnnotatedRouteControllerLoader;
@@ -101,6 +102,7 @@ class PimcoreCoreExtension extends Extension implements PrependExtensionInterfac
         $this->configurePasswordEncoders($container, $config);
         $this->configureAdapterFactories($container, $config['newsletter']['source_adapters'], 'pimcore.newsletter.address_source_adapter.factories', 'Newsletter Address Source Adapter Factory');
         $this->configureAdapterFactories($container, $config['custom_report']['adapters'], 'pimcore.custom_report.adapter.factories', 'Custom Report Adapter Factory');
+        $this->configureMigrations($container, $config['migrations']);
 
         // load engine specific configuration only if engine is active
         $configuredEngines = ['twig', 'php'];
@@ -306,6 +308,22 @@ class PimcoreCoreExtension extends Extension implements PrependExtensionInterfac
         }
 
         $definition->replaceArgument(1, $factoryMapping);
+    }
+
+    private function configureMigrations(ContainerBuilder $container, array $config)
+    {
+        $configurations = [];
+        foreach ($config['sets'] as $identifier => $set) {
+            $configurations[] = array_merge([
+                'identifier' => $identifier
+            ], $set);
+        }
+
+        $factory = $container->findDefinition(ConfigurationFactory::class);
+        $factory->setArgument(
+            '$migrationSetConfigurations',
+            $configurations
+        );
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/migrations.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/migrations.yml
@@ -9,7 +9,5 @@ services:
 
     Pimcore\Migrations\Configuration\ConfigurationFactory:
         public: true
-        arguments:
-            $rootDir: '%kernel.root_dir%'
 
     Pimcore\Migrations\MigrationManager: ~

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/config.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/config.yml
@@ -198,6 +198,18 @@ pimcore:
         translations:
             path: "@PimcoreCoreBundle/Resources/translations"
 
+    # Pimcore migration sets
+    # Bundles can define their own migration sets - the sets defined here act as global sets
+    # available to the whole application
+    migrations:
+        sets:
+            # this is the default migration set which will be used if the
+            # migration commands do not specify --set or --bundle
+            app:
+                name: Migrations
+                namespace: App\Migrations
+                directory: "%kernel.root_dir%/Resources/migrations"
+
 swiftmailer:
     default_mailer: pimcore_mailer
     mailers:

--- a/pimcore/lib/Pimcore/Migrations/Command/Traits/PimcoreMigrationsConfiguration.php
+++ b/pimcore/lib/Pimcore/Migrations/Command/Traits/PimcoreMigrationsConfiguration.php
@@ -89,6 +89,12 @@ trait PimcoreMigrationsConfiguration
             } else {
                 $this->migrationConfiguration = $factory->getForSet($input->getOption('set'), $connection, $outputWriter);
             }
+
+            // the migration configuration might use another connection than the one resolved in getConnection
+            // e.g. when the migration set defines a dedicate connection
+            if ($this->migrationConfiguration->getConnection() !== $this->connection) {
+                $this->connection = $this->migrationConfiguration->getConnection();
+            }
         }
 
         return $this->migrationConfiguration;

--- a/pimcore/lib/Pimcore/Migrations/Command/Traits/PimcoreMigrationsConfiguration.php
+++ b/pimcore/lib/Pimcore/Migrations/Command/Traits/PimcoreMigrationsConfiguration.php
@@ -58,9 +58,19 @@ trait PimcoreMigrationsConfiguration
                 'b',
                 InputOption::VALUE_REQUIRED,
                 sprintf(
-                    'The bundle to migrate. If no bundle is set it will handle app migrations from <comment>%s</comment>',
+                    'The bundle to migrate. If no bundle is set it will use the <comment>app</comment> set from <comment>%s</comment>.',
                     'app/Resources/migrations'
                 )
+            )
+            ->addOption(
+                'set',
+                's',
+                InputOption::VALUE_REQUIRED,
+                sprintf(
+                    'The migration set to use (will be overridden by bundle if <comment>--bundle</comment> option is set).' . PHP_EOL . 'Defaults to <comment>app</comment> which loads migrations from <comment>%s</comment>.',
+                    'app/Resources/migrations'
+                ),
+                'app'
             );
     }
 
@@ -77,7 +87,7 @@ trait PimcoreMigrationsConfiguration
             if ($bundle) {
                 $this->migrationConfiguration = $factory->getForBundle($bundle, $connection, $outputWriter);
             } else {
-                $this->migrationConfiguration = $factory->getForSet('app', $connection, $outputWriter);
+                $this->migrationConfiguration = $factory->getForSet($input->getOption('set'), $connection, $outputWriter);
             }
         }
 

--- a/pimcore/lib/Pimcore/Migrations/Configuration/ConfigurationFactory.php
+++ b/pimcore/lib/Pimcore/Migrations/Configuration/ConfigurationFactory.php
@@ -35,11 +35,6 @@ class ConfigurationFactory implements EventSubscriberInterface
     private $container;
 
     /**
-     * @var string
-     */
-    private $rootDir;
-
-    /**
      * @var MigrationSetConfiguration[]
      */
     private $migrationSets = [];
@@ -54,12 +49,11 @@ class ConfigurationFactory implements EventSubscriberInterface
      */
     private $installConfigurations = [];
 
-    public function __construct(ContainerInterface $container, string $rootDir)
+    public function __construct(ContainerInterface $container, array $migrationSetConfigurations = [])
     {
         $this->container = $container;
-        $this->rootDir   = $rootDir;
 
-        $this->buildDefaultMigrationSets();
+        $this->buildMigrationSets($migrationSetConfigurations);
     }
 
     public static function getSubscribedEvents()
@@ -68,6 +62,13 @@ class ConfigurationFactory implements EventSubscriberInterface
         return [
             TestEvents::KERNEL_BOOTED => 'reset'
         ];
+    }
+
+    private function buildMigrationSets(array $configurations)
+    {
+        foreach ($configurations as $configuration) {
+            $this->registerMigrationSet(MigrationSetConfiguration::fromConfig($configuration));
+        }
     }
 
     public function getForSet(
@@ -205,18 +206,6 @@ class ConfigurationFactory implements EventSubscriberInterface
         }
     }
 
-    protected function buildDefaultMigrationSets()
-    {
-        $this->registerMigrationSet(
-            new MigrationSetConfiguration(
-                'app',
-                'Migrations',
-                'App\\Migrations',
-                $this->rootDir . '/Resources/migrations'
-            )
-        );
-    }
-
     private function getMigrationSetForBundle(BundleInterface $bundle): MigrationSetConfiguration
     {
         if (!isset($this->migrationSets[$bundle->getName()])) {
@@ -239,7 +228,7 @@ class ConfigurationFactory implements EventSubscriberInterface
     private function registerMigrationSet(MigrationSetConfiguration $migrationSet)
     {
         if (isset($this->migrationSets[$migrationSet->getIdentifier()])) {
-            throw new \RuntimeException(sprintf('Migration set "%s" is already registered', $migrationSet->getIdentifier()));
+            throw new \RuntimeException(sprintf('Migration set "%s" is already registered.', $migrationSet->getIdentifier()));
         }
 
         $this->migrationSets[$migrationSet->getIdentifier()] = $migrationSet;
@@ -248,7 +237,7 @@ class ConfigurationFactory implements EventSubscriberInterface
     protected function getMigrationSet(string $set): MigrationSetConfiguration
     {
         if (!isset($this->migrationSets[$set])) {
-            throw new \InvalidArgumentException(sprintf('Migration set "%s" is not registered', $set));
+            throw new \InvalidArgumentException(sprintf('Migration set "%s" is not registered.', $set));
         }
 
         return $this->migrationSets[$set];

--- a/pimcore/lib/Pimcore/Migrations/Configuration/ConfigurationFactory.php
+++ b/pimcore/lib/Pimcore/Migrations/Configuration/ConfigurationFactory.php
@@ -115,6 +115,14 @@ class ConfigurationFactory implements EventSubscriberInterface
             return $this->configurations[$migrationSet->getIdentifier()];
         }
 
+        // fetch custom connection if migration set defines a dedicated one
+        if (null !== $migrationSet->getConnection()) {
+            $connection = $this->container->get(sprintf(
+                'doctrine.dbal.%s_connection',
+                $migrationSet->getConnection()
+            ));
+        }
+
         $configuration = new Configuration(
             $migrationSet->getIdentifier(),
             $connection,

--- a/pimcore/lib/Pimcore/Migrations/Configuration/MigrationSetConfiguration.php
+++ b/pimcore/lib/Pimcore/Migrations/Configuration/MigrationSetConfiguration.php
@@ -42,16 +42,24 @@ final class MigrationSetConfiguration
     private $directory;
 
     /**
+     * Optional database connection name
+     *
+     * @var string|null
+     */
+    private $connection;
+
+    /**
      * @var OptionsResolver
      */
     private static $configResolver;
 
-    public function __construct(string $identifier, string $name, string $namespace, string $directory)
+    public function __construct(string $identifier, string $name, string $namespace, string $directory, string $connection = null)
     {
         $this->identifier = $identifier;
         $this->name       = $name;
         $this->namespace  = $namespace;
         $this->directory  = $directory;
+        $this->connection = $connection;
     }
 
     public static function fromConfig(array $config): self
@@ -67,7 +75,8 @@ final class MigrationSetConfiguration
             $resolvedConfig['identifier'],
             $resolvedConfig['name'],
             $resolvedConfig['namespace'],
-            $resolvedConfig['directory']
+            $resolvedConfig['directory'],
+            $resolvedConfig['connection']
         );
     }
 
@@ -79,6 +88,9 @@ final class MigrationSetConfiguration
         foreach ($keys as $key) {
             $resolver->setAllowedTypes($key, 'string');
         }
+
+        // database connection name
+        $resolver->setDefault('connection', null);
     }
 
     public function getIdentifier(): string
@@ -99,5 +111,13 @@ final class MigrationSetConfiguration
     public function getDirectory(): string
     {
         return $this->directory;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getConnection()
+    {
+        return $this->connection;
     }
 }

--- a/pimcore/lib/Pimcore/Migrations/Configuration/MigrationSetConfiguration.php
+++ b/pimcore/lib/Pimcore/Migrations/Configuration/MigrationSetConfiguration.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 
 namespace Pimcore\Migrations\Configuration;
 
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
 final class MigrationSetConfiguration
 {
     /**
@@ -39,12 +41,44 @@ final class MigrationSetConfiguration
      */
     private $directory;
 
+    /**
+     * @var OptionsResolver
+     */
+    private static $configResolver;
+
     public function __construct(string $identifier, string $name, string $namespace, string $directory)
     {
         $this->identifier = $identifier;
         $this->name       = $name;
         $this->namespace  = $namespace;
         $this->directory  = $directory;
+    }
+
+    public static function fromConfig(array $config): self
+    {
+        if (null === self::$configResolver) {
+            self::$configResolver = new OptionsResolver();
+            self::configureConfigResolver(self::$configResolver);
+        }
+
+        $resolvedConfig = self::$configResolver->resolve($config);
+
+        return new self(
+            $resolvedConfig['identifier'],
+            $resolvedConfig['name'],
+            $resolvedConfig['namespace'],
+            $resolvedConfig['directory']
+        );
+    }
+
+    private static function configureConfigResolver(OptionsResolver $resolver)
+    {
+        $keys = ['identifier', 'name', 'namespace', 'directory'];
+
+        $resolver->setRequired($keys);
+        foreach ($keys as $key) {
+            $resolver->setAllowedTypes($key, 'string');
+        }
     }
 
     public function getIdentifier(): string


### PR DESCRIPTION
At the moment, two types of migration sets exist:

* the `app` set, which acts as global set for application migrations
* one set per bundle via `--bundle` option when using the migrate commands or via `MigrationInstaller`

This adds the possibility to add arbitrary migration sets via configuration and moves the definition for the `app` set to configuration as well. New migration sets can be defined as follows:

```yaml
pimcore:
    migrations:
        sets:
            testset:
                name: Test Migrations
                namespace: Test\Migrations
                directory: "%kernel.project_dir%/src/Test/Migrations"

            # migration sets now can also define a DBAL connection to use
            testset2:
                name: Test Migrations 2
                namespace: Test\Migrations2
                directory: "%kernel.project_dir%/src/Test/Migrations2"
                connection: conn2
```

Note: this adds a small BC break in the `ConfigurationFactory` as the constructor and the `buildMigrationSets` methods changed, but with this change overriding those methods should be obsolete, so I think it's worth the break.