### PR TITLE
Image thumbnails: added SVG placeholder support

### DIFF
--- a/doc/Development_Documentation/03_Documents/01_Editables/14_Image.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/14_Image.md
@@ -36,6 +36,7 @@ The biggest advantages of using that instead of (for example) the href editable:
 | `dropClass`                    | string  | This option can be used to add multiple alternative drop-targets and context menus on custom HTML elements in your code. <br /><br />Just add the class specified here also to custom HTML elements and they will get a drop target too. |
 | `deferred`                     | bool    | Set to false to disable deferred (on demand) thumbnail rendering                                                                                                                                                                         |
 | `class`                        | string  | A CSS class that is added to the surrounding container of this element in editmode                                                                                                                                                       |
+| `svgPlaceholder`               | bool    | Put's a small SVG placeholder image into the `src` (data-uri), the real image path is placed in `data-src` and `data-srcset`. (requires https://github.com/technopagan/sqip)                                                                    |
 
 You can also pass every valid `<img>` tag attribute ([w3.org Image](http://www.w3.org/TR/html401/struct/objects.html#edef-IMG)), such as: `class`, `style`
 

--- a/install-profiles/demo-basic/app/Resources/views/Areas/gallery-single-images/view.html.php
+++ b/install-profiles/demo-basic/app/Resources/views/Areas/gallery-single-images/view.html.php
@@ -19,7 +19,8 @@
                 <?php } ?>
 
                     <?= $this->image("image", [
-                        "thumbnail" => "galleryThumbnail"
+                        "thumbnail" => "galleryThumbnail",
+                        'svgPlaceholder' => true
                     ]); ?>
 
                 <?php if(!$this->editmode) { ?>

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/ImageSVGPreviewCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/ImageSVGPreviewCommand.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Command;
+
+use Pimcore\Console\AbstractCommand;
+use Pimcore\Model\Asset;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ImageSVGPreviewCommand extends AbstractCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('pimcore:image:svg-preview')
+            ->setDescription('Regenerates SVG image previews for all image assets')
+            ->addOption(
+                'parent',
+                'p',
+                InputOption::VALUE_OPTIONAL,
+                'only create thumbnails of images in this folder (ID)'
+            );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // get only images
+        $conditions = ["type = 'image'"];
+
+        if ($input->getOption('parent')) {
+            $parent = Asset::getById($input->getOption('parent'));
+            if ($parent instanceof Asset\Folder) {
+                $conditions[] = "path LIKE '" . $parent->getRealFullPath() . "/%'";
+            } else {
+                $this->writeError($input->getOption('parent') . ' is not a valid asset folder ID!');
+                exit;
+            }
+        }
+
+        $list = new Asset\Listing();
+        $list->setCondition(implode(' AND ', $conditions));
+        $total = $list->getTotalCount();
+        $perLoop = 10;
+
+        for ($i=0; $i < (ceil($total / $perLoop)); $i++) {
+            $list->setLimit($perLoop);
+            $list->setOffset($i * $perLoop);
+
+            $images = $list->load();
+            foreach ($images as $image) {
+                $image->generateSvgPreview();
+                $this->output->writeln('generating svg preview for image: ' . $image->getRealFullPath() . ' | ' . $image->getId());
+            }
+            \Pimcore::collectGarbage();
+        }
+    }
+}

--- a/pimcore/lib/Pimcore/Tool/Requirements.php
+++ b/pimcore/lib/Pimcore/Tool/Requirements.php
@@ -426,6 +426,17 @@ class Requirements
             'state' => $pdftotextBin ? Check::STATE_OK : Check::STATE_WARNING
         ]);
 
+        try {
+            $sqipAvailable = \Pimcore\Tool\Console::getExecutable('sqip');
+        } catch (\Exception $e) {
+            $sqipAvailable = false;
+        }
+
+        $checks[] = new Check([
+            'name' => 'SQIP - SVG Placeholder',
+            'state' => $sqipAvailable ? Check::STATE_OK : Check::STATE_WARNING
+        ]);
+
         return $checks;
     }
 

--- a/pimcore/lib/helper-functions.php
+++ b/pimcore/lib/helper-functions.php
@@ -197,6 +197,25 @@ function array_toquerystring($args)
 }
 
 /**
+ * @param $array
+ * @return string
+ */
+function array_to_html_attribute_string($array) {
+
+    $data = '';
+    foreach($array as $key => $value) {
+        if(is_scalar($value)) {
+            if(!empty($data)) {
+                $data .= ' ';
+            }
+            $data .= $key . '="' . htmlspecialchars($value) . '""';
+        }
+    }
+
+    return $data;
+}
+
+/**
  * @param string $var
  */
 function urlencode_ignore_slash($var)


### PR DESCRIPTION
Adds support for small SVG placeholder images to thumbnails. 
The placeholder is placed into the `src` attribute of the `<img>` tag, the real paths are available in `data-src` and `data-srcset`. 

You have to use a script of your choice to replace the `src` with the proper image path in `data-src` / `data-srcset`. 

### Example 
```php
<?= $this->image("image", [
	"thumbnail" => "galleryThumbnail",
	'svgPlaceholder' => true
]); ?>
```

Result: 
```html
<img width="260"" height="180"" alt=""" title=""" src="data:image/svg+xml;base64,PHN2ZyB4b...Zz48L3N2Zz4="" data-src="/examples/south-africa/image-thumb__51__galleryThumbnail/img_1842.jpeg"" data-srcset="/examples/south-africa/image-thumb__51__galleryThumbnail/img_1842.jpeg 1x, /examples/south-africa/image-thumb__51__galleryThumbnail/img_1842@2x.jpeg 2x"" />
```

### Notes
- SVG preview/placeholder are generated when saving the asset
- existing images do not have a SVG preview, please use `./bin/console pimcore:image:svg-preview` to generate them (after the update and setting up SQIP
