### PR TITLE
fix json generation of objectbricks

### DIFF
--- a/pimcore/models/DataObject/ClassDefinition/Service.php
+++ b/pimcore/models/DataObject/ClassDefinition/Service.php
@@ -145,7 +145,13 @@ class Service
         // this will allow to import the brick on a different instance with identical class names but different class IDs
         if (is_array($objectBrick->classDefinitions)) {
             foreach ($objectBrick->classDefinitions as &$cd) {
-                $class = DataObject\ClassDefinition::getById($cd['classname']);
+                // for compatibility (upgraded pimcore4s that may deliver class ids in $cd['classname'] we need to 
+                // get the class by id in order to be able to correctly set the classname for the generated json
+                if (is_numeric($cd['classname'])) {
+                    $class = DataObject\ClassDefinition::getById($cd['classname']);
+                } else {
+                    $class = DataObject\ClassDefinition::getByName($cd['classname']);
+                }
                 if ($class) {
                     $cd['classname'] = $class->getName();
                 }

--- a/pimcore/models/DataObject/ClassDefinition/Service.php
+++ b/pimcore/models/DataObject/ClassDefinition/Service.php
@@ -145,13 +145,12 @@ class Service
         // this will allow to import the brick on a different instance with identical class names but different class IDs
         if (is_array($objectBrick->classDefinitions)) {
             foreach ($objectBrick->classDefinitions as &$cd) {
-                // for compatibility (upgraded pimcore4s that may deliver class ids in $cd['classname'] we need to 
+                // for compatibility (upgraded pimcore4s that may deliver class ids in $cd['classname'] we need to
                 // get the class by id in order to be able to correctly set the classname for the generated json
-                if (is_numeric($cd['classname'])) {
+                if (!$class = DataObject\ClassDefinition::getByName($cd['classname'])) {
                     $class = DataObject\ClassDefinition::getById($cd['classname']);
-                } else {
-                    $class = DataObject\ClassDefinition::getByName($cd['classname']);
                 }
+
                 if ($class) {
                     $cd['classname'] = $class->getName();
                 }


### PR DESCRIPTION
due to upgraded pimcore 4s (that may deliver ids in the classDefinitions) the generateObjectbrickJson function implemented a getById in order to correctly set the classname for generated json. 

Unfortunately fresh pimcore 5s deliver a real classname in the classDefinitions
