### PR TITLE
[AREABRICKS] Add support for areabricks registered as private service

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Compiler/AreabrickPass.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Compiler/AreabrickPass.php
@@ -36,11 +36,16 @@ class AreabrickPass implements CompilerPassInterface
     {
         $config = $container->getParameter('pimcore.config');
 
-        $areaManagerDefinition = $container->getDefinition(AreabrickManager::class);
-        $taggedServices        = $container->findTaggedServiceIds('pimcore.area.brick');
+        $areabrickManager = $container->getDefinition(AreabrickManager::class);
+        $areabrickLocator = $container->getDefinition('pimcore.document.areabrick.brick_locator');
+
+        $taggedServices = $container->findTaggedServiceIds('pimcore.area.brick');
 
         // keep a list of areas loaded via tags - those classes won't be autoloaded
         $taggedAreas = [];
+
+        // the service mapping for the service locator
+        $locatorMapping = [];
 
         foreach ($taggedServices as $id => $tags) {
             $definition    = $container->getDefinition($id);
@@ -53,16 +58,23 @@ class AreabrickPass implements CompilerPassInterface
                     throw new ConfigurationException(sprintf('Missing "id" attribute on areabrick DI tag for service %s', $id));
                 }
 
-                $areaManagerDefinition->addMethodCall('registerService', [$tag['id'], $id]);
+                // add the service to the locator
+                $locatorMapping[$tag['id']] = new Reference($id);
+
+                // register the brick with its ID on the areabrick manager
+                $areabrickManager->addMethodCall('registerService', [$tag['id'], $id]);
             }
 
+            // handle bricks implementing ContainerAwareInterface
             $this->handleContainerAwareDefinition($container, $definition);
         }
 
         // autoload areas from bundles if not yet defined via service config
         if ($config['documents']['areas']['autoload']) {
-            $this->autoloadAreabricks($container, $areaManagerDefinition, $taggedAreas);
+            $locatorMapping = $this->autoloadAreabricks($container, $areabrickManager, $locatorMapping, $taggedAreas);
         }
+
+        $areabrickLocator->setArgument(0, $locatorMapping);
     }
 
     /**
@@ -79,9 +91,17 @@ class AreabrickPass implements CompilerPassInterface
      *
      * @param ContainerBuilder $container
      * @param Definition $areaManagerDefinition
+     * @param array $locatorMapping
      * @param array $excludedClasses
+     *
+     * @return array
      */
-    protected function autoloadAreabricks(ContainerBuilder $container, Definition $areaManagerDefinition, array $excludedClasses = [])
+    protected function autoloadAreabricks(
+        ContainerBuilder $container,
+        Definition $areaManagerDefinition,
+        array $locatorMapping,
+        array $excludedClasses
+    )
     {
         $bundles = $container->getParameter('kernel.bundles_metadata');
         foreach ($bundles as $bundleName => $bundleMetadata) {
@@ -92,20 +112,26 @@ class AreabrickPass implements CompilerPassInterface
                 $reflector = $bundleArea['reflector'];
 
                 $definition = new Definition($reflector->getName());
+                $definition->setPublic(false);
 
                 // add brick definition to container
                 $container->setDefinition($bundleArea['serviceId'], $definition);
 
-                // handle bricks implementing ContainerAwareInterface
-                $this->handleContainerAwareDefinition($container, $definition, $reflector);
+                // add the service to the locator
+                $locatorMapping[$bundleArea['brickId']] = new Reference($bundleArea['serviceId']);
 
                 // register brick on the areabrick manager
                 $areaManagerDefinition->addMethodCall('registerService', [
                     $bundleArea['brickId'],
                     $bundleArea['serviceId']
                 ]);
+
+                // handle bricks implementing ContainerAwareInterface
+                $this->handleContainerAwareDefinition($container, $definition, $reflector);
             }
         }
+
+        return $locatorMapping;
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/documents.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/documents.yml
@@ -44,8 +44,18 @@ services:
     #
 
     pimcore.area.brick_manager: '@Pimcore\Extension\Document\Areabrick\AreabrickManager'
+
+    # scoped container containing only the registered area bricks
+    # will be configured in areabrick pass
+    pimcore.document.areabrick.brick_locator:
+        class: Symfony\Component\DependencyInjection\ServiceLocator
+        public: false
+        tags: ['container.service_locator']
+
     Pimcore\Extension\Document\Areabrick\AreabrickManagerInterface: '@Pimcore\Extension\Document\Areabrick\AreabrickManager'
-    Pimcore\Extension\Document\Areabrick\AreabrickManager: ~
+    Pimcore\Extension\Document\Areabrick\AreabrickManager:
+        arguments:
+            $container: '@pimcore.document.areabrick.brick_locator'
 
 
     #

--- a/pimcore/lib/Pimcore/Extension/Document/Areabrick/AreabrickManager.php
+++ b/pimcore/lib/Pimcore/Extension/Document/Areabrick/AreabrickManager.php
@@ -20,7 +20,7 @@ namespace Pimcore\Extension\Document\Areabrick;
 use Pimcore\Extension;
 use Pimcore\Extension\Document\Areabrick\Exception\BrickNotFoundException;
 use Pimcore\Extension\Document\Areabrick\Exception\ConfigurationException;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 class AreabrickManager implements AreabrickManagerInterface
 {
@@ -166,7 +166,7 @@ class AreabrickManager implements AreabrickManagerInterface
         }
 
         $serviceId = $this->brickServiceIds[$id];
-        if (!$this->container->has($serviceId)) {
+        if (!$this->container->has($id)) {
             throw new ConfigurationException(sprintf(
                 'Definition for areabrick %s (defined as service %s) does not exist',
                 $id,
@@ -174,7 +174,7 @@ class AreabrickManager implements AreabrickManagerInterface
             ));
         }
 
-        $brick = $this->container->get($serviceId);
+        $brick = $this->container->get($id);
         if (!($brick instanceof AreabrickInterface)) {
             throw new ConfigurationException(sprintf(
                 'Definition for areabrick %s (defined as service %s) does not implement AreabrickInterface (got %s)',


### PR DESCRIPTION
Instead of injecting the whole container into the areabrick manager, now a scoped service locator only containing the bricks is injected.

Fixes #2104