### PR TITLE
Allow to depend on dev packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,8 @@
     "optimize-autoloader": true,
     "sort-packages": true
   },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "repositories": {
     "vrana-jush": {
       "info1": "External dependency of vrana/adminer which isn't included or referenced by adminer, see also https://sourceforge.net/p/adminer/bugs-and-features/468/ ",


### PR DESCRIPTION
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.
  
## Changes in this pull request  

Update composer.json to allow depending on dev packages for local development.  It is not possible to set those options in `composer.local.json` unfortunately, only in the root `composer.json` file.

## Additional info  

Without this option set it is not possible to depend on development version of any package.