### PR TITLE
Checking if folder has children by searching only one child instead of all children

### DIFF
--- a/pimcore/models/DataObject/AbstractObject/Dao.php
+++ b/pimcore/models/DataObject/AbstractObject/Dao.php
@@ -295,7 +295,7 @@ class Dao extends Model\Element\Dao
      */
     public function hasChildren($objectTypes = [DataObject::OBJECT_TYPE_OBJECT, DataObject::OBJECT_TYPE_FOLDER])
     {
-        $c = $this->db->fetchOne("SELECT o_id FROM objects WHERE o_parentId = ? AND o_type IN ('" . implode("','", $objectTypes) . "')", $this->model->getId());
+        $c = $this->db->fetchOne("SELECT o_id FROM objects WHERE o_parentId = ? AND o_type IN ('" . implode("','", $objectTypes) . "') LIMIT 1", $this->model->getId());
 
         return (bool)$c;
     }


### PR DESCRIPTION
## Fixes Issue #2597 

## Changes in this pull request  
Added LIMIT to query that should only checks if object has children.

### Steps to reproduce  
1. Create folder in Data Objects -> Home
2. Create 10 subfolders within folder created in 1.
3. Into each of subfolders generate 100 000 objects
4. Refresh page
5. Try to expand folder created in 1.


