### PR TITLE
[PIWIK][ECOMMERCE] Add Piwik reports to ecommerce menu

### DIFF
--- a/pimcore/lib/Pimcore/Analytics/Piwik/Config/Config.php
+++ b/pimcore/lib/Pimcore/Analytics/Piwik/Config/Config.php
@@ -181,18 +181,18 @@ class Config
         return $this->normalizeStringValue($this->config->iframe_password);
     }
 
-    public function generateIframeUrl(): string
+    public function generateIframeUrl(array $parameters = []): string
     {
         if (!$this->isIframeIntegrationConfigured()) {
             throw new \RuntimeException('Iframe integration is not configured');
         }
 
-        $parameters = [
+        $parameters = array_merge([
             'module'   => 'Login',
             'action'   => 'logme',
             'login'    => $this->getIframeUsername(),
             'password' => $this->getIframePassword(),
-        ];
+        ], $parameters);
 
         return sprintf(
             '%s/index.php?%s',

--- a/pimcore/lib/Pimcore/Analytics/Piwik/WidgetBroker.php
+++ b/pimcore/lib/Pimcore/Analytics/Piwik/WidgetBroker.php
@@ -122,7 +122,7 @@ class WidgetBroker
         return $references;
     }
 
-    public function getWidgetConfig(string $widgetId, string $configKey, string $locale = null): WidgetConfig
+    public function getWidgetConfig(string $widgetId, string $configKey, string $locale = null, array $urlParams = []): WidgetConfig
     {
         $config  = $this->loadConfig();
         $locale  = $this->resolveLocale($locale);
@@ -133,7 +133,7 @@ class WidgetBroker
         }
 
         $widget = $widgets[$widgetId];
-        $url    = $this->generateWidgetUrl($config, $configKey, $widget, $locale);
+        $url    = $this->generateWidgetUrl($config, $configKey, $widget, $locale, $urlParams);
 
         return new WidgetConfig($widgetId, $widget['name'], $this->generateTitle($widget), $url, $widget);
     }
@@ -308,9 +308,9 @@ class WidgetBroker
         return $this->apiClient->get($params);
     }
 
-    private function generateWidgetUrl(Config $config, string $configKey, array $widget, string $locale = null): string
+    private function generateWidgetUrl(Config $config, string $configKey, array $widget, string $locale = null, array $urlParams = []): string
     {
-        $params = [
+        $params = array_merge([
             'module'      => 'Widgetize',
             'action'      => 'iframe',
             'widget'      => 1,
@@ -319,7 +319,7 @@ class WidgetBroker
             'disableLink' => 1,
             'idSite'      => $config->getPiwikSiteId($configKey),
             'token_auth'  => $config->getReportToken()
-        ];
+        ], $urlParams);
 
         $params['moduleToWidgetize'] = $widget['module'];
         $params['actionToWidgetize'] = $widget['action'];

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Controller/Reports/PiwikController.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Controller/Reports/PiwikController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\EcommerceFrameworkBundle\Controller\Reports;
+
+use Pimcore\Bundle\AdminBundle\Controller\AdminController;
+use Pimcore\Bundle\EcommerceFrameworkBundle\Reports\Piwik\PiwikReportsProvider;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+
+/**
+ * @Route("/reports/piwik")
+ */
+class PiwikController extends AdminController
+{
+    /**
+     * @Route("/reports")
+     */
+    public function reportsAction(PiwikReportsProvider $reportsProvider)
+    {
+        $this->checkPermission('piwik_reports');
+
+        $reports = $reportsProvider->getPiwikEcommerceReports();
+
+        return $this->json(['data' => $reports]);
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Reports/Piwik/PiwikReportsProvider.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Reports/Piwik/PiwikReportsProvider.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\EcommerceFrameworkBundle\Reports\Piwik;
+
+use Pimcore\Analytics\Piwik\Config\Config;
+use Pimcore\Analytics\Piwik\WidgetBroker;
+use Pimcore\Analytics\SiteId\SiteId;
+use Pimcore\Analytics\SiteId\SiteIdProvider;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class PiwikReportsProvider
+{
+    /**
+     * @var SiteIdProvider
+     */
+    private $siteIdProvider;
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @var WidgetBroker
+     */
+    private $widgetBroker;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(
+        SiteIdProvider $siteIdProvider,
+        Config $config,
+        WidgetBroker $widgetBroker,
+        TranslatorInterface $translator
+    )
+    {
+        $this->siteIdProvider = $siteIdProvider;
+        $this->config         = $config;
+        $this->widgetBroker   = $widgetBroker;
+        $this->translator     = $translator;
+    }
+
+    public function getPiwikEcommerceReports(): array
+    {
+        if (empty($this->config->getReportToken())) {
+            return [];
+        }
+
+        $siteConfigs = $this->siteIdProvider->getSiteIds();
+
+        $reports = [];
+        foreach ($siteConfigs as $siteConfig) {
+            if (!$this->config->isSiteConfigured($siteConfig->getConfigKey())) {
+                continue;
+            }
+
+            $entries = $this->getEcommerceWidgets($siteConfig);
+            if (empty($entries)) {
+                continue;
+            }
+
+            $reports[] = [
+                'id'      => $siteConfig->getConfigKey(),
+                'title'   => $siteConfig->getTitle($this->translator),
+                'entries' => $entries,
+            ];
+        }
+
+        return $reports;
+    }
+
+    private function getEcommerceWidgets(SiteId $siteConfig): array
+    {
+        $widgets = $this->widgetBroker->getWidgetData($siteConfig->getConfigKey());
+
+        $whitelist = [
+            'widgetEcommerceOverview',
+            'widgetEcommercegetEcommerceLog',
+            'widgetGoalsgetItemsSku',
+            'widgetGoalsgetVisitsUntilConversionforceView1viewDataTabletabledocumentationForGoalsPage1idGoalecommerceOrder' // yes, that's the real name in piwik..
+        ];
+
+        $showAsWidgetWhitelist = [
+            'widgetEcommerceOverview'
+        ];
+
+        $canIframe = $this->config->isIframeIntegrationConfigured();
+
+        $result = [];
+        foreach ($whitelist as $widgetId) {
+            if (isset($widgets[$widgetId])) {
+                $widgetConfig = $this->widgetBroker->getWidgetConfig($widgetId, $siteConfig->getConfigKey(), null, [
+                    'period' => 'month'
+                ]);
+
+                $widgetData = $widgetConfig->getData();
+
+                $entry = [
+                    'title' => $widgetData['subcategory']['name']
+                ];
+
+                if ($canIframe) {
+                    $entry['type'] = 'iframe';
+                    $entry['url']  = $this->generateIframeUrl($siteConfig, $widgetData);
+                } elseif (in_array($widgetId, $showAsWidgetWhitelist)) {
+                    $entry['type'] = 'widget';
+                    $entry['url']  = $widgetConfig->getUrl();
+                } else {
+                    continue;
+                }
+
+                $result[] = $entry;
+            }
+        }
+
+        return $result;
+    }
+
+    private function generateIframeUrl(SiteId $siteConfig, array $widgetData)
+    {
+        $piwikSiteId = $this->config->getPiwikSiteId($siteConfig->getConfigKey());
+
+        $url = $this->config->generateIframeUrl([
+            'idSite' => $piwikSiteId
+        ]);
+
+        $hashParams = [
+            'idSite'      => $piwikSiteId,
+            'period'      => 'month',
+            'date'        => 'yesterday',
+            'category'    => $widgetData['category']['id'],
+            'subcategory' => $widgetData['subcategory']['id'],
+        ];
+
+        return sprintf(
+            '%s#?%s',
+            $url,
+            http_build_query($hashParams)
+        );
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Resources/config/services.yml
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Resources/config/services.yml
@@ -39,3 +39,10 @@ services:
     # auto-register all commands as services
     Pimcore\Bundle\EcommerceFrameworkBundle\Command\:
         resource: '../../Command'
+
+
+    #
+    # REPORTS
+    #
+
+    Pimcore\Bundle\EcommerceFrameworkBundle\Reports\Piwik\PiwikReportsProvider: ~

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Resources/public/js/bundle.js
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Resources/public/js/bundle.js
@@ -14,100 +14,97 @@
 
 pimcore.registerNS("pimcore.bundle.EcommerceFramework.bundle");
 
-pimcore.bundle.EcommerceFramework.bundle = Class.create(pimcore.plugin.admin,{
+pimcore.bundle.EcommerceFramework.bundle = Class.create(pimcore.plugin.admin, {
 
     menuItems: null,
 
-    getClassName: function (){
+    getClassName: function () {
         return "pimcore.bundle.EcommerceFramework.bundle";
     },
 
-    initialize: function(){
+    initialize: function () {
         pimcore.plugin.broker.registerPlugin(this);
     },
 
-    uninstall: function(){
+    uninstall: function () {
     },
 
-    pimcoreReady: function (params,broker) {
+    pimcoreReady: function (params, broker) {
+        var perspectiveCfg = pimcore.globalmanager.get("perspective");
+
+        if (!perspectiveCfg.inToolbar("ecommerce")) {
+            return
+        }
 
         var toolbar = pimcore.globalmanager.get("layout_toolbar");
 
-        var perspectiveCfg = pimcore.globalmanager.get("perspective");
+        // init
+        var menuItems = toolbar.ecommerceMenu;
+        if (!menuItems) {
+            menuItems = new Ext.menu.Menu({cls: "pimcore_navigation_flyout"});
+            toolbar.ecommerceMenu = menuItems;
+        }
+        var user = pimcore.globalmanager.get("user");
 
-        if(true || perspectiveCfg.inToolbar("ecommerce")) {
-
-            // init
-            var menuItems = toolbar.ecommerceMenu;
-            if (!menuItems) {
-                menuItems = new Ext.menu.Menu({cls: "pimcore_navigation_flyout"});
-                toolbar.ecommerceMenu = menuItems;
-            }
-            var user = pimcore.globalmanager.get("user");
-
-            var insertPoint = Ext.get("pimcore_menu_settings");
-            if(!insertPoint) {
-                var dom = Ext.dom.Query.select('#pimcore_navigation ul li:last');
-                insertPoint = Ext.get(dom[0]);
-            }
-
-            var config = pimcore.bundle.EcommerceFramework.bundle.config;
-
-            // pricing rules
-            if (perspectiveCfg.inToolbar("ecommerce.rules") && user.isAllowed("bundle_ecommerce_pricing_rules") && (!config.menu || config.menu.pricing_rules.enabled)) {
-                // add pricing rules to menu
-                // create item
-                var pricingPanelId = "bundle_ecommerce_pricing_config";
-                var item = {
-                    text: t("bundle_ecommerce_pricing_rules"),
-                    iconCls: "bundle_ecommerce_pricing_rules",
-                    handler: function () {
-                        try {
-                            pimcore.globalmanager.get(pricingPanelId).activate();
-                        }
-                        catch (e) {
-                            pimcore.globalmanager.add(pricingPanelId, new pimcore.bundle.EcommerceFramework.pricing.config.panel(pricingPanelId));
-                        }
-                    }
-                };
-
-                // add to menu
-                menuItems.add(item);
-            }
-
-
-            // order backend
-            if (perspectiveCfg.inToolbar("ecommerce.orderbackend") && user.isAllowed("bundle_ecommerce_back-office_order") && (!config.menu || config.menu.order_list.enabled)) {
-                // create item
-                var orderPanelId = "bundle_ecommerce_back-office_order";
-                var item = {
-                    text: t("bundle_ecommerce_back-office_order"),
-                    iconCls: "bundle_ecommerce_back-office_order",
-                    handler: function () {
-                        try {
-                            pimcore.globalmanager.get(orderPanelId).activate();
-                        }
-                        catch (e) {
-                            pimcore.globalmanager.add(orderPanelId, new pimcore.tool.genericiframewindow(orderPanelId, config.menu.order_list.route, "bundle_ecommerce_back-office_order", t('bundle_ecommerce_back-office_order')));
-                        }
-                    }
-                };
-
-                // add to menu
-                menuItems.add(item);
-            }
-
-            // add e-commerce framework main menu
-            if (menuItems.items.length > 0) {
-                this.navEl = Ext.get('pimcore_menu_ecommerce');
-                this.navEl.show();
-                this.navEl.on("mousedown", toolbar.showSubMenu.bind(menuItems));
-                pimcore.helpers.initMenuTooltips();
-            }
+        var insertPoint = Ext.get("pimcore_menu_settings");
+        if (!insertPoint) {
+            var dom = Ext.dom.Query.select('#pimcore_navigation ul li:last');
+            insertPoint = Ext.get(dom[0]);
         }
 
-    },
+        var config = pimcore.bundle.EcommerceFramework.bundle.config;
 
+        // pricing rules
+        if (perspectiveCfg.inToolbar("ecommerce.rules") && user.isAllowed("bundle_ecommerce_pricing_rules") && (!config.menu || config.menu.pricing_rules.enabled)) {
+            // add pricing rules to menu
+            // create item
+            var pricingPanelId = "bundle_ecommerce_pricing_config";
+            var item = {
+                text: t("bundle_ecommerce_pricing_rules"),
+                iconCls: "bundle_ecommerce_pricing_rules",
+                handler: function () {
+                    try {
+                        pimcore.globalmanager.get(pricingPanelId).activate();
+                    }
+                    catch (e) {
+                        pimcore.globalmanager.add(pricingPanelId, new pimcore.bundle.EcommerceFramework.pricing.config.panel(pricingPanelId));
+                    }
+                }
+            };
+
+            // add to menu
+            menuItems.add(item);
+        }
+
+        // order backend
+        if (perspectiveCfg.inToolbar("ecommerce.orderbackend") && user.isAllowed("bundle_ecommerce_back-office_order") && (!config.menu || config.menu.order_list.enabled)) {
+            // create item
+            var orderPanelId = "bundle_ecommerce_back-office_order";
+            var item = {
+                text: t("bundle_ecommerce_back-office_order"),
+                iconCls: "bundle_ecommerce_back-office_order",
+                handler: function () {
+                    try {
+                        pimcore.globalmanager.get(orderPanelId).activate();
+                    }
+                    catch (e) {
+                        pimcore.globalmanager.add(orderPanelId, new pimcore.tool.genericiframewindow(orderPanelId, config.menu.order_list.route, "bundle_ecommerce_back-office_order", t('bundle_ecommerce_back-office_order')));
+                    }
+                }
+            };
+
+            // add to menu
+            menuItems.add(item);
+        }
+
+        // add e-commerce framework main menu
+        if (menuItems.items.length > 0) {
+            this.navEl = Ext.get('pimcore_menu_ecommerce');
+            this.navEl.show();
+            this.navEl.on("mousedown", toolbar.showSubMenu.bind(menuItems));
+            pimcore.helpers.initMenuTooltips();
+        }
+    },
 
     postOpenObject: function (object, type) {
         if (pimcore.globalmanager.get("user").isAllowed("bundle_ecommerce_pricing_rules")) {


### PR DESCRIPTION
Resolves #2047. Adds Piwik reports to ecommerce menu if Piwik is configured. If Piwik is not configured for iframe integration (logme) but a report token is set, a single overview widget will be openened.