### PR TITLE
Fix problem with subType in multihref.js

### DIFF
--- a/web/pimcore/static6/js/pimcore/document/tags/multihref.js
+++ b/web/pimcore/static6/js/pimcore/document/tags/multihref.js
@@ -272,7 +272,7 @@ pimcore.document.tags.multihref = Class.create(pimcore.document.tag, {
                 if (type == data.data.elementType) {
                     found = true;
 
-                    if (this.options.subtypes[type] && this.options.subtypes[type].length) {
+                    if (this.options.subtypes && this.options.subtypes[type] && this.options.subtypes[type].length) {
                         checkSubType = true;
                     }
                     if (data.data.elementType == "object" && this.options.classes) {


### PR DESCRIPTION
Check if subTypes exist because if we don't add subType to our multihref configuration we get: "Uncaught TypeError: Cannot read property 'object' of undefined" when we try drop object to multiherf.

How to reproduce bug:
Create filed like: {{ pimcore_multihref("slider", {types:['object'], classes: ['Product']}) }}
And try drop object to this multihref.

