### PR TITLE
Run assets:install after installation and fix assets:install after bundle CLI commands

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/DisableCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/DisableCommand.php
@@ -24,6 +24,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DisableCommand extends AbstractBundleCommand
 {
+    /**
+     * @var PostStateChange
+     */
+    private $postStateChangeHelper;
+
+    public function __construct(PostStateChange $postStateChangeHelper)
+    {
+        parent::__construct();
+
+        $this->postStateChangeHelper = $postStateChangeHelper;
+    }
+
     protected function configure()
     {
         $this
@@ -50,7 +62,9 @@ class DisableCommand extends AbstractBundleCommand
             return;
         }
 
-        $postStateChange = new PostStateChange($this->getApplication());
-        $postStateChange->runPostStateChangeCommands($this->io);
+        $this->postStateChangeHelper->runPostStateChangeCommands(
+            $this->io,
+            $this->getApplication()->getKernel()->getEnvironment()
+        );
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/EnableCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/EnableCommand.php
@@ -26,6 +26,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class EnableCommand extends AbstractBundleCommand
 {
+    /**
+     * @var PostStateChange
+     */
+    private $postStateChangeHelper;
+
+    public function __construct(PostStateChange $postStateChangeHelper)
+    {
+        parent::__construct();
+
+        $this->postStateChangeHelper = $postStateChangeHelper;
+    }
+
     protected function configure()
     {
         $this
@@ -79,8 +91,10 @@ class EnableCommand extends AbstractBundleCommand
             return;
         }
 
-        $postStateChange = new PostStateChange($this->getApplication());
-        $postStateChange->runPostStateChangeCommands($this->io);
+        $this->postStateChangeHelper->runPostStateChangeCommands(
+            $this->io,
+            $this->getApplication()->getKernel()->getEnvironment()
+        );
     }
 
     /**

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/Helper/PostStateChange.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/Helper/PostStateChange.php
@@ -17,23 +17,41 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\CoreBundle\Command\Bundle\Helper;
 
-use Pimcore\Console\Application;
+use Pimcore\Cache\Symfony\CacheClearer;
 use Pimcore\Console\Style\PimcoreStyle;
 use Pimcore\Tool\AssetsInstaller;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 
 class PostStateChange
 {
     /**
-     * @var Application
+     * @var CacheClearer
      */
-    private $application;
+    private $cacheClearer;
 
-    public function __construct(Application $application)
+    /**
+     * @var AssetsInstaller
+     */
+    private $assetsInstaller;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    public function __construct(
+        CacheClearer $cacheClearer,
+        AssetsInstaller $assetsInstaller,
+        EventDispatcherInterface $eventDispatcher
+    )
     {
-        $this->application = $application;
+        $this->cacheClearer    = $cacheClearer;
+        $this->assetsInstaller = $assetsInstaller;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     public static function configureStateChangeCommandOptions(Command $command)
@@ -60,7 +78,7 @@ class PostStateChange
         );
     }
 
-    public function runPostStateChangeCommands(PimcoreStyle $io)
+    public function runPostStateChangeCommands(PimcoreStyle $io, string $environment)
     {
         $input = $io->getInput();
 
@@ -71,92 +89,47 @@ class PostStateChange
         $runAssetsInstall = $input->getOption('no-assets-install') ? false : true;
         $runCacheClear    = $input->getOption('no-cache-clear') ? false : true;
 
-        $commands = [];
-
-        if ($runAssetsInstall) {
-            $commands[] = ['assets:install', $this->resolveAssetsInstallOptions()];
-        }
-
-        if ($runCacheClear) {
-            $commands[] = ['cache:clear'];
-        }
-
-        if (empty($commands)) {
+        if (!$runAssetsInstall && !$runCacheClear) {
             return;
         }
+
+        $runCallback = function($type, $buffer) use ($io) {
+            $io->write($buffer);
+        };
 
         $io->newLine();
         $io->section('Running post state change commands');
 
-        foreach ($commands as $command) {
-            $this->runCommand($io, $command[0], $command[1] ?? []);
-        }
-    }
+        if ($runAssetsInstall) {
+            $io->comment('Running bin/console assets:install...');
 
-    private function runCommand(PimcoreStyle $io, string $command, array $arguments = [])
-    {
-        $this->writeCommandInfo($io, $command, $arguments);
-
-        $command   = $this->application->find($command);
-        $arguments = array_merge(['command' => $command], $arguments);
-
-        $code = $command->run(new ArrayInput($arguments), $io);
-        if ($code > 0) {
-            throw new \RuntimeException(sprintf('Command "%s" failed', $command));
-        }
-    }
-
-    private function resolveAssetsInstallOptions(): array
-    {
-        $assetsInstaller = $this->application->getKernel()->getContainer()->get(AssetsInstaller::class);
-
-        $assetsOptions = [];
-        foreach ($assetsInstaller->resolveOptions(['ansi' => true]) as $option => $value) {
-            // do not set env and ansi options again for our subcommand
-            if (in_array($option, ['ansi', 'env'])) {
-                continue;
-            }
-
-            $assetsOptions['--' . $option] = $value;
-        }
-
-        return $assetsOptions;
-    }
-
-    /**
-     * Prints information about the command about to be run
-     *
-     * @param string $command
-     * @param array $arguments
-     */
-    private function writeCommandInfo(PimcoreStyle $io, string $command, array $arguments)
-    {
-        $argumentsInfo = [];
-        foreach ($arguments as $key => $value) {
-            if (0 === strpos($key, '--')) {
-                // --option
-                $option = $key;
-
-                if (is_bool($value)) {
-                    if (!$value) {
-                        $option .= '=0';
-                    }
-                } else {
-                    $option .= sprintf('="%s"', $value);
-                }
-
-                $argumentsInfo[] = $option;
-            } else {
-                // arguments just add the value
-                $argumentsInfo[] = sprintf('"%s"', $value);
+            try {
+                $this->assetsInstaller->setRunCallback($runCallback);
+                $this->assetsInstaller->install([
+                    'env'  => $environment,
+                    'ansi' => $io->isDecorated(),
+                ]);
+            } catch (ProcessFailedException $e) {
+                // noop - output should be enough
             }
         }
 
-        $commandInfo = $command;
-        if (!empty($argumentsInfo)) {
-            $commandInfo .= ' ' . implode(' ', $argumentsInfo);
-        }
+        if ($runCacheClear) {
+            // remove terminate event listeners as they break with a cleared container
+            foreach ($this->eventDispatcher->getListeners(ConsoleEvents::TERMINATE) as $listener) {
+                $this->eventDispatcher->removeListener(ConsoleEvents::TERMINATE, $listener);
+            }
 
-        $io->comment(sprintf('Running command %s', $commandInfo));
+            $io->comment('Running bin/console cache:clear...');
+
+            try {
+                $this->cacheClearer->setRunCallback($runCallback);
+                $this->cacheClearer->clear($environment, [
+                    'ansi' => $io->isDecorated()
+                ]);
+            } catch (ProcessFailedException $e) {
+                // noop - output should be enough
+            }
+        }
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/Helper/PostStateChange.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/Bundle/Helper/PostStateChange.php
@@ -112,8 +112,8 @@ class PostStateChange
 
         $assetsOptions = [];
         foreach ($assetsInstaller->resolveOptions(['ansi' => true]) as $option => $value) {
-            // do not set ansi option again for our subcommand
-            if ('ansi' === $option) {
+            // do not set env and ansi options again for our subcommand
+            if (in_array($option, ['ansi', 'env'])) {
                 continue;
             }
 

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/extensions.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/extensions.yml
@@ -44,5 +44,3 @@ services:
 
     Pimcore\Tool\AssetsInstaller:
         public: true
-        arguments:
-            $serializer: '@pimcore_admin.serializer'

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/extensions.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/extensions.yml
@@ -42,5 +42,7 @@ services:
 
     Pimcore\Config\BundleConfigLocator: ~
 
+    Pimcore\Bundle\CoreBundle\Command\Bundle\Helper\PostStateChange: ~
+
     Pimcore\Tool\AssetsInstaller:
         public: true

--- a/pimcore/lib/Pimcore/Bundle/InstallBundle/Command/InstallCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/InstallBundle/Command/InstallCommand.php
@@ -202,6 +202,8 @@ class InstallCommand extends Command
 
         $this->io = new PimcoreStyle($input, $output);
 
+        $this->installer->setCommandLineOutput($this->io);
+
         foreach ($this->getOptions() as $name => $config) {
             if (!$this->installerNeedsOption($config)) {
                 continue;

--- a/pimcore/lib/Pimcore/Process/PartsBuilder.php
+++ b/pimcore/lib/Pimcore/Process/PartsBuilder.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Process;
+
+class PartsBuilder
+{
+    /**
+     * @var array
+     */
+    private $arguments = [];
+
+    /**
+     * @var array
+     */
+    private $options = [];
+
+    public function __construct(array $arguments = [], array $options = [])
+    {
+        $this->addArguments($arguments);
+        $this->addOptions($options);
+    }
+
+    public function addArguments(array $arguments)
+    {
+        foreach ($arguments as $argument) {
+            $this->addArgument($argument);
+        }
+    }
+
+    public function addArgument($argument)
+    {
+        if (!empty($argument)) {
+            $this->arguments[] = $argument;
+        }
+    }
+
+    public function addOptions(array $options)
+    {
+        foreach ($options as $option => $value) {
+            $this->addOption($option, $value);
+        }
+    }
+
+    public function addOption(string $option, $value = null)
+    {
+        if (empty($option)) {
+            return;
+        }
+
+        // do not set null values
+        if (null === $value) {
+            return;
+        }
+
+        // do not set option if it is false
+        if (is_bool($value) && !$value) {
+            return;
+        }
+
+        $part = '';
+        if (1 === strlen($option)) {
+            $part = '-' . $option;
+        } else {
+            $part = '--' . $option;
+        }
+
+        if (!is_bool($value) && $value) {
+            $part .= '=' . $value;
+        }
+
+        $this->options[] = $part;
+    }
+
+    public function getParts(): array
+    {
+        return array_merge($this->arguments, $this->options);
+    }
+}

--- a/pimcore/lib/Pimcore/Tool/AssetsInstaller.php
+++ b/pimcore/lib/Pimcore/Tool/AssetsInstaller.php
@@ -35,6 +35,11 @@ class AssetsInstaller
     private $kernel;
 
     /**
+     * @var \Closure
+     */
+    private $runCallback;
+
+    /**
      * @var string
      */
     private $composerJsonSetting;
@@ -54,7 +59,7 @@ class AssetsInstaller
     public function install(array $options = []): Process
     {
         $process = $this->buildProcess($options);
-        $process->run();
+        $process->run($this->runCallback);
 
         if (!$process->isSuccessful()) {
             throw new ProcessFailedException($process);
@@ -116,6 +121,14 @@ class AssetsInstaller
         $this->configureOptions($resolver);
 
         return $resolver->resolve($options);
+    }
+
+    /**
+     * @param \Closure $runCallback
+     */
+    public function setRunCallback(\Closure $runCallback = null)
+    {
+        $this->runCallback = $runCallback;
     }
 
     private function configureOptions(OptionsResolver $resolver)

--- a/pimcore/tests/unit/Process/PartsBuilderTest.php
+++ b/pimcore/tests/unit/Process/PartsBuilderTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Tests\Unit\Process;
+
+use Pimcore\Process\PartsBuilder;
+use Pimcore\Tests\Test\TestCase;
+
+/**
+ * @covers PartsBuilder
+ */
+class PartsBuilderTest extends TestCase
+{
+    private $inputArguments = [
+        'foo',
+        'bar',
+        'baz:inga'
+    ];
+
+    private $inputOptions = [
+        'foo'  => true,
+        'bar'  => false, // omitted because false
+        'baz'  => 'inga',
+        'test' => null,  // omitted because null
+        'o'    => true,
+        'x'    => 'yz'
+    ];
+
+    private $expected = [
+        'foo',
+        'bar',
+        'baz:inga',
+        '--foo',
+        '--baz=inga',
+        '-o',
+        '-x=yz'
+    ];
+
+    public function testSetPartsInConstructor()
+    {
+        $builder = new PartsBuilder($this->inputArguments, $this->inputOptions);
+
+        $this->assertEquals($this->expected, $builder->getParts());
+    }
+
+    public function testSetPartsAsArray()
+    {
+        $builder = new PartsBuilder();
+        $builder->addArguments($this->inputArguments);
+        $builder->addOptions($this->inputOptions);
+
+        $this->assertEquals($this->expected, $builder->getParts());
+    }
+
+    public function testSetPartsSingle()
+    {
+        $builder = new PartsBuilder();
+
+        foreach ($this->inputArguments as $argument) {
+            $builder->addArgument($argument);
+        }
+
+        foreach ($this->inputOptions as $option => $value) {
+            $builder->addOption($option, $value);
+        }
+
+        $this->assertEquals($this->expected, $builder->getParts());
+    }
+
+    public function testMergeParts()
+    {
+        $builder = new PartsBuilder([
+            'foo',
+            'bar',
+        ], [
+            'foo' => true,
+            'bar' => false,
+            'baz' => 'inga'
+        ]);
+
+        $builder->addArgument('baz:inga');
+        $builder->addOption('test', null);
+        $builder->addOption('o', true);
+        $builder->addOption('x', 'yz');
+
+        $this->assertEquals($this->expected, $builder->getParts());
+    }
+
+    public function testOptionIsSetMultipleTimes()
+    {
+        $builder = new PartsBuilder([
+            'foo',
+            'bar',
+        ], [
+            'foo' => 'bar',
+            'bar' => true,
+            'x'   => 'yz',
+            'y'   => 'z',
+        ]);
+
+        $builder->addOption('foo', 'baz');
+        $builder->addOption('x', 'ab');
+        $builder->addOption('y', 'b');
+        $builder->addOption('bar', false);
+        $builder->addOption('baz', true);
+
+        $this->assertEquals([
+            'foo',
+            'bar',
+            '--foo=bar',
+            '--bar',
+            '-x=yz',
+            '-y=z',
+            '--foo=baz',
+            '-x=ab',
+            '-y=b',
+            '--baz'
+        ], $builder->getParts());
+    }
+}


### PR DESCRIPTION
* Runs `assets:install` after installation (see #1974)
* Fixes `assets:install` which is run after `pimcore:bundle:enable` not picking up the newly added bundle as it was executed from the same, old kernel
* Unifies `assets:install` and `cache:clear` process handling