### PR TITLE
Doc for setting up a new environment name

### DIFF
--- a/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
+++ b/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
@@ -74,7 +74,7 @@ use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
 				$collection->addBundle(
 					new SensioGeneratorBundle(),
 					80, // priority
-					['staging'] // will use the staging config files of the bundle
+					['staging'] // the bundle will only be loaded in the staging environment
 				);
 				// PimcoreGeneratorBundle depends on SensioGeneratorBundle
 				$collection->addBundle(

--- a/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
+++ b/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
@@ -33,15 +33,43 @@ var/config/system.php
 > **Note:** If you put your configurations into `app/config/pimcore/` they might not writable by the Pimcore backend UI. 
 > This can be especially useful when having automated building environments and don't want the user to allow changing settings.  
 
-If you add a new environment which is not an existing one by default (those are `dev`, `test` and `prod`), you need to
-manually create a YAML config file for the project. If you set environment before installation, this is needed to be done
-before installation. For instance, for a `staging` environment, you will need to add a `app/config/config_staging.yml` file
-with the following content:
+## Set a new Environment name
 
-```yaml
-imports:
-    - { resource: config.yml }
+If you add a new environment which is not an existing one by default (those are `dev`, `test` and `prod`), you need to
+manually create a YAML config file for the project in two places (you can start by copying config_dev.yml for instance in each of those):
 ```
+app/config/pimcore/
+pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/
+```
+
+If you use some specific bundles, you need to activate them in the method `app\AppKernel.php`.
+For instance for an new environment called `staging` (copied from `dev` environment YAML config) you should add in the method `registerBundlesToCollection`:
+```
+// environment specific bundles
+if (in_array($this->getEnvironment(), ['staging'])) {
+	$collection->addBundles([
+		new DebugBundle(),
+		new WebProfilerBundle(),
+		new SensioDistributionBundle()
+	], 80);
+	// add generator bundle only if installed
+	if (class_exists('Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle')) {
+		$collection->addBundle(
+			new SensioGeneratorBundle(),
+			80, // priority
+			['dev'] // will use the dev config files of the bundle
+		);
+		// PimcoreGeneratorBundle depends on SensioGeneratorBundle
+		$collection->addBundle(
+			new PimcoreGeneratorBundle(),
+			60,
+			['dev']
+		);
+	}
+}
+```
+
+If you set `PIMCORE_ENVIRONMENT` to a new environment name before installation, all those steps need to be done before running the installation.
 
 ## Set the Environment
 

--- a/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
+++ b/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
@@ -40,79 +40,17 @@ You can need to configure a new environment name different than the existing one
 > **Note:** The default `test` environment should only be used for running test suite (like Travis).
 > It use the session.storage.mock_file which fakes sessions (as consequence, the administrator cannot log in Pimcore for instance)
 
-To configure a new environment, you need to manually create a YAML config file for the project in:
-
-```
-app/config/pimcore/
-```
-
-As a starting point, you can inspire your new YAML config file from the existing YAML config files for dev and prod environment in `app/config/pimcore/` and `pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/`.
-
-For instance, the most minimal config, reproducting prod environment, will be:
+To create a new config, e.g. staging, which is based on the dev config, you must set `staging` as PIMCORE_ENVIRONMENT and create the following config file `app/config/config_staging.yml`:
 
 ```
 imports:
+    - { resource: '@PimcoreCoreBundle/Resources/config/pimcore/dev.yml' }
     - { resource: config.yml }
-
-monolog:
-    handlers:
-        main:
-            type:         fingers_crossed
-            action_level: error
-            buffer_size: 2000
-            handler:      nested
-        nested:
-            type:  stream
-            path:  "%kernel.logs_dir%/%kernel.environment%.log"
-            level: debug
-        console:
-            type:  console
-```
-
-A config file, reproducting dev environment (and using specific bundles, see below how to register them) will be like this:
-
-```
-imports:
-    - { resource: config.yml }
-
-framework:
-    router:
-        resource: "%kernel.root_dir%/config/routing_dev.yml"
-        strict_requirements: true
-    profiler: { only_exceptions: false }
-
-web_profiler:
-    toolbar: true
-    intercept_redirects: false
-
-monolog:
-    handlers:
-        main:
-            type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.log"
-            level: debug
-            channels: ["!event"]
-        console:
-            type:   console
-            channels: ["!event"]
-
-pimcore:
-    error_handling:
-        render_error_document: false
-
-    web_profiler:
-        toolbar:
-            excluded_routes: ~
-
-    translations:
-        # enables support for the pimcore_debug_translations magic parameter
-        # see https://pimcore.com/docs/5.0.x/Development_Tools_and_Details/Magic_Parameters.html
-        debugging:
-            enabled: true
 ```
 
 If you use some specific bundles, you need to register them in `app\AppKernel.php`.
 For instance for an new environment called `staging` using web profiler, you should add in the method `registerBundlesToCollection`:
+
 ```
 use Pimcore\Bundle\GeneratorBundle\PimcoreGeneratorBundle;
 use Sensio\Bundle\DistributionBundle\SensioDistributionBundle;

--- a/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
+++ b/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
@@ -35,14 +35,19 @@ var/config/system.php
 
 ## Set a new Environment name
 
-If you add a new environment which is not an existing one by default (those are `dev`, `test` and `prod`), you need to
-manually create a YAML config file for the project in two places (you can start by copying config_dev.yml for instance in each of those):
+You can need to configure a new environment name different than the existing ones, which respect Symfony convention: `dev`, `test` and `prod`.
+
+> **Note:** The default `test` environment should only be used for running test suite (like Travis).
+> It use the session.storage.mock_file which fakes sessions (as consequence, the administrator cannot log in Pimcore for instance)
+
+To configure a new environment, you need to manually create a YAML config file for the project in two places (you can start by copying config_dev.yml for instance in each of those):
+
 ```
 app/config/pimcore/
 pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/
 ```
 
-If you use some specific bundles, you need to activate them in the method `app\AppKernel.php`.
+If you use some specific bundles, you need to activate them in `app\AppKernel.php`.
 For instance for an new environment called `staging` (copied from `dev` environment YAML config) you should add in the method `registerBundlesToCollection`:
 ```
 // environment specific bundles

--- a/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
+++ b/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
@@ -74,13 +74,13 @@ use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
 				$collection->addBundle(
 					new SensioGeneratorBundle(),
 					80, // priority
-					['dev'] // will use the dev config files of the bundle
+					['staging'] // will use the staging config files of the bundle
 				);
 				// PimcoreGeneratorBundle depends on SensioGeneratorBundle
 				$collection->addBundle(
 					new PimcoreGeneratorBundle(),
 					60,
-					['dev']
+					['staging']
 				);
 			}
 		}

--- a/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
+++ b/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
@@ -50,28 +50,41 @@ pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/
 If you use some specific bundles, you need to activate them in `app\AppKernel.php`.
 For instance for an new environment called `staging` (copied from `dev` environment YAML config) you should add in the method `registerBundlesToCollection`:
 ```
-// environment specific bundles
-if (in_array($this->getEnvironment(), ['staging'])) {
-	$collection->addBundles([
-		new DebugBundle(),
-		new WebProfilerBundle(),
-		new SensioDistributionBundle()
-	], 80);
-	// add generator bundle only if installed
-	if (class_exists('Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle')) {
-		$collection->addBundle(
-			new SensioGeneratorBundle(),
-			80, // priority
-			['dev'] // will use the dev config files of the bundle
-		);
-		// PimcoreGeneratorBundle depends on SensioGeneratorBundle
-		$collection->addBundle(
-			new PimcoreGeneratorBundle(),
-			60,
-			['dev']
-		);
+use Pimcore\Bundle\GeneratorBundle\PimcoreGeneratorBundle;
+use Sensio\Bundle\DistributionBundle\SensioDistributionBundle;
+use Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle;
+use Symfony\Bundle\DebugBundle\DebugBundle;
+use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
+...
+	public function registerBundlesToCollection(BundleCollection $collection)
+	{
+		//...
+		
+		// environment specific bundles
+		if (in_array($this->getEnvironment(), ['staging'])) {
+			$collection->addBundles([
+				new DebugBundle(),
+				new WebProfilerBundle(),
+				new SensioDistributionBundle()
+			], 80);
+			// add generator bundle only if installed
+			if (class_exists('Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle')) {
+				$collection->addBundle(
+					new SensioGeneratorBundle(),
+					80, // priority
+					['dev'] // will use the dev config files of the bundle
+				);
+				// PimcoreGeneratorBundle depends on SensioGeneratorBundle
+				$collection->addBundle(
+					new PimcoreGeneratorBundle(),
+					60,
+					['dev']
+				);
+			}
+		}
+
+		//...
 	}
-}
 ```
 
 If you set `PIMCORE_ENVIRONMENT` to a new environment name before installation, all those steps need to be done before running the installation.

--- a/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
+++ b/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
@@ -42,7 +42,7 @@ You can need to configure a new environment name different than the existing one
 
 To create a new config, e.g. staging, which is based on the dev config, you must set `staging` as PIMCORE_ENVIRONMENT and create the following config file `app/config/config_staging.yml`:
 
-```
+```yaml
 imports:
     - { resource: '@PimcoreCoreBundle/Resources/config/pimcore/dev.yml' }
     - { resource: config.yml }


### PR DESCRIPTION
This PR is to give clues how to configure a new environment name.

Even if it follow symfony standard, i think it is worth mentionning this in the documentation to help people (and those comming from Pimcore 4 can get trapped in the test environment which has a special signification in Symfony).

I state too that some environment file need to be created in `pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/` which seems is not documented.

This PR was done because of those issues relating some difficulties to set a new environment:
https://github.com/pimcore/pimcore/issues/2265
https://github.com/pimcore/pimcore/issues/2346