### PR TITLE
DocumentRenderer/SEO Document Editor Improvements

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DocumentController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DocumentController.php
@@ -1163,7 +1163,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
 
         $root = Document::getById(1);
         if ($root->isAllowed('list')) {
-            $nodeConfig = $this->getSeoNodeConfig($request, $root);
+            $nodeConfig = $this->getSeoNodeConfig($root);
 
             return $this->adminJson($nodeConfig);
         }
@@ -1216,7 +1216,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
                     $list->setCondition('path LIKE ? and type = ?', [$childDocument->getRealFullPath() . '/%', 'page']);
 
                     if ($childDocument instanceof Document\Page || $list->getTotalCount() > 0) {
-                        $documents[] = $this->getSeoNodeConfig($request, $childDocument);
+                        $documents[] = $this->getSeoNodeConfig($childDocument);
                     }
                 }
             }
@@ -1357,13 +1357,12 @@ class DocumentController extends ElementControllerBase implements EventedControl
      *
      * @return array
      */
-    private function getSeoNodeConfig(Request $request, $document)
+    private function getSeoNodeConfig($document)
     {
         $nodeConfig = $this->getTreeNodeConfig($document);
 
         if (method_exists($document, 'getTitle') && method_exists($document, 'getDescription')) {
-
-            // anaylze content
+            // analyze content
             $nodeConfig['prettyUrl']     = $document->getPrettyUrl();
             $nodeConfig['links']         = 0;
             $nodeConfig['externallinks'] = 0;
@@ -1377,12 +1376,10 @@ class DocumentController extends ElementControllerBase implements EventedControl
             $description = null;
 
             try {
-
-                // cannot use the rendering service from Document\Service::render() because of singleton's ...
-                // $content = Document\Service::render($childDocument, array("pimcore_admin" => true, "pimcore_preview" => true), true);
-
-                $contentUrl = $request->getScheme() . '://' . $request->getHttpHost() . $document->getFullPath();
-                $content    = Tool::getHttpData($contentUrl, ['pimcore_preview' => true, 'pimcore_admin' => true, '_dc' => time()]);
+                $content = Document\Service::render($document, [], true, [
+                    'pimcore_admin' => true,
+                    'pimcore_preview' => true
+                ]);
 
                 if ($content) {
                     include_once(PIMCORE_PATH . '/lib/simple_html_dom.php');

--- a/pimcore/lib/Pimcore/Document/Renderer/DocumentRenderer.php
+++ b/pimcore/lib/Pimcore/Document/Renderer/DocumentRenderer.php
@@ -104,7 +104,9 @@ class DocumentRenderer implements DocumentRendererInterface
         // this is needed for logic relying on the current route (e.g. pimcoreUrl helper)
         if (!isset($attributes['_route'])) {
             $route = $this->documentRouteHandler->buildRouteForDocument($document);
-            $attributes['_route'] = $route->getRouteKey();
+            if (null !== $route) {
+                $attributes['_route'] = $route->getRouteKey();
+            }
         }
 
         try {

--- a/pimcore/lib/Pimcore/Document/Renderer/DocumentRenderer.php
+++ b/pimcore/lib/Pimcore/Document/Renderer/DocumentRenderer.php
@@ -17,11 +17,14 @@ declare(strict_types=1);
 
 namespace Pimcore\Document\Renderer;
 
+use Pimcore\Event\DocumentEvents;
+use Pimcore\Event\Model\DocumentEvent;
 use Pimcore\Http\RequestHelper;
 use Pimcore\Model\Document;
 use Pimcore\Routing\Dynamic\DocumentRouteHandler;
 use Pimcore\Targeting\Document\DocumentTargetingConfigurator;
 use Pimcore\Templating\Renderer\ActionRenderer;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 
@@ -52,6 +55,11 @@ class DocumentRenderer implements DocumentRendererInterface
      */
     private $targetingConfigurator;
 
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
     public function __construct(
         RequestHelper $requestHelper,
         ActionRenderer $actionRenderer,
@@ -67,10 +75,28 @@ class DocumentRenderer implements DocumentRendererInterface
     }
 
     /**
+     * TODO Pimcore 6 set event dispatcher as constructor parameter
+     *
+     * @internal
+     * @required
+     *
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
      * @inheritdoc
      */
     public function render(Document\PageSnippet $document, array $attributes = [], array $query = [], array $options = []): string
     {
+        $this->eventDispatcher->dispatch(
+            DocumentEvents::RENDERER_PRE_RENDER,
+            new DocumentEvent($document)
+        );
+
         // apply best matching target group (if any)
         $this->targetingConfigurator->configureTargetGroup($document);
 
@@ -89,6 +115,11 @@ class DocumentRenderer implements DocumentRendererInterface
 
         $uri      = $this->actionRenderer->createDocumentReference($document, $attributes, $query);
         $response = $this->fragmentRenderer->render($uri, $request, $options);
+
+        $this->eventDispatcher->dispatch(
+            DocumentEvents::RENDERER_POST_RENDER,
+            new DocumentEvent($document)
+        );
 
         return $response->getContent();
     }

--- a/pimcore/lib/Pimcore/Event/DocumentEvents.php
+++ b/pimcore/lib/Pimcore/Event/DocumentEvents.php
@@ -139,4 +139,22 @@ final class DocumentEvents
      * @Event("Pimcore\Event\Model\Document\TagNameEvent")
      */
     const TAG_NAME = 'pimcore.document.tag.name';
+
+    /**
+     * The RENDERER_PRE_RENDER event is triggered before the DocumentRenderer renders a document
+     *
+     * @Event("Pimcore\Event\Model\DocumentEvent")
+     *
+     * @var string
+     */
+    const RENDERER_PRE_RENDER = 'pimcore.document.renderer.pre_render';
+
+    /**
+     * The RENDERER_POST_RENDER event is triggered after the DocumentRenderer rendered a document
+     *
+     * @Event("Pimcore\Event\Model\DocumentEvent")
+     *
+     * @var string
+     */
+    const RENDERER_POST_RENDER = 'pimcore.document.renderer.post_render';
 }

--- a/pimcore/lib/Pimcore/Templating/Helper/Placeholder/AbstractHelper.php
+++ b/pimcore/lib/Pimcore/Templating/Helper/Placeholder/AbstractHelper.php
@@ -59,6 +59,11 @@ use Symfony\Component\Templating\Helper\Helper;
 abstract class AbstractHelper extends Helper implements \IteratorAggregate, \Countable, \ArrayAccess
 {
     /**
+     * @var ContainerService
+     */
+    protected $containerService;
+
+    /**
      * @var Container
      */
     protected $_container;
@@ -78,16 +83,9 @@ abstract class AbstractHelper extends Helper implements \IteratorAggregate, \Cou
      */
     protected $_autoEscape = true;
 
-    /**
-     * AbstractHelper constructor.
-     *
-     * @param ContainerService $containerService
-     *
-     * @internal param Container $container
-     */
     public function __construct(ContainerService $containerService)
     {
-        $this->setContainer($containerService->getContainer($this->_regKey));
+        $this->containerService = $containerService;
     }
 
     /**
@@ -135,7 +133,7 @@ abstract class AbstractHelper extends Helper implements \IteratorAggregate, \Cou
      */
     public function setContainer(Container $container)
     {
-        $this->_container = $container;
+        $this->containerService->setContainer($this->_regKey, $container);
 
         return $this;
     }
@@ -147,7 +145,7 @@ abstract class AbstractHelper extends Helper implements \IteratorAggregate, \Cou
      */
     public function getContainer()
     {
-        return $this->_container;
+        return $this->containerService->getContainer($this->_regKey);
     }
 
     /**

--- a/pimcore/lib/Pimcore/Templating/Helper/Placeholder/ContainerService.php
+++ b/pimcore/lib/Pimcore/Templating/Helper/Placeholder/ContainerService.php
@@ -36,6 +36,9 @@
  */
 
 namespace Pimcore\Templating\Helper\Placeholder;
+use Pimcore\Event\DocumentEvents;
+use Pimcore\Event\Model\DocumentEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Registry for placeholder containers
@@ -43,11 +46,68 @@ namespace Pimcore\Templating\Helper\Placeholder;
 class ContainerService
 {
     /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var int
+     */
+    private $currentIndex = 0;
+
+    /**
      * Placeholder containers
      *
      * @var array
      */
     protected $_items = [];
+
+    public function __construct()
+    {
+        $this->_items[$this->currentIndex] = [];
+    }
+
+    /**
+     * TODO Pimcore 6 set event dispatcher as constructor parameter
+     *
+     * @internal
+     * @required
+     *
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+
+        // lazily add event listeners - these listeners are only added if the container service is actually built
+        // when rendering a new document, the index is pushed to create a new, empty context
+        $eventDispatcher->addListener(DocumentEvents::RENDERER_PRE_RENDER, [$this, 'pushIndex']);
+        $eventDispatcher->addListener(DocumentEvents::RENDERER_POST_RENDER, [$this, 'popIndex']);
+    }
+
+    public function pushIndex()
+    {
+        ++$this->currentIndex;
+
+        if (isset($this->_items[$this->currentIndex])) {
+            throw new \RuntimeException(sprintf('Items at index %d already exist', $this->currentIndex));
+        }
+
+        $this->_items[$this->currentIndex] = [];
+    }
+
+    public function popIndex()
+    {
+        if (0 === $this->currentIndex) {
+            throw new \OutOfBoundsException('Current index is already at 0');
+        }
+
+        if (isset($this->_items[$this->currentIndex])) {
+            unset($this->_items[$this->currentIndex]);
+        }
+
+        --$this->currentIndex;
+    }
 
     /**
      * createContainer
@@ -61,9 +121,9 @@ class ContainerService
     {
         $key = (string) $key;
 
-        $this->_items[$key] = new Container($value);
+        $this->_items[$this->currentIndex][$key] = new Container($value);
 
-        return $this->_items[$key];
+        return $this->_items[$this->currentIndex][$key];
     }
 
     /**
@@ -76,8 +136,8 @@ class ContainerService
     public function getContainer($key)
     {
         $key = (string) $key;
-        if (isset($this->_items[$key])) {
-            return $this->_items[$key];
+        if (isset($this->_items[$this->currentIndex][$key])) {
+            return $this->_items[$this->currentIndex][$key];
         }
 
         $container = $this->createContainer($key);
@@ -95,7 +155,7 @@ class ContainerService
     public function containerExists($key)
     {
         $key = (string) $key;
-        $return =  array_key_exists($key, $this->_items);
+        $return =  array_key_exists($key, $this->_items[$this->currentIndex]);
 
         return $return;
     }
@@ -111,7 +171,7 @@ class ContainerService
     public function setContainer($key, Container $container)
     {
         $key = (string) $key;
-        $this->_items[$key] = $container;
+        $this->_items[$this->currentIndex][$key] = $container;
 
         return $this;
     }
@@ -126,8 +186,8 @@ class ContainerService
     public function deleteContainer($key)
     {
         $key = (string) $key;
-        if (isset($this->_items[$key])) {
-            unset($this->_items[$key]);
+        if (isset($this->_items[$this->currentIndex][$key])) {
+            unset($this->_items[$this->currentIndex][$key]);
 
             return true;
         }


### PR DESCRIPTION
* Fixes #2098 - SEO Document Editor now uses the `DocumentRenderer`. To make this possible, core view helpers keeping state (e.g. the `headTitle` helper) need a way to start with a fresh context for each rendered document. The newly introduced events `DocumentEvents::RENDERER_PRE_RENDER` and `DocumentEvents::RENDERER_POST_RENDER` are fired by the document renderer and allow components to start with a fresh state. In case of the placeholder helpers, they initialize a new placeholder container for each rendered document. Not doing so would result in a document including placeholder parts of the previously rendered one (e.g. the title containing the title from the previous document and getting longer for each rendered document).
* Fixes #2354 implicitely by using the document renderer
* Fixes #2121 by checking if a route is set before trying to use it