### PR TITLE
[ECOMMERCE] Remove unneeded getById() methods on abstract models

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Model/AbstractCategory.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Model/AbstractCategory.php
@@ -20,24 +20,6 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
 class AbstractCategory extends \Pimcore\Model\DataObject\Concrete
 {
     /**
-     * @static
-     *
-     * @param int $id
-     *
-     * @return null|\Pimcore\Model\DataObject\AbstractObject
-     */
-    public static function getById($id)
-    {
-        $object = \Pimcore\Model\DataObject\AbstractObject::getById($id);
-
-        if ($object instanceof AbstractCategory) {
-            return $object;
-        }
-
-        return null;
-    }
-
-    /**
      * defines if product is visible in product index queries for parent categories of product category.
      * e.g.
      *   football

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Model/AbstractFilterDefinition.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Model/AbstractFilterDefinition.php
@@ -20,24 +20,6 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
 abstract class AbstractFilterDefinition extends \Pimcore\Model\DataObject\Concrete
 {
     /**
-     * @static
-     *
-     * @param int $id
-     *
-     * @return null|\Pimcore\Model\DataObject\AbstractObject
-     */
-    public static function getById($id)
-    {
-        $object = \Pimcore\Model\DataObject\AbstractObject::getById($id);
-
-        if ($object instanceof AbstractFilterDefinition) {
-            return $object;
-        }
-
-        return null;
-    }
-
-    /**
      * returns page limit for product list
      *
      * @abstract

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Model/AbstractProduct.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Model/AbstractProduct.php
@@ -217,22 +217,4 @@ class AbstractProduct extends \Pimcore\Model\DataObject\Concrete implements IInd
     {
         return $this->getAvailabilitySystemImplementation()->getAvailabilityInfo($this, $quantity);
     }
-
-    /**
-     * @static
-     *
-     * @param int $id
-     *
-     * @return null|\Pimcore\Model\DataObject\AbstractObject
-     */
-    public static function getById($id)
-    {
-        $object = \Pimcore\Model\DataObject\AbstractObject::getById($id);
-
-        if ($object instanceof AbstractProduct) {
-            return $object;
-        }
-
-        return null;
-    }
 }


### PR DESCRIPTION
As discussed in https://github.com/pimcore/pimcore/commit/40502c79514902788a0cb102a417b1f3db6e54d0#commitcomment-24803057 these methods are not needed.