### PR TITLE
Bugfix cs boolean select

### DIFF
--- a/pimcore/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/pimcore/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -308,8 +308,15 @@ class Classificationstore extends Model\DataObject\ClassDefinition\Data
 
                         $dataFromEditMode = $dataDefinition->getDataFromEditmode($value);
                         $activeGroups[$groupId] = true;
+                        
+                        $forceCreateItem = false;
 
-                        $classificationStore->setLocalizedKeyValue($groupId, $keyId, $dataFromEditMode, $language);
+	                    // CS item must be created in case of "false" or "null" value in booleanSelect too
+                        if($dataDefinition instanceof BooleanSelect && empty($dataFromEditMode)) {
+                        	$forceCreateItem = true;
+                        }
+
+                        $classificationStore->setLocalizedKeyValue($groupId, $keyId, $dataFromEditMode, $language, $forceCreateItem);
                     }
                 }
             }

--- a/pimcore/models/DataObject/Classificationstore.php
+++ b/pimcore/models/DataObject/Classificationstore.php
@@ -151,14 +151,16 @@ class Classificationstore extends Model\AbstractModel
     }
 
     /**
-     * @param $groupId
-     * @param $keyId
-     * @param $value
-     * @param null $language
-     *
-     * @return $this
-     */
-    public function setLocalizedKeyValue($groupId, $keyId, $value, $language = null)
+	 * @param $groupId
+	 * @param $keyId
+	 * @param $value
+	 * @param null $language
+	 * @param bool $forceCreateItem
+	 *
+	 * @return $this
+	 * @throws \Exception
+	 */
+    public function setLocalizedKeyValue($groupId, $keyId, $value, $language = null, $forceCreateItem = false)
     {
         if (!$groupId) {
             throw new \Exception('groupId not valid');
@@ -171,7 +173,7 @@ class Classificationstore extends Model\AbstractModel
         $language  = $this->getLanguage($language);
 
         // treat value "0" nonempty
-        $nonEmpty = (is_string($value) || is_numeric($value)) && strlen($value) > 0;
+        $nonEmpty = ((is_string($value) || is_numeric($value)) && strlen($value) > 0) || $forceCreateItem;
 
         if ($nonEmpty || $value) {
             $this->items[$groupId][$keyId][$language] = $value;

--- a/pimcore/models/DataObject/Classificationstore/Dao.php
+++ b/pimcore/models/DataObject/Classificationstore/Dao.php
@@ -162,7 +162,14 @@ class Dao extends Model\Dao\AbstractDao
             $value = $fd->getDataFromResource($value, $object);
 
             $language = $item['language'];
-            $classificationStore->setLocalizedKeyValue($groupId, $keyId, $value, $language);
+            
+            $forceCreateItem = false;
+
+            // CS item must be created in case of "false" or "null" value in booleanSelect too
+	        if($fd instanceof DataObject\ClassDefinition\Data\BooleanSelect && empty($value)) {
+		        $forceCreateItem = true;
+	        }
+            $classificationStore->setLocalizedKeyValue($groupId, $keyId, $value, $language, $forceCreateItem);
         }
 
         $groupsTableName = $this->getGroupsTableName();


### PR DESCRIPTION
## Bug in Classification Store handling booleanSelect

### General preparations

- Create a key definition of type "booleanSelect" in the classification store
- Assign the keyDefintion to a group
- Assign the classification store to an class attribute
- Create an object of this class
- Assign the above created group in the classification store attribute
- Assign all possible values ​​(No / Yes / Empty) to the booleanSelect attribute

### Expected behavior
- Correct values are saved
- Display the correct values ​​after reload
  
### Actual Behavior

- Only saves the "Yes value" correctly
- The values ​​"No" and "Empty" are not stored in the database
- Even after manually setting the correct values ​​in the database (-1 for "No", and NULL for "Empty"), the values ​​are not displayed correctly
