### PR TITLE
Update system requirements to meet PHP 7.1

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/01_System_Requirements.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/01_System_Requirements.md
@@ -9,9 +9,9 @@ For production we highly recommend a *nix based system.
 - Nginx
 
 
-### PHP >= 7.0
+### PHP >= 7.1
 Both **mod_php** and **FCGI (FPM)** are supported.  
-Please note that the usage of **PHP 7.1 is strongly recommended** as future versions of Pimcore 5 will require PHP 7.1. 
+
 
 #### Required Settings and Modules & Extensions
 - `memory_limit` >= 128M


### PR DESCRIPTION
Since dependencies will likely need PHP 7.1 often. Updating Pimcore 5.0.2 to 5.1 will fail with PHP 7.0 because of dependencies using 7.1 syntax so we should probably update the docs.

