### PR TITLE
Added getter for update host

### DIFF
--- a/pimcore/lib/Pimcore/Update.php
+++ b/pimcore/lib/Pimcore/Update.php
@@ -534,4 +534,12 @@ class Update
             Logger::debug('MayMind GeoIP2 Download skipped, everything up to date, last update: ' . date('m/d/Y H:i', $filemtime));
         }
     }
+    
+    /**
+     * @return string
+     */
+    public static function getUpdateHost(): string
+    {
+        return self::$updateHost;
+    }
 }


### PR DESCRIPTION
Because the updateHost variables has private access, it is causing an error in the RunUpdateScriptCommand
