### PR TITLE
Thumbnail-Action: Return NotFound-Response if asset does not exist

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Controller/PublicServicesController.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Controller/PublicServicesController.php
@@ -108,6 +108,8 @@ class PublicServicesController extends FrameworkController
                 Logger::error($message);
                 throw $this->createNotFoundException($message, $e);
             }
+        } else {
+            throw $this->createNotFoundException("Asset with ID '" . $assetId . "' doesn't exist");
         }
     }
 


### PR DESCRIPTION
An action has to result a response, in this case a 404 fits best.

Response before: LogicException - The controller must return a response (null given). Did you forget to add a return statement somewhere in your controller?
Response after: NotFoundHttpException - Asset with ID '12345' doesn't exist
