### PR TITLE
Speed up count of children

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectController.php
@@ -138,8 +138,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             //pagination for custom view
             $total = $cv
                 ? $childsList->count()
-                : $object->getChildAmount([DataObject\AbstractObject::OBJECT_TYPE_OBJECT, DataObject\AbstractObject::OBJECT_TYPE_FOLDER,
-                    DataObject\AbstractObject::OBJECT_TYPE_VARIANT], $this->getAdminUser());
+                : $object->getChildAmount(null, $this->getAdminUser());
         }
 
         //Hook for modifying return value - e.g. for changing permissions based on object data

--- a/pimcore/models/DataObject/AbstractObject/Dao.php
+++ b/pimcore/models/DataObject/AbstractObject/Dao.php
@@ -317,21 +317,24 @@ class Dao extends Model\Element\Dao
     /**
      * returns the amount of directly childs (not recursivly)
      *
-     * @param array $objectTypes
+     * @param array|null $objectTypes
      * @param Model\User $user
      *
      * @return int
      */
     public function getChildAmount($objectTypes = [DataObject::OBJECT_TYPE_OBJECT, DataObject::OBJECT_TYPE_FOLDER], $user = null)
     {
+        $query = 'SELECT COUNT(*) AS count FROM objects o WHERE o_parentId = ?';
+
+        if (!empty($objectTypes)) {
+            $query .= sprintf(' AND o_type IN (\'%s\')', implode("','", $objectTypes));
+        }
+
         if ($user and !$user->isAdmin()) {
             $userIds = $user->getRoles();
             $userIds[] = $user->getId();
 
-            $query = "SELECT COUNT(*) AS count FROM objects o WHERE o_parentId = ? AND o_type IN ('" . implode("','", $objectTypes) . "')
-                              AND (select list as locate from users_workspaces_object where userId in (" . implode(',', $userIds) . ') and LOCATE(cpath,CONCAT(o.o_path,o.o_key))=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1;';
-        } else {
-            $query = "SELECT COUNT(*) AS count FROM objects WHERE o_parentId = ? AND o_type IN ('" . implode("','", $objectTypes) . "')";
+            $query .= " AND (select list as locate from users_workspaces_object where userId in (" . implode(',', $userIds) . ') and LOCATE(cpath,CONCAT(o.o_path,o.o_key))=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1;';
         }
 
         $c = $this->db->fetchOne($query, $this->model->getId());


### PR DESCRIPTION
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.
  
  
## Fixes Issue #2601 

## Changes in this pull request  
First param of Method Dao::getChildAmount() can now be null. This will lead to two thinks:
1. Objects of all counts will be counted (same as setting [DataObject\AbstractObject::OBJECT_TYPE_OBJECT, DataObject\AbstractObject::OBJECT_TYPE_FOLDER, DataObject\AbstractObject::OBJECT_TYPE_VARIANT])
2. It will speed up drastically with large amount of data.

## Additional info  
It speeds up expanding folder in tree, if the folder has a lot of subelements (500k+), but there still place for improvement (expanding folder generates >100 queries!).
