### PR TITLE
[AREABRICKS] Handle responses returned from an areabrick action and postRenderAction method

### DIFF
--- a/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/02_Bricks.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/02_Bricks.md
@@ -298,6 +298,9 @@ object as parameter. The `action()` method is no real controller action, it is j
  and code out of the 
 view. However, you can use the action method to prepare data for the view (for example parse request params).
 
+Since Pimcore 5.0.3 you can return a Response object from `action()` and `postRenderAction()` and this response
+will be sent back to the client.
+
 If you need to influence the HTML open and close tag, you can do so by customizing `getHtmlTagOpen()` and 
 `getHtmlTagClose()` (see example below). 
  
@@ -308,6 +311,7 @@ namespace AppBundle\Document\Areabrick;
 
 use Pimcore\Extension\Document\Areabrick\AbstractTemplateAreabrick;
 use Pimcore\Model\Document\Tag\Area\Info;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class Iframe extends AbstractTemplateAreabrick
 {
@@ -318,6 +322,11 @@ class Iframe extends AbstractTemplateAreabrick
         $myVar = $info->getRequest()->get('myParam');
 
         $info->getView()->myVar = $myVar;
+
+        // optionally return a response object
+        if ('POST' === $info->getRequest()->getMethod()) {
+            return new RedirectResponse('/foo');
+        }
     }
 
     // OPTIONAL METHODS

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/ResponseStackListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/ResponseStackListener.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\EventListener;
+
+use Pimcore\Http\ResponseStack;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class ResponseStackListener implements EventSubscriberInterface
+{
+    /**
+     * @var ResponseStack
+     */
+    private $responseStack;
+
+    /**
+     * @param ResponseStack $responseStack
+     */
+    public function __construct(ResponseStack $responseStack)
+    {
+        $this->responseStack = $responseStack;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::RESPONSE => ['onKernelResponse', 24]
+        ];
+    }
+
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        if ($this->responseStack->hasResponses()) {
+            $event->setResponse($this->responseStack->getLastResponse());
+        }
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/documents.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/documents.yml
@@ -34,6 +34,7 @@ services:
             $templating: '@templating'
             $translator: '@Pimcore\Bundle\AdminBundle\Translation\AdminUserTranslator'
         calls:
+            - [setResponseStack, ['@Pimcore\Http\ResponseStack']] # TODO Pimcore 6 add as constructor dependency
             - [setLogger, ['@logger']]
         tags:
             - { name: monolog.logger, channel: pimcore }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/event_listeners.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/event_listeners.yml
@@ -103,6 +103,10 @@ services:
         calls:
             - [setLogger, ['@logger']]
 
+    Pimcore\Bundle\CoreBundle\EventListener\ResponseStackListener:
+        arguments:
+            $responseStack: '@Pimcore\Http\ResponseStack'
+
 
     #
     # FRONTEND LISTENERS

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/request_response.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/request_response.yml
@@ -14,6 +14,8 @@ services:
     Pimcore\Http\Context\PimcoreContextGuesser:
         public: false
 
+    Pimcore\Http\ResponseStack:
+        public: false
 
     #
     # REQUEST RESOLVERS

--- a/pimcore/lib/Pimcore/Extension/Document/Areabrick/AreabrickInterface.php
+++ b/pimcore/lib/Pimcore/Extension/Document/Areabrick/AreabrickInterface.php
@@ -15,6 +15,7 @@
 namespace Pimcore\Extension\Document\Areabrick;
 
 use Pimcore\Model\Document\Tag\Area\Info;
+use Symfony\Component\HttpFoundation\Response;
 
 interface AreabrickInterface
 {
@@ -93,14 +94,22 @@ interface AreabrickInterface
     /**
      * Will be called before the view is rendered. Acts as extension point for custom area logic.
      *
+     * If this method returns a Response object, it will be pushed onto the response stack and returned to the client.
+     *
      * @param Info $info
+     *
+     * @return null|Response
      */
     public function action(Info $info);
 
     /**
      * Will be called after rendering.
      *
+     * If this method returns a Response object, it will be pushed onto the response stack and returned to the client.
+     *
      * @param Info $info
+     *
+     * @return null|Response
      */
     public function postRenderAction(Info $info);
 

--- a/pimcore/lib/Pimcore/Http/ResponseStack.php
+++ b/pimcore/lib/Pimcore/Http/ResponseStack.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Http;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * This stack can be used to collect responses to be sent from parts which cannot
+ * directly influence the request-response cycle (e.g. templating parts). For example
+ * this is used to read responses from an areabrick's action() method which is pushed
+ * to this stack.
+ *
+ * The ResponseStackListener takes care of sending back the response set on this stack.
+ */
+class ResponseStack
+{
+    /**
+     * @var Response[]
+     */
+    private $responses = [];
+
+    public function push(Response $response)
+    {
+        $this->responses[] = $response;
+    }
+
+    public function hasResponses(): bool
+    {
+        return !empty($this->responses);
+    }
+
+    /**
+     * @return Response[]
+     */
+    public function getResponses(): array
+    {
+        return $this->responses;
+    }
+
+    public function pop(): Response
+    {
+        if (empty($this->responses)) {
+            throw new \UnderflowException('There are no responses on the stack.');
+        }
+
+        return array_pop($this->responses);
+    }
+
+    public function getLastResponse(): Response
+    {
+        if (empty($this->responses)) {
+            throw new \UnderflowException('There are no responses on the stack.');
+        }
+
+        return end($this->responses);
+    }
+}


### PR DESCRIPTION
Areabrick `action` methods may need to return a response (e.g. a redirect after a form is submitted). This PR adds the concept of a `ResponseStack` which is used as follows:

- the return value of `action()` and `postRenderAction()` is evaluated, and if it is a response it is pushed onto the `ResponseStack`
- the `ResponseStackListener` operates on `kernel.response` and sets the last response from the response stack on the event if the stack contains responses.

The stack can also be used from other parts of the system which don't have direct access to the request/response cycle.