### PR TITLE
Application logger: Apply search form on ENTER key

### DIFF
--- a/web/pimcore/static6/js/pimcore/log/admin.js
+++ b/web/pimcore/static6/js/pimcore/log/admin.js
@@ -274,11 +274,14 @@ pimcore.log.admin = Class.create({
                 height: 500,
                 border: false,
                 autoScroll: true,
+                referenceHolder: true,
+                defaultButton: 'log_search_button',
                 buttons: [{
                     text: t("log_reset_search"),
                     handler: this.clearValues.bind(this),
                     iconCls: "pimcore_icon_stop"
                 },{
+                    reference: 'log_search_button',
                     text: t("log_search"),
                     handler: this.find.bind(this),
                     iconCls: "pimcore_icon_search"


### PR DESCRIPTION
With this change the search filter form is submitted on ENTER key, too.
E.g. when typing in a search term in "Message". Before the filter could only
be applied by clicking on button "Search".

Ext JS reference: http://docs.sencha.com/extjs/6.0.2/classic/Ext.panel.Panel.html#cfg-defaultButton
