### PR TITLE
Fix Symfony 3.4 issues on cache clear and update

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
@@ -47,6 +47,8 @@ services:
         tags:
             - { name: kernel.cache_warmer }
 
+    Pimcore\Cache\Symfony\CacheClearer:
+        public: true
 
     #
     # CONFIG

--- a/pimcore/lib/Pimcore/Cache/Symfony/CacheClearer.php
+++ b/pimcore/lib/Pimcore/Cache/Symfony/CacheClearer.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Cache\Symfony;
+
+use Pimcore\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CacheClearer
+{
+    public function clear(KernelInterface $kernel, array $options = [])
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'no-warmup'           => false,
+            'no-optional-warmers' => false,
+            'env'                 => $kernel->getEnvironment()
+        ]);
+
+        $this->runCommand($kernel, 'cache:clear', [], $resolver->resolve($options));
+    }
+
+    public function warmup(KernelInterface $kernel, array $options = [])
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'no-optional-warmers' => false,
+            'env'                 => $kernel->getEnvironment()
+        ]);
+
+        $this->runCommand($kernel, 'cache:warmup', [], $resolver->resolve($options));
+    }
+
+    private function runCommand(KernelInterface $kernel, string $command, array $arguments = [], array $options = [])
+    {
+        $input = $this->createInput($command, $arguments, $options);
+
+        $application = new Application($kernel);
+        $application->setAutoExit(false);
+
+        $output = new BufferedOutput();
+        $result = $application->run($input, $output);
+
+        if (0 !== $result) {
+            throw new \RuntimeException(sprintf(
+                'Command "%s" failed: %s',
+                $command,
+                $output->fetch()
+            ));
+        }
+    }
+
+    private function createInput(string $command, array $arguments = [], array $options = []): ArrayInput
+    {
+        $input = array_merge($arguments, [
+            'command' => $command
+        ]);
+
+        foreach ($options as $optionKey => $option) {
+            // do not set option if it is false
+            if (is_bool($option) && !$option) {
+                continue;
+            }
+
+            $input['--' . $optionKey] = $option;
+        }
+
+        return new ArrayInput($input);
+    }
+}


### PR DESCRIPTION
* resolves #2434 
* resolves #2452 
* resolves #1958

Symfony 3.4 introduced a new file structure for its cached container, splitting up service definitions which are loaded via `require_once` on demand. This introduces errors when clearing the container via code in the "clear cache" admin action and during updates as calls to a stale container can lead to `require_once` errors when the files don't exist anymore.

As an example, the `Symfony\Bundle\SwiftmailerBundle\EventListener\EmailSenderListener` which runs in the `kernel.terminate` event fetches the Swiftmailer service to send mails. This fails and leads to errors as described in #2434.

This PR changes multiple things:

* it uses the Symfony `cache:clear` command logic to clear and optionally warm up the cache as there is much optimization going on inside that command to make sure the clear is done in an atomic way
* it hard-exits after a clear by calling `exit()` to make sure no code is running after the clear
* it disables any `kernel.terminate` and `console.terminate` event handlers for the case we don't reach the exit statements