### PR TITLE
PIMCORE4 MultihrefMetdata columnbool

### DIFF
--- a/pimcore/config/texts/en.json
+++ b/pimcore/config/texts/en.json
@@ -4593,6 +4593,10 @@
         "definition": "Bool"
     },
     {
+        "term": "objectsMetadata_type_columnbool",
+        "definition": "Column Bool"
+    },
+    {
         "term": "objectsMetadata_type_select",
         "definition": "Select"
     },

--- a/pimcore/static6/js/pimcore/object/classes/data/multihrefMetadata.js
+++ b/pimcore/static6/js/pimcore/object/classes/data/multihrefMetadata.js
@@ -400,11 +400,11 @@ pimcore.object.classes.data.multihrefMetadata = Class.create(pimcore.object.clas
 
                 if (value.length > 1 && regresult == value
                     && in_array(value.toLowerCase(), ["id","key","path","type","index","classname",
-                    "creationdate","userowner","value","class","list","fullpath","childs","values","cachetag",
-                    "cachetags","parent","published","valuefromparent","userpermissions","dependencies",
-                    "modificationdate","usermodification","byid","bypath","data","versions","properties",
-                    "permissions","permissionsforuser","childamount","apipluginbroker","resource",
-                    "parentClass","definition","locked","language"]) == false) {
+                        "creationdate","userowner","value","class","list","fullpath","childs","values","cachetag",
+                        "cachetags","parent","published","valuefromparent","userpermissions","dependencies",
+                        "modificationdate","usermodification","byid","bypath","data","versions","properties",
+                        "permissions","permissionsforuser","childamount","apipluginbroker","resource",
+                        "parentClass","definition","locked","language"]) == false) {
                     return true;
                 } else {
                     return t("objectsMetadata_invalid_key");
@@ -426,6 +426,7 @@ pimcore.object.classes.data.multihrefMetadata = Class.create(pimcore.object.clas
                 text: t("objectsMetadata_type_text"),
                 select: t("objectsMetadata_type_select"),
                 bool: t("objectsMetadata_type_bool"),
+                columnbool: t("objectsMetadata_type_columnbool"),
                 multiselect: t("objectsMetadata_type_multiselect")
             };
 
@@ -441,8 +442,14 @@ pimcore.object.classes.data.multihrefMetadata = Class.create(pimcore.object.clas
                         'value',
                         'label'
                     ],
-                    data: [['number', types.number], ['text', types.text], ['select', types.select],
-                        ['bool', types.bool],  ['multiselect', types.multiselect]]
+                    data: [
+                        ['number', types.number],
+                        ['text', types.text],
+                        ['select', types.select],
+                        ['bool', types.bool],
+                        ['columnbool', types.columnbool],
+                        ['multiselect', types.multiselect]
+                    ]
                 }),
                 valueField: 'value',
                 displayField: 'label'

--- a/pimcore/static6/js/pimcore/object/tags/multihrefMetadata.js
+++ b/pimcore/static6/js/pimcore/object/tags/multihrefMetadata.js
@@ -141,7 +141,7 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                         fieldInfo: fieldInfo
                     });
                 }.bind(this, this.fieldConfig.columns[i]);
-            } else if(this.fieldConfig.columns[i].type == "bool") {
+            } else if(this.fieldConfig.columns[i].type === "bool" || this.fieldConfig.columns[i].type === "columnbool") {
                 renderer = function (value, metaData, record, rowIndex, colIndex, store) {
                     if (value) {
                         return '<div style="text-align: center"><div role="button" class="x-grid-checkcolumn x-grid-checkcolumn-checked" style=""></div></div>';
@@ -160,6 +160,24 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                         renderer: renderer
                     });
                     continue;
+                }
+
+                if (!readOnly && this.fieldConfig.columns[i].type === "columnbool") {
+                    editor.addListener('change', function(el, newValue) {
+                        window.gridPanel = el.up('gridpanel');
+                        window.el = el;
+                        var gridPanel = el.up('gridpanel');
+                        var columnKey = el.up().column.dataIndex;
+                        if(newValue) {
+                            gridPanel.getStore().each(function(record){
+                                if (!!record.get(columnKey)) {
+                                    // note, we don't need to check for the row here as the editor fires another change
+                                    // on blur, which updates the underlying record without a subsequent event being fired.
+                                    record.set(columnKey, false);
+                                }
+                            });
+                        }
+                    });
                 }
 
             }
@@ -578,10 +596,10 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
         }
 
         pimcore.helpers.itemselector(true, this.addDataFromSelector.bind(this), {
-            type: allowedTypes,
-            subtype: allowedSubtypes,
-            specific: allowedSpecific
-        },
+                type: allowedTypes,
+                subtype: allowedSubtypes,
+                specific: allowedSpecific
+            },
             {
                 context: this.getContext()
             });
@@ -774,10 +792,10 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
         }
 
         pimcore.helpers.itemselector(true, this.addDataFromSelector.bind(this), {
-            type: allowedTypes,
-            subtype: allowedSubtypes,
-            specific: allowedSpecific
-        },
+                type: allowedTypes,
+                subtype: allowedSubtypes,
+                specific: allowedSpecific
+            },
             {
                 context: Ext.apply({scope: "objectEditor"}, this.getContext())
             });


### PR DESCRIPTION
This is a slightly different implementation of the boolean field on the multihrefmetadata component.

It forces a whole column of hrefs to be limited to one selection only. Similar to Magento 1's image selection component (that's why i had to implement it)

![columnbool](https://user-images.githubusercontent.com/1098498/33178013-80524540-d05c-11e7-9fae-8819e7c2294e.gif)

Currently only frontend, it probably needs some backend validation, I'm happy to PR too just let me know.

This is reletively easy to port to Pimcore 5, if you think its a good feature let me know and I will port.

