### PR TITLE
Pimcore 5 translation fix for exporting voucher-tokens

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/VoucherService/TokenManager/AbstractTokenManager.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/VoucherService/TokenManager/AbstractTokenManager.php
@@ -20,7 +20,6 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractVoucherSeries;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractVoucherTokenType;
 use Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\Token;
 use Pimcore\Model\DataObject\OnlineShopVoucherSeries;
-use Pimcore\View\Helper\TranslateAdmin;
 
 abstract class AbstractTokenManager implements ITokenManager
 {
@@ -130,14 +129,14 @@ abstract class AbstractTokenManager implements ITokenManager
      */
     public function exportCsv(array $params)
     {
-        $translator = new TranslateAdmin();
+       $translator = \Pimcore::getContainer()->get("pimcore.translator");
 
         $stream = fopen('php://temp', 'w+');
         fputcsv($stream, [
-            $translator->translateAdmin('bundle_ecommerce_voucherservice_table-token'),
-            $translator->translateAdmin('bundle_ecommerce_voucherservice_table-usages'),
-            $translator->translateAdmin('bundle_ecommerce_voucherservice_table-length'),
-            $translator->translateAdmin('bundle_ecommerce_voucherservice_table-date'),
+            $translator->trans('bundle_ecommerce_voucherservice_table-token', [], 'admin'),
+            $translator->trans('bundle_ecommerce_voucherservice_table-usages', [], 'admin'),
+            $translator->trans('bundle_ecommerce_voucherservice_table-length', [], 'admin'),
+            $translator->trans('bundle_ecommerce_voucherservice_table-date', [], 'admin'),
         ]);
 
         $data = null;


### PR DESCRIPTION
## Bugfix

When exporting voucher tokens via the button _Export CSV_ in the top right corner in the Voucher Details Tab inside an object of class `OnlineShopVoucherSeries` it failes, because of the missing class `Pimcore\View\Helper\TranslateAdmin`. Fixed by using the Pimore 5 Translation Service.
  
![image](https://user-images.githubusercontent.com/9052094/33438359-e0a359dc-d5ea-11e7-972c-beccc620f7dc.png)


