### PR TITLE
[CACHE] Fix doctrine adapter failing on PHP 7.2 due to wrong type passed when clearing tags

### DIFF
--- a/pimcore/lib/Pimcore/Cache/Pool/Doctrine.php
+++ b/pimcore/lib/Pimcore/Cache/Pool/Doctrine.php
@@ -258,7 +258,7 @@ SQL;
                 $tags
             ],
             [
-                \PDO::PARAM_INT,
+                \PDO::PARAM_STR,
                 Connection::PARAM_STR_ARRAY
             ]
         );


### PR DESCRIPTION
Although the table column is a varchar, a PARAM_INT was passed. This seems to work fine until PHP 7.2 where this is apparently enforced and converted to an integer, resulting in too many tags being deleted.