### PR TITLE
fix for caching Staticroutes objects which doesn't exist

### DIFF
--- a/pimcore/models/Staticroute.php
+++ b/pimcore/models/Staticroute.php
@@ -155,9 +155,9 @@ class Staticroute extends AbstractModel
         } catch (\Exception $e) {
             try {
                 $route = new self();
-                \Pimcore\Cache\Runtime::set($cacheKey, $route);
                 $route->setId(intval($id));
                 $route->getDao()->getById();
+                \Pimcore\Cache\Runtime::set($cacheKey, $route);
             } catch (\Exception $e) {
                 Logger::error($e);
 


### PR DESCRIPTION
### Example

```php
$route = Staticroute::getById(123); // does not exist -> $route is null
$route = Staticroute::getById(123); // $route is empty object as it is saved in runtime cache
``` 

### Solution

This pull request provides a fix.