### PR TITLE
[XLIFF] Send XLIFF admin request as POST

### DIFF
--- a/pimcore/modules/admin/controllers/TranslationController.php
+++ b/pimcore/modules/admin/controllers/TranslationController.php
@@ -604,6 +604,7 @@ class Admin_TranslationController extends \Pimcore\Controller\Action\Admin
         foreach ($elements as $chunk) {
             $jobs[] = [[
                 "url" => "/admin/translation/" . $type . "-export",
+                "method" => "POST",
                 "params" => [
                     "id" => $exportId,
                     "source" => $source,

--- a/pimcore/static6/js/pimcore/settings/translation/xliff.js
+++ b/pimcore/static6/js/pimcore/settings/translation/xliff.js
@@ -258,6 +258,7 @@ pimcore.settings.translation.xliff = Class.create({
 
         Ext.Ajax.request({
             url: "/admin/translation/content-export-jobs",
+            method: 'POST',
             params: {
                 source: this.exportSourceLanguageSelector.getValue(),
                 target: this.exportTargetLanguageSelector.getValue(),

--- a/pimcore/static6/js/pimcore/tool/paralleljobs.js
+++ b/pimcore/static6/js/pimcore/tool/paralleljobs.js
@@ -100,8 +100,9 @@ pimcore.tool.paralleljobs = Class.create({
 
             this.jobsRunning++;
 
-            Ext.Ajax.request({
+            var requestConfig = {
                 url: this.config.jobs[this.groupsFinished][this.jobsStarted].url,
+                params: this.config.jobs[this.groupsFinished][this.jobsStarted].params,
                 success: function (response) {
 
                     try {
@@ -129,9 +130,14 @@ pimcore.tool.paralleljobs = Class.create({
                     if(!this.config["stopOnError"]) {
                         this.continue();
                     }
-                }.bind(this),
-                params: this.config.jobs[this.groupsFinished][this.jobsStarted].params
-            });
+                }.bind(this)
+            };
+
+            if ('undefined' !== typeof this.config.jobs[this.groupsFinished][this.jobsStarted].method) {
+                requestConfig.method = this.config.jobs[this.groupsFinished][this.jobsStarted].method;
+            }
+
+            Ext.Ajax.request(requestConfig);
 
             this.jobsStarted++;
         }


### PR DESCRIPTION
Send documents/jobs to translate as POST to avoid "414 Request URI too long" errors when submitting many documents.