### PR TITLE
Update documentation

### DIFF
--- a/doc/Development_Documentation/20_Extending_Pimcore/17_Custom_Persistent_Models.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/17_Custom_Persistent_Models.md
@@ -12,7 +12,7 @@ Pimcore provides 2 possible ways of working with custom entities namely Doctrine
 
 ## Option 1: Use Doctrine ORM
 Pimcore comes already with the Doctrine bundle, so you can easily create your own entities. 
-Please check <http://symfony.com/doc/current/doctrine.html> for more details.  
+Please check <http://symfony.com/doc/3.4/doctrine.html> for more details.  
 
 ## Option 2: Working with Pimcore Data Access Objects (Dao)
 


### PR DESCRIPTION
Now **Use Doctrine ORM** section in **Custom Persistent Models** docs links to the right version of symfony docs.
