### PR TITLE
doc permissions improvement

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/11_Console_CLI.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/11_Console_CLI.md
@@ -44,7 +44,9 @@ commands either by hooking into an event or by placing your commands in predefin
 
 ### Usage
 Call `bin/console list` script from the command line to get a list of available commands. To call 
-a command, use `bin/console <subcommand>`. 
+a command, use `bin/console <subcommand>`.
+
+> Be sure to run the console with the PHP user to prevent writing permissions issues later, either by calling `php bin/console` or by switching to the appropriate user, for instance on Debian system `su -l www-data -s /bin/bash`.
 
 ##### Examples:
 ```php 

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/03_File_Permissions.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/03_File_Permissions.md
@@ -1,16 +1,26 @@
 # File Permissions
 
-Pimcore requires write access to the following directories: `/web/var` , `/var` , `/app/config` and `/pimcore`.  
+Pimcore requires write access to the following directories: `/app/config`, `/bin`, `/composer.json`, `/pimcore`, `/var`, `/web/pimcore` and `/web/var`.   
 
 If you know which user executes PHP on your system (PHP-FPM user, Apache user, ...), simply give write access to the appropriate user.
-Execute the following commands on the shell (eg. via SSH, …) - replace `YOURUSER` and `YOURGROUP` with your configuration:
+Execute the following commands on the shell (eg. via SSH, …) in your install directory - replace `YOURUSER` and `YOURGROUP` with your configuration:
 
 ```bash
-chown -R YOURUSER:YOURGROUP web/var var pimcore app/config
+chown -R YOURUSER:YOURGROUP app/config bin composer.json pimcore var web/pimcore web/var
+```
+
+Be aware that some dependencies could need to be able to write in others directories (like Ocramius/PackageVersions that manage package versions and need to be able to write in other directories during updates).
+In such case, you should ensure to configure properly the permissions for each one, or more simply add write permissions to all the files by running `chown -R YOURUSER:YOURGROUP *`.
+You can get further generic information about Symfony file permissions here: [Symfony file permissions](https://symfony.com/doc/current/setup/file_permissions.html).
+
+To be able to execute cli tools (pimcore or symfony console for instance), you need to give execute permissions to the cli tools. Here it add execute permissions to the user and group:
+```bash
+chmod ug+x bin/*
 ```
 
 On Debian systems (and most other Linux distributions) mostly the www-data user executes the PHP files, just execute the following commands in your install directory.
 
 ```bash
-chown -R www-data:www-data web/var var pimcore app/config
+chown -R YOURUSER:YOURGROUP app/config bin composer.json pimcore var web/pimcore web/var
+chmod ug+x bin/*
 ```

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/03_File_Permissions.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/03_File_Permissions.md
@@ -9,8 +9,6 @@ Execute the following commands on the shell (eg. via SSH, …) in your install d
 chown -R YOURUSER:YOURGROUP app/config bin composer.json pimcore var web/pimcore web/var
 ```
 
-Be aware that some dependencies could need to be able to write in others directories (like Ocramius/PackageVersions that manage package versions and need to be able to write in other directories during updates).
-In such case, you should ensure to configure properly the permissions for each one, or more simply add write permissions to all the files by running `chown -R YOURUSER:YOURGROUP *`.
 You can get further generic information about Symfony file permissions here: [Symfony file permissions](https://symfony.com/doc/current/setup/file_permissions.html).
 
 To be able to execute cli tools (pimcore or symfony console for instance), you need to give execute permissions to the cli tools. Here it add execute permissions to the user and group:


### PR DESCRIPTION
This pull request add informations to the documentation to help setting permissions.

It is intended to resolve issue https://github.com/pimcore/pimcore/issues/2234, so the process can be more easy for new users.
(it doesn't resolve the Ocramius/PackageVersions touch problem which lead to the necessity to make a `chown -R YOURUSER:YOURGROUP *`, so setting directory by directory write permissions don't work for now).
