### PR TITLE
check field editable in completed grid cell edit

### DIFF
--- a/web/pimcore/static6/js/pimcore/object/helpers/gridCellEditor.js
+++ b/web/pimcore/static6/js/pimcore/object/helpers/gridCellEditor.js
@@ -116,8 +116,13 @@ Ext.define('pimcore.object.helpers.gridCellEditor', {
     completeEdit: function(remainVisible) {
         var me = this,
             field = me.field,
+            fieldInfo = me.config.fieldInfo,
             startValue = me.startValue,
             value;
+
+        if(fieldInfo.layout.noteditable) {
+            return;
+        }
 
         value = me.getValue();
 


### PR DESCRIPTION
This PR fixes a nasty js error in grid cell editing. steps: to reproduce on demo:

- open folder with objects
- click "column configuration"
- add a "Operator Trimmer" and any field as child
- save
- click on a cell from the just created operater, a message appears "This element cannot be edited"
- now click on the refresh button on bottom which will trigger an error:

![bildschirmfoto 2018-01-22 um 12 42 34](https://user-images.githubusercontent.com/700119/35219232-1d95dc10-ff72-11e7-978a-907de4f8a982.png)

After that you need to reload the whole folder element.

By the way: the `startEdit` method is deprecated in extjs since 5.5:
http://docs.sencha.com/extjs/6.0.2/classic/Ext.grid.plugin.CellEditing.html#method-startEdit