### PR TITLE
Fix config merging to never overwrite with scalars/null and add tests

### DIFF
--- a/pimcore/lib/Pimcore/DependencyInjection/ConfigMerger.php
+++ b/pimcore/lib/Pimcore/DependencyInjection/ConfigMerger.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\DependencyInjection;
+
+class ConfigMerger
+{
+    /**
+     * Recursively merges arrays.
+     *
+     * Merge two arrays as array_merge_recursive does, but instead of converting values to arrays when keys are the
+     * same, it replaces the value from the first array with the value from the second one. Array values in the first
+     * array are never overwritten with scalars from the second (e.g. an array can't be overwritten with null).
+     *
+     * IMPORTANT: never change this behaviour as it is needed to properly handle security config merging!
+     *
+     * @see https://github.com/oro-subtree/PhpUtils/blob/master/ArrayUtil.php
+     *
+     * @param array $first
+     * @param array $second
+     *
+     * @return array
+     */
+    public function merge(array $first, array $second): array
+    {
+        foreach ($second as $idx => $value) {
+            if (is_integer($idx)) {
+                $first[] = $value;
+            } else {
+                if (!array_key_exists($idx, $first)) {
+                    $first[$idx] = $value;
+                } elseif (is_array($value) && is_array($first[$idx])) {
+                    $first[$idx] = $this->merge($first[$idx], $value);
+                } elseif (!is_array($first[$idx])) {
+                    $first[$idx] = $value;
+                }
+            }
+        }
+
+        return $first;
+    }
+}

--- a/pimcore/lib/Pimcore/Tool/ArrayUtils.php
+++ b/pimcore/lib/Pimcore/Tool/ArrayUtils.php
@@ -14,16 +14,12 @@
 
 namespace Pimcore\Tool;
 
+use Pimcore\DependencyInjection\ConfigMerger;
+
 class ArrayUtils
 {
     /**
-     *
-     * Recursively merge arrays.
-     *
-     * Merge two arrays as array_merge_recursive do, but instead of converting values to arrays when keys are same
-     * replaces value from first array with value from second
-     *
-     * @see https://github.com/oro-subtree/PhpUtils/blob/master/ArrayUtil.php
+     * @deprecated Use the ConfigMerger instead
      *
      * @param array $first
      * @param array $second
@@ -32,26 +28,8 @@ class ArrayUtils
      */
     public static function arrayMergeRecursiveDistinct(array $first, array $second)
     {
-        foreach ($second as $idx => $value) {
-            if (is_integer($idx)) {
-                $first[] = $value;
-            } else {
-                if (!array_key_exists($idx, $first)) {
-                    $first[$idx] = $value;
-                } else {
-                    if (is_array($value)) {
-                        if (is_array($first[$idx])) {
-                            $first[$idx] = self::arrayMergeRecursiveDistinct($first[$idx], $value);
-                        } else {
-                            $first[$idx] = $value;
-                        }
-                    } else {
-                        $first[$idx] = $value;
-                    }
-                }
-            }
-        }
+        $merger = new ConfigMerger();
 
-        return $first;
+        return $merger->merge($first, $second);
     }
 }

--- a/pimcore/tests/unit/DependencyInjection/ConfigMergerTest.php
+++ b/pimcore/tests/unit/DependencyInjection/ConfigMergerTest.php
@@ -1,0 +1,368 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Tests\Unit\Tool;
+
+use Pimcore\DependencyInjection\ConfigMerger;
+use Pimcore\Tests\Test\TestCase;
+
+class ConfigMergerTest extends TestCase
+{
+    /**
+     * @var ConfigMerger
+     */
+    private $configMerger;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->configMerger = new ConfigMerger();
+    }
+
+    public function testMerge()
+    {
+        $coreConfig = [
+            'providers'      => [
+                'pimcore_admin' => [
+                    'id' => 'Pimcore\\Bundle\\AdminBundle\\Security\\User\\UserProvider'
+                ]
+            ],
+            'firewalls'      => [
+                'dev'   => [
+                    'pattern'  => '^/(_(profiler|wdt)|css|images|js)/',
+                    'security' => false
+                ],
+                'admin' => [
+                    'anonymous' => null,
+                    'pattern'   => '^/admin',
+                    'stateless' => true,
+                    'provider'  => 'pimcore_admin',
+                    'logout'    => [
+                        'path'            => '/admin/logout',
+                        'target'          => '/admin/login',
+                        'success_handler' => 'Pimcore\\Bundle\\AdminBundle\\Security\\LogoutSuccessHandler'
+                    ],
+                    'guard'     => [
+                        'entry_point'    => 'Pimcore\\Bundle\\AdminBundle\\Security\\Guard\\AdminAuthenticator',
+                        'authenticators' => [
+                            'Pimcore\\Bundle\\AdminBundle\\Security\\Guard\\AdminAuthenticator'
+                        ]
+                    ]
+                ],
+            ],
+            'access_control' => [
+                [
+                    'path'  => '^/admin/settings/display-custom-logo',
+                    'roles' => 'IS_AUTHENTICATED_ANONYMOUSLY'
+                ],
+                [
+                    'path'  => '^/admin/login$',
+                    'roles' => 'IS_AUTHENTICATED_ANONYMOUSLY'
+                ],
+                [
+                    'path'  => '^/admin/login/(login|lostpassword|deeplink)$',
+                    'roles' => 'IS_AUTHENTICATED_ANONYMOUSLY'
+                ],
+                [
+                    'path'  => '^/admin',
+                    'roles' => 'ROLE_PIMCORE_USER'
+                ],
+            ],
+            'role_hierarchy' => [
+                'ROLE_PIMCORE_ADMIN' => ['ROLE_PIMCORE_USER']
+            ]
+        ];
+
+        $appConfig = [
+            'providers'      => [
+                'demo_cms_provider' => [
+                    'id' => 'app.security.user_provider'
+                ]
+            ],
+            'firewalls'      => [
+                'demo_cms_fw' => [
+                    'anonymous'             => null,
+                    'provider'              => 'demo_cms_provider',
+                    'form_login'            => [
+                        'login_path' => 'demo_login',
+                        'check_path' => 'demo_login'
+                    ],
+                    'logout'                => [
+                        'path'               => 'demo_logout',
+                        'target'             => 'demo_login',
+                        'invalidate_session' => false
+                    ],
+                    'logout_on_user_change' => true
+                ]
+            ],
+            'access_control' => [
+                [
+                    'path'  => '^/secure',
+                    'roles' => 'ROLE_USER'
+                ],
+                [
+                    'path'  => '^/secure/admin',
+                    'roles' => 'ROLE_ADMIN'
+                ],
+            ],
+            'role_hierarchy' => [
+                'ROLE_ADMIN' => ['ROLE_USER']
+            ]
+        ];
+
+        $merged = $this->configMerger->merge($coreConfig, $appConfig);
+
+        $this->assertEquals([
+            'providers'      => [
+                'pimcore_admin'     => [
+                    'id' => 'Pimcore\\Bundle\\AdminBundle\\Security\\User\\UserProvider'
+                ],
+                'demo_cms_provider' => [
+                    'id' => 'app.security.user_provider'
+                ]
+            ],
+            'firewalls'      => [
+                'dev'         => [
+                    'pattern'  => '^/(_(profiler|wdt)|css|images|js)/',
+                    'security' => false
+                ],
+                'admin'       => [
+                    'anonymous' => null,
+                    'pattern'   => '^/admin',
+                    'stateless' => true,
+                    'provider'  => 'pimcore_admin',
+                    'logout'    => [
+                        'path'            => '/admin/logout',
+                        'target'          => '/admin/login',
+                        'success_handler' => 'Pimcore\\Bundle\\AdminBundle\\Security\\LogoutSuccessHandler'
+                    ],
+                    'guard'     => [
+                        'entry_point'    => 'Pimcore\\Bundle\\AdminBundle\\Security\\Guard\\AdminAuthenticator',
+                        'authenticators' => [
+                            'Pimcore\\Bundle\\AdminBundle\\Security\\Guard\\AdminAuthenticator'
+                        ]
+                    ]
+                ],
+                'demo_cms_fw' => [
+                    'anonymous'             => null,
+                    'provider'              => 'demo_cms_provider',
+                    'form_login'            => [
+                        'login_path' => 'demo_login',
+                        'check_path' => 'demo_login'
+                    ],
+                    'logout'                => [
+                        'path'               => 'demo_logout',
+                        'target'             => 'demo_login',
+                        'invalidate_session' => false
+                    ],
+                    'logout_on_user_change' => true
+                ]
+            ],
+            'access_control' => [
+                [
+                    'path'  => '^/admin/settings/display-custom-logo',
+                    'roles' => 'IS_AUTHENTICATED_ANONYMOUSLY'
+                ],
+                [
+                    'path'  => '^/admin/login$',
+                    'roles' => 'IS_AUTHENTICATED_ANONYMOUSLY'
+                ],
+                [
+                    'path'  => '^/admin/login/(login|lostpassword|deeplink)$',
+                    'roles' => 'IS_AUTHENTICATED_ANONYMOUSLY'
+                ],
+                [
+                    'path'  => '^/admin',
+                    'roles' => 'ROLE_PIMCORE_USER'
+                ],
+                [
+                    'path'  => '^/secure',
+                    'roles' => 'ROLE_USER'
+                ],
+                [
+                    'path'  => '^/secure/admin',
+                    'roles' => 'ROLE_ADMIN'
+                ]
+            ],
+            'role_hierarchy' => [
+                'ROLE_PIMCORE_ADMIN' => ['ROLE_PIMCORE_USER'],
+                'ROLE_ADMIN'         => ['ROLE_USER']
+            ]
+        ], $merged);
+    }
+
+    public function testIndexedArraysAreExtended()
+    {
+        $arr1 = [
+            'foo' => [
+                'A', 'B', 'C'
+            ]
+        ];
+
+        $arr2 = [
+            'foo' => [
+                'D', 'E', 'F'
+            ]
+        ];
+
+        $this->assertEquals([
+            'foo' => ['A', 'B', 'C', 'D', 'E', 'F']
+        ], $this->configMerger->merge($arr1, $arr2));
+    }
+
+    public function testAssociativeArraysAreMerged()
+    {
+        $arr1 = [
+            'foo' => [
+                'bar'         => 'baz',
+                'tooverwrite' => 'xyz',
+                'tomerge'     => [
+                    'A', 'B'
+                ]
+            ]
+        ];
+
+        $arr2 = [
+            'foo' => [
+                'baz'         => 'inga',
+                'tooverwrite' => 'abc',
+                'tomerge'     => [
+                    'C', 'D'
+                ]
+            ]
+        ];
+
+        $this->assertEquals([
+            'foo' => [
+                'bar'         => 'baz',
+                'baz'         => 'inga',
+                'tooverwrite' => 'abc',
+                'tomerge'     => [
+                    'A', 'B', 'C', 'D'
+                ]
+            ]
+        ], $this->configMerger->merge($arr1, $arr2));
+    }
+
+    public function testIndexedArraysAreNotOverwrittenWithNull()
+    {
+        $arr1 = [
+            'access_control' => [
+                [
+                    'path'  => '^/secure',
+                    'roles' => 'ROLE_USER'
+                ],
+                [
+                    'path'  => '^/secure/admin',
+                    'roles' => 'ROLE_ADMIN'
+                ],
+            ],
+        ];
+
+        $arr2 = [
+            'access_control' => null
+        ];
+
+        $this->assertEquals($arr1, $this->configMerger->merge($arr1, $arr2));
+    }
+
+    public function testIndexedArraysOverwriteNull()
+    {
+        $arr1 = [
+            'access_control' => null
+        ];
+
+        $arr2 = [
+            'access_control' => [
+                [
+                    'path'  => '^/secure',
+                    'roles' => 'ROLE_USER'
+                ],
+                [
+                    'path'  => '^/secure/admin',
+                    'roles' => 'ROLE_ADMIN'
+                ],
+            ],
+        ];
+
+        $this->assertEquals($arr2, $this->configMerger->merge($arr1, $arr2));
+    }
+
+    public function testAssociativeArraysAreNotOverwrittenWithNull()
+    {
+        $arr1 = [
+            'firewalls' => [
+                'demo_cms_fw' => [
+                    'anonymous'             => null,
+                    'provider'              => 'demo_cms_provider',
+                    'form_login'            => [
+                        'login_path' => 'demo_login',
+                        'check_path' => 'demo_login'
+                    ],
+                    'logout'                => [
+                        'path'               => 'demo_logout',
+                        'target'             => 'demo_login',
+                        'invalidate_session' => false
+                    ],
+                    'logout_on_user_change' => true
+                ]
+            ],
+        ];
+
+        $arr2 = [
+            'firewalls' => [
+                'demo_cms_fw' => null
+            ]
+        ];
+
+        $this->assertEquals($arr1, $this->configMerger->merge($arr1, $arr2));
+    }
+
+    public function testAssociativeArraysOverwriteNull()
+    {
+        $arr1 = [
+            'firewalls' => [
+                'demo_cms_fw' => null
+            ]
+        ];
+
+        $arr2 = [
+            'firewalls' => [
+                'demo_cms_fw' => [
+                    'anonymous'             => null,
+                    'provider'              => 'demo_cms_provider',
+                    'form_login'            => [
+                        'login_path' => 'demo_login',
+                        'check_path' => 'demo_login'
+                    ],
+                    'logout'                => [
+                        'path'               => 'demo_logout',
+                        'target'             => 'demo_login',
+                        'invalidate_session' => false
+                    ],
+                    'logout_on_user_change' => true
+                ]
+            ],
+        ];
+
+        $this->assertEquals($arr2, $this->configMerger->merge($arr1, $arr2));
+    }
+}

--- a/pimcore/tests/unit/Tool/ArrayNormalizerTest.php
+++ b/pimcore/tests/unit/Tool/ArrayNormalizerTest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-namespace Pimcore\Tests\Unit\Mail;
+namespace Pimcore\Tests\Unit\Tool;
 
 use Pimcore\Tests\Test\TestCase;
 use Pimcore\Tool\ArrayNormalizer;

--- a/pimcore/tests/unit/Tool/HtmlUtilsTest.php
+++ b/pimcore/tests/unit/Tool/HtmlUtilsTest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-namespace Pimcore\Tests\Unit\Mail;
+namespace Pimcore\Tests\Unit\Tool;
 
 use Pimcore\Tests\Test\TestCase;
 use Pimcore\Tool\HtmlUtils;


### PR DESCRIPTION
Merging

    access_control:
        - { path: '^/test' }
        - { path: '^/test2' }

with

    access_control: ~

resulted in

    access_control: ~

as the null overwrote the array. Now, only merging is done, and arrays
are never overwritten from scalars. This should make the merging behaviour
the same as the core config component handles it.