### PR TITLE
add gift item to cart only if available

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PricingManager/Action/Gift.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PricingManager/Action/Gift.php
@@ -47,7 +47,10 @@ class Gift implements IGift
     public function executeOnCart(IEnvironment $environment)
     {
         $comment = $environment->getRule()->getDescription();
-        $environment->getCart()->addGiftItem($this->getProduct(), 1, null, true, [], [], $comment);
+        $isAvailable = $this->getProduct()->getOSAvailabilityInfo()->getAvailable();
+        if ( $isAvailable) {
+            $environment->getCart()->addGiftItem($this->getProduct(), 1, null, true, array(), array(), $comment);
+        }
     }
 
     /**


### PR DESCRIPTION
Gift items should only be added to a cart or a order if they are still available based on the information of the availability system.


