### PR TITLE
Fixing undefined index -1 error

### DIFF
--- a/pimcore/models/Element/Service.php
+++ b/pimcore/models/Element/Service.php
@@ -760,7 +760,7 @@ class Service extends Model\AbstractModel
         if (!($foundElement = $type::getByPath($sanitizedPath))) {
             foreach ($parts as $part) {
                 $pathPart = '';
-                if (array_key_exists(count($pathsArray) - 1, $pathsArray)) {
+                if (count($pathsArray) > 0 ) {
                     $pathPart = $pathsArray[count($pathsArray) - 1];
                 }
                 $pathsArray[] = $pathPart . '/' . self::getValidKey($part, $type);

--- a/pimcore/models/Element/Service.php
+++ b/pimcore/models/Element/Service.php
@@ -759,7 +759,11 @@ class Service extends Model\AbstractModel
 
         if (!($foundElement = $type::getByPath($sanitizedPath))) {
             foreach ($parts as $part) {
-                $pathsArray[] = $pathsArray[count($pathsArray) - 1] . '/' . self::getValidKey($part, $type);
+                $pathPart = '';
+                if (array_key_exists(count($pathsArray) - 1, $pathsArray)) {
+                    $pathPart = $pathsArray[count($pathsArray) - 1];
+                }
+                $pathsArray[] = $pathPart . '/' . self::getValidKey($part, $type);
             }
 
             for ($i = 0; $i < count($pathsArray); $i++) {

--- a/pimcore/models/Element/Service.php
+++ b/pimcore/models/Element/Service.php
@@ -759,10 +759,7 @@ class Service extends Model\AbstractModel
 
         if (!($foundElement = $type::getByPath($sanitizedPath))) {
             foreach ($parts as $part) {
-                $pathPart = '';
-                if (count($pathsArray) > 0 ) {
-                    $pathPart = $pathsArray[count($pathsArray) - 1];
-                }
+                $pathPart = $pathsArray[count($pathsArray) - 1] ?? '';
                 $pathsArray[] = $pathPart . '/' . self::getValidKey($part, $type);
             }
 


### PR DESCRIPTION
## Fixes Issue #
Undefined index -1 warning when creating new folder by path.
On the line 751 variable $pathsArray is initialized as empty array.
On the first loop iteration (line 762) PHP tires to get value from element with index -1 what causes problems with tests.
## Changes in this pull request  
Checking if key in array exists.