### PR TITLE
Update outdated pimcore.org links

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
   ],
   "support": {
     "issues": "https://github.com/pimcore/pimcore/issues",
-    "wiki": "https://www.pimcore.org/wiki/",
+    "wiki": "https://pimcore.com/docs/5.0.x/index.html",
     "source": "https://github.com/pimcore/pimcore",
     "forum": "https://groups.google.com/forum/#!forum/pimcore",
-    "docs": "https://www.pimcore.org/wiki/"
+    "docs": "https://pimcore.com/docs/5.0.x/index.html"
   },
   "config": {
     "optimize-autoloader": true,

--- a/doc/Development_Documentation/00_Overview/00_Pimcore_Ecosystem.md
+++ b/doc/Development_Documentation/00_Overview/00_Pimcore_Ecosystem.md
@@ -2,11 +2,11 @@
 
 The following list of resources should show you where to get information about Pimcore and whats going on in the whole ecosystem. 
 
-* [Pimcore Blog](https://www.pimcore.org/en/resources/blog)
+* [Pimcore Blog](https://pimcore.com/en/resources/blog)
 * [Pimcore Documentation](../README.md)
 * [Pimcore at Github](https://github.com/pimcore/pimcore)
 * [Pimcore at Google Groups](https://groups.google.com/forum/#!forum/pimcore)
 * [Pimcore at Stackoverflow](http://stackoverflow.com/questions/tagged/pimcore)
 * [Pimcore at Packagist](https://packagist.org/search/?q=pimcore)
-* [Pimcore Support / Professional Services](https://www.pimcore.org/en/services/professional-services)
+* [Pimcore Support / Professional Services](https://pimcore.com/en/services/support)
 * [Pimcore at Gitter](https://gitter.im/pimcore/pimcore)

--- a/doc/Development_Documentation/01_Getting_Started/00_Installation.md
+++ b/doc/Development_Documentation/01_Getting_Started/00_Installation.md
@@ -17,7 +17,7 @@ Change into the root folder of your project (**please remember project root != d
 cd /your/project
 ```
 
-Pimcore is offering [2 installation packages](https://www.pimcore.org/download) for different use-cases:
+Pimcore is offering [2 installation packages](https://pimcore.com/en/download) for different use-cases:
 
 | Version | Description |
 |--------------------|---------------------------------------------------------------------------------|
@@ -27,7 +27,7 @@ Pimcore is offering [2 installation packages](https://www.pimcore.org/download) 
 ### Download a Package:
 
 ```bash
-wget https://www.pimcore.org/download-5/pimcore-latest.zip -O pimcore-install.zip
+wget https://pimcore.com/download-5/pimcore-latest.zip -O pimcore-install.zip
 ```
 
 Unzip the installer package into the current folder (project root):
@@ -45,7 +45,7 @@ Specific configurations and optimizations for your webserver are available here:
 Pimcore requires write access to the following directories (relative to your project root): `/var`, `/web/var` and `/pimcore`
 ([Details](../23_Installation_and_Upgrade/03_System_Setup_and_Hosting/03_File_Permissions.md))
 
-> No CLI? Click [Latest Release](https://www.pimcore.org/download/pimcore-latest.zip) or [Nightly Build](https://www.pimcore.org/download/pimcore-data.zip) to download the package with your browser and extract/upload Pimcore manually on your server (outside document root!).
+> No CLI? Click [Latest Release](https://pimcore.com/download/pimcore-latest.zip) or [Nightly Build](https://www.pimcore.org/download/pimcore-data.zip) to download the package with your browser and extract/upload Pimcore manually on your server (outside document root!).
 
 ## 3. Create Database
 

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/views/Admin/Index/index.html.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/views/Admin/Index/index.html.php
@@ -153,7 +153,7 @@ $runtimePerspective = \Pimcore\Config::getRuntimePerspective($user);
     <div id="pimcore_status_dev" data-menu-tooltip="DEV MODE" style="display: none;"></div>
     <div id="pimcore_status_debug" data-menu-tooltip="<?= $this->translate("debug_mode_on") ?>" style="display: none;"></div>
     <div id="pimcore_status_email" data-menu-tooltip="<?= $this->translate("mail_settings_incomplete") ?>" style="display: none;"></div>
-    <a id="pimcore_status_maintenance" data-menu-tooltip="<?= $this->translate("maintenance_not_active") ?>" style="display: none;" href="https://www.pimcore.org/wiki/pages/viewpage.action?pageId=16854184#Installation(Apache)-SetuptheMaintenance-Script"></a>
+    <a id="pimcore_status_maintenance" data-menu-tooltip="<?= $this->translate("maintenance_not_active") ?>" style="display: none;" href="https://pimcore.com/docs/5.0.x/Getting_Started/Installation.html#page_5_Maintenance_Cron_Job"></a>
     <div id="pimcore_status_update" data-menu-tooltip="<?= $this->translate("update_available") ?>" style="display: none;"></div>
 </div>
 

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/config_dev.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/config_dev.yml
@@ -32,6 +32,6 @@ pimcore:
 
     translations:
         # enables support for the pimcore_debug_translations magic parameter
-        # see https://www.pimcore.org/docs/5.0.0/Development_Tools_and_Details/Magic_Parameters.html
+        # see https://pimcore.com/docs/5.0.x/Development_Tools_and_Details/Magic_Parameters.html
         debugging:
             enabled: true

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Readme.md
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Readme.md
@@ -33,6 +33,6 @@ Run `composer update`
 
 ### E-Commerce Framework Demo
 
-The e-commerce framework demo implementation can be downloaded at https://www.pimcore.org/download/pimcore-ecommerce-demo.zip. 
+The e-commerce framework demo implementation can be downloaded at https://pimcore.com/download/pimcore-ecommerce-demo.zip. 
 This demo is always based on the latest build of pimcore. 
 > Database user needs the permission FILE in order to install the demo. 

--- a/pimcore/lib/Pimcore/Update.php
+++ b/pimcore/lib/Pimcore/Update.php
@@ -281,7 +281,7 @@ class Update
                 }
 
                 if (array_key_exists('id', $file) && $file['id']) {
-                    // this is the new style, see https://www.pimcore.org/issues/browse/PIMCORE-2722
+                    // this is the new style
                     $srcFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/update/'.$revision.'/files/' . $file['id'] . '-' . $file['revision'];
                 } else {
                     // this is the old style, which we still have to support here, otherwise there's the risk that the

--- a/update-scripts/60/postupdate.php
+++ b/update-scripts/60/postupdate.php
@@ -3,7 +3,7 @@
 $message = <<<EOF
 The navigation view helper signature changed with build 60 and now handles building and rendering the navigation
 in 2 distinct steps. If you use the navigation view helper, please update your views accordingly. Plase have a look
-at the <a href="https://www.pimcore.org/docs/5.0.0/Documents/Navigation.html">navigation docs</a> for details.
+at the <a href="https://pimcore.com/docs/5.0.x/Documents/Navigation.html">navigation docs</a> for details.
 EOF;
 
 echo sprintf('<p> %s</p>' . PHP_EOL, $message);

--- a/web/pimcore/static6/js/pimcore/settings/update.js
+++ b/web/pimcore/static6/js/pimcore/settings/update.js
@@ -21,7 +21,7 @@ pimcore.settings.update = Class.create({
             + 'Please do not update this pimcore installation unless you are sure what you are doing.<br/>'
             + '<b style="color:red;"><u>Updates should be performed only by developers!</u></b><br />'
             + 'Please read the '
-            + ' <a href="https://www.pimcore.org/docs/latest/Installation_and_Upgrade/Upgrade_Notes/index.html" target="_blank">'
+            + ' <a href="https://pimcore.com/docs/5.0.x/Installation_and_Upgrade/Upgrade_Notes/index.html" target="_blank">'
             + 'upgrade notes</a> before you start the update.<br /><br />Are you sure?',
             function (buttonValue) {
                 if (buttonValue == "yes") {


### PR DESCRIPTION
This PR updated all outdated pimcore.org links in the repository.
Some were directed to a 404 page.