### PR TITLE
Variable confusing naming quickfix

### DIFF
--- a/pimcore/models/Document/Tag.php
+++ b/pimcore/models/Document/Tag.php
@@ -436,20 +436,20 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
      */
     public function __toString()
     {
-        $return = '';
+        $result = '';
 
         try {
             if ($this->editmode) {
-                $return = $this->admin();
+                $result = $this->admin();
             } else {
-                $return = $this->frontend();
+                $result = $this->frontend();
             }
         } catch (\Throwable $e) {
             if (\Pimcore::inDebugMode()) {
                 // the __toString method isn't allowed to throw exceptions
-                $return = '<b style="color:#f00">' . $e->getMessage().'</b><br/>'.$e->getTraceAsString();
+                $result = '<b style="color:#f00">' . $e->getMessage().'</b><br/>'.$e->getTraceAsString();
 
-                return $return;
+                return $result;
             }
 
             Logger::error('toString() returned an exception: {exception}', [
@@ -459,9 +459,9 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
             return '';
         }
 
-        if (is_string($return) || is_numeric($return)) {
+        if (is_string($result) || is_numeric($result)) {
             // we have to cast to string, because int/float is not auto-converted and throws an exception
-            return (string) $return;
+            return (string) $result;
         }
 
         return '';


### PR DESCRIPTION
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features neaed to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
  
  
## Fixes Issue #
---
## Changes in this pull request  
`$return` is confused name for a variable. We just have an example of mistake because of it on the gitter:
![image](https://user-images.githubusercontent.com/16497506/31997891-e91aac42-b98d-11e7-96b1-2cee1e6317cb.png)

## Additional info  

