### PR TITLE
Implemented workaround for Bug in ClassificationStore booleanSelect

### DIFF
--- a/pimcore/models/DataObject/ClassDefinition/Data/BooleanSelect.php
+++ b/pimcore/models/DataObject/ClassDefinition/Data/BooleanSelect.php
@@ -270,8 +270,7 @@ class BooleanSelect extends Model\DataObject\ClassDefinition\Data
      */
     public function isEmpty($data)
     {
-    	// For all 3 states never empty
-        return false;
+        return $data !== true && $data !== false;
     }
 
     /**

--- a/pimcore/models/DataObject/ClassDefinition/Data/BooleanSelect.php
+++ b/pimcore/models/DataObject/ClassDefinition/Data/BooleanSelect.php
@@ -270,7 +270,8 @@ class BooleanSelect extends Model\DataObject\ClassDefinition\Data
      */
     public function isEmpty($data)
     {
-        return $data !== true && $data !== false;
+    	// For all 3 states never empty
+        return false;
     }
 
     /**

--- a/pimcore/models/DataObject/Classificationstore.php
+++ b/pimcore/models/DataObject/Classificationstore.php
@@ -150,14 +150,15 @@ class Classificationstore extends Model\AbstractModel
         return 'default';
     }
 
-    /**
-     * @param $groupId
-     * @param $keyId
-     * @param $value
-     * @param null $language
-     *
-     * @return $this
-     */
+	/**
+	 * @param $groupId
+	 * @param $keyId
+	 * @param $value
+	 * @param null $language
+	 *
+	 * @return $this
+	 * @throws \Exception
+	 */
     public function setLocalizedKeyValue($groupId, $keyId, $value, $language = null)
     {
         if (!$groupId) {
@@ -170,8 +171,17 @@ class Classificationstore extends Model\AbstractModel
 
         $language  = $this->getLanguage($language);
 
-        // treat value "0" nonempty
-        $nonEmpty = (is_string($value) || is_numeric($value)) && strlen($value) > 0;
+	    // treat value "0" nonempty
+	    $nonEmpty = (is_string($value) || is_numeric($value)) && strlen($value) > 0;
+
+	    // Workaround for booleanSelect
+	    // @TODO Find a better solution for using isEmpty() in all ClassDefintion DataTypes
+
+	    $keyConfig = Model\DataObject\Classificationstore\DefinitionCache::get($keyId);
+	    $dataDefinition = Model\DataObject\Classificationstore\Service::getFieldDefinitionFromKeyConfig($keyConfig);
+	    if($dataDefinition instanceof Model\DataObject\ClassDefinition\Data\BooleanSelect) {
+		    $nonEmpty = ! $dataDefinition->isEmpty($value);
+	    }
 
         if ($nonEmpty || $value) {
             $this->items[$groupId][$keyId][$language] = $value;

--- a/pimcore/models/DataObject/Classificationstore.php
+++ b/pimcore/models/DataObject/Classificationstore.php
@@ -180,7 +180,7 @@ class Classificationstore extends Model\AbstractModel
 	    $keyConfig = Model\DataObject\Classificationstore\DefinitionCache::get($keyId);
 	    $dataDefinition = Model\DataObject\Classificationstore\Service::getFieldDefinitionFromKeyConfig($keyConfig);
 	    if($dataDefinition instanceof Model\DataObject\ClassDefinition\Data\BooleanSelect) {
-		    $nonEmpty = ! $dataDefinition->isEmpty($value);
+		    $nonEmpty = true;
 	    }
 
         if ($nonEmpty || $value) {


### PR DESCRIPTION
## General preparations

- Create a key definition of type "booleanSelect" in the classification store
- Assign the keyDefintion to a group
- Assign the classification store to an class attribute
- Create an object of this class
- Assign the above created group in the classification store attribute
- Assign all possible values ​​(No / Yes / Empty) to the booleanSelect attribute

## Expected behavior

- Correct values are saved
- Display the correct values ​​after reload

## Actual Behavior

- Only saves the "Yes value" correctly
- The values ​​"No" and "Empty" are not stored in the database
- Even after manually setting the correct values ​​in the database (-1 for "No", and NULL for "Empty"), the values ​​are not displayed correctly

## Workaround

As discussed we implemented a workaround for this bug and inserted a TODO for a final fix