### PR TITLE
add Doctrine filter for DeepCopy

### DIFF
--- a/pimcore/models/Element/Service.php
+++ b/pimcore/models/Element/Service.php
@@ -1038,6 +1038,8 @@ class Service extends Model\AbstractModel
         $deepCopy->addFilter(new \DeepCopy\Filter\SetNullFilter(), new \DeepCopy\Matcher\PropertyNameMatcher('dao'));
         $deepCopy->addFilter(new \DeepCopy\Filter\SetNullFilter(), new \DeepCopy\Matcher\PropertyNameMatcher('resource'));
         $deepCopy->addFilter(new \DeepCopy\Filter\SetNullFilter(), new \DeepCopy\Matcher\PropertyNameMatcher('writeResource'));
+        $deepCopy->addFilter(new \DeepCopy\Filter\Doctrine\DoctrineCollectionFilter(), new \DeepCopy\Matcher\PropertyTypeMatcher('Doctrine\Common\Collections\Collection'));
+        
         if ($element instanceof DataObject\Concrete) {
             DataObject\Service::loadAllObjectFields($element);
         }


### PR DESCRIPTION
This PR makes it possible to clone Pimcore Objects which relate to Doctrine Objects (Collections). Otherwise cloning entities is impossible, since it throws a "container not clone-able" exception.