### PR TITLE
WebLink Support

### DIFF
--- a/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/01_HeadLink.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/01_HeadLink.md
@@ -29,7 +29,7 @@ The `headLink()` helper method allows specifying all attributes necessary for a 
 and allows you to also specify placement -- whether the new element replaces all others, prepends (top of stack), 
 or appends (end of stack).
 
-### Basic Usage
+## Basic Usage
 
 You may specify a headLink at any time. 
 Typically, you will specify global links in your layout script, and application specific links in your 
@@ -45,3 +45,50 @@ $this->headLink()->appendStylesheet('/styles/basic.css')
 <?= $this->headLink() ?>
 ```
 
+## HTTP/2 Push Support
+
+The HeadLink and HeadScript helpers have internal support for the [WebLink Component](https://symfony.com/blog/new-in-symfony-3-3-weblink-component).
+While you can call `$this->webLink()->preload('/path/to/file.css', ['as' => 'style'])` directly in your templates, the HeadLink
+and HeadScript helpers take care of adding a cache buster aware link instead of the unprefixed file path. Push support is
+currently opt-in - to make the helpers automatically include links to the served assets either enable it globally on the 
+helper level or individually for each item.
+
+```php
+<?php
+/** @var \Pimcore\Templating\PhpEngine $this */
+
+// enable web links for every item
+$this->headLink()->enableWebLinks();
+
+// set web link attributes passed to every item
+$this->headLink()->setWebLinkAttributes(['as' => 'style']);
+
+// enable webLink on an item level
+// the item will be added even if enableWebLinks() was not called
+$this->headLink()->appendStylesheet('/static/css/styles.css', 'screen', false, [
+    'webLink' => ['as' => 'style']
+]);
+
+// disable webLink on an item level
+// the item won't be added even if enableWebLinks() was called
+$this->headLink()->appendStylesheet('/static/css/styles.css', 'screen', false, [
+    'webLink' => false
+]);
+
+// override the used method (default is preload())
+$this->headLink()->appendStylesheet('/static/css/styles.css', 'screen', false, [
+    'webLink' => ['method' => 'prefetch']
+]);
+?>
+```
+
+Added links will be handled by the web link component and injected into the response. Make sure Symfony is properly configured
+(this setting is enabled by default from Pimcore's core config):
+
+```yaml
+# config.yml
+
+framework:
+    web_links:
+        enabled: true
+```

--- a/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/03_HeadScript.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/03_HeadScript.md
@@ -111,3 +111,8 @@ pass it as the second argument to `captureStart()`.
 
 If you wish to specify any additional attributes for the `<script>` tag, pass them in an array as the third 
 argument to `captureStart()`.
+
+
+## HTTP/2 Push Support
+
+See [HTTP/2 Push Support on the HeadLink page](./01_HeadLink.md#page_HTTP-2-Push-Support).

--- a/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/README.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/README.md
@@ -343,3 +343,13 @@ View helper for getting translation from shared translations. For details also s
 <a href="/"><?= $this->translate("Home"); ?></a>
 ```
 
+
+### `$this->webLink()`
+
+Exposes methods provided by Symfony's [WebLink Component](https://symfony.com/blog/new-in-symfony-3-3-weblink-component).
+See [WebLink](https://github.com/pimcore/pimcore/blob/web-link-support/pimcore/lib/Pimcore/Templating/Helper/WebLink.php)
+for details.
+
+```php
+<link rel="stylesheet" href="<?= $this->webLink()->preload('/static/css/global.css', ['as' => 'style']) ?>">
+```

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/default.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/default.yml
@@ -16,6 +16,8 @@ framework:
     validation: { enable_annotations: true }
     templating:
         engines: ['php', 'twig']
+    web_link:
+        enabled: true
     default_locale:  "%locale%"
     session:
         # http://symfony.com/doc/current/reference/configuration/framework.html#handler-id

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating_php.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating_php.yml
@@ -95,6 +95,10 @@ services:
         tags:
             - { name: templating.helper, alias: headMeta }
 
+    Pimcore\Templating\Helper\WebLink:
+        tags:
+            - { name: templating.helper, alias: webLink }
+
     Pimcore\Templating\Helper\Device:
         tags:
             - { name: templating.helper, alias: device }

--- a/pimcore/lib/Pimcore/Templating/Helper/HeadLink.php
+++ b/pimcore/lib/Pimcore/Templating/Helper/HeadLink.php
@@ -41,6 +41,7 @@ use Pimcore\Event\FrontendEvents;
 use Pimcore\Templating\Helper\Placeholder\CacheBusterAware;
 use Pimcore\Templating\Helper\Placeholder\Container;
 use Pimcore\Templating\Helper\Placeholder\ContainerService;
+use Pimcore\Templating\Helper\Traits\WebLinksTrait;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -59,6 +60,8 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class HeadLink extends CacheBusterAware
 {
+    use WebLinksTrait;
+
     /**
      * $_validAttributes
      *
@@ -84,15 +87,28 @@ class HeadLink extends CacheBusterAware
     protected $_regKey = 'HeadLink';
 
     /**
+     * Default attributes for generated WebLinks (HTTP/2 push).
+     *
+     * @var array
+     */
+    protected $webLinkAttributes = ['as' => 'style'];
+
+    /**
      * HeadLink constructor.
      *
      * Use PHP_EOL as separator
      *
      * @param ContainerService $containerService
+     * @param WebLink $webLinkHelper
      */
-    public function __construct(ContainerService $containerService)
+    public function __construct(
+        ContainerService $containerService,
+        WebLink $webLinkHelper
+    )
     {
         parent::__construct($containerService);
+
+        $this->webLinkHelper = $webLinkHelper;
         $this->setSeparator(PHP_EOL);
     }
 
@@ -364,6 +380,17 @@ class HeadLink extends CacheBusterAware
             \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::VIEW_HELPER_HEAD_LINK, new GenericEvent($this, [
                 'item' => $item
             ]));
+
+            $source         = (string)($item->href ?? '');
+            $itemAttributes = isset($item->extras) ? $item->extras : [];
+
+            if (is_array($item->extras) && isset($item->extras['webLink'])) {
+                unset($item->extras['webLink']);
+            }
+
+            if (is_array($itemAttributes) && !empty($source)) {
+                $this->handleWebLink($item, $source, $itemAttributes);
+            }
         }
     }
 

--- a/pimcore/lib/Pimcore/Templating/Helper/HeadScript.php
+++ b/pimcore/lib/Pimcore/Templating/Helper/HeadScript.php
@@ -41,6 +41,7 @@ use Pimcore\Event\FrontendEvents;
 use Pimcore\Templating\Helper\Placeholder\CacheBusterAware;
 use Pimcore\Templating\Helper\Placeholder\Container;
 use Pimcore\Templating\Helper\Placeholder\ContainerService;
+use Pimcore\Templating\Helper\Traits\WebLinksTrait;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -55,6 +56,8 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class HeadScript extends CacheBusterAware
 {
+    use WebLinksTrait;
+
     /**#@+
      * Script type contants
      * @const string
@@ -112,15 +115,28 @@ class HeadScript extends CacheBusterAware
     public $useCdata = false;
 
     /**
+     * Default attributes for generated WebLinks (HTTP/2 push).
+     *
+     * @var array
+     */
+    protected $webLinkAttributes = ['as' => 'script'];
+
+    /**
      * HeadScript constructor.
      *
      * Set separator to PHP_EOL.
      *
      * @param ContainerService $containerService
+     * @param WebLink $webLinkHelper
      */
-    public function __construct(ContainerService $containerService)
+    public function __construct(
+        ContainerService $containerService,
+        WebLink $webLinkHelper
+    )
     {
         parent::__construct($containerService);
+
+        $this->webLinkHelper = $webLinkHelper;
         $this->setSeparator(PHP_EOL);
     }
 
@@ -542,6 +558,19 @@ class HeadScript extends CacheBusterAware
             \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::VIEW_HELPER_HEAD_SCRIPT, new GenericEvent($this, [
                 'item' => $item
             ]));
+
+            if (isset($item->attributes) && is_array($item->attributes)) {
+                $source         = (string)($item->attributes['src'] ?? '');
+                $itemAttributes = $item->attributes;
+
+                if (isset($item->attributes['webLink'])) {
+                    unset($item->attributes['webLink']);
+                }
+
+                if (!empty($source)) {
+                    $this->handleWebLink($item, $source, $itemAttributes);
+                }
+            }
         }
     }
 

--- a/pimcore/lib/Pimcore/Templating/Helper/Traits/WebLinksTrait.php
+++ b/pimcore/lib/Pimcore/Templating/Helper/Traits/WebLinksTrait.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Templating\Helper\Traits;
+
+use Pimcore\Templating\Helper\WebLink;
+
+trait WebLinksTrait
+{
+    /**
+     * @var WebLink
+     */
+    protected $webLinkHelper;
+
+    /**
+     * Whether to use WebLinks (HTTP/2 push) for every item. Can be
+     * overridden on an item level.
+     *
+     * @var bool
+     */
+    protected $webLinksEnabled = false;
+
+    public function webLinksEnabled(bool $enabled = null)
+    {
+        if (null !== $enabled) {
+            $this->webLinksEnabled = $enabled;
+        }
+
+        return $this->webLinksEnabled;
+    }
+
+    public function enableWebLinks(): self
+    {
+        $this->webLinksEnabled(true);
+
+        return $this;
+    }
+
+    public function getWebLinkAttributes(): array
+    {
+        return $this->webLinkAttributes;
+    }
+
+    public function setWebLinkAttributes(array $webLinkAttributes)
+    {
+        $this->webLinkAttributes = $webLinkAttributes;
+    }
+
+    protected function handleWebLink(\stdClass $item, string $source, array $itemAttributes)
+    {
+        if (empty($source)) {
+            return;
+        }
+
+        if (!$this->webLinksEnabled && !isset($itemAttributes['webLink'])) {
+            return;
+        }
+
+        $attributes = $this->webLinkAttributes;
+        if (isset($itemAttributes['webLink'])) {
+            if (is_bool($itemAttributes['webLink'])) {
+                // set webLink to false to disable webLink on the item level. this allows to
+                // enable web links for the whole helper while disabling them for individual items
+                if (!$itemAttributes['webLink']) {
+                    return;
+                } else {
+                    $itemAttributes['webLink'] = [];
+                }
+            }
+
+            $attributes = array_merge($attributes, $itemAttributes['webLink']);
+        }
+
+        $method = 'preload';
+        if (isset($attributes['method'])) {
+            $method = $attributes['method'];
+            unset($attributes['method']);
+        }
+
+        call_user_func([$this->webLinkHelper, $method], $source, $attributes);
+    }
+}

--- a/pimcore/lib/Pimcore/Templating/Helper/WebLink.php
+++ b/pimcore/lib/Pimcore/Templating/Helper/WebLink.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Templating\Helper;
+
+use Symfony\Bridge\Twig\Extension\WebLinkExtension;
+use Symfony\Component\Templating\Helper\Helper;
+
+class WebLink extends Helper
+{
+    /**
+     * @var WebLinkExtension
+     */
+    private $webLinkExtension;
+
+    public function __construct(WebLinkExtension $webLinkExtension)
+    {
+        $this->webLinkExtension = $webLinkExtension;
+    }
+
+    public function getName()
+    {
+        return 'webLink';
+    }
+
+    /**
+     * Adds a "Link" HTTP header.
+     *
+     * @param string $uri       The relation URI
+     * @param string $rel       The relation type (e.g. "preload", "prefetch", "prerender" or "dns-prefetch")
+     * @param array $attributes The attributes of this link (e.g. "array('as' => true)", "array('pr' => 0.5)")
+     *
+     * @return string The relation URI
+     */
+    public function link($uri, $rel, array $attributes = [])
+    {
+        return $this->webLinkExtension->link($uri, $rel, $attributes);
+    }
+
+    /**
+     * Preloads a resource.
+     *
+     * @param string $uri       A public path
+     * @param array $attributes The attributes of this link (e.g. "array('as' => true)", "array('crossorigin' =>
+     *                          'use-credentials')")
+     *
+     * @return string The path of the asset
+     */
+    public function preload($uri, array $attributes = [])
+    {
+        return $this->webLinkExtension->preload($uri, $attributes);
+    }
+
+    /**
+     * Resolves a resource origin as early as possible.
+     *
+     * @param string $uri       A public path
+     * @param array $attributes The attributes of this link (e.g. "array('as' => true)", "array('pr' => 0.5)")
+     *
+     * @return string The path of the asset
+     */
+    public function dnsPrefetch($uri, array $attributes = [])
+    {
+        return $this->webLinkExtension->dnsPrefetch($uri, $attributes);
+    }
+
+    /**
+     * Initiates a early connection to a resource (DNS resolution, TCP handshake, TLS negotiation).
+     *
+     * @param string $uri       A public path
+     * @param array $attributes The attributes of this link (e.g. "array('as' => true)", "array('pr' => 0.5)")
+     *
+     * @return string The path of the asset
+     */
+    public function preconnect($uri, array $attributes = [])
+    {
+        return $this->webLinkExtension->preconnect($uri, $attributes);
+    }
+
+    /**
+     * Indicates to the client that it should prefetch this resource.
+     *
+     * @param string $uri       A public path
+     * @param array $attributes The attributes of this link (e.g. "array('as' => true)", "array('pr' => 0.5)")
+     *
+     * @return string The path of the asset
+     */
+    public function prefetch($uri, array $attributes = [])
+    {
+        return $this->webLinkExtension->prefetch($uri, $attributes);
+    }
+
+    /**
+     * Indicates to the client that it should prerender this resource .
+     *
+     * @param string $uri       A public path
+     * @param array $attributes The attributes of this link (e.g. "array('as' => true)", "array('pr' => 0.5)")
+     *
+     * @return string The path of the asset
+     */
+    public function prerender($uri, array $attributes = [])
+    {
+        return $this->webLinkExtension->prerender($uri, $attributes);
+    }
+}

--- a/pimcore/lib/Pimcore/Templating/PhpEngine.php
+++ b/pimcore/lib/Pimcore/Templating/PhpEngine.php
@@ -27,6 +27,7 @@ use Pimcore\Templating\Helper\HeadTitle;
 use Pimcore\Templating\Helper\InlineScript;
 use Pimcore\Templating\Helper\Navigation;
 use Pimcore\Templating\Helper\Placeholder\Container;
+use Pimcore\Templating\Helper\WebLink;
 use Pimcore\Templating\HelperBroker\HelperBrokerInterface;
 use Pimcore\Templating\Model\ViewModel;
 use Pimcore\Templating\Model\ViewModelInterface;
@@ -89,6 +90,7 @@ use Symfony\Component\Templating\Storage\Storage;
  * @method HeadTitle headTitle($title = null, $setType = null)
  * @method string inc($include, array $params = [], $cacheEnabled = true, $editmode = null)
  * @method InlineScript inlineScript($mode = HeadScript::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
+ * @method WebLink webLink()
  * @method Navigation navigation()
  * @method Config|mixed websiteConfig($key = null, $default = null)
  * @method string pimcoreUrl(array $urlOptions = [], $name = null, $reset = false, $encode = true, $relative = false)


### PR DESCRIPTION
Resolves #1534 

Adds support for Symfony's [WebLink Component](https://symfony.com/blog/new-in-symfony-3-3-weblink-component) in both the PHP templating engine and in `HeadLink` and `HeadScript` helpers. The Head* view helpers need extra logic as they need to add processed assets with cache buster support.

Usage in templates:

```php
<!-- direct usage -->
<link rel="stylesheet" href="<?= $this->webLink()->preload('/static/css/global.css', ['as' => 'style']) ?>">

<?php
// headLink usage
$this->headLink()->enableWebLinks();
$this->headLink()->appendStylesheet('/static/asset.css');
echo $this->headLink();
?>
```


