### PR TITLE
Fix for mass publication of objects.

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
@@ -2304,7 +2304,7 @@ class DataObjectHelperController extends AdminController
 
                 try {
                     // don't check for mandatory fields here
-                    $object->setOmitMandatoryCheck(true);
+                    $object->setOmitMandatoryCheck(!$object->isPublished());
                     $object->setUserModification($this->getAdminUser()->getId());
                     $object->save();
                     $success = true;


### PR DESCRIPTION
## How to reproduce the issue
Create class with at least one mandatory field and then create some objects. Leave mandatory field empty. Go to the grid and select created class. Choose column named "Published", select "Batch Assignment" option and then mark "Published" checkbox. Objects were published although mandatory field was empty.
  
## Fixes Issue #
If object is published then set ```$omitMandatoryCheck``` flag to ```false```.

## Changes in this pull request  
There is one change in the class ```Pimcore\Bundle\AdminBundle\Controller\Admin\DataObjectHelperController``` (line 2307).