### PR TITLE
Track voucher codes in purchase

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Tracking/Tracker/Analytics/EnhancedEcommerce.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Tracking/Tracker/Analytics/EnhancedEcommerce.php
@@ -257,6 +257,7 @@ class EnhancedEcommerce extends Tracker implements
             'affilation' => $transaction->getAffiliation() ?: '',            // affiliation or store name
             'revenue'    => round($transaction->getTotal(), 2),     // total - required
             'tax'        => round($transaction->getTax(), 2),       // tax
+            'coupon'     => $transaction->getCoupon(), // voucher code - optional
             'shipping'   => round($transaction->getShipping(), 2),  // shipping
         ];
     }


### PR DESCRIPTION
Voucher codes (coupon) is not lost any more when displaying the tracking code on the purchase page.

