### PR TITLE
[PIMCORE4] Fix for the update command: --ignore-maintenance-mode

### DIFF
--- a/pimcore/lib/Pimcore/Console/Command/UpdateCommand.php
+++ b/pimcore/lib/Pimcore/Console/Command/UpdateCommand.php
@@ -157,7 +157,7 @@ class UpdateCommand extends AbstractCommand
                 }
 
                 $script = realpath(PIMCORE_PATH . DIRECTORY_SEPARATOR . "cli" . DIRECTORY_SEPARATOR . "console.php");
-                $return = Console::runPhpScript($script, "internal:update-processor " . escapeshellarg(json_encode($job)));
+                $return = Console::runPhpScript($script, "internal:update-processor --ignore-maintenance-mode " . escapeshellarg(json_encode($job)));
 
                 $return = trim($return);
 


### PR DESCRIPTION
Update puts the system into maintenance mode, so the internal:update-process command should ignore maintenance mode when being run.

