### PR TITLE
[CACHE] Fix options behaviour in pimcore:cache:clear command

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5.md
@@ -1,5 +1,11 @@
 # Upgrade Notes for Upgrades within Pimcore 5
 
+## Build 181 (2018-01-xx)
+
+The `pimcore:cache:clear` command semantics for the `-o` and `-a` option changed to follow option semantics as in other
+commands. Instead of `-a=1`, `-o=1`, now just pass `-a` and `-o`. The tags option now accepts multiple options, so you can
+use `-t foo -t bar` instead of `-t foo,bar` (old syntax still works).
+
 ## Build 173 (2018-01-09)
 
 The Google Analytics and Google Tag Manager code generation was refactored to use the same extendable block logic as the 


### PR DESCRIPTION
-o and -a now do not support values anymore. Instead of having to pass -o=1, just pass -o
-t is now handled as array

The change in options changes behaviour and can be considered a BC
break, but the current implementation is quite misleading as
"pimcore:cache:clear -o" clears the whole cache instead of only clearing
the output tag as expected.