### PR TITLE
fix for batch actions related with classification store fields

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
@@ -2205,7 +2205,6 @@ class DataObjectHelperController extends AdminController
                             $fd = $class->getFieldDefinition($field);
                             $keyConfig = $fd->getKeyConfiguration($keyid);
                             $dataDefinition = DataObject\Classificationstore\Service::getFieldDefinitionFromKeyConfig($keyConfig);
-                            $language = $fd->isLocalized() ? $requestedLanguage : null;
 
                             /** @var $classificationStoreData DataObject\Classificationstore */
                             $classificationStoreData = $object->$getter();
@@ -2213,7 +2212,7 @@ class DataObjectHelperController extends AdminController
                                 $groupId,
                                 $keyid,
                                 $dataDefinition->getDataFromEditmode($value),
-                                $language
+                                $requestedLanguage
                             );
                         }
                     } else {

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
@@ -2201,13 +2201,19 @@ class DataObjectHelperController extends AdminController
 
                         $getter = 'get' . ucfirst($field);
                         if (method_exists($object, $getter)) {
+                            /** @var $fd DataObject\ClassDefinition\Data\Classificationstore */
+                            $fd = $class->getFieldDefinition($field);
+                            $keyConfig = $fd->getKeyConfiguration($keyid);
+                            $dataDefinition = DataObject\Classificationstore\Service::getFieldDefinitionFromKeyConfig($keyConfig);
+                            $language = $fd->isLocalized() ? $requestedLanguage : null;
+
                             /** @var $classificationStoreData DataObject\Classificationstore */
                             $classificationStoreData = $object->$getter();
                             $classificationStoreData->setLocalizedKeyValue(
                                 $groupId,
                                 $keyid,
-                                $value,
-                                $requestedLanguage
+                                $dataDefinition->getDataFromEditmode($value),
+                                $language
                             );
                         }
                     } else {


### PR DESCRIPTION
It seems that classification store fields are not saved due the lack of the important code.