### PR TITLE
Deeplink: Added helper and respect server port

### DIFF
--- a/web/pimcore/static6/js/pimcore/asset/asset.js
+++ b/web/pimcore/static6/js/pimcore/asset/asset.js
@@ -462,7 +462,7 @@ pimcore.asset.asset = Class.create(pimcore.element.abstract, {
             },
             {
                 name: "deeplink",
-                value: window.location.protocol + "//" + window.location.hostname + "/admin/login/deeplink?asset_" + this.data.id + "_" + this.data.type
+                value: pimcore.helpers.getDeeplink("asset", this.data.id, this.data.type)
             }
         ], "asset");
     }

--- a/web/pimcore/static6/js/pimcore/asset/folder.js
+++ b/web/pimcore/static6/js/pimcore/asset/folder.js
@@ -397,7 +397,7 @@ pimcore.asset.folder = Class.create(pimcore.asset.asset, {
             },
             {
                 name: "deeplink",
-                value: window.location.protocol + "//" + window.location.hostname + "/admin/login/deeplink?asset_" + this.data.id + "_" + this.data.type
+                value: pimcore.helpers.getDeeplink("asset", this.data.id, this.data.type)
             }
         ], "folder");
     }

--- a/web/pimcore/static6/js/pimcore/document/folder.js
+++ b/web/pimcore/static6/js/pimcore/document/folder.js
@@ -280,7 +280,7 @@ pimcore.document.folder = Class.create(pimcore.document.document, {
             },
             {
                 name: "deeplink",
-                value: window.location.protocol + "//" + window.location.hostname + "/admin/login/deeplink?document_" + this.data.id + "_" + this.data.type
+                value: pimcore.helpers.getDeeplink("document", this.data.id, this.data.type)
             }
         ], "folder");
     }

--- a/web/pimcore/static6/js/pimcore/document/page_snippet.js
+++ b/web/pimcore/static6/js/pimcore/document/page_snippet.js
@@ -375,7 +375,7 @@ pimcore.document.page_snippet = Class.create(pimcore.document.document, {
             },
             {
                 name: "deeplink",
-                value: window.location.protocol + "//" + window.location.hostname + "/admin/login/deeplink?document_" + this.data.id + "_" + this.data.type
+                value: pimcore.helpers.getDeeplink("document", this.data.id, this.data.type)
             }
         ], "document");
     }

--- a/web/pimcore/static6/js/pimcore/helpers.js
+++ b/web/pimcore/static6/js/pimcore/helpers.js
@@ -3170,5 +3170,10 @@ pimcore.helpers.isValidPassword = function (pass) {
     return true;
 };
 
-
+pimcore.helpers.getDeeplink = function(type, id, subtype) {
+    return window.location.protocol + "//"
+        + window.location.hostname
+        + (window.location.port && window.location.port !== "80" && window.location.port !== "443" ? ":" + window.location.port : "")
+        + "/admin/login/deeplink?" + type + "_" + id + "_" + subtype;
+};
 

--- a/web/pimcore/static6/js/pimcore/object/folder.js
+++ b/web/pimcore/static6/js/pimcore/object/folder.js
@@ -402,7 +402,7 @@ pimcore.object.folder = Class.create(pimcore.object.abstract, {
         },
         {
             name: "deeplink",
-            value: window.location.protocol + "//" + window.location.hostname + "/admin/login/deeplink?object_" + this.data.general.o_id + "_folder"
+            value: pimcore.helpers.getDeeplink("object", this.data.general.o_id, "folder")
         }
         ], "folder");
     }

--- a/web/pimcore/static6/js/pimcore/object/object.js
+++ b/web/pimcore/static6/js/pimcore/object/object.js
@@ -848,7 +848,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
             },
             {
                 name: "deeplink",
-                value: window.location.protocol + "//" + window.location.hostname + "/admin/login/deeplink?object_" + this.data.general.o_id + "_object"
+                value: pimcore.helpers.getDeeplink("object", this.data.general.o_id, "object")
             }
         ], "object");
     }


### PR DESCRIPTION
This change consolidates the deeplink generation (helper).

Further more, it now respects the server port so links for Pimcore installations on non-standard ports are correct, e.g.:
https://example.com:81/admin/login/deeplink?object_12345_object

