### PR TITLE
ECommerce | FilterService | Filter Type| Number Range | upport for {{empty}} placeholder.

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/FilterService/FilterType/NumberRange.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/FilterService/FilterType/NumberRange.php
@@ -49,14 +49,14 @@ class NumberRange extends AbstractFilterType
             if (!empty($value['from'])) {
                 if ($isPrecondition) {
                     $productList->addCondition($this->getField($filterDefinition) . ' >= ' . $productList->quote($value['from']), 'PRECONDITION_' . $this->getField($filterDefinition));
-                } else {
+                } elseif ($value['from'] != AbstractFilterType::EMPTY_STRING) {
                     $productList->addCondition($this->getField($filterDefinition) . ' >= ' . $productList->quote($value['from']), $this->getField($filterDefinition));
                 }
             }
             if (!empty($value['to'])) {
                 if ($isPrecondition) {
                     $productList->addCondition($this->getField($filterDefinition) . ' <= ' . $productList->quote($value['to']), 'PRECONDITION_' . $this->getField($filterDefinition));
-                } else {
+                } elseif($value['to'] != AbstractFilterType::EMPTY_STRING) {
                     $productList->addCondition($this->getField($filterDefinition) . ' <= ' . $productList->quote($value['to']), $this->getField($filterDefinition));
                 }
             }


### PR DESCRIPTION
In case that the keyword {{empty}} is passed a number range filter only has to be applied if there is a precondition.

