### PR TITLE
Pimcore Mail helper bugfix

### DIFF
--- a/pimcore/lib/Pimcore/Helper/Mail.php
+++ b/pimcore/lib/Pimcore/Helper/Mail.php
@@ -225,10 +225,12 @@ CSS;
                 $replacePrefix = $site->getRootPath();
             }
 
-            // fallback
-            if (!$hostUrl) {
-                $hostUrl = \Pimcore\Tool::getHostUrl();
-            }
+
+        }
+
+        // fallback
+        if (!$hostUrl) {
+            $hostUrl = \Pimcore\Tool::getHostUrl();
         }
 
         //matches all links


### PR DESCRIPTION
The fallback for the host url has to be outside of the if() statement because otherwise this wouldn't work

\Pimcore\Web2Print\Processor::getInstance()->getPdfFromString($html)

beause no document is passed
