### PR TITLE
[DEBUG] Use IpUtils to check debug mode adresses and to support IP ranges

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/15_Magic_Parameters.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/15_Magic_Parameters.md
@@ -40,3 +40,15 @@ pimcore:
             # you could also change the parameter from pimcore_debug_translations to something else
             parameter: my_custom_parameter
 ```
+
+
+## Magic cookies
+
+### `pimcore_disable_debug`
+
+You can set the `pimcore_disable_debug` cookie to something truthy (e.g. `1`) to disable the debug mode for requests
+from your browser. The cookie will only be checked if debug mode would be turned on (e.g. is activated and your IP matches).
+
+The following bookmarklet can be used to set the cookie:
+
+* <a href="javascript:(function()%7Bdocument.cookie%3D%22pimcore_disable_debug%3D1%3B%20path%3D%2F%22%7D)()">Disable Pimcore Debug</a> 

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/translations/en.json
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/translations/en.json
@@ -875,7 +875,7 @@
   "error_moving_document": "Your document could not be moved.",
   "translations": "Website Translations",
   "translations_admin": "Admin Translations",
-  "debug_description": "With debug-mode on errors and warnings are displayed directly in the browser, otherwise they are deactivated and the error-controller is active (Error Page). Multiple IP addresses can be specified by separating them with a comma.",
+  "debug_description": "With debug-mode on errors and warnings are displayed directly in the browser, otherwise they are deactivated and the error-controller is active (Error Page). Multiple IP addresses can be specified by separating them with a comma. You can also specify IP ranges by specifying a mask, e.g. 192.168.1.0/24",
   "icon": "Icon",
   "add_document": "Add document",
   "please_enter_the_name_of_the_new_document": "Please enter the name of the new document",

--- a/pimcore/lib/Pimcore/Tool.php
+++ b/pimcore/lib/Pimcore/Tool.php
@@ -317,7 +317,7 @@ class Tool
      *
      * @return null|Request
      */
-    private static function resolveRequest(Request $request = null)
+    public static function resolveRequest(Request $request = null)
     {
         if (null === $request) {
             // do an extra check for the container as we might be in a state where no container is set yet


### PR DESCRIPTION
Fixes #2268. Additionally adds support to disable debug mode via `pimcore_disable_debug` cookie.