### PR TITLE
[NewsletterAdapter, CustomReportAdapter] add service locator facade

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -100,8 +100,8 @@ class PimcoreCoreExtension extends Extension implements PrependExtensionInterfac
         $this->configureCache($container, $loader, $config);
         $this->configureTranslations($container, $config['translations']);
         $this->configurePasswordEncoders($container, $config);
-        $this->configureAdapterFactories($container, $config['newsletter']['source_adapters'], 'pimcore.newsletter.address_source_adapter.factories', 'Newsletter Address Source Adapter Factory');
-        $this->configureAdapterFactories($container, $config['custom_report']['adapters'], 'pimcore.custom_report.adapter.factories', 'Custom Report Adapter Factory');
+        $this->configureAdapterFactories($container, $config['newsletter']['source_adapters'], 'pimcore.newsletter.address_source_adapter.factories.service_locator', 'Newsletter Address Source Adapter Factory');
+        $this->configureAdapterFactories($container, $config['custom_report']['adapters'], 'pimcore.custom_report.adapter.factories.service_locator', 'Custom Report Adapter Factory');
         $this->configureMigrations($container, $config['migrations']);
 
         // load engine specific configuration only if engine is active

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
@@ -114,9 +114,14 @@ services:
       arguments:
         - '@pimcore.custom_report.adapter.factories'
 
-    pimcore.newsletter.address_source_adapter.factories:
+    pimcore.newsletter.address_source_adapter.factories.service_locator:
         class: Symfony\Component\DependencyInjection\ServiceLocator
         tags: ['container.service_locator']
+
+    pimcore.newsletter.address_source_adapter.factories:
+        class: Pimcore\Locator\ServiceLocatorFacade
+        arguments:
+          - '@pimcore.newsletter.address_source_adapter.factories.service_locator'
 
 
     # CustomReport Adapter
@@ -130,6 +135,11 @@ services:
       arguments:
         - 'Pimcore\Model\Tool\CustomReport\Adapter\Analytics'
 
-    pimcore.custom_report.adapter.factories:
+    pimcore.custom_report.adapter.factories.service_locator:
         class: Symfony\Component\DependencyInjection\ServiceLocator
         tags: ['container.service_locator']
+
+    pimcore.custom_report.adapter.factories:
+        class: Pimcore\Locator\ServiceLocatorFacade
+        arguments:
+          - '@pimcore.custom_report.adapter.factories.service_locator'

--- a/pimcore/lib/Pimcore/Locator/ServiceLocatorFacade.php
+++ b/pimcore/lib/Pimcore/Locator/ServiceLocatorFacade.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Locator;
+
+use Psr\Container\ContainerInterface;
+
+final class ServiceLocatorFacade implements ContainerInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    protected $serviceContainer;
+
+    /**
+     * @param ContainerInterface $serviceContainer
+     */
+    public function __construct(ContainerInterface $serviceContainer)
+    {
+        $this->serviceContainer = $serviceContainer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($id)
+    {
+        return $this->serviceContainer->get($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id)
+    {
+        return $this->serviceContainer->has($id);
+    }
+}


### PR DESCRIPTION
This PR adds a Facade Service for Newsletter Adapter and Custom Report Adapter. This can then be extended to handle services internally somehow different. This also fixes #2094 