### PR TITLE
[TARGETING] Expire session cookie storage with a fixed timeout instead of using session cookies

### DIFF
--- a/doc/Development_Documentation/18_Tools_and_Features/37_Targeting_and_Personalization/09_Targeting_Storage.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/37_Targeting_and_Personalization/09_Targeting_Storage.md
@@ -61,8 +61,9 @@ Note that using plain text cookie data is inherently insecure and can open vulne
 the client cookie. Use only for testing!
 </div>
 
-Default session scope timeout: The cookie is set as session cookie - the browser is expected to expire it when closing the
-page.
+Default session scope timeout: 30 minutes. This is also enforced in the JWT handler by setting an expiration value for the
+signed data to the same timeout as the cookie. This means even if somebody changes the cookie lifetime on the client side
+the data will still expire when loaded on the backend.
 
 Pros
 

--- a/pimcore/lib/Pimcore/Targeting/Storage/Cookie/JWTCookieSaveHandler.php
+++ b/pimcore/lib/Pimcore/Targeting/Storage/Cookie/JWTCookieSaveHandler.php
@@ -124,7 +124,7 @@ class JWTCookieSaveHandler extends AbstractCookieSaveHandler
             ->set(self::CLAIM_TARGETING_DATA, $data);
 
         if (0 === $expire) {
-            $builder->setExpiration($time + (60 * 60)); // expire in 1h
+            $builder->setExpiration($time + (60 * 30)); // expire in 30 min
         } elseif (is_int($expire) && $expire > 0) {
             $builder->setExpiration($expire);
         } elseif ($expire instanceof \DateTimeInterface) {

--- a/pimcore/lib/Pimcore/Targeting/Storage/CookieStorage.php
+++ b/pimcore/lib/Pimcore/Targeting/Storage/CookieStorage.php
@@ -252,6 +252,8 @@ class CookieStorage implements TargetingStorageInterface
         $expiry = 0;
         if (self::SCOPE_VISITOR === $scope) {
             $expiry = new \DateTime('+1 year');
+        } elseif (self::SCOPE_SESSION === $scope) {
+            $expiry = new \DateTime('+30 minutes');
         }
 
         return $expiry;


### PR DESCRIPTION
Session cookies do not always behave as expected (expire when closing the browser):

> The cookie created above is a session cookie: it is deleted when the client shuts down, because it didn't specify an Expires or Max-Age directive. However, web browsers may use session restoring, which makes most session cookies permanent, as if the browser was never closed.

Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies

This sets a fixed expiration for session storage cookies + enforces the expiration in the JWT signed variant by setting an explicit token expiration. Even if the client sets another expiration date, the data will still expire when the token expires.