### PR TITLE
fallback translation in combination with caseinsensitive website translations bugfix

### DIFF
--- a/pimcore/lib/Pimcore/Translation/Translator.php
+++ b/pimcore/lib/Pimcore/Translation/Translator.php
@@ -343,11 +343,20 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
             foreach (Tool::getFallbackLanguagesFor($locale) as $fallbackLanguage) {
                 $this->lazyInitialize($domain, $fallbackLanguage);
                 $catalogue = $this->getCatalogue($fallbackLanguage);
-                if ($catalogue->has($id, $domain)) {
+
+                $fallbackValue = '';
+
+                if($catalogue->has($id, $domain)) {
                     $fallbackValue = $catalogue->get($id, $domain);
-                    if ($fallbackValue) {
-                        return $fallbackValue;
-                    }
+                }
+
+                if($this->caseInsensitive && (empty($fallbackValue) || $fallbackValue == $id)) {
+                    $fallbackValue = $this->getCaseInsensitiveFromCatalogue($catalogue, $fallbackValue, $id, $domain);
+                }
+                if($fallbackValue) {
+                    // update fallback value in original catalogue otherwise multiple calls to the same id will not work
+                    $this->getCatalogue($locale)->set($id, $fallbackValue, $domain);
+                    return $fallbackValue;
                 }
             }
 


### PR DESCRIPTION
Fallback languages did not work correctly in combination with case insensitive translations enabled.

for example:

Translation key is "myTranslation"

If the translation key is empty but a "mytranslation" TK exists with a translated value in one of the fallback languages the translation key was printed instead of the fallback value.

I'm not sure if my solution is a good one - escpecially the part where the original locale catalogue get's updated but I have no idea how to solve it differently. 

