### PR TITLE
Bugfix for showing the tooltip on the leftside when righttree panel was open #2383

### DIFF
--- a/web/pimcore/static6/css/admin.css
+++ b/web/pimcore/static6/css/admin.css
@@ -239,6 +239,12 @@
     border-bottom: 8px solid transparent;
 }
 
+#pimcore_tooltip.right:after {
+    left: 100%;
+    border-left: 8px solid #000000;
+    border-right: 0px solid #000000;
+}
+
 
 .pimcore_hidden {
     display:none !important;

--- a/web/pimcore/static6/js/pimcore/asset/tree.js
+++ b/web/pimcore/static6/js/pimcore/asset/tree.js
@@ -347,14 +347,24 @@ pimcore.asset.tree = Class.create({
                         text += (t("type") + ": "+ t(record.data.type));
                     }
 
-
                     $("#pimcore_tooltip").show();
                     $("#pimcore_tooltip").html(text);
+                    $("#pimcore_tooltip").removeClass('right');
 
                     var offsetTabPanel = $("#pimcore_panel_tabs").offset();
+
                     var offsetTreeNode = $(item).offset();
 
-                    $("#pimcore_tooltip").css({top: offsetTreeNode.top + 8, left: offsetTabPanel.left});
+                    var parentTree = el.ownerCt.ownerCt;
+
+                    if(parentTree.region == 'west') {
+                        $("#pimcore_tooltip").css({top: offsetTreeNode.top + 8, left: offsetTabPanel.left, right: 'auto'});
+                    }
+
+                    if(parentTree.region == 'east') {
+                        $("#pimcore_tooltip").addClass('right');
+                        $("#pimcore_tooltip").css({top: offsetTreeNode.top + 8, right: parentTree.width+35, left: 'auto'});
+                    }
                 }
             },
             "itemmouseleave": function () {

--- a/web/pimcore/static6/js/pimcore/document/tree.js
+++ b/web/pimcore/static6/js/pimcore/document/tree.js
@@ -195,14 +195,24 @@ pimcore.document.tree = Class.create({
                         text += (t("type") + ": "+ t(record.data.type));
                     }
 
-
                     $("#pimcore_tooltip").show();
                     $("#pimcore_tooltip").html(text);
+                    $("#pimcore_tooltip").removeClass('right');
 
                     var offsetTabPanel = $("#pimcore_panel_tabs").offset();
+
                     var offsetTreeNode = $(item).offset();
 
-                    $("#pimcore_tooltip").css({top: offsetTreeNode.top + 8, left: offsetTabPanel.left});
+                    var parentTree = el.ownerCt.ownerCt;
+
+                    if(parentTree.region == 'west') {
+                        $("#pimcore_tooltip").css({top: offsetTreeNode.top + 8, left: offsetTabPanel.left, right: 'auto'});
+                    }
+
+                    if(parentTree.region == 'east') {
+                        $("#pimcore_tooltip").addClass('right');
+                        $("#pimcore_tooltip").css({top: offsetTreeNode.top + 8, right: parentTree.width+35, left: 'auto'});
+                    }
                 }
             },
             "itemmouseleave": function () {

--- a/web/pimcore/static6/js/pimcore/helpers.js
+++ b/web/pimcore/static6/js/pimcore/helpers.js
@@ -2930,6 +2930,7 @@ pimcore.helpers.initMenuTooltips = function () {
 
     items.mouseenter(function (e) {
         $("#pimcore_tooltip").show();
+        $("#pimcore_tooltip").removeClass('right');
         $("#pimcore_tooltip").html($(this).data("menu-tooltip"));
 
         var closestEl = $(e.target).closest('[data-menu-tooltip]');
@@ -2937,7 +2938,7 @@ pimcore.helpers.initMenuTooltips = function () {
         var top = offset.top;
         top = top + (closestEl.height() / 2);
 
-        $("#pimcore_tooltip").css({top: top, left: 60});
+        $("#pimcore_tooltip").css({top: top, left: 60, right: 'auto'});
     });
 
     items.mouseleave(function () {

--- a/web/pimcore/static6/js/pimcore/object/tree.js
+++ b/web/pimcore/static6/js/pimcore/object/tree.js
@@ -183,14 +183,24 @@ pimcore.object.tree = Class.create({
                         text += (t("type") + ": "+ t(record.data.type));
                     }
 
-
                     $("#pimcore_tooltip").show();
                     $("#pimcore_tooltip").html(text);
+                    $("#pimcore_tooltip").removeClass('right');
 
                     var offsetTabPanel = $("#pimcore_panel_tabs").offset();
+
                     var offsetTreeNode = $(item).offset();
 
-                    $("#pimcore_tooltip").css({top: offsetTreeNode.top + 8, left: offsetTabPanel.left});
+                    var parentTree = el.ownerCt.ownerCt;
+
+                    if(parentTree.region == 'west') {
+                        $("#pimcore_tooltip").css({top: offsetTreeNode.top + 8, left: offsetTabPanel.left, right: 'auto'});
+                    }
+
+                    if(parentTree.region == 'east') {
+                        $("#pimcore_tooltip").addClass('right');
+                        $("#pimcore_tooltip").css({top: offsetTreeNode.top + 8, right: parentTree.width+35, left: 'auto'});
+                    }
                 }
             },
             "itemmouseleave": function () {


### PR DESCRIPTION
## Fixes Issue #
#2383 
## Changes in this pull request  
Added styling to the tooltip so it can now point left and right, fixed for object/asset/document the problem that it appeared on the left side

