### PR TITLE
Properly read the Date type of a DataObject as DATE, not DATETIME.

### DIFF
--- a/pimcore/models/DataObject/ClassDefinition/Data/Date.php
+++ b/pimcore/models/DataObject/ClassDefinition/Data/Date.php
@@ -93,7 +93,7 @@ class Date extends Model\DataObject\ClassDefinition\Data
     public function getDataFromResource($data, $object = null, $params = [])
     {
         if ($data) {
-            if ($this->getColumnType() == 'datetime') {
+            if ($this->getColumnType() == 'date') {
                 $data = strtotime($data);
                 if ($data === false) {
                     return null;


### PR DESCRIPTION
When a Date Field of a DataObject ist configured to be stored as DATE in the database, it currently doesnt read back the proper value.
getDataFromResource does the format conversion based on the wrong columnType.
This fixes a bug introduced for feature request #2211 in commit 23f5677a435c6058e3270ee99a94bd1f13432387