### PR TITLE
Fixes broken document view in the admin

### DIFF
--- a/pimcore/lib/Pimcore/Config.php
+++ b/pimcore/lib/Pimcore/Config.php
@@ -140,11 +140,13 @@ class Config
             } elseif (Tool::isFrontentRequestByAdmin()) {
                 // this is necessary to set the correct settings in editmode/preview (using the main domain)
                 $front = \Zend_Controller_Front::getInstance();
-                $originDocument = $front->getRequest()->getParam("document");
-                if ($originDocument) {
-                    $site = Tool\Frontend::getSiteForDocument($originDocument);
-                    if ($site) {
-                        $siteId = $site->getId();
+                if ($request = $front->getRequest()) {
+                    $originDocument = $request->getParam("document");
+                    if ($originDocument) {
+                        $site = Tool\Frontend::getSiteForDocument($originDocument);
+                        if ($site) {
+                            $siteId = $site->getId();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
 We upgraded from v3.1.1 to v4.0.0 and then from v4.0.0 to v4.6.2.

After the upgrade we noticed that no documents were being displayed in the admin, it was just displaying a white screen. Although they were working fine in the frontend.

That was due to PHP throwing a fatal error:

`PHP Fatal error:  Call to a member function getParam() on null in /var/www/branches/master/builds/build-14/pimcore/lib/Pimcore/Config.php on line 143`

That was because `$front->getRequest()` (see PR code change) was returning null. I'm not sure why though. We are not using multi-site or anything. It's just a standard install.

The fix was to wrap that code inside an if statement and only execute it if there is a request object.
