### PR TITLE
Workaround for Logging on Install - Checks

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/InstallBundle/Resources/config/config.yml
+++ b/pimcore/lib/Pimcore/Bundle/InstallBundle/Resources/config/config.yml
@@ -11,6 +11,7 @@ twig:
     strict_variables: '%kernel.debug%'
 
 monolog:
+    channels: ['pimcore']
     handlers:
         main:
             type: stream


### PR DESCRIPTION
Hi,

Maybe a little bit special, but i got an error because of undefined Service for `monolog.logger.pimcore` while Check Requirements Route.

best regards
  
  
## Fixes Issue #

Caused by undefined Service for `monolog.logger.pimcore` while Check Requirements Route.

The Exception:
```
request.CRITICAL: Uncaught PHP Exception Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: "You have requested a non-existent service "monolog.logger.pimcore". Did you mean one of these: "monolog.logger.event", "monolog.logger.php", "monolog.logger.request", "monolog.logger.cache", "monolog.logger.console"?" at /var/www/html/client.local/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Container.php line 348 {"exception":"[object] (Symfony\\Component\\DependencyInjection\\Exception\\ServiceNotFoundException(code: 0): You have requested a non-existent service \"monolog.logger.pimcore\". Did you mean one of these: \"monolog.logger.event\", \"monolog.logger.php\", \"monolog.logger.request\", \"monolog.logger.cache\", \"monolog.logger.console\"? at /var/www/html/client.local/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Container.php:348)"} []
```

## Changes in this pull request  

- Add monolog channel for `Pimcore\Logger`

## Additional info  

It is caused because of Pimcore\Logger usage of some Methods like `Pimcore\Config::getSystemConfig()`

An Example ExceptionTrace (Working dir is replaced with `./`)
````
#0 ./pimcore/lib/Pimcore/Logger.php(29): Symfony\Component\DependencyInjection\Container->get('monolog.logger....')
#1 ./pimcore/lib/Pimcore/Logger.php(44): Pimcore\Logger::log('Cannot find sys...', 'emergency', Array)
#2 ./pimcore/lib/Pimcore/Config.php(114): Pimcore\Logger::emergency('Cannot find sys...')
#3 ./pimcore/lib/Pimcore/Tool/Console.php(80): Pimcore\Config::getSystemConfig()
#4 ./pimcore/lib/Pimcore/Tool/Console.php(233): Pimcore\Tool\Console::getExecutable('php', true)
#5 ./pimcore/lib/Pimcore/Tool/Requirements.php(328): Pimcore\Tool\Console::getPhpCli()
#6 ./pimcore/lib/Pimcore/Bundle/InstallBundle/Controller/InstallController.php(88): Pimcore\Tool\Requirements::checkExternalApplications()
#7 ./vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(151): Pimcore\Bundle\InstallBundle\Controller\InstallController->checkAction(Object(Symfony\Component\HttpFoundation\Request), Object(Pimcore\Install\Installer))
#8 ./vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(68): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#9 ./vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php(202): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#10./web/install.php(72): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#11 {main}
````
