### PR TITLE
Re-Introduce support for /app/startup.php and remove hardcoded environments

### DIFF
--- a/doc/Development_Documentation/01_Getting_Started/03_Configuration.md
+++ b/doc/Development_Documentation/01_Getting_Started/03_Configuration.md
@@ -99,3 +99,25 @@ control over the used paths here.
 
 In contrast to the other constants, `PIMCORE_PROJECT_ROOT` can not be set via `.env` Pimcore doesn't know where to look
 for a `.env` file at this point.
+
+
+## Adding logic to the startup process
+
+If you need to execute code to influence Pimcore's startup process, you can do so by adding a file in `/app/startup.php`
+which will be automatically included as part of the bootstrap process. Specifically, it will be loaded after all other
+bootstrapping (loading the autoloader, parsing constants, ...) is done, but **before** the kernel is loaded and booted.
+This gives you the possibility to reconfigure environment settings before they are used and to configure the system for
+your needs. Examples:
+
+* Defining the [Trusted Proxies](http://symfony.com/doc/3.4/deployment/proxies.html) configuration on the `Request` object
+* Influencing the default [environment handling](../21_Deployment/03_Multi_Environment.md)
+
+```php
+<?php
+
+// /app/startup.php
+
+use \Symfony\Component\HttpFoundation\Request;
+
+Request::setTrustedProxies(['192.0.0.1', '10.0.0.0/8']);
+```

--- a/pimcore/config/bootstrap.php
+++ b/pimcore/config/bootstrap.php
@@ -30,3 +30,10 @@ if ('syslog' === PIMCORE_PHP_ERROR_LOG || is_writable(dirname(PIMCORE_PHP_ERROR_
     ini_set('error_log', PIMCORE_PHP_ERROR_LOG);
     ini_set('log_errors', '1');
 }
+
+// load a startup file if it exists - this is a good place to preconfigure the system
+// before the kernel is loaded - e.g. to set trusted proxies on the request object
+$startupFile = PIMCORE_PROJECT_ROOT . '/app/startup.php';
+if (file_exists($startupFile)) {
+    include_once $startupFile;
+}

--- a/pimcore/config/kernel.php
+++ b/pimcore/config/kernel.php
@@ -11,16 +11,19 @@
  * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
+
 use Pimcore\Config;
 use Symfony\Component\Debug\Debug;
 
-$debug = Pimcore::inDebugMode() || in_array(Config::getEnvironment(), ['dev', 'test']);
+$environment = Config::getEnvironment();
+$debug       = Config::getEnvironmentConfig()->activatesKernelDebugMode($environment);
+
 if ($debug) {
     Debug::enable();
     @ini_set('display_errors', 'On');
 }
 
-$kernel = new AppKernel(Config::getEnvironment(), $debug);
+$kernel = new AppKernel($environment, $debug);
 Pimcore::setKernel($kernel);
 $kernel->boot();
 

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Update/IndexController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Update/IndexController.php
@@ -18,6 +18,7 @@ use Pimcore\Bundle\AdminBundle\Controller\AdminController;
 use Pimcore\Cache\Symfony\CacheClearer;
 use Pimcore\Config;
 use Pimcore\Controller\EventedControllerInterface;
+use Pimcore\Kernel;
 use Pimcore\Update;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -34,13 +35,13 @@ class IndexController extends AdminController implements EventedControllerInterf
     /**
      * @Route("/check-debug-mode")
      *
-     * @param Request $request
+     * @param KernelInterface $kernel
      *
-     * @return \Pimcore\Bundle\AdminBundle\HttpFoundation\JsonResponse
+     * @return JsonResponse
      */
-    public function checkDebugModeAction(Request $request)
+    public function checkDebugModeAction(KernelInterface $kernel)
     {
-        $debug = \Pimcore::inDebugMode() || in_array(Config::getEnvironment(), ['dev', 'test']);
+        $debug = \Pimcore::inDebugMode() || $kernel->isDebug();
 
         return $this->adminJson([
             'success' => (bool) $debug

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/UpdateCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/UpdateCommand.php
@@ -126,7 +126,7 @@ class UpdateCommand extends AbstractCommand
                 exit;
             }
 
-            $debug = \Pimcore::inDebugMode() || in_array(Config::getEnvironment(), ['dev', 'test']);
+            $debug = \Pimcore::inDebugMode() || $this->getApplication()->getKernel()->isDebug();
             if (!$debug) {
                 $this->writeError('Enable debug mode in system settings or set PIMCORE_ENVIRONMENT=dev');
                 exit;

--- a/pimcore/lib/Pimcore/Config.php
+++ b/pimcore/lib/Pimcore/Config.php
@@ -14,11 +14,16 @@
 
 namespace Pimcore;
 
+use Pimcore\Config\EnvironmentConfig;
+use Pimcore\Config\EnvironmentConfigInterface;
 use Pimcore\Model\WebsiteSetting;
 use Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter;
 
 class Config
 {
+    /**
+     * @deprecated Default environment is now determined by EnvironmentConfig
+     */
     const DEFAULT_ENVIRONMENT = 'prod';
 
     /**
@@ -30,6 +35,11 @@ class Config
      * @var string
      */
     protected static $environment = null;
+
+    /**
+     * @var EnvironmentConfigInterface
+     */
+    private static $environmentConfig;
 
     /**
      * @param $name - name of configuration file. slash is allowed for subdirectories.
@@ -779,10 +789,12 @@ class Config
                 if (null !== $default) {
                     $environment = $default;
                 } else {
+                    $environmentConfig = static::getEnvironmentConfig();
+
                     if (\Pimcore::inDebugMode()) {
-                        $environment = 'dev';
+                        $environment = $environmentConfig->getDefaultDebugModeEnvironment();
                     } else {
-                        $environment = static::DEFAULT_ENVIRONMENT;
+                        $environment = $environmentConfig->getDefaultEnvironment();
                     }
                 }
             }
@@ -799,6 +811,20 @@ class Config
     public static function setEnvironment($environment)
     {
         static::$environment = $environment;
+    }
+
+    public static function getEnvironmentConfig(): EnvironmentConfigInterface
+    {
+        if (null === static::$environmentConfig) {
+            static::$environmentConfig = new EnvironmentConfig();
+        }
+
+        return static::$environmentConfig;
+    }
+
+    public static function setEnvironmentConfig(EnvironmentConfigInterface $environmentConfig)
+    {
+        self::$environmentConfig = $environmentConfig;
     }
 
     /**

--- a/pimcore/lib/Pimcore/Config/EnvironmentConfig.php
+++ b/pimcore/lib/Pimcore/Config/EnvironmentConfig.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Config;
+
+class EnvironmentConfig implements EnvironmentConfigInterface
+{
+    /**
+     * Environments activating the kernel debug mode
+     *
+     * @var array
+     */
+    private $kernelDebugEnvironments = ['dev', 'test'];
+
+    /**
+     * The default environment to use used if no environment is explicitely
+     * set and Pimcore is not in debug mode.
+     *
+     * @var string
+     */
+    private $defaultEnvironment = 'prod';
+
+    /**
+     * The default environment to use used if no environment is explicitely
+     * set and Pimcore is in debug mode.
+     *
+     * @var string
+     */
+    private $defaultDebugModeEnvironment = 'dev';
+
+    /**
+     * Environments which will be handled by the profiler cleanup job
+     *
+     * @var array
+     */
+    private $profilerHousekeepingEnvironments = ['dev'];
+
+    public function activatesKernelDebugMode(string $environment): bool
+    {
+        if (\Pimcore::inDebugMode()) {
+            return true;
+        }
+
+        return in_array($environment, $this->kernelDebugEnvironments, true);
+    }
+
+    public function setKernelDebugEnvironments(array $kernelDebugEnvironments)
+    {
+        $this->kernelDebugEnvironments = $kernelDebugEnvironments;
+    }
+
+    public function getKernelDebugEnvironments(): array
+    {
+        return $this->kernelDebugEnvironments;
+    }
+
+    public function getDefaultEnvironment(): string
+    {
+        return $this->defaultEnvironment;
+    }
+
+    public function setDefaultEnvironment(string $defaultEnvironment)
+    {
+        $this->defaultEnvironment = $defaultEnvironment;
+    }
+
+    public function getDefaultDebugModeEnvironment(): string
+    {
+        return $this->defaultDebugModeEnvironment;
+    }
+
+    public function setDefaultDebugModeEnvironment(string $defaultDebugModeEnvironment)
+    {
+        $this->defaultDebugModeEnvironment = $defaultDebugModeEnvironment;
+    }
+
+    public function setProfilerHousekeepingEnvironments(array $profilerHousekeepingEnvironments)
+    {
+        $this->profilerHousekeepingEnvironments = $profilerHousekeepingEnvironments;
+    }
+
+    public function getProfilerHousekeepingEnvironments(): array
+    {
+        return $this->profilerHousekeepingEnvironments;
+    }
+}

--- a/pimcore/lib/Pimcore/Config/EnvironmentConfigInterface.php
+++ b/pimcore/lib/Pimcore/Config/EnvironmentConfigInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Config;
+
+interface EnvironmentConfigInterface
+{
+    /**
+     * Determines if the environment activates the kernel debug mode.
+     *
+     * @param string $environment
+     *
+     * @return bool
+     */
+    public function activatesKernelDebugMode(string $environment): bool;
+
+    /**
+     * Default environment to use if no environment is explicitely defined
+     *
+     * @return string
+     */
+    public function getDefaultEnvironment(): string;
+
+    /**
+     * Default environment to use if no environment is explicitely defined and Pimcore is in debug mode
+     *
+     * @return string
+     */
+    public function getDefaultDebugModeEnvironment(): string;
+
+    /**
+     * Environments to handle in housekeeping maintenance job
+     *
+     * @return array
+     */
+    public function getProfilerHousekeepingEnvironments(): array;
+}

--- a/pimcore/lib/Pimcore/Kernel.php
+++ b/pimcore/lib/Pimcore/Kernel.php
@@ -259,8 +259,8 @@ abstract class Kernel extends SymfonyKernel
             new PimcoreAdminBundle()
         ], 60);
 
-        // environment specific dev + test bundles
-        if (in_array($this->getEnvironment(), ['dev', 'test'])) {
+        // load development bundles only in matching environments
+        if (in_array($this->getEnvironment(), $this->getEnvironmentsForDevBundles(), true)) {
             $collection->addBundles([
                 new DebugBundle(),
                 new WebProfilerBundle(),
@@ -269,20 +269,32 @@ abstract class Kernel extends SymfonyKernel
 
             // add generator bundle only if installed
             if (class_exists('Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle')) {
+                $generatorEnvironments = $this->getEnvironmentsForDevGeneratorBundles();
+
                 $collection->addBundle(
                     new SensioGeneratorBundle(),
                     80,
-                    ['dev']
+                    $generatorEnvironments
                 );
 
                 // PimcoreGeneratorBundle depends on SensioGeneratorBundle
                 $collection->addBundle(
                     new PimcoreGeneratorBundle(),
                     60,
-                    ['dev']
+                    $generatorEnvironments
                 );
             }
         }
+    }
+
+    protected function getEnvironmentsForDevBundles(): array
+    {
+        return ['dev', 'test'];
+    }
+
+    protected function getEnvironmentsForDevGeneratorBundles(): array
+    {
+        return ['dev'];
     }
 
     /**

--- a/pimcore/lib/Pimcore/Tool/Housekeeping.php
+++ b/pimcore/lib/Pimcore/Tool/Housekeeping.php
@@ -14,6 +14,8 @@
 
 namespace Pimcore\Tool;
 
+use Pimcore\Config;
+
 class Housekeeping
 {
     /**
@@ -29,10 +31,13 @@ class Housekeeping
      */
     public static function cleanupSymfonyProfilingData($olderThanDays = 4)
     {
+        $environments = Config::getEnvironmentConfig()->getProfilerHousekeepingEnvironments();
 
-        // currently only for the 'dev' environment which has enabled the profiler by default
-        $profilerDir = PIMCORE_PRIVATE_VAR . '/cache/dev/profiler';
-        self::deleteFilesInFolderOlderThanDays($profilerDir, $olderThanDays);
+        foreach ($environments as $environment) {
+            $profilerDir = sprintf('%s/cache/%s/profiler', PIMCORE_PRIVATE_VAR, $environment);
+
+            self::deleteFilesInFolderOlderThanDays($profilerDir, $olderThanDays);
+        }
     }
 
     /**


### PR DESCRIPTION
Hardcoded environments are now handled in a configurable EnvironmentConfig class which is initialized at boot, but can be overridden/reconfigured during the startup process.

EnvironmentConfig can either be reconfigured using setters or completely replaced by implementing a custom config class. Environments to register in development are still hardcoded on the kernel, but extracted into a method which can be overridden.

* Resolves #2520 
* Resolves #2059 