### PR TITLE
Application Logger: Monolog Handler

### DIFF
--- a/doc/Development_Documentation/18_Tools_and_Features/17_Application_Logger.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/17_Application_Logger.md
@@ -19,7 +19,7 @@ The logs are visible and searchable within the Pimcore backend GUI ![Tools menu]
 ## How to create log entries
 
 The application logger is a PSR-3 compatible component and available on the service container as service `Pimcore\Log\ApplicationLogger`
-(aliased to `pimcore.app_logger`) and therefore it can be used the usual way:
+and therefore it can be used the usual way.
 
 ### Basic Usage - Example
 
@@ -27,19 +27,35 @@ The application logger is a PSR-3 compatible component and available on the serv
 
 ```php
 <?php
-$this->get(\Pimcore\Log\ApplicationLogger::class)->error('Your error message');
-$this->get(\Pimcore\Log\ApplicationLogger::class)->alert('Your alert');
-$this->get(\Pimcore\Log\ApplicationLogger::class)->debug('Your debug message', ['foo' => 'bar']); // additional context information
 
-// or
-$this->get('pimcore.app_logger')->error('Your error message');
+namespace AppBundle\Controller;
+
+use Pimcore\Log\ApplicationLogger;
+use Pimcore\Controller\FrontendController;
+
+class TestController extends FrontendController
+{
+    // injected as action argument (controller needs to be registered as service)
+    public function testAction(ApplicationLogger $logger)
+    {
+        $logger->error('Your error message');
+        $logger->alert('Your alert');
+        $logger->debug('Your debug message', ['foo' => 'bar']); // additional context information
+    }
+    
+    public function anotherAction()
+    {
+        // fetched from container
+        $logger = $this->get(ApplicationLogger::class);
+        $logger->error('Your error message');
+    }
+}
 ```
 
-#### Dependency Injection / Container
+#### Dependency Injection
 
 ```yaml
-app.your_service:
-    class: AppBundle\YourService
+AppBundle\YourService: 
     calls:
         - [setLogger, ['@Pimcore\Log\ApplicationLogger']]
 ```
@@ -77,23 +93,146 @@ class YourService
 }
 ```
 
-### Advanced Usage - Example
+### Usage as monolog handler
 
-There are some context variables with a special functionality: fileObject, relatedObject, component.
+Instead of using the `ApplicationLogger` class, you can configure monolog to use the application logger as monolog log handler
+and make full use of monolog's possibilities. To do so, Pimcore provides the `ApplicationLoggerDb` monolog handler which
+is already preconfigured as service and can easily be registered to monolog:
+
+```yaml
+monolog:
+    handlers:
+        # monolog allows us to register custom handlers via type: service
+        # note that the only supported extra option besides type and id is channels
+        application_logger_db:
+            type: service
+            id: Pimcore\Log\Handler\ApplicationLoggerDb
+            channels: ["application_logger"]
+``` 
+
+Note that the channel(s) need to exist. This can either by achieved by [configuring them manually](https://symfony.com/doc/current/logging/channels_handlers.html#creating-your-own-channel)
+or by using [DI tags](https://symfony.com/doc/current/reference/dic_tags.html#dic-tags-monolog) to select the logger for
+the channel you want to log to. When using DI tags, the channel will be created implicitely by monolog.
+
+> **IMPORTANT**: As the `ApplicationLoggerDb` handler has a dependency on the database connection it is important to exclude
+  channels logging database queries (typically the `doctrine` channel) from the handler to avoid infinite loops. Either
+  specify a whitelist of supported channels (as shown in the example above) or exclude the `doctrine` channel by setting
+  channels to `["!doctrine"]`.
+  
+As the `type: service` handler config does not support filtering by log level, you can use the `filter` handler type to
+wrap the application logger and to filter by a specific log level:
+
+```yaml
+monolog:
+    handlers:
+        # The filter handler can be used to filter for a given log level.
+        # Note that the supported channels are now configured on the filter
+        # handler. To filter by level you can set accepted_levels or min_level and max_level.
+        # See https://github.com/symfony/monolog-bundle/blob/master/DependencyInjection/Configuration.php#L97
+        # for details.
+        application_logger_filter:
+            type: filter
+            channels: ["application_logger"]
+            handler: application_logger_db
+            min_level: ERROR
+        application_logger_db:
+            type: service
+            id: Pimcore\Log\Handler\ApplicationLoggerDb
+```
+
+Of course you can also use the handler in combination with other log handlers such as the [Fingers Crossed Handler](https://symfony.com/doc/current/logging.html#handlers-that-modify-log-entries).
+See the [Symfony Logging Documentation](https://symfony.com/doc/current/logging.html) for details.
+
+As soon as the handler is configured, you can use it (as any other monolog logger) either by fetching a dedicated monolog
+channel logger or by using a DI tag to specify the channel you want to log to:
 
 ```php
 <?php
 
-$logger = \Pimcore::getContainer()->get(\Pimcore\Log\ApplicationLogger::class); 
- 
-$fileObject = new \Pimcore\Log\FileObject("some interesting data");
-$myObject = \Pimcore\Model\DataObject\AbstractObject::getById(73);
- 
-$logger->error("my error message", [
-    "fileObject" => $fileObject,
-    "relatedObject" => $myObject, 
-    "component" => "different component"
-]);
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+
+class TestController extends FrontendController
+{
+    public function testAction()
+    {
+        // fetch the channel logger by its known name monolog.logger.<channel>
+        $logger = $this->get('monolog.logger.application_logger');
+        $logger->error('Your error message');
+    }   
+}
+```
+
+Or use DI tags in combination with the `@logger` service to inject the channel logger you want to use:
+
+```php
+<?php
+
+namespace AppBundle\Controller;
+
+use Psr\Log\LoggerInterface;
+
+// we take a controller as example here, but this can be any service
+// no need to extend a base controller here as we inject our dependencies
+// via DI
+class TestController
+{
+    /**
+     * @var LoggerInterface 
+     */
+    private $logger;
+    
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;   
+    }   
+    
+    public function testAction()
+    {
+        $this->logger->error('Your error message');
+    }   
+}
+```
+
+The service definition can add a DI tag to specify which logger should be injected:
+
+```yaml
+services:
+    AppBundle\Controller\TestController:
+        arguments:
+            $logger: '@logger'
+        tags:
+            - { name: monolog.logger, channel: application_logger }
+``` 
+
+### Special context variables
+
+There are some context variables with a special functionality: `fileObject`, `relatedObject`, `component`.
+
+```php
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Log\ApplicationLogger;
+use Pimcore\Log\FileObject;
+use Pimcore\Model\DataObject\AbstractObject;
+
+class TestController
+{
+    public function testAction(ApplicationLogger $logger)
+    {
+        $fileObject = new FileObject('some interesting data');
+        $myObject   = AbstractObject::getById(73);
+        
+        $logger->error('my error message', [
+            'fileObject'    => $fileObject,
+            'relatedObject' => $myObject, 
+            'component'     => 'different component'
+        ]);
+    }
+}
 ```
 
 In the application logger grid, the new row was created: *my error message* with related object. 
@@ -101,6 +240,34 @@ In the application logger grid, the new row was created: *my error message* with
 If you click on the row you can go to the object editor by clicking on the *Related object* edit icon in the popup.
 
 ![App logger popup](../img/applogger_backend_popup.png)
+
+
+### Logging exceptions
+
+The application logger provides a helper method to log exceptions and implicitely create a `FileObject` from the exception
+when writing the log entry. This can be done in 2 ways depending on how you use the application logger:
+
+```php
+<?php
+
+use Pimcore\Log\ApplicationLogger;
+
+$exception = new \RuntimeException('failed :(');
+
+// 1) When directly using the application logger (see basic usage above). Given your
+//    logger is an instance of `ApplicationLogger`:
+
+/** @var ApplicationLogger $appLogger */
+$appLogger->logException('Oh no!', $exception, 'alert', $relatedObject, $component);
+
+// 2) When using as monolog handler (see above). Given your logger is any PSR-3 compatible logger, you
+//    can use a static helper to generate a log entry with the same file object as the logging call
+//    above.
+
+/** @var \Psr\Log\LoggerInterface $logger */
+ApplicationLogger::logExceptionObject($logger, 'Oh no!', $exception, 'alert', $relatedObject);
+```
+
 
 ### Setting an individual logger level
 

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -82,6 +82,7 @@ class PimcoreCoreExtension extends Extension implements PrependExtensionInterfac
         $loader->load('services.yml');
         $loader->load('services_routing.yml');
         $loader->load('extensions.yml');
+        $loader->load('logging.yml');
         $loader->load('request_response.yml');
         $loader->load('l10n.yml');
         $loader->load('argument_resolvers.yml');

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/logging.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/logging.yml
@@ -1,0 +1,44 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    #
+    # APPLICATION LOGGER
+    #
+
+    pimcore.app_logger: '@pimcore.app_logger.default'
+    pimcore.app_logger.default: '@Pimcore\Log\ApplicationLogger'
+
+    # Monolog processors for the application logger. Autoconfigure is set to false as we don't
+    # want Symfony to auto-register them for all handlers (this isn't the case at the moment as
+    # there is no interface for a processor, but in case support for autoconfiguration is added
+    # we want to keep those processors only for the application logger.
+
+    # ApplicationLoggerProcessor prepares data for the DB handler. This basically
+    # mimics functionality from the ApplicationLogger itself to be used from any
+    # monolog handler.
+    Pimcore\Log\Processor\ApplicationLoggerProcessor:
+        public: false
+
+    # IntrospectionProcessor adds data regarding called function/line. The skipClassesPartials makes sure
+    # we skip the stack frame when called through ApplicationLogger.
+    pimcore.app_logger.introspection_processor:
+        class: Monolog\Processor\IntrospectionProcessor
+        public: false
+        autoconfigure: false
+        arguments:
+            $level: 'DEBUG'
+            $skipClassesPartials:
+                - 'Pimcore\Log\ApplicationLogger'
+
+    # the DB write handler
+    Pimcore\Log\Handler\ApplicationLoggerDb:
+        calls:
+            - [pushProcessor, ['@monolog.processor.psr_log_message']]
+            - [pushProcessor, ['@Pimcore\Log\Processor\ApplicationLoggerProcessor']]
+            - [pushProcessor, ['@pimcore.app_logger.introspection_processor']]
+
+    Pimcore\Log\ApplicationLogger:
+        calls:
+            - [addWriter, ['@Pimcore\Log\Handler\ApplicationLoggerDb']]

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
@@ -30,21 +30,6 @@ services:
         arguments: ['@pimcore.security.encoder_factory.inner', '@?']
         public: false
 
-
-    #
-    # APPLICATION LOGGER
-    #
-
-    pimcore.app_logger: '@pimcore.app_logger.default'
-    pimcore.app_logger.default: '@Pimcore\Log\ApplicationLogger'
-
-    Pimcore\Log\ApplicationLogger:
-        calls:
-            - [addWriter, ['@Pimcore\Log\Handler\ApplicationLoggerDb']]
-
-    Pimcore\Log\Handler\ApplicationLoggerDb: ~
-
-
     #
     # INFRASTRUCTURE
     #

--- a/pimcore/lib/Pimcore/Log/Processor/ApplicationLoggerProcessor.php
+++ b/pimcore/lib/Pimcore/Log/Processor/ApplicationLoggerProcessor.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Log\Processor;
+
+use Pimcore\Log\FileObject;
+use Pimcore\Model\Asset;
+use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\Document;
+
+/**
+ * Make sure you add this processor when using the ApplicationLoggerDb handler as is
+ * prepares data to be written by the handler. This replicates the functionalty implemented
+ * in ApplicationLogger, but makes it available when using the ApplicationLoggerDb handler
+ * in a pure PSR-3 handler context configured as monolog channel handler instead of
+ * the ApplicationLogger class.
+ */
+class ApplicationLoggerProcessor
+{
+    public function __invoke(array $record): array
+    {
+        $record = $this->processFileObject($record);
+        $record = $this->processRelatedObject($record);
+        $record = $this->processLoggingSource($record);
+
+        return $record;
+    }
+
+    private function processFileObject(array $record): array
+    {
+        $context = $record['context'] ?? [];
+
+        if (isset($context['fileObject'])) {
+            if (is_string($context['fileObject'])) {
+                $context['fileObject'] = str_replace(PIMCORE_PROJECT_ROOT, '', $context['fileObject']);
+            } elseif ($context['fileObject'] instanceof FileObject) {
+                $context['fileObject'] = str_replace(PIMCORE_PROJECT_ROOT, '', $context['fileObject']->getFilename());
+            }
+        }
+
+        $record['context'] = $context;
+
+        return $record;
+    }
+
+    private function processRelatedObject(array $record): array
+    {
+        if (!isset($record['context']['relatedObject'])) {
+            // remove related object type if no object is set
+            if (isset($record['context']['relatedObjectType'])) {
+                unset($record['context']['relatedObjectType']);
+            }
+
+            return $record;
+        }
+
+        $relatedObject     = $record['context']['relatedObject'] ?? null;
+        $relatedObjectType = null;
+
+        if (null !== $relatedObject && is_object($relatedObject)) {
+            if ($relatedObject instanceof AbstractObject) {
+                $relatedObject     = $relatedObject->getId();
+                $relatedObjectType = 'object';
+            } elseif ($relatedObject instanceof Asset) {
+                $relatedObject     = $relatedObject->getId();
+                $relatedObjectType = 'asset';
+            } elseif ($relatedObject instanceof Document) {
+                $relatedObject     = $relatedObject->getId();
+                $relatedObjectType = 'document';
+            }
+        }
+
+        $record['context']['relatedObject']     = $relatedObject;
+        $record['context']['relatedObjectType'] = $relatedObjectType;
+
+        return $record;
+    }
+
+    private function processLoggingSource(array $record): array
+    {
+        $source = $record['context']['source'] ?? null;
+        if ($source) {
+            return $record;
+        }
+
+        $extra = $record['extra'];
+        if (!isset($extra['file']) || !isset($extra['line'])) {
+            $record['context']['source'] = null;
+            return $record;
+        }
+
+        if (isset($extra['class']) && isset($extra['function'])) {
+            // called from a class method
+            // ClassName->methodName():line
+            $source = sprintf(
+                '%s::%s:%d',
+                $extra['class'],
+                $extra['function'],
+                $extra['line']
+            );
+        } elseif (isset($extra['function'])) {
+            // called from a function
+            // filename.php::functionName():line
+            $source = sprintf(
+                '%s::%s:%d',
+                $this->normalizeFilename($extra['file']),
+                $extra['function'],
+                $extra['line']
+            );
+        } else {
+            // we don't have a previous call when the logger was directly called
+            // from a standalone PHP file (e.g. from a CLI script)
+            // filename.php:line
+            $source = sprintf(
+                '%s:%d',
+                $this->normalizeFilename($extra['file']),
+                $extra['line']
+            );
+        }
+
+        $record['context']['source'] = $source;
+
+        return $record;
+    }
+
+    private function normalizeFilename($filename)
+    {
+        return str_replace(PIMCORE_PROJECT_ROOT . '/', '', $filename);
+    }
+}


### PR DESCRIPTION
Implements #1998

Application Logger logic (file objects, related objects, source) is replicated to an `ApplicationLoggerProcessor` which is added to the `ApplicationLoggerDb` handler. In the long term the `ApplicationLogger` class itself won't be necessary as it is now possible to handle application logging entries completely via monolog's configuration. When we drop `Zend_Log` support we can remove the now duplicated logic from the `ApplicationLogger` class itself.
