### PR TITLE
Symfony 3.4: Breaking Admin Changes

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/AssetController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/AssetController.php
@@ -163,11 +163,11 @@ class AssetController extends ElementControllerBase implements EventedController
 
             // get assets
             $childsList = new Asset\Listing();
-            if ($this->getUser()->isAdmin()) {
+            if ($this->getAdminUser()->isAdmin()) {
                 $childsList->setCondition('parentId = ? ', $asset->getId());
             } else {
-                $userIds = $this->getUser()->getRoles();
-                $userIds[] = $this->getUser()->getId();
+                $userIds = $this->getAdminUser()->getRoles();
+                $userIds[] = $this->getAdminUser()->getId();
                 $childsList->setCondition('parentId = ? and
                     (
                     (select list from users_workspaces_asset where userId in (' . implode(',', $userIds) . ') and LOCATE(CONCAT(path,filename),cpath)=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
@@ -193,7 +193,7 @@ class AssetController extends ElementControllerBase implements EventedController
             return $this->json([
                 'offset' => $offset,
                 'limit' => $limit,
-                'total' => $asset->getChildAmount($this->getUser()),
+                'total' => $asset->getChildAmount($this->getAdminUser()),
                 'nodes' => $assets
             ]);
         } else {
@@ -321,8 +321,8 @@ class AssetController extends ElementControllerBase implements EventedController
             $asset = Asset::create($parentId, [
                 'filename' => $filename,
                 'sourcePath' => $sourcePath,
-                'userOwner' => $this->getUser()->getId(),
-                'userModification' => $this->getUser()->getId()
+                'userOwner' => $this->getAdminUser()->getId(),
+                'userModification' => $this->getAdminUser()->getId()
             ]);
             $success = true;
 
@@ -391,7 +391,7 @@ class AssetController extends ElementControllerBase implements EventedController
         $stream = fopen($_FILES['Filedata']['tmp_name'], 'r+');
         $asset->setStream($stream);
         $asset->setCustomSetting('thumbnails', null);
-        $asset->setUserModification($this->getUser()->getId());
+        $asset->setUserModification($this->getAdminUser()->getId());
         $newFilename = Element\Service::getValidKey($_FILES['Filedata']['name'], 'asset');
         if ($newFilename != $asset->getFilename()) {
             $newFilename = Element\Service::getSaveCopyName('asset', $newFilename, $asset->getParent());
@@ -435,8 +435,8 @@ class AssetController extends ElementControllerBase implements EventedController
                 $asset = Asset::create($request->get('parentId'), [
                     'filename' => $request->get('name'),
                     'type' => 'folder',
-                    'userOwner' => $this->getUser()->getId(),
-                    'userModification' => $this->getUser()->getId()
+                    'userOwner' => $this->getAdminUser()->getId(),
+                    'userModification' => $this->getAdminUser()->getId()
                 ]);
                 $success = true;
             }
@@ -742,7 +742,7 @@ class AssetController extends ElementControllerBase implements EventedController
 
         $asset = Asset::getById($request->get('id'));
         if ($asset->isAllowed('settings')) {
-            $asset->setUserModification($this->getUser()->getId());
+            $asset->setUserModification($this->getAdminUser()->getId());
 
             // if the position is changed the path must be changed || also from the childs
             if ($request->get('parentId')) {
@@ -914,7 +914,7 @@ class AssetController extends ElementControllerBase implements EventedController
                         $asset->setData($request->get('data'));
                     }
 
-                    $asset->setUserModification($this->getUser()->getId());
+                    $asset->setUserModification($this->getAdminUser()->getId());
 
                     try {
                         $asset->save();
@@ -959,7 +959,7 @@ class AssetController extends ElementControllerBase implements EventedController
         $currentAsset = Asset::getById($asset->getId());
         if ($currentAsset->isAllowed('publish')) {
             try {
-                $asset->setUserModification($this->getUser()->getId());
+                $asset->setUserModification($this->getAdminUser()->getId());
                 $asset->save();
 
                 return $this->json(['success' => true]);
@@ -1410,7 +1410,7 @@ class AssetController extends ElementControllerBase implements EventedController
         }
 
         $asset->setData(Tool::getHttpData($request->get('url')));
-        $asset->setUserModification($this->getUser()->getId());
+        $asset->setUserModification($this->getAdminUser()->getId());
         $asset->save();
 
         return $this->json(['success' => true]);
@@ -1441,9 +1441,9 @@ class AssetController extends ElementControllerBase implements EventedController
         $list = new Asset\Listing();
         $conditionFilters[] = 'path LIKE ' . ($folder->getRealFullPath() == '/' ? "'/%'" : $list->quote($folder->getRealFullPath() . '/%')) ." AND type != 'folder'";
 
-        if (!$this->getUser()->isAdmin()) {
-            $userIds = $this->getUser()->getRoles();
-            $userIds[] = $this->getUser()->getId();
+        if (!$this->getAdminUser()->isAdmin()) {
+            $userIds = $this->getAdminUser()->getRoles();
+            $userIds[] = $this->getAdminUser()->getId();
             $conditionFilters[] .= ' (
                                                     (select list from users_workspaces_asset where userId in (' . implode(',', $userIds) . ') and LOCATE(CONCAT(path, filename),cpath)=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
                                                     OR
@@ -1655,9 +1655,9 @@ class AssetController extends ElementControllerBase implements EventedController
             $db = \Pimcore\Db::get();
             $conditionFilters = [];
             $conditionFilters[] .= 'path LIKE ' . $db->quote($parentPath . '/%') .' AND type != ' . $db->quote('folder');
-            if (!$this->getUser()->isAdmin()) {
-                $userIds = $this->getUser()->getRoles();
-                $userIds[] = $this->getUser()->getId();
+            if (!$this->getAdminUser()->isAdmin()) {
+                $userIds = $this->getAdminUser()->getRoles();
+                $userIds[] = $this->getAdminUser()->getId();
                 $conditionFilters[] .= ' (
                                                     (select list from users_workspaces_asset where userId in (' . implode(',', $userIds) . ') and LOCATE(CONCAT(path, filename),cpath)=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
                                                     OR
@@ -1722,9 +1722,9 @@ class AssetController extends ElementControllerBase implements EventedController
                 $db = \Pimcore\Db::get();
                 $conditionFilters = [];
                 $conditionFilters[] .= "type != 'folder' AND path LIKE " . $db->quote($parentPath . '/%');
-                if (!$this->getUser()->isAdmin()) {
-                    $userIds = $this->getUser()->getRoles();
-                    $userIds[] = $this->getUser()->getId();
+                if (!$this->getAdminUser()->isAdmin()) {
+                    $userIds = $this->getAdminUser()->getRoles();
+                    $userIds[] = $this->getAdminUser()->getId();
                     $conditionFilters[] .= ' (
                                                     (select list from users_workspaces_asset where userId in (' . implode(',', $userIds) . ') and LOCATE(CONCAT(path, filename),cpath)=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
                                                     OR
@@ -1883,8 +1883,8 @@ class AssetController extends ElementControllerBase implements EventedController
                             $asset = Asset::create($parent->getId(), [
                                 'filename' => $filename,
                                 'sourcePath' => $tmpFile,
-                                'userOwner' => $this->getUser()->getId(),
-                                'userModification' => $this->getUser()->getId()
+                                'userOwner' => $this->getAdminUser()->getId(),
+                                'userModification' => $this->getAdminUser()->getId()
                             ]);
 
                             @unlink($tmpFile);
@@ -1979,8 +1979,8 @@ class AssetController extends ElementControllerBase implements EventedController
                     $asset = Asset::create($folder->getId(), [
                         'filename' => $filename,
                         'sourcePath' => $absolutePath,
-                        'userOwner' => $this->getUser()->getId(),
-                        'userModification' => $this->getUser()->getId()
+                        'userOwner' => $this->getAdminUser()->getId(),
+                        'userModification' => $this->getAdminUser()->getId()
                     ]);
                 } else {
                     Logger::debug('prevented creating asset because of missing permissions ');
@@ -2025,8 +2025,8 @@ class AssetController extends ElementControllerBase implements EventedController
             $asset = Asset::create($parentId, [
                 'filename' => $filename,
                 'data' => $data,
-                'userOwner' => $this->getUser()->getId(),
-                'userModification' => $this->getUser()->getId()
+                'userOwner' => $this->getAdminUser()->getId(),
+                'userModification' => $this->getAdminUser()->getId()
             ]);
             $success = true;
         } else {
@@ -2163,9 +2163,9 @@ class AssetController extends ElementControllerBase implements EventedController
                 }
             }
 
-            if (!$this->getUser()->isAdmin()) {
-                $userIds = $this->getUser()->getRoles();
-                $userIds[] = $this->getUser()->getId();
+            if (!$this->getAdminUser()->isAdmin()) {
+                $userIds = $this->getAdminUser()->getRoles();
+                $userIds[] = $this->getAdminUser()->getId();
                 $conditionFilters[] .= ' (
                                                     (select list from users_workspaces_asset where userId in (' . implode(',', $userIds) . ') and LOCATE(CONCAT(path, filename),cpath)=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
                                                     OR
@@ -2241,7 +2241,7 @@ class AssetController extends ElementControllerBase implements EventedController
             'getImageThumbnailAction', 'getVideoThumbnailAction', 'getDocumentThumbnailAction'
         ]);
 
-        $this->_assetService = new Asset\Service($this->getUser());
+        $this->_assetService = new Asset\Service($this->getAdminUser());
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/AssetController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/AssetController.php
@@ -56,7 +56,7 @@ class AssetController extends ElementControllerBase implements EventedController
 
         // check for lock
         if (Element\Editlock::isLocked($request->get('id'), 'asset')) {
-            return $this->json([
+            return $this->adminJson([
                 'editlock' => Element\Editlock::getByElement($request->get('id'), 'asset')
             ]);
         }
@@ -66,7 +66,7 @@ class AssetController extends ElementControllerBase implements EventedController
         $asset = clone $asset;
 
         if (!$asset instanceof Asset) {
-            return $this->json(['success' => false, 'message' => "asset doesn't exist"]);
+            return $this->adminJson(['success' => false, 'message' => "asset doesn't exist"]);
         }
 
         $asset->setMetadata(Asset\Service::expandMetadataForEditmode($asset->getMetadata()));
@@ -131,10 +131,10 @@ class AssetController extends ElementControllerBase implements EventedController
         $data = $event->getArgument('data');
 
         if ($asset->isAllowed('view')) {
-            return $this->json($data);
+            return $this->adminJson($data);
         }
 
-        return $this->json(['success' => false, 'message' => 'missing_permission']);
+        return $this->adminJson(['success' => false, 'message' => 'missing_permission']);
     }
 
     /**
@@ -190,14 +190,14 @@ class AssetController extends ElementControllerBase implements EventedController
         }
 
         if ($request->get('limit')) {
-            return $this->json([
+            return $this->adminJson([
                 'offset' => $offset,
                 'limit' => $limit,
                 'total' => $asset->getChildAmount($this->getAdminUser()),
                 'nodes' => $assets
             ]);
         } else {
-            return $this->json($assets);
+            return $this->adminJson($assets);
         }
     }
 
@@ -212,7 +212,7 @@ class AssetController extends ElementControllerBase implements EventedController
     {
         $res = $this->addAsset($request);
 
-        return $this->json(['success' => $res['success'], 'msg' => 'Success']);
+        return $this->adminJson(['success' => $res['success'], 'msg' => 'Success']);
     }
 
     /**
@@ -227,7 +227,7 @@ class AssetController extends ElementControllerBase implements EventedController
         // this is a special action for the compatibility mode upload (without flash)
         $res = $this->addAsset($request);
 
-        $response = $this->json([
+        $response = $this->adminJson([
             'success' => $res['success'],
             'msg' => $res['success'] ? 'Success' : 'Error',
             'id' => $res['asset'] ? $res['asset']->getId() : null,
@@ -382,7 +382,7 @@ class AssetController extends ElementControllerBase implements EventedController
         if ($newType != $asset->getType()) {
             $translator = $this->get('translator');
 
-            return $this->json([
+            return $this->adminJson([
                 'success'=>false,
                 'message'=> sprintf($translator->trans('asset_type_change_not_allowed', [], 'admin'), $asset->getType(), $newType)
             ]);
@@ -401,7 +401,7 @@ class AssetController extends ElementControllerBase implements EventedController
         if ($asset->isAllowed('publish')) {
             $asset->save();
 
-            $response = $this->json([
+            $response = $this->adminJson([
                 'id' => $asset->getId(),
                 'path' => $asset->getRealFullPath(),
                 'success' => true
@@ -444,7 +444,7 @@ class AssetController extends ElementControllerBase implements EventedController
             Logger::debug('prevented creating asset because of missing permissions');
         }
 
-        return $this->json(['success' => $success]);
+        return $this->adminJson(['success' => $success]);
     }
 
     /**
@@ -478,18 +478,18 @@ class AssetController extends ElementControllerBase implements EventedController
                 }
             }
 
-            return $this->json(['success' => true, 'deleted' => $deletedItems]);
+            return $this->adminJson(['success' => true, 'deleted' => $deletedItems]);
         } elseif ($request->get('id')) {
             $asset = Asset::getById($request->get('id'));
 
             if ($asset->isAllowed('delete')) {
                 $asset->delete();
 
-                return $this->json(['success' => true]);
+                return $this->adminJson(['success' => true]);
             }
         }
 
-        return $this->json(['success' => false, 'message' => 'missing_permission']);
+        return $this->adminJson(['success' => false, 'message' => 'missing_permission']);
     }
 
     /**
@@ -579,7 +579,7 @@ class AssetController extends ElementControllerBase implements EventedController
 
         $deleteJobs = array_merge($recycleJobs, $deleteJobs);
 
-        return $this->json([
+        return $this->adminJson([
             'hasDependencies' => $hasDependency,
             'childs' => $totalChilds,
             'deletejobs' => $deleteJobs,
@@ -784,13 +784,13 @@ class AssetController extends ElementControllerBase implements EventedController
                     $asset->save();
                     $success = true;
                 } catch (\Exception $e) {
-                    return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                    return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                 }
             } else {
                 $msg = 'prevented moving asset, asset with same path+key already exists at target location or the asset is locked. ID: ' . $asset->getId();
                 Logger::debug($msg);
 
-                return $this->json(['success' => $success, 'message' => $msg]);
+                return $this->adminJson(['success' => $success, 'message' => $msg]);
             }
         } elseif ($asset->isAllowed('rename') && $request->get('filename')) {
             //just rename
@@ -799,13 +799,13 @@ class AssetController extends ElementControllerBase implements EventedController
                 $asset->save();
                 $success = true;
             } catch (\Exception $e) {
-                return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
             }
         } else {
             Logger::debug('prevented update asset because of missing permissions ');
         }
 
-        return $this->json(['success' => $success]);
+        return $this->adminJson(['success' => $success]);
     }
 
     /**
@@ -925,20 +925,20 @@ class AssetController extends ElementControllerBase implements EventedController
                             throw $e;
                         }
 
-                        return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                        return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                     }
                 } else {
                     Logger::debug('prevented save asset because of missing permissions ');
                 }
 
-                return $this->json(['success' => $success]);
+                return $this->adminJson(['success' => $success]);
             }
 
-            return $this->json(false);
+            return $this->adminJson(false);
         } catch (\Exception $e) {
             Logger::log($e);
             if ($e instanceof Element\ValidationException) {
-                return $this->json(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
+                return $this->adminJson(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
             }
             throw $e;
         }
@@ -962,13 +962,13 @@ class AssetController extends ElementControllerBase implements EventedController
                 $asset->setUserModification($this->getAdminUser()->getId());
                 $asset->save();
 
-                return $this->json(['success' => true]);
+                return $this->adminJson(['success' => true]);
             } catch (\Exception $e) {
-                return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
             }
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -1179,7 +1179,7 @@ class AssetController extends ElementControllerBase implements EventedController
         $thumbnail = $image->getThumbnail($thumbnail);
 
         if ($fileinfo) {
-            return $this->json([
+            return $this->adminJson([
                 'width' => $thumbnail->getWidth(),
                 'height' => $thumbnail->getHeight()]);
         }
@@ -1413,7 +1413,7 @@ class AssetController extends ElementControllerBase implements EventedController
         $asset->setUserModification($this->getAdminUser()->getId());
         $asset->save();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -1488,7 +1488,7 @@ class AssetController extends ElementControllerBase implements EventedController
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'assets' => $assets,
             'success' => true,
             'total' => $list->getTotalCount()
@@ -1562,7 +1562,7 @@ class AssetController extends ElementControllerBase implements EventedController
             ]];
         }
 
-        return $this->json([
+        return $this->adminJson([
             'pastejobs' => $pasteJobs
         ]);
     }
@@ -1624,12 +1624,12 @@ class AssetController extends ElementControllerBase implements EventedController
         } else {
             Logger::error('could not execute copy/paste because of missing permissions on target [ ' . $targetId . ' ]');
 
-            return $this->json(['error' => false, 'message' => 'missing_permission']);
+            return $this->adminJson(['error' => false, 'message' => 'missing_permission']);
         }
 
         Tool\Session::writeClose();
 
-        return $this->json(['success' => $success]);
+        return $this->adminJson(['success' => $success]);
     }
 
     /**
@@ -1685,7 +1685,7 @@ class AssetController extends ElementControllerBase implements EventedController
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true,
             'jobs' => $jobs,
             'jobId' => $jobId
@@ -1754,7 +1754,7 @@ class AssetController extends ElementControllerBase implements EventedController
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success
         ]);
     }
@@ -1901,7 +1901,7 @@ class AssetController extends ElementControllerBase implements EventedController
             unlink($zipFile);
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true
         ]);
     }
@@ -1945,7 +1945,7 @@ class AssetController extends ElementControllerBase implements EventedController
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success,
             'jobs' => $jobs
         ]);
@@ -1988,7 +1988,7 @@ class AssetController extends ElementControllerBase implements EventedController
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true
         ]);
     }
@@ -2033,7 +2033,7 @@ class AssetController extends ElementControllerBase implements EventedController
             Logger::debug('prevented creating asset because of missing permissions');
         }
 
-        return $this->json(['success' => $success]);
+        return $this->adminJson(['success' => $success]);
     }
 
     /**
@@ -2060,7 +2060,7 @@ class AssetController extends ElementControllerBase implements EventedController
             }
         }
 
-        return $this->json(['success' => $success]);
+        return $this->adminJson(['success' => $success]);
     }
 
     /**
@@ -2200,7 +2200,7 @@ class AssetController extends ElementControllerBase implements EventedController
                 ];
             }
 
-            return $this->json(['data' => $assets, 'success' => true, 'total' => $list->getTotalCount()]);
+            return $this->adminJson(['data' => $assets, 'success' => true, 'total' => $list->getTotalCount()]);
         }
     }
 
@@ -2224,7 +2224,7 @@ class AssetController extends ElementControllerBase implements EventedController
             $text = $asset->getText($page);
         }
 
-        return $this->json(['success' => 'true', 'text' => $text]);
+        return $this->adminJson(['success' => 'true', 'text' => $text]);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ClassController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ClassController.php
@@ -95,7 +95,7 @@ class ClassController extends AdminController implements EventedControllerInterf
         if ($request->get('createAllowed')) {
             $tmpClasses = [];
             foreach ($classes as $class) {
-                if ($this->getUser()->isAllowed($class->getId(), 'class')) {
+                if ($this->getAdminUser()->isAllowed($class->getId(), 'class')) {
                     $tmpClasses[] = $class;
                 }
             }
@@ -226,7 +226,7 @@ class ClassController extends AdminController implements EventedControllerInterf
     {
         $class = DataObject\ClassDefinition::create(
             ['name' => $this->correctClassname($request->get('name')),
-                'userOwner' => $this->getUser()->getId()]
+                'userOwner' => $this->getAdminUser()->getId()]
         );
 
         $class->save();
@@ -245,7 +245,7 @@ class ClassController extends AdminController implements EventedControllerInterf
     {
         $customLayout = DataObject\ClassDefinition\CustomLayout::create(
             ['name' => $request->get('name'),
-                'userOwner' => $this->getUser()->getId(),
+                'userOwner' => $this->getAdminUser()->getId(),
                 'classId' => $request->get('classId')]
         );
 
@@ -374,7 +374,7 @@ class ClassController extends AdminController implements EventedControllerInterf
 
             $class->setLayoutDefinitions($layout);
 
-            $class->setUserModification($this->getUser()->getId());
+            $class->setUserModification($this->getAdminUser()->getId());
             $class->setModificationDate(time());
 
             $propertyVisibility = [];
@@ -1087,7 +1087,7 @@ class ClassController extends AdminController implements EventedControllerInterf
 
                 $currentLayoutId = $request->get('layoutId', null);
 
-                $user = $this->getUser();
+                $user = $this->getAdminUser();
                 if ($currentLayoutId == -1 && $user->isAdmin()) {
                     DataObject\Service::createSuperLayout($layout);
                     $objectData['layout'] = $layout;

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ClassController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ClassController.php
@@ -52,7 +52,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             ];
         }
 
-        return $this->json($typeItems);
+        return $this->adminJson($typeItems);
     }
 
     /**
@@ -72,7 +72,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             ];
         }
 
-        return $this->json($typeItems);
+        return $this->adminJson($typeItems);
     }
 
     /**
@@ -183,7 +183,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             }
         }
 
-        return $this->json($treeNodes);
+        return $this->adminJson($treeNodes);
     }
 
     /**
@@ -198,7 +198,7 @@ class ClassController extends AdminController implements EventedControllerInterf
         $class = DataObject\ClassDefinition::getById(intval($request->get('id')));
         $class->setFieldDefinitions(null);
 
-        return $this->json($class);
+        return $this->adminJson($class);
     }
 
     /**
@@ -212,7 +212,7 @@ class ClassController extends AdminController implements EventedControllerInterf
     {
         $customLayout = DataObject\ClassDefinition\CustomLayout::getById(intval($request->get('id')));
 
-        return $this->json(['success' => true, 'data' => $customLayout]);
+        return $this->adminJson(['success' => true, 'data' => $customLayout]);
     }
 
     /**
@@ -231,7 +231,7 @@ class ClassController extends AdminController implements EventedControllerInterf
 
         $class->save();
 
-        return $this->json(['success' => true, 'id' => $class->getId()]);
+        return $this->adminJson(['success' => true, 'id' => $class->getId()]);
     }
 
     /**
@@ -251,8 +251,8 @@ class ClassController extends AdminController implements EventedControllerInterf
 
         $customLayout->save();
 
-        return $this->json(['success' => true, 'id' => $customLayout->getId(), 'name' => $customLayout->getName(),
-            'data' => $customLayout]);
+        return $this->adminJson(['success' => true, 'id' => $customLayout->getId(), 'name' => $customLayout->getName(),
+                                 'data'    => $customLayout]);
     }
 
     /**
@@ -284,7 +284,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             $customLayout->delete();
         }
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -304,7 +304,7 @@ class ClassController extends AdminController implements EventedControllerInterf
 
         $modificationDate = intval($values['modificationDate']);
         if ($modificationDate < $customLayout->getModificationDate()) {
-            return $this->json(['success' => false, 'msg' => 'custom_layout_changed']);
+            return $this->adminJson(['success' => false, 'msg' => 'custom_layout_changed']);
         }
 
         $configuration['datatype'] = 'layout';
@@ -319,11 +319,11 @@ class ClassController extends AdminController implements EventedControllerInterf
             $customLayout->setDefault($values['default']);
             $customLayout->save();
 
-            return $this->json(['success' => true, 'id' => $customLayout->getId(), 'data' => $customLayout]);
+            return $this->adminJson(['success' => true, 'id' => $customLayout->getId(), 'data' => $customLayout]);
         } catch (\Exception $e) {
             Logger::error($e->getMessage());
 
-            return $this->json(['success' => false, 'message' => $e->getMessage()]);
+            return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
         }
     }
 
@@ -396,11 +396,11 @@ class ClassController extends AdminController implements EventedControllerInterf
             // set the fielddefinitions to null because we don't need them in the response
             $class->setFieldDefinitions(null);
 
-            return $this->json(['success' => true, 'class' => $class]);
+            return $this->adminJson(['success' => true, 'class' => $class]);
         } catch (\Exception $e) {
             Logger::error($e->getMessage());
 
-            return $this->json(['success' => false, 'message' => $e->getMessage()]);
+            return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
         }
     }
 
@@ -431,7 +431,7 @@ class ClassController extends AdminController implements EventedControllerInterf
 
         $success = DataObject\ClassDefinition\Service::importClassDefinitionFromJson($class, $json);
 
-        $response = $this->json([
+        $response = $this->adminJson([
             'success' => $success
         ]);
         // set content-type to text/html, otherwise (when application/json is sent) chrome will complain in
@@ -468,7 +468,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             }
         }
 
-        $response = $this->json([
+        $response = $this->adminJson([
             'success' => $success
         ]);
 
@@ -503,7 +503,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             ];
         }
 
-        return $this->json(['success' => true, 'data' => $result]);
+        return $this->adminJson(['success' => true, 'data' => $result]);
     }
 
     /**
@@ -551,7 +551,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             }
         }
 
-        return $this->json(['data' => $resultList]);
+        return $this->adminJson(['data' => $resultList]);
     }
 
     /**
@@ -635,7 +635,7 @@ class ClassController extends AdminController implements EventedControllerInterf
     {
         $fc = DataObject\Fieldcollection\Definition::getByKey($request->get('id'));
 
-        return $this->json($fc);
+        return $this->adminJson($fc);
     }
 
     /**
@@ -682,11 +682,11 @@ class ClassController extends AdminController implements EventedControllerInterf
 
             $fc->save();
 
-            return $this->json(['success' => true, 'id' => $fc->getKey()]);
+            return $this->adminJson(['success' => true, 'id' => $fc->getKey()]);
         } catch (\Exception $e) {
             Logger::error($e->getMessage());
 
-            return $this->json(['success' => false, 'message' => $e->getMessage()]);
+            return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
         }
     }
 
@@ -705,7 +705,7 @@ class ClassController extends AdminController implements EventedControllerInterf
 
         $success = DataObject\ClassDefinition\Service::importFieldCollectionFromJson($fieldCollection, $data);
 
-        $response = $this->json([
+        $response = $this->adminJson([
             'success' => $success
         ]);
 
@@ -753,7 +753,7 @@ class ClassController extends AdminController implements EventedControllerInterf
         $fc = DataObject\Fieldcollection\Definition::getByKey($request->get('id'));
         $fc->delete();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -777,7 +777,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             ];
         }
 
-        return $this->json($items);
+        return $this->adminJson($items);
     }
 
     /**
@@ -824,7 +824,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             $list = $filteredList;
         }
 
-        return $this->json(['fieldcollections' => $list]);
+        return $this->adminJson(['fieldcollections' => $list]);
     }
 
     /**
@@ -887,7 +887,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             }
         }
 
-        return $this->json($result);
+        return $this->adminJson($result);
     }
 
     /**
@@ -905,7 +905,7 @@ class ClassController extends AdminController implements EventedControllerInterf
     {
         $fc = DataObject\Objectbrick\Definition::getByKey($request->get('id'));
 
-        return $this->json($fc);
+        return $this->adminJson($fc);
     }
 
     /**
@@ -955,11 +955,11 @@ class ClassController extends AdminController implements EventedControllerInterf
 
             $fc->save();
 
-            return $this->json(['success' => true, 'id' => $fc->getKey()]);
+            return $this->adminJson(['success' => true, 'id' => $fc->getKey()]);
         } catch (\Exception $e) {
             Logger::error($e->getMessage());
 
-            return $this->json(['success' => false, 'message' => $e->getMessage()]);
+            return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
         }
     }
 
@@ -977,7 +977,7 @@ class ClassController extends AdminController implements EventedControllerInterf
         $data = file_get_contents($_FILES['Filedata']['tmp_name']);
         $success = DataObject\ClassDefinition\Service::importObjectBrickFromJson($objectBrick, $data);
 
-        $response = $this->json([
+        $response = $this->adminJson([
             'success' => $success
         ]);
 
@@ -1025,7 +1025,7 @@ class ClassController extends AdminController implements EventedControllerInterf
         $fc = DataObject\Objectbrick\Definition::getByKey($request->get('id'));
         $fc->delete();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -1049,7 +1049,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             ];
         }
 
-        return $this->json($items);
+        return $this->adminJson($items);
     }
 
     /**
@@ -1115,7 +1115,7 @@ class ClassController extends AdminController implements EventedControllerInterf
         \Pimcore::getEventDispatcher()->dispatch(AdminEvents::CLASS_OBJECTBRICK_LIST_PRE_SEND_DATA, $event);
         $list = $event->getArgument('list');
 
-        return $this->json(['objectbricks' => $list]);
+        return $this->adminJson(['objectbricks' => $list]);
     }
 
     /**
@@ -1172,7 +1172,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             }
         }
 
-        $response = $this->json(['success' => true, 'filename' => $tmpName, 'data' => $result]);
+        $response = $this->adminJson(['success' => true, 'filename' => $tmpName, 'data' => $result]);
         $response->headers->set('Content-Type', 'text/html');
 
         return $response;
@@ -1220,7 +1220,7 @@ class ClassController extends AdminController implements EventedControllerInterf
                 }
                 $success = DataObject\ClassDefinition\Service::importClassDefinitionFromJson($class, json_encode($item), true);
 
-                return $this->json(['success' => $success !== false]);
+                return $this->adminJson(['success' => $success !== false]);
             } elseif ($type == 'objectbrick' && $item['key'] == $name) {
                 try {
                     $brick = DataObject\Objectbrick\Definition::getByKey($name);
@@ -1231,7 +1231,7 @@ class ClassController extends AdminController implements EventedControllerInterf
 
                 $success = DataObject\ClassDefinition\Service::importObjectBrickFromJson($brick, json_encode($item), true);
 
-                return $this->json(['success' => $success !== false]);
+                return $this->adminJson(['success' => $success !== false]);
             } elseif ($type == 'fieldcollection' && $item['key'] == $name) {
                 try {
                     $fieldCollection = DataObject\Fieldcollection\Definition::getByKey($name);
@@ -1241,7 +1241,7 @@ class ClassController extends AdminController implements EventedControllerInterf
                 }
                 $success = DataObject\ClassDefinition\Service::importFieldCollectionFromJson($fieldCollection, json_encode($item), true);
 
-                return $this->json(['success' => $success !== false]);
+                return $this->adminJson(['success' => $success !== false]);
             } elseif ($type == 'customlayout') {
                 $layoutData = unserialize($data['name']);
                 $className = $layoutData['className'];
@@ -1279,13 +1279,13 @@ class ClassController extends AdminController implements EventedControllerInterf
                     } catch (\Exception $e) {
                         Logger::error($e->getMessage());
 
-                        return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                        return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                     }
                 }
             }
         }
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ClassificationstoreController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ClassificationstoreController.php
@@ -50,7 +50,7 @@ class ClassificationstoreController extends AdminController
         $config = Classificationstore\CollectionConfig::getById($id);
         $config->delete();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -71,7 +71,7 @@ class ClassificationstoreController extends AdminController
 
         $config->delete();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -92,7 +92,7 @@ class ClassificationstoreController extends AdminController
 
         $config->delete();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -109,7 +109,7 @@ class ClassificationstoreController extends AdminController
         $config = Classificationstore\GroupConfig::getById($id);
         $config->delete();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -133,7 +133,7 @@ class ClassificationstoreController extends AdminController
             $config->save();
         }
 
-        return $this->json(['success' => !$alreadyExist, 'id' => $config->getName()]);
+        return $this->adminJson(['success' => !$alreadyExist, 'id' => $config->getName()]);
     }
 
     /**
@@ -159,7 +159,7 @@ class ClassificationstoreController extends AdminController
             throw new \Exception('Store with the given name exists');
         }
 
-        return $this->json(['success' => true, 'storeId' => $config->getId()]);
+        return $this->adminJson(['success' => true, 'storeId' => $config->getId()]);
     }
 
     /**
@@ -183,7 +183,7 @@ class ClassificationstoreController extends AdminController
             $config->save();
         }
 
-        return $this->json(['success' => !$alreadyExist, 'id' => $config->getName()]);
+        return $this->adminJson(['success' => !$alreadyExist, 'id' => $config->getName()]);
     }
 
     /**
@@ -217,7 +217,7 @@ class ClassificationstoreController extends AdminController
             $contents[] = $itemConfig;
         }
 
-        return $this->json($contents);
+        return $this->adminJson($contents);
     }
 
     /**
@@ -240,7 +240,7 @@ class ClassificationstoreController extends AdminController
             'sorter' => (int) $config->getSorter()
         ];
 
-        return $this->json($data);
+        return $this->adminJson($data);
     }
 
     /**
@@ -268,7 +268,7 @@ class ClassificationstoreController extends AdminController
 
             $config->save();
 
-            return $this->json(['success' => true, 'data' => $config]);
+            return $this->adminJson(['success' => true, 'data' => $config]);
         } else {
             $start = 0;
             $limit = $request->get('limit') ? $request->get('limit') : 15;
@@ -384,7 +384,7 @@ class ClassificationstoreController extends AdminController
             $rootElement['success'] = true;
             $rootElement['total'] = $list->getTotalCount();
 
-            return $this->json($rootElement);
+            return $this->adminJson($rootElement);
         }
     }
 
@@ -413,7 +413,7 @@ class ClassificationstoreController extends AdminController
 
             $config->save();
 
-            return $this->json(['success' => true, 'data' => $config]);
+            return $this->adminJson(['success' => true, 'data' => $config]);
         } else {
             $start = 0;
             $limit = 15;
@@ -520,7 +520,7 @@ class ClassificationstoreController extends AdminController
             $rootElement['success'] = true;
             $rootElement['total'] = $list->getTotalCount();
 
-            return $this->json($rootElement);
+            return $this->adminJson($rootElement);
         }
     }
 
@@ -556,7 +556,7 @@ class ClassificationstoreController extends AdminController
                 $row['id'] = $config->getColId() . '-' . $config->getGroupId();
             }
 
-            return $this->json(['success' => true, 'data' => $data]);
+            return $this->adminJson(['success' => true, 'data' => $data]);
         } else {
             $mapping = ['groupName' => 'name', 'groupDescription' => 'description'];
 
@@ -643,7 +643,7 @@ class ClassificationstoreController extends AdminController
             $rootElement['success'] = true;
             $rootElement['total'] = $list->getTotalCount();
 
-            return $this->json($rootElement);
+            return $this->adminJson($rootElement);
         }
     }
 
@@ -659,7 +659,7 @@ class ClassificationstoreController extends AdminController
         $list = new Classificationstore\StoreConfig\Listing();
         $list = $list->load();
 
-        return $this->json($list);
+        return $this->adminJson($list);
     }
 
     /**
@@ -772,7 +772,7 @@ class ClassificationstoreController extends AdminController
         $rootElement['success'] = true;
         $rootElement['total'] = $list->getTotalCount();
 
-        return $this->json($rootElement);
+        return $this->adminJson($rootElement);
     }
 
     /**
@@ -802,7 +802,7 @@ class ClassificationstoreController extends AdminController
             $config->save();
             $data['id'] = $config->getGroupId() . '-' . $config->getKeyId();
 
-            return $this->json(['success' => true, 'data' => $data]);
+            return $this->adminJson(['success' => true, 'data' => $data]);
         } else {
             $mapping = ['keyName' => 'name', 'keyDescription' => 'description'];
 
@@ -907,7 +907,7 @@ class ClassificationstoreController extends AdminController
             $rootElement['success'] = true;
             $rootElement['total'] = $list->getTotalCount();
 
-            return $this->json($rootElement);
+            return $this->adminJson($rootElement);
         }
     }
 
@@ -1014,7 +1014,7 @@ class ClassificationstoreController extends AdminController
             }
         }
 
-        return $this->json($data);
+        return $this->adminJson($data);
     }
 
     /**
@@ -1090,7 +1090,7 @@ class ClassificationstoreController extends AdminController
             $data[$groupId]['keys'] = $keyList;
         }
 
-        return $this->json($data);
+        return $this->adminJson($data);
     }
 
     /**
@@ -1121,7 +1121,7 @@ class ClassificationstoreController extends AdminController
             $config->save();
             $item = $this->getConfigItem($config);
 
-            return $this->json(['success' => true, 'data' => $item]);
+            return $this->adminJson(['success' => true, 'data' => $item]);
         } else {
             $storeId = $request->get('storeId');
             $frameName = $request->get('frameName');
@@ -1262,7 +1262,7 @@ class ClassificationstoreController extends AdminController
             $rootElement['success'] = true;
             $rootElement['total'] = $list->getTotalCount();
 
-            return $this->json($rootElement);
+            return $this->adminJson($rootElement);
         }
     }
 
@@ -1333,7 +1333,7 @@ class ClassificationstoreController extends AdminController
             $config->save();
         }
 
-        return $this->json(['success' => !$alreadyExist, 'id' => $config->getName()]);
+        return $this->adminJson(['success' => !$alreadyExist, 'id' => $config->getName()]);
     }
 
     /**
@@ -1352,7 +1352,7 @@ class ClassificationstoreController extends AdminController
         $config->setEnabled(false);
         $config->save();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -1391,7 +1391,7 @@ class ClassificationstoreController extends AdminController
         $config->setDescription($description);
         $config->save();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -1426,7 +1426,7 @@ class ClassificationstoreController extends AdminController
             $result[] = $resultItem;
         }
 
-        return $this->json($result);
+        return $this->adminJson($result);
     }
 
     /**
@@ -1476,6 +1476,6 @@ class ClassificationstoreController extends AdminController
 
         $page = (int) $result[0]['page'] ;
 
-        return $this->json(['success' => true, 'page' => $page]);
+        return $this->adminJson(['success' => true, 'page' => $page]);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectController.php
@@ -98,9 +98,9 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             }
             // custom views end
 
-            if (!$this->getUser()->isAdmin()) {
-                $userIds = $this->getUser()->getRoles();
-                $userIds[] = $this->getUser()->getId();
+            if (!$this->getAdminUser()->isAdmin()) {
+                $userIds = $this->getAdminUser()->getRoles();
+                $userIds[] = $this->getAdminUser()->getId();
                 $condition .= ' AND (
                                                     (select list from users_workspaces_object where userId in (' . implode(',', $userIds) . ') and LOCATE(CONCAT(o_path,o_key),cpath)=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
                                                     OR
@@ -129,7 +129,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             $total = $cv
                 ? $childsList->count()
                 : $object->getChildAmount([DataObject\AbstractObject::OBJECT_TYPE_OBJECT, DataObject\AbstractObject::OBJECT_TYPE_FOLDER,
-                    DataObject\AbstractObject::OBJECT_TYPE_VARIANT], $this->getUser());
+                    DataObject\AbstractObject::OBJECT_TYPE_VARIANT], $this->getAdminUser());
         }
 
         //Hook for modifying return value - e.g. for changing permissions based on object data
@@ -739,7 +739,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             $objectData['classes'] = $this->prepareChildClasses($object->getDao()->getClasses());
 
             // grid-config
-            $configFile = PIMCORE_CONFIGURATION_DIRECTORY . '/object/grid/' . $object->getId() . '-user_' . $this->getUser()->getId() . '.psf';
+            $configFile = PIMCORE_CONFIGURATION_DIRECTORY . '/object/grid/' . $object->getId() . '-user_' . $this->getAdminUser()->getId() . '.psf';
             if (is_file($configFile)) {
                 $gridConfig = Tool\Serialize::unserialize(file_get_contents($configFile));
                 if ($gridConfig) {
@@ -816,8 +816,8 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 $object->setParentId($request->get('parentId'));
                 $object->setKey($request->get('key'));
                 $object->setCreationDate(time());
-                $object->setUserOwner($this->getUser()->getId());
-                $object->setUserModification($this->getUser()->getId());
+                $object->setUserOwner($this->getAdminUser()->getId());
+                $object->setUserModification($this->getAdminUser()->getId());
                 $object->setPublished(false);
 
                 if ($request->get('objecttype') == DataObject\AbstractObject::OBJECT_TYPE_OBJECT
@@ -872,15 +872,15 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 $folder = DataObject\Folder::create([
                     'o_parentId' => $request->get('parentId'),
                     'o_creationDate' => time(),
-                    'o_userOwner' => $this->getUser()->getId(),
-                    'o_userModification' => $this->getUser()->getId(),
+                    'o_userOwner' => $this->getAdminUser()->getId(),
+                    'o_userModification' => $this->getAdminUser()->getId(),
                     'o_key' => $request->get('key'),
                     'o_published' => true
                 ]);
 
                 $folder->setCreationDate(time());
-                $folder->setUserOwner($this->getUser()->getId());
-                $folder->setUserModification($this->getUser()->getId());
+                $folder->setUserOwner($this->getAdminUser()->getId());
+                $folder->setUserModification($this->getAdminUser()->getId());
 
                 try {
                     $folder->save();
@@ -1104,7 +1104,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
 
             if ($allowUpdate) {
                 $object->setModificationDate(time());
-                $object->setUserModification($this->getUser()->getId());
+                $object->setUserModification($this->getAdminUser()->getId());
 
                 try {
                     $object->save();
@@ -1152,7 +1152,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
 
             // set the latest available version for editmode
             $object = $this->getLatestVersion($object);
-            $object->setUserModification($this->getUser()->getId());
+            $object->setUserModification($this->getAdminUser()->getId());
 
             // data
             if ($request->get('data')) {
@@ -1349,7 +1349,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 // general settings
                 $general = $this->decodeJson($request->get('general'));
                 $object->setValues($general);
-                $object->setUserModification($this->getUser()->getId());
+                $object->setUserModification($this->getAdminUser()->getId());
 
                 $object = $this->assignPropertiesFromEditmode($request, $object);
 
@@ -1422,7 +1422,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         $currentObject = DataObject::getById($object->getId());
         if ($currentObject->isAllowed('publish')) {
             $object->setPublished(true);
-            $object->setUserModification($this->getUser()->getId());
+            $object->setUserModification($this->getAdminUser()->getId());
             try {
                 $object->save();
                 $treeData = [];
@@ -1732,9 +1732,9 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 $conditionFilters[] = '(o_path = ' . $quotedPath . ' OR o_path LIKE ' . $quotedWildcardPath . ')';
             }
 
-            if (!$this->getUser()->isAdmin()) {
-                $userIds = $this->getUser()->getRoles();
-                $userIds[] = $this->getUser()->getId();
+            if (!$this->getAdminUser()->isAdmin()) {
+                $userIds = $this->getAdminUser()->getRoles();
+                $userIds[] = $this->getAdminUser()->getId();
                 $conditionFilters[] .= ' (
                                                     (select list from users_workspaces_object where userId in (' . implode(',', $userIds) . ') and LOCATE(CONCAT(o_path,o_key),cpath)=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
                                                     OR
@@ -1753,7 +1753,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                     $featureJoins = array_merge($featureJoins, $featureFilters['joins']);
                 }
             }
-            if ($request->get('condition') && $this->getUser()->isAdmin()) {
+            if ($request->get('condition') && $this->getAdminUser()->isAdmin()) {
                 $conditionFilters[] = '(' . $request->get('condition') . ')';
             }
 
@@ -1946,7 +1946,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
 
         $object = DataObject\Service::rewriteIds($object, $rewriteConfig);
 
-        $object->setUserModification($this->getUser()->getId());
+        $object->setUserModification($this->getAdminUser()->getId());
         $object->save();
 
         // write the store back to the session
@@ -2096,7 +2096,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                         if ($currentData[$i]->getId() == $object->getId()) {
                             unset($currentData[$i]);
                             $owner->$setter($currentData);
-                            $owner->setUserModification($this->getUser()->getId());
+                            $owner->setUserModification($this->getAdminUser()->getId());
                             $owner->save();
                             Logger::debug('Saved object id [ ' . $owner->getId() . ' ] by remote modification through [' . $object->getId() . '], Action: deleted [ ' . $object->getId() . " ] from [ $ownerFieldName]");
                             break;
@@ -2114,7 +2114,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 $currentData[] = $object;
 
                 $owner->$setter($currentData);
-                $owner->setUserModification($this->getUser()->getId());
+                $owner->setUserModification($this->getAdminUser()->getId());
                 $owner->save();
                 Logger::debug('Saved object id [ ' . $owner->getId() . ' ] by remote modification through [' . $object->getId() . '], Action: added [ ' . $object->getId() . " ] to [ $ownerFieldName ]");
             }
@@ -2200,7 +2200,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         // check permissions
         $this->checkPermission('objects');
 
-        $this->_objectService = new DataObject\Service($this->getUser());
+        $this->_objectService = new DataObject\Service($this->getAdminUser());
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectController.php
@@ -141,7 +141,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         $objects = $event->getArgument('objects');
 
         if ($request->get('limit')) {
-            return $this->json([
+            return $this->adminJson([
                 'offset' => $offset,
                 'limit' => $limit,
                 'total' => $total,
@@ -149,7 +149,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 'fromPaging' => intval($request->get('fromPaging'))
             ]);
         } else {
-            return $this->json($objects);
+            return $this->adminJson($objects);
         }
     }
 
@@ -291,7 +291,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             $object = $parent;
         }
 
-        return $this->json($data);
+        return $this->adminJson($data);
     }
 
     /**
@@ -305,7 +305,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
     {
         // check for lock
         if (Element\Editlock::isLocked($request->get('id'), 'object')) {
-            return $this->json([
+            return $this->adminJson([
                 'editlock' => Element\Editlock::getByElement($request->get('id'), 'object')
             ]);
         }
@@ -425,11 +425,11 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             \Pimcore::getEventDispatcher()->dispatch(AdminEvents::OBJECT_GET_PRE_SEND_DATA, $event);
             $data = $event->getArgument('data');
 
-            return $this->json($data);
+            return $this->adminJson($data);
         } else {
             Logger::debug('prevented getting object id [ ' . $object->getId() . ' ] because of missing permissions');
 
-            return $this->json(['success' => false, 'message' => 'missing_permission']);
+            return $this->adminJson(['success' => false, 'message' => 'missing_permission']);
         }
     }
 
@@ -712,7 +712,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
     {
         // check for lock
         if (Element\Editlock::isLocked($request->get('id'), 'object')) {
-            return $this->json([
+            return $this->adminJson([
                 'editlock' => Element\Editlock::getByElement($request->get('id'), 'object')
             ]);
         }
@@ -754,11 +754,11 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 }
             }
 
-            return $this->json($objectData);
+            return $this->adminJson($objectData);
         } else {
             Logger::debug('prevented getting folder id [ ' . $object->getId() . ' ] because of missing permissions');
 
-            return $this->json(['success' => false, 'message' => 'missing_permission']);
+            return $this->adminJson(['success' => false, 'message' => 'missing_permission']);
         }
     }
 
@@ -829,7 +829,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                     $object->save();
                     $success = true;
                 } catch (\Exception $e) {
-                    return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                    return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                 }
             } else {
                 $message = 'prevented creating object because object with same path+key already exists';
@@ -841,14 +841,14 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         }
 
         if ($success) {
-            return $this->json([
+            return $this->adminJson([
                 'success' => $success,
                 'id' => $object->getId(),
                 'type' => $object->getType(),
                 'message' => $message
             ]);
         } else {
-            return $this->json([
+            return $this->adminJson([
                 'success' => $success,
                 'message' => $message
             ]);
@@ -886,14 +886,14 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                     $folder->save();
                     $success = true;
                 } catch (\Exception $e) {
-                    return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                    return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                 }
             }
         } else {
             Logger::debug('prevented creating object id because of missing permissions');
         }
 
-        return $this->json(['success' => $success]);
+        return $this->adminJson(['success' => $success]);
     }
 
     /**
@@ -924,19 +924,19 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 }
             }
 
-            return $this->json(['success' => true, 'deleted' => $deletedItems]);
+            return $this->adminJson(['success' => true, 'deleted' => $deletedItems]);
         } elseif ($request->get('id')) {
             $object = DataObject::getById($request->get('id'));
             if ($object) {
                 if (!$object->isAllowed('delete')) {
-                    return $this->json(['success' => false, 'message' => 'missing_permission']);
+                    return $this->adminJson(['success' => false, 'message' => 'missing_permission']);
                 } else {
                     $object->delete();
                 }
             }
 
             // return true, even when the object doesn't exist, this can be the case when using batch delete incl. children
-            return $this->json(['success' => true]);
+            return $this->adminJson(['success' => true]);
         }
     }
 
@@ -1027,7 +1027,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
 
         $deleteJobs = array_merge($recycleJobs, $deleteJobs);
 
-        return $this->json([
+        return $this->adminJson([
             'hasDependencies' => $hasDependency,
             'childs' => $totalChilds,
             'deletejobs' => $deleteJobs,
@@ -1060,7 +1060,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         if ($object instanceof DataObject\Concrete) {
             $latestVersion = $object->getLatestVersion();
             if ($latestVersion && $latestVersion->getData()->getModificationDate() != $object->getModificationDate()) {
-                return $this->json(['success' => false, 'message' => "You can't relocate if there's a newer not published version"]);
+                return $this->adminJson(['success' => false, 'message' => "You can't relocate if there's a newer not published version"]);
             }
         }
 
@@ -1087,11 +1087,11 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                     if ($objectWithSamePath != null) {
                         $allowUpdate = false;
 
-                        return $this->json(['success' => false, 'message' => 'prevented creating object because object with same path+key already exists']);
+                        return $this->adminJson(['success' => false, 'message' => 'prevented creating object because object with same path+key already exists']);
                     }
 
                     if ($object->isLocked()) {
-                        return $this->json(['success' => false, 'message' => 'prevented moving object, because it is locked: ID: ' . $object->getId()]);
+                        return $this->adminJson(['success' => false, 'message' => 'prevented moving object, because it is locked: ID: ' . $object->getId()]);
                     }
 
                     $object->setParentId($values['parentId']);
@@ -1112,7 +1112,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 } catch (\Exception $e) {
                     Logger::error($e);
 
-                    return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                    return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                 }
             } else {
                 Logger::debug('prevented move of object, object with same path+key already exists in this location.');
@@ -1126,13 +1126,13 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             } catch (\Exception $e) {
                 Logger::error($e);
 
-                return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
             }
         } else {
             Logger::debug('prevented update object because of missing permissions.');
         }
 
-        return $this->json(['success' => $success]);
+        return $this->adminJson(['success' => $success]);
     }
 
     /**
@@ -1247,7 +1247,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
 
                 $newObject = DataObject\AbstractObject::getById($object->getId(), true);
 
-                return $this->json([
+                return $this->adminJson([
                     'success' => true,
                     'general' => ['o_modificationDate' => $object->getModificationDate(),
                         'versionDate' => $newObject->getModificationDate()
@@ -1262,7 +1262,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                     $session->set($key, $object);
                 }, 'pimcore_objects');
 
-                return $this->json(['success' => true]);
+                return $this->adminJson(['success' => true]);
             } else {
                 if ($object->isAllowed('save')) {
                     $object->saveVersion();
@@ -1270,7 +1270,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
 
                     $newObject = DataObject\AbstractObject::getById($object->getId(), true);
 
-                    return $this->json([
+                    return $this->adminJson([
                         'success' => true,
                         'general' => ['o_modificationDate' => $object->getModificationDate(),
                             'versionDate' => $newObject->getModificationDate()
@@ -1292,7 +1292,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                     $detailedInfo .= '<br><br><b>Previous Trace:</b><br>' . $e->getPrevious()->getTraceAsString();
                 }
 
-                return $this->json(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $detailedInfo, 'code' => $e->getCode()]);
+                return $this->adminJson(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $detailedInfo, 'code' => $e->getCode()]);
             }
             throw $e;
         }
@@ -1321,7 +1321,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                             $childDefinitions = $fdDef->getFieldDefinitions();
                             foreach ($childDefinitions as $childDef) {
                                 if ($childDef instanceof DataObject\ClassDefinition\Data\Localizedfields) {
-                                    return $this->json(['success' => false, 'message' => 'Could be that someone messed around with the fieldcollection in the meantime. Please reload and try again']);
+                                    return $this->adminJson(['success' => false, 'message' => 'Could be that someone messed around with the fieldcollection in the meantime. Please reload and try again']);
                                 }
                             }
                         }
@@ -1355,13 +1355,13 @@ class DataObjectController extends ElementControllerBase implements EventedContr
 
                 $object->save();
 
-                return $this->json(['success' => true]);
+                return $this->adminJson(['success' => true]);
             } catch (\Exception $e) {
-                return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
             }
         }
 
-        return $this->json(['success' => false, 'message' => 'missing_permission']);
+        return $this->adminJson(['success' => false, 'message' => 'missing_permission']);
     }
 
     /**
@@ -1428,18 +1428,18 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 $treeData = [];
                 $treeData['qtipCfg'] = $object->getElementAdminStyle()->getElementQtipConfig();
 
-                return $this->json(
+                return $this->adminJson(
                     [
                         'success' => true,
                         'general' => ['o_modificationDate' => $object->getModificationDate() ],
                         'treeData' => $treeData]
                 );
             } catch (\Exception $e) {
-                return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
             }
         }
 
-        return $this->json(['success' => false, 'message' => 'missing_permission']);
+        return $this->adminJson(['success' => false, 'message' => 'missing_permission']);
     }
 
     /**
@@ -1645,9 +1645,9 @@ class DataObjectController extends ElementControllerBase implements EventedContr
 
                     $object->save();
 
-                    return $this->json(['data' => DataObject\Service::gridObjectData($object, $request->get('fields'), $requestedLanguage), 'success' => true]);
+                    return $this->adminJson(['data' => DataObject\Service::gridObjectData($object, $request->get('fields'), $requestedLanguage), 'success' => true]);
                 } catch (\Exception $e) {
-                    return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                    return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                 }
             }
         } else {
@@ -1792,7 +1792,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 $objects[] = $o;
             }
 
-            return $this->json(['data' => $objects, 'success' => true, 'total' => $list->getTotalCount()]);
+            return $this->adminJson(['data' => $objects, 'success' => true, 'total' => $list->getTotalCount()]);
         }
     }
 
@@ -1914,7 +1914,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             ]];
         }
 
-        return $this->json([
+        return $this->adminJson([
             'pastejobs' => $pasteJobs
         ]);
     }
@@ -1954,7 +1954,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             $session->set($transactionId, $idStore);
         }, 'pimcore_copy');
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true,
             'id' => $id
         ]);
@@ -2023,15 +2023,15 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             } else {
                 Logger::error("could not execute copy/paste, source object with id [ $sourceId ] not found");
 
-                return $this->json(['success' => false, 'message' => 'source object not found']);
+                return $this->adminJson(['success' => false, 'message' => 'source object not found']);
             }
         } else {
             Logger::error('could not execute copy/paste because of missing permissions on target [ ' . $targetId . ' ]');
 
-            return $this->json(['error' => false, 'message' => 'missing_permission']);
+            return $this->adminJson(['error' => false, 'message' => 'missing_permission']);
         }
 
-        return $this->json(['success' => $success, 'message' => $message]);
+        return $this->adminJson(['success' => $success, 'message' => $message]);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
@@ -69,7 +69,7 @@ class DataObjectHelperController extends AdminController
             $result['success'] = false;
         }
 
-        return $this->json($result);
+        return $this->adminJson($result);
     }
 
     /**
@@ -211,7 +211,7 @@ class DataObjectHelperController extends AdminController
         $importConfigData = $importService->createFromExportConfig($gridConfig);
         $selectedGridColumns = $importConfigData->selectedGridColumns;
 
-        return $this->json([ 'success' => true, 'selectedGridColumns' => $selectedGridColumns]);
+        return $this->adminJson(['success' => true, 'selectedGridColumns' => $selectedGridColumns]);
     }
 
     /**
@@ -275,7 +275,7 @@ class DataObjectHelperController extends AdminController
             }
         }
 
-        return $this->json([ 'success' => true, 'data' => $result]);
+        return $this->adminJson(['success' => true, 'data' => $result]);
     }
 
     /**
@@ -302,7 +302,7 @@ class DataObjectHelperController extends AdminController
             $success = true;
         }
 
-        return $this->json(['deleteSuccess' => $success]);
+        return $this->adminJson(['deleteSuccess' => $success]);
     }
 
     /**
@@ -332,7 +332,7 @@ class DataObjectHelperController extends AdminController
         $newGridConfig = $this->doGetGridColumnConfig($request, true);
         $newGridConfig['deleteSuccess'] = $success;
 
-        return $this->json($newGridConfig);
+        return $this->adminJson($newGridConfig);
     }
 
     /**
@@ -346,7 +346,7 @@ class DataObjectHelperController extends AdminController
     {
         $result =  $this->doGetGridColumnConfig($request);
 
-        return $this->json($result);
+        return $this->adminJson($result);
     }
 
     /**
@@ -780,7 +780,7 @@ class DataObjectHelperController extends AdminController
             $session->set('helpercolumns', $helperColumns);
         }, 'pimcore_gridconfig');
 
-        return $this->json(['success' => true, 'columns' => $newData]);
+        return $this->adminJson(['success' => true, 'columns' => $newData]);
     }
 
     /**
@@ -807,9 +807,9 @@ class DataObjectHelperController extends AdminController
                 ' and searchType = ' . $db->quote($searchType)
                 . ' and objectId != ' . $objectId . ' and objectId != 0');
 
-            return $this->json(['success' => true]);
+            return $this->adminJson(['success' => true]);
         } else {
-            return $this->json(['success' => false, 'message' => 'missing_permission']);
+            return $this->adminJson(['success' => false, 'message' => 'missing_permission']);
         }
     }
 
@@ -866,9 +866,9 @@ class DataObjectHelperController extends AdminController
                 $favourite->delete();
             }
 
-            return $this->json(['success' => true, 'spezializedConfigs' => $specializedConfigs]);
+            return $this->adminJson(['success' => true, 'spezializedConfigs' => $specializedConfigs]);
         } else {
-            return $this->json(['success' => false, 'message' => 'missing_permission']);
+            return $this->adminJson(['success' => false, 'message' => 'missing_permission']);
         }
     }
 
@@ -955,13 +955,13 @@ class DataObjectHelperController extends AdminController
 
             $this->updateImportConfigShares($importConfig, $configData);
 
-            return $this->json(['success' => true,
-                        'importConfigId' => $importConfig->getId(),
-                    'availableConfigs' => $this->getImportConfigs($importService, $this->getAdminUser(), $classId)
+            return $this->adminJson(['success'          => true,
+                                     'importConfigId'   => $importConfig->getId(),
+                                     'availableConfigs' => $this->getImportConfigs($importService, $this->getAdminUser(), $classId)
                     ]
                 );
         } catch (\Exception $e) {
-            return $this->json(['success' => false, 'message' => $e->getMessage()]);
+            return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
         }
     }
 
@@ -1035,18 +1035,18 @@ class DataObjectHelperController extends AdminController
                 $settings['shareGlobally'] = $gridConfig->isShareGlobally();
                 $settings['isShared'] = !$gridConfig || ($gridConfig->getOwnerId() != $this->getAdminUser()->getId());
 
-                return $this->json(['success' => true,
-                    'settings' => $settings,
-                    'availableConfigs' => $availableConfigs,
-                    'sharedConfigs' => $sharedConfigs,
+                return $this->adminJson(['success'          => true,
+                                         'settings'         => $settings,
+                                         'availableConfigs' => $availableConfigs,
+                                         'sharedConfigs'    => $sharedConfigs,
                     ]
                     );
             } catch (\Exception $e) {
-                return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
             }
         }
 
-        return $this->json(['success' => false, 'message' => 'missing_permission']);
+        return $this->adminJson(['success' => false, 'message' => 'missing_permission']);
     }
 
     /**
@@ -1219,7 +1219,7 @@ class DataObjectHelperController extends AdminController
             Logger::error($e);
         }
 
-        $response = $this->json([
+        $response = $this->adminJson([
             'success' => true
         ]);
 
@@ -1393,7 +1393,7 @@ class DataObjectHelperController extends AdminController
         $importFileOriginal = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/import_' . $importId . '_original';
         File::put($importFileOriginal, $data);
 
-        $response = $this->json([
+        $response = $this->adminJson([
             'success' => true
         ]);
 
@@ -1498,7 +1498,7 @@ class DataObjectHelperController extends AdminController
 
         $dialect->lineterminator =  bin2hex($dialect->lineterminator);
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success,
             'config' => [
                 'importConfigId' => $importConfigId,
@@ -1613,9 +1613,9 @@ class DataObjectHelperController extends AdminController
                 $eventDispatcher->dispatch(DataObjectImportEvents::DONE, $eventData);
             }
 
-            return $this->json(['success' => true, 'rowId' => $rowId, 'message' => $object->getFullPath(), 'objectId' => $object->getId()]);
+            return $this->adminJson(['success' => true, 'rowId' => $rowId, 'message' => $object->getFullPath(), 'objectId' => $object->getId()]);
         } catch (\Exception $e) {
-            return $this->json(['success' => false, 'rowId' => $rowId, 'message' => $e->getMessage()]);
+            return $this->adminJson(['success' => false, 'rowId' => $rowId, 'message' => $e->getMessage()]);
         }
     }
 
@@ -1764,7 +1764,7 @@ class DataObjectHelperController extends AdminController
         $fileHandle = uniqid('export-');
         file_put_contents($this->getCsvFile($fileHandle), '');
 
-        return $this->json(['success' => true, 'jobs' => $jobs, 'fileHandle' => $fileHandle]);
+        return $this->adminJson(['success' => true, 'jobs' => $jobs, 'fileHandle' => $fileHandle]);
     }
 
     /**
@@ -1819,7 +1819,7 @@ class DataObjectHelperController extends AdminController
 
         fclose($fp);
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     public function encodeFunc($value)
@@ -2113,7 +2113,7 @@ class DataObjectHelperController extends AdminController
 
         $jobs = $list->loadIdList();
 
-        return $this->json(['success' => true, 'jobs' => $jobs]);
+        return $this->adminJson(['success' => true, 'jobs' => $jobs]);
     }
 
     /**
@@ -2128,14 +2128,14 @@ class DataObjectHelperController extends AdminController
         $id = $request->get('id');
         $object = DataObject\Concrete::getById($id);
         if (!$object) {
-            return $this->json(['success' => false]);
+            return $this->adminJson(['success' => false]);
         }
 
         $class = $object->getClass();
         $generator = DataObject\ClassDefinition\Helper\LinkGeneratorResolver::resolveGenerator($class->getLinkGeneratorReference());
         $link = $generator->generate($object, []);
 
-        return $this->json(['success' => true, 'link' => $link]);
+        return $this->adminJson(['success' => true, 'link' => $link]);
     }
 
     /**
@@ -2265,19 +2265,19 @@ class DataObjectHelperController extends AdminController
                     $object->save();
                     $success = true;
                 } catch (\Exception $e) {
-                    return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                    return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                 }
             } else {
                 Logger::debug('DataObjectController::batchAction => There is no object left to update.');
 
-                return $this->json(['success' => false, 'message' => 'DataObjectController::batchAction => There is no object left to update.']);
+                return $this->adminJson(['success' => false, 'message' => 'DataObjectController::batchAction => There is no object left to update.']);
             }
         } catch (\Exception $e) {
             Logger::err($e);
 
-            return $this->json(['success' => false, 'message' => $e->getMessage()]);
+            return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
         }
 
-        return $this->json(['success' => $success]);
+        return $this->adminJson(['success' => $success]);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DocumentController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DocumentController.php
@@ -67,10 +67,10 @@ class DocumentController extends ElementControllerBase implements EventedControl
         $data = $event->getArgument('data');
 
         if ($document->isAllowed('view')) {
-            return $this->json($data);
+            return $this->adminJson($data);
         }
 
-        return $this->json(['success' => false, 'message' => 'missing_permission']);
+        return $this->adminJson(['success' => false, 'message' => 'missing_permission']);
     }
 
     /**
@@ -130,14 +130,14 @@ class DocumentController extends ElementControllerBase implements EventedControl
         }
 
         if ($request->get('limit')) {
-            return $this->json([
+            return $this->adminJson([
                 'offset' => $offset,
                 'limit' => $limit,
                 'total' => $document->getChildAmount($this->getAdminUser()),
                 'nodes' => $documents
             ]);
         } else {
-            return $this->json($documents);
+            return $this->adminJson($documents);
         }
     }
 
@@ -221,7 +221,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
                             $document->save();
                             $success = true;
                         } catch (\Exception $e) {
-                            return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                            return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                         }
                         break;
                     default:
@@ -242,7 +242,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
                                 $document->save();
                                 $success = true;
                             } catch (\Exception $e) {
-                                return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                                return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                             }
                             break;
                         } else {
@@ -273,13 +273,13 @@ class DocumentController extends ElementControllerBase implements EventedControl
                 $service->addTranslation($translationsBaseDocument, $document);
             }
 
-            return $this->json([
+            return $this->adminJson([
                 'success' => $success,
                 'id' => $document->getId(),
                 'type' => $document->getType()
             ]);
         } else {
-            return $this->json([
+            return $this->adminJson([
                 'success' => $success,
                 'message' => $errorMessage
             ]);
@@ -314,23 +314,23 @@ class DocumentController extends ElementControllerBase implements EventedControl
                 }
             }
 
-            return $this->json(['success' => true, 'deleted' => $deletedItems]);
+            return $this->adminJson(['success' => true, 'deleted' => $deletedItems]);
         } elseif ($request->get('id')) {
             $document = Document::getById($request->get('id'));
             if ($document->isAllowed('delete')) {
                 try {
                     $document->delete();
 
-                    return $this->json(['success' => true]);
+                    return $this->adminJson(['success' => true]);
                 } catch (\Exception $e) {
                     Logger::err($e);
 
-                    return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                    return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                 }
             }
         }
 
-        return $this->json(['success' => false, 'message' => 'missing_permission']);
+        return $this->adminJson(['success' => false, 'message' => 'missing_permission']);
     }
 
     /**
@@ -403,7 +403,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
         // get the element key
         $elementKey = $document->getKey();
 
-        return $this->json([
+        return $this->adminJson([
             'hasDependencies' => $hasDependency,
             'childs' => $childs,
             'deletejobs' => $deleteJobs,
@@ -432,7 +432,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
         if ($document instanceof Document\PageSnippet) {
             $latestVersion = $document->getLatestVersion();
             if ($latestVersion && $latestVersion->getData()->getModificationDate() != $document->getModificationDate()) {
-                return $this->json(['success' => false, 'message' => "You can't relocate if there's a newer not published version"]);
+                return $this->adminJson(['success' => false, 'message' => "You can't relocate if there's a newer not published version"]);
             }
         }
 
@@ -505,13 +505,13 @@ class DocumentController extends ElementControllerBase implements EventedControl
                     $document->save();
                     $success = true;
                 } catch (\Exception $e) {
-                    return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                    return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                 }
             } else {
                 $msg = 'Prevented moving document, because document with same path+key already exists or the document is locked. ID: ' . $document->getId();
                 Logger::debug($msg);
 
-                return $this->json(['success' => false, 'message' => $msg]);
+                return $this->adminJson(['success' => false, 'message' => $msg]);
             }
         } elseif ($document->isAllowed('rename') && $request->get('key')) {
             //just rename
@@ -521,13 +521,13 @@ class DocumentController extends ElementControllerBase implements EventedControl
                 $document->save();
                 $success = true;
             } catch (\Exception $e) {
-                return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
             }
         } else {
             Logger::debug('Prevented update document, because of missing permissions.');
         }
 
-        return $this->json(['success' => $success]);
+        return $this->adminJson(['success' => $success]);
     }
 
     /**
@@ -548,7 +548,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
                 $type = Document\DocType::getById($id);
                 $type->delete();
 
-                return $this->json(['success' => true, 'data' => []]);
+                return $this->adminJson(['success' => true, 'data' => []]);
             } elseif ($request->get('xaction') == 'update') {
                 $data = $this->decodeJson($request->get('data'));
 
@@ -558,7 +558,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
                 $type->setValues($data);
                 $type->save();
 
-                return $this->json(['data' => $type, 'success' => true]);
+                return $this->adminJson(['data' => $type, 'success' => true]);
             } elseif ($request->get('xaction') == 'create') {
                 $data = $this->decodeJson($request->get('data'));
                 unset($data['id']);
@@ -569,7 +569,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
 
                 $type->save();
 
-                return $this->json(['data' => $type, 'success' => true]);
+                return $this->adminJson(['data' => $type, 'success' => true]);
             }
         } else {
             // get list of types
@@ -583,10 +583,10 @@ class DocumentController extends ElementControllerBase implements EventedControl
                 }
             }
 
-            return $this->json(['data' => $docTypes, 'success' => true, 'total' => count($docTypes)]);
+            return $this->adminJson(['data' => $docTypes, 'success' => true, 'total' => count($docTypes)]);
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -618,7 +618,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
             $docTypes[] = $type;
         }
 
-        return $this->json(['docTypes' => $docTypes]);
+        return $this->adminJson(['docTypes' => $docTypes]);
     }
 
     /**
@@ -665,11 +665,11 @@ class DocumentController extends ElementControllerBase implements EventedControl
 
                 $document->save();
             } catch (\Exception $e) {
-                return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
             }
         }
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -700,7 +700,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
         $site->save();
 
         $site->setRootDocument(null); // do not send the document to the frontend
-        return $this->json($site);
+        return $this->adminJson($site);
     }
 
     /**
@@ -715,7 +715,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
         $site = Site::getByRootId(intval($request->get('id')));
         $site->delete();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -805,7 +805,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
             ]];
         }
 
-        return $this->json([
+        return $this->adminJson([
             'pastejobs' => $pasteJobs
         ]);
     }
@@ -849,7 +849,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
             $session->set($transactionId, $idStore);
         }, 'pimcore_copy');
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true,
             'id' => $id
         ]);
@@ -917,11 +917,11 @@ class DocumentController extends ElementControllerBase implements EventedControl
             } else {
                 Logger::error('could not execute copy/paste because of missing permissions on target [ ' . $targetId . ' ]');
 
-                return $this->json(['success' => false, 'message' => 'missing_permission']);
+                return $this->adminJson(['success' => false, 'message' => 'missing_permission']);
             }
         }
 
-        return $this->json(['success' => $success]);
+        return $this->adminJson(['success' => $success]);
     }
 
     /**
@@ -1126,12 +1126,12 @@ class DocumentController extends ElementControllerBase implements EventedControl
     public function getIdForPathAction(Request $request)
     {
         if ($doc = Document::getByPath($request->get('path'))) {
-            return $this->json([
+            return $this->adminJson([
                 'id' => $doc->getId(),
                 'type' => $doc->getType()
             ]);
         } else {
-            return $this->json(false);
+            return $this->adminJson(false);
         }
     }
 
@@ -1154,10 +1154,10 @@ class DocumentController extends ElementControllerBase implements EventedControl
         if ($root->isAllowed('list')) {
             $nodeConfig = $this->getSeoNodeConfig($request, $root);
 
-            return $this->json($nodeConfig);
+            return $this->adminJson($nodeConfig);
         }
 
-        return $this->json(['success' => false, 'message' => 'missing_permission']);
+        return $this->adminJson(['success' => false, 'message' => 'missing_permission']);
     }
 
     /**
@@ -1195,7 +1195,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
             }
         }
 
-        return $this->json($documents);
+        return $this->adminJson($documents);
     }
 
     /**
@@ -1235,7 +1235,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
             $new->save();
         }
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -1261,7 +1261,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success,
             'targetPath' => $targetPath
         ]);
@@ -1284,7 +1284,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
             $service->addTranslation($sourceDocument, $targetDocument);
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true
         ]);
     }
@@ -1309,7 +1309,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success,
             'language' => $language
         ]);

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DocumentController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DocumentController.php
@@ -99,11 +99,11 @@ class DocumentController extends ElementControllerBase implements EventedControl
             }
 
             $list = new Document\Listing();
-            if ($this->getUser()->isAdmin()) {
+            if ($this->getAdminUser()->isAdmin()) {
                 $list->setCondition('parentId = ? ', $document->getId());
             } else {
-                $userIds = $this->getUser()->getRoles();
-                $userIds[] = $this->getUser()->getId();
+                $userIds = $this->getAdminUser()->getRoles();
+                $userIds[] = $this->getAdminUser()->getId();
                 $list->setCondition('parentId = ? and
                                         (
                                         (select list from users_workspaces_document where userId in (' . implode(',', $userIds) . ') and LOCATE(CONCAT(path,`key`),cpath)=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
@@ -133,7 +133,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
             return $this->json([
                 'offset' => $offset,
                 'limit' => $limit,
-                'total' => $document->getChildAmount($this->getUser()),
+                'total' => $document->getChildAmount($this->getAdminUser()),
                 'nodes' => $documents
             ]);
         } else {
@@ -160,8 +160,8 @@ class DocumentController extends ElementControllerBase implements EventedControl
 
             if (!Document\Service::pathExists($intendedPath)) {
                 $createValues = [
-                    'userOwner' => $this->getUser()->getId(),
-                    'userModification' => $this->getUser()->getId(),
+                    'userOwner' => $this->getAdminUser()->getId(),
+                    'userModification' => $this->getAdminUser()->getId(),
                     'published' => false
                 ];
 
@@ -500,7 +500,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
                     }
                 }
 
-                $document->setUserModification($this->getUser()->getId());
+                $document->setUserModification($this->getAdminUser()->getId());
                 try {
                     $document->save();
                     $success = true;
@@ -517,7 +517,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
             //just rename
             try {
                 $document->setKey($request->get('key'));
-                $document->setUserModification($this->getUser()->getId());
+                $document->setUserModification($this->getAdminUser()->getId());
                 $document->save();
                 $success = true;
             } catch (\Exception $e) {
@@ -578,7 +578,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
 
             $docTypes = [];
             foreach ($list->getDocTypes() as $type) {
-                if ($this->getUser()->isAllowed($type->getId(), 'docType')) {
+                if ($this->getAdminUser()->isAllowed($type->getId(), 'docType')) {
                     $docTypes[] = $type;
                 }
             }
@@ -661,7 +661,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
             try {
                 $document->setKey($currentDocument->getKey());
                 $document->setPath($currentDocument->getRealPath());
-                $document->setUserModification($this->getUser()->getId());
+                $document->setUserModification($this->getAdminUser()->getId());
 
                 $document->save();
             } catch (\Exception $e) {
@@ -840,7 +840,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
                 'enableInheritance' => ($request->get('enableInheritance') == 'true') ? true : false
             ]);
 
-            $document->setUserModification($this->getUser()->getId());
+            $document->setUserModification($this->getAdminUser()->getId());
             $document->save();
         }
 
@@ -1461,7 +1461,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
         // check permissions
         $this->checkActionPermission($event, 'documents', ['docTypesAction']);
 
-        $this->_documentService = new Document\Service($this->getUser());
+        $this->_documentService = new Document\Service($this->getAdminUser());
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DocumentControllerBase.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DocumentControllerBase.php
@@ -181,7 +181,7 @@ abstract class DocumentControllerBase extends AdminController implements Evented
             Session::writeClose();
         }
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -215,7 +215,7 @@ abstract class DocumentControllerBase extends AdminController implements Evented
             $session->remove($key);
         }, 'pimcore_documents');
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -264,7 +264,7 @@ abstract class DocumentControllerBase extends AdminController implements Evented
             $doc->saveVersion();
         }
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ElementController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ElementController.php
@@ -407,7 +407,7 @@ class ElementController extends AdminController
                 $element = Asset\Service::rewriteIds($element, $rewriteConfig);
             }
 
-            $element->setUserModification($this->getUser()->getId());
+            $element->setUserModification($this->getAdminUser()->getId());
             $element->save();
 
             $success = true;

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ElementController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ElementController.php
@@ -42,7 +42,7 @@ class ElementController extends AdminController
     {
         Element\Editlock::lock($request->get('id'), $request->get('type'));
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -56,7 +56,7 @@ class ElementController extends AdminController
     {
         Element\Editlock::unlock($request->get('id'), $request->get('type'));
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -77,7 +77,7 @@ class ElementController extends AdminController
             $response['idPath'] = Element\Service::getIdPath($element);
         }
 
-        return $this->json($response);
+        return $this->adminJson($response);
     }
 
     /**
@@ -112,14 +112,14 @@ class ElementController extends AdminController
                 $subtype = 'folder';
             }
 
-            return $this->json([
+            return $this->adminJson([
                 'subtype' => $subtype,
                 'id' => $el->getId(),
                 'type' => $type,
                 'success' => true
             ]);
         } else {
-            return $this->json([
+            return $this->adminJson([
                 'success' => false
             ]);
         }
@@ -300,7 +300,7 @@ class ElementController extends AdminController
             $notes[] = $e;
         }
 
-        return $this->json([
+        return $this->adminJson([
             'data' => $notes,
             'success' => true,
             'total' => $list->getTotalCount()
@@ -327,7 +327,7 @@ class ElementController extends AdminController
         $note->setType($request->get('type'));
         $note->save();
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true
         ]);
     }
@@ -367,7 +367,7 @@ class ElementController extends AdminController
             $success = true;
         }
 
-        return $this->json([
+        return $this->adminJson([
             'data' => $results,
             'hasHidden' => $hasHidden,
             'success' => $success
@@ -415,7 +415,7 @@ class ElementController extends AdminController
             $message = 'source-type and target-type do not match';
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success,
             'message' => $message
         ]);
@@ -438,7 +438,7 @@ class ElementController extends AdminController
             $success = true;
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success
         ]);
     }
@@ -471,7 +471,7 @@ class ElementController extends AdminController
         $data['typePath'] = $typePath;
         $data['fullpath'] = $element->getRealFullPath();
 
-        return $this->json($data);
+        return $this->adminJson($data);
     }
 
     /**
@@ -490,7 +490,7 @@ class ElementController extends AdminController
         $version->setNote($data['note']);
         $version->save();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -561,7 +561,7 @@ class ElementController extends AdminController
             }
         }
 
-        return $this->json(['success' => true, 'data' => $result]);
+        return $this->adminJson(['success' => true, 'data' => $result]);
     }
 
     /**
@@ -600,7 +600,7 @@ class ElementController extends AdminController
                         }
                     }
 
-                    return $this->json(['versions' => $versions]);
+                    return $this->adminJson(['versions' => $versions]);
                 } else {
                     throw new \Exception('Permission denied, ' . $type . ' id [' . $id . ']');
                 }
@@ -622,7 +622,7 @@ class ElementController extends AdminController
         $version = Model\Version::getById($request->get('id'));
         $version->delete();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -643,11 +643,11 @@ class ElementController extends AdminController
             if ($element instanceof Model\Element\ElementInterface) {
                 $dependencies = Model\Element\Service::getRequiresDependenciesForFrontend($element->getDependencies());
 
-                return $this->json($dependencies);
+                return $this->adminJson($dependencies);
             }
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -668,11 +668,11 @@ class ElementController extends AdminController
             if ($element instanceof Model\Element\ElementInterface) {
                 $dependencies = Model\Element\Service::getRequiredByDependenciesForFrontend($element->getDependencies());
 
-                return $this->json($dependencies);
+                return $this->adminJson($dependencies);
             }
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -705,7 +705,7 @@ class ElementController extends AdminController
             }
         }
 
-        return $this->json(['properties' => $properties]);
+        return $this->adminJson(['properties' => $properties]);
     }
 
     /**
@@ -733,7 +733,7 @@ class ElementController extends AdminController
 
         $result = Element\PermissionChecker::check($element, $userList);
 
-        return $this->json(
+        return $this->adminJson(
             [
                 'data' => $result,
                 'success' => true

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ElementControllerBase.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ElementControllerBase.php
@@ -52,10 +52,10 @@ class ElementControllerBase extends AdminController
         if (in_array($type, $allowedTypes)) {
             $root = Service::getElementById($type, $id);
             if ($root->isAllowed('list')) {
-                return $this->json($this->getTreeNodeConfig($root));
+                return $this->adminJson($this->getTreeNodeConfig($root));
             }
         }
 
-        return $this->json(['success' => false, 'message' => 'missing_permission']);
+        return $this->adminJson(['success' => false, 'message' => 'missing_permission']);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/EmailController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/EmailController.php
@@ -100,7 +100,7 @@ class EmailController extends DocumentControllerBase
                 $page = Document\Email::getById($request->get('id'));
 
                 $page = $this->getLatestVersion($page);
-                $page->setUserModification($this->getUser()->getId());
+                $page->setUserModification($this->getAdminUser()->getId());
 
                 if ($request->get('task') == 'unpublish') {
                     $page->setPublished(false);
@@ -177,7 +177,7 @@ class EmailController extends DocumentControllerBase
      */
     public function emailLogsAction(Request $request)
     {
-        if (!$this->getUser()->isAllowed('emails')) {
+        if (!$this->getAdminUser()->isAllowed('emails')) {
             throw new \Exception("Permission denied, user needs 'emails' permission.");
         }
 
@@ -240,7 +240,7 @@ class EmailController extends DocumentControllerBase
      */
     public function showEmailLogAction(Request $request)
     {
-        if (!$this->getUser()->isAllowed('emails')) {
+        if (!$this->getAdminUser()->isAllowed('emails')) {
             throw new \Exception("Permission denied, user needs 'emails' permission.");
         }
 
@@ -357,7 +357,7 @@ class EmailController extends DocumentControllerBase
      */
     public function deleteEmailLogAction(Request $request)
     {
-        if (!$this->getUser()->isAllowed('emails')) {
+        if (!$this->getAdminUser()->isAllowed('emails')) {
             throw new \Exception("Permission denied, user needs 'emails' permission.");
         }
 
@@ -384,7 +384,7 @@ class EmailController extends DocumentControllerBase
      */
     public function resendEmailAction(Request $request)
     {
-        if (!$this->getUser()->isAllowed('emails')) {
+        if (!$this->getAdminUser()->isAllowed('emails')) {
             throw new \Exception("Permission denied, user needs 'emails' permission.");
         }
 
@@ -439,7 +439,7 @@ class EmailController extends DocumentControllerBase
      */
     public function sendTestEmailAction(Request $request)
     {
-        if (!$this->getUser()->isAllowed('emails')) {
+        if (!$this->getAdminUser()->isAllowed('emails')) {
             throw new \Exception("Permission denied, user needs 'emails' permission.");
         }
 
@@ -472,7 +472,7 @@ class EmailController extends DocumentControllerBase
      */
     public function blacklistAction(Request $request)
     {
-        if (!$this->getUser()->isAllowed('emails')) {
+        if (!$this->getAdminUser()->isAllowed('emails')) {
             throw new \Exception("Permission denied, user needs 'emails' permission.");
         }
 

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/EmailController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/EmailController.php
@@ -43,7 +43,7 @@ class EmailController extends DocumentControllerBase
 
         // check for lock
         if (Element\Editlock::isLocked($request->get('id'), 'document')) {
-            return $this->json([
+            return $this->adminJson([
                 'editlock' => Element\Editlock::getByElement($request->get('id'), 'document')
             ]);
         }
@@ -78,10 +78,10 @@ class EmailController extends DocumentControllerBase
         $data = $event->getArgument('data');
 
         if ($email->isAllowed('view')) {
-            return $this->json($data);
+            return $this->adminJson($data);
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -116,11 +116,11 @@ class EmailController extends DocumentControllerBase
                         $page->save();
                         $this->saveToSession($page);
 
-                        return $this->json(['success' => true]);
+                        return $this->adminJson(['success' => true]);
                     } catch (\Exception $e) {
                         Logger::err($e);
 
-                        return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                        return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                     }
                 } else {
                     if ($page->isAllowed('save')) {
@@ -130,7 +130,7 @@ class EmailController extends DocumentControllerBase
                             $page->saveVersion();
                             $this->saveToSession($page);
 
-                            return $this->json(['success' => true]);
+                            return $this->adminJson(['success' => true]);
                         } catch (\Exception $e) {
                             if ($e instanceof Element\ValidationException) {
                                 throw $e;
@@ -138,7 +138,7 @@ class EmailController extends DocumentControllerBase
 
                             Logger::err($e);
 
-                            return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                            return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                         }
                     }
                 }
@@ -146,12 +146,12 @@ class EmailController extends DocumentControllerBase
         } catch (\Exception $e) {
             Logger::log($e);
             if ($e instanceof Element\ValidationException) {
-                return $this->json(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
+                return $this->adminJson(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
             }
             throw $e;
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -222,7 +222,7 @@ class EmailController extends DocumentControllerBase
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'data' => $jsonData,
             'success' => true,
             'total' => $list->getTotalCount()
@@ -262,7 +262,7 @@ class EmailController extends DocumentControllerBase
                 $this->enhanceLoggingData($entry);
             }
 
-            return $this->json($params);
+            return $this->adminJson($params);
         } else {
             return new Response('No Type specified');
         }
@@ -368,7 +368,7 @@ class EmailController extends DocumentControllerBase
             $success = true;
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success,
         ]);
     }
@@ -423,7 +423,7 @@ class EmailController extends DocumentControllerBase
             $success = true;
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success,
         ]);
     }
@@ -456,7 +456,7 @@ class EmailController extends DocumentControllerBase
 
         $mail->send();
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true,
         ]);
     }
@@ -491,13 +491,13 @@ class EmailController extends DocumentControllerBase
                 $address = Tool\Email\Blacklist::getByAddress($data['address']);
                 $address->delete();
 
-                return $this->json(['success' => true, 'data' => []]);
+                return $this->adminJson(['success' => true, 'data' => []]);
             } elseif ($request->get('xaction') == 'update') {
                 $address = Tool\Email\Blacklist::getByAddress($data['address']);
                 $address->setValues($data);
                 $address->save();
 
-                return $this->json(['data' => $address, 'success' => true]);
+                return $this->adminJson(['data' => $address, 'success' => true]);
             } elseif ($request->get('xaction') == 'create') {
                 unset($data['id']);
 
@@ -505,7 +505,7 @@ class EmailController extends DocumentControllerBase
                 $address->setValues($data);
                 $address->save();
 
-                return $this->json(['data' => $address, 'success' => true]);
+                return $this->adminJson(['data' => $address, 'success' => true]);
             }
         } else {
             // get list of routes
@@ -529,13 +529,13 @@ class EmailController extends DocumentControllerBase
 
             $data = $list->load();
 
-            return $this->json([
+            return $this->adminJson([
                 'success' => true,
                 'data' => $data,
                 'total' => $list->getTotalCount()
             ]);
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/FolderController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/FolderController.php
@@ -39,7 +39,7 @@ class FolderController extends DocumentControllerBase
     {
         // check for lock
         if (Element\Editlock::isLocked($request->get('id'), 'document')) {
-            return $this->json([
+            return $this->adminJson([
                 'editlock' => Element\Editlock::getByElement($request->get('id'), 'document')
             ]);
         }
@@ -67,10 +67,10 @@ class FolderController extends DocumentControllerBase
         $data = $event->getArgument('data');
 
         if ($folder->isAllowed('view')) {
-            return $this->json($data);
+            return $this->adminJson($data);
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -94,18 +94,18 @@ class FolderController extends DocumentControllerBase
                     $this->setValuesToDocument($request, $folder);
                     $folder->save();
 
-                    return $this->json(['success' => true]);
+                    return $this->adminJson(['success' => true]);
                 }
             }
         } catch (\Exception $e) {
             Logger::log($e);
             if ($e instanceof Element\ValidationException) {
-                return $this->json(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
+                return $this->adminJson(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
             }
             throw $e;
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/FolderController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/FolderController.php
@@ -88,7 +88,7 @@ class FolderController extends DocumentControllerBase
             if ($request->get('id')) {
                 $folder = Document\Folder::getById($request->get('id'));
                 $folder->setModificationDate(time());
-                $folder->setUserModification($this->getUser()->getId());
+                $folder->setUserModification($this->getAdminUser()->getId());
 
                 if ($folder->isAllowed('publish')) {
                     $this->setValuesToDocument($request, $folder);

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/HardlinkController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/HardlinkController.php
@@ -95,7 +95,7 @@ class HardlinkController extends DocumentControllerBase
                 $this->setValuesToDocument($request, $link);
 
                 $link->setModificationDate(time());
-                $link->setUserModification($this->getUser()->getId());
+                $link->setUserModification($this->getAdminUser()->getId());
 
                 if ($request->get('task') == 'unpublish') {
                     $link->setPublished(false);

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/HardlinkController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/HardlinkController.php
@@ -40,7 +40,7 @@ class HardlinkController extends DocumentControllerBase
 
         // check for lock
         if (Element\Editlock::isLocked($request->get('id'), 'document')) {
-            return $this->json([
+            return $this->adminJson([
                 'editlock' => Element\Editlock::getByElement($request->get('id'), 'document')
             ]);
         }
@@ -72,10 +72,10 @@ class HardlinkController extends DocumentControllerBase
         $data = $event->getArgument('data');
 
         if ($link->isAllowed('view')) {
-            return $this->json($data);
+            return $this->adminJson($data);
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -108,18 +108,18 @@ class HardlinkController extends DocumentControllerBase
                 if (($request->get('task') == 'publish' && $link->isAllowed('publish')) || ($request->get('task') == 'unpublish' && $link->isAllowed('unpublish'))) {
                     $link->save();
 
-                    return $this->json(['success' => true]);
+                    return $this->adminJson(['success' => true]);
                 }
             }
         } catch (\Exception $e) {
             Logger::log($e);
             if ($e instanceof Element\ValidationException) {
-                return $this->json(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
+                return $this->adminJson(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
             }
             throw $e;
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/IndexController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/IndexController.php
@@ -56,7 +56,7 @@ class IndexController extends AdminController
      */
     public function indexAction(Request $request)
     {
-        $user = $this->getUser();
+        $user = $this->getAdminUser();
         $view = new ViewModel([
             'config' => Config::getSystemConfig()
         ]);
@@ -147,7 +147,7 @@ class IndexController extends AdminController
         $settings->getParameters()->add([
             'language'         => $request->getLocale(),
             'websiteLanguages' => Admin::reorderWebsiteLanguages(
-                $this->getUser(),
+                $this->getAdminUser(),
                 $config->general->validLanguages,
                 true
             )

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/LinkController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/LinkController.php
@@ -42,7 +42,7 @@ class LinkController extends DocumentControllerBase
 
         // check for lock
         if (Element\Editlock::isLocked($request->get('id'), 'document')) {
-            return $this->json([
+            return $this->adminJson([
                 'editlock' => Element\Editlock::getByElement($request->get('id'), 'document')
             ]);
         }
@@ -76,10 +76,10 @@ class LinkController extends DocumentControllerBase
         $data = $event->getArgument('data');
 
         if ($link->isAllowed('view')) {
-            return $this->json($data);
+            return $this->adminJson($data);
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -112,18 +112,18 @@ class LinkController extends DocumentControllerBase
                 if (($request->get('task') == 'publish' && $link->isAllowed('publish')) || ($request->get('task') == 'unpublish' && $link->isAllowed('unpublish'))) {
                     $link->save();
 
-                    return $this->json(['success' => true]);
+                    return $this->adminJson(['success' => true]);
                 }
             }
         } catch (\Exception $e) {
             Logger::log($e);
             if ($e instanceof Element\ValidationException) {
-                return $this->json(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
+                return $this->adminJson(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
             }
             throw $e;
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/LinkController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/LinkController.php
@@ -99,7 +99,7 @@ class LinkController extends DocumentControllerBase
                 $this->setValuesToDocument($request, $link);
 
                 $link->setModificationDate(time());
-                $link->setUserModification($this->getUser()->getId());
+                $link->setUserModification($this->getAdminUser()->getId());
 
                 if ($request->get('task') == 'unpublish') {
                     $link->setPublished(false);

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/LogController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/LogController.php
@@ -35,7 +35,7 @@ class LogController extends AdminController implements EventedControllerInterfac
      */
     public function onKernelController(FilterControllerEvent $event)
     {
-        if (!$this->getUser()->isAllowed('application_logging')) {
+        if (!$this->getAdminUser()->isAllowed('application_logging')) {
             throw new AccessDeniedHttpException("Permission denied, user needs 'application_logging' permission.");
         }
     }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/LogController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/LogController.php
@@ -144,7 +144,7 @@ class LogController extends AdminController implements EventedControllerInterfac
             $logEntries[] = $logEntry;
         }
 
-        return $this->json([
+        return $this->adminJson([
             'p_totalCount' => $total,
             'p_results'    => $logEntries
         ]);
@@ -202,7 +202,7 @@ class LogController extends AdminController implements EventedControllerInterfac
             $priorities[] = ['key' => $key, 'value' => $p];
         }
 
-        return $this->json(['priorities' => $priorities]);
+        return $this->adminJson(['priorities' => $priorities]);
     }
 
     /**
@@ -219,7 +219,7 @@ class LogController extends AdminController implements EventedControllerInterfac
             $components[] = ['key' => $p, 'value' => $p];
         }
 
-        return $this->json(['components' => $components]);
+        return $this->adminJson(['components' => $components]);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/LoginController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/LoginController.php
@@ -72,7 +72,7 @@ class LoginController extends AdminController implements BruteforceProtectedCont
             return $this->redirect('/install');
         }
 
-        $user = $this->getUser();
+        $user = $this->getAdminUser();
         if ($user instanceof UserInterface) {
             return $this->redirectToRoute('pimcore_admin_index');
         }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/MiscController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/MiscController.php
@@ -668,7 +668,7 @@ class MiscController extends AdminController
      */
     public function phpinfoAction(Request $request)
     {
-        if (!$this->getUser()->isAdmin()) {
+        if (!$this->getAdminUser()->isAdmin()) {
             throw new \Exception('Permission denied');
         }
 

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/MiscController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/MiscController.php
@@ -49,7 +49,7 @@ class MiscController extends AdminController
             ];
         }, $bundles);
 
-        return $this->json([
+        return $this->adminJson([
             'data' => $result
         ]);
     }
@@ -73,7 +73,7 @@ class MiscController extends AdminController
             ];
         }, $controllers);
 
-        return $this->json([
+        return $this->adminJson([
             'data' => $result
         ]);
     }
@@ -102,7 +102,7 @@ class MiscController extends AdminController
             ];
         }, $actions);
 
-        return $this->json([
+        return $this->adminJson([
             'data' => $result
         ]);
     }
@@ -124,7 +124,7 @@ class MiscController extends AdminController
             ];
         }, $templates);
 
-        return $this->json([
+        return $this->adminJson([
             'data' => $result
         ]);
     }
@@ -234,7 +234,7 @@ class MiscController extends AdminController
             'success' => true
         ];
 
-        return $this->json($response);
+        return $this->adminJson($response);
     }
 
     /**
@@ -262,7 +262,7 @@ class MiscController extends AdminController
      */
     public function getValidFilenameAction(Request $request)
     {
-        return $this->json([
+        return $this->adminJson([
             'filename' => \Pimcore\Model\Element\Service::getValidKey($request->get('value'), $request->get('type'))
         ]);
     }
@@ -315,7 +315,7 @@ class MiscController extends AdminController
             }
         }
 
-        return $this->json($contents);
+        return $this->adminJson($contents);
     }
 
     /**
@@ -340,7 +340,7 @@ class MiscController extends AdminController
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success,
             'content' => $content,
             'writeable' => $writeable,
@@ -370,7 +370,7 @@ class MiscController extends AdminController
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success
         ]);
     }
@@ -406,7 +406,7 @@ class MiscController extends AdminController
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success
         ]);
     }
@@ -442,7 +442,7 @@ class MiscController extends AdminController
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success
         ]);
     }
@@ -466,7 +466,7 @@ class MiscController extends AdminController
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success
         ]);
     }
@@ -510,7 +510,7 @@ class MiscController extends AdminController
             Tool\Admin::deactivateMaintenanceMode();
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true
         ]);
     }
@@ -560,7 +560,7 @@ class MiscController extends AdminController
         $logs = $db->fetchAll('SELECT code,uri,`count`,date FROM http_error_log ' . $condition . ' ORDER BY ' . $sort . ' ' . $dir . ' LIMIT ' . $offset . ',' . $limit);
         $total = $db->fetchOne('SELECT count(*) FROM http_error_log ' . $condition);
 
-        return $this->json([
+        return $this->adminJson([
             'items' => $logs,
             'total' => $total,
             'success' => true
@@ -581,7 +581,7 @@ class MiscController extends AdminController
         $db = Db::get();
         $db->query('TRUNCATE TABLE http_error_log');
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true
         ]);
     }
@@ -633,7 +633,7 @@ class MiscController extends AdminController
             }
         }
 
-        return $this->json(['data' => $options]);
+        return $this->adminJson(['data' => $options]);
     }
 
     /**
@@ -654,7 +654,7 @@ class MiscController extends AdminController
             ];
         }
 
-        return $this->json(['data' => $options]);
+        return $this->adminJson(['data' => $options]);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/NewsletterController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/NewsletterController.php
@@ -99,7 +99,7 @@ class NewsletterController extends DocumentControllerBase
                 $page = Document\Newsletter::getById($request->get('id'));
 
                 $page = $this->getLatestVersion($page);
-                $page->setUserModification($this->getUser()->getId());
+                $page->setUserModification($this->getAdminUser()->getId());
 
                 if ($request->get('task') == 'unpublish') {
                     $page->setPublished(false);

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/NewsletterController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/NewsletterController.php
@@ -42,7 +42,7 @@ class NewsletterController extends DocumentControllerBase
     {
         // check for lock
         if (Element\Editlock::isLocked($request->get('id'), 'document')) {
-            return $this->json([
+            return $this->adminJson([
                 'editlock' => Element\Editlock::getByElement($request->get('id'), 'document')
             ]);
         }
@@ -77,10 +77,10 @@ class NewsletterController extends DocumentControllerBase
         $data = $event->getArgument('data');
 
         if ($email->isAllowed('view')) {
-            return $this->json($data);
+            return $this->adminJson($data);
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -115,11 +115,11 @@ class NewsletterController extends DocumentControllerBase
                         $page->save();
                         $this->saveToSession($page);
 
-                        return $this->json(['success' => true]);
+                        return $this->adminJson(['success' => true]);
                     } catch (\Exception $e) {
                         Logger::err($e);
 
-                        return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                        return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                     }
                 } else {
                     if ($page->isAllowed('save')) {
@@ -129,7 +129,7 @@ class NewsletterController extends DocumentControllerBase
                             $page->saveVersion();
                             $this->saveToSession($page);
 
-                            return $this->json(['success' => true]);
+                            return $this->adminJson(['success' => true]);
                         } catch (\Exception $e) {
                             if ($e instanceof Element\ValidationException) {
                                 throw $e;
@@ -137,7 +137,7 @@ class NewsletterController extends DocumentControllerBase
 
                             Logger::err($e);
 
-                            return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                            return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                         }
                     }
                 }
@@ -145,12 +145,12 @@ class NewsletterController extends DocumentControllerBase
         } catch (\Exception $e) {
             Logger::log($e);
             if ($e instanceof Element\ValidationException) {
-                return $this->json(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
+                return $this->adminJson(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
             }
             throw $e;
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -189,7 +189,7 @@ class NewsletterController extends DocumentControllerBase
         } catch (\Exception $e) {
         }
 
-        return $this->json([
+        return $this->adminJson([
             'count' => $count,
             'success' => $success
         ]);
@@ -222,7 +222,7 @@ class NewsletterController extends DocumentControllerBase
             }
         }
 
-        return $this->json(['data' => $availableClasses]);
+        return $this->adminJson(['data' => $availableClasses]);
     }
 
     /**
@@ -244,7 +244,7 @@ class NewsletterController extends DocumentControllerBase
                 $availableReports[] = ['id' => $report['id'], 'text' => $report['text']];
             }
 
-            return $this->json(['data' => $availableReports]);
+            return $this->adminJson(['data' => $availableReports]);
         } elseif ($task === 'fieldNames') {
             $reportId = $request->get('reportId');
             $report = \Pimcore\Model\Tool\CustomReport\Config::getByName($reportId);
@@ -257,7 +257,7 @@ class NewsletterController extends DocumentControllerBase
                 }
             }
 
-            return $this->json(['data' => $availableColumns]);
+            return $this->adminJson(['data' => $availableColumns]);
         }
     }
 
@@ -273,7 +273,7 @@ class NewsletterController extends DocumentControllerBase
         $document = Document\Newsletter::getById($request->get('id'));
         $data = Tool\TmpStore::get($document->getTmpStoreId());
 
-        return $this->json([
+        return $this->adminJson([
             'data' => $data ? $data->getData() : null,
             'success' => true
         ]);
@@ -291,7 +291,7 @@ class NewsletterController extends DocumentControllerBase
         $document = Document\Newsletter::getById($request->get('id'));
         Tool\TmpStore::delete($document->getTmpStoreId());
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true
         ]);
     }
@@ -323,7 +323,7 @@ class NewsletterController extends DocumentControllerBase
 
         \Pimcore\Tool\Console::runPhpScriptInBackground(realpath(PIMCORE_PROJECT_ROOT . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'console'), 'internal:newsletter-document-send ' . escapeshellarg($document->getTmpStoreId()) . ' ' . escapeshellarg(\Pimcore\Tool::getHostUrl()), PIMCORE_LOG_DIRECTORY . DIRECTORY_SEPARATOR . 'newsletter-sending-output.log');
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -342,7 +342,7 @@ class NewsletterController extends DocumentControllerBase
         $serviceLocator = $this->get('pimcore.newsletter.address_source_adapter.factories');
 
         if (!$serviceLocator->has($addressSourceAdapterName)) {
-            return $this->json(['success' => false, 'error' => sprintf('Cannot send newsletters because Address Source Adapter with identifier %s could not be found', $addressSourceAdapterName)]);
+            return $this->adminJson(['success' => false, 'error' => sprintf('Cannot send newsletters because Address Source Adapter with identifier %s could not be found', $addressSourceAdapterName)]);
         }
 
         /**
@@ -356,6 +356,6 @@ class NewsletterController extends DocumentControllerBase
         $mail = \Pimcore\Tool\Newsletter::prepareMail($document);
         \Pimcore\Tool\Newsletter::sendNewsletterDocumentBasedMail($mail, $sendingContainer);
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/PageController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/PageController.php
@@ -44,7 +44,7 @@ class PageController extends DocumentControllerBase
     {
         // check for lock
         if (Element\Editlock::isLocked($request->get('id'), 'document')) {
-            return $this->json([
+            return $this->adminJson([
                 'editlock' => Element\Editlock::getByElement($request->get('id'), 'document')
             ]);
         }
@@ -89,10 +89,10 @@ class PageController extends DocumentControllerBase
         $data = $event->getArgument('data');
 
         if ($page->isAllowed('view')) {
-            return $this->json($data);
+            return $this->adminJson($data);
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -206,14 +206,14 @@ class PageController extends DocumentControllerBase
                         $page->save();
                         $this->saveToSession($page);
 
-                        return $this->json(['success' => true]);
+                        return $this->adminJson(['success' => true]);
                     } catch (\Exception $e) {
                         if ($e instanceof Element\ValidationException) {
                             throw $e;
                         }
                         Logger::err($e);
 
-                        return $this->json(['success' => false, 'message'=>$e->getMessage()]);
+                        return $this->adminJson(['success' => false, 'message' =>$e->getMessage()]);
                     }
                 } else {
                     if ($page->isAllowed('save')) {
@@ -223,11 +223,11 @@ class PageController extends DocumentControllerBase
                             $page->saveVersion();
                             $this->saveToSession($page);
 
-                            return $this->json(['success' => true]);
+                            return $this->adminJson(['success' => true]);
                         } catch (\Exception $e) {
                             Logger::err($e);
 
-                            return $this->json(['success' => false, 'message'=>$e->getMessage()]);
+                            return $this->adminJson(['success' => false, 'message' =>$e->getMessage()]);
                         }
                     }
                 }
@@ -235,12 +235,12 @@ class PageController extends DocumentControllerBase
         } catch (\Exception $e) {
             Logger::log($e);
             if ($e instanceof Element\ValidationException) {
-                return $this->json(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
+                return $this->adminJson(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
             }
             throw $e;
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -256,7 +256,7 @@ class PageController extends DocumentControllerBase
         $list->setCondition('type = ?', ['page']);
         $data = $list->loadIdPathList();
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true,
             'data' => $data
         ]);
@@ -284,7 +284,7 @@ class PageController extends DocumentControllerBase
             File::put($file, $data);
         }
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -334,7 +334,7 @@ class PageController extends DocumentControllerBase
             }
         }
 
-        return $this->json(['success' => $success]);
+        return $this->adminJson(['success' => $success]);
     }
 
     /**
@@ -375,7 +375,7 @@ class PageController extends DocumentControllerBase
             $success = false;
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success
         ]);
     }
@@ -409,7 +409,7 @@ class PageController extends DocumentControllerBase
 
         $this->saveToSession($doc, true);
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true
         ]);
     }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/PageController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/PageController.php
@@ -135,7 +135,7 @@ class PageController extends DocumentControllerBase
                     $page = $this->getLatestVersion($page);
                 }
 
-                $page->setUserModification($this->getUser()->getId());
+                $page->setUserModification($this->getAdminUser()->getId());
 
                 if ($request->get('task') == 'unpublish') {
                     $page->setPublished(false);
@@ -150,7 +150,7 @@ class PageController extends DocumentControllerBase
                 }
 
                 // check for redirects
-                if ($this->getUser()->isAllowed('redirects') && $request->get('settings')) {
+                if ($this->getAdminUser()->isAllowed('redirects') && $request->get('settings')) {
                     if (is_array($settings)) {
                         $redirectList = new Redirect\Listing();
                         $redirectList->setCondition('target = ?', $page->getId());

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/PortalController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/PortalController.php
@@ -338,7 +338,7 @@ class PortalController extends AdminController implements EventedControllerInter
                 'type' => $doc->getType(),
                 'path' => $doc->getRealFullPath(),
                 'date' => $doc->getModificationDate(),
-                'condition' => "userModification = '".$this->getUser()->getId()."'"
+                'condition' => "userModification = '".$this->getAdminUser()->getId()."'"
             ];
         }
 
@@ -369,7 +369,7 @@ class PortalController extends AdminController implements EventedControllerInter
                 'type' => $doc->getType(),
                 'path' => $doc->getRealFullPath(),
                 'date' => $doc->getModificationDate(),
-                'condition' => "userModification = '".$this->getUser()->getId()."'"
+                'condition' => "userModification = '".$this->getAdminUser()->getId()."'"
             ];
         }
 
@@ -389,7 +389,7 @@ class PortalController extends AdminController implements EventedControllerInter
             'limit' => 10,
             'order' => 'DESC',
             'orderKey' => 'o_modificationDate',
-            'condition' => "o_userModification = '".$this->getUser()->getId()."'"
+            'condition' => "o_userModification = '".$this->getAdminUser()->getId()."'"
         ]);
 
         $response = [];
@@ -490,7 +490,7 @@ class PortalController extends AdminController implements EventedControllerInter
             return;
         }
 
-        $this->dashboardHelper = new \Pimcore\Helper\Dashboard($this->getUser());
+        $this->dashboardHelper = new \Pimcore\Helper\Dashboard($this->getAdminUser());
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/PortalController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/PortalController.php
@@ -76,7 +76,7 @@ class PortalController extends AdminController implements EventedControllerInter
             }
         }
 
-        return $this->json($data);
+        return $this->adminJson($data);
     }
 
     /**
@@ -94,13 +94,13 @@ class PortalController extends AdminController implements EventedControllerInter
         $key = trim($request->get('key'));
 
         if ($dashboards[$key]) {
-            return $this->json(['success' => false, 'message' => 'dashboard_already_exists']);
+            return $this->adminJson(['success' => false, 'message' => 'dashboard_already_exists']);
         } elseif (!empty($key)) {
             $this->dashboardHelper->saveDashboard($key);
 
-            return $this->json(['success' => true]);
+            return $this->adminJson(['success' => true]);
         } else {
-            return $this->json(['success' => false, 'message' => 'empty']);
+            return $this->adminJson(['success' => false, 'message' => 'empty']);
         }
     }
 
@@ -116,7 +116,7 @@ class PortalController extends AdminController implements EventedControllerInter
         $key = $request->get('key');
         $this->dashboardHelper->deleteDashboard($key);
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -128,7 +128,7 @@ class PortalController extends AdminController implements EventedControllerInter
      */
     public function getConfigurationAction(Request $request)
     {
-        return $this->json($this->getCurrentConfiguration($request));
+        return $this->adminJson($this->getCurrentConfiguration($request));
     }
 
     /**
@@ -156,7 +156,7 @@ class PortalController extends AdminController implements EventedControllerInter
         $config['positions'] = $newConfig;
         $this->saveConfiguration($request, $config);
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -182,7 +182,7 @@ class PortalController extends AdminController implements EventedControllerInter
 
         $this->saveConfiguration($request, $config);
 
-        return $this->json(['success' => true, 'id' => $nextId]);
+        return $this->adminJson(['success' => true, 'id' => $nextId]);
     }
 
     /**
@@ -214,7 +214,7 @@ class PortalController extends AdminController implements EventedControllerInter
         $config['positions'] = $newConfig;
         $this->saveConfiguration($request, $config);
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -241,7 +241,7 @@ class PortalController extends AdminController implements EventedControllerInter
         }
         $this->dashboardHelper->saveDashboard($key, $dashboard);
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -309,7 +309,7 @@ class PortalController extends AdminController implements EventedControllerInter
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'entries' => $entries
         ]);
     }
@@ -342,7 +342,7 @@ class PortalController extends AdminController implements EventedControllerInter
             ];
         }
 
-        return $this->json($response);
+        return $this->adminJson($response);
     }
 
     /**
@@ -373,7 +373,7 @@ class PortalController extends AdminController implements EventedControllerInter
             ];
         }
 
-        return $this->json($response);
+        return $this->adminJson($response);
     }
 
     /**
@@ -404,7 +404,7 @@ class PortalController extends AdminController implements EventedControllerInter
             ];
         }
 
-        return $this->json($response);
+        return $this->adminJson($response);
     }
 
     /**
@@ -446,7 +446,7 @@ class PortalController extends AdminController implements EventedControllerInter
 
         $data = array_reverse($data);
 
-        return $this->json(['data' => $data]);
+        return $this->adminJson(['data' => $data]);
     }
 
     /**
@@ -477,7 +477,7 @@ class PortalController extends AdminController implements EventedControllerInter
             }
         }
 
-        return $this->json(['data' => $data]);
+        return $this->adminJson(['data' => $data]);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/PrintpageControllerBase.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/PrintpageControllerBase.php
@@ -100,7 +100,7 @@ class PrintpageControllerBase extends DocumentControllerBase
             $page = Document\Printpage::getById($request->get('id'));
 
             $page = $this->getLatestVersion($page);
-            $page->setUserModification($this->getUser()->getId());
+            $page->setUserModification($this->getAdminUser()->getId());
 
             // save to session
             $key = 'document_' . $request->get('id');
@@ -332,7 +332,7 @@ class PrintpageControllerBase extends DocumentControllerBase
      */
     private function getStoredProcessingOptions($documentId)
     {
-        $filename = PIMCORE_SYSTEM_TEMP_DIRECTORY . DIRECTORY_SEPARATOR . 'web2print-processingoptions-' . $documentId . '_' . $this->getUser()->getId() . '.psf';
+        $filename = PIMCORE_SYSTEM_TEMP_DIRECTORY . DIRECTORY_SEPARATOR . 'web2print-processingoptions-' . $documentId . '_' . $this->getAdminUser()->getId() . '.psf';
         if (file_exists($filename)) {
             return \Pimcore\Tool\Serialize::unserialize(file_get_contents($filename));
         } else {
@@ -346,7 +346,7 @@ class PrintpageControllerBase extends DocumentControllerBase
      */
     private function saveProcessingOptions($documentId, $options)
     {
-        file_put_contents(PIMCORE_SYSTEM_TEMP_DIRECTORY . DIRECTORY_SEPARATOR . 'web2print-processingoptions-' . $documentId . '_' . $this->getUser()->getId() . '.psf', \Pimcore\Tool\Serialize::serialize($options));
+        file_put_contents(PIMCORE_SYSTEM_TEMP_DIRECTORY . DIRECTORY_SEPARATOR . 'web2print-processingoptions-' . $documentId . '_' . $this->getAdminUser()->getId() . '.psf', \Pimcore\Tool\Serialize::serialize($options));
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/PrintpageControllerBase.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/PrintpageControllerBase.php
@@ -41,7 +41,7 @@ class PrintpageControllerBase extends DocumentControllerBase
     {
         // check for lock
         if (\Pimcore\Model\Element\Editlock::isLocked($request->get('id'), 'document')) {
-            return $this->json([
+            return $this->adminJson([
                 'editlock' => \Pimcore\Model\Element\Editlock::getByElement($request->get('id'), 'document')
             ]);
         }
@@ -81,10 +81,10 @@ class PrintpageControllerBase extends DocumentControllerBase
         if ($page->isAllowed('view')) {
             $data = $event->getArgument('data');
 
-            return $this->json($data);
+            return $this->adminJson($data);
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -130,11 +130,11 @@ class PrintpageControllerBase extends DocumentControllerBase
                 try {
                     $page->save();
 
-                    return $this->json(['success' => true]);
+                    return $this->adminJson(['success' => true]);
                 } catch (\Exception $e) {
                     Logger::err($e);
 
-                    return $this->json(['success' => false, 'message'=>$e->getMessage()]);
+                    return $this->adminJson(['success' => false, 'message' =>$e->getMessage()]);
                 }
             } else {
                 if ($page->isAllowed('save')) {
@@ -143,17 +143,17 @@ class PrintpageControllerBase extends DocumentControllerBase
                     try {
                         $page->saveVersion();
 
-                        return $this->json(['success' => true]);
+                        return $this->adminJson(['success' => true]);
                     } catch (\Exception $e) {
                         Logger::err($e);
 
-                        return $this->json(['success' => false, 'message'=>$e->getMessage()]);
+                        return $this->adminJson(['success' => false, 'message' =>$e->getMessage()]);
                     }
                 }
             }
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -198,7 +198,7 @@ class PrintpageControllerBase extends DocumentControllerBase
             $statusUpdate = Processor::getInstance()->getStatusUpdate($document->getId());
         }
 
-        return $this->json([
+        return $this->adminJson([
             'activeGenerateProcess' => !empty($inProgress),
             'date' => $date,
             'message' => $document->getLastGenerateMessage(),
@@ -270,7 +270,7 @@ class PrintpageControllerBase extends DocumentControllerBase
 
         $this->saveProcessingOptions($document->getId(), $allParams);
 
-        return $this->json(['success' => $result]);
+        return $this->adminJson(['success' => $result]);
     }
 
     /**
@@ -289,7 +289,7 @@ class PrintpageControllerBase extends DocumentControllerBase
             $dirty = $printDocument->pdfIsDirty();
         }
 
-        return $this->json(['pdfDirty' => $dirty]);
+        return $this->adminJson(['pdfDirty' => $dirty]);
     }
 
     /**
@@ -322,7 +322,7 @@ class PrintpageControllerBase extends DocumentControllerBase
             ];
         }
 
-        return $this->json(['options' => $returnValue]);
+        return $this->adminJson(['options' => $returnValue]);
     }
 
     /**
@@ -360,6 +360,6 @@ class PrintpageControllerBase extends DocumentControllerBase
     {
         Processor::getInstance()->cancelGeneration(intval($request->get('id')));
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/QuantityValueController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/QuantityValueController.php
@@ -43,7 +43,7 @@ class QuantityValueController extends AdminController
                 if (!empty($unit)) {
                     $unit->delete();
 
-                    return $this->json(['data' => [], 'success' => true]);
+                    return $this->adminJson(['data' => [], 'success' => true]);
                 } else {
                     throw new \Exception('Unit with id ' . $id . ' not found.');
                 }
@@ -54,7 +54,7 @@ class QuantityValueController extends AdminController
                     $unit->setValues($data);
                     $unit->save();
 
-                    return $this->json(['data' => get_object_vars($unit), 'success' => true]);
+                    return $this->adminJson(['data' => get_object_vars($unit), 'success' => true]);
                 } else {
                     throw new \Exception('Unit with id ' . $data['id'] . ' not found.');
                 }
@@ -65,7 +65,7 @@ class QuantityValueController extends AdminController
                 $unit->setValues($data);
                 $unit->save();
 
-                return $this->json(['data' => get_object_vars($unit), 'success' => true]);
+                return $this->adminJson(['data' => get_object_vars($unit), 'success' => true]);
             }
         } else {
             $list = new Unit\Listing();
@@ -110,7 +110,7 @@ class QuantityValueController extends AdminController
                 $units[] = get_object_vars($u);
             }
 
-            return $this->json(['data' => $units, 'success' => true, 'total' => $list->getTotalCount()]);
+            return $this->adminJson(['data' => $units, 'success' => true, 'total' => $list->getTotalCount()]);
         }
     }
 
@@ -155,6 +155,6 @@ class QuantityValueController extends AdminController
 
         $units = $list->getUnits();
 
-        return $this->json(['data' => $units, 'success' => true, 'total' => $list->getTotalCount()]);
+        return $this->adminJson(['data' => $units, 'success' => true, 'total' => $list->getTotalCount()]);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/RecyclebinController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/RecyclebinController.php
@@ -39,7 +39,7 @@ class RecyclebinController extends AdminController implements EventedControllerI
             $item = Recyclebin\Item::getById(\Pimcore\Bundle\AdminBundle\Helper\QueryParams::getRecordIdForGridRequest($request->get('data')));
             $item->delete();
 
-            return $this->json(['success' => true, 'data' => []]);
+            return $this->adminJson(['success' => true, 'data' => []]);
         } else {
             $db = \Pimcore\Db::get();
 
@@ -125,7 +125,7 @@ class RecyclebinController extends AdminController implements EventedControllerI
 
             $items = $list->load();
 
-            return $this->json(['data' => $items, 'success' => true, 'total' => $list->getTotalCount()]);
+            return $this->adminJson(['data' => $items, 'success' => true, 'total' => $list->getTotalCount()]);
         }
     }
 
@@ -141,7 +141,7 @@ class RecyclebinController extends AdminController implements EventedControllerI
         $item = Recyclebin\Item::getById($request->get('id'));
         $item->restore();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -156,7 +156,7 @@ class RecyclebinController extends AdminController implements EventedControllerI
         $bin = new Element\Recyclebin();
         $bin->flush();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -182,9 +182,9 @@ class RecyclebinController extends AdminController implements EventedControllerI
                 Recyclebin\Item::create($element, $this->getAdminUser());
             }
 
-            return $this->json(['success' => true]);
+            return $this->adminJson(['success' => true]);
         } else {
-            return $this->json(['success' => false]);
+            return $this->adminJson(['success' => false]);
         }
     }
 

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/RecyclebinController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/RecyclebinController.php
@@ -179,7 +179,7 @@ class RecyclebinController extends AdminController implements EventedControllerI
             $children = $list->getTotalCount();
 
             if ($children <= 100) {
-                Recyclebin\Item::create($element, $this->getUser());
+                Recyclebin\Item::create($element, $this->getAdminUser());
             }
 
             return $this->json(['success' => true]);

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/RedirectsController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/RedirectsController.php
@@ -88,7 +88,7 @@ class RedirectsController extends AdminController
 
         $result = $csv->import($file->getRealPath());
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true,
             'data'    => $result
         ]);

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/SettingsController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/SettingsController.php
@@ -58,7 +58,7 @@ class SettingsController extends AdminController
                 $metadata = Metadata\Predefined::getById($id);
                 $metadata->delete();
 
-                return $this->json(['success' => true, 'data' => []]);
+                return $this->adminJson(['success' => true, 'data' => []]);
             } elseif ($request->get('xaction') == 'update') {
                 $data = $this->decodeJson($request->get('data'));
 
@@ -69,14 +69,14 @@ class SettingsController extends AdminController
 
                 $existingItem = Metadata\Predefined\Listing::getByKeyAndLanguage($metadata->getName(), $metadata->getLanguage(), $metadata->getTargetSubtype());
                 if ($existingItem && $existingItem->getId() != $metadata->getId()) {
-                    return $this->json(['message' => 'rule_violation', 'success' => false]);
+                    return $this->adminJson(['message' => 'rule_violation', 'success' => false]);
                 }
 
                 $metadata->minimize();
                 $metadata->save();
                 $metadata->expand();
 
-                return $this->json(['data' => $metadata, 'success' => true]);
+                return $this->adminJson(['data' => $metadata, 'success' => true]);
             } elseif ($request->get('xaction') == 'create') {
                 $data = $this->decodeJson($request->get('data'));
                 unset($data['id']);
@@ -88,12 +88,12 @@ class SettingsController extends AdminController
 
                 $existingItem = Metadata\Predefined\Listing::getByKeyAndLanguage($metadata->getName(), $metadata->getLanguage(), $metadata->getTargetSubtype());
                 if ($existingItem) {
-                    return $this->json(['message' => 'rule_violation', 'success' => false]);
+                    return $this->adminJson(['message' => 'rule_violation', 'success' => false]);
                 }
 
                 $metadata->save();
 
-                return $this->json(['data' => $metadata, 'success' => true]);
+                return $this->adminJson(['data' => $metadata, 'success' => true]);
             }
         } else {
             // get list of types
@@ -123,7 +123,7 @@ class SettingsController extends AdminController
                 }
             }
 
-            return $this->json(['data' => $properties, 'success' => true, 'total' => $list->getTotalCount()]);
+            return $this->adminJson(['data' => $properties, 'success' => true, 'total' => $list->getTotalCount()]);
         }
     }
 
@@ -146,7 +146,7 @@ class SettingsController extends AdminController
             $result[] = $item;
         }
 
-        return $this->json(['data' => $result, 'success' => true]);
+        return $this->adminJson(['data' => $result, 'success' => true]);
     }
 
     /**
@@ -167,7 +167,7 @@ class SettingsController extends AdminController
                 $property = Property\Predefined::getById($id);
                 $property->delete();
 
-                return $this->json(['success' => true, 'data' => []]);
+                return $this->adminJson(['success' => true, 'data' => []]);
             } elseif ($request->get('xaction') == 'update') {
                 $data = $this->decodeJson($request->get('data'));
 
@@ -177,7 +177,7 @@ class SettingsController extends AdminController
 
                 $property->save();
 
-                return $this->json(['data' => $property, 'success' => true]);
+                return $this->adminJson(['data' => $property, 'success' => true]);
             } elseif ($request->get('xaction') == 'create') {
                 $data = $this->decodeJson($request->get('data'));
                 unset($data['id']);
@@ -188,7 +188,7 @@ class SettingsController extends AdminController
 
                 $property->save();
 
-                return $this->json(['data' => $property, 'success' => true]);
+                return $this->adminJson(['data' => $property, 'success' => true]);
             }
         } else {
             // get list of types
@@ -222,7 +222,7 @@ class SettingsController extends AdminController
                 }
             }
 
-            return $this->json(['data' => $properties, 'success' => true, 'total' => $list->getTotalCount()]);
+            return $this->adminJson(['data' => $properties, 'success' => true, 'total' => $list->getTotalCount()]);
         }
     }
 
@@ -353,7 +353,7 @@ class SettingsController extends AdminController
             ]
         ];
 
-        return $this->json($response);
+        return $this->adminJson($response);
     }
 
     /**
@@ -539,7 +539,7 @@ class SettingsController extends AdminController
             'ip' => $values['general.debug_ip'],
         ]));
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -599,7 +599,7 @@ class SettingsController extends AdminController
             'values' => $valueArray
         ];
 
-        return $this->json($response);
+        return $this->adminJson($response);
     }
 
     /**
@@ -632,7 +632,7 @@ class SettingsController extends AdminController
         $configFile = \Pimcore\Config::locateConfigFile('web2print.php');
         File::putPhpFile($configFile, to_php_data_file_format($values));
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -670,7 +670,7 @@ class SettingsController extends AdminController
             \Pimcore::getEventDispatcher()->dispatch(\Pimcore\Event\SystemEvents::CACHE_CLEAR);
         }
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -692,7 +692,7 @@ class SettingsController extends AdminController
 
         \Pimcore::getEventDispatcher()->dispatch(\Pimcore\Event\SystemEvents::CACHE_CLEAR_FULLPAGE_CACHE);
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -718,7 +718,7 @@ class SettingsController extends AdminController
 
         \Pimcore::getEventDispatcher()->dispatch(\Pimcore\Event\SystemEvents::CACHE_CLEAR_TEMPORARY_FILES);
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -749,7 +749,7 @@ class SettingsController extends AdminController
                 $route = Staticroute::getById($id);
                 $route->delete();
 
-                return $this->json(['success' => true, 'data' => []]);
+                return $this->adminJson(['success' => true, 'data' => []]);
             } elseif ($request->get('xaction') == 'update') {
                 // save routes
                 $route = Staticroute::getById($data['id']);
@@ -757,7 +757,7 @@ class SettingsController extends AdminController
 
                 $route->save();
 
-                return $this->json(['data' => $route, 'success' => true]);
+                return $this->adminJson(['data' => $route, 'success' => true]);
             } elseif ($request->get('xaction') == 'create') {
                 unset($data['id']);
 
@@ -767,7 +767,7 @@ class SettingsController extends AdminController
 
                 $route->save();
 
-                return $this->json(['data' => $route, 'success' => true]);
+                return $this->adminJson(['data' => $route, 'success' => true]);
             }
         } else {
             // get list of routes
@@ -803,10 +803,10 @@ class SettingsController extends AdminController
                 $routes[] = $route;
             }
 
-            return $this->json(['data' => $routes, 'success' => true, 'total' => $list->getTotalCount()]);
+            return $this->adminJson(['data' => $routes, 'success' => true, 'total' => $list->getTotalCount()]);
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -819,12 +819,12 @@ class SettingsController extends AdminController
     public function getAvailableLanguagesAction(Request $request)
     {
         if ($languages = Tool::getValidLanguages()) {
-            return $this->json($languages);
+            return $this->adminJson($languages);
         }
 
         $t = new Model\Translation\Website();
 
-        return $this->json($t->getAvailableLanguages());
+        return $this->adminJson($t->getAvailableLanguages());
     }
 
     /**
@@ -849,7 +849,7 @@ class SettingsController extends AdminController
             }
         }
 
-        return $this->json($langs);
+        return $this->adminJson($langs);
     }
 
     /**
@@ -873,7 +873,7 @@ class SettingsController extends AdminController
                     $redirect->delete();
                 }
 
-                return $this->json(['success' => true, 'data' => []]);
+                return $this->adminJson(['success' => true, 'data' => []]);
             } elseif ($request->get('xaction') == 'update') {
                 $data = $this->decodeJson($request->get('data'));
 
@@ -901,7 +901,7 @@ class SettingsController extends AdminController
                     }
                 }
 
-                return $this->json(['data' => $redirect, 'success' => true]);
+                return $this->adminJson(['data' => $redirect, 'success' => true]);
             } elseif ($request->get('xaction') == 'create') {
                 $data = $this->decodeJson($request->get('data'));
                 unset($data['id']);
@@ -930,7 +930,7 @@ class SettingsController extends AdminController
                     }
                 }
 
-                return $this->json(['data' => $redirect, 'success' => true]);
+                return $this->adminJson(['data' => $redirect, 'success' => true]);
             }
         } else {
             // get list of routes
@@ -964,10 +964,10 @@ class SettingsController extends AdminController
                 $redirects[] = $redirect;
             }
 
-            return $this->json(['data' => $redirects, 'success' => true, 'total' => $list->getTotalCount()]);
+            return $this->adminJson(['data' => $redirects, 'success' => true, 'total' => $list->getTotalCount()]);
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -990,7 +990,7 @@ class SettingsController extends AdminController
                 $glossary = Glossary::getById($id);
                 $glossary->delete();
 
-                return $this->json(['success' => true, 'data' => []]);
+                return $this->adminJson(['success' => true, 'data' => []]);
             } elseif ($request->get('xaction') == 'update') {
                 $data = $this->decodeJson($request->get('data'));
 
@@ -1015,7 +1015,7 @@ class SettingsController extends AdminController
                     }
                 }
 
-                return $this->json(['data' => $glossary, 'success' => true]);
+                return $this->adminJson(['data' => $glossary, 'success' => true]);
             } elseif ($request->get('xaction') == 'create') {
                 $data = $this->decodeJson($request->get('data'));
                 unset($data['id']);
@@ -1041,7 +1041,7 @@ class SettingsController extends AdminController
                     }
                 }
 
-                return $this->json(['data' => $glossary, 'success' => true]);
+                return $this->adminJson(['data' => $glossary, 'success' => true]);
             }
         } else {
             // get list of glossaries
@@ -1075,10 +1075,10 @@ class SettingsController extends AdminController
                 $glossaries[] = $glossary;
             }
 
-            return $this->json(['data' => $glossaries, 'success' => true, 'total' => $list->getTotalCount()]);
+            return $this->adminJson(['data' => $glossaries, 'success' => true, 'total' => $list->getTotalCount()]);
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -1117,7 +1117,7 @@ class SettingsController extends AdminController
             }
         }
 
-        return $this->json($sites);
+        return $this->adminJson($sites);
     }
 
     /**
@@ -1145,7 +1145,7 @@ class SettingsController extends AdminController
 
         $result = ['data' => $options, 'success' => true, 'total' => count($options)];
 
-        return $this->json($result);
+        return $this->adminJson($result);
     }
 
     /**
@@ -1192,7 +1192,7 @@ class SettingsController extends AdminController
             ];
         }
 
-        return $this->json($thumbnails);
+        return $this->adminJson($thumbnails);
     }
 
     /**
@@ -1218,7 +1218,7 @@ class SettingsController extends AdminController
             $success = true;
         }
 
-        return $this->json(['success' => $success, 'id' => $pipe->getName()]);
+        return $this->adminJson(['success' => $success, 'id' => $pipe->getName()]);
     }
 
     /**
@@ -1235,7 +1235,7 @@ class SettingsController extends AdminController
         $pipe = Asset\Image\Thumbnail\Config::getByName($request->get('name'));
         $pipe->delete();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -1251,7 +1251,7 @@ class SettingsController extends AdminController
 
         $pipe = Asset\Image\Thumbnail\Config::getByName($request->get('name'));
 
-        return $this->json($pipe);
+        return $this->adminJson($pipe);
     }
 
     /**
@@ -1291,7 +1291,7 @@ class SettingsController extends AdminController
 
         $this->deleteThumbnailTmpFiles($pipe);
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -1337,7 +1337,7 @@ class SettingsController extends AdminController
             ];
         }
 
-        return $this->json($thumbnails);
+        return $this->adminJson($thumbnails);
     }
 
     /**
@@ -1363,7 +1363,7 @@ class SettingsController extends AdminController
             $success = true;
         }
 
-        return $this->json(['success' => $success, 'id' => $pipe->getName()]);
+        return $this->adminJson(['success' => $success, 'id' => $pipe->getName()]);
     }
 
     /**
@@ -1380,7 +1380,7 @@ class SettingsController extends AdminController
         $pipe = Asset\Video\Thumbnail\Config::getByName($request->get('name'));
         $pipe->delete();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -1396,7 +1396,7 @@ class SettingsController extends AdminController
 
         $pipe = Asset\Video\Thumbnail\Config::getByName($request->get('name'));
 
-        return $this->json($pipe);
+        return $this->adminJson($pipe);
     }
 
     /**
@@ -1438,7 +1438,7 @@ class SettingsController extends AdminController
 
         $this->deleteVideoThumbnailTmpFiles($pipe);
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -1464,7 +1464,7 @@ class SettingsController extends AdminController
             // save data
             \Pimcore\File::put($robotsPath, $request->get('data'));
 
-            return $this->json([
+            return $this->adminJson([
                 'success' => true
             ]);
         } else {
@@ -1474,7 +1474,7 @@ class SettingsController extends AdminController
                 $data = file_get_contents($robotsPath);
             }
 
-            return $this->json([
+            return $this->adminJson([
                 'success' => true,
                 'data' => $data,
                 'onFileSystem' => file_exists(PIMCORE_WEB_ROOT . '/robots.txt')
@@ -1505,7 +1505,7 @@ class SettingsController extends AdminController
             ];
         }
 
-        return $this->json($tags);
+        return $this->adminJson($tags);
     }
 
     /**
@@ -1531,7 +1531,7 @@ class SettingsController extends AdminController
             $success = true;
         }
 
-        return $this->json(['success' => $success, 'id' => $tag->getName()]);
+        return $this->adminJson(['success' => $success, 'id' => $tag->getName()]);
     }
 
     /**
@@ -1548,7 +1548,7 @@ class SettingsController extends AdminController
         $tag = Model\Tool\Tag\Config::getByName($request->get('name'));
         $tag->delete();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -1564,7 +1564,7 @@ class SettingsController extends AdminController
 
         $tag = Model\Tool\Tag\Config::getByName($request->get('name'));
 
-        return $this->json($tag);
+        return $this->adminJson($tag);
     }
 
     /**
@@ -1617,7 +1617,7 @@ class SettingsController extends AdminController
 
         $tag->save();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -1648,7 +1648,7 @@ class SettingsController extends AdminController
                     $setting = WebsiteSetting::getById($id);
                     $setting->delete();
 
-                    return $this->json(['success' => true, 'data' => []]);
+                    return $this->adminJson(['success' => true, 'data' => []]);
                 } elseif ($request->get('xaction') == 'update') {
                     // save routes
                     $setting = WebsiteSetting::getById($data['id']);
@@ -1671,7 +1671,7 @@ class SettingsController extends AdminController
 
                     $data = $this->getWebsiteSettingForEditMode($setting);
 
-                    return $this->json(['data' => $data, 'success' => true]);
+                    return $this->adminJson(['data' => $data, 'success' => true]);
                 } elseif ($request->get('xaction') == 'create') {
                     unset($data['id']);
 
@@ -1681,7 +1681,7 @@ class SettingsController extends AdminController
 
                     $setting->save();
 
-                    return $this->json(['data' => $setting, 'success' => true]);
+                    return $this->adminJson(['data' => $setting, 'success' => true]);
                 }
             } else {
                 // get list of routes
@@ -1713,13 +1713,13 @@ class SettingsController extends AdminController
                     $settings[] = $resultItem;
                 }
 
-                return $this->json(['data' => $settings, 'success' => true, 'total' => $totalCount]);
+                return $this->adminJson(['data' => $settings, 'success' => true, 'total' => $totalCount]);
             }
         } catch (\Exception $e) {
             throw $e;
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -1782,7 +1782,7 @@ class SettingsController extends AdminController
 
         $result = ['data' => $options, 'success' => true, 'total' => count($options)];
 
-        return $this->json($result);
+        return $this->adminJson($result);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/SnippetController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/SnippetController.php
@@ -100,7 +100,7 @@ class SnippetController extends DocumentControllerBase
                 $snippet = Document\Snippet::getById($request->get('id'));
                 $snippet = $this->getLatestVersion($snippet);
 
-                $snippet->setUserModification($this->getUser()->getId());
+                $snippet->setUserModification($this->getAdminUser()->getId());
 
                 if ($request->get('task') == 'unpublish') {
                     $snippet->setPublished(false);

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/SnippetController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/SnippetController.php
@@ -39,7 +39,7 @@ class SnippetController extends DocumentControllerBase
     {
         // check for lock
         if (Element\Editlock::isLocked($request->get('id'), 'document')) {
-            return $this->json([
+            return $this->adminJson([
                 'editlock' => Element\Editlock::getByElement($request->get('id'), 'document')
             ]);
         }
@@ -78,10 +78,10 @@ class SnippetController extends DocumentControllerBase
         $data = $event->getArgument('data');
 
         if ($snippet->isAllowed('view')) {
-            return $this->json($data);
+            return $this->adminJson($data);
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**
@@ -116,13 +116,13 @@ class SnippetController extends DocumentControllerBase
                         $snippet->save();
                         $this->saveToSession($snippet);
 
-                        return $this->json(['success' => true]);
+                        return $this->adminJson(['success' => true]);
                     } catch (\Exception $e) {
                         if ($e instanceof Element\ValidationException) {
                             throw $e;
                         }
 
-                        return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                        return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                     }
                 } else {
                     if ($snippet->isAllowed('save')) {
@@ -132,9 +132,9 @@ class SnippetController extends DocumentControllerBase
                             $snippet->saveVersion();
                             $this->saveToSession($snippet);
 
-                            return $this->json(['success' => true]);
+                            return $this->adminJson(['success' => true]);
                         } catch (\Exception $e) {
-                            return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                            return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                         }
                     }
                 }
@@ -142,12 +142,12 @@ class SnippetController extends DocumentControllerBase
         } catch (\Exception $e) {
             Logger::log($e);
             if ($e instanceof Element\ValidationException) {
-                return $this->json(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
+                return $this->adminJson(['success' => false, 'type' => 'ValidationException', 'message' => $e->getMessage(), 'stack' => $e->getTraceAsString(), 'code' => $e->getCode()]);
             }
             throw $e;
         }
 
-        return $this->json(false);
+        return $this->adminJson(false);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TagsController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TagsController.php
@@ -289,9 +289,9 @@ class TagsController extends AdminController
     {
         $childsList = new \Pimcore\Model\DataObject\Listing();
         $condition = 'o_path LIKE ?';
-        if (!$this->getUser()->isAdmin()) {
-            $userIds = $this->getUser()->getRoles();
-            $userIds[] = $this->getUser()->getId();
+        if (!$this->getAdminUser()->isAdmin()) {
+            $userIds = $this->getAdminUser()->getRoles();
+            $userIds[] = $this->getAdminUser()->getId();
             $condition .= ' AND (
                 (SELECT `view` FROM users_workspaces_object WHERE userId IN (' . implode(',', $userIds) . ') and LOCATE(CONCAT(o_path,o_key),cpath)=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
                     OR
@@ -313,9 +313,9 @@ class TagsController extends AdminController
     {
         $childsList = new \Pimcore\Model\Asset\Listing();
         $condition = 'path LIKE ?';
-        if (!$this->getUser()->isAdmin()) {
-            $userIds = $this->getUser()->getRoles();
-            $userIds[] = $this->getUser()->getId();
+        if (!$this->getAdminUser()->isAdmin()) {
+            $userIds = $this->getAdminUser()->getRoles();
+            $userIds[] = $this->getAdminUser()->getId();
             $condition .= ' AND (
                 (SELECT `view` FROM users_workspaces_asset WHERE userId IN (' . implode(',', $userIds) . ') and LOCATE(CONCAT(path,filename),cpath)=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
                     OR
@@ -337,9 +337,9 @@ class TagsController extends AdminController
     {
         $childsList = new \Pimcore\Model\Document\Listing();
         $condition = 'path LIKE ?';
-        if (!$this->getUser()->isAdmin()) {
-            $userIds = $this->getUser()->getRoles();
-            $userIds[] = $this->getUser()->getId();
+        if (!$this->getAdminUser()->isAdmin()) {
+            $userIds = $this->getAdminUser()->getRoles();
+            $userIds[] = $this->getAdminUser()->getId();
             $condition .= ' AND (
                 (SELECT `view` FROM users_workspaces_document WHERE userId IN (' . implode(',', $userIds) . ') and LOCATE(CONCAT(path,`key`),cpath)=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
                     OR

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TagsController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TagsController.php
@@ -39,7 +39,7 @@ class TagsController extends AdminController
         $tag->setParentId(intval($request->get('parentId')));
         $tag->save();
 
-        return $this->json(['success' => true, 'id' => $tag->getId()]);
+        return $this->adminJson(['success' => true, 'id' => $tag->getId()]);
     }
 
     /**
@@ -57,7 +57,7 @@ class TagsController extends AdminController
         if ($tag) {
             $tag->delete();
 
-            return $this->json(['success' => true]);
+            return $this->adminJson(['success' => true]);
         } else {
             throw new \Exception('Tag with ID ' . $request->get('id') . ' not found.');
         }
@@ -86,7 +86,7 @@ class TagsController extends AdminController
 
             $tag->save();
 
-            return $this->json(['success' => true]);
+            return $this->adminJson(['success' => true]);
         } else {
             throw new \Exception('Tag with ID ' . $request->get('id') . ' not found.');
         }
@@ -127,7 +127,7 @@ class TagsController extends AdminController
             $tags[] = $this->convertTagToArray($tag, $showSelection, $assignedTagIds, true);
         }
 
-        return $this->json($tags);
+        return $this->adminJson($tags);
     }
 
     /**
@@ -186,7 +186,7 @@ class TagsController extends AdminController
             }
         }
 
-        return $this->json($assignedTagArray);
+        return $this->adminJson($assignedTagArray);
     }
 
     /**
@@ -206,9 +206,9 @@ class TagsController extends AdminController
         if ($tag) {
             Tag::addTagToElement($assginmentCType, $assginmentCId, $tag);
 
-            return $this->json(['success' => true, 'id' => $tag->getId()]);
+            return $this->adminJson(['success' => true, 'id' => $tag->getId()]);
         } else {
-            return $this->json(['success' => false]);
+            return $this->adminJson(['success' => false]);
         }
     }
 
@@ -229,9 +229,9 @@ class TagsController extends AdminController
         if ($tag) {
             Tag::removeTagFromElement($assginmentCType, $assginmentCId, $tag);
 
-            return $this->json(['success' => true, 'id' => $tag->getId()]);
+            return $this->adminJson(['success' => true, 'id' => $tag->getId()]);
         } else {
-            return $this->json(['success' => false]);
+            return $this->adminJson(['success' => false]);
         }
     }
 
@@ -277,7 +277,7 @@ class TagsController extends AdminController
             $offset += $size;
         }
 
-        return $this->json(['success' => true, 'idLists' => $idListParts, 'totalCount' => count($idList)]);
+        return $this->adminJson(['success' => true, 'idLists' => $idListParts, 'totalCount' => count($idList)]);
     }
 
     /**
@@ -368,6 +368,6 @@ class TagsController extends AdminController
 
         Tag::batchAssignTagsToElement($cType, $elementIds, $assignedTags, $doCleanupTags);
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TranslationController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TranslationController.php
@@ -58,7 +58,7 @@ class TranslationController extends AdminController
         if ($admin) {
             $delta = Translation\Admin::importTranslationsFromFile($tmpFile, $overwrite, Tool\Admin::getLanguages());
         } else {
-            $delta = Translation\Website::importTranslationsFromFile($tmpFile, $overwrite, $this->getUser()->getAllowedLanguagesForEditingWebsiteTranslations());
+            $delta = Translation\Website::importTranslationsFromFile($tmpFile, $overwrite, $this->getAdminUser()->getAllowedLanguagesForEditingWebsiteTranslations());
         }
 
         $result =[
@@ -145,7 +145,7 @@ class TranslationController extends AdminController
                 $languages = Tool\Admin::getLanguages();
             } else {
                 $t = new Translation\Website();
-                $languages = $this->getUser()->getAllowedLanguagesForViewingWebsiteTranslations();
+                $languages = $this->getAdminUser()->getAllowedLanguagesForViewingWebsiteTranslations();
             }
 
             foreach ($languages as $language) {
@@ -168,7 +168,7 @@ class TranslationController extends AdminController
         if ($admin) {
             $languages = Tool\Admin::getLanguages();
         } else {
-            $languages = $this->getUser()->getAllowedLanguagesForViewingWebsiteTranslations();
+            $languages = $this->getAdminUser()->getAllowedLanguagesForViewingWebsiteTranslations();
         }
 
         //add language columns which have no translations yet
@@ -350,7 +350,7 @@ class TranslationController extends AdminController
                 $list = new Translation\Website\Listing();
             }
 
-            $validLanguages = $admin ? Tool\Admin::getLanguages() : $this->getUser()->getAllowedLanguagesForViewingWebsiteTranslations();
+            $validLanguages = $admin ? Tool\Admin::getLanguages() : $this->getAdminUser()->getAllowedLanguagesForViewingWebsiteTranslations();
 
             $list->setOrder('asc');
             $list->setOrderKey($tableName . '.key', false);
@@ -457,7 +457,7 @@ class TranslationController extends AdminController
     {
         $joins = [];
         $conditions = [];
-        $validLanguages = $this->getUser()->getAllowedLanguagesForViewingWebsiteTranslations();
+        $validLanguages = $this->getAdminUser()->getAllowedLanguagesForViewingWebsiteTranslations();
 
         $db = \Pimcore\Db::get();
         $conditionFilters = [];
@@ -1394,11 +1394,11 @@ class TranslationController extends AdminController
     public function getWebsiteTranslationLanguagesAction(Request $request)
     {
         return $this->json([
-            'view' => $this->getUser()->getAllowedLanguagesForViewingWebsiteTranslations(),
+            'view' => $this->getAdminUser()->getAllowedLanguagesForViewingWebsiteTranslations(),
 
             //when no view language is defined, all languages are editable. if one view language is defined, it
             //may be possible that no edit language is set intentionally
-            'edit' => $this->getUser()->getAllowedLanguagesForEditingWebsiteTranslations()
+            'edit' => $this->getAdminUser()->getAllowedLanguagesForEditingWebsiteTranslations()
         ]);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TranslationController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/TranslationController.php
@@ -79,7 +79,7 @@ class TranslationController extends AdminController
             $result['delta'] = base64_encode(json_encode($enrichedDelta));
         }
 
-        $response = $this->json($result);
+        $response = $this->adminJson($result);
         // set content-type to text/html, otherwise (when application/json is sent) chrome will complain in
         // Ext.form.Action.Submit and mark the submission as failed
         $response->headers->set('Content-Type', 'text/html');
@@ -259,7 +259,7 @@ class TranslationController extends AdminController
             }
         }
 
-        return $this->json(null);
+        return $this->adminJson(null);
     }
 
     /**
@@ -294,7 +294,7 @@ class TranslationController extends AdminController
                 $t = $class::getByKey($data['key']);
                 $t->delete();
 
-                return $this->json(['success' => true, 'data' => []]);
+                return $this->adminJson(['success' => true, 'data' => []]);
             } elseif ($request->get('xaction') == 'update') {
                 $t = $class::getByKey($data['key']);
 
@@ -317,7 +317,7 @@ class TranslationController extends AdminController
                     $t->getTranslations()
                 );
 
-                return $this->json(['data' => $return, 'success' => true]);
+                return $this->adminJson(['data' => $return, 'success' => true]);
             } elseif ($request->get('xaction') == 'create') {
                 try {
                     $t = $class::getByKey($data['key']);
@@ -340,7 +340,7 @@ class TranslationController extends AdminController
                     'modificationDate' => $t->getModificationDate(),
                 ], $t->getTranslations());
 
-                return $this->json(['data' => $return, 'success' => true]);
+                return $this->adminJson(['data' => $return, 'success' => true]);
             }
         } else {
             // get list of types
@@ -397,7 +397,7 @@ class TranslationController extends AdminController
                     'modificationDate' => $t->getModificationDate()]);
             }
 
-            return $this->json(['data' => $translations, 'success' => true, 'total' => $list->getTotalCount()]);
+            return $this->adminJson(['data' => $translations, 'success' => true, 'total' => $list->getTotalCount()]);
         }
     }
 
@@ -555,10 +555,10 @@ class TranslationController extends AdminController
 
             \Pimcore\Cache::clearTags(['translator', 'translate']);
 
-            return $this->json(['success' => true]);
+            return $this->adminJson(['success' => true]);
         }
 
-        return $this->json(['success' => false]);
+        return $this->adminJson(['success' => false]);
     }
 
     /**
@@ -644,7 +644,7 @@ class TranslationController extends AdminController
             ]];
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true,
             'jobs' => $jobs,
             'id' => $exportId
@@ -804,7 +804,7 @@ class TranslationController extends AdminController
 
         $xliff->asXML($exportFile);
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true
         ]);
     }
@@ -856,7 +856,7 @@ class TranslationController extends AdminController
             ]];
         }
 
-        $response = $this->json([
+        $response = $this->adminJson([
             'success' => true,
             'jobs' => $jobs,
             'id' => $id
@@ -895,7 +895,7 @@ class TranslationController extends AdminController
         if (!Tool::isValidLanguage($target)) {
             $target = \Locale::getPrimaryLanguage($target);
             if (!Tool::isValidLanguage($target)) {
-                return $this->json([
+                return $this->adminJson([
                     'success' => false
                 ]);
             }
@@ -964,7 +964,7 @@ class TranslationController extends AdminController
             Logger::error('Could not resolve element ' . $file['original']);
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true
         ]);
     }
@@ -1291,7 +1291,7 @@ class TranslationController extends AdminController
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true
         ]);
     }
@@ -1379,7 +1379,7 @@ class TranslationController extends AdminController
             $t->save();
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true
         ]);
     }
@@ -1393,7 +1393,7 @@ class TranslationController extends AdminController
      */
     public function getWebsiteTranslationLanguagesAction(Request $request)
     {
-        return $this->json([
+        return $this->adminJson([
             'view' => $this->getAdminUser()->getAllowedLanguagesForViewingWebsiteTranslations(),
 
             //when no view language is defined, all languages are editable. if one view language is defined, it

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/UserController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/UserController.php
@@ -56,7 +56,7 @@ class UserController extends AdminController implements EventedControllerInterfa
             }
         }
 
-        return $this->json($users);
+        return $this->adminJson($users);
     }
 
     /**
@@ -177,12 +177,12 @@ class UserController extends AdminController implements EventedControllerInterfa
                 }
             }
 
-            return $this->json([
+            return $this->adminJson([
                 'success' => true,
                 'id' => $user->getId()
             ]);
         } catch (\Exception $e) {
-            return $this->json(['success' => false, 'message' => $e->getMessage()]);
+            return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
         }
     }
 
@@ -276,7 +276,7 @@ class UserController extends AdminController implements EventedControllerInterfa
             }
         }
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -361,7 +361,7 @@ class UserController extends AdminController implements EventedControllerInterfa
 
         $user->save();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -376,7 +376,7 @@ class UserController extends AdminController implements EventedControllerInterfa
     public function getAction(Request $request)
     {
         if (intval($request->get('id')) < 1) {
-            return $this->json(['success' => false]);
+            return $this->adminJson(['success' => false]);
         }
 
         $user = User::getById(intval($request->get('id')));
@@ -441,7 +441,7 @@ class UserController extends AdminController implements EventedControllerInterfa
 
         $conf = \Pimcore\Config::getSystemConfig();
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true,
             'wsenabled' => $conf->webservice->enabled,
             'user' => $userData,
@@ -476,7 +476,7 @@ class UserController extends AdminController implements EventedControllerInterfa
         $minimalUserData['permissionInfo']['documents'] = $user->isAllowed('documents');
         $minimalUserData['permissionInfo']['objects'] = $user->isAllowed('objects');
 
-        return $this->json($minimalUserData);
+        return $this->adminJson($minimalUserData);
     }
 
     /**
@@ -495,10 +495,10 @@ class UserController extends AdminController implements EventedControllerInterfa
             } else {
                 Logger::warn('prevented save current user, because ids do not match. ');
 
-                return $this->json(false);
+                return $this->adminJson(false);
             }
         } else {
-            return $this->json(false);
+            return $this->adminJson(false);
         }
     }
 
@@ -548,21 +548,21 @@ class UserController extends AdminController implements EventedControllerInterfa
                     if ($oldPasswordCheck && $values['new_password'] == $values['retype_password']) {
                         $values['password'] = Tool\Authentication::getPasswordHash($user->getName(), $values['new_password']);
                     } else {
-                        return $this->json(['success' => false, 'message' => 'password_cannot_be_changed']);
+                        return $this->adminJson(['success' => false, 'message' => 'password_cannot_be_changed']);
                     }
                 }
 
                 $user->setValues($values);
                 $user->save();
 
-                return $this->json(['success' => true]);
+                return $this->adminJson(['success' => true]);
             } else {
                 Logger::warn('prevented save current user, because ids do not match. ');
 
-                return $this->json(false);
+                return $this->adminJson(false);
             }
         } else {
-            return $this->json(false);
+            return $this->adminJson(false);
         }
     }
 
@@ -618,7 +618,7 @@ class UserController extends AdminController implements EventedControllerInterfa
             }
         }
 
-        return $this->json($roles);
+        return $this->adminJson($roles);
     }
 
     /**
@@ -688,7 +688,7 @@ class UserController extends AdminController implements EventedControllerInterfa
 
         $availablePerspectives = \Pimcore\Config::getAvailablePerspectives(null);
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true,
             'role' => $role,
             'permissions' => $role->generatePermissionList(),
@@ -731,7 +731,7 @@ class UserController extends AdminController implements EventedControllerInterfa
         // set content-type to text/html, otherwise (when application/json is sent) chrome will complain in
         // Ext.form.Action.Submit and mark the submission as failed
 
-        $response = $this->json(['success' => true]);
+        $response = $this->adminJson(['success' => true]);
         $response->headers->set('Content-Type', 'text/html');
 
         return $response;
@@ -787,7 +787,7 @@ class UserController extends AdminController implements EventedControllerInterfa
 
             $link = $request->getScheme() . '://' . $request->getHttpHost() . '/admin/login/login?username=' . $user->getName() . '&token=' . $token;
 
-            return $this->json([
+            return $this->adminJson([
                 'link' => $link
             ]);
         }
@@ -825,7 +825,7 @@ class UserController extends AdminController implements EventedControllerInterfa
             }
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true,
             'users' => $users
         ]);
@@ -880,7 +880,7 @@ class UserController extends AdminController implements EventedControllerInterfa
             ];
         }
 
-        return $this->json(['success' => true, 'total' => count($users), 'data' => $users]);
+        return $this->adminJson(['success' => true, 'total' => count($users), 'data' => $users]);
     }
 
     /**
@@ -903,6 +903,6 @@ class UserController extends AdminController implements EventedControllerInterfa
             ];
         }
 
-        return $this->json(['success' => true, 'total' => count($roles), 'data' => $roles]);
+        return $this->adminJson(['success' => true, 'total' => count($roles), 'data' => $roles]);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/UserController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/UserController.php
@@ -162,7 +162,7 @@ class UserController extends AdminController implements EventedControllerInterfa
 
                         if ($type == 'user') {
                             $user->setAdmin(false);
-                            if ($this->getUser()->isAdmin()) {
+                            if ($this->getAdminUser()->isAdmin()) {
                                 $user->setAdmin($rObject->getAdmin());
                             }
                             $user->setActive($rObject->getActive());
@@ -236,7 +236,7 @@ class UserController extends AdminController implements EventedControllerInterfa
 
         // only admins are allowed to delete admins and folders
         // because a folder might contain an admin user, so it is simply not allowed for users with the "users" permission
-        if (($user instanceof User\Folder && !$this->getUser()->isAdmin()) || ($user instanceof User && $user->isAdmin() && !$this->getUser()->isAdmin())) {
+        if (($user instanceof User\Folder && !$this->getAdminUser()->isAdmin()) || ($user instanceof User && $user->isAdmin() && !$this->getAdminUser()->isAdmin())) {
             throw new \Exception('You are not allowed to delete this user');
         } else {
             if ($user instanceof User\Role\Folder) {
@@ -294,7 +294,7 @@ class UserController extends AdminController implements EventedControllerInterfa
 
         $user = User\AbstractUser::getById(intval($request->get('id')));
 
-        if ($user instanceof User && $user->isAdmin() && !$this->getUser()->isAdmin()) {
+        if ($user instanceof User && $user->isAdmin() && !$this->getAdminUser()->isAdmin()) {
             throw new \Exception('Only admin users are allowed to modify admin users');
         }
 
@@ -319,7 +319,7 @@ class UserController extends AdminController implements EventedControllerInterfa
 
             // only admins are allowed to create admin users
             // if the logged in user isn't an admin, set admin always to false
-            if (!$this->getUser()->isAdmin() && $user instanceof User) {
+            if (!$this->getAdminUser()->isAdmin() && $user instanceof User) {
                 if ($user instanceof User) {
                     $user->setAdmin(false);
                 }
@@ -381,7 +381,7 @@ class UserController extends AdminController implements EventedControllerInterfa
 
         $user = User::getById(intval($request->get('id')));
 
-        if ($user->isAdmin() && !$this->getUser()->isAdmin()) {
+        if ($user->isAdmin() && !$this->getAdminUser()->isAdmin()) {
             throw new \Exception('Only admin users are allowed to modify admin users');
         }
 
@@ -488,7 +488,7 @@ class UserController extends AdminController implements EventedControllerInterfa
      */
     public function uploadCurrentUserImageAction(Request $request)
     {
-        $user = $this->getUser();
+        $user = $this->getAdminUser();
         if ($user != null) {
             if ($user->getId() == $request->get('id')) {
                 $this->uploadImageAction();
@@ -513,7 +513,7 @@ class UserController extends AdminController implements EventedControllerInterfa
     {
         $this->protectCsrf($request);
 
-        $user = $this->getUser();
+        $user = $this->getAdminUser();
         if ($user != null) {
             if ($user->getId() == $request->get('id')) {
                 $values = $this->decodeJson($request->get('data'), true);
@@ -575,7 +575,7 @@ class UserController extends AdminController implements EventedControllerInterfa
      */
     public function getCurrentUserAction(Request $request)
     {
-        $user = $this->getUser();
+        $user = $this->getAdminUser();
 
         $list = new User\Permission\Definition\Listing();
         $definitions = $list->load();
@@ -712,17 +712,17 @@ class UserController extends AdminController implements EventedControllerInterfa
     public function uploadImageAction(Request $request)
     {
         if ($request->get('id')) {
-            if ($this->getUser()->getId() != $request->get('id')) {
+            if ($this->getAdminUser()->getId() != $request->get('id')) {
                 $this->checkPermission('users');
             }
             $id = $request->get('id');
         } else {
-            $id = $this->getUser()->getId();
+            $id = $this->getAdminUser()->getId();
         }
 
         $userObj = User::getById($id);
 
-        if ($userObj->isAdmin() && !$this->getUser()->isAdmin()) {
+        if ($userObj->isAdmin() && !$this->getAdminUser()->isAdmin()) {
             throw new \Exception('Only admin users are allowed to modify admin users');
         }
 
@@ -747,12 +747,12 @@ class UserController extends AdminController implements EventedControllerInterfa
     public function getImageAction(Request $request)
     {
         if ($request->get('id')) {
-            if ($this->getUser()->getId() != $request->get('id')) {
+            if ($this->getAdminUser()->getId() != $request->get('id')) {
                 $this->checkPermission('users');
             }
             $id = $request->get('id');
         } else {
-            $id = $this->getUser()->getId();
+            $id = $this->getAdminUser()->getId();
         }
 
         /** @var User $userObj */
@@ -778,7 +778,7 @@ class UserController extends AdminController implements EventedControllerInterfa
     {
         $user = User::getById($request->get('id'));
 
-        if ($user->isAdmin() && !$this->getUser()->isAdmin()) {
+        if ($user->isAdmin() && !$this->getAdminUser()->isAdmin()) {
             throw new \Exception('Only admin users are allowed to login as an admin user');
         }
 
@@ -868,7 +868,7 @@ class UserController extends AdminController implements EventedControllerInterfa
 
         // get available user
         $list = new \Pimcore\Model\User\Listing();
-        $list->setCondition('type = "user" and id != ' . $this->getUser()->getId());
+        $list->setCondition('type = "user" and id != ' . $this->getAdminUser()->getId());
 
         $list->load();
         $userList = $list->getUsers();

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/VariantsController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/VariantsController.php
@@ -43,12 +43,12 @@ class VariantsController extends AdminController
                 $object->setKey($key);
                 $object->save();
 
-                return $this->json(['success' => true]);
+                return $this->adminJson(['success' => true]);
             } else {
                 throw new \Exception('No Object found for given id.');
             }
         } catch (\Exception $e) {
-            return $this->json(['success' => false, 'message' => $e->getMessage()]);
+            return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
         }
     }
 
@@ -107,9 +107,9 @@ class VariantsController extends AdminController
                 try {
                     $object->save();
 
-                    return $this->json(['data' => DataObject\Service::gridObjectData($object, $request->get('fields')), 'success' => true]);
+                    return $this->adminJson(['data' => DataObject\Service::gridObjectData($object, $request->get('fields')), 'success' => true]);
                 } catch (\Exception $e) {
-                    return $this->json(['success' => false, 'message' => $e->getMessage()]);
+                    return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
                 }
             } else {
                 throw new \Exception('Permission denied');
@@ -211,7 +211,7 @@ class VariantsController extends AdminController
                     }
                 }
 
-                return $this->json(['data' => $objects, 'success' => true, 'total' => $list->getTotalCount()]);
+                return $this->adminJson(['data' => $objects, 'success' => true, 'total' => $list->getTotalCount()]);
             } else {
                 throw new \Exception('Permission denied');
             }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/WorkflowController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/WorkflowController.php
@@ -187,7 +187,7 @@ class WorkflowController extends AdminController implements EventedControllerInt
     protected function getWorkflowManager()
     {
         if (!$this->manager) {
-            $this->manager = Workflow\Manager\Factory::getManager($this->element, $this->getUser());
+            $this->manager = Workflow\Manager\Factory::getManager($this->element, $this->getAdminUser());
         }
 
         return $this->manager;
@@ -271,7 +271,7 @@ class WorkflowController extends AdminController implements EventedControllerInt
 
         //get the latest available version of the element -
         $this->element = $this->getLatestVersion($this->element);
-        $this->element->setUserModification($this->getUser()->getId());
+        $this->element->setUserModification($this->getAdminUser()->getId());
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/WorkflowController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/WorkflowController.php
@@ -137,7 +137,7 @@ class WorkflowController extends AdminController implements EventedControllerInt
             $wfConfig['message'] = $e->getMessage();
         }
 
-        return $this->json($wfConfig);
+        return $this->adminJson($wfConfig);
     }
 
     /**
@@ -176,7 +176,7 @@ class WorkflowController extends AdminController implements EventedControllerInt
             ];
         }
 
-        return $this->json($data);
+        return $this->adminJson($data);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/AdminController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/AdminController.php
@@ -172,7 +172,7 @@ abstract class AdminController extends Controller implements AdminControllerInte
      *
      * @return JsonResponse
      */
-    protected function json($data, $status = 200, $headers = [], $context = [], bool $useAdminSerializer = true)
+    protected function adminJson($data, $status = 200, $headers = [], $context = [], bool $useAdminSerializer = true)
     {
         $json = $this->encodeJson($data, $context, JsonResponse::DEFAULT_ENCODING_OPTIONS, $useAdminSerializer);
 

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/AdminController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/AdminController.php
@@ -53,7 +53,7 @@ abstract class AdminController extends Controller implements AdminControllerInte
      *
      * @return UserProxy|User
      */
-    protected function getUser($proxyUser = false)
+    protected function getAdminUser($proxyUser = false)
     {
         $resolver = $this->get(TokenStorageUserResolver::class);
 
@@ -73,11 +73,11 @@ abstract class AdminController extends Controller implements AdminControllerInte
      */
     protected function checkPermission($permission)
     {
-        if (!$this->getUser() || !$this->getUser()->isAllowed($permission)) {
+        if (!$this->getAdminUser() || !$this->getAdminUser()->isAllowed($permission)) {
             $this->get('monolog.logger.security')->error(
                 'User {user} attempted to access {permission}, but has no permission to do so',
                 [
-                    'user'       => $this->getUser()->getName(),
+                    'user'       => $this->getAdminUser()->getName(),
                     'permission' => $permission
                 ]
             );

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
@@ -94,7 +94,7 @@ class ExtensionManagerController extends AdminController implements EventedContr
             $extensions = array_merge($extensions, $legacyController->getExtensions());
         }
 
-        return $this->json(['extensions' => $extensions]);
+        return $this->adminJson(['extensions' => $extensions]);
     }
 
     /**
@@ -142,7 +142,7 @@ class ExtensionManagerController extends AdminController implements EventedContr
 
         $this->bundleManager->setStates($updates);
 
-        return $this->json([
+        return $this->adminJson([
             'extensions' => $this->getBundleList(array_keys($updates))
         ]);
     }
@@ -189,7 +189,7 @@ class ExtensionManagerController extends AdminController implements EventedContr
             $data['message'] = $message;
         }
 
-        return $this->json($data);
+        return $this->adminJson($data);
     }
 
     /**
@@ -271,14 +271,14 @@ class ExtensionManagerController extends AdminController implements EventedContr
                 $data['message'] = $message;
             }
 
-            return $this->json($data);
+            return $this->adminJson($data);
         } catch (BundleNotFoundException $e) {
-            return $this->json([
+            return $this->adminJson([
                 'success' => false,
                 'message' => $e->getMessage()
             ], 404);
         } catch (\Exception $e) {
-            return $this->json([
+            return $this->adminJson([
                 'success' => false,
                 'message' => $e->getMessage()
             ], 400);
@@ -349,14 +349,14 @@ class ExtensionManagerController extends AdminController implements EventedContr
                 $data['message'] = $message;
             }
 
-            return $this->json($data);
+            return $this->adminJson($data);
         } catch (BundleNotFoundException $e) {
-            return $this->json([
+            return $this->adminJson([
                 'success' => false,
                 'message' => $e->getMessage()
             ], 404);
         } catch (\Exception $e) {
-            return $this->json([
+            return $this->adminJson([
                 'success' => false,
                 'message' => $e->getMessage()
             ], 400);

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/GDPR/AdminController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/GDPR/AdminController.php
@@ -36,7 +36,7 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
             ];
         }
 
-        return $this->json($response);
+        return $this->adminJson($response);
     }
 
     public function onKernelController(FilterControllerEvent $event)

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/GDPR/DataObjectController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/GDPR/DataObjectController.php
@@ -60,7 +60,7 @@ class DataObjectController extends \Pimcore\Bundle\AdminBundle\Controller\AdminC
             $allParams['sort']
         );
 
-        return $this->json($result);
+        return $this->adminJson($result);
     }
 
     /**
@@ -71,7 +71,7 @@ class DataObjectController extends \Pimcore\Bundle\AdminBundle\Controller\AdminC
     {
         $object = AbstractObject::getById($request->get('id'));
         $exportResult = $service->doExportData($object);
-        $jsonResponse = $this->json($exportResult);
+        $jsonResponse = $this->adminJson($exportResult);
         $jsonResponse->headers->set('Content-Disposition', 'attachment; filename="export-data-object-' . $object->getId() . '.json"');
 
         return $jsonResponse;

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/GDPR/PimcoreUsersController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/GDPR/PimcoreUsersController.php
@@ -60,7 +60,7 @@ class PimcoreUsersController extends \Pimcore\Bundle\AdminBundle\Controller\Admi
             $allParams['sort']
         );
 
-        return $this->json($result);
+        return $this->adminJson($result);
     }
 
     /**
@@ -74,7 +74,7 @@ class PimcoreUsersController extends \Pimcore\Bundle\AdminBundle\Controller\Admi
     {
         $userData = $pimcoreUsers->getExportData(intval($request->get('id')));
 
-        $jsonResponse = $this->json($userData);
+        $jsonResponse = $this->adminJson($userData);
         $jsonResponse->headers->set('Content-Disposition', 'attachment; filename="export-userdata-' . $userData['id'] . '.json"');
 
         return $jsonResponse;

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/GDPR/SentMailController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/GDPR/SentMailController.php
@@ -53,7 +53,7 @@ class SentMailController extends \Pimcore\Bundle\AdminBundle\Controller\AdminCon
         $sentMailArray['htmlBody'] = $sentMail->getHtmlLog();
         $sentMailArray['textBody'] = $sentMail->getTextLog();
 
-        $jsonResponse = $this->json($sentMailArray);
+        $jsonResponse = $this->adminJson($sentMailArray);
         $jsonResponse->headers->set('Content-Disposition', 'attachment; filename="export-mail-' . $sentMail->getId() . '.json"');
 
         return $jsonResponse;

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/AnalyticsController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/AnalyticsController.php
@@ -89,9 +89,9 @@ class AnalyticsController extends ReportsControllerBase implements EventedContro
                 }
             }
 
-            return $this->json($data);
+            return $this->adminJson($data);
         } catch (\Exception $e) {
-            return $this->json(false);
+            return $this->adminJson(false);
         }
     }
 
@@ -217,7 +217,7 @@ class AnalyticsController extends ReportsControllerBase implements EventedContro
             $data[] = $tmpData;
         }
 
-        return $this->json(['data' => $data]);
+        return $this->adminJson(['data' => $data]);
     }
 
     /**
@@ -290,7 +290,7 @@ class AnalyticsController extends ReportsControllerBase implements EventedContro
 
         ksort($outputData);
 
-        return $this->json(['data' => $outputData]);
+        return $this->adminJson(['data' => $outputData]);
     }
 
     /**
@@ -342,7 +342,7 @@ class AnalyticsController extends ReportsControllerBase implements EventedContro
             ];
         }
 
-        return $this->json(['data' => $data]);
+        return $this->adminJson(['data' => $data]);
     }
 
     /**
@@ -411,7 +411,7 @@ class AnalyticsController extends ReportsControllerBase implements EventedContro
             ];
         }
 
-        return $this->json(['data' => $data]);
+        return $this->adminJson(['data' => $data]);
     }
 
     /**
@@ -423,7 +423,7 @@ class AnalyticsController extends ReportsControllerBase implements EventedContro
      */
     public function getDimensionsAction(Request $request)
     {
-        return $this->json(['data' => Google\Api::getAnalyticsDimensions()]);
+        return $this->adminJson(['data' => Google\Api::getAnalyticsDimensions()]);
     }
 
     /**
@@ -435,7 +435,7 @@ class AnalyticsController extends ReportsControllerBase implements EventedContro
      */
     public function getMetricsAction(Request $request)
     {
-        return $this->json(['data' => Google\Api::getAnalyticsMetrics()]);
+        return $this->adminJson(['data' => Google\Api::getAnalyticsMetrics()]);
     }
 
     /**
@@ -458,7 +458,7 @@ class AnalyticsController extends ReportsControllerBase implements EventedContro
             ];
         }
 
-        return $this->json(['data' => $data]);
+        return $this->adminJson(['data' => $data]);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/CustomReportController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/CustomReportController.php
@@ -41,9 +41,9 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
         $reports = CustomReport\Config::getReportsList();
 
         if ($request->get('portlet')) {
-            return $this->json(['data' => $reports]);
+            return $this->adminJson(['data' => $reports]);
         } else {
-            return $this->json($reports);
+            return $this->adminJson($reports);
         }
     }
 
@@ -68,7 +68,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
             $success = true;
         }
 
-        return $this->json(['success' => $success, 'id' => $report->getName()]);
+        return $this->adminJson(['success' => $success, 'id' => $report->getName()]);
     }
 
     /**
@@ -83,7 +83,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
         $report = CustomReport\Config::getByName($request->get('name'));
         $report->delete();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -117,7 +117,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
 
         $report->save();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -131,7 +131,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
     {
         $report = CustomReport\Config::getByName($request->get('name'));
 
-        return $this->json($report);
+        return $this->adminJson($report);
     }
 
     /**
@@ -159,7 +159,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
 
         $report->save();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -209,7 +209,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
             $errorMessage = $e->getMessage();
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => $success,
             'columns' => $result,
             'errorMessage' => $errorMessage
@@ -243,7 +243,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
             ];
         }
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true,
             'reports' => $reports
         ]);
@@ -277,7 +277,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
 
         $result = $adapter->getData($filters, $sort, $dir, $offset, $limit, null, $drillDownFilters, $config);
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true,
             'data' => $result['data'],
             'total' => $result['total']
@@ -303,7 +303,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
         $adapter = CustomReport\Config::getAdapter($configuration, $config);
         $result = $adapter->getAvailableOptions($filters, $field, $drillDownFilters);
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true,
             'data' => $result['data'],
         ]);
@@ -330,7 +330,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
         $adapter = CustomReport\Config::getAdapter($configuration, $config);
         $result = $adapter->getData($filters, $sort, $dir, null, null, null, $drillDownFilters);
 
-        return $this->json([
+        return $this->adminJson([
             'success' => true,
             'data' => $result['data'],
             'total' => $result['total']

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/PiwikController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/PiwikController.php
@@ -191,7 +191,7 @@ class PiwikController extends ReportsControllerBase
         $siteConfig = $siteConfigProvider->getSiteId($configKey);
         $siteId     = $sitesManager->addSite($siteConfig);
 
-        return $this->json([
+        return $this->adminJson([
             'site_id' => $siteId
         ]);
     }
@@ -216,7 +216,7 @@ class PiwikController extends ReportsControllerBase
         $siteConfig = $siteConfigProvider->getSiteId($configKey);
         $siteId     = $sitesManager->updateSite($siteConfig);
 
-        return $this->json([
+        return $this->adminJson([
             'site_id' => $siteId
         ]);
     }
@@ -234,6 +234,6 @@ class PiwikController extends ReportsControllerBase
      */
     private function jsonResponse($data, int $status = JsonResponse::HTTP_OK, array $headers = [], array $context = []): JsonResponse
     {
-        return $this->json($data, $status, $headers, $context, false);
+        return $this->adminJson($data, $status, $headers, $context, false);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/QrcodeController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/QrcodeController.php
@@ -50,7 +50,7 @@ class QrcodeController extends ReportsControllerBase implements EventedControlle
             ];
         }
 
-        return $this->json($codes);
+        return $this->adminJson($codes);
     }
 
     /**
@@ -74,7 +74,7 @@ class QrcodeController extends ReportsControllerBase implements EventedControlle
             $success = true;
         }
 
-        return $this->json(['success' => $success, 'id' => $code->getName()]);
+        return $this->adminJson(['success' => $success, 'id' => $code->getName()]);
     }
 
     /**
@@ -89,7 +89,7 @@ class QrcodeController extends ReportsControllerBase implements EventedControlle
         $code = Qrcode\Config::getByName($request->get('name'));
         $code->delete();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**
@@ -103,7 +103,7 @@ class QrcodeController extends ReportsControllerBase implements EventedControlle
     {
         $code = Qrcode\Config::getByName($request->get('name'));
 
-        return $this->json($code);
+        return $this->adminJson($code);
     }
 
     /**
@@ -127,7 +127,7 @@ class QrcodeController extends ReportsControllerBase implements EventedControlle
 
         $code->save();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/SettingsController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/SettingsController.php
@@ -48,7 +48,7 @@ class SettingsController extends ReportsControllerBase
             'config' => []
         ];
 
-        return $this->json($response);
+        return $this->adminJson($response);
     }
 
     /**
@@ -81,6 +81,6 @@ class SettingsController extends ReportsControllerBase
 
         $configWriter->write($values);
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/SettingsController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/SettingsController.php
@@ -39,7 +39,7 @@ class SettingsController extends ReportsControllerBase
         // special piwik handling - as the piwik settings tab is on the same page as the other settings
         // we need to check here if we want to include the piwik config in the response
         $config = $this->getConfig()->toArray();
-        if (!$this->getUser()->isAllowed('piwik_settings') && isset($config['piwik'])) {
+        if (!$this->getAdminUser()->isAllowed('piwik_settings') && isset($config['piwik'])) {
             unset($config['piwik']);
         }
 
@@ -71,7 +71,7 @@ class SettingsController extends ReportsControllerBase
         // special piwik handling - if the user is not allowed to save piwik settings
         // force override the settings to write with the current config and ignore the
         // submitted values
-        if (!$this->getUser()->isAllowed('piwik_settings')) {
+        if (!$this->getAdminUser()->isAllowed('piwik_settings')) {
             $currentConfig = Config::getReportConfig()->toArray();
             $piwikConfig   = $currentConfig['piwik'] ?? [];
 

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/TargetingController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Reports/TargetingController.php
@@ -51,7 +51,7 @@ class TargetingController extends AdminController implements EventedControllerIn
             ];
         }
 
-        return $this->json($targets);
+        return $this->adminJson($targets);
     }
 
     /**
@@ -67,7 +67,7 @@ class TargetingController extends AdminController implements EventedControllerIn
         $target->setName($request->get('name'));
         $target->save();
 
-        return $this->json(['success' => true, 'id' => $target->getId()]);
+        return $this->adminJson(['success' => true, 'id' => $target->getId()]);
     }
 
     /**
@@ -87,7 +87,7 @@ class TargetingController extends AdminController implements EventedControllerIn
             $success = true;
         }
 
-        return $this->json(['success' => $success]);
+        return $this->adminJson(['success' => $success]);
     }
 
     /**
@@ -108,7 +108,7 @@ class TargetingController extends AdminController implements EventedControllerIn
             }
         }
 
-        return $this->json($target);
+        return $this->adminJson($target);
     }
 
     /**
@@ -145,7 +145,7 @@ class TargetingController extends AdminController implements EventedControllerIn
 
         $target->save();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /* PERSONAS */
@@ -178,7 +178,7 @@ class TargetingController extends AdminController implements EventedControllerIn
             ];
         }
 
-        return $this->json($personas);
+        return $this->adminJson($personas);
     }
 
     /**
@@ -194,7 +194,7 @@ class TargetingController extends AdminController implements EventedControllerIn
         $persona->setName($request->get('name'));
         $persona->save();
 
-        return $this->json(['success' => true, 'id' => $persona->getId()]);
+        return $this->adminJson(['success' => true, 'id' => $persona->getId()]);
     }
 
     /**
@@ -214,7 +214,7 @@ class TargetingController extends AdminController implements EventedControllerIn
             $success = true;
         }
 
-        return $this->json(['success' => $success]);
+        return $this->adminJson(['success' => $success]);
     }
 
     /**
@@ -228,7 +228,7 @@ class TargetingController extends AdminController implements EventedControllerIn
     {
         $persona = Targeting\Persona::getById($request->get('id'));
 
-        return $this->json($persona);
+        return $this->adminJson($persona);
     }
 
     /**
@@ -248,7 +248,7 @@ class TargetingController extends AdminController implements EventedControllerIn
         $persona->setConditions($data['conditions']);
         $persona->save();
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/AbstractRestController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/AbstractRestController.php
@@ -153,7 +153,7 @@ abstract class AbstractRestController extends AdminController
     /**
      * @inheritDoc
      */
-    protected function createNotFoundException($message = null, \Exception $previous = null)
+    protected function createNotFoundResponseException($message = null, \Exception $previous = null)
     {
         return new ResponseException($this->createErrorResponse(
             $message ?: Response::$statusTexts[Response::HTTP_NOT_FOUND],

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/AbstractRestController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/AbstractRestController.php
@@ -116,7 +116,7 @@ abstract class AbstractRestController extends AdminController
      */
     protected function createSuccessResponse($data = null, $wrapInDataProperty = true, $status = Response::HTTP_OK)
     {
-        return $this->json(
+        return $this->adminJson(
             $this->createSuccessData($data, $wrapInDataProperty),
             $status
         );
@@ -144,7 +144,7 @@ abstract class AbstractRestController extends AdminController
      */
     protected function createErrorResponse($data = null, $status = Response::HTTP_BAD_REQUEST)
     {
-        return $this->json(
+        return $this->adminJson(
             $this->createErrorData($data),
             $status
         );

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/ClassController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/ClassController.php
@@ -52,7 +52,7 @@ class ClassController extends AbstractRestController
             $this->getLogger()->error($e);
         }
 
-        throw $this->createNotFoundException(sprintf('Class %d does not exist', $id), $e);
+        throw $this->createNotFoundResponseException(sprintf('Class %d does not exist', $id), $e);
     }
 
     /**
@@ -111,7 +111,7 @@ class ClassController extends AbstractRestController
             $this->getLogger()->error($e);
         }
 
-        throw $this->createNotFoundException($e ? $e->getMessage() : null, $e);
+        throw $this->createNotFoundResponseException($e ? $e->getMessage() : null, $e);
     }
 
     /**
@@ -171,7 +171,7 @@ class ClassController extends AbstractRestController
             $this->getLogger()->error($e);
         }
 
-        throw $this->createNotFoundException($e ? $e->getMessage() : null, $e);
+        throw $this->createNotFoundResponseException($e ? $e->getMessage() : null, $e);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/Element/AbstractElementController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/Element/AbstractElementController.php
@@ -117,7 +117,7 @@ abstract class AbstractElementController extends AbstractRestController
             $this->get('monolog.logger.security')->error(
                 'User {user} attempted to access {permission} on {elementType} {elementId}, but has no permission to do so',
                 [
-                    'user'        => $this->getUser()->getName(),
+                    'user'        => $this->getAdminUser()->getName(),
                     'permission'  => $permission,
                     'elementType' => $element->getType(),
                     'elementId'   => $element->getId(),

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/Element/AssetController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/Element/AssetController.php
@@ -299,7 +299,7 @@ class AssetController extends AbstractElementController
             return $asset;
         }
 
-        throw $this->createNotFoundException([
+        throw $this->createNotFoundResponseException([
             'msg'  => sprintf('Asset %d does not exist', (int)$id),
             'code' => static::ELEMENT_DOES_NOT_EXIST
         ]);

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/Element/DataObjectController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/Element/DataObjectController.php
@@ -441,7 +441,7 @@ class DataObjectController extends AbstractElementController
 
         $class = $this->service->getObjectMetadataById($id);
         if (!$class) {
-            throw $this->createNotFoundException();
+            throw $this->createNotFoundResponseException();
         }
 
         return $this->createSuccessResponse($class);
@@ -543,7 +543,7 @@ class DataObjectController extends AbstractElementController
             return $object;
         }
 
-        throw $this->createNotFoundException([
+        throw $this->createNotFoundResponseException([
             'msg'  => sprintf('Object %d does not exist', (int)$id),
             'code' => static::ELEMENT_DOES_NOT_EXIST
         ]);

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/Element/DataObjectController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/Element/DataObjectController.php
@@ -142,7 +142,7 @@ class DataObjectController extends AbstractElementController
             $data['profiling'] = $this->getProfilingData($profileName);
         }
 
-        return $this->json($data);
+        return $this->adminJson($data);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/Element/DocumentController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/Element/DocumentController.php
@@ -350,7 +350,7 @@ class DocumentController extends AbstractElementController
             return $document;
         }
 
-        throw $this->createNotFoundException([
+        throw $this->createNotFoundResponseException([
             'msg'  => sprintf('Document %d does not exist', (int)$id),
             'code' => static::ELEMENT_DOES_NOT_EXIST
         ]);

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/ImageController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/ImageController.php
@@ -43,7 +43,7 @@ class ImageController extends AbstractRestController
 
         $config = Config::getByName($id);
         if (!$config instanceof Config) {
-            throw $this->createNotFoundException(sprintf('Thumbnail "%s" doesn\'t exist', htmlentities($id)));
+            throw $this->createNotFoundResponseException(sprintf('Thumbnail "%s" doesn\'t exist', htmlentities($id)));
         }
 
         $data = $config->getForWebserviceExport();

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/InfoController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/InfoController.php
@@ -44,7 +44,7 @@ class InfoController extends AbstractRestController
     {
         // serialize user to JSON and de-serialize to drop sensitive properties
         // TODO implement JsonSerializable on model when applicable - currently it breaks admin responses
-        $userData = $this->decodeJson($this->encodeJson($this->getUser()));
+        $userData = $this->decodeJson($this->encodeJson($this->getAdminUser()));
         foreach (['password', 'apiKey'] as $property) {
             unset($userData[$property]);
         }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -54,7 +54,7 @@ class SearchController extends AdminController
         \Pimcore::getEventDispatcher()->dispatch(AdminEvents::SEARCH_LIST_BEFORE_FILTER_PREPARE, $filterPrepareEvent);
 
         $allParams = $filterPrepareEvent->getArgument('requestParams');
-        $user = $this->getUser();
+        $user = $this->getAdminUser();
 
         $query = $allParams['query'];
         if ($query == '*') {

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -333,6 +333,6 @@ class SearchController extends AdminController
         \Pimcore::getEventDispatcher()->dispatch(AdminEvents::SEARCH_LIST_AFTER_LIST_LOAD, $afterListLoadEvent);
         $result = $afterListLoadEvent->getArgument('list');
 
-        return $this->json($result);
+        return $this->adminJson($result);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Update/IndexController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Update/IndexController.php
@@ -40,7 +40,7 @@ class IndexController extends AdminController implements EventedControllerInterf
     {
         $debug = \Pimcore::inDebugMode() || in_array(Config::getEnvironment(), ['dev', 'test']);
 
-        return $this->json([
+        return $this->adminJson([
             'success' => (bool) $debug
         ]);
     }
@@ -54,7 +54,7 @@ class IndexController extends AdminController implements EventedControllerInterf
      */
     public function checkComposerInstalledAction(Request $request)
     {
-        return $this->json([
+        return $this->adminJson([
             'success' => Update::isComposerAvailable()
         ]);
     }
@@ -68,7 +68,7 @@ class IndexController extends AdminController implements EventedControllerInterf
      */
     public function checkFilePermissionsAction(Request $request)
     {
-        return $this->json([
+        return $this->adminJson([
             'success' => Update::isWriteable()
         ]);
     }
@@ -84,7 +84,7 @@ class IndexController extends AdminController implements EventedControllerInterf
     {
         $availableUpdates = Update::getAvailableUpdates();
 
-        return $this->json($availableUpdates);
+        return $this->adminJson($availableUpdates);
     }
 
     /**
@@ -98,7 +98,7 @@ class IndexController extends AdminController implements EventedControllerInterf
     {
         $jobs = Update::getJobs($request->get('toRevision'));
 
-        return $this->json($jobs);
+        return $this->adminJson($jobs);
     }
 
     /**
@@ -114,7 +114,7 @@ class IndexController extends AdminController implements EventedControllerInterf
             Update::downloadData($request->get('revision'), $request->get('url'));
         }
 
-        return $this->json(['success' => true]);
+        return $this->adminJson(['success' => true]);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Controller/IndexController.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Controller/IndexController.php
@@ -52,7 +52,7 @@ class IndexController extends AdminController
             }
         }
 
-        return $this->json(['data' => array_values($data)]);
+        return $this->adminJson(['data' => array_values($data)]);
     }
 
     /**
@@ -92,9 +92,9 @@ class IndexController extends AdminController
                 $data = $helper->getGroupByValuesForFilterGroup($columnGroup, $productList, $request->get('field'));
             }
 
-            return $this->json(['data' => array_values($data)]);
+            return $this->adminJson(['data' => array_values($data)]);
         } catch (\Exception $e) {
-            return $this->json(['message' => $e->getMessage()]);
+            return $this->adminJson(['message' => $e->getMessage()]);
         }
     }
 
@@ -147,7 +147,7 @@ class IndexController extends AdminController
 
         ksort($fields);
 
-        return $this->json(['data' => array_values($fields)]);
+        return $this->adminJson(['data' => array_values($fields)]);
     }
 
     /**
@@ -166,6 +166,6 @@ class IndexController extends AdminController
             }
         }
 
-        return $this->json(['data' => $data]);
+        return $this->adminJson(['data' => $data]);
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Controller/PricingController.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Controller/PricingController.php
@@ -78,7 +78,7 @@ class PricingController extends AdminController implements EventedControllerInte
             ];
         }
 
-        return $this->json($json);
+        return $this->adminJson($json);
     }
 
     /**
@@ -117,7 +117,7 @@ class PricingController extends AdminController implements EventedControllerInte
                 $json['actions'][] = json_decode($action->toJSON());
             }
 
-            return $this->json($json);
+            return $this->adminJson($json);
         }
     }
 
@@ -148,7 +148,7 @@ class PricingController extends AdminController implements EventedControllerInte
         }
 
         // send respone
-        return $this->json($return);
+        return $this->adminJson($return);
     }
 
     /**
@@ -175,7 +175,7 @@ class PricingController extends AdminController implements EventedControllerInte
         }
 
         // send respone
-        return $this->json($return);
+        return $this->adminJson($return);
     }
 
     /**
@@ -266,7 +266,7 @@ class PricingController extends AdminController implements EventedControllerInte
         }
 
         // send respone
-        return $this->json($return);
+        return $this->adminJson($return);
     }
 
     /**
@@ -293,7 +293,7 @@ class PricingController extends AdminController implements EventedControllerInte
         $return['success'] = true;
 
         // send respone
-        return $this->json($return);
+        return $this->adminJson($return);
     }
 
     /**
@@ -305,7 +305,7 @@ class PricingController extends AdminController implements EventedControllerInte
     {
         $pricingManager = Factory::getInstance()->getPricingManager();
 
-        return $this->json([
+        return $this->adminJson([
             'condition' => array_keys($pricingManager->getConditionMapping()),
             'action'    => array_keys($pricingManager->getActionMapping())
         ]);

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Controller/PricingController.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Controller/PricingController.php
@@ -38,7 +38,7 @@ class PricingController extends AdminController implements EventedControllerInte
     public function onKernelController(FilterControllerEvent $event)
     {
         // permission check
-        $access = $this->getUser()->isAllowed('bundle_ecommerce_pricing_rules');
+        $access = $this->getAdminUser()->isAllowed('bundle_ecommerce_pricing_rules');
         if (!$access) {
             throw new \Exception('this function requires "bundle_ecommerce_pricing_rules" permission!');
         }


### PR DESCRIPTION
We're currently overwriting 3 methods on the `AdminController` which will be final in Symfony 4 and which we need to rename now to avoid having deprecation notices for those methods in every future version and having a hard time upgrading to Symfony 4. As this only affects admin controllers the effort of migrating any custom bundles which depend on those methods should be rather low and we decided to introduce this BC break to stay ready for the future.

If you implement any controller which inherits from Pimcore's `AdminController` please make sure to update the following
method calls to ensure the same functionality:

Controllers inheriting from `Pimcore\Bundle\AdminBundle\Controller\AdminController`:

| Old call           | New call                | Note                                                                                                                                                                                                                   |
|--------------------|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `$this->json()`    | `$this->adminJson()`    | You can still use `json()` as it is a standard Symfony controller method, but please be aware that it uses the Symfony Serializer instead of Pimcore's admin serializer and the results may differ from `adminJson()`. |
| `$this->getUser()` | `$this->getAdminUser()` | You can still use `getUser()`, but please be aware that the returned user is a `Pimcore\Bundle\AdminBundle\Security\User\User` and not the `Pimcore\Model\User` which is returned in `getAdminUser()`.                 |

Controllers inheriting from `Pimcore\Bundle\AdminBundle\Controller\Rest\AbstractRestController`:

| Old call                           | New call                                    | Note |
|------------------------------------|---------------------------------------------|------|
| `$this->createNotFoundException()` | `$this-> createNotFoundResponseException()` |      |