### PR TITLE
Add doc information that setCondition and addConditionParam cannot be used together

### DIFF
--- a/doc/Development_Documentation/05_Objects/03_Working_with_PHP_API.md
+++ b/doc/Development_Documentation/05_Objects/03_Working_with_PHP_API.md
@@ -82,7 +82,7 @@ $entries->setOrder("desc");
 $entries->setCondition("name LIKE ?", ["%bernie%"]); // use prepared statements! Mysqli only supports ? placeholders
 // or
 $entries->setCondition("name LIKE :name", ["name" => "%bernie%"]); // With PDO_Mysql you can use named parameters
-// to add param to the condition
+// to add param to the condition (cannot be used with setCondition in the same listing, you should use setCondition OR addConditionParam but not both)
 $entries->addConditionParam("city = ?", "New York", "AND"); // concatenator can be AND or OR
    
 //if necessary you can of course custom build your query


### PR DESCRIPTION
This pull request is for https://github.com/pimcore/pimcore/issues/1831

It add information to the documentation that setCondition and addConditionParam cannot be used together.
(as explained in the issue it lead to error/strange result)
