### PR TITLE
Re-introduce copy/paste for areablocks with legacy naming scheme

### DIFF
--- a/web/pimcore/static6/js/pimcore/document/tags/areablock.js
+++ b/web/pimcore/static6/js/pimcore/document/tags/areablock.js
@@ -243,8 +243,28 @@ pimcore.document.tags.areablock = Class.create(pimcore.document.tag, {
         });
 
         this.namingStrategies.legacy = Class.create(this.namingStrategies.abstract, {
-            supportsCopyPaste: function () {
-                return false;
+            supportsCopyPaste: function() {
+                return true;
+            },
+
+            copyData: function (areaIdentifier, editable) {
+                if (!(editable.getName().indexOf(areaIdentifier.name + areaIdentifier.key) > 0)) {
+                    return false;
+                }
+
+                return this.createItem(editable);
+            },
+
+            getPasteName: function(areaIdentifier, item, editableData) {
+                var newKey = editableData.name.replace(new RegExp(item.identifier.name + item.identifier.key, 'g'), areaIdentifier.name + areaIdentifier.key);
+                var tmpKey;
+
+                while('undefined' === typeof tmpKey || tmpKey !== newKey) {
+                    tmpKey = newKey;
+                    newKey = newKey.replace(new RegExp(item.identifier.name + "_(.*)" + item.identifier.key + "_", "g"), areaIdentifier.name + "_$1" + areaIdentifier.key + "_");
+                }
+
+                return newKey;
             }
         });
 


### PR DESCRIPTION
C/p support was removed in https://github.com/pimcore/pimcore/commit/007e77028c95c0876dbae0278be121abfb8bb4f4 as we decided to only support it for the new naming scheme. This re-introduces c/p for the legacy scheme, with the same errors and implications as outlined in https://github.com/pimcore/pimcore/issues/559.

Upgrade to the nested naming scheme is still highly recommended.