### PR TITLE
Fix context resolver not matching profiler due to wrong pattern

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/config.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/config.yml
@@ -165,7 +165,7 @@ pimcore:
     context:
         profiler:
             routes:
-                - { path: ^/_(_profiler|wdt) }
+                - { path: ^/_(profiler|wdt) }
         admin:
             routes:
                 - { path: ^/admin }


### PR DESCRIPTION
Profiler was resolved to `default` context resulting in frontend listeners (e.g. tracking codes) being injected into profiler page.