### PR TITLE
Fix for calling undefined method

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/WorkflowManagementListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/WorkflowManagementListener.php
@@ -146,7 +146,7 @@ class WorkflowManagementListener implements EventSubscriberInterface
                         if ($validLayouts && $validLayouts[$workflowLayoutId]) {
                             $customLayout = ClassDefinition\CustomLayout::getById($workflowLayoutId);
                             $customLayoutDefinition = $customLayout->getLayoutDefinitions();
-                            DataObject\Service::enrichLayoutDefinition($customLayoutDefinition, $e->getParam('object'));
+                            DataObject\Service::enrichLayoutDefinition($customLayoutDefinition, $e->getArgument('object'));
                             $data['layout'] = $customLayoutDefinition;
                         }
                     }


### PR DESCRIPTION
This PR resolves following problem while opening object: Attempted to call an undefined method named "getParam" of class "Symfony\Component\EventDispatcher\GenericEvent".
![workflow-custom-layouts](https://user-images.githubusercontent.com/26323830/32214035-db05b7a2-be1d-11e7-8767-cc87a109ac03.png)
