### PR TITLE
Fix Page instance in Navigation docs

### DIFF
--- a/doc/Development_Documentation/03_Documents/03_Navigation.md
+++ b/doc/Development_Documentation/03_Documents/03_Navigation.md
@@ -321,7 +321,7 @@ $navigation = $this->navigation()->buildNavigation($this->document, $navStartNod
                 "prefix" => $this->document->getFullPath()
             ], "news", true);
 
-            $uri = new Pimcore\Navigation\Page\Uri([
+            $uri = new Pimcore\Navigation\Page\Document([
                 "label" => $news->getTitle(),
                 "id" => "object-" . $news->getId(),
                 "uri" => $detailLink


### PR DESCRIPTION
Change removed Page\Uri to Page\Document - class in Navigation documentation page, according to the migration guide.


## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
  
  
## Fixes Issue #

## Changes in this pull request  

## Additional info  

