### PR TITLE
AbstractCart - add getter for ignoreReadonly

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/CartManager/AbstractCart.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/CartManager/AbstractCart.php
@@ -152,7 +152,7 @@ abstract class AbstractCart extends \Pimcore\Model\AbstractModel implements ICar
      */
     protected function checkCartIsReadOnly()
     {
-        if (!$this->ignoreReadonly) {
+        if (!$this->getIgnoreReadonly()) {
             if ($this->isCartReadOnly()) {
                 throw new \Exception('Cart ' . $this->getId() . ' is readonly.');
             }

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/CartManager/AbstractCart.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/CartManager/AbstractCart.php
@@ -23,6 +23,10 @@ use Pimcore\Logger;
 
 abstract class AbstractCart extends \Pimcore\Model\AbstractModel implements ICart
 {
+
+    /**
+     * @var bool
+     */
     private $ignoreReadonly = false;
 
     /**
@@ -105,6 +109,13 @@ abstract class AbstractCart extends \Pimcore\Model\AbstractModel implements ICar
         $this->setIgnoreReadonly();
         $this->setCreationDate(new \DateTime());
         $this->unsetIgnoreReadonly();
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIgnoreReadonly(){
+        return $this->ignoreReadonly;
     }
 
     /**


### PR DESCRIPTION
Added a getter for ignoreReadonly so we can access the value from a extended class. 
E.g to automatically cance a active payment