### PR TITLE
[XLIFF] Send XLIFF admin request as POST

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TranslationController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TranslationController.php
@@ -634,6 +634,7 @@ class TranslationController extends AdminController
         foreach ($elements as $chunk) {
             $jobs[] = [[
                 'url' => '/admin/translation/' . $type . '-export',
+                'method' => 'POST',
                 'params' => [
                     'id' => $exportId,
                     'source' => $source,

--- a/web/pimcore/static6/js/pimcore/settings/translation/xliff.js
+++ b/web/pimcore/static6/js/pimcore/settings/translation/xliff.js
@@ -258,6 +258,7 @@ pimcore.settings.translation.xliff = Class.create({
 
         Ext.Ajax.request({
             url: "/admin/translation/content-export-jobs",
+            method: 'POST',
             params: {
                 source: this.exportSourceLanguageSelector.getValue(),
                 target: this.exportTargetLanguageSelector.getValue(),

--- a/web/pimcore/static6/js/pimcore/tool/paralleljobs.js
+++ b/web/pimcore/static6/js/pimcore/tool/paralleljobs.js
@@ -100,8 +100,9 @@ pimcore.tool.paralleljobs = Class.create({
 
             this.jobsRunning++;
 
-            Ext.Ajax.request({
+            var requestConfig = {
                 url: this.config.jobs[this.groupsFinished][this.jobsStarted].url,
+                params: this.config.jobs[this.groupsFinished][this.jobsStarted].params,
                 success: function (response) {
 
                     try {
@@ -129,9 +130,14 @@ pimcore.tool.paralleljobs = Class.create({
                     if(!this.config["stopOnError"]) {
                         this.continue();
                     }
-                }.bind(this),
-                params: this.config.jobs[this.groupsFinished][this.jobsStarted].params
-            });
+                }.bind(this)
+            };
+
+            if ('undefined' !== typeof this.config.jobs[this.groupsFinished][this.jobsStarted].method) {
+                requestConfig.method = this.config.jobs[this.groupsFinished][this.jobsStarted].method;
+            }
+
+            Ext.Ajax.request(requestConfig);
 
             this.jobsStarted++;
         }


### PR DESCRIPTION
Send documents/jobs to translate as POST to avoid "414 Request URI too long" errors when submitting many documents.