### PR TITLE
[DOCS] Build docs on travis

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,29 @@
+image: tetraweb/php:7.1
+
+stages:
+  - docs
+
+cache:
+  key: "$CI_BUILD_REF_NAME"
+  paths:
+    - ~/.composer/cache
+
+before_script:
+  - docker-php-ext-enable zip opcache
+
+docs:
+  stage: docs
+  when: always
+  artifacts:
+    name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
+    expire_in: 1 week
+    paths:
+      - documentation
+  script:
+    - rm -rf tmp documentation
+    - git clone https://github.com/pimcore/pimcore-docs.git tmp/pimcore-docs
+    - cd tmp/pimcore-docs
+    - composer install
+    - bin/console prepare ../../doc
+    - bin/console generate
+    - mv build/static ../../documentation

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,9 @@ docs:
     - rm -rf tmp documentation
     - git clone https://github.com/pimcore/pimcore-docs.git tmp/pimcore-docs
     - cd tmp/pimcore-docs
+    - LATEST_VERSION=$(git describe --abbrev=0)
+    - echo "Checking out latest pimcore-docs version ${LATEST_VERSION}"
+    - git checkout ${LATEST_VERSION}
     - composer install
     - bin/console prepare ../../doc
     - bin/console generate

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,13 @@ matrix:
           - PIMCORE_TEST_SUITE=cache
           - PIMCORE_TEST_GROUP=cache.core.redis
           - PIMCORE_TEST_SETUP_SKIP_PHP_REDIS_EXTENSION=true
+    - os: linux
+      php: 7.1
+      services: ~
+      addons: ~
+      env:
+        - TASK_TESTS=0
+        - TASK_DOCS=1
 
 cache:
   directories:
@@ -51,6 +58,8 @@ cache:
 
 env:
   global:
+    - TASK_TESTS=1
+    - TASK_DOCS=0
     - PIMCORE_ENVIRONMENT=test
     - PIMCORE_TEST=1
     - PIMCORE_TEST_URL=http://pimcore-test.dev
@@ -62,16 +71,13 @@ before_install:
   - mysql -e "CREATE DATABASE pimcore_test CHARSET=utf8mb4;"
 
 install:
-  # add config templates
-  - mkdir -p var/config
-  - cp .travis/system.template.php var/config/system.php
-  - cp .travis/extensions.template.php var/config/extensions.php
-  - cp app/config/parameters.example.yml app/config/parameters.yml
-  - composer install
+  - if [ $TASK_TESTS == 1 ]; then .travis/setup-tests.sh; fi
+  - if [ $TASK_DOCS == 1 ]; then .travis/setup-docs.sh; fi
 
 before_script:
-  - .travis/setup-php.sh
-  - .travis/setup-functional-tests.sh
+  - if [ $TASK_TESTS == 1 ]; then .travis/setup-php.sh; fi
+  - if [ $TASK_TESTS == 1 ]; then .travis/setup-functional-tests.sh; fi
 
 script:
-  - .travis/run-tests.sh
+  - if [ $TASK_TESTS == 1 ]; then .travis/run-tests.sh; fi
+  - if [ $TASK_DOCS == 1 ]; then .travis/run-docs.sh; fi

--- a/.travis/run-docs.sh
+++ b/.travis/run-docs.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euv
+
+cd tmp-docs/pimcore-docs
+bin/console generate

--- a/.travis/setup-docs.sh
+++ b/.travis/setup-docs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euv
+
+rm -rf tmp-docs
+git clone https://github.com/pimcore/pimcore-docs.git tmp-docs/pimcore-docs
+cd tmp-docs/pimcore-docs
+composer install  --no-interaction --optimize-autoloader
+bin/console prepare ../../doc

--- a/.travis/setup-docs.sh
+++ b/.travis/setup-docs.sh
@@ -5,5 +5,14 @@ set -euv
 rm -rf tmp-docs
 git clone https://github.com/pimcore/pimcore-docs.git tmp-docs/pimcore-docs
 cd tmp-docs/pimcore-docs
+
+# check out latest pimcore-docs release
+LATEST_VERSION=$(git describe --abbrev=0)
+echo "Checking out latest pimcore-docs release ${LATEST_VERSION}"
+git checkout ${LATEST_VERSION}
+
+# install composer dependencies
 composer install  --no-interaction --optimize-autoloader
+
+# prepare docs
 bin/console prepare ../../doc

--- a/.travis/setup-tests.sh
+++ b/.travis/setup-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+# add config templates
+mkdir -p var/config
+cp .travis/system.template.php var/config/system.php
+cp .travis/extensions.template.php var/config/extensions.php
+cp app/config/parameters.example.yml app/config/parameters.yml
+
+# install composer dependencies
+composer install --no-interaction --optimize-autoloader

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,5 +1,6 @@
 # Pimcore Documentation
 
-## Getting Started
-* [For Developers](./Development_Documentation/README.md) 
-* [For Users](./User_Documentation/README.md)
+Welcome to Pimcore's documentation. The documentation is split up into a [Development Documentation](./Development_Documentation)
+and a dedicated [User Documentation](./User_Documentation) section. 
+
+<!-- navigation for dev and user docs will be automatically inserted here (hardcoded in daux theme) -->


### PR DESCRIPTION
Builds docs on travis for verification. Docs are built using [daux.io](https://daux.io) with the [pimcore/pimcore-docs](https://github.com/pimcore/pimcore-docs) setup.

Additionally, a config file for gitlab allows building docs on Gitlab CI.