### PR TITLE
[EXTENSIONMANAGER] Use a default priority of 10 for bundles enabled via extension manager 

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5.md
@@ -1,5 +1,11 @@
 # Upgrade Notes for Upgrades within Pimcore 5
 
+## Pimcore 5.1
+
+* The default priority of bundles enabled via extension manager was changed from `0` to `10` to make sure
+  those bundles are loaded before the `AppBundle` is loaded. Please make sure this works for your application
+  and set a manual priority otherwise. See https://github.com/pimcore/pimcore/pull/2328 for details.
+
 ## Build 156 (2017-12-13)
 
 The experimental `GridColumnConfig` feature was revamped to register and build its operators via DI instead of predefined

--- a/pimcore/lib/Pimcore/Extension/Bundle/Config/StateConfig.php
+++ b/pimcore/lib/Pimcore/Extension/Bundle/Config/StateConfig.php
@@ -34,7 +34,7 @@ final class StateConfig
      */
     private static $optionDefaults = [
         'enabled'      => false,
-        'priority'     => 0,
+        'priority'     => 10,
         'environments' => []
     ];
 


### PR DESCRIPTION
Fixes #2183

**IMPORTANT**: Targeted for 5.1 as this change potentially influences existing applications by changing the priority of bundles without a explicit priority.