### PR TITLE
Add Predefined Data Templates for Hotspots/Marker on Image Editables

### DIFF
--- a/doc/Development_Documentation/03_Documents/01_Editables/14_Image.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/14_Image.md
@@ -37,6 +37,7 @@ The biggest advantages of using that instead of (for example) the href editable:
 | `deferred`                     | bool    | Set to false to disable deferred (on demand) thumbnail rendering                                                                                                                                                                         |
 | `class`                        | string  | A CSS class that is added to the surrounding container of this element in editmode                                                                                                                                                       |
 | `lowQualityPlaceholder`        | bool    | Put's a small SVG/JPEG placeholder image into the `src` (data-uri), the real image path is placed in `data-src` and `data-srcset`. (requires [SQIP](https://github.com/technopagan/sqip) or [Imagick](http://php.net/imagick), details see [setup of additional tools](../../23_Installation_and_Upgrade/03_System_Setup_and_Hosting/06_Additional_Tools_Installation.md)                                                                    |
+| `predefinedDataTemplates`        | array    | Add predefined config sets for hotspots and images |
 
 You can also pass every valid `<img>` tag attribute ([w3.org Image](http://www.w3.org/TR/html401/struct/objects.html#edef-IMG)), such as: `class`, `style`
 
@@ -287,7 +288,45 @@ All dimensions are in percent and therefore independent from the image size, you
             "title" => "Drag your image here",
             "width" => 400,
             "height" => 400,
-            "thumbnail" => "content"
+            "thumbnail" => "content",
+            /* 
+            //adds predefined config sets
+            "predefinedDataTemplates" => [
+                            "marker" => [
+                                [
+                                    "menuName" => "marker config 1",
+                                    "name" => "marker name",
+                                    "data" => [
+                                        [
+                                            "name" => "my textfield",
+                                            "type" => "textfield"
+                                        ],
+                                        [
+                                            "name" => "my asset href",
+                                            "type" => "asset",
+                                            "value" => "/testimage1.jpg"
+                                        ]
+                                    ]
+                                ]
+                            ],
+                            "hotspot" => [
+                                [
+                                    "menuName" => "hotspot config 1",
+                                    "name" => "hotspot name",
+                                    "data" => [
+                                        [
+                                            "name" => "my textfield",
+                                            "type" => "textfield"
+                                        ],
+                                        [
+                                            "name" => "my asset href",
+                                            "type" => "asset",
+                                            "value" => "/testimage1.jpg"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]*/
         ]); ?>
         
         <?php if(!$this->editmode): ?>

--- a/pimcore/models/Document/Tag/Image.php
+++ b/pimcore/models/Document/Tag/Image.php
@@ -172,7 +172,8 @@ class Image extends Model\Document\Tag
                 'cropTop' => $this->cropTop,
                 'cropLeft' => $this->cropLeft,
                 'hotspots' => $hotspots,
-                'marker' => $marker
+                'marker' => $marker,
+                'predefinedDataTemplates' => $this->getOptions()['predefinedDataTemplates']
             ];
         }
 

--- a/web/pimcore/static6/js/pimcore/document/tags/image.js
+++ b/web/pimcore/static6/js/pimcore/document/tags/image.js
@@ -451,7 +451,8 @@ pimcore.document.tags.image = Class.create(pimcore.document.tag, {
                     cropTop: this.datax.cropTop,
                     cropLeft: this.datax.cropLeft,
                     cropPercent: this.datax.cropPercent
-                }
+                },
+                predefinedDataTemplates : this.options.predefinedDataTemplates
             }
 
         );


### PR DESCRIPTION
See https://github.com/pimcore/pimcore/issues/2551

Usage example:

        <?= $this->image("image", [
            "thumbnail" => "content",
            "predefinedDataTemplates" => [
                "marker" => [
                    [
                        "menuName" => "marker config 1",
                        "name" => "marker name",
                        "data" => [
                            [
                                "name" => "my textfield",
                                "type" => "textfield"
                            ],
                            [
                                "name" => "my asset href",
                                "type" => "asset",
                                "value" => "/71ILAjFd7oL._SY623_.jpg"
                            ]
                        ]
                    ]
                ],
                "hotspot" => [
                    [
                        "menuName" => "hotspot config 1",
                        "name" => "hotspot name",
                        "data" => [
                            [
                                "name" => "my textfield",
                                "type" => "textfield"
                            ],
                            [
                                "name" => "my asset href",
                                "type" => "asset",
                                "value" => "/71ILAjFd7oL._SY623_.jpg"
                            ]
                        ]
                    ]
                ]
            ]
        ]) ?>