### PR TITLE
Fix problem with subType

### DIFF
--- a/web/pimcore/static6/js/pimcore/document/tags/multihref.js
+++ b/web/pimcore/static6/js/pimcore/document/tags/multihref.js
@@ -272,7 +272,7 @@ pimcore.document.tags.multihref = Class.create(pimcore.document.tag, {
                 if (type == data.data.elementType) {
                     found = true;
 
-                    if (this.options.subtypes[type] && this.options.subtypes[type].length) {
+                    if (this.options.subtypes && this.options.subtypes[type] && this.options.subtypes[type].length) {
                         checkSubType = true;
                     }
                     if (data.data.elementType == "object" && this.options.classes) {


### PR DESCRIPTION
Check if subTypes exist because if we don't add subType to our multihref configuration we get: "Uncaught TypeError: Cannot read property 'object' of undefined" when we try drop object to multiherf.

How to reproduce bug:
Create filed like: {{ pimcore_multihref("slider", {types:['object'], classes: ['Product']}) }}
And try drop object to this multihref.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
  
  
## Fixes Issue #

## Changes in this pull request  

## Additional info  

