### PR TITLE
fixed: if memory-limit for CLI is set to -1 install fails

### DIFF
--- a/pimcore/lib/Pimcore/Tool/Requirements.php
+++ b/pimcore/lib/Pimcore/Tool/Requirements.php
@@ -462,17 +462,21 @@ class Requirements
 
         // check for memory limit
         $memoryLimit = ini_get('memory_limit');
-        $memoryLimit = filesize2bytes($memoryLimit . 'B');
         $memoryLimitState = Check::STATE_OK;
         $memoryLimitMessage = '';
 
-        if ($memoryLimit < 67108000) {
-            $memoryLimitState = Check::STATE_ERROR;
-            $memoryLimitMessage = 'Your memory limit is by far too low. Set `memory_limit` in your php.ini at least to `150M`.';
-        } elseif ($memoryLimit < 134217000) {
-            $memoryLimitState = Check::STATE_WARNING;
-            $memoryLimitMessage = 'Your memory limit is probably too low. Set `memory_limit` in your php.ini to `150M` or higher to avoid issues.';
-        }
+        // check bytes of memory limit if it's not set to unlimited ('-1')
+		// http://php.net/manual/en/ini.core.php#ini.memory-limit
+        if($memoryLimit !== '-1') {
+			$memoryLimit = filesize2bytes($memoryLimit . 'B');
+			if ($memoryLimit < 67108000) {
+				$memoryLimitState = Check::STATE_ERROR;
+				$memoryLimitMessage = 'Your memory limit is by far too low. Set `memory_limit` in your php.ini at least to `150M`.';
+			} elseif ($memoryLimit < 134217000) {
+				$memoryLimitState = Check::STATE_WARNING;
+				$memoryLimitMessage = 'Your memory limit is probably too low. Set `memory_limit` in your php.ini to `150M` or higher to avoid issues.';
+			}
+		}
 
         $checks[] = new Check([
             'name' => 'memory_limit (in php.ini)',


### PR DESCRIPTION
[Install Command] if memory-limit for CLI is set to -1 install fails #2089
https://github.com/pimcore/pimcore/issues/2089

## Fixes Issue 
the install command failed if the php.ini setting for memory_limit was set to '-1'. 
I added a condition to convert the value of the memory_limit only if it is not set to -1

## Additional info  
see issue: https://github.com/pimcore/pimcore/issues/2089