### PR TITLE
Update Klarna PaymentProvider because of fatal errors

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PaymentManager/Payment/Klarna.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PaymentManager/Payment/Klarna.php
@@ -56,9 +56,9 @@ class Klarna implements IPayment
 
         // set endpoint depending on mode
         if ('live' === $options['mode']) {
-            $this->endpoint = 'https://checkout.klarna.com/checkout/orders';
+            $this->endpoint = \Klarna_Checkout_Connector::BASE_URL
         } else {
-            $this->endpoint = 'https://checkout.testdrive.klarna.com/checkout/orders';
+            $this->endpoint = \Klarna_Checkout_Connector::BASE_TEST_URL;
         }
     }
 
@@ -261,10 +261,9 @@ class Klarna implements IPayment
     public function createOrder($uri = null)
     {
         // init
-        \Klarna_Checkout_Order::$baseUri = $this->endpoint;
-        \Klarna_Checkout_Order::$contentType = 'application/vnd.klarna.checkout.aggregated-order-v2+json';
-
-        $connector = \Klarna_Checkout_Connector::create($this->sharedSecretKey);
+        $connector = \Klarna_Checkout_Connector::create(
+            $this->sharedSecretKey,
+            $this->endpoint);
 
         return new \Klarna_Checkout_Order($connector, $uri);
     }


### PR DESCRIPTION
1. The static variables $baseUri and $contentType are not accessible, they aren't even existing. See https://developers.klarna.com/sdk-references/kco_v2_php_4_0_0/class-Klarna_Checkout_Order.html
2. Better idea would be to set the endpoint via the static variable of the Klarna_Checkout_Connector class.



