### PR TITLE
Multiselect didn't return definition without options provider present

### DIFF
--- a/pimcore/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/pimcore/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -506,8 +506,8 @@ class Multiselect extends Model\DataObject\ClassDefinition\Data
 
             $hasStaticOptions = $optionsProvider->{'hasStaticOptions'}($context, $this);
             $this->dynamicOptions = !$hasStaticOptions;
-
-            return $this;
         }
+
+        return $this;
     }
 }


### PR DESCRIPTION
## Fixes Issue
When you're using a multiselect in a classification store the definition of the class does not get returned if no options provider is present since the return statement lies within the option provider conditional check.

## Changes in this pull request  
Moved return statement outside the conditional scope.

## Additional info  

