### PR TITLE
bugfix: inherit label width from localized fields configuration

### DIFF
--- a/web/pimcore/static6/js/pimcore/object/tags/localizedfields.js
+++ b/web/pimcore/static6/js/pimcore/object/tags/localizedfields.js
@@ -259,6 +259,11 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
                                         for (var i = 0; i < l.childs.length; i++) {
                                             var childConfig = l.childs[i];
 
+                                            // inherit label width from localized fields configuration
+                                            if (this.fieldConfig.labelWidth) {
+                                                childConfig.labelWidth = this.fieldConfig.labelWidth; //TEST
+                                            }
+
                                             var children = this.getRecursiveLayout(childConfig, !editable, runtimeContext, false, false, dataProvider, true);
                                             if (children) {
                                                 panel.add(children);

--- a/web/pimcore/static6/js/pimcore/object/tags/localizedfields.js
+++ b/web/pimcore/static6/js/pimcore/object/tags/localizedfields.js
@@ -261,7 +261,7 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
 
                                             // inherit label width from localized fields configuration
                                             if (this.fieldConfig.labelWidth) {
-                                                childConfig.labelWidth = this.fieldConfig.labelWidth; //TEST
+                                                childConfig.labelWidth = this.fieldConfig.labelWidth;
                                             }
 
                                             var children = this.getRecursiveLayout(childConfig, !editable, runtimeContext, false, false, dataProvider, true);


### PR DESCRIPTION
## Steps to reproduce
- Vanilla installation Pimcore 5.0.2 Build 147
- Creating class with localized fields element
- Set label width on localized fields element
- Add input element to localized fields element
- Set label name to input element
- Create object with class

## Expected  behavior
- Label width of localized fields element is used for input element

## Actual behavior
- Label width of localized fields element is ignored and default of 100 px is used for input element

## Changes in this pull request 

Add label width inheritance. It's just a proposal, maybe there are better ways to place that code or achieve it otherwise.

## Screenshots from Pimcore demo

![label_width_configuration_localized_fields](https://user-images.githubusercontent.com/13463597/32775316-5f59fbe6-c92f-11e7-9eac-4da640efd8b6.png)
![label_width_localized_fields](https://user-images.githubusercontent.com/13463597/32775318-60809caa-c92f-11e7-9c17-15f5efa93f3a.png)


