### PR TITLE
Allow to override system translations using JSON files

### DIFF
--- a/doc/Development_Documentation/06_Multi_Language_i18n/README.md
+++ b/doc/Development_Documentation/06_Multi_Language_i18n/README.md
@@ -49,4 +49,16 @@ English is maintained by the core team. In addition to that, everybody can join 
  [Pimcore translation project](http://www.pimcore.org/en/community/translations) to add system translations in additional
  languages. With every Pimcore release, newly added translations are added to the Pimcore installation package.
 
-System translations can be overwritten by [Admin Translations](./07_Admin_Translations.md). 
+System translations can be overwritten by [Admin Translations](./07_Admin_Translations.md).
+
+Another option to override existing system translations is to provide custom `%locale%.json` file(s) from your bundle(s).
+Register additional resource paths by setting:
+
+```yaml
+pimcore:
+    translations:
+        paths:
+            - "@AppBundle/Resources/translations/pimcore"
+```
+
+Pimcore will automatically load your translations which will override [original ones](https://github.com/pimcore/pimcore/tree/master/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/translations).

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -257,7 +257,9 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('translations')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('path')->defaultNull()->end()
+                        ->arrayNode('paths')
+                            ->prototype('scalar')->end()
+                        ->end()
                     ->end()
                 ->end()
             ->end();

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -61,7 +61,7 @@ class PimcoreCoreExtension extends Extension implements PrependExtensionInterfac
         $container->setParameter('pimcore.admin.unauthenticated_routes', $config['admin']['unauthenticated_routes']);
 
         $container->setParameter('pimcore.admin.session.attribute_bags', $config['admin']['session']['attribute_bags']);
-        $container->setParameter('pimcore.admin.translations.path', $config['admin']['translations']['path']);
+        $container->setParameter('pimcore.admin.translations.paths', $config['admin']['translations']['paths']);
 
         $container->setParameter('pimcore.web_profiler.toolbar.excluded_routes', $config['web_profiler']['toolbar']['excluded_routes']);
 

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/l10n.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/l10n.yml
@@ -13,7 +13,7 @@ services:
             - '@Pimcore\Translation\Translator.inner'
         calls:
             - [setKernel, ['@kernel']]
-            - [setAdminPath, ['%pimcore.admin.translations.path%']]
+            - [setAdminPaths, ['%pimcore.admin.translations.paths%']]
 
     #
     # LOCALE

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/config.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/config.yml
@@ -196,7 +196,8 @@ pimcore:
             - { route: pimcore_admin_webdav }
 
         translations:
-            path: "@PimcoreCoreBundle/Resources/translations"
+            paths:
+                - "@PimcoreCoreBundle/Resources/translations"
 
     # Pimcore migration sets
     # Bundles can define their own migration sets - the sets defined here act as global sets

--- a/pimcore/lib/Pimcore/Tool/Admin.php
+++ b/pimcore/lib/Pimcore/Tool/Admin.php
@@ -33,7 +33,7 @@ class Admin
      */
     public static function getLanguageFile($language)
     {
-        $baseResource = \Pimcore::getContainer()->getParameter('pimcore.admin.translations.path');
+        $baseResource = \Pimcore::getContainer()->getParameter('pimcore.admin.translations.paths');
         $languageFile = \Pimcore::getKernel()->locateResource($baseResource . '/' . $language . '.json');
 
         return $languageFile;
@@ -48,11 +48,13 @@ class Admin
      */
     public static function getLanguages()
     {
-        $baseResource = \Pimcore::getContainer()->getParameter('pimcore.admin.translations.path');
-        $languageDir = \Pimcore::getKernel()->locateResource($baseResource);
+        $baseResources = \Pimcore::getContainer()->getParameter('pimcore.admin.translations.paths');
+        $languageDirs = [];
+        foreach ($baseResources as $baseResource) {
+            $languageDirs[] = \Pimcore::getKernel()->locateResource($baseResource);
+        }
 
         $languages = [];
-        $languageDirs = [$languageDir];
         foreach ($languageDirs as $filesDir) {
             if (is_dir($filesDir)) {
                 $files = scandir($filesDir);
@@ -81,14 +83,14 @@ class Admin
      */
     public static function getMinimizedScriptPath($scriptContent)
     {
-        $scriptPath = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/minified_javascript_core_'.md5($scriptContent).'.js';
+        $scriptPath = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/minified_javascript_core_' . md5($scriptContent) . '.js';
 
         if (!is_file($scriptPath)) {
             File::put($scriptPath, $scriptContent);
         }
 
         $params = [
-            'scripts' =>  basename($scriptPath),
+            'scripts' => basename($scriptPath),
             '_dc' => \Pimcore\Version::getRevision()
         ];
 
@@ -105,7 +107,7 @@ class Admin
 
         // minimum 10 lines, to be sure take more
         $sample = '';
-        for ($i=0; $i < 10; $i++) {
+        for ($i = 0; $i < 10; $i++) {
             $sample .= implode('', array_slice(file($file), 0, 11)); // grab 20 lines
         }
 


### PR DESCRIPTION
## Changes in this pull request  

Allow to override system translations by providing custom `%locale%.json` files from project's bundle(s).