### PR TITLE
fix for "get batch jobs" action

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
@@ -2093,7 +2093,7 @@ class DataObjectHelperController extends AdminController
         $folder = DataObject::getById($request->get('folderId'));
         $class = DataObject\ClassDefinition::getById($request->get('classId'));
 
-        $conditionFilters = ["o_path = ? OR o_path LIKE '" . str_replace('//', '/', $folder->getRealFullPath() . '/') . "%'"];
+        $conditionFilters = ["(o_path = ? OR o_path LIKE '" . str_replace('//', '/', $folder->getRealFullPath() . '/') . "%')"];
 
         if ($request->get('filter')) {
             $conditionFilters[] = DataObject\Service::getFilterCondition($request->get('filter'), $class);


### PR DESCRIPTION
This PR resolves problem with batch assignment. Due to the lack of parentheses in the SQL query, filters are not included when calculating objects for editing.