### PR TITLE
Modifing unit abbreviation length

### DIFF
--- a/update-scripts/154/postupdate.php
+++ b/update-scripts/154/postupdate.php
@@ -1,0 +1,8 @@
+<?php
+
+$db = \Pimcore\Db::get();
+$db->query('
+ALTER TABLE `quantityvalue_units` 
+    MODIFY `abbreviation` varchar(20)
+;
+');


### PR DESCRIPTION
Currently in Pimcore database in table **quantityvalue_units** column **abbreviation** has length of 10 chars.

Maximum length of unit in standard Etim classification is 15 characters, so importing etim classification ends up with incorrect, cut units.
(All units can be found here: https://www.etim-international.com/downloads/category/8-model-releases)
  
## Fixes Issue #
Too short abbreviation column length.
## Changes in this pull request  
Change of length of **abbreviation** column from 10 characters to 20 characters.

