### PR TITLE
Fix documentation

### DIFF
--- a/doc/Development_Documentation/02_MVC/04_Routing_and_URLs/02_Custom_Routes.md
+++ b/doc/Development_Documentation/02_MVC/04_Routing_and_URLs/02_Custom_Routes.md
@@ -264,7 +264,7 @@ use \Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 public function testAction(Request $request) {
     $object = DataObject::getById($request->get("id")); 
     if( !$object || ( !$object->isPublished() && !$this->editmode) ) {
-        return new NotFoundHttpException('Not found');
+        throw new NotFoundHttpException('Not found');
     }
 }
 ```


### PR DESCRIPTION
Small fix for the documentation:

In a controller action the exception need to be thrown - not returned.