### PR TITLE
Use class attribute instead of static url in pimcore.object.tree class

### DIFF
--- a/web/pimcore/static6/js/pimcore/object/tree.js
+++ b/web/pimcore/static6/js/pimcore/object/tree.js
@@ -82,7 +82,7 @@ pimcore.object.tree = Class.create({
             autoSync: false,
             proxy: {
                 type: 'ajax',
-                url: "/admin/object/tree-get-childs-by-id",
+                url: this.treeDataUrl,
                 reader: {
                     type: 'json',
                     totalProperty : 'total',


### PR DESCRIPTION
## Fixes Issue #
In method init variable class attribute treeDataUrl is not used (is uses just static url)
