### PR TITLE
Fix errors after activating extensions via extension manager which rely on parameters (e.g. ecommerce)

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
@@ -18,6 +18,7 @@ use ForceUTF8\Encoding;
 use Pimcore\Bundle\AdminBundle\Controller\AdminController;
 use Pimcore\Bundle\AdminBundle\HttpFoundation\JsonResponse;
 use Pimcore\Bundle\LegacyBundle\Controller\Admin\ExtensionManager\LegacyExtensionManagerController;
+use Pimcore\Cache\Symfony\CacheClearer;
 use Pimcore\Controller\EventedControllerInterface;
 use Pimcore\Extension\Bundle\Exception\BundleNotFoundException;
 use Pimcore\Extension\Bundle\PimcoreBundleInterface;
@@ -34,6 +35,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 
 /**
@@ -151,11 +153,17 @@ class ExtensionManagerController extends AdminController implements EventedContr
      * @Route("/admin/toggle-extension-state")
      *
      * @param Request $request
+     * @param KernelInterface $kernel
      * @param AssetsInstaller $assetsInstaller
      *
      * @return JsonResponse
      */
-    public function toggleExtensionStateAction(Request $request, AssetsInstaller $assetsInstaller)
+    public function toggleExtensionStateAction(
+        Request $request,
+        KernelInterface $kernel,
+        CacheClearer $cacheClearer,
+        AssetsInstaller $assetsInstaller
+    )
     {
         if (null !== $response = $this->handleLegacyRequest($request, __FUNCTION__)) {
             return $response;
@@ -168,20 +176,33 @@ class ExtensionManagerController extends AdminController implements EventedContr
         $reload  = false;
         $message = null;
 
+        $data = [
+            'success' => true,
+            'errors'  => []
+        ];
+
         if ($type === 'bundle') {
             $this->bundleManager->setState($id, ['enabled' => $enable]);
             $reload = true;
 
             $message = $this->installAssets($assetsInstaller, $enable);
+
+            // clear the cache if kernel is not in debug mode (= auto-rebuilds container)
+            if (!$kernel->isDebug()) {
+                try {
+                    $cacheClearer->clear($kernel->getEnvironment(), [
+                        'no-warmup' => true
+                    ]);
+                } catch (\Throwable $e) {
+                    $data['errors'][] = $e->getMessage();
+                }
+            }
         } elseif ($type === 'areabrick') {
             $this->areabrickManager->setState($id, $enable);
             $reload = true;
         }
 
-        $data = [
-            'success' => true,
-            'reload'  => $reload,
-        ];
+        $data['reload'] = $reload;
 
         if ($message) {
             $data['message'] = $message;

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PimcoreEcommerceFrameworkBundle.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PimcoreEcommerceFrameworkBundle.php
@@ -79,12 +79,17 @@ class PimcoreEcommerceFrameworkBundle extends AbstractPimcoreBundle
     {
         $container = $this->container;
 
-        // set default decimal scale from config
-        Decimal::setDefaultScale($container->getParameter('pimcore_ecommerce.decimal_scale'));
+        if ($container->hasParameter('pimcore_ecommerce.decimal_scale')) {
+            // set default decimal scale from config
+            Decimal::setDefaultScale($container->getParameter('pimcore_ecommerce.decimal_scale'));
+        }
 
         // use legacy class mapping if configured
-        if ($container->getParameter('pimcore_ecommerce.use_legacy_class_mapping')) {
-            //load legacy class mapping only when ecommerce framework bundle is installed.
+        if (
+            $container->hasParameter('pimcore_ecommerce.use_legacy_class_mapping')
+            && $container->getParameter('pimcore_ecommerce.use_legacy_class_mapping')
+        ) {
+            // load legacy class mapping only when ecommerce framework bundle is installed
             LegacyClassMappingTool::loadMapping();
         }
     }


### PR DESCRIPTION
Resolves #2267

* Kernel now handles a `FileExistenceResource` for every possible location of the `extensions.php` to make sure a debug container is rebuilt when a file is created. For example, in the empty install profile the file doesn't exist at all and the container didn't track if it is created.
* When activating an extension via extension manager in a non-debug container, the cache is implicitly cleared.
* The Ecommerce Framework now checks for parameter existence before using them in `boot()`. This is done as fallback if previous the measures do not work, e.g. when activating an extension by manually editing `extensions.php` for a non-debug container.



