### PR TITLE
Dependency handling for Bundles

### DIFF
--- a/doc/Development_Documentation/20_Extending_Pimcore/01_Add_Your_Own_Dependencies_and_Packages.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/01_Add_Your_Own_Dependencies_and_Packages.md
@@ -52,9 +52,7 @@ class AppKernel extends Kernel
 }
 ```
 
- Internally, the `BundleCollection` will be ordered by priority, filtered by environment and returned as plain array in
-`registerBundles`. If you need full control over the registered bundles, you can override `registerBundles` and add your
-customizations on the resulting array.
+You can read more about the bundle collection and handling of dependencies in [Bundle Collection](./13_Bundle_Developers_Guide/04_Bundle_Collection.md).
 
 ### Pimcore Bundles
 

--- a/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/04_Bundle_Collection.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/04_Bundle_Collection.md
@@ -1,0 +1,149 @@
+# Bundle Collection
+
+The `BundleCollection` is a container which is used to register every used bundle. As Pimcore gathers bundles from multiple 
+sources - registered via code in `AppKernel` and registered through the extension manager config, it makes sense to have 
+a unified API how bundles can be registered. 
+
+While Symfony's standard edition uses a `registerBundles` method building an array of bundles to load, Pimcore expects you
+to register your bundles in the `registerBundlesToCollection()` method and to use the bundle collection to add bundles.
+
+> Bundles without a priority are registered with a default priority of 0. You can set a negative value if you need to set
+  a priority lower than default.
+
+Below are a couple of examples how the bundle collection can be used:
+
+```php
+<?php
+
+use Pimcore\HttpKernel\BundleCollection\BundleCollection;
+use Pimcore\HttpKernel\BundleCollection\Item;
+use Pimcore\HttpKernel\BundleCollection\LazyLoadedItem;
+use Pimcore\Kernel;
+
+class AppKernel extends Kernel
+{
+    public function registerBundlesToCollection(BundleCollection $collection)
+    {
+        // add a bundle
+        $collection->addBundle(new BundleA());
+
+        // add a bundle, set a higher priority and restrict it to an environment
+        $collection->addBundle(new BundleB(), 10, ['dev']);
+
+        // add a bundle again - it will be ignored and still be loaded with prio 10
+        $collection->addBundle(new BundleB());
+
+        // add a bundle as string argument to load it lazily - the class instance will
+        // only be built when really needed (when the environment matches), so this makes
+        // sense for every item added with an environment restriction
+        $collection->addBundle(BundleC::class, 10, ['dev']);
+
+        // addBundle() is actually just a wrapper for add() which you can also directly use
+        $collection->add(new Item(new BundleD(), 10, ['dev', 'prod']));
+
+        // addBundle() is actually just a wrapper for add() which you can also directly use
+        $collection->add(new LazyLoadedItem(BundleE::class, 10, ['dev']));
+
+        // the collection expectes an ItemInterface - if needed you can get fancy and implement
+        // your own item type
+        $collection->add(new FancyItem(/* whatever your item needs */));
+    }
+}
+```
+
+## Bundle Dependencies
+
+If a bundle depends on other bundles, e.g. because it uses features provided by a third-party bundle you need to
+make sure that third-party bundle is loaded together with your bundle. You can either instruct your users to manually
+load the bundles your bundle depends on in their `AppKernel` or you can implement the [`DependentBundleInterface`](https://github.com/pimcore/pimcore/blob/master/pimcore/lib/Pimcore/HttpKernel/Bundle/DependentBundleInterface.php)
+and define a list of bundles which should be loaded together with your bundle:
+
+```php
+<?php
+
+namespace CustomBundle;
+
+use Pimcore\HttpKernel\Bundle\DependentBundleInterface;
+use Pimcore\HttpKernel\BundleCollection\BundleCollection;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class CustomBundle extends Bundle implements DependentBundleInterface
+{
+    public static function registerDependentBundles(BundleCollection $collection)
+    {
+        // register any bundles your bundle depends on here
+        $collection->addBundle(new FooBundle);
+    }
+}
+```
+
+**Important:** the `registerDependentBundles` method will be called as soon as your bundle is added to the collection. Even
+if your bundle has environment restrictions, the bundles added to the collection from `registerDependentBundles` will still
+be loaded. If you need to restrict the environments where the dependencies should be loaded, restrict them with the `env`
+argument to `addBundle()`. For performance reasons, you should add the bundle as lazy by adding a class name as string or
+by using `addItem` directly and passing a `LazyLoadedItem` instance. This ensures that the bundle instance is only built
+when it is really needed. Example:  
+
+As example:
+
+```php
+<?php
+
+// ...
+use Pimcore\HttpKernel\BundleCollection\LazyLoadedItem;
+
+class CustomBundle extends Bundle implements DependentBundleInterface
+{
+    public static function registerDependentBundles(BundleCollection $collection)
+    {
+        // call addBundle with a class name as string and restrict it to the dev environment
+        $collection->addBundle(FooBundle::class, 0, ['dev']);
+
+        // directly add a LazyLoadedItem - this is was addBundle does internally when gets a string
+        $collection->add(new LazyLoadedItem(FooBundle::class, 0, ['dev']));
+    }
+}
+```
+
+## Overriding collection items
+
+In case bundle defines a dependency which has the wrong priority or environment restrictions for your project you can
+override the dependency definition by adding the item to the collection **before** it is loaded as dependency. The dependency
+is simply ignored and your item will be used. Let's assume `CustomBundle` defines `FooBundle` as dependency and loads it 
+with a priority of 10, but we need to set the priority to 25:
+
+```php
+<?php
+
+// ...
+
+class CustomBundle extends Bundle implements DependentBundleInterface
+{
+    public static function registerDependentBundles(BundleCollection $collection)
+    {
+        $collection->addBundle(FooBundle::class, 10);
+    }
+}
+``` 
+
+To override this, register `FooBundle` manually with your priority:
+
+
+```php
+<?php
+
+use Pimcore\HttpKernel\BundleCollection\BundleCollection;
+use Pimcore\Kernel;
+
+class AppKernel extends Kernel
+{
+    public function registerBundlesToCollection(BundleCollection $collection)
+    {
+        // register FooBundle manually
+        $collection->addBundle(FooBundle::class, 25);
+        
+        // FooBundle won't be registered again here as it is already registered
+        $collection->addBundle(new \CustomBundle\CustomBundle);
+    }
+}
+```

--- a/pimcore/lib/Pimcore/HttpKernel/Bundle/DependentBundleInterface.php
+++ b/pimcore/lib/Pimcore/HttpKernel/Bundle/DependentBundleInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\HttpKernel\Bundle;
+
+use Pimcore\HttpKernel\BundleCollection\BundleCollection;
+
+/**
+ * Defines a bundle which has dependencies on other bundles. When adding a DependentBundle to the collection, the
+ * collection will call the static method to register additional bundles.
+ */
+interface DependentBundleInterface
+{
+    /**
+     * Register bundles to collection.
+     *
+     * WARNING: this method will be called as soon as this bundle is added to the collection, independent if
+     * it will finally be included due to environment restrictions. If you need to load your dependencies conditionally,
+     * specify the environments to use on the collection item.
+     *
+     * @param BundleCollection $collection
+     */
+    public static function registerDependentBundles(BundleCollection $collection);
+}

--- a/pimcore/lib/Pimcore/HttpKernel/BundleCollection/BundleCollection.php
+++ b/pimcore/lib/Pimcore/HttpKernel/BundleCollection/BundleCollection.php
@@ -113,9 +113,25 @@ class BundleCollection
      *
      * @return array
      */
-    public function getIdentifiers(): array
+    public function getIdentifiers(string $environment = null): array
     {
-        return array_keys($this->items);
+        return array_map(function (ItemInterface $item) {
+            return $item->getBundleIdentifier();
+        }, $this->getItems($environment));
+    }
+
+    /**
+     * Get bundles matching environment ordered by priority
+     *
+     * @param string $environment
+     *
+     * @return BundleInterface[]
+     */
+    public function getBundles(string $environment): array
+    {
+        return array_map(function (ItemInterface $item) {
+            return $item->getBundle();
+        }, $this->getItems($environment));
     }
 
     /**
@@ -158,19 +174,5 @@ class BundleCollection
         }
 
         return $this;
-    }
-
-    /**
-     * Get bundles matching environment ordered by priority
-     *
-     * @param string $environment
-     *
-     * @return BundleInterface[]
-     */
-    public function getBundles(string $environment): array
-    {
-        return array_map(function (ItemInterface $item) {
-            return $item->getBundle();
-        }, $this->getItems($environment));
     }
 }

--- a/pimcore/lib/Pimcore/HttpKernel/BundleCollection/BundleCollection.php
+++ b/pimcore/lib/Pimcore/HttpKernel/BundleCollection/BundleCollection.php
@@ -46,8 +46,10 @@ class BundleCollection
     public function add(ItemInterface $item): self
     {
         $identifier = $item->getBundleIdentifier();
+
+        // a bundle can only be registered once
         if ($this->hasItem($identifier)) {
-            throw new \LogicException(sprintf('Trying to register the bundle "%s" multiple times', $identifier));
+            return $this;
         }
 
         $this->items[$item->getBundleIdentifier()] = $item;

--- a/pimcore/lib/Pimcore/HttpKernel/BundleCollection/BundleCollection.php
+++ b/pimcore/lib/Pimcore/HttpKernel/BundleCollection/BundleCollection.php
@@ -44,6 +44,11 @@ class BundleCollection
 
         $this->items[$identifier] = $item;
 
+        // handle DependentBundleInterface by adding a bundle's dependencies tothe collection. dependencies
+        // are added AFTER the item was added to the collection to avoid circular reference loops, but the
+        // sort order can be influenced by specifying a priority on the item
+        $item->registerDependencies($this);
+
         return $this;
     }
 
@@ -164,11 +169,8 @@ class BundleCollection
      */
     public function getBundles(string $environment): array
     {
-        $bundles = [];
-        foreach ($this->getItems($environment) as $item) {
-            $bundles[] = $item->getBundle();
-        }
-
-        return $bundles;
+        return array_map(function (ItemInterface $item) {
+            return $item->getBundle();
+        }, $this->getItems($environment));
     }
 }

--- a/pimcore/lib/Pimcore/HttpKernel/BundleCollection/BundleCollection.php
+++ b/pimcore/lib/Pimcore/HttpKernel/BundleCollection/BundleCollection.php
@@ -135,21 +135,31 @@ class BundleCollection
     /**
      * Adds a bundle
      *
-     * @param BundleInterface $bundle
+     * @param BundleInterface|string $bundle
      * @param int $priority
      * @param array $environments
      *
      * @return self
      */
-    public function addBundle(BundleInterface $bundle, int $priority = 0, array $environments = []): self
+    public function addBundle($bundle, int $priority = 0, array $environments = []): self
     {
-        return $this->add(new Item($bundle, $priority, $environments));
+        $item = null;
+
+        if ($bundle instanceof BundleInterface) {
+            $item = new Item($bundle, $priority, $environments);
+        } elseif (is_string($bundle) || !empty($bundle)) {
+            $item = new LazyLoadedItem($bundle, $priority, $environments);
+        } else {
+            throw new \InvalidArgumentException('Bundle must be either an instance of BundleInterface or a string containing the bundle class name');
+        }
+
+        return $this->add($item);
     }
 
     /**
      * Adds a collection of bundles with the same priority and environments
      *
-     * @param BundleInterface[] $bundles
+     * @param BundleInterface[]|string[] $bundles
      * @param int $priority
      * @param array $environments
      *

--- a/pimcore/lib/Pimcore/HttpKernel/BundleCollection/BundleCollection.php
+++ b/pimcore/lib/Pimcore/HttpKernel/BundleCollection/BundleCollection.php
@@ -44,7 +44,7 @@ class BundleCollection
 
         $this->items[$identifier] = $item;
 
-        // handle DependentBundleInterface by adding a bundle's dependencies tothe collection. dependencies
+        // handle DependentBundleInterface by adding a bundle's dependencies to the collection - dependencies
         // are added AFTER the item was added to the collection to avoid circular reference loops, but the
         // sort order can be influenced by specifying a priority on the item
         $item->registerDependencies($this);

--- a/pimcore/lib/Pimcore/HttpKernel/BundleCollection/Item.php
+++ b/pimcore/lib/Pimcore/HttpKernel/BundleCollection/Item.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Pimcore\HttpKernel\BundleCollection;
 
 use Pimcore\Extension\Bundle\PimcoreBundleInterface;
+use Pimcore\HttpKernel\Bundle\DependentBundleInterface;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 class Item extends AbstractItem
@@ -51,5 +52,12 @@ class Item extends AbstractItem
     public function isPimcoreBundle(): bool
     {
         return $this->bundle instanceof PimcoreBundleInterface;
+    }
+
+    public function registerDependencies(BundleCollection $collection)
+    {
+        if ($this->bundle instanceof DependentBundleInterface) {
+            $this->bundle::registerDependentBundles($collection);
+        }
     }
 }

--- a/pimcore/lib/Pimcore/HttpKernel/BundleCollection/ItemInterface.php
+++ b/pimcore/lib/Pimcore/HttpKernel/BundleCollection/ItemInterface.php
@@ -34,6 +34,13 @@ interface ItemInterface
 
     public function getEnvironments(): array;
 
+    /**
+     * Registers dependent bundles if the bundle implements DependentBundleInterface
+     *
+     * @param BundleCollection $collection
+     */
+    public function registerDependencies(BundleCollection $collection);
+
     public function matchesEnvironment(string $environment): bool;
 
     public function getSource(): string;

--- a/pimcore/lib/Pimcore/Kernel.php
+++ b/pimcore/lib/Pimcore/Kernel.php
@@ -166,7 +166,7 @@ abstract class Kernel extends SymfonyKernel
      */
     public function registerBundles(): array
     {
-        $collection = new BundleCollection();
+        $collection = $this->createBundleCollection();
 
         // core bundles (Symfony, Pimcore)
         $this->registerCoreBundlesToCollection($collection);
@@ -182,6 +182,17 @@ abstract class Kernel extends SymfonyKernel
         $this->bundleCollection = $collection;
 
         return $bundles;
+    }
+
+    /**
+     * Creates bundle collection. Use this method to set bundles on the collection
+     * early.
+     *
+     * @return BundleCollection
+     */
+    protected function createBundleCollection(): BundleCollection
+    {
+        return new BundleCollection();
     }
 
     /**

--- a/pimcore/tests/unit/HttpKernel/BundleCollection/BundleCollectionTest.php
+++ b/pimcore/tests/unit/HttpKernel/BundleCollection/BundleCollectionTest.php
@@ -62,11 +62,39 @@ class BundleCollectionTest extends TestCase
         $this->assertEquals($this->bundles, $this->collection->getBundles('prod'));
     }
 
+    public function testAddBundleAsString()
+    {
+        $identifiers = [];
+
+        foreach ($this->bundles as $bundle) {
+            $className     = get_class($bundle);
+            $identifiers[] = $className;
+
+            $this->collection->addBundle($className);
+        }
+
+        $this->assertEquals($identifiers, $this->collection->getIdentifiers());
+    }
+
     public function testAddBundles()
     {
         $this->collection->addBundles($this->bundles);
 
         $this->assertEquals($this->bundles, $this->collection->getBundles('prod'));
+    }
+
+    public function testAddBundlesAsString()
+    {
+        $identifiers = [];
+
+        foreach ($this->bundles as $bundle) {
+            $className     = get_class($bundle);
+            $identifiers[] = $className;
+        }
+
+        $this->collection->addBundles($identifiers);
+
+        $this->assertEquals($identifiers, $this->collection->getIdentifiers());
     }
 
     public function testAddItem()

--- a/pimcore/tests/unit/HttpKernel/BundleCollection/BundleCollectionTest.php
+++ b/pimcore/tests/unit/HttpKernel/BundleCollection/BundleCollectionTest.php
@@ -19,7 +19,6 @@ namespace Pimcore\Tests\Unit\HttpKernel\BundleCollection;
 
 use Pimcore\HttpKernel\BundleCollection\BundleCollection;
 use Pimcore\HttpKernel\BundleCollection\Item;
-use Pimcore\HttpKernel\BundleCollection\LazyLoadedItem;
 use Pimcore\Tests\Test\TestCase;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
@@ -163,48 +162,6 @@ class BundleCollectionTest extends TestCase
         }
 
         $this->assertEquals($identifiers, $this->collection->getIdentifiers());
-    }
-
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Trying to register the bundle "Pimcore\Tests\Unit\HttpKernel\BundleCollection\BundleA" multiple times
-     */
-    public function testExceptionOnDoubleBundle()
-    {
-        $this->collection->addBundle($this->bundles[0]);
-        $this->collection->addBundle($this->bundles[0]);
-    }
-
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Trying to register the bundle "Pimcore\Tests\Unit\HttpKernel\BundleCollection\BundleA" multiple times
-     */
-    public function testExceptionOnDoubleBundleWithDifferentInstance()
-    {
-        $this->collection->addBundle(new BundleA);
-        $this->collection->addBundle(new BundleA);
-    }
-
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Trying to register the bundle "Pimcore\Tests\Unit\HttpKernel\BundleCollection\BundleA" multiple times
-     */
-    public function testExceptionOnDoubleBundleWithItem()
-    {
-        $this->collection->add(new Item($this->bundles[0]));
-        $this->collection->add(new Item($this->bundles[0]));
-    }
-
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Trying to register the bundle "Pimcore\Tests\Unit\HttpKernel\BundleCollection\BundleA" multiple times
-     */
-    public function testExceptionOnDoubleLazyLoadedBundle()
-    {
-        $bundleClass = get_class($this->bundles[0]);
-
-        $this->collection->add(new LazyLoadedItem($bundleClass));
-        $this->collection->add(new LazyLoadedItem($bundleClass));
     }
 
     public function testBundlesAreOrderedByPriority()

--- a/pimcore/tests/unit/HttpKernel/BundleCollection/ItemTest.php
+++ b/pimcore/tests/unit/HttpKernel/BundleCollection/ItemTest.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
 namespace Pimcore\Tests\Unit\HttpKernel\BundleCollection;
 
 use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
+use Pimcore\HttpKernel\Bundle\DependentBundleInterface;
+use Pimcore\HttpKernel\BundleCollection\BundleCollection;
 use Pimcore\HttpKernel\BundleCollection\Item;
 use Pimcore\Tests\Test\TestCase;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -73,6 +75,18 @@ class ItemTest extends TestCase
         $this->assertFalse($itemA->isPimcoreBundle());
         $this->assertTrue($itemB->isPimcoreBundle());
     }
+
+    public function testRegistersDependencies()
+    {
+        $collection = new BundleCollection();
+
+        $collection->add(new Item(new ItemTestBundleC()));
+
+        $this->assertEquals([
+            ItemTestBundleC::class,
+            ItemTestBundleA::class,
+        ], $collection->getIdentifiers());
+    }
 }
 
 class ItemTestBundleA extends Bundle
@@ -81,4 +95,12 @@ class ItemTestBundleA extends Bundle
 
 class ItemTestBundleB extends AbstractPimcoreBundle
 {
+}
+
+class ItemTestBundleC extends Bundle implements DependentBundleInterface
+{
+    public static function registerDependentBundles(BundleCollection $collection)
+    {
+        $collection->add(new Item(new ItemTestBundleA()));
+    }
 }


### PR DESCRIPTION
As described in #1780, dependencies between bundles are a common issue which currently needs to be solved manually. As we already have the `BundleCollection`, adding a way to handle dependencies on a simple level is possible without a performance hit coming from dependency resolution. This change:

* Removes the exception which is thrown on the bundle collection when a bundle is added multiple times. Instead, subsequent adds are simply ignored. An already added item can never be changed, so the first item added wins. This also means that an item which is added from the core or from another bundle can be overridden on the collection by adding it manually before it is added from core/dependency. See the new `createBundleCollection` method on the kernel which can be used to add items to the collection early.
* Introduces a new `DependentBundleInterface` a bundle can implement. As soon as the bundle is added to the collection, the `registerDependentBundles()` method is called which allows the bundle to implicitly load dependencies. Order is resolved through the item priority.
* Dependencies of dependencies also work as the `registerDependentBundles()` method is called from the `add()` method on the collection which is always called to add an item. If a bundle adds a dependency, the dependency can again be a `DependentBundleInterface` adding further dependencies (see tests for an example). Circular reference loops are simply avoided by stopping as soon as the item to be added already exists on the collection (see first point).

@dpfaffenbauer want to give this a try for CoreShop's `RegisterBundleHelper` before we merge?