### PR TITLE
setFrom() in Pimcore\Mail does not work with array of mail addresses

### DIFF
--- a/pimcore/lib/Pimcore/Mail.php
+++ b/pimcore/lib/Pimcore/Mail.php
@@ -531,22 +531,29 @@ class Mail extends \Swift_Message
     /**
      * resets all from headers before setting the new one.
      *
-     * @param string $email
+     * @param string|array $addresses
      * @param null $name
      *
      * @return \Pimcore\Mail
      */
-    public function setFrom($email, $name = null)
+    public function setFrom($addresses, $name = null)
     {
         // mitigate "pwnscriptum" attack
         // see https://framework.zend.com/security/advisory/ZF2016-04 for ZF2+ fix
-        if (preg_match('/\\\"/', $email)) {
-            throw new \RuntimeException('Potential code injection in From header');
+
+        if(!is_array($addresses)){
+            $addresses = [$addresses];
+        }
+
+        foreach ($addresses as $email) {
+            if (preg_match('/\\\"/', $email)) {
+                throw new \RuntimeException('Potential code injection in From header');
+            }
         }
 
         $this->getHeaders()->removeAll('from');
 
-        return parent::setFrom($email, $name);
+        return parent::setFrom($addresses, $name);
     }
 
     /**


### PR DESCRIPTION
The `setFrom($email, $name = null)` function of `\Pimcore\Mail` is not working if an array gets passed as `$email` parameter, which is not compatible with the `addFrom()` function of the extended class `\Swift_Mime_SimpleMessage`. This produces an error in line 543 `Warning: preg_match() expects parameter 2 to be string, array given`.

**Reproduce:**
```
$froms = ["test@test.test","asdf@asdf.asdf"];

$mail = new Mail();
$mail->setDocument($myDocument);
$mail->setTo($myMail);

foreach ($froms as $from) {
     $mail->addFrom($from);
}
```