### PR TITLE
Update Select.php

### DIFF
--- a/pimcore/models/Object/ClassDefinition/Data/Select.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Select.php
@@ -102,7 +102,7 @@ class Select extends Model\Object\ClassDefinition\Data
      */
     public function getColumnType()
     {
-        return $this->columnType . "(" . $this->getColumnLength() . ")";
+        return $this->columnType;
     }
 
     /**
@@ -110,7 +110,7 @@ class Select extends Model\Object\ClassDefinition\Data
      */
     public function getQueryColumnType()
     {
-        return $this->queryColumnType . "(" . $this->getColumnLength() . ")";
+        return $this->queryColumnType;
     }
 
     /**

--- a/pimcore/models/Object/ClassDefinition/Data/Select.php
+++ b/pimcore/models/Object/ClassDefinition/Data/Select.php
@@ -98,11 +98,28 @@ class Select extends Model\Object\ClassDefinition\Data
     }
 
     /**
+     * Correct old column definitions (e.g varchar(255)) to the new format
+     * @param $type
+     */
+    protected function correctColumnDefinition($type){
+        preg_match("/(.*)\((\d+)\)/i",$this->$type,$matches);
+        if($matches[2]){
+            $this->{"set" . ucfirst($type)}($matches[1]);
+            if($matches[2] > 190){
+                $matches[2] = 190;
+            }
+            $this->setColumnLength($matches[2] <= 190 ? $matches[2] : 190);
+        }
+    }
+
+
+    /**
      * @return string
      */
     public function getColumnType()
     {
-        return $this->columnType;
+        $this->correctColumnDefinition('columnType');
+        return $this->columnType . "(" . $this->getColumnLength() . ")";
     }
 
     /**
@@ -110,7 +127,8 @@ class Select extends Model\Object\ClassDefinition\Data
      */
     public function getQueryColumnType()
     {
-        return $this->queryColumnType;
+        $this->correctColumnDefinition('queryColumnType');
+        return $this->queryColumnType . "(" . $this->getColumnLength() . ")";
     }
 
     /**


### PR DESCRIPTION
This will fix (in pimcore 4.6.3) so that you don't fetch columnLength (that's already in columnType) -> varchar(255)(190).

Reproduce by saving a fieldcollection with select data type through `->save();`

Fatal error: Uncaught PDOException: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '(190) NULL' at line 1 in /opt/pim/www/vendor/zendframework/zendframework1/library/Zend/Db/Statement/Pdo.php on line 235

Zend_Db_Statement_Exception: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '(190) NULL' at line 1, query was: ALTER TABLE `object_collection_DeviceBatteryTimes_1` CHANGE COLUMN `Standard` `Standard` varchar(255)(190) NULL; in /opt/pim/www/vendor/zendframework/zendframework1/library/Zend/Db/Statement/Pdo.php on line 235


## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
  
  
## Fixes Issue #

## Changes in this pull request  

## Additional info  

