### PR TITLE
Classificationstore bug

### DIFF
--- a/pimcore/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/pimcore/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -441,11 +441,13 @@ class Classificationstore extends Model\DataObject\ClassDefinition\Data
             if (is_array($items)) {
                 foreach ($items as $groupId => $groupData) {
                     $groupDef = DataObject\Classificationstore\GroupConfig::getById($groupId);
-                    $activeGroups[] = [
-                        'id' => $groupId,
-                        'name' => $groupDef->getName(). ' - ' . $groupDef->getDescription(),
-                        'enabled' => $groupData
-                    ];
+                    if (!is_null($groupDef)) {
+                        $activeGroups[] = [
+                            'id' => $groupId,
+                            'name' => $groupDef->getName(). ' - ' . $groupDef->getDescription(),
+                            'enabled' => $groupData
+                        ];
+                    }
                 }
             }
 
@@ -478,11 +480,13 @@ class Classificationstore extends Model\DataObject\ClassDefinition\Data
 
                 if ($groupResult) {
                     $groupDef = DataObject\Classificationstore\GroupConfig::getById($groupId);
-                    $groupResult = [
-                        'id' => $groupId,
-                        'name' => $groupDef->getName(). ' - ' . $groupDef->getDescription(),
-                        'keys' => $groupResult
-                    ];
+                   if (!is_null($groupDef)) {
+                        $groupResult = [
+                            'id' => $groupId,
+                            'name' => $groupDef->getName(). ' - ' . $groupDef->getDescription(),
+                            'keys' => $groupResult
+                        ];
+                   }
                 }
 
                 $result['groups'][] = $groupResult;


### PR DESCRIPTION
If a classificationstore group is deleted, getForWebserviceExport will fail for objects containing values for that group.

BugFix : 
Create a classificationstore group and assigne a key
Save a vlaue for an object for that group.
a websevice reading the object will fail with an error (xxx/webservice/rest/object/id/123)

Bug in Pimcore 5 & Pimcore 4


## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
  
  
## Fixes Issue #

## Changes in this pull request  

## Additional info  

