### PR TITLE
[CACHE][REDIS] Fix concurrency issues in Lua mode

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/09_Cache/README.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/09_Cache/README.md
@@ -85,6 +85,11 @@ maxmemory-policy volatile-lru
 save ""
 ```
 
+> With the default settings, the minimum supported Redis version is 2.6.0 as it uses Redis' Lua scripting feature.
+
+> Please note that the Redis adapter currently doesn't properly support Redis Cluster setups.
+
+
 ## Element Cache Workflow (Asset, Document, Object)
 
 ![Element Cache Workflow](../../img/pimcore-cache.png)

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5.md
@@ -1,5 +1,12 @@
 # Upgrade Notes for Upgrades within Pimcore 5
 
+## Build 188 (2018-01-26)
+
+In a highly concurrent setup, the [**Redis Cache**](../../19_Development_Tools_and_Details/09_Cache/README.md)
+adapter can lead to inconsistencies resulting in items losing cache tags and not being cleared anymore on save. This was
+fixed in the Lua version of the cache adapter and the `use_lua` option now defaults to true. Please note that Lua scripting
+is not available in Redis versions prior to 2.6.0.
+
 ## Build 183 (2018-01-23)
 
 The `pimcore:cache:clear` command semantics for the `-o` and `-a` option changed to follow option semantics as in other

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -256,12 +256,12 @@ class PimcoreCoreExtension extends ConfigurableExtension implements PrependExten
         if ($config['cache']['pools']['redis']['enabled']) {
             $container->setParameter(
                 'pimcore.cache.core.redis.connection',
-                $config['cache']['pools']['redis']['connection']
+                $config['cache']['pools']['redis']['connection'] ?? []
             );
 
             $container->setParameter(
                 'pimcore.cache.core.redis.options',
-                $config['cache']['pools']['redis']['options']
+                $config['cache']['pools']['redis']['options'] ?? []
             );
 
             $loader->load('cache_redis.yml');

--- a/pimcore/lib/Pimcore/Cache/Pool/Redis.php
+++ b/pimcore/lib/Pimcore/Cache/Pool/Redis.php
@@ -82,7 +82,7 @@ class Redis extends AbstractCacheItemPool implements PurgeableCacheItemPoolInter
     /**
      * @var bool
      */
-    protected $useLua = false;
+    protected $useLua = true;
 
     /**
      * Lua's unpack() has a limit on the size of the table imposed by

--- a/pimcore/lib/Pimcore/Cache/Pool/Redis.php
+++ b/pimcore/lib/Pimcore/Cache/Pool/Redis.php
@@ -372,7 +372,22 @@ LUA;
 
         /** @var CacheItem $item */
         while ($item = array_shift($this->deferred)) {
-            $result = $result && $this->commitItem($item);
+            try {
+                $res = $this->commitItem($item);
+            } catch (\Throwable $e) {
+                $res = false;
+
+                CacheItem::log(
+                    $this->logger,
+                    'Failed to commit key "{key}"',
+                    [
+                        'key'       => $item->getKey(),
+                        'exception' => $e
+                    ]
+                );
+            }
+
+            $result = $result && (bool)$res;
         }
 
         return $result;

--- a/pimcore/tests/cache/Core/RedisLuaCoreHandlerTest.php
+++ b/pimcore/tests/cache/Core/RedisLuaCoreHandlerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Pimcore\Tests\Cache\Core;
+
+use Pimcore\Cache\Pool\Redis;
+use Pimcore\Tests\Cache\Pool\Traits\RedisItemPoolTrait;
+
+/**
+ * @group cache.core.redis
+ * @group cache.core.redis_lua
+ */
+class RedisLuaCoreHandlerTest extends AbstractCoreHandlerTest
+{
+    use RedisItemPoolTrait;
+
+    protected function getRedisOptions(): array
+    {
+        return [
+            'use_lua' => true
+        ];
+    }
+
+    /**
+     * Initializes item pool
+     *
+     * @return Redis
+     */
+    protected function createCachePool()
+    {
+        return $this->buildCachePool();
+    }
+}

--- a/pimcore/tests/cache/Pool/RedisLuaTest.php
+++ b/pimcore/tests/cache/Pool/RedisLuaTest.php
@@ -8,10 +8,10 @@ namespace Pimcore\Tests\Cache\Pool;
  */
 class RedisLuaTest extends RedisTest
 {
-    /**
-     * @var array
-     */
-    protected $redisOptions = [
-        'use_lua' => true
-    ];
+    protected function getRedisOptions(): array
+    {
+        return [
+            'use_lua' => true
+        ];
+    }
 }

--- a/pimcore/tests/cache/Pool/TaggableRedisLuaTest.php
+++ b/pimcore/tests/cache/Pool/TaggableRedisLuaTest.php
@@ -8,10 +8,10 @@ namespace Pimcore\Tests\Cache\Pool;
  */
 class TaggableRedisLuaTest extends TaggableRedisTest
 {
-    /**
-     * @var array
-     */
-    protected $redisOptions = [
-        'use_lua' => true
-    ];
+    protected function getRedisOptions(): array
+    {
+        return [
+            'use_lua' => true
+        ];
+    }
 }

--- a/pimcore/tests/cache/Pool/TaggableRedisTest.php
+++ b/pimcore/tests/cache/Pool/TaggableRedisTest.php
@@ -16,7 +16,7 @@ class TaggableRedisTest extends TaggableCachePoolTest
     use RedisItemPoolTrait;
 
     protected $skippedTests = [
-        'testInvalidateTag' => 'Invalidate tags is currently not working properly on redis',
+        'testInvalidateTag' => 'Invalidate tags is currently not working properly on Redis.',
     ];
 
     /**

--- a/pimcore/tests/cache/Pool/Traits/RedisItemPoolTrait.php
+++ b/pimcore/tests/cache/Pool/Traits/RedisItemPoolTrait.php
@@ -11,15 +11,17 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 trait RedisItemPoolTrait
 {
-    /**
-     * @var array
-     */
-    protected $redisConnectionOptions = [];
+    protected function getRedisConnectionOptions(): array
+    {
+        return [];
+    }
 
-    /**
-     * @var array
-     */
-    protected $redisOptions = [];
+    protected function getRedisOptions(): array
+    {
+        return [
+            'use_lua' => false
+        ];
+    }
 
     /**
      * @return PimcoreCacheItemPoolInterface|Redis
@@ -37,9 +39,9 @@ trait RedisItemPoolTrait
             }
         }
 
-        $connectionOptions = array_merge($this->redisConnectionOptions, $envOptions);
+        $connectionOptions = array_merge($this->getRedisConnectionOptions(), $envOptions);
 
-        return (new Factory())->createRedisItemPool($this->defaultLifetime, $connectionOptions, $this->redisOptions);
+        return (new Factory())->createRedisItemPool($this->defaultLifetime, $connectionOptions, $this->getRedisOptions());
     }
 
     protected function getRedisConnection(Redis $cache): Connection


### PR DESCRIPTION
In a high concurrency situation, the current Redis implementation can lead to inconsistencies resulting in items losing their cache tags. This happens when a save and an invalidateTag with a tag assigned to the saved item are issued within a short amount of time. 

This PR fixes only the Lua implementation of the cache adapter, the concurrency issue still exists in non-Lua mode. Changes include:

* Doing everything data related in a single script to ensure the data is accessed transactionally. This concerns mainly the oldTags clearing during a commit which previously handled the oldTags clearing outside of the script, leading to the same inconsistencies as in non-Lua mode.
* Defining Lua as properly intended and commented scripts instead of the unmaintainable blob it was before.
* Sending all Keys which are known before starting the script as `KEYS`. This still violates `EVAL` semantics, but at least sends every key it is able to know as `KEYS` (see note below).

**Note:** as the Lua mode violates the Redis [`EVAL`](https://redis.io/commands/eval) semantics which demand that every accessed key is sent through the `KEYS` argument, the Lua mode does not work properly in Redis Cluster setups. Unfortunately this is a conceptional problem as the accessed keys for item tags or for items when clearing a tag are not known before issuing the script, so we can't easily change this.

**Note 2:** this does not fix those issues in non-Lua mode, so using Lua is recommended.