### PR TITLE
fix xliffImport header status

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TranslationController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TranslationController.php
@@ -858,7 +858,7 @@ class TranslationController extends AdminController
             'success' => true,
             'jobs' => $jobs,
             'id' => $id
-        ], false);
+        ]);
         // set content-type to text/html, otherwise (when application/json is sent) chrome will complain in
         // Ext.form.Action.Submit and mark the submission as failed
         $response->headers->set('Content-Type', 'text/html');


### PR DESCRIPTION
funny, apparently no one has ever noticed that the xliffImport actually never worked in p5. The second parameter returns `false` which will lead to a `The HTTP status code "0" is not valid.` error message.