### PR TITLE
[TARGETING] Debug Toolbar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,6 +111,7 @@
     "symfony/swiftmailer-bundle": "^2.6.4",
     "symfony/symfony": "3.4.*",
     "tijsverkoyen/css-to-inline-styles": "~1.5",
+    "twig/extensions": "^1.5",
     "twig/twig": "^2.0",
     "vrana/adminer": "~4.2",
     "vrana/jush": "*",

--- a/doc/Development_Documentation/18_Tools_and_Features/37_Targeting_and_Personalization/README.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/37_Targeting_and_Personalization/README.md
@@ -137,3 +137,12 @@ See the following resources for further details:
 * [Action Handlers](./07_Action_Handlers.md)
 * [Targeting Storage](./09_Targeting_Storage.md)
 * [Frontend Javascript](./11_Frontend_Javascript.md)
+
+
+## Debugging Targeting Data
+
+As shown above, targeting date is added to the Symfony profiler. In addition you can enable a dedicated targeting toolbar
+which also works outside the `dev` environment when you are logged into the admin interface. The toolbar is only shown if
+a `pimcore_targeting_debug` cookie exists and is set to true. You can do so with the following bookmarklet:
+
+* <a href="javascript:(function()%7Bdocument.cookie %3D 'pimcore_targeting_debug%3D1%3B path%3D%2F'%7D)()">Enable Pimcore Targeting Toolbar</a> 

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DataCollector/PimcoreTargetingDataCollector.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DataCollector/PimcoreTargetingDataCollector.php
@@ -18,17 +18,11 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\CoreBundle\DataCollector;
 
 use Pimcore\Http\Request\Resolver\DocumentResolver;
-use Pimcore\Model\Document;
-use Pimcore\Model\Document\Targeting\TargetingDocumentInterface;
-use Pimcore\Model\Tool\Targeting\TargetGroup;
-use Pimcore\Targeting\Document\DocumentTargetingConfigurator;
-use Pimcore\Targeting\Model\VisitorInfo;
-use Pimcore\Targeting\Storage\TargetingStorageInterface;
+use Pimcore\Targeting\Debug\TargetingDataCollector;
 use Pimcore\Targeting\VisitorInfoStorageInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
-use Symfony\Component\Stopwatch\Stopwatch;
 
 class PimcoreTargetingDataCollector extends DataCollector
 {
@@ -38,37 +32,24 @@ class PimcoreTargetingDataCollector extends DataCollector
     private $visitorInfoStorage;
 
     /**
-     * @var TargetingStorageInterface
-     */
-    private $targetingStorage;
-
-    /**
      * @var DocumentResolver
      */
     private $documentResolver;
 
     /**
-     * @var DocumentTargetingConfigurator
+     * @var TargetingDataCollector
      */
-    private $targetingConfigurator;
-
-    /**
-     * @var Stopwatch
-     */
-    private $stopwatch;
+    private $targetingDataCollector;
 
     public function __construct(
         VisitorInfoStorageInterface $visitorInfoStorage,
-        TargetingStorageInterface $targetingStorage,
         DocumentResolver $documentResolver,
-        DocumentTargetingConfigurator $targetingConfigurator,
-        Stopwatch $stopwatch = null
-    ) {
-        $this->visitorInfoStorage    = $visitorInfoStorage;
-        $this->targetingStorage      = $targetingStorage;
-        $this->documentResolver      = $documentResolver;
-        $this->targetingConfigurator = $targetingConfigurator;
-        $this->stopwatch             = $stopwatch;
+        TargetingDataCollector $targetingDataCollector
+    )
+    {
+        $this->visitorInfoStorage     = $visitorInfoStorage;
+        $this->documentResolver       = $documentResolver;
+        $this->targetingDataCollector = $targetingDataCollector;
     }
 
     public function getName()
@@ -86,131 +67,23 @@ class PimcoreTargetingDataCollector extends DataCollector
 
         $document    = $this->documentResolver->getDocument($request);
         $visitorInfo = $this->visitorInfoStorage->getVisitorInfo();
+        $tdc         = $this->targetingDataCollector;
 
-        $this->collectVisitorInfo($visitorInfo);
-        $this->collectStorage($visitorInfo);
-        $this->collectMatchedRules($visitorInfo);
-        $this->collectTargetGroups($visitorInfo);
-        $this->collectDocumentTargetGroup($document);
-        $this->collectDocumentTargetGroupMapping();
+        $data = [
+            'visitor_info'           => $tdc->collectVisitorInfo($visitorInfo),
+            'storage'                => $tdc->collectStorage($visitorInfo),
+            'rules'                  => $tdc->collectMatchedRules($visitorInfo),
+            'target_groups'          => $tdc->collectTargetGroups($visitorInfo),
+            'document_target_group'  => $tdc->collectDocumentTargetGroup($document),
+            'document_target_groups' => $tdc->collectDocumentTargetGroupMapping(),
+        ];
 
-        $this->data = $this->cloneVar($this->data);
+        $this->data = $this->cloneVar($data);
     }
 
     public function reset()
     {
         $this->data = [];
-    }
-
-    private function collectVisitorInfo(VisitorInfo $visitorInfo)
-    {
-        $this->data['visitor_info'] = [
-            'visitorId' => $visitorInfo->getVisitorId(),
-            'sessionId' => $visitorInfo->getSessionId(),
-            'actions'   => $visitorInfo->getActions(),
-            'data'      => $visitorInfo->getData(),
-        ];
-    }
-
-    private function collectStorage(VisitorInfo $visitorInfo)
-    {
-        $this->data['storage'] = [];
-
-        foreach (TargetingStorageInterface::VALID_SCOPES as $scope) {
-            $created = $this->targetingStorage->getCreatedAt($visitorInfo, $scope);
-            $updated = $this->targetingStorage->getCreatedAt($visitorInfo, $scope);
-
-            $this->data['storage'][$scope] = array_merge([
-                'created' => $created ? $created->format('c') : null,
-                'updated' => $updated ? $updated->format('c') : null
-            ], $this->targetingStorage->all($visitorInfo, $scope));
-        }
-    }
-
-    private function collectMatchedRules(VisitorInfo $visitorInfo)
-    {
-        $rules = [];
-        foreach ($visitorInfo->getMatchingTargetingRules() as $rule) {
-            $duration = null;
-            if (null !== $this->stopwatch) {
-                try {
-                    $event    = $this->stopwatch->getEvent(sprintf('Targeting:match:%s', $rule->getName()));
-                    $duration = $event->getDuration();
-                } catch (\Throwable $e) {
-                    // noop
-                }
-            }
-
-            $rules[] = [
-                'id'         => $rule->getId(),
-                'name'       => $rule->getName(),
-                'duration'   => $duration,
-                'conditions' => $rule->getConditions(),
-                'actions'    => $rule->getActions(),
-            ];
-        }
-
-        $this->data['rules'] = $rules;
-    }
-
-    private function collectTargetGroups(VisitorInfo $visitorInfo)
-    {
-        $targetGroups = [];
-
-        foreach ($visitorInfo->getTargetGroupAssignments() as $assignment) {
-            $targetGroups[] = [
-                'id'        => $assignment->getTargetGroup()->getId(),
-                'name'      => $assignment->getTargetGroup()->getName(),
-                'threshold' => $assignment->getTargetGroup()->getThreshold(),
-                'count'     => $assignment->getCount(),
-            ];
-        }
-
-        $this->data['target_groups'] = $targetGroups;
-    }
-
-    private function collectDocumentTargetGroup(Document $document = null)
-    {
-        if (!$document instanceof TargetingDocumentInterface) {
-            return;
-        }
-
-        $targetGroupId = $document->getUseTargetGroup();
-        if (!$targetGroupId) {
-            return;
-        }
-
-        $targetGroup = TargetGroup::getById($targetGroupId);
-        if ($targetGroup) {
-            $this->data['document_target_group'] = [
-                'id'   => $targetGroup->getId(),
-                'name' => $targetGroup->getName()
-            ];
-        }
-    }
-
-    private function collectDocumentTargetGroupMapping()
-    {
-        $resolvedMapping = $this->targetingConfigurator->getResolvedTargetGroupMapping();
-        $mapping         = [];
-
-        /** @var TargetGroup $targetGroup */
-        foreach ($resolvedMapping as $documentId => $targetGroup) {
-            $document = Document::getById($documentId);
-
-            $mapping[] = [
-                'document'    => [
-                    'id'   => $document->getId(),
-                    'path' => $document->getRealFullPath(),
-                ],
-                'targetGroup' => [
-                    'id'   => $targetGroup->getId(),
-                    'name' => $targetGroup->getName(),
-                ],
-            ];
-        }
-
-        $this->data['document_target_groups'] = $mapping;
     }
 
     public function getVisitorInfo()
@@ -235,7 +108,7 @@ class PimcoreTargetingDataCollector extends DataCollector
 
     public function getDocumentTargetGroup()
     {
-        return $this->data['document_target_group'] ?? null;
+        return $this->data['document_target_group'];
     }
 
     public function getDocumentTargetGroups()

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Compiler/DebugStopwatchPass.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Compiler/DebugStopwatchPass.php
@@ -19,6 +19,7 @@ namespace Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler;
 
 use Pimcore\Targeting\DataLoader;
 use Pimcore\Targeting\DataProvider\Piwik;
+use Pimcore\Targeting\Debug\TargetingDataCollector;
 use Pimcore\Targeting\EventListener\TargetingListener;
 use Pimcore\Targeting\VisitorInfoResolver;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -47,6 +48,7 @@ class DebugStopwatchPass implements CompilerPassInterface
             DataLoader::class,
             VisitorInfoResolver::class,
             TargetingListener::class,
+            TargetingDataCollector::class,
             Piwik::class,
         ];
 

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Compiler/DebugStopwatchPass.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DependencyInjection/Compiler/DebugStopwatchPass.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Pimcore\Targeting\DataLoader;
+use Pimcore\Targeting\DataProvider\Piwik;
+use Pimcore\Targeting\EventListener\TargetingListener;
+use Pimcore\Targeting\VisitorInfoResolver;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * The debug.stopwatch service is always defined, so we can't just add it to services if defined. This
+ * only adds the stopwatch to services if the debug flag is set.
+ */
+class DebugStopwatchPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $debug = $container->getParameter('kernel.debug');
+        if (!$debug) {
+            return;
+        }
+
+        if (!$container->hasDefinition('debug.stopwatch')) {
+            return;
+        }
+
+        $services = [
+            DataLoader::class,
+            VisitorInfoResolver::class,
+            TargetingListener::class,
+            Piwik::class,
+        ];
+
+        foreach ($services as $service) {
+            if ($container->hasDefinition($service)) {
+                $container
+                    ->getDefinition($service)
+                    ->addMethodCall('setStopwatch', [
+                        new Reference(
+                            'debug.stopwatch',
+                            ContainerInterface::IGNORE_ON_INVALID_REFERENCE
+                        )
+                    ]);
+            }
+        }
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/PimcoreCoreBundle.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/PimcoreCoreBundle.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\CoreBundle;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\AreabrickPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\CacheCollectorPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\ComposerConfigNormalizersPass;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\DebugStopwatchPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\DoctrineMigrationsParametersPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\MonologPsrLogMessageProcessorPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\MonologPublicLoggerPass;
@@ -76,5 +77,6 @@ class PimcoreCoreBundle extends Bundle
         $container->addCompilerPass(new MonologPublicLoggerPass());
         $container->addCompilerPass(new MonologPsrLogMessageProcessorPass());
         $container->addCompilerPass(new ComposerConfigNormalizersPass());
+        $container->addCompilerPass(new DebugStopwatchPass());
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/profiler.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/profiler.yml
@@ -17,8 +17,6 @@ services:
                 priority: 500
 
     Pimcore\Bundle\CoreBundle\DataCollector\PimcoreTargetingDataCollector:
-        arguments:
-            $stopwatch: '@?debug.stopwatch'
         tags:
             -
                 name:     data_collector

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/targeting.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/targeting.yml
@@ -56,10 +56,7 @@ services:
 
     Pimcore\Targeting\VisitorInfoStorageInterface: '@Pimcore\Targeting\VisitorInfoStorage'
     Pimcore\Targeting\VisitorInfoStorage: ~
-
-    Pimcore\Targeting\VisitorInfoResolver:
-        calls:
-            - [setStopwatch, ['@?debug.stopwatch']]
+    Pimcore\Targeting\VisitorInfoResolver: ~
 
 
     #
@@ -72,9 +69,7 @@ services:
             $filename: '%pimcore.geoip.db_file%'
 
     Pimcore\Targeting\DataLoaderInterface: '@Pimcore\Targeting\DataLoader'
-    Pimcore\Targeting\DataLoader:
-        calls:
-            - [setStopwatch, ['@?debug.stopwatch']]
+    Pimcore\Targeting\DataLoader: ~
 
     Pimcore\Targeting\DataProvider\GeoIp:
         calls:
@@ -87,10 +82,7 @@ services:
             - [setCache, ['@Pimcore\Cache\Core\CoreHandlerInterface']]
             - [setCachePool, ['@Pimcore\Cache\Pool\PimcoreCacheItemPoolInterface']]
 
-    Pimcore\Targeting\DataProvider\Piwik:
-        calls:
-            - [setStopwatch, ['@?debug.stopwatch']]
-
+    Pimcore\Targeting\DataProvider\Piwik: ~
     Pimcore\Targeting\DataProvider\TargetingStorage: ~
 
     Pimcore\Targeting\Service\VisitedPagesCounter: ~

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/targeting.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/targeting.yml
@@ -133,3 +133,9 @@ services:
     #
 
     Pimcore\Targeting\Code\TargetingCodeGenerator: ~
+
+    #
+    # TOOLBAR AND PROFILER
+    #
+
+    Pimcore\Targeting\Debug\TargetingDataCollector: ~

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/targeting/listeners.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/targeting/listeners.yml
@@ -4,10 +4,7 @@ services:
         autoconfigure: true
         public: false
 
-    Pimcore\Targeting\EventListener\TargetingListener:
-        calls:
-            - [setStopwatch, ['@?debug.stopwatch']]
-
+    Pimcore\Targeting\EventListener\TargetingListener: ~
     Pimcore\Targeting\EventListener\PiwikVisitorIdListener: ~
     Pimcore\Targeting\EventListener\DocumentTargetGroupListener: ~
     Pimcore\Targeting\EventListener\FullPageCacheCookieCleanupListener: ~

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/targeting/listeners.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/targeting/listeners.yml
@@ -10,3 +10,4 @@ services:
     Pimcore\Targeting\EventListener\FullPageCacheCookieCleanupListener: ~
     Pimcore\Targeting\EventListener\VisitedPagesCountListener: ~
     Pimcore\Targeting\EventListener\MaintenanceListener: ~
+    Pimcore\Targeting\EventListener\ToolbarListener: ~

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating_twig.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/templating_twig.yml
@@ -35,3 +35,7 @@ services:
     # as otherwise the placeholder block would be rendered before any
     # content was added (e.g. headTitle)
     Phive\Twig\Extensions\Deferred\DeferredExtension: ~
+
+    # provides truncate and wordwrap filters
+    Twig_Extensions_Extension_Text:
+        class: Twig_Extensions_Extension_Text

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Profiler/target.svg.twig
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Profiler/target.svg.twig
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
      viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
     <style type="text/css">

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Profiler/targeting_data_collector.html.twig
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Profiler/targeting_data_collector.html.twig
@@ -107,7 +107,7 @@
                             <tr>
                                 <th>{{ rule.id }}</th>
                                 <td>{{ rule.name }}</td>
-                                <td>{{ rule.duration }} ms</td>
+                                <td>{{ rule.duration|round(2) }} ms</td>
                                 <td>{{ profiler_dump(rule.conditions, maxDepth=maxDepth|default(0)) }}</td>
                                 <td>{{ profiler_dump(rule.actions, maxDepth=maxDepth|default(0)) }}</td>
                             </tr>

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/icon/close.svg.twig
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/icon/close.svg.twig
@@ -1,0 +1,6 @@
+{# this file was copied from Symfony's WebProfilerBundle - see vendor/symfony/symfony/src/Symfony/Bundle/WebProfilerBundle/LICENSE #}
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<path fill="#AAAAAA" d="M21.1,18.3c0.8,0.8,0.8,2,0,2.8c-0.4,0.4-0.9,0.6-1.4,0.6s-1-0.2-1.4-0.6L12,14.8l-6.3,6.3
+    c-0.4,0.4-0.9,0.6-1.4,0.6s-1-0.2-1.4-0.6c-0.8-0.8-0.8-2,0-2.8L9.2,12L2.9,5.7c-0.8-0.8-0.8-2,0-2.8c0.8-0.8,2-0.8,2.8,0L12,9.2
+    l6.3-6.3c0.8-0.8,2-0.8,2.8,0c0.8,0.8,0.8,2,0,2.8L14.8,12L21.1,18.3z"/>
+</svg>

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.css
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.css
@@ -1,0 +1,99 @@
+._ptg-toolbar {
+  display: block;
+  width: 450px;
+  position: absolute;
+  right: 0;
+  top: 0px;
+  z-index: 100;
+  background: rgba(68, 68, 68, 0.97);
+  border-bottom-left-radius: 4px;
+  font: 12px Arial, 'Helvetica Neue', Helvetica, sans-serif;
+  color: #fff; }
+  ._ptg-toolbar._ptg-toolbar--hidden {
+    right: -414px; }
+  ._ptg-toolbar ._ptg-toolbar__trigger {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 36px;
+    height: 100%;
+    background: #222;
+    border-bottom-left-radius: 4px;
+    cursor: pointer; }
+  ._ptg-toolbar ._ptg-toolbar__trigger-icon {
+    display: block;
+    position: absolute;
+    width: 36px;
+    height: 36px;
+    text-align: center; }
+    ._ptg-toolbar ._ptg-toolbar__trigger-icon._ptg-toolbar__trigger-icon--target {
+      top: 0;
+      left: 0; }
+    ._ptg-toolbar ._ptg-toolbar__trigger-icon._ptg-toolbar__trigger-icon--close {
+      bottom: 0;
+      left: 0;
+      background: #444;
+      cursor: pointer;
+      border-bottom-left-radius: 4px; }
+      ._ptg-toolbar ._ptg-toolbar__trigger-icon._ptg-toolbar__trigger-icon--close:hover {
+        background: #626262; }
+    ._ptg-toolbar ._ptg-toolbar__trigger-icon svg {
+      display: inline-block;
+      height: 18px;
+      max-height: 18px;
+      margin-top: 10px; }
+  ._ptg-toolbar ._ptg-toolbar__content {
+    margin-left: 36px; }
+    ._ptg-toolbar ._ptg-toolbar__content ._ptg-toolbar__content-inner {
+      padding: 15px; }
+    ._ptg-toolbar ._ptg-toolbar__content h1 {
+      font-size: 18px;
+      margin-top: 0; }
+    ._ptg-toolbar ._ptg-toolbar__content h2 {
+      font-size: 14px; }
+      ._ptg-toolbar ._ptg-toolbar__content h2 ._ptg-toolbar__label {
+        position: relative;
+        top: -1px; }
+    ._ptg-toolbar ._ptg-toolbar__content table {
+      width: 100%; }
+      ._ptg-toolbar ._ptg-toolbar__content table td, ._ptg-toolbar ._ptg-toolbar__content table th {
+        padding: 3px 0; }
+  ._ptg-toolbar ._ptg-toolbar__table__col-number {
+    text-align: right; }
+  ._ptg-toolbar ._ptg-toolbar__table__col-right {
+    text-align: right; }
+  ._ptg-toolbar ._ptg-toolbar__table__row-with-details__trigger {
+    cursor: pointer; }
+  ._ptg-toolbar ._ptg-toolbar__table__row-with-details__trigger-arrow {
+    display: inline-block; }
+  ._ptg-toolbar ._ptg-toolbar__table__row-details td:first-child {
+    padding-left: 10px; }
+  ._ptg-toolbar ._ptg-toolbar__table__row-details._ptg-toolbar__table__row-details--collapsed {
+    display: none; }
+  ._ptg-toolbar ._ptg-toolbar__label,
+  ._ptg-toolbar ._ptg-toolbar__metric {
+    font: 11px Menlo, Monaco, Consolas, "Courier New", monospace; }
+  ._ptg-toolbar ._ptg-toolbar__label {
+    display: inline-block;
+    padding: 3px 5px;
+    background: #888;
+    border-radius: 1px; }
+    ._ptg-toolbar ._ptg-toolbar__label._ptg-toolbar__label--target-group {
+      background: #4f805d; }
+    ._ptg-toolbar ._ptg-toolbar__label._ptg-toolbar__label--rule {
+      background: #a46a1f; }
+  ._ptg-toolbar ._ptg-toolbar__metric {
+    display: inline-block;
+    margin: 0 5px 3px 0;
+    border-radius: 1px; }
+  ._ptg-toolbar ._ptg-toolbar__metric__label,
+  ._ptg-toolbar ._ptg-toolbar__metric__value {
+    display: inline-block;
+    padding: 3px 5px;
+    background: #333;
+    border-top-left-radius: 1px;
+    border-bottom-left-radius: 1px; }
+  ._ptg-toolbar ._ptg-toolbar__metric__label {
+    background: #656565;
+    border-top-right-radius: 1px;
+    border-bottom-right-radius: 1px; }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.html.twig
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.html.twig
@@ -1,0 +1,16 @@
+<div id="_ptg-toolbar-{{ token }}" class="_ptg-toolbar _ptg-toolbar--hidden">
+    <div class="_ptg-toolbar__trigger">
+        <span class="_ptg-toolbar__icon _ptg-toolbar__icon--target">
+            {{ include('@PimcoreCore/Profiler/target.svg.twig') }}
+        </span>
+
+        <a class="_ptg-toolbar__icon _ptg-toolbar__icon--close" data-selector="#_ptg-toolbar-{{ token }}" title="Close Toolbar">
+            {{ include('@PimcoreCore/Targeting/toolbar/icon/close.svg.twig') }}
+        </a>
+    </div>
+</div>
+<style type="text/css">
+    {{ include('@PimcoreCore/Targeting/toolbar/toolbar.css') }}
+</style>
+{{ include('@PimcoreCore/Targeting/toolbar/toolbar_js.html.twig') }}
+

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.html.twig
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.html.twig
@@ -1,5 +1,6 @@
+{% spaceless %}
 <div id="_ptg-toolbar-{{ token }}" class="_ptg-toolbar _ptg-toolbar--hidden">
-    <div class="_ptg-toolbar__trigger">
+    <div class="_ptg-toolbar__trigger" title="{% trans from 'admin' %}targeting{% endtrans %}">
         <span class="_ptg-toolbar__icon _ptg-toolbar__icon--target">
             {{ include('@PimcoreCore/Profiler/target.svg.twig') }}
         </span>
@@ -8,9 +9,83 @@
             {{ include('@PimcoreCore/Targeting/toolbar/icon/close.svg.twig') }}
         </a>
     </div>
+
+    <div class="_ptg-toolbar__content">
+        <div class="_ptg-toolbar__content-inner">
+            <table class="_ptg-toolbar__table">
+                {% if documentTargetGroup is not null %}
+                    <tr>
+                        <th>Document Target Group</th>
+                        <td class="_ptg-toolbar__table__col-right">
+                            <span class="_ptg-toolbar__label _ptg-toolbar__label--target-group">{{ documentTargetGroup.name }}</span>
+                        </td>
+                    </tr>
+                {% endif %}
+
+                <tr>
+                    <th>Matched Rules</th>
+                    <td class="_ptg-toolbar__table__col-number">
+                        <span class="_ptg-toolbar__label">{{ rules|length }}</span>
+                    </td>
+                </tr>
+
+                <tr>
+                    <th>Assigned Target Groups</th>
+                    <td class="_ptg-toolbar__table__col-number">
+                        <span class="_ptg-toolbar__label">{{ targetGroups|length }}</span>
+                    </td>
+                </tr>
+            </table>
+
+            {% if rules is not empty %}
+                <h2>Matched Rules</h2>
+                <ul class="_ptg-toolbar__list">
+                    {% for rule in rules %}
+                        <li>
+                            <span class="_ptg-toolbar__label _ptg-toolbar__label--rule">{{ rule.name }}</span>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+
+            {% if targetGroups is not empty %}
+                <h2>Assigned Target Groups</h2>
+
+                <table class="_ptg-toolbar__table">
+                    {% for targetGroup in targetGroups %}
+                        <tr>
+                            <td>
+                                <span class="_ptg-toolbar__label _ptg-toolbar__label--target-group">{{ targetGroup.name }}</span>
+                            </td>
+                            <td class="_ptg-toolbar__table__col-number">
+                                <span class="_ptg-toolbar__label" title="Threshold: {{ targetGroup.threshold }}">{{ targetGroup.count }}</span>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </table>
+            {% endif %}
+
+            {% if documentTargetGroups is not empty %}
+                <h2>Document Target Groups</h2>
+
+                <table class="_ptg-toolbar__table">
+                    {% for assignment in documentTargetGroups %}
+                        <tr>
+                            <td>
+                                <span class="_ptg-toolbar__label">{{ assignment.document.path }}</span>
+                            </td>
+                            <td class="_ptg-toolbar__table__col-right">
+                                <span class="_ptg-toolbar__label _ptg-toolbar__label--target-group">{{ assignment.targetGroup.name }}</span>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </table>
+            {% endif %}
+        </div>
+    </div>
 </div>
+{% endspaceless %}
 <style type="text/css">
     {{ include('@PimcoreCore/Targeting/toolbar/toolbar.css') }}
 </style>
 {{ include('@PimcoreCore/Targeting/toolbar/toolbar_js.html.twig') }}
-

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.html.twig
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.html.twig
@@ -1,11 +1,11 @@
 {% spaceless %}
 <div id="_ptg-toolbar-{{ token }}" class="_ptg-toolbar _ptg-toolbar--hidden">
     <div class="_ptg-toolbar__trigger" title="{% trans from 'admin' %}targeting{% endtrans %}">
-        <span class="_ptg-toolbar__icon _ptg-toolbar__icon--target">
+        <span class="_ptg-toolbar__trigger-icon _ptg-toolbar__trigger-icon--target">
             {{ include('@PimcoreCore/Profiler/target.svg.twig') }}
         </span>
 
-        <a class="_ptg-toolbar__icon _ptg-toolbar__icon--close" data-selector="#_ptg-toolbar-{{ token }}" title="Close Toolbar">
+        <a class="_ptg-toolbar__trigger-icon _ptg-toolbar__trigger-icon--close" data-selector="#_ptg-toolbar-{{ token }}" title="Close Toolbar">
             {{ include('@PimcoreCore/Targeting/toolbar/icon/close.svg.twig') }}
         </a>
     </div>

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.html.twig
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.html.twig
@@ -12,6 +12,8 @@
 
     <div class="_ptg-toolbar__content">
         <div class="_ptg-toolbar__content-inner">
+            <h1>Targeting</h1>
+
             <table class="_ptg-toolbar__table">
                 {% if documentTargetGroup is not null %}
                     <tr>
@@ -23,42 +25,128 @@
                 {% endif %}
 
                 <tr>
-                    <th>Matched Rules</th>
-                    <td class="_ptg-toolbar__table__col-number">
-                        <span class="_ptg-toolbar__label">{{ rules|length }}</span>
+                    <th>Visitor ID</th>
+                    <td class="_ptg-toolbar__table__col-right">
+                        {% if visitorInfo.visitorId is not empty %}
+                            <span class="_ptg-toolbar__label">{{ visitorInfo.visitorId }}</span>
+                        {% else %}
+                            -
+                        {% endif %}
                     </td>
                 </tr>
 
                 <tr>
-                    <th>Assigned Target Groups</th>
-                    <td class="_ptg-toolbar__table__col-number">
-                        <span class="_ptg-toolbar__label">{{ targetGroups|length }}</span>
+                    <th>Session ID</th>
+                    <td class="_ptg-toolbar__table__col-right">
+                        {% if visitorInfo.sessionId is not empty %}
+                            <span class="_ptg-toolbar__label">{{ visitorInfo.sessionId }}</span>
+                        {% else %}
+                            -
+                        {% endif %}
                     </td>
                 </tr>
             </table>
 
             {% if rules is not empty %}
-                <h2>Matched Rules</h2>
-                <ul class="_ptg-toolbar__list">
+                <h2>
+                    Matched Rules
+                    <span class="_ptg-toolbar__label">{{ rules|length }}</span>
+                </h2>
+
+                <table class="_ptg-toolbar__table">
                     {% for rule in rules %}
-                        <li>
-                            <span class="_ptg-toolbar__label _ptg-toolbar__label--rule">{{ rule.name }}</span>
-                        </li>
+
+                        <tr class="_ptg-toolbar__table__row-with-details" data-index="{{ loop.index }}">
+                            <td>
+                                <span class="_ptg-toolbar__label _ptg-toolbar__label--rule _ptg-toolbar__table__row-with-details__trigger">
+                                    {{ rule.name }}
+                                </span>
+                            </td>
+                        </tr>
+                        <tr class="_ptg-toolbar__table__row-details _ptg-toolbar__table__row-details--collapsed" data-index="{{ loop.index }}">
+                            <td>
+                                <span class="_ptg-toolbar__metric">
+                                    <span class="_ptg-toolbar__metric__label">
+                                        Rule ID
+                                    </span>
+                                    <span class="_ptg-toolbar__metric__value">
+                                        {{ rule.id }}
+                                    </span>
+                                </span>
+
+                                {% if rule.duration is not null %}
+                                <span class="_ptg-toolbar__metric">
+                                    <span class="_ptg-toolbar__metric__label">
+                                        Duration
+                                    </span>
+                                    <span class="_ptg-toolbar__metric__value">
+                                        {{ rule.duration|round(2) }} ms
+                                    </span>
+                                </span>
+                                {% endif %}
+
+                                <span class="_ptg-toolbar__metric">
+                                    <span class="_ptg-toolbar__metric__label">
+                                        Conditions
+                                    </span>
+                                    <span class="_ptg-toolbar__metric__value">
+                                        {{ rule.conditions|length }}
+                                    </span>
+                                </span>
+
+                                <span class="_ptg-toolbar__metric">
+                                    <span class="_ptg-toolbar__metric__label">
+                                        Actions
+                                    </span>
+                                    <span class="_ptg-toolbar__metric__value">
+                                        {{ rule.actions|length }}
+                                    </span>
+                                </span>
+                            </td>
+                        </tr>
+
                     {% endfor %}
-                </ul>
+                </table>
             {% endif %}
 
             {% if targetGroups is not empty %}
-                <h2>Assigned Target Groups</h2>
+                <h2>
+                    Assigned Target Groups
+                    <span class="_ptg-toolbar__label">{{ targetGroups|length }}</span>
+                </h2>
 
                 <table class="_ptg-toolbar__table">
                     {% for targetGroup in targetGroups %}
-                        <tr>
+                        <tr class="_ptg-toolbar__table__row-with-details" data-index="{{ loop.index }}">
                             <td>
-                                <span class="_ptg-toolbar__label _ptg-toolbar__label--target-group">{{ targetGroup.name }}</span>
+                                <span class="_ptg-toolbar__label _ptg-toolbar__label--target-group _ptg-toolbar__table__row-with-details__trigger">
+                                    {{ targetGroup.name }}
+                                </span>
                             </td>
                             <td class="_ptg-toolbar__table__col-number">
                                 <span class="_ptg-toolbar__label" title="Threshold: {{ targetGroup.threshold }}">{{ targetGroup.count }}</span>
+                            </td>
+                        </tr>
+
+                        <tr class="_ptg-toolbar__table__row-details _ptg-toolbar__table__row-details--collapsed" data-index="{{ loop.index }}">
+                            <td colspan="2">
+                                <span class="_ptg-toolbar__metric">
+                                    <span class="_ptg-toolbar__metric__label">
+                                        Target Group ID
+                                    </span>
+                                    <span class="_ptg-toolbar__metric__value">
+                                        {{ targetGroup.id }}
+                                    </span>
+                                </span>
+
+                                <span class="_ptg-toolbar__metric">
+                                    <span class="_ptg-toolbar__metric__label">
+                                        Threshold
+                                    </span>
+                                    <span class="_ptg-toolbar__metric__value">
+                                        {{ targetGroup.threshold }}
+                                    </span>
+                                </span>
                             </td>
                         </tr>
                     {% endfor %}
@@ -66,16 +154,43 @@
             {% endif %}
 
             {% if documentTargetGroups is not empty %}
-                <h2>Document Target Groups</h2>
+                <h2>
+                    Document Target Groups
+                    <span class="_ptg-toolbar__label">{{ documentTargetGroups|length }}</span>
+                </h2>
 
                 <table class="_ptg-toolbar__table">
                     {% for assignment in documentTargetGroups %}
-                        <tr>
+                        <tr class="_ptg-toolbar__table__row-with-details" data-index="{{ loop.index }}">
                             <td>
-                                <span class="_ptg-toolbar__label">{{ assignment.document.path }}</span>
+                                <span class="_ptg-toolbar__label _ptg-toolbar__table__row-with-details__trigger" title="{{ assignment.document.path }}">
+                                    {{ assignment.document.path|truncate(32) }}
+                                </span>
                             </td>
                             <td class="_ptg-toolbar__table__col-right">
                                 <span class="_ptg-toolbar__label _ptg-toolbar__label--target-group">{{ assignment.targetGroup.name }}</span>
+                            </td>
+                        </tr>
+
+                        <tr class="_ptg-toolbar__table__row-details _ptg-toolbar__table__row-details--collapsed" data-index="{{ loop.index }}">
+                            <td colspan="2">
+                                <span class="_ptg-toolbar__metric">
+                                    <span class="_ptg-toolbar__metric__label">
+                                        Document ID
+                                    </span>
+                                    <span class="_ptg-toolbar__metric__value">
+                                        {{ assignment.document.id }}
+                                    </span>
+                                </span>
+
+                                <span class="_ptg-toolbar__metric">
+                                    <span class="_ptg-toolbar__metric__label">
+                                        Target Group ID
+                                    </span>
+                                    <span class="_ptg-toolbar__metric__value">
+                                        {{ assignment.targetGroup.id }}
+                                    </span>
+                                </span>
                             </td>
                         </tr>
                     {% endfor %}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.scss
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.scss
@@ -18,7 +18,6 @@ $color-rule: #a46a1f;
     border-bottom-left-radius: 4px;
     font: 12px Arial, 'Helvetica Neue', Helvetica, sans-serif;
     color: #fff;
-    transition: 0.3s ease-in-out;
 
     &._ptg-toolbar--hidden {
         right: $triggerWidth - $width;
@@ -107,8 +106,6 @@ $color-rule: #a46a1f;
         }
 
         tr {
-            transition: 0.3s ease-in-out;
-
             &._ptg-toolbar__table__row-details--collapsed {
                 display: none;
             }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.scss
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.scss
@@ -32,28 +32,21 @@ $color-rule: #a46a1f;
         background: #222;
         border-bottom-left-radius: 4px;
         cursor: pointer;
+    }
 
-        ._ptg-toolbar__icon {
-            display: block;
-            position: absolute;
-            width: $triggerWidth;
-            height: $triggerWidth;
-            text-align: center;
+    ._ptg-toolbar__trigger-icon {
+        display: block;
+        position: absolute;
+        width: $triggerWidth;
+        height: $triggerWidth;
+        text-align: center;
 
-            svg {
-                display: inline-block;
-                height: 18px;
-                max-height: 18px;
-                margin-top: 10px;
-            }
-        }
-
-        ._ptg-toolbar__icon--target {
+        &._ptg-toolbar__trigger-icon--target {
             top: 0;
             left: 0;
         }
 
-        ._ptg-toolbar__icon--close {
+        &._ptg-toolbar__trigger-icon--close {
             bottom: 0;
             left: 0;
             background: #444;
@@ -63,6 +56,13 @@ $color-rule: #a46a1f;
             &:hover {
                 background: #626262;
             }
+        }
+
+        svg {
+            display: inline-block;
+            height: 18px;
+            max-height: 18px;
+            margin-top: 10px;
         }
     }
 
@@ -96,42 +96,29 @@ $color-rule: #a46a1f;
         }
     }
 
-    ._ptg-toolbar__table {
-        ._ptg-toolbar__table__col-number {
-            text-align: right;
-        }
-
-        ._ptg-toolbar__table__col-right {
-            text-align: right;
-        }
-
-        tr {
-            &._ptg-toolbar__table__row-details--collapsed {
-                display: none;
-            }
-        }
-
-        ._ptg-toolbar__table__row-with-details__trigger {
-            cursor: pointer;
-
-            ._ptg-toolbar__table__row-with-details__trigger-arrow {
-                display: inline-block;
-            }
-        }
-
-        ._ptg-toolbar__table__row-details {
-            td:first-child {
-                padding-left: 10px;
-            }
-        }
+    ._ptg-toolbar__table__col-number {
+        text-align: right;
     }
 
-    ._ptg-toolbar__list {
-        list-style: none;
-        padding: 0;
+    ._ptg-toolbar__table__col-right {
+        text-align: right;
+    }
 
-        li {
-            margin-bottom: 6px;
+    ._ptg-toolbar__table__row-with-details__trigger {
+        cursor: pointer;
+    }
+
+    ._ptg-toolbar__table__row-with-details__trigger-arrow {
+        display: inline-block;
+    }
+
+    ._ptg-toolbar__table__row-details {
+        td:first-child {
+            padding-left: 10px;
+        }
+
+        &._ptg-toolbar__table__row-details--collapsed {
+            display: none;
         }
     }
 
@@ -159,20 +146,20 @@ $color-rule: #a46a1f;
         display: inline-block;
         margin: 0 5px 3px 0;
         border-radius: 1px;
+    }
 
-        ._ptg-toolbar__metric__label,
-        ._ptg-toolbar__metric__value {
-            display: inline-block;
-            padding: 3px 5px;
-            background: #333;
-            border-top-left-radius: 1px;
-            border-bottom-left-radius: 1px;
-        }
+    ._ptg-toolbar__metric__label,
+    ._ptg-toolbar__metric__value {
+        display: inline-block;
+        padding: 3px 5px;
+        background: #333;
+        border-top-left-radius: 1px;
+        border-bottom-left-radius: 1px;
+    }
 
-        ._ptg-toolbar__metric__label {
-            background: #656565;
-            border-top-right-radius: 1px;
-            border-bottom-right-radius: 1px;
-        }
+    ._ptg-toolbar__metric__label {
+        background: #656565;
+        border-top-right-radius: 1px;
+        border-bottom-right-radius: 1px;
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.scss
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.scss
@@ -4,8 +4,8 @@
 
 $width: 400px;
 $triggerWidth: 36px;
-$color-target-group: #00a7d0;
-$color-rule: #d00168;
+$color-target-group: #4f805d;
+$color-rule: #a46a1f;
 
 ._ptg-toolbar {
     display: block;

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.scss
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.scss
@@ -1,0 +1,65 @@
+// to build the CSS file use
+// `sass --sourcemap=none toolbar.scss toolbar.css`
+// and commit the built CSS file
+
+$width: 350px;
+$triggerWidth: 36px;
+
+._ptg-toolbar {
+    display: block;
+    width: $width;
+    height: 500px;
+    position: absolute;
+    right: 0;
+    top: 150px;
+    z-index: 100;
+    background: #444;
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+    font: 12px Arial, sans-serif;
+    transition: 0.3s ease-in-out;
+
+    &._ptg-toolbar--hidden {
+        right: $triggerWidth - $width;
+    }
+
+    ._ptg-toolbar__trigger {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: $triggerWidth;
+        height: 100%;
+        background: #222;
+        border-top-left-radius: 4px;
+        border-bottom-left-radius: 4px;
+        cursor: pointer;
+
+        ._ptg-toolbar__icon {
+            display: block;
+            position: absolute;
+            width: $triggerWidth;
+            height: $triggerWidth;
+            text-align: center;
+
+            svg {
+                display: inline-block;
+                height: 18px;
+                max-height: 18px;
+                margin-top: 10px;
+            }
+        }
+
+        ._ptg-toolbar__icon--target {
+            top: 0;
+            left: 0;
+        }
+
+        ._ptg-toolbar__icon--close {
+            bottom: 0;
+            left: 0;
+            background: #444;
+            cursor: pointer;
+            border-bottom-left-radius: 4px;
+        }
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.scss
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.scss
@@ -2,21 +2,23 @@
 // `sass --sourcemap=none toolbar.scss toolbar.css`
 // and commit the built CSS file
 
-$width: 350px;
+$width: 400px;
 $triggerWidth: 36px;
+$color-target-group: #00a7d0;
+$color-rule: #d00168;
 
 ._ptg-toolbar {
     display: block;
     width: $width;
-    height: 500px;
     position: absolute;
     right: 0;
-    top: 150px;
+    top: 0px;
     z-index: 100;
-    background: #444;
+    background: rgba(68, 68, 68, 0.97); // #444
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
-    font: 12px Arial, sans-serif;
+    font: 12px Arial, 'Helvetica Neue', Helvetica, sans-serif;
+    color: #fff;
     transition: 0.3s ease-in-out;
 
     &._ptg-toolbar--hidden {
@@ -60,6 +62,61 @@ $triggerWidth: 36px;
             background: #444;
             cursor: pointer;
             border-bottom-left-radius: 4px;
+        }
+    }
+
+    ._ptg-toolbar__content {
+        margin-left: $triggerWidth;
+
+        ._ptg-toolbar__content-inner {
+            padding: 15px;
+        }
+
+        h2 {
+            font-size: 14px;
+        }
+
+        table {
+            width: 100%;
+
+            td, th {
+                padding: 3px 0;
+            }
+        }
+    }
+
+    ._ptg-toolbar__table {
+        ._ptg-toolbar__table__col-number {
+            text-align: right;
+        }
+
+        ._ptg-toolbar__table__col-right {
+            text-align: right;
+        }
+    }
+
+    ._ptg-toolbar__list {
+        list-style: none;
+        padding: 0;
+
+        li {
+            margin-bottom: 6px;
+        }
+    }
+
+    ._ptg-toolbar__label {
+        font-size: 11px;
+        font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+        display: inline-block;
+        padding: 3px 5px;
+        background: #888;
+
+        &._ptg-toolbar__label--target-group {
+            background: $color-target-group;
+        }
+
+        &._ptg-toolbar__label--rule {
+            background: $color-rule;
         }
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.scss
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar.scss
@@ -2,7 +2,7 @@
 // `sass --sourcemap=none toolbar.scss toolbar.css`
 // and commit the built CSS file
 
-$width: 400px;
+$width: 450px;
 $triggerWidth: 36px;
 $color-target-group: #4f805d;
 $color-rule: #a46a1f;
@@ -15,7 +15,6 @@ $color-rule: #a46a1f;
     top: 0px;
     z-index: 100;
     background: rgba(68, 68, 68, 0.97); // #444
-    border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
     font: 12px Arial, 'Helvetica Neue', Helvetica, sans-serif;
     color: #fff;
@@ -32,7 +31,6 @@ $color-rule: #a46a1f;
         width: $triggerWidth;
         height: 100%;
         background: #222;
-        border-top-left-radius: 4px;
         border-bottom-left-radius: 4px;
         cursor: pointer;
 
@@ -62,6 +60,10 @@ $color-rule: #a46a1f;
             background: #444;
             cursor: pointer;
             border-bottom-left-radius: 4px;
+
+            &:hover {
+                background: #626262;
+            }
         }
     }
 
@@ -72,8 +74,18 @@ $color-rule: #a46a1f;
             padding: 15px;
         }
 
+        h1 {
+            font-size: 18px;
+            margin-top: 0;
+        }
+
         h2 {
             font-size: 14px;
+
+            ._ptg-toolbar__label {
+                position: relative;
+                top: -1px;
+            }
         }
 
         table {
@@ -93,6 +105,28 @@ $color-rule: #a46a1f;
         ._ptg-toolbar__table__col-right {
             text-align: right;
         }
+
+        tr {
+            transition: 0.3s ease-in-out;
+
+            &._ptg-toolbar__table__row-details--collapsed {
+                display: none;
+            }
+        }
+
+        ._ptg-toolbar__table__row-with-details__trigger {
+            cursor: pointer;
+
+            ._ptg-toolbar__table__row-with-details__trigger-arrow {
+                display: inline-block;
+            }
+        }
+
+        ._ptg-toolbar__table__row-details {
+            td:first-child {
+                padding-left: 10px;
+            }
+        }
     }
 
     ._ptg-toolbar__list {
@@ -104,12 +138,16 @@ $color-rule: #a46a1f;
         }
     }
 
+    ._ptg-toolbar__label,
+    ._ptg-toolbar__metric {
+        font: 11px Menlo, Monaco, Consolas, "Courier New", monospace;
+    }
+
     ._ptg-toolbar__label {
-        font-size: 11px;
-        font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
         display: inline-block;
         padding: 3px 5px;
         background: #888;
+        border-radius: 1px;
 
         &._ptg-toolbar__label--target-group {
             background: $color-target-group;
@@ -117,6 +155,27 @@ $color-rule: #a46a1f;
 
         &._ptg-toolbar__label--rule {
             background: $color-rule;
+        }
+    }
+
+    ._ptg-toolbar__metric {
+        display: inline-block;
+        margin: 0 5px 3px 0;
+        border-radius: 1px;
+
+        ._ptg-toolbar__metric__label,
+        ._ptg-toolbar__metric__value {
+            display: inline-block;
+            padding: 3px 5px;
+            background: #333;
+            border-top-left-radius: 1px;
+            border-bottom-left-radius: 1px;
+        }
+
+        ._ptg-toolbar__metric__label {
+            background: #656565;
+            border-top-right-radius: 1px;
+            border-bottom-right-radius: 1px;
         }
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar_js.html.twig
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar_js.html.twig
@@ -42,26 +42,82 @@
                 } else {
                     el.className = el.className.replace(new RegExp('(^|\\b)' + className.split(' ').join('|') + '(\\b|$)', 'gi'), ' ');
                 }
-            }
+            },
+
+            featureDetect: (function () {
+                // most tests come from to modernizr (MIT license)
+                // https://github.com/Modernizr/Modernizr/tree/master/feature-detects
+                var tests = {
+                    localStorage: function () {
+                        var v = 'test';
+
+                        try {
+                            localStorage.setItem(v, v);
+                            localStorage.removeItem(v);
+
+                            return true;
+                        } catch (e) {
+                            return false;
+                        }
+                    }
+                };
+
+                var results = {};
+
+                return function (type) {
+                    if ('undefined' === typeof tests[type]) {
+                        throw new Error('Test ' + type + ' is not defined');
+                    }
+
+                    if ('undefined' === typeof results[type]) {
+                        results[type] = tests[type].call();
+                    }
+
+                    return results[type];
+                };
+            }())
         };
 
         util.addEventListener(document, 'DOMContentLoaded', function () {
+            var localStorageStateKey = 'pimcore/targeting/toolbar/displayState';
+            var hiddenClass = '_ptg-toolbar--hidden';
+
+            // whole toolbar
             document.querySelectorAll('._ptg-toolbar__trigger').forEach(function (trigger) {
+                var toolbar = trigger.parentNode;
+
+                var showToolbar = function(show) {
+                    if (show) {
+                        util.removeClass(toolbar, hiddenClass);
+                    } else {
+                        util.addClass(toolbar, hiddenClass);
+                    }
+
+                    if (util.featureDetect('localStorage')) {
+                        localStorage.setItem(localStorageStateKey, show ? 'block' : 'none');
+                    }
+                };
+
+                if (util.featureDetect('localStorage')) {
+                    var state = localStorage.getItem(localStorageStateKey);
+                    if ('block' === state) {
+                        showToolbar(true);
+                    }
+                }
+
                 util.addEventListener(trigger, 'click', function (e) {
                     e.preventDefault();
                     e.stopPropagation();
 
-                    var parent = this.parentNode;
-                    var hiddenClass = '_ptg-toolbar--hidden';
-
-                    if (util.hasClass(parent, hiddenClass)) {
-                        util.removeClass(parent, hiddenClass);
+                    if (util.hasClass(toolbar, hiddenClass)) {
+                        showToolbar(true);
                     } else {
-                        util.addClass(parent, hiddenClass);
+                        showToolbar(false);
                     }
                 });
             });
 
+            // close icon
             document.querySelectorAll('._ptg-toolbar__icon--close').forEach(function (close) {
                 util.addEventListener(close, 'click', function (e) {
                     e.preventDefault();
@@ -79,6 +135,7 @@
                 });
             });
 
+            // collapsible detail table rows
             var detailRowCollapsedClass = '_ptg-toolbar__table__row-details--collapsed';
             document.querySelectorAll('._ptg-toolbar__table__row-with-details').forEach(function (row) {
                 var index = row.getAttribute('data-index');

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar_js.html.twig
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar_js.html.twig
@@ -118,7 +118,7 @@
             });
 
             // close icon
-            document.querySelectorAll('._ptg-toolbar__icon--close').forEach(function (close) {
+            document.querySelectorAll('._ptg-toolbar__trigger-icon--close').forEach(function (close) {
                 util.addEventListener(close, 'click', function (e) {
                     e.preventDefault();
                     e.stopPropagation();

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar_js.html.twig
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar_js.html.twig
@@ -78,6 +78,60 @@
                     }
                 });
             });
+
+            var detailRowCollapsedClass = '_ptg-toolbar__table__row-details--collapsed';
+            document.querySelectorAll('._ptg-toolbar__table__row-with-details').forEach(function (row) {
+                var index = row.getAttribute('data-index');
+                if (!index) {
+                    return;
+                }
+
+                var trigger = row.querySelector('._ptg-toolbar__table__row-with-details__trigger');
+                if (!trigger) {
+                    return;
+                }
+
+                var detailRows = row.parentElement.querySelectorAll('._ptg-toolbar__table__row-details[data-index="' + index + '"]');
+                if (0 === detailRows.length) {
+                    return;
+                }
+
+                var arrow = document.createElement('span');
+                util.addClass(arrow, '_ptg-toolbar__table__row-with-details__trigger-arrow');
+
+                var toggleDetails = function (show) {
+                    if (show) {
+                        arrow.innerHTML = '▼';
+                        arrow.setAttribute('data-collapsed', '0');
+
+                        detailRows.forEach(function (detailRow) {
+                            util.removeClass(detailRow, detailRowCollapsedClass);
+                        });
+                    } else {
+                        arrow.innerHTML = '▶';
+                        arrow.setAttribute('data-collapsed', '1');
+
+                        detailRows.forEach(function(detailRow) {
+                            util.addClass(detailRow, detailRowCollapsedClass);
+                        });
+                    }
+                };
+
+                toggleDetails(false);
+                trigger.appendChild(arrow);
+
+                util.addEventListener(trigger, 'click', function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+
+                    var collapsed = arrow.getAttribute('data-collapsed');
+                    if ('1' === collapsed) {
+                        toggleDetails(true);
+                    } else {
+                        toggleDetails(false);
+                    }
+                });
+            });
         });
 
     }(window, document));

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar_js.html.twig
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar_js.html.twig
@@ -1,0 +1,84 @@
+<script type="text/javascript">
+    (function (window, document, undefined) {
+        'use strict';
+
+        var util = {
+            addEventListener: function (el, eventName, handler) {
+                if (el.addEventListener) {
+                    el.addEventListener(eventName, handler);
+                } else {
+                    el.attachEvent('on' + eventName, function () {
+                        handler.call(el);
+                    });
+                }
+            },
+
+            removeEventListener: function (el, eventName, handler) {
+                if (el.removeEventListener)
+                    el.removeEventListener(eventName, handler);
+                else
+                    el.detachEvent('on' + eventName, handler);
+            },
+
+            addClass: function (el, className) {
+                if (el.classList) {
+                    el.classList.add(className);
+                } else {
+                    el.className += ' ' + className;
+                }
+            },
+
+            hasClass: function (el, className) {
+                if (el.classList) {
+                    return el.classList.contains(className);
+                } else {
+                    return new RegExp('(^| )' + className + '( |$)', 'gi').test(el.className);
+                }
+            },
+
+            removeClass: function (el, className) {
+                if (el.classList) {
+                    el.classList.remove(className);
+                } else {
+                    el.className = el.className.replace(new RegExp('(^|\\b)' + className.split(' ').join('|') + '(\\b|$)', 'gi'), ' ');
+                }
+            }
+        };
+
+        util.addEventListener(document, 'DOMContentLoaded', function () {
+            document.querySelectorAll('._ptg-toolbar__trigger').forEach(function (trigger) {
+                util.addEventListener(trigger, 'click', function (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+
+                    var parent = this.parentNode;
+                    var hiddenClass = '_ptg-toolbar--hidden';
+
+                    if (util.hasClass(parent, hiddenClass)) {
+                        util.removeClass(parent, hiddenClass);
+                    } else {
+                        util.addClass(parent, hiddenClass);
+                    }
+                });
+            });
+
+            document.querySelectorAll('._ptg-toolbar__icon--close').forEach(function (close) {
+                util.addEventListener(close, 'click', function (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+
+                    var selector = this.getAttribute('data-selector');
+                    if (!selector) {
+                        return;
+                    }
+
+                    var toolbar = document.querySelector(selector);
+                    if (toolbar) {
+                        toolbar.parentNode.removeChild(toolbar);
+                    }
+                });
+            });
+        });
+
+    }(window, document));
+</script>

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar_js.html.twig
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Targeting/toolbar/toolbar_js.html.twig
@@ -132,6 +132,9 @@
                     if (toolbar) {
                         toolbar.parentNode.removeChild(toolbar);
                     }
+
+                    // delete cookie to disable toolbar
+                    document.cookie = 'pimcore_targeting_debug=; path=/'
                 });
             });
 

--- a/pimcore/lib/Pimcore/Targeting/Debug/TargetingDataCollector.php
+++ b/pimcore/lib/Pimcore/Targeting/Debug/TargetingDataCollector.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Targeting\Debug;
+
+use Pimcore\Debug\Traits\StopwatchTrait;
+use Pimcore\Model\Document;
+use Pimcore\Model\Document\Targeting\TargetingDocumentInterface;
+use Pimcore\Model\Tool\Targeting\TargetGroup;
+use Pimcore\Targeting\Document\DocumentTargetingConfigurator;
+use Pimcore\Targeting\Model\VisitorInfo;
+use Pimcore\Targeting\Storage\TargetingStorageInterface;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+class TargetingDataCollector
+{
+    use StopwatchTrait;
+
+    /**
+     * @var TargetingStorageInterface
+     */
+    private $targetingStorage;
+
+    /**
+     * @var DocumentTargetingConfigurator
+     */
+    private $targetingConfigurator;
+
+    /**
+     * @var Stopwatch|null
+     */
+    private $stopwatch;
+
+    public function __construct(
+        TargetingStorageInterface $targetingStorage,
+        DocumentTargetingConfigurator $targetingConfigurator
+    )
+    {
+        $this->targetingStorage      = $targetingStorage;
+        $this->targetingConfigurator = $targetingConfigurator;
+    }
+
+    public function collectVisitorInfo(VisitorInfo $visitorInfo): array
+    {
+        return [
+            'visitorId' => $visitorInfo->getVisitorId(),
+            'sessionId' => $visitorInfo->getSessionId(),
+            'actions'   => $visitorInfo->getActions(),
+            'data'      => $visitorInfo->getData(),
+        ];
+    }
+
+    public function collectStorage(VisitorInfo $visitorInfo): array
+    {
+        $storage = [];
+
+        foreach (TargetingStorageInterface::VALID_SCOPES as $scope) {
+            $created = $this->targetingStorage->getCreatedAt($visitorInfo, $scope);
+            $updated = $this->targetingStorage->getCreatedAt($visitorInfo, $scope);
+
+            $storage[$scope] = array_merge([
+                'created' => $created ? $created->format('c') : null,
+                'updated' => $updated ? $updated->format('c') : null
+            ], $this->targetingStorage->all($visitorInfo, $scope));
+        }
+
+        return $storage;
+    }
+
+    public function collectMatchedRules(VisitorInfo $visitorInfo): array
+    {
+        $rules = [];
+
+        foreach ($visitorInfo->getMatchingTargetingRules() as $rule) {
+            $duration = null;
+            if (null !== $this->stopwatch) {
+                try {
+                    $event    = $this->stopwatch->getEvent(sprintf('Targeting:match:%s', $rule->getName()));
+                    $duration = $event->getDuration();
+                } catch (\Throwable $e) {
+                    // noop
+                }
+            }
+
+            $rules[] = [
+                'id'         => $rule->getId(),
+                'name'       => $rule->getName(),
+                'duration'   => $duration,
+                'conditions' => $rule->getConditions(),
+                'actions'    => $rule->getActions(),
+            ];
+        }
+
+        return $rules;
+    }
+
+    public function collectTargetGroups(VisitorInfo $visitorInfo): array
+    {
+        $targetGroups = [];
+
+        foreach ($visitorInfo->getTargetGroupAssignments() as $assignment) {
+            $targetGroups[] = [
+                'id'        => $assignment->getTargetGroup()->getId(),
+                'name'      => $assignment->getTargetGroup()->getName(),
+                'threshold' => $assignment->getTargetGroup()->getThreshold(),
+                'count'     => $assignment->getCount(),
+            ];
+        }
+
+        return $targetGroups;
+    }
+
+    /**
+     * @param Document|null $document
+     *
+     * @return array|null
+     */
+    public function collectDocumentTargetGroup(Document $document = null)
+    {
+        if (!$document instanceof TargetingDocumentInterface) {
+            return null;
+        }
+
+        $targetGroupId = $document->getUseTargetGroup();
+        if (!$targetGroupId) {
+            return null;
+        }
+
+        $targetGroup = TargetGroup::getById($targetGroupId);
+        if ($targetGroup) {
+            return [
+                'id'   => $targetGroup->getId(),
+                'name' => $targetGroup->getName()
+            ];
+        }
+    }
+
+    public function collectDocumentTargetGroupMapping(): array
+    {
+        $resolvedMapping = $this->targetingConfigurator->getResolvedTargetGroupMapping();
+        $mapping         = [];
+
+        /** @var TargetGroup $targetGroup */
+        foreach ($resolvedMapping as $documentId => $targetGroup) {
+            $document = Document::getById($documentId);
+
+            $mapping[] = [
+                'document'    => [
+                    'id'   => $document->getId(),
+                    'path' => $document->getRealFullPath(),
+                ],
+                'targetGroup' => [
+                    'id'   => $targetGroup->getId(),
+                    'name' => $targetGroup->getName(),
+                ],
+            ];
+        }
+
+        return $mapping;
+    }
+}

--- a/pimcore/lib/Pimcore/Targeting/EventListener/ToolbarListener.php
+++ b/pimcore/lib/Pimcore/Targeting/EventListener/ToolbarListener.php
@@ -122,10 +122,11 @@ class ToolbarListener implements EventSubscriberInterface
         $tdc = $this->targetingDataCollector;
 
         $data = [
-            'token'               => $token,
-            'targetGroups'        => $tdc->collectTargetGroups($visitorInfo),
-            'rules'               => $tdc->collectMatchedRules($visitorInfo),
-            'documentTargetGroup' => $tdc->collectDocumentTargetGroup($document),
+            'token'                => $token,
+            'visitorInfo'          => $tdc->collectVisitorInfo($visitorInfo),
+            'targetGroups'         => $tdc->collectTargetGroups($visitorInfo),
+            'rules'                => $tdc->collectMatchedRules($visitorInfo),
+            'documentTargetGroup'  => $tdc->collectDocumentTargetGroup($document),
             'documentTargetGroups' => $tdc->collectDocumentTargetGroupMapping(),
         ];
 

--- a/pimcore/lib/Pimcore/Targeting/EventListener/ToolbarListener.php
+++ b/pimcore/lib/Pimcore/Targeting/EventListener/ToolbarListener.php
@@ -105,6 +105,11 @@ class ToolbarListener implements EventSubscriberInterface
             return;
         }
 
+        $cookieValue = (bool)$request->cookies->get('pimcore_targeting_debug', false);
+        if (!$cookieValue) {
+            return;
+        }
+
         $document    = $this->documentResolver->getDocument($request);
         $visitorInfo = $this->visitorInfoStorage->getVisitorInfo();
         $data        = $this->collectTemplateData($visitorInfo, $document);

--- a/pimcore/lib/Pimcore/Targeting/EventListener/ToolbarListener.php
+++ b/pimcore/lib/Pimcore/Targeting/EventListener/ToolbarListener.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Targeting\EventListener;
+
+use Pimcore\Bundle\CoreBundle\EventListener\Traits\PimcoreContextAwareTrait;
+use Pimcore\Http\Request\Resolver\PimcoreContextResolver;
+use Pimcore\Http\Response\CodeInjector;
+use Pimcore\Targeting\Model\VisitorInfo;
+use Pimcore\Targeting\VisitorInfoStorageInterface;
+use Pimcore\Tool\Authentication;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Templating\EngineInterface;
+
+class ToolbarListener implements EventSubscriberInterface
+{
+    use PimcoreContextAwareTrait;
+
+    /**
+     * @var EngineInterface
+     */
+    private $templatingEngine;
+
+    /**
+     * @var CodeInjector
+     */
+    private $codeInjector;
+
+    /**
+     * @var VisitorInfoStorageInterface
+     */
+    private $visitorInfoStorage;
+
+    public function __construct(
+        EngineInterface $templatingEngine,
+        CodeInjector $codeInjector,
+        VisitorInfoStorageInterface $visitorInfoStorage
+    )
+    {
+        $this->templatingEngine   = $templatingEngine;
+        $this->codeInjector       = $codeInjector;
+        $this->visitorInfoStorage = $visitorInfoStorage;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::RESPONSE => ['onKernelResponse', -127],
+        ];
+    }
+
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        if (!$this->matchesPimcoreContext($request, PimcoreContextResolver::CONTEXT_DEFAULT)) {
+            return;
+        }
+
+        // only inject toolbar for logged in admin users
+        $adminUser = Authentication::authenticateSession($request);
+        if (!$adminUser) {
+            return;
+        }
+
+        // only inject toolbar if there's a visitor info
+        if (!$this->visitorInfoStorage->hasVisitorInfo()) {
+            return;
+        }
+
+        $visitorInfo = $this->visitorInfoStorage->getVisitorInfo();
+
+        $this->injectToolbar(
+            $event->getResponse(),
+            $visitorInfo
+        );
+    }
+
+    private function injectToolbar(Response $response, VisitorInfo $visitorInfo)
+    {
+        $token = substr(hash('sha256', uniqid((string)mt_rand(), true)), 0, 6);
+        $code  = $this->templatingEngine->render('@PimcoreCore/Targeting/toolbar/toolbar.html.twig', [
+            'token' => $token
+        ]);
+
+        $this->codeInjector->inject(
+            $response,
+            $code,
+            CodeInjector::SELECTOR_BODY,
+            CodeInjector::POSITION_END
+        );
+    }
+}


### PR DESCRIPTION
Implements data debug feature of #2427. Implements a debug tool which works outside the Symfony profiler context (also in `prod`) when a user is logged in. To enable the toolbar, it's necessary to set a `pimcore_targeting_debug` cookie to true (see docs for a bookmarklet).

![image](https://user-images.githubusercontent.com/27403/35744285-4a6a097e-0840-11e8-8cd5-6196876b8b62.png)
