### PR TITLE
Feature toggles for debug and dev mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,6 +89,7 @@
     "monolog/monolog": "~1",
     "mpratt/embera": "~1",
     "myclabs/deep-copy": "~1.3",
+    "myclabs/php-enum": "^1.5",
     "neitanod/forceutf8": "~2",
     "nesbot/carbon": "~1",
     "ocramius/package-versions": "^1.1",

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/03_Feature_Flags_Debug_Mode.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/03_Feature_Flags_Debug_Mode.md
@@ -1,0 +1,147 @@
+# Feature Flags and Debug Mode 
+
+Starting with version 5.2.0, Pimcore adds a system to handle feature flags in a unified manner. Pimcore itself uses the 
+feature flag system for its own Debug Mode and Dev Mode flags. One or more features can be registered and queried on a 
+`FeatureManager` object which is either accessible via `Pimcore::getFeatureManager()` or by type hinting against
+`FeatureManagerInterface` in your code in a DI context.
+
+> As soon as you set a custom state on the feature manager, the default behavior (e.g. reading debug mode setting from the
+  `debug-mode.php` config file will be omitted.
+  
+To define and query a set of features define a feature as a bit field enum extending the `Pimcore\FeatureToggles\Feature`
+class. This class can be used to set and query a feature state on the feature manager. Besides the flags you define on
+your feature class, the `Feature` base class will define a special `NONE` and an `ALL` value representing all flags turned
+off and all flags turned on. To register a state on the feature manager, set a `FeatureState` object on the manager which
+contains a `type` (e.g. `debug_mode`) and a `value` (an integer value representing one or more flags in the bit field).
+
+> Due to integer limits on 32-bit systems, you can define a maximum of 31 flags in a feature class.
+
+The example below uses Pimcore's own `DebugMode` and `DevMode` flags to demonstrate the API of the feature manager.
+
+```php
+<?php
+
+// the code below could be added to startup.php, but you can this basically everywhere if it soon enough in the
+// application bootstrap context
+
+use Pimcore\FeatureToggles\Features\DebugMode;
+use Pimcore\FeatureToggles\Features\DevMode;
+use Pimcore\FeatureToggles\FeatureState;
+
+$featureManager = Pimcore::getFeatureManager(); // or inject FeatureManagerInterface in a DI context
+
+// enable selected features
+$featureManager->setState(new FeatureState(
+    DebugMode::getType(),
+    DebugMode::MAGIC_PARAMS | DebugMode::ERROR_REPORTING | DebugMode::RENDER_DOCUMENT_TAG_ERRORS
+));
+
+// enable everything, but exclude selected features
+// ALL is dynamic, so instead of the constant, the magic method to build the enum
+// instance needs to be used
+$featureManager->setState(new FeatureState(
+    DebugMode::getType(),
+    DebugMode::ALL()->getValue() & ~DebugMode::DISABLE_HTTP_CACHE & ~DebugMode::MAGIC_PARAMS
+));
+
+// enable a single feature (this will overwrite previous calls)
+$featureManager->setState(FeatureState::fromFeature(DebugMode::MAGIC_PARAMS()));
+
+// enable all flags by using the special ALL enum member
+$featureManager->setState(FeatureState::fromFeature(DebugMode::ALL()));
+
+// disable all flags by using the special NONE enum member
+$featureManager->setState(FeatureState::fromFeature(DebugMode::NONE()));
+
+// same logic applies to other feature sets
+$featureManager->setState(FeatureState::fromFeature(DevMode::ALL()));
+
+// query for a specific feature
+$featureManager->isEnabled(DebugMode::MAGIC_PARAMS());
+
+// alternative method to build the feature instance (see https://github.com/myclabs/php-enum)
+$featureManager->isEnabled(new DebugMode(DebugMode::MAGIC_PARAMS));
+
+// get the current flag value (e.g. for merging)
+$featureManager->getState(DebugMode::getType())->getValue();
+
+// pimcore shortcuts to check for debug and dev flags
+Pimcore::inDebugMode(DebugMode::MAGIC_PARAMS);
+Pimcore::inDevMode(DevMode::UNMINIFIED_JS);
+```
+
+Pimcore ships a default `FeatureState`, but you can build your own with custom logic as long as it implements the `FeatureStateInterface`. 
+For example, you could implement a feature state which activates certain features only during a given time span.
+
+## Migrating from existing `Pimcore::inDebugMode()` calls
+
+As the debug mode isn't simply a boolean anymore, the call to `\Pimcore::inDebugMode()` without any arguments queries for
+the `DebugMode::ALL()` state with all debug features enabled. Always specify a specific flag instead to have the condition 
+match the debug feature you need.
+
+## Create your own feature flags
+
+First, create a feature class holding one or more flags:
+
+```php
+<?php
+
+// src/AppBundle/FeatureToggles/AppFeatures.php
+
+namespace AppBundle\FeatureToggles;
+
+use Pimcore\FeatureToggles\Feature;
+
+/**
+ * This docblock adds type hints for IDEs as the enum class exposes
+ * every flag as static factory method, e.g. AppFeatures::FEATURE_1().
+ *
+ * @method static AppFeatures FEATURE_1()
+ * @method static AppFeatures FEATURE_2()
+ * @method static AppFeatures FEATURE_3()
+ * @method static AppFeatures FEATURE_4()
+ */
+class AppFeatures extends Feature
+{
+    // features must be powers of 2
+    const FEATURE_1 = 1;
+    const FEATURE_2 = 2;
+    const FEATURE_3 = 4;
+    const FEATURE_4 = 8;
+
+    public static function getType(): string
+    {
+        return 'app';
+    }
+}
+```
+
+You can now set and query the features everwhere you need. As an example, in a controller:
+
+```php
+<?php
+
+namespace AppBundle\Controller;
+
+use AppBundle\FeatureToggles\AppFeatures;
+use Pimcore\FeatureToggles\FeatureManagerInterface;
+use Pimcore\FeatureToggles\FeatureState;
+
+class TestController
+{
+    public function testAction(FeatureManagerInterface $featureManager)
+    {
+        // false
+        $featureManager->isEnabled(AppFeatures::FEATURE_1());
+
+        // enable FEATURE_1 and FEATURE_2
+        $featureManager->setState(new FeatureState(
+            AppFeatures::getType(),
+            AppFeatures::FEATURE_1 | AppFeatures::FEATURE_2
+        ));
+
+        // true
+        $featureManager->isEnabled(AppFeatures::FEATURE_1());
+    }
+}
+```

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/15_Magic_Parameters.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/15_Magic_Parameters.md
@@ -11,7 +11,7 @@ Disables all output filters, incl. the output-cache. But this doesn't disable th
 eg.: `http://www.example.com/my/page?pimcore_outputfilters_disabled=1`  
 This parameter only works if [`DEBUG MODE`](../18_Tools_and_Features/25_System_Settings.md) is on.
 
-### disable_minify_js
+### unminified_js
 
 Disables the JavaScript minifier. Useful for ExtJS debugging. Disabled by default if in [`DEV MODE`](../18_Tools_and_Features/25_System_Settings.md). 
 

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5.md
@@ -1,5 +1,11 @@
 # Upgrade Notes for Upgrades within Pimcore 5
 
+## Build 205 (2018-02-19)
+
+The debug mode was changed from being a boolean setting to a more granular feature flag setting. If you query the debug 
+mode in your code, you might update the call to specify which kind of debug setting you want to query. See
+[Feature Flags and Debug Mode](../../19_Development_Tools_and_Details/03_Feature_Flags_Debug_Mode.md) for details.
+
 ## Build 195 (2018-02-01)
 New MySQL/MariaDB requirements are introduced, ensure the following system variables are set accordingly.
 ```

--- a/pimcore/lib/Pimcore.php
+++ b/pimcore/lib/Pimcore.php
@@ -394,7 +394,7 @@ class Pimcore
         }
 
         // magic parameter for debugging ExtJS stuff
-        if (array_key_exists('disable_minify_js', $_REQUEST) && self::inDebugMode(DebugMode::MAGIC_PARAMS)) {
+        if (array_key_exists('unminified_js', $_REQUEST) && self::inDebugMode(DebugMode::MAGIC_PARAMS)) {
             return true;
         }
 

--- a/pimcore/lib/Pimcore.php
+++ b/pimcore/lib/Pimcore.php
@@ -387,26 +387,24 @@ class Pimcore
         Model\Tool\Lock::releaseAll();
     }
 
-    /**
-     * @static
-     *
-     */
-    public static function disableMinifyJs()
+    public static function disableMinifyJs(): bool
     {
-        // magic parameter for debugging ExtJS stuff
-        if (PIMCORE_DEVMODE || (array_key_exists('disable_minify_js', $_REQUEST) && self::inDebugMode())) {
+        if (self::inDevMode(DevMode::UNMINIFIED_JS)) {
             return true;
         }
+
+        // magic parameter for debugging ExtJS stuff
+        if (array_key_exists('disable_minify_js', $_REQUEST) && self::inDebugMode(DebugMode::MAGIC_PARAMS)) {
+            return true;
+        }
+
+        return false;
     }
 
-    /**
-     * @static
-     *
-     */
     public static function initLogger()
     {
         // special request log -> if parameter pimcore_log is set
-        if (array_key_exists('pimcore_log', $_REQUEST) && self::inDebugMode()) {
+        if (array_key_exists('pimcore_log', $_REQUEST) && self::inDebugMode(DebugMode::MAGIC_PARAMS)) {
             if (empty($_REQUEST['pimcore_log'])) {
                 $requestLogName = date('Y-m-d_H-i-s');
             } else {

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/IndexController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/IndexController.php
@@ -20,6 +20,7 @@ use Pimcore\Config;
 use Pimcore\Controller\Configuration\TemplatePhp;
 use Pimcore\Event\Admin\IndexSettingsEvent;
 use Pimcore\Event\AdminEvents;
+use Pimcore\FeatureToggles\Features\DevMode;
 use Pimcore\Google;
 use Pimcore\Model\Element\Service;
 use Pimcore\Model\Schedule\Manager\Procedural;
@@ -146,14 +147,14 @@ class IndexController extends AdminController
         $config = $view->config;
 
         $settings = new ViewModel([
-            'version'   => Version::getVersion(),
-            'build'     => Version::getRevision(),
-            'buildDate'     => Version::getBuildDate(),
-            'debug'     => \Pimcore::inDebugMode(),
-            'devmode'   => PIMCORE_DEVMODE,
-            'disableMinifyJs' => \Pimcore::disableMinifyJs(),
-            'environment' => $kernel->getEnvironment(),
-            'sessionId' => htmlentities(Session::getSessionId(), ENT_QUOTES, 'UTF-8'),
+            'version'               => Version::getVersion(),
+            'build'                 => Version::getRevision(),
+            'buildDate'             => Version::getBuildDate(),
+            'debug'                 => \Pimcore::inDebugMode(),
+            'devmode'               => \Pimcore::inDevMode(DevMode::ADMIN),
+            'disableMinifyJs'       => \Pimcore::disableMinifyJs(),
+            'environment'           => $kernel->getEnvironment(),
+            'sessionId'             => htmlentities(Session::getSessionId(), ENT_QUOTES, 'UTF-8'),
             'isLegacyModeAvailable' => \Pimcore::isLegacyModeAvailable()
         ]);
 

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/AbstractRestController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/AbstractRestController.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\AdminBundle\Controller\Rest;
 
 use Pimcore\Bundle\AdminBundle\Controller\AdminController;
 use Pimcore\Bundle\AdminBundle\HttpFoundation\JsonResponse;
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Http\Exception\ResponseException;
 use Pimcore\Model\Webservice\Service;
 use Psr\Log\LoggerInterface;
@@ -188,7 +189,7 @@ abstract class AbstractRestController extends AdminController
 
         if (!is_array($data)) {
             $message = 'Invalid data';
-            if (\Pimcore::inDebugMode()) {
+            if (\Pimcore::inDebugMode(DebugMode::REST_ERRORS)) {
                 $message .= ': ' . $error;
             }
 

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/Element/DocumentController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Rest/Element/DocumentController.php
@@ -15,6 +15,7 @@
 namespace Pimcore\Bundle\AdminBundle\Controller\Rest\Element;
 
 use Pimcore\Bundle\AdminBundle\HttpFoundation\JsonResponse;
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Http\Exception\ResponseException;
 use Pimcore\Model\Document;
 use Pimcore\Model\Webservice;
@@ -370,7 +371,7 @@ class DocumentController extends AbstractElementController
         $className = $this->getWebserviceInClassName($type);
         $method    = 'createDocument' . $typeUpper;
 
-        $this->checkWebserviceMethod($method);
+        $this->checkWebserviceMethod($method, $type);
 
         $wsData = $this->fillWebserviceData($className, $data);
 
@@ -409,7 +410,7 @@ class DocumentController extends AbstractElementController
         $className = $this->getWebserviceInClassName($type);
         $method    = 'updateDocument' . $typeUpper;
 
-        $this->checkWebserviceMethod($method);
+        $this->checkWebserviceMethod($method, $type);
 
         $wsData  = $this->fillWebserviceData($className, $data);
         $success = $this->service->$method($wsData);
@@ -444,13 +445,14 @@ class DocumentController extends AbstractElementController
 
     /**
      * @param string $method
+     * @param string $type
      *
      * @throws ResponseException
      */
-    protected function checkWebserviceMethod($method)
+    protected function checkWebserviceMethod($method, $type)
     {
         if (!method_exists($this->service, $method)) {
-            if (\Pimcore::inDebugMode()) {
+            if (\Pimcore::inDebugMode(DebugMode::REST_ERRORS)) {
                 throw new ResponseException(
                     $this->createErrorResponse(sprintf('Method %s does not exist', $method))
                 );

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Update/IndexController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Update/IndexController.php
@@ -38,10 +38,8 @@ class IndexController extends AdminController implements EventedControllerInterf
      */
     public function checkDebugModeAction(KernelInterface $kernel)
     {
-        $debug = \Pimcore::inDebugMode() || $kernel->isDebug();
-
         return $this->adminJson([
-            'success' => (bool) $debug
+            'success' => $kernel->isDebug()
         ]);
     }
 

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/EventListener/AdminExceptionListener.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/EventListener/AdminExceptionListener.php
@@ -19,6 +19,7 @@ namespace Pimcore\Bundle\AdminBundle\EventListener;
 
 use Pimcore\Bundle\AdminBundle\HttpFoundation\JsonResponse;
 use Pimcore\Bundle\CoreBundle\EventListener\Traits\PimcoreContextAwareTrait;
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Http\Request\Resolver\PimcoreContextResolver;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -63,7 +64,7 @@ class AdminExceptionListener implements EventSubscriberInterface
                 'message' => $message,
             ];
 
-            if (\Pimcore::inDebugMode()) {
+            if (\Pimcore::inDebugMode(DebugMode::EXCEPTION_TRACES)) {
                 $data['trace'] = $ex->getTrace();
             }
 

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/EventListener/HttpCacheListener.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/EventListener/HttpCacheListener.php
@@ -15,6 +15,7 @@
 namespace Pimcore\Bundle\AdminBundle\EventListener;
 
 use Pimcore\Bundle\CoreBundle\EventListener\Traits\PimcoreContextAwareTrait;
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Http\Request\Resolver\PimcoreContextResolver;
 use Pimcore\Http\RequestHelper;
 use Pimcore\Http\ResponseHelper;
@@ -72,7 +73,7 @@ class HttpCacheListener implements EventSubscriberInterface
                 $disable = true;
             }
 
-            if (\Pimcore::inDebugMode()) {
+            if (\Pimcore::inDebugMode(DebugMode::DISABLE_HTTP_CACHE)) {
                 $disable = true;
             }
         }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/UpdateCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/UpdateCommand.php
@@ -125,7 +125,7 @@ class UpdateCommand extends AbstractCommand
                 exit;
             }
 
-            $debug = \Pimcore::inDebugMode() || $this->getApplication()->getKernel()->isDebug();
+            $debug = $this->getApplication()->getKernel()->isDebug();
             if (!$debug) {
                 $this->writeError('Enable debug mode in system settings or set PIMCORE_ENVIRONMENT=dev');
                 exit;

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/DataCollector/PimcoreDataCollector.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/DataCollector/PimcoreDataCollector.php
@@ -14,6 +14,10 @@
 
 namespace Pimcore\Bundle\CoreBundle\DataCollector;
 
+use Pimcore\FeatureToggles\Feature;
+use Pimcore\FeatureToggles\FeatureManagerInterface;
+use Pimcore\FeatureToggles\Features\DebugMode;
+use Pimcore\FeatureToggles\Features\DevMode;
 use Pimcore\Http\Request\Resolver\PimcoreContextResolver;
 use Pimcore\Version;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,23 +31,53 @@ class PimcoreDataCollector extends DataCollector
      */
     protected $contextResolver;
 
-    public function __construct(PimcoreContextResolver $contextResolver)
+    /**
+     * @var FeatureManagerInterface
+     */
+    private $featureManager;
+
+    public function __construct(
+        PimcoreContextResolver $contextResolver,
+        FeatureManagerInterface $featureManager
+    )
     {
         $this->contextResolver = $contextResolver;
+        $this->featureManager  = $featureManager;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
         $this->data = [
-            'version'    => Version::getVersion(),
-            'revision'   => Version::getRevision(),
-            'debug_mode' => (bool)\Pimcore::inDebugMode(),
-            'dev_mode'   => defined('PIMCORE_DEVMODE') ? (bool)PIMCORE_DEVMODE : false,
-            'context'    => $this->contextResolver->getPimcoreContext($request),
+            'version'  => Version::getVersion(),
+            'revision' => Version::getRevision(),
+            'context'  => $this->contextResolver->getPimcoreContext($request),
+            'features' => []
         ];
+
+        /** @var Feature $feature */
+        foreach ([DebugMode::class, DevMode::class] as $feature) {
+            $featureConfig = [
+                'all'   => false,
+                'flags' => []
+            ];
+
+            $all = $this->featureManager->isEnabled($feature::ALL());
+            if ($all) {
+                $featureConfig['all'] = true;
+            } else {
+                foreach ($feature::toArray() as $name => $flag) {
+                    if (0 === $flag) {
+                        continue;
+                    }
+
+                    if ($this->featureManager->isEnabled(new $feature($flag))) {
+                        $featureConfig['flags'][] = $name;
+                    }
+                }
+            }
+
+            $this->data['features'][$feature::getType()] = $featureConfig;
+        }
     }
 
     public function reset()
@@ -51,9 +85,6 @@ class PimcoreDataCollector extends DataCollector
         $this->data = [];
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getName()
     {
         return 'pimcore';
@@ -83,19 +114,23 @@ class PimcoreDataCollector extends DataCollector
         return $this->data['revision'];
     }
 
-    /**
-     * @return bool
-     */
-    public function getDebugMode()
+    public function getFeatures(): array
     {
-        return $this->data['debug_mode'];
+        return $this->data['features'];
     }
 
-    /**
-     * @return bool
-     */
-    public function getDevMode()
+    public function isFeatureAllFlagSet(string $feature): bool
     {
-        return $this->data['dev_mode'];
+        return $this->data['features'][$feature]['all'];
+    }
+
+    public function featureHasFlags(string $feature): bool
+    {
+        return !empty($this->getFeatureFlags($feature));
+    }
+
+    public function getFeatureFlags(string $feature): array
+    {
+        return $this->data['features'][$feature]['flags'] ?? [];
     }
 }

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
@@ -20,6 +20,7 @@ use Pimcore\Cache\FullPage\SessionStatus;
 use Pimcore\Event\Cache\FullPage\CacheResponseEvent;
 use Pimcore\Event\Cache\FullPage\PrepareResponseEvent;
 use Pimcore\Event\FullPageCacheEvents;
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Http\Request\Resolver\PimcoreContextResolver;
 use Pimcore\Logger;
 use Pimcore\Targeting\VisitorInfoStorageInterface;
@@ -205,8 +206,8 @@ class FullPageCacheListener
                     return $this->disable();
                 }
 
-                if (\Pimcore::inDebugMode()) {
-                    return $this->disable('in debug mode');
+                if (\Pimcore::inDebugMode(DebugMode::DISABLE_FULL_PAGE_CACHE)) {
+                    return $this->disable('Debug flag DISABLE_FULL_PAGE_CACHE is enabled');
                 }
 
                 if ($conf->lifetime) {

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/ResponseExceptionListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/ResponseExceptionListener.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\CoreBundle\EventListener;
 
 use Pimcore\Bundle\CoreBundle\EventListener\Traits\PimcoreContextAwareTrait;
 use Pimcore\Config;
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Http\Exception\ResponseException;
 use Pimcore\Http\Request\Resolver\PimcoreContextResolver;
 use Pimcore\Model\Document;
@@ -86,7 +87,7 @@ class ResponseExceptionListener implements EventSubscriberInterface
 
     protected function handleErrorPage(GetResponseForExceptionEvent $event)
     {
-        if (\Pimcore::inDebugMode() || PIMCORE_DEVMODE) {
+        if (\Pimcore::inDebugMode(DebugMode::NO_ERROR_PAGE)) {
             return;
         }
 
@@ -97,7 +98,7 @@ class ResponseExceptionListener implements EventSubscriberInterface
 
         if ($exception instanceof HttpExceptionInterface) {
             $statusCode = $exception->getStatusCode();
-            $header     = $exception->getHeaders();
+            $headers    = $exception->getHeaders();
         }
 
         $errorPath = Config::getSystemConfig()->documents->error_pages->default;

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/services.yml
@@ -63,6 +63,10 @@ services:
 
     Pimcore\Config\ReportConfigWriter: ~
 
+    Pimcore\FeatureToggles\FeatureManagerInterface:
+        public: true
+        shared: false
+        factory: ['Pimcore', getFeatureManager]
 
     #
     # CONTROLLERS

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/translations/en.json
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/translations/en.json
@@ -914,6 +914,7 @@
   "translations": "Website Translations",
   "admin_translations": "Admin Translations",
   "debug_description": "With debug-mode on errors and warnings are displayed directly in the browser, otherwise they are deactivated and the error-controller is active (Error Page). Multiple IP addresses can be specified by separating them with a comma. You can also specify IP ranges by specifying a mask, e.g. 192.168.1.0/24",
+  "debug_override_warning": "<strong>WARNING:</strong> If the debug mode is explicitely set via code, this setting will be ignored. See <a target='_blank' href='https://pimcore.com/docs/5.1.x/Development_Documentation/Development_Tools_and_Details/Feature_Flags_Debug_Mode.html'>documentation</a> for details.",
   "icon": "Icon",
   "add_document": "Add document",
   "please_enter_the_name_of_the_new_document": "Please enter the name of the new document",

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Profiler/data_collector.html.twig
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/views/Profiler/data_collector.html.twig
@@ -1,6 +1,55 @@
 {% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
 
+{% macro feature_flags_toolbar(collector, type, title) %}
+    {% if collector.isFeatureAllFlagSet(type) or collector.featureHasFlags(type) %}
+        <div class="sf-toolbar-info-piece">
+            <b>{{ title }}</b>
+
+            <span>
+                {% if collector.isFeatureAllFlagSet(type) %}
+                    enabled
+                {% else %}
+                    {% transchoice collector.getFeatureFlags(type)|length %}
+                        {0} No flags enabled|{1} %count% flag enabled|]1,Inf] %count% flags enabled
+                    {% endtranschoice %}
+                {% endif %}
+            </span>
+        </div>
+    {% endif %}
+{% endmacro %}
+
+{% macro feature_flags_metric(collector, type, title) %}
+    <div class="metric">
+        <span class="value">
+            {% if collector.isFeatureAllFlagSet(type) %}
+                enabled
+            {% elseif collector.featureHasFlags(type) %}
+                {% transchoice collector.getFeatureFlags(type)|length %}
+                    {0} No flags enabled|{1} %count% flag enabled|]1,Inf] %count% flags enabled
+                {% endtranschoice %}
+            {% else %}
+                disabled
+            {% endif %}
+        </span>
+        <span class="label">{{ title }}</span>
+    </div>
+{% endmacro %}
+
+{% macro feature_flags_list(collector, type, title) %}
+    {% if collector.featureHasFlags(type) %}
+        <h3>{{ title }}</h3>
+
+        <div class="card">
+            {% for flag in collector.getFeatureFlags(type) %}
+                <span class="label" style="margin-bottom: 2px">{{ flag }}</span>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endmacro %}
+
 {% block toolbar %}
+    {% import _self as macros %}
+
     {% set icon %}
         {# this is the content displayed as a panel in the toolbar #}
         <div style="padding-top: 3px">
@@ -17,19 +66,12 @@
         </div>
 
         <div class="sf-toolbar-info-piece">
-            <b>Debug Mode</b>
-            <span>{{ collector.debugMode ? 'enabled' : 'disabled' }}</span>
-        </div>
-
-        <div class="sf-toolbar-info-piece">
-            <b>Dev Mode</b>
-            <span>{{ collector.devMode ? 'enabled' : 'disabled' }}</span>
-        </div>
-
-        <div class="sf-toolbar-info-piece">
             <b>Context</b>
             <span>{{ collector.context }}</span>
         </div>
+
+        {{ macros.feature_flags_toolbar(collector, 'debug_mode', 'Debug Mode') }}
+        {{ macros.feature_flags_toolbar(collector, 'dev_mode', 'Dev Mode') }}
     {% endset %}
 
     {# the 'link' value set to 'false' means that this panel doesn't
@@ -47,6 +89,8 @@
 {% endblock %}
 
 {% block panel %}
+    {% import _self as macros %}
+
     <h2>Pimcore</h2>
 
     <div class="metrics">
@@ -61,18 +105,14 @@
         </div>
 
         <div class="metric">
-            <span class="value">{{ collector.debugMode ? 'enabled' : 'disabled' }}</span>
-            <span class="label">Debug Mode</span>
-        </div>
-
-        <div class="metric">
-            <span class="value">{{ collector.devMode ? 'enabled' : 'disabled' }}</span>
-            <span class="label">Dev Mode</span>
-        </div>
-
-        <div class="metric">
             <span class="value">{{ collector.context }}</span>
             <span class="label">Request Context</span>
         </div>
+
+        {{ macros.feature_flags_metric(collector, 'debug_mode', 'Debug Mode') }}
+        {{ macros.feature_flags_metric(collector, 'dev_mode', 'Dev Mode') }}
     </div>
+
+    {{ macros.feature_flags_list(collector, 'debug_mode', 'Debug Mode Flags') }}
+    {{ macros.feature_flags_list(collector, 'dev_mode', 'Dev Mode Flags') }}
 {% endblock %}

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Model/DefaultMockup.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Model/DefaultMockup.php
@@ -14,6 +14,7 @@
 
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
 
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Logger;
 
 class DefaultMockup implements IProduct
@@ -130,7 +131,8 @@ class DefaultMockup implements IProduct
             }
         }
         $msg = "Method $method not in Mockup implemented, delegating to object with id {$this->id}.";
-        if (PIMCORE_DEBUG) {
+
+        if (\Pimcore::inDebugMode(DebugMode::LOG)) {
             Logger::warn($msg);
         } else {
             Logger::info($msg);

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PaymentManager/Payment/WirecardSeamless.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PaymentManager/Payment/WirecardSeamless.php
@@ -26,6 +26,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\IPrice;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\Price;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Tools\SessionConfigurator;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Type\Decimal;
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Logger;
 use Pimcore\Model\DataObject\Fieldcollection\Data\OrderPriceModifications;
 use Pimcore\Model\DataObject\OnlineShopOrder;
@@ -368,7 +369,7 @@ class WirecardSeamless implements IPayment
         $redirectURL = $result['redirectUrl'];
 
         if (!$redirectURL) {
-            if (PIMCORE_DEBUG) {
+            if (\Pimcore::inDebugMode(DebugMode::LOG)) {
                 Logger::error('seamless result: ' . var_export($result, true));
             }
             throw new \Exception('redirect url could not be evalutated');

--- a/pimcore/lib/Pimcore/Cache.php
+++ b/pimcore/lib/Pimcore/Cache.php
@@ -16,6 +16,7 @@ namespace Pimcore;
 
 use Pimcore\Cache\Core\CoreHandlerInterface;
 use Pimcore\Event\CoreCacheEvents;
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -57,7 +58,7 @@ class Cache
                 ->get('event_dispatcher')
                 ->dispatch(CoreCacheEvents::INIT, new Event());
 
-            if (isset($_REQUEST['pimcore_nocache']) && \Pimcore::inDebugMode()) {
+            if (isset($_REQUEST['pimcore_nocache']) && \Pimcore::inDebugMode(DebugMode::MAGIC_PARAMS)) {
                 self::getHandler()->disable();
             }
         }

--- a/pimcore/lib/Pimcore/Config.php
+++ b/pimcore/lib/Pimcore/Config.php
@@ -16,6 +16,7 @@ namespace Pimcore;
 
 use Pimcore\Config\EnvironmentConfig;
 use Pimcore\Config\EnvironmentConfigInterface;
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Model\WebsiteSetting;
 use Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter;
 
@@ -791,7 +792,7 @@ class Config
                 } else {
                     $environmentConfig = static::getEnvironmentConfig();
 
-                    if (\Pimcore::inDebugMode()) {
+                    if (\Pimcore::inDebugMode(DebugMode::SYMFONY_ENVIRONMENT)) {
                         $environment = $environmentConfig->getDefaultDebugModeEnvironment();
                     } else {
                         $environment = $environmentConfig->getDefaultEnvironment();

--- a/pimcore/lib/Pimcore/Config/EnvironmentConfig.php
+++ b/pimcore/lib/Pimcore/Config/EnvironmentConfig.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 
 namespace Pimcore\Config;
 
+use Pimcore\FeatureToggles\Features\DebugMode;
+
 class EnvironmentConfig implements EnvironmentConfigInterface
 {
     /**
@@ -51,7 +53,7 @@ class EnvironmentConfig implements EnvironmentConfigInterface
 
     public function activatesKernelDebugMode(string $environment): bool
     {
-        if (\Pimcore::inDebugMode()) {
+        if (\Pimcore::inDebugMode(DebugMode::SYMFONY_KERNEL_DEBUG)) {
             return true;
         }
 

--- a/pimcore/lib/Pimcore/Console/Application.php
+++ b/pimcore/lib/Pimcore/Console/Application.php
@@ -55,7 +55,7 @@ class Application extends \Symfony\Bundle\FrameworkBundle\Console\Application
         $this->setDispatcher($dispatcher);
 
         $dispatcher->addListener(ConsoleEvents::COMMAND, function (ConsoleCommandEvent $event) {
-            if ($event->getInput()->getOption('no-debug') && \Pimcore::inDebugMode()) {
+            if ($event->getInput()->getOption('no-debug')) {
                 \Pimcore::setDebugMode(false);
             }
 

--- a/pimcore/lib/Pimcore/FeatureToggles/Feature.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/Feature.php
@@ -56,6 +56,7 @@ abstract class Feature extends Enum
 
         // add a magic ALL constant
         $allMask = 0;
+        $count   = 0;
         $defined = [];
 
         foreach ($constants as $name => $mask) {
@@ -96,6 +97,11 @@ abstract class Feature extends Enum
                     $name,
                     $defined[$mask]
                 ));
+            }
+
+            // limit flags to 31 as ALL would exceed PHP_INT_MAX on 32-bit systems with more flags
+            if (++$count > 31) {
+                throw new \LogicException('A feature can have a maximum of 31 flags excluding NONE and ALL.');
             }
 
             $defined[$mask] = $name;

--- a/pimcore/lib/Pimcore/FeatureToggles/Feature.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/Feature.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\FeatureToggles;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @method static Feature NONE()
+ * @method static Feature ALL()
+ */
+abstract class Feature extends Enum
+{
+    const NONE = 0;
+
+    /**
+     * Type is used to register different feature types on the feature manager
+     *
+     * @return string
+     */
+    abstract public static function getType(): string;
+
+    public static function fromName(string $name): self
+    {
+        return static::__callStatic($name, []);
+    }
+
+    public static function toArray()
+    {
+        $class = get_called_class();
+        if (!array_key_exists($class, static::$cache)) {
+            static::$cache[$class] = static::buildConstants($class);
+        }
+
+        return static::$cache[$class];
+    }
+
+    private static function buildConstants(string $class): array
+    {
+        $reflection = new \ReflectionClass($class);
+        $constants  = $reflection->getConstants();
+
+        // add a magic ALL constant
+        $allMask = 0;
+        $defined = [];
+
+        foreach ($constants as $name => $mask) {
+            // check if 0 is used for another constant
+            if (0 === $mask) {
+                if ('NONE' !== $name) {
+                    throw new \LogicException(sprintf(
+                        'The constant %s tries to re-define the bit mask 0 which is reserved for the NONE value.',
+                        $name
+                    ));
+                }
+
+                continue;
+            }
+
+            // check if none is overwritten
+            if ('NONE' === $name && 0 !== $mask) {
+                throw new \LogicException(sprintf(
+                    'The constant NONE is overwritten with value %d, but NONE needs to be 0.',
+                    $mask
+                ));
+            }
+
+            // check if the mask is a power of 2
+            if (($mask & ($mask - 1)) !== 0) {
+                throw new \LogicException(sprintf(
+                    'The mask %d for constant %s is not a power of 2.',
+                    $mask,
+                    $name
+                ));
+            }
+
+            // check for duplicate values
+            if (isset($defined[$mask])) {
+                throw new \LogicException(sprintf(
+                    'The bit value %d for constant %s is already defined by %s. Please use distinct values for every feature.',
+                    $mask,
+                    $name,
+                    $defined[$mask]
+                ));
+            }
+
+            $defined[$mask] = $name;
+
+            $allMask |= $mask;
+        }
+
+        $constants['ALL'] = $allMask;
+        asort($constants);
+
+        return $constants;
+    }
+
+    public function getValue(): int
+    {
+        return parent::getValue();
+    }
+}

--- a/pimcore/lib/Pimcore/FeatureToggles/FeatureContext.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/FeatureContext.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\FeatureToggles;
+
+class FeatureContext implements FeatureContextInterface
+{
+    /**
+     * @var array
+     */
+    private $parameters;
+
+    public function __construct(array $parameters = [])
+    {
+        $this->parameters = $parameters;
+    }
+
+    public function all(): array
+    {
+        return $this->parameters;
+    }
+
+    public function keys(): array
+    {
+        return array_keys($this->parameters);
+    }
+
+    public function get(string $key, $default = null)
+    {
+        return array_key_exists($key, $this->parameters) ? $this->parameters[$key] : $default;
+    }
+
+    public function set(string $key, $value)
+    {
+        $this->parameters[$key] = $value;
+    }
+
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->parameters);
+    }
+
+    public function remove(string $key)
+    {
+        unset($this->parameters[$key]);
+    }
+
+    public function getIterator(): \Iterator
+    {
+        return new \ArrayIterator($this->parameters);
+    }
+
+    public function count(): int
+    {
+        return count($this->parameters);
+    }
+}

--- a/pimcore/lib/Pimcore/FeatureToggles/FeatureContext.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/FeatureContext.php
@@ -56,7 +56,9 @@ class FeatureContext implements FeatureContextInterface
 
     public function remove(string $key)
     {
-        unset($this->parameters[$key]);
+        if (isset($this->parameters[$key])) {
+            unset($this->parameters[$key]);
+        }
     }
 
     public function getIterator(): \Iterator

--- a/pimcore/lib/Pimcore/FeatureToggles/FeatureContextInterface.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/FeatureContextInterface.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\FeatureToggles;
 
-interface FeatureContextInterface
+interface FeatureContextInterface extends \Countable, \IteratorAggregate
 {
     public function all(): array;
 
@@ -30,8 +30,4 @@ interface FeatureContextInterface
     public function has(string $key): bool;
 
     public function remove(string $key);
-
-    public function getIterator(): \Iterator;
-
-    public function count(): int;
 }

--- a/pimcore/lib/Pimcore/FeatureToggles/FeatureContextInterface.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/FeatureContextInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\FeatureToggles;
+
+interface FeatureContextInterface
+{
+    public function all(): array;
+
+    public function keys(): array;
+
+    public function get(string $key, $default = null);
+
+    public function set(string $key, $value);
+
+    public function has(string $key): bool;
+
+    public function remove(string $key);
+
+    public function getIterator(): \Iterator;
+
+    public function count(): int;
+}

--- a/pimcore/lib/Pimcore/FeatureToggles/FeatureManager.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/FeatureManager.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\FeatureToggles;
+
+class FeatureManager implements FeatureManagerInterface
+{
+    /**
+     * @var FeatureContextInterface
+     */
+    private $context;
+
+    /**
+     * @var array
+     */
+    private $states = [];
+
+    /**
+     * @var array
+     */
+    private $initializers = [];
+
+    public function __construct(FeatureContextInterface $context = null, array $initializers = [])
+    {
+        $this->setContext($context ?? new FeatureContext());
+
+        foreach ($initializers as $initializer) {
+            $this->addInitializer($initializer);
+        }
+    }
+
+    public function setContext(FeatureContextInterface $context)
+    {
+        $this->context = $context;
+    }
+
+    public function getContext(): FeatureContextInterface
+    {
+        return $this->context;
+    }
+
+    public function isEnabled(Feature $feature): bool
+    {
+        $states = $this->getStates($feature::getType());
+        if (empty($states)) {
+            return false;
+        }
+
+        /** @var FeatureStateInterface $state */
+        foreach ($states as $state) {
+            if ($state->isEnabled($feature, $this->context)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function addState(FeatureStateInterface $featureState)
+    {
+        $type = $featureState->getType();
+
+        if (isset($this->states[$type])) {
+            $this->states[$type][] = $featureState;
+        } else {
+            $this->states[$type] = [$featureState];
+        }
+    }
+
+    /**
+     * @param FeatureStateInterface[] $states
+     */
+    public function addStates(array $states)
+    {
+        foreach ($states as $state) {
+            $this->addState($state);
+        }
+    }
+
+    public function setState(FeatureStateInterface $featureState)
+    {
+        $this->clear($featureState->getType());
+        $this->addState($featureState);
+    }
+
+    public function hasStates(string $type): bool
+    {
+        return count($this->getStates($type)) > 0;
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return FeatureStateInterface[]
+     */
+    public function getStates(string $type): array
+    {
+        if (!isset($this->states[$type]) && isset($this->initializers[$type])) {
+            /** @var FeatureStateInitializerInterface $initializer */
+            foreach ($this->initializers[$type] as $initializer) {
+                $this->addStates($initializer->getStates($this->context));
+            }
+        }
+
+        return $this->states[$type] ?? [];
+    }
+
+    public function getRegisteredTypes(): array
+    {
+        return array_keys($this->states);
+    }
+
+    public function clear(string $type = null)
+    {
+        if (null !== $type) {
+            if (isset($this->states[$type])) {
+                unset($this->states[$type]);
+            }
+        } else {
+            $this->states = [];
+        }
+    }
+
+    public function addInitializer(FeatureStateInitializerInterface $initializer)
+    {
+        $this->initializers[$initializer->getType()][] = $initializer;
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return FeatureStateInitializerInterface[]
+     */
+    public function getInitializers(string $type): array
+    {
+        return $this->initializers[$type] ?? [];
+    }
+
+    /**
+     * @param string $type
+     * @param FeatureStateInitializerInterface[] $initializers
+     */
+    public function setInitializers(string $type, array $initializers)
+    {
+        $this->initializers[$type] = [];
+
+        foreach ($initializers as $initializer) {
+            $this->addInitializer($initializer);
+        }
+    }
+
+    public function clearInitializers(string $type = null)
+    {
+        if (null !== $type) {
+            if (isset($this->initializers[$type])) {
+                unset($this->initializers[$type]);
+            }
+        } else {
+            $this->initializers = [];
+        }
+    }
+
+    public function getInitializerTypes(): array
+    {
+        return array_keys($this->initializers);
+    }
+}

--- a/pimcore/lib/Pimcore/FeatureToggles/FeatureManager.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/FeatureManager.php
@@ -126,9 +126,9 @@ class FeatureManager implements FeatureManagerInterface
         if (null === $type) {
             return $this->initializers;
         } else {
-            return array_filter($this->initializers, function (FeatureStateInitializerInterface $initializer) use ($type) {
+            return array_values(array_filter($this->initializers, function (FeatureStateInitializerInterface $initializer) use ($type) {
                 return $initializer->getType() === $type;
-            });
+            }));
         }
     }
 

--- a/pimcore/lib/Pimcore/FeatureToggles/FeatureManagerInterface.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/FeatureManagerInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\FeatureToggles;
+
+interface FeatureManagerInterface
+{
+    public function getContext(): FeatureContextInterface;
+
+    public function isEnabled(Feature $feature): bool;
+
+    public function addState(FeatureStateInterface $featureState);
+
+    public function setState(FeatureStateInterface $featureState);
+
+    public function hasStates(string $type): bool;
+
+    /**
+     * @param string $type
+     *
+     * @return FeatureStateInterface[]
+     */
+    public function getStates(string $type): array;
+
+    public function getRegisteredTypes(): array;
+
+    public function clear(string $type = null);
+}

--- a/pimcore/lib/Pimcore/FeatureToggles/FeatureManagerInterface.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/FeatureManagerInterface.php
@@ -23,20 +23,16 @@ interface FeatureManagerInterface
 
     public function isEnabled(Feature $feature): bool;
 
-    public function addState(FeatureStateInterface $featureState);
+    public function setState(FeatureStateInterface $state);
 
-    public function setState(FeatureStateInterface $featureState);
-
-    public function hasStates(string $type): bool;
+    public function hasState(string $type): bool;
 
     /**
      * @param string $type
      *
-     * @return FeatureStateInterface[]
+     * @return FeatureStateInterface|null
      */
-    public function getStates(string $type): array;
-
-    public function getRegisteredTypes(): array;
+    public function getState(string $type);
 
     public function clear(string $type = null);
 }

--- a/pimcore/lib/Pimcore/FeatureToggles/FeatureState.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/FeatureState.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\FeatureToggles;
+
+class FeatureState implements FeatureStateInterface
+{
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var int
+     */
+    private $value;
+
+    public function __construct(string $type, int $state)
+    {
+        if ($state < 0) {
+            throw new \InvalidArgumentException('State must be >= 0');
+        }
+
+        $this->type  = $type;
+        $this->value = $state;
+    }
+
+    public static function fromFeature(Feature $feature): self
+    {
+        return new self($feature::getType(), $feature->getValue());
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getValue(): int
+    {
+        return $this->value;
+    }
+
+    public function isEnabled(Feature $feature, FeatureContextInterface $context): bool
+    {
+        if ($feature::getType() !== $this->type) {
+            return false;
+        }
+
+        $value = $feature->getValue();
+
+        // if NONE was requested, return false if anything is enabled but true
+        // if current value is NONE
+        if (0 === $value) {
+            if ($this->value > 0) {
+                return false;
+            } else if (0 === $this->value) {
+                return true;
+            }
+        }
+
+        // 0 is a special value denoting off at any time
+        if (0 === $this->value) {
+            return false;
+        }
+
+        return ($value & $this->value) === $value;
+    }
+}

--- a/pimcore/lib/Pimcore/FeatureToggles/FeatureStateInitializerInterface.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/FeatureStateInitializerInterface.php
@@ -29,8 +29,9 @@ interface FeatureStateInitializerInterface
 
     /**
      * @param FeatureContextInterface $context
+     * @param FeatureStateInterface|null $previousState
      *
-     * @return FeatureStateInterface[]
+     * @return FeatureStateInterface|null
      */
-    public function getStates(FeatureContextInterface $context): array;
+    public function getState(FeatureContextInterface $context, FeatureStateInterface $previousState = null);
 }

--- a/pimcore/lib/Pimcore/FeatureToggles/FeatureStateInitializerInterface.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/FeatureStateInitializerInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\FeatureToggles;
+
+/**
+ * Lazily loads a state if no state is set. When a feature toggle state is requested and no
+ * value is registered, the feature manager will delegate initialization to its registered
+ * initializers to provide a default state. As soon as there is a state for a specific feature,
+ * initializers won't be called anymore.
+ */
+interface FeatureStateInitializerInterface
+{
+    public function getType(): string;
+
+    /**
+     * @param FeatureContextInterface $context
+     *
+     * @return FeatureStateInterface[]
+     */
+    public function getStates(FeatureContextInterface $context): array;
+}

--- a/pimcore/lib/Pimcore/FeatureToggles/FeatureStateInterface.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/FeatureStateInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\FeatureToggles;
+
+interface FeatureStateInterface
+{
+    public function getType(): string;
+
+    public function getValue(): int;
+
+    public function isEnabled(Feature $feature, FeatureContextInterface $context): bool;
+}

--- a/pimcore/lib/Pimcore/FeatureToggles/Features/DebugMode.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/Features/DebugMode.php
@@ -21,6 +21,7 @@ use Pimcore\FeatureToggles\Feature;
 use Pimcore\FeatureToggles\FeatureContextInterface;
 use Pimcore\FeatureToggles\FeatureState;
 use Pimcore\FeatureToggles\FeatureStateInitializerInterface;
+use Pimcore\FeatureToggles\FeatureStateInterface;
 use Pimcore\FeatureToggles\Initializers\ClosureInitializer;
 use Pimcore\Tool;
 use Symfony\Component\HttpFoundation\IpUtils;
@@ -49,7 +50,11 @@ final class DebugMode extends Feature
 
     public static function getDefaultInitializer(): FeatureStateInitializerInterface
     {
-        $initializer = function (FeatureContextInterface $context): array {
+        $initializer = function (FeatureContextInterface $context, FeatureStateInterface $previousState = null) {
+            if (null !== $previousState) {
+                return $previousState;
+            }
+
             $debug = false;
 
             if (defined('PIMCORE_DEBUG')) {
@@ -84,9 +89,7 @@ final class DebugMode extends Feature
                 }
             }
 
-            return [
-                FeatureState::fromFeature($debug ? static::ALL() : static::NONE())
-            ];
+            return FeatureState::fromFeature($debug ? static::ALL() : static::NONE());
         };
 
         return new ClosureInitializer(static::getType(), $initializer);

--- a/pimcore/lib/Pimcore/FeatureToggles/Features/DebugMode.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/Features/DebugMode.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\FeatureToggles\Features;
+
+use Pimcore\FeatureToggles\Feature;
+use Pimcore\FeatureToggles\FeatureContextInterface;
+use Pimcore\FeatureToggles\FeatureState;
+use Pimcore\FeatureToggles\FeatureStateInitializerInterface;
+use Pimcore\FeatureToggles\Initializers\ClosureInitializer;
+use Pimcore\Tool;
+use Symfony\Component\HttpFoundation\IpUtils;
+
+final class DebugMode extends Feature
+{
+    const SYMFONY_ENVIRONMENT        = 1;
+    const SYMFONY_KERNEL_DEBUG       = 2;
+    const MAGIC_PARAMS               = 4;
+    const EXCEPTION_TRACES           = 8;
+    const ERROR_REPORTING            = 16;
+    const NO_ERROR_PAGE              = 32;
+    const REST_ERRORS                = 64;
+    const RENDER_DOCUMENT_TAG_ERRORS = 128;
+    const MAIL                       = 256;
+    const LOG                        = 512;
+    const UPDATE                     = 1024;
+    const DISABLE_HTTP_CACHE         = 2048;
+    const DISABLE_FULL_PAGE_CACHE    = 4096;
+    const TARGETING                  = 8192;
+
+    public static function getType(): string
+    {
+        return 'debug_mode';
+    }
+
+    public static function getDefaultInitializer(): FeatureStateInitializerInterface
+    {
+        $initializer = function (FeatureContextInterface $context): array {
+            $debug = false;
+
+            if (defined('PIMCORE_DEBUG')) {
+                $debug = true;
+            } else {
+                $debugModeFile = PIMCORE_CONFIGURATION_DIRECTORY . '/debug-mode.php';
+
+                if (file_exists($debugModeFile)) {
+                    $conf  = include $debugModeFile;
+                    $debug = $conf['active'];
+
+                    // enable debug mode only for a comma-separated list of IP addresses/ranges
+                    if ($debug && $conf['ip']) {
+                        $debug = false;
+
+                        $clientIp = Tool::getClientIp();
+                        if (null !== $clientIp) {
+                            $debugIpAddresses = explode_and_trim(',', $conf['ip']);
+
+                            if (IpUtils::checkIp($clientIp, $debugIpAddresses)) {
+                                $debug = true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if ($debug) {
+                $request = Tool::resolveRequest();
+                if ($request && (bool)$request->cookies->get('pimcore_disable_debug')) {
+                    $debug = false;
+                }
+            }
+
+            return [
+                FeatureState::fromFeature($debug ? static::ALL() : static::NONE())
+            ];
+        };
+
+        return new ClosureInitializer(static::getType(), $initializer);
+    }
+}

--- a/pimcore/lib/Pimcore/FeatureToggles/Features/DebugMode.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/Features/DebugMode.php
@@ -26,6 +26,22 @@ use Pimcore\FeatureToggles\Initializers\ClosureInitializer;
 use Pimcore\Tool;
 use Symfony\Component\HttpFoundation\IpUtils;
 
+/**
+ * @method static DebugMode SYMFONY_ENVIRONMENT()
+ * @method static DebugMode SYMFONY_KERNEL_DEBUG()
+ * @method static DebugMode MAGIC_PARAMS()
+ * @method static DebugMode EXCEPTION_TRACES()
+ * @method static DebugMode ERROR_REPORTING()
+ * @method static DebugMode NO_ERROR_PAGE()
+ * @method static DebugMode REST_ERRORS()
+ * @method static DebugMode RENDER_DOCUMENT_TAG_ERRORS()
+ * @method static DebugMode MAIL()
+ * @method static DebugMode LOG()
+ * @method static DebugMode UPDATE()
+ * @method static DebugMode DISABLE_HTTP_CACHE()
+ * @method static DebugMode DISABLE_FULL_PAGE_CACHE()
+ * @method static DebugMode TARGETING()
+ */
 final class DebugMode extends Feature
 {
     const SYMFONY_ENVIRONMENT        = 1;

--- a/pimcore/lib/Pimcore/FeatureToggles/Features/DevMode.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/Features/DevMode.php
@@ -21,6 +21,7 @@ use Pimcore\FeatureToggles\Feature;
 use Pimcore\FeatureToggles\FeatureContextInterface;
 use Pimcore\FeatureToggles\FeatureState;
 use Pimcore\FeatureToggles\FeatureStateInitializerInterface;
+use Pimcore\FeatureToggles\FeatureStateInterface;
 use Pimcore\FeatureToggles\Initializers\ClosureInitializer;
 
 final class DevMode extends Feature
@@ -36,15 +37,17 @@ final class DevMode extends Feature
 
     public static function getDefaultInitializer(): FeatureStateInitializerInterface
     {
-        $initializer = function (FeatureContextInterface $context): array {
+        $initializer = function (FeatureContextInterface $context, FeatureStateInterface $previousState = null) {
+            if (null !== $previousState) {
+                return $previousState;
+            }
+
             $devMode = false;
             if (defined('PIMCORE_DEVMODE') && PIMCORE_DEVMODE) {
                 $devMode = true;
             }
 
-            return [
-                FeatureState::fromFeature($devMode ? static::ALL() : static::NONE())
-            ];
+            return FeatureState::fromFeature($devMode ? static::ALL() : static::NONE());
         };
 
         return new ClosureInitializer(static::getType(), $initializer);

--- a/pimcore/lib/Pimcore/FeatureToggles/Features/DevMode.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/Features/DevMode.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\FeatureToggles\Features;
+
+use Pimcore\FeatureToggles\Feature;
+use Pimcore\FeatureToggles\FeatureContextInterface;
+use Pimcore\FeatureToggles\FeatureState;
+use Pimcore\FeatureToggles\FeatureStateInitializerInterface;
+use Pimcore\FeatureToggles\Initializers\ClosureInitializer;
+
+final class DevMode extends Feature
+{
+    const ADMIN         = 1;
+    const UPDATES       = 2;
+    const UNMINIFIED_JS = 4;
+
+    public static function getType(): string
+    {
+        return 'dev_mode';
+    }
+
+    public static function getDefaultInitializer(): FeatureStateInitializerInterface
+    {
+        $initializer = function (FeatureContextInterface $context): array {
+            $devMode = false;
+            if (defined('PIMCORE_DEVMODE') && PIMCORE_DEVMODE) {
+                $devMode = true;
+            }
+
+            return [
+                FeatureState::fromFeature($devMode ? static::ALL() : static::NONE())
+            ];
+        };
+
+        return new ClosureInitializer(static::getType(), $initializer);
+    }
+}

--- a/pimcore/lib/Pimcore/FeatureToggles/Features/DevMode.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/Features/DevMode.php
@@ -24,6 +24,11 @@ use Pimcore\FeatureToggles\FeatureStateInitializerInterface;
 use Pimcore\FeatureToggles\FeatureStateInterface;
 use Pimcore\FeatureToggles\Initializers\ClosureInitializer;
 
+/**
+ * @method static DevMode ADMIN()
+ * @method static DevMode UPDATES()
+ * @method static DevMode UNMINIFIED_JS()
+ */
 final class DevMode extends Feature
 {
     const ADMIN         = 1;

--- a/pimcore/lib/Pimcore/FeatureToggles/Initializers/ClosureInitializer.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/Initializers/ClosureInitializer.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\FeatureToggles\Initializers;
+
+use Pimcore\FeatureToggles\FeatureContextInterface;
+use Pimcore\FeatureToggles\FeatureStateInitializerInterface;
+
+class ClosureInitializer implements FeatureStateInitializerInterface
+{
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var \Closure
+     */
+    private $closure;
+
+    public function __construct(string $type, \Closure $closure)
+    {
+        $this->type    = $type;
+        $this->closure = $closure;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getStates(FeatureContextInterface $context): array
+    {
+        return call_user_func($this->closure, $context);
+    }
+}

--- a/pimcore/lib/Pimcore/FeatureToggles/Initializers/ClosureInitializer.php
+++ b/pimcore/lib/Pimcore/FeatureToggles/Initializers/ClosureInitializer.php
@@ -19,6 +19,7 @@ namespace Pimcore\FeatureToggles\Initializers;
 
 use Pimcore\FeatureToggles\FeatureContextInterface;
 use Pimcore\FeatureToggles\FeatureStateInitializerInterface;
+use Pimcore\FeatureToggles\FeatureStateInterface;
 
 class ClosureInitializer implements FeatureStateInitializerInterface
 {
@@ -43,8 +44,8 @@ class ClosureInitializer implements FeatureStateInitializerInterface
         return $this->type;
     }
 
-    public function getStates(FeatureContextInterface $context): array
+    public function getState(FeatureContextInterface $context, FeatureStateInterface $previousState = null)
     {
-        return call_user_func($this->closure, $context);
+        return call_user_func($this->closure, $context, $previousState);
     }
 }

--- a/pimcore/lib/Pimcore/Mail.php
+++ b/pimcore/lib/Pimcore/Mail.php
@@ -18,6 +18,7 @@ use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\RFCValidation;
 use Pimcore\Event\MailEvents;
 use Pimcore\Event\Model\MailEvent;
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Helper\Mail as MailHelper;
 
 class Mail extends \Swift_Message
@@ -265,7 +266,7 @@ class Mail extends \Swift_Message
             return true;
         }
 
-        return \Pimcore::inDebugMode() && $this->ignoreDebugMode === false;
+        return \Pimcore::inDebugMode(DebugMode::MAIL) && $this->ignoreDebugMode === false;
     }
 
     /**
@@ -629,7 +630,7 @@ class Mail extends \Swift_Message
         }
 
         if ($this->loggingIsEnabled()) {
-            if (\Pimcore::inDebugMode()) {
+            if (\Pimcore::inDebugMode(DebugMode::MAIL)) {
                 $recipients = $this->getDebugMailRecipients($recipients);
             }
 

--- a/pimcore/lib/Pimcore/Mail/Plugins/RedirectingPlugin.php
+++ b/pimcore/lib/Pimcore/Mail/Plugins/RedirectingPlugin.php
@@ -14,6 +14,7 @@
 
 namespace Pimcore\Mail\Plugins;
 
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Helper\Mail as MailHelper;
 use Pimcore\Mail;
 
@@ -56,13 +57,13 @@ class RedirectingPlugin extends \Swift_Plugins_RedirectingPlugin
             }
         } else {
             // default symfony behavior - only redirect when recipients are set and pimcore debug mode is active
-            if (\Pimcore::inDebugMode() && $this->getRecipient()) {
+            if (\Pimcore::inDebugMode(DebugMode::MAIL) && $this->getRecipient()) {
                 parent::beforeSendPerformed($evt);
             }
         }
 
         $headers = $message->getHeaders();
-        if (\Pimcore::inDebugMode()) {
+        if (\Pimcore::inDebugMode(DebugMode::MAIL)) {
             $headers->addMailboxHeader('X-Pimcore-Debug-To', $message->getTo());
             $headers->addMailboxHeader('X-Pimcore-Debug-Cc', $message->getCc());
             $headers->addMailboxHeader('X-Pimcore-Debug-Bcc', $message->getBcc());

--- a/pimcore/lib/Pimcore/Targeting/Code/TargetingCodeGenerator.php
+++ b/pimcore/lib/Pimcore/Targeting/Code/TargetingCodeGenerator.php
@@ -20,6 +20,7 @@ namespace Pimcore\Targeting\Code;
 use Pimcore\Analytics\Code\CodeBlock;
 use Pimcore\Event\Targeting\TargetingCodeEvent;
 use Pimcore\Event\TargetingEvents;
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Targeting\Model\VisitorInfo;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Templating\EngineInterface;
@@ -62,7 +63,7 @@ class TargetingCodeGenerator
     public function generateCode(VisitorInfo $visitorInfo): string
     {
         $data = [
-            'inDebugMode'      => \Pimcore::inDebugMode(),
+            'inDebugMode'      => \Pimcore::inDebugMode(DebugMode::TARGETING),
             'dataProviderKeys' => $visitorInfo->getFrontendDataProviders()
         ];
 

--- a/pimcore/lib/Pimcore/Tool.php
+++ b/pimcore/lib/Pimcore/Tool.php
@@ -16,6 +16,7 @@ namespace Pimcore;
 
 use GuzzleHttp\RequestOptions;
 use Pimcore\Cache\Symfony\CacheClearer;
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -417,7 +418,7 @@ class Tool
         ]);
 
         // check for manually disabled ?pimcore_outputfilters_disabled=true
-        if (array_key_exists('pimcore_outputfilters_disabled', $requestKeys) && PIMCORE_DEBUG) {
+        if (array_key_exists('pimcore_outputfilters_disabled', $requestKeys) && \Pimcore::inDebugMode(DebugMode::MAGIC_PARAMS)) {
             return false;
         }
 

--- a/pimcore/lib/Pimcore/Update.php
+++ b/pimcore/lib/Pimcore/Update.php
@@ -16,6 +16,8 @@ namespace Pimcore;
 
 use Pimcore\Cache\Symfony\CacheClearer;
 use Pimcore\Composer\Config\ConfigMerger;
+use Pimcore\FeatureToggles\Features\DebugMode;
+use Pimcore\FeatureToggles\Features\DevMode;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Process\Process;
 
@@ -73,7 +75,8 @@ class Update
         self::cleanup();
 
         $updateInfoUrl = 'https://' . self::$updateHost . '/get-update-info?revision=' . $currentRev;
-        if (PIMCORE_DEVMODE) {
+
+        if (\Pimcore::inDevMode(DevMode::UPDATES)) {
             $updateInfoUrl .= '&devmode=1';
         }
 

--- a/pimcore/models/Document/Tag.php
+++ b/pimcore/models/Document/Tag.php
@@ -21,6 +21,7 @@ use Pimcore\Document\Tag\Block\BlockName;
 use Pimcore\Document\Tag\Block\BlockState;
 use Pimcore\Event\DocumentEvents;
 use Pimcore\Event\Model\Document\TagNameEvent;
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Document;
@@ -446,7 +447,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
                 $result = $this->frontend();
             }
         } catch (\Throwable $e) {
-            if (\Pimcore::inDebugMode()) {
+            if (\Pimcore::inDebugMode(DebugMode::RENDER_DOCUMENT_TAG_ERRORS)) {
                 // the __toString method isn't allowed to throw exceptions
                 $result = '<b style="color:#f00">' . $e->getMessage().'</b><br/>'.$e->getTraceAsString();
 

--- a/pimcore/models/Document/Tag/Pdf.php
+++ b/pimcore/models/Document/Tag/Pdf.php
@@ -17,6 +17,7 @@
 
 namespace Pimcore\Model\Document\Tag;
 
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
@@ -531,7 +532,7 @@ HTML;
         }
 
         // only display error message in debug mode
-        if (!\Pimcore::inDebugMode()) {
+        if (!\Pimcore::inDebugMode(DebugMode::RENDER_DOCUMENT_TAG_ERRORS)) {
             $message = '';
         }
 

--- a/pimcore/models/Document/Tag/Renderlet.php
+++ b/pimcore/models/Document/Tag/Renderlet.php
@@ -18,6 +18,7 @@
 namespace Pimcore\Model\Document\Tag;
 
 use Pimcore\Config;
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
@@ -170,7 +171,7 @@ class Renderlet extends Model\Document\Tag
 
                 return $content;
             } catch (\Exception $e) {
-                if (\Pimcore::inDebugMode()) {
+                if (\Pimcore::inDebugMode(DebugMode::RENDER_DOCUMENT_TAG_ERRORS)) {
                     return 'ERROR: ' . $e->getMessage() . ' (for details see log files in /var/logs)';
                 }
                 Logger::error($e);

--- a/pimcore/models/Document/Tag/Snippet.php
+++ b/pimcore/models/Document/Tag/Snippet.php
@@ -18,6 +18,7 @@
 namespace Pimcore\Model\Document\Tag;
 
 use Pimcore\Cache;
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Document;
@@ -168,7 +169,7 @@ class Snippet extends Model\Document\Tag
         } catch (\Exception $e) {
             Logger::error($e);
 
-            if (\Pimcore::inDebugMode()) {
+            if (\Pimcore::inDebugMode(DebugMode::RENDER_DOCUMENT_TAG_ERRORS)) {
                 return 'ERROR: ' . $e->getMessage() . ' (for details see log files in /var/logs)';
             }
         }

--- a/pimcore/models/Document/Tag/Video.php
+++ b/pimcore/models/Document/Tag/Video.php
@@ -17,6 +17,7 @@
 
 namespace Pimcore\Model\Document\Tag;
 
+use Pimcore\FeatureToggles\Features\DebugMode;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
@@ -436,7 +437,7 @@ class Video extends Model\Document\Tag
         }
 
         // only display error message in debug mode
-        if (!\Pimcore::inDebugMode()) {
+        if (!\Pimcore::inDebugMode(DebugMode::RENDER_DOCUMENT_TAG_ERRORS)) {
             $message = '';
         }
 

--- a/pimcore/tests/unit/FeatureToggles/FeatureContextTest.php
+++ b/pimcore/tests/unit/FeatureToggles/FeatureContextTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Tests\Unit\FeatureToggles;
+
+use Pimcore\FeatureToggles\FeatureContext;
+use Pimcore\Tests\Test\TestCase;
+
+/**
+ * @covers \Pimcore\FeatureToggles\FeatureContext
+ */
+class FeatureContextTest extends TestCase
+{
+    /**
+     * @var FeatureContext
+     */
+    private $context;
+
+    /**
+     * @var array
+     */
+    private $data = [
+        'A' => 1,
+        'B' => 2,
+        'C' => [
+            'D' => 3,
+            'E' => 4
+        ]
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->context = new FeatureContext($this->data);
+    }
+
+    public function testAll()
+    {
+        $this->assertEquals($this->data, $this->context->all());
+    }
+
+    public function testKeys()
+    {
+        $this->assertEquals(['A', 'B', 'C'], $this->context->keys());
+    }
+
+    public function testGet()
+    {
+        $this->assertSame(1, $this->context->get('A'));
+        $this->assertSame(2, $this->context->get('B'));
+        $this->assertEquals(['D' => 3, 'E' => 4], $this->context->get('C'));
+    }
+
+    public function testGetDefault()
+    {
+        $this->assertNull($this->context->get('F'));
+        $this->assertSame(5, $this->context->get('F', 5));
+    }
+
+    public function testSet()
+    {
+        $this->assertSame(2, $this->context->get('B'));
+
+        $this->context->set('B', 7);
+
+        $this->assertSame(7, $this->context->get('B'));
+    }
+
+    public function testHas()
+    {
+        $this->assertTrue($this->context->has('A'));
+        $this->assertFalse($this->context->has('F'));
+
+        $this->context->set('F', 5);
+
+        $this->assertTrue($this->context->has('A'));
+        $this->assertTrue($this->context->has('F'));
+    }
+
+    public function testRemove()
+    {
+        $this->assertTrue($this->context->has('A'));
+        $this->assertEquals(1, $this->context->get('A'));
+
+        $this->context->remove('A');
+
+        $this->assertFalse($this->context->has('A'));
+        $this->assertNull($this->context->get('A'));
+
+        // can remove again
+        $this->context->remove('A');
+
+        $this->assertFalse($this->context->has('A'));
+        $this->assertNull($this->context->get('A'));
+    }
+
+    public function testCount()
+    {
+        $this->assertEquals(3, $this->context->count());
+        $this->assertEquals(3, count($this->context));
+    }
+
+    public function testIterator()
+    {
+        foreach ($this->context as $key => $value) {
+            $this->assertTrue(array_key_exists($key, $this->data));
+            $this->assertEquals($this->data[$key], $value);
+        }
+    }
+}

--- a/pimcore/tests/unit/FeatureToggles/FeatureManagerTest.php
+++ b/pimcore/tests/unit/FeatureToggles/FeatureManagerTest.php
@@ -1,0 +1,431 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Tests\Unit\FeatureToggles;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Pimcore\FeatureToggles\FeatureContext;
+use Pimcore\FeatureToggles\FeatureManager;
+use Pimcore\FeatureToggles\FeatureState;
+use Pimcore\FeatureToggles\FeatureStateInitializerInterface;
+use Pimcore\FeatureToggles\FeatureStateInterface;
+use Pimcore\Tests\Test\TestCase;
+use Pimcore\Tests\Unit\FeatureToggles\Fixtures\ValidFeature;
+use Pimcore\Tests\Unit\FeatureToggles\Fixtures\ValidFeatureMaximumFlags;
+
+require_once __DIR__ . '/Fixtures/Features.php';
+
+/**
+ * @covers \Pimcore\FeatureToggles\FeatureManager
+ */
+class FeatureManagerTest extends TestCase
+{
+    /**
+     * @var \ReflectionProperty
+     */
+    private $stateProperty;
+
+    /**
+     * @var FeatureContext
+     */
+    private $context;
+
+    /**
+     * @var FeatureStateInitializerInterface[]|MockObject[]
+     */
+    private $initializers = [];
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->stateProperty = (new \ReflectionClass(FeatureManager::class))->getProperty('states');
+        $this->stateProperty->setAccessible(true);
+
+        $this->context = new FeatureContext();
+
+        $this->initializers = [
+            $this->createInitializerMock(
+                ValidFeature::getType(),
+                FeatureState::fromFeature(ValidFeature::FLAG_1())
+            ),
+            $this->createInitializerMock(
+                ValidFeature::getType(),
+                FeatureState::fromFeature(ValidFeature::FLAG_2())
+            ),
+            $this->createInitializerMock(
+                ValidFeatureMaximumFlags::getType(),
+                FeatureState::fromFeature(ValidFeature::NONE())
+            ),
+            $this->createInitializerMock(
+                ValidFeatureMaximumFlags::getType(),
+                FeatureState::fromFeature(ValidFeature::ALL())
+            ),
+        ];
+    }
+
+    public function testSetGetHasState()
+    {
+        $manager = new FeatureManager($this->context);
+
+        $this->assertFalse($manager->hasState(ValidFeature::getType()));
+        $this->assertNull($manager->getState(ValidFeature::getType()));
+
+        $state = FeatureState::fromFeature(ValidFeature::FLAG_1());
+
+        $manager->setState($state);
+
+        $this->assertTrue($manager->hasState(ValidFeature::getType()));
+        $this->assertEquals($state, $manager->getState(ValidFeature::getType()));
+
+        // test overwrite state
+        $state2 = FeatureState::fromFeature(ValidFeature::FLAG_2());
+
+        $manager->setState($state2);
+
+        $this->assertTrue($manager->hasState(ValidFeature::getType()));
+        $this->assertEquals($state2, $manager->getState(ValidFeature::getType()));
+    }
+
+    public function testClearState()
+    {
+        $manager = new FeatureManager($this->context);
+
+        $this->assertEmpty($this->stateProperty->getValue($manager));
+        $this->assertStateProperty(
+            $manager,
+            0,
+            [],
+            []
+        );
+
+        $state1 = FeatureState::fromFeature(ValidFeature::FLAG_1());
+        $state2 = FeatureState::fromFeature(ValidFeatureMaximumFlags::FLAG_2());
+
+        $manager->setState($state1);
+        $manager->setState($state2);
+
+        $this->assertStateProperty(
+            $manager,
+            2,
+            [ValidFeature::getType(), ValidFeatureMaximumFlags::getType()],
+            [$state1, $state2]
+        );
+
+        $manager->clear(ValidFeature::getType());
+
+        $this->assertStateProperty(
+            $manager,
+            1,
+            [ValidFeatureMaximumFlags::getType()],
+            [$state2]
+        );
+
+        // clear again - no change
+        $manager->clear(ValidFeature::getType());
+
+        $this->assertStateProperty(
+            $manager,
+            1,
+            [ValidFeatureMaximumFlags::getType()],
+            [$state2]
+        );
+
+        $manager->clear(ValidFeatureMaximumFlags::getType());
+
+        $this->assertEmpty($this->stateProperty->getValue($manager));
+        $this->assertStateProperty(
+            $manager,
+            0,
+            [],
+            []
+        );
+    }
+
+    public function testClearAllStates()
+    {
+        $manager = new FeatureManager($this->context);
+
+        $this->assertEmpty($this->stateProperty->getValue($manager));
+        $this->assertStateProperty(
+            $manager,
+            0,
+            [],
+            []
+        );
+
+        $state1 = FeatureState::fromFeature(ValidFeature::FLAG_1());
+        $state2 = FeatureState::fromFeature(ValidFeatureMaximumFlags::FLAG_2());
+
+        $manager->setState($state1);
+        $manager->setState($state2);
+
+        $this->assertStateProperty(
+            $manager,
+            2,
+            [ValidFeature::getType(), ValidFeatureMaximumFlags::getType()],
+            [$state1, $state2]
+        );
+
+        $manager->clear();
+
+        $this->assertEmpty($this->stateProperty->getValue($manager));
+        $this->assertStateProperty(
+            $manager,
+            0,
+            [],
+            []
+        );
+    }
+
+    private function assertStateProperty(FeatureManager $manager, int $count, array $keys, array $values)
+    {
+        $propertyValue = $this->stateProperty->getValue($manager);
+
+        $this->assertCount($count, $propertyValue);
+        $this->assertEquals($keys, array_keys($propertyValue));
+
+        $values         = array_values($values);
+        $propertyValues = array_values($propertyValue);
+
+        for ($i = 0; $i < count($values); $i++) {
+            $this->assertSame($values[$i], $propertyValues[$i]);
+        }
+    }
+
+    /**
+     * @group only
+     */
+    public function testIsEnabledReturnsFalseWhenNoStateIsSet()
+    {
+        $manager = new FeatureManager($this->context);
+
+        $this->assertFalse($manager->isEnabled(ValidFeature::FLAG_1()));
+    }
+
+    /**
+     * @group only
+     */
+    public function testIsEnabled()
+    {
+        $feature1 = ValidFeature::FLAG_1();
+        $feature2 = ValidFeature::FLAG_2();
+
+        /** @var FeatureStateInterface|MockObject $state */
+        $state = $this->createMock(FeatureStateInterface::class);
+        $state
+            ->method('getType')
+            ->willReturn(ValidFeature::getType());
+
+        $state
+            ->expects($this->exactly(2))
+            ->method('isEnabled')
+            ->withConsecutive(
+                [
+                    $this->equalTo($feature1),
+                    $this->equalTo($this->context)
+                ],
+                [
+                    $this->equalTo($feature2),
+                    $this->equalTo($this->context)
+                ]
+            )
+            ->willReturnOnConsecutiveCalls(true, false);
+
+        $manager = new FeatureManager($this->context);
+        $manager->setState($state);
+
+        $this->assertTrue($manager->isEnabled($feature1));
+        $this->assertFalse($manager->isEnabled($feature2));
+    }
+
+    public function testContextIsSet()
+    {
+        $manager = new FeatureManager($this->context);
+
+        $this->assertSame($this->context, $manager->getContext());
+    }
+
+    public function testDefaultContextIsInitialized()
+    {
+        $manager = new FeatureManager();
+
+        $this->assertNotNull($manager->getContext());
+        $this->assertInstanceOf(FeatureContext::class, $manager->getContext());
+    }
+
+    public function testContextCanBeOverwritten()
+    {
+        $manager = new FeatureManager();
+
+        $this->assertNotNull($manager->getContext());
+        $this->assertNotSame($this->context, $manager->getContext());
+
+        $manager->setContext($this->context);
+
+        $this->assertSame($this->context, $manager->getContext());
+    }
+
+    public function testInitializersAreSet()
+    {
+        $manager = new FeatureManager($this->context, $this->initializers);
+
+        $this->testDefaultInitializers($manager);
+    }
+
+    public function testInitializersAreAdded()
+    {
+        $manager = new FeatureManager($this->context);
+
+        $this->assertEmpty($manager->getInitializers());
+        $this->assertEmpty($manager->getInitializers(ValidFeature::getType()));
+        $this->assertEmpty($manager->getInitializers(ValidFeatureMaximumFlags::getType()));
+
+        foreach ($this->initializers as $initializer) {
+            $manager->addInitializer($initializer);
+        }
+
+        $this->testDefaultInitializers($manager);
+    }
+
+    public function testInitializersAreOverwritten()
+    {
+        $initializers = [
+            $this->createInitializerMock(
+                ValidFeature::getType(),
+                FeatureState::fromFeature(ValidFeature::FLAG_3())
+            ),
+            $this->createInitializerMock(
+                ValidFeatureMaximumFlags::getType(),
+                FeatureState::fromFeature(ValidFeatureMaximumFlags::FLAG_4())
+            ),
+        ];
+
+        $manager = new FeatureManager($this->context, $this->initializers);
+        $manager->setInitializers($initializers);
+
+        $this->assertCount(2, $manager->getInitializers());
+        $this->assertCount(1, $manager->getInitializers(ValidFeature::getType()));
+        $this->assertCount(1, $manager->getInitializers(ValidFeatureMaximumFlags::getType()));
+
+        $this->assertSame($initializers, $manager->getInitializers());
+    }
+
+    public function testInitializerIsCalledWhenNoStateIsSet()
+    {
+        $state = FeatureState::fromFeature(ValidFeature::FLAG_3());
+
+        $initializer = $this->createInitializerMock(ValidFeature::getType(), $state);
+        $initializer
+            ->expects($this->once())
+            ->method('getType');
+
+        $initializer
+            ->expects($this->once())
+            ->method('getState');
+
+        $manager = new FeatureManager($this->context, $this->initializers);
+        $manager->addInitializer($initializer);
+
+        $this->assertSame($state, $manager->getState(ValidFeature::getType()));
+    }
+
+    public function testInitializerIsNotCalledWhenAStateIsSet()
+    {
+        $state  = FeatureState::fromFeature(ValidFeature::FLAG_3());
+        $state2 = FeatureState::fromFeature(ValidFeature::FLAG_2());
+
+        $initializer = $this->createInitializerMock(ValidFeature::getType(), $state);
+        $initializer
+            ->expects($this->never())
+            ->method('getType');
+
+        $initializer
+            ->expects($this->never())
+            ->method('getState');
+
+        $manager = new FeatureManager($this->context, $this->initializers);
+        $manager->addInitializer($initializer);
+        $manager->setState($state2);
+
+        $this->assertSame($state2, $manager->getState(ValidFeature::getType()));
+    }
+
+    public function testInitializerIsCalledAfterStateWasCleared()
+    {
+        $state  = FeatureState::fromFeature(ValidFeature::FLAG_3());
+        $state2 = FeatureState::fromFeature(ValidFeature::FLAG_2());
+
+        $initializer = $this->createInitializerMock(ValidFeature::getType(), $state);
+
+        $manager = new FeatureManager($this->context, $this->initializers);
+        $manager->addInitializer($initializer);
+        $manager->setState($state2);
+
+        $this->assertSame($state2, $manager->getState(ValidFeature::getType()));
+
+        $manager->clear();
+
+        $initializer
+            ->expects($this->once())
+            ->method('getType');
+
+        $initializer
+            ->expects($this->once())
+            ->method('getState');
+
+        $this->assertSame($state, $manager->getState(ValidFeature::getType()));
+    }
+
+    private function testDefaultInitializers(FeatureManager $manager)
+    {
+        $this->assertCount(4, $manager->getInitializers());
+        $this->assertCount(2, $manager->getInitializers(ValidFeature::getType()));
+        $this->assertCount(2, $manager->getInitializers(ValidFeatureMaximumFlags::getType()));
+
+        $byType = [
+            ValidFeature::getType()             => $manager->getInitializers(ValidFeature::getType()),
+            ValidFeatureMaximumFlags::getType() => $manager->getInitializers(ValidFeatureMaximumFlags::getType()),
+        ];
+
+        $this->assertSame($this->initializers[0], $byType[ValidFeature::getType()][0]);
+        $this->assertSame($this->initializers[1], $byType[ValidFeature::getType()][1]);
+        $this->assertSame($this->initializers[2], $byType[ValidFeatureMaximumFlags::getType()][0]);
+        $this->assertSame($this->initializers[3], $byType[ValidFeatureMaximumFlags::getType()][1]);
+    }
+
+    /**
+     * @param string $type
+     * @param FeatureStateInterface $state
+     *
+     * @return FeatureStateInitializerInterface|MockObject
+     */
+    private function createInitializerMock(string $type, FeatureStateInterface $state): FeatureStateInitializerInterface
+    {
+        /** @var MockObject $mock */
+        $mock = $this->createMock(FeatureStateInitializerInterface::class);
+        $mock
+            ->method('getType')
+            ->will($this->returnValue($type));
+
+        $mock
+            ->method('getState')
+            ->will($this->returnValue($state));
+
+        return $mock;
+    }
+}

--- a/pimcore/tests/unit/FeatureToggles/FeatureStateTest.php
+++ b/pimcore/tests/unit/FeatureToggles/FeatureStateTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Tests\Unit\FeatureToggles;
+
+use Pimcore\FeatureToggles\FeatureContext;
+use Pimcore\FeatureToggles\FeatureState;
+use Pimcore\Tests\Test\TestCase;
+use Pimcore\Tests\Unit\FeatureToggles\Fixtures\ValidFeature;
+
+require_once __DIR__ . '/Fixtures/Features.php';
+
+/**
+ * @covers \Pimcore\FeatureToggles\FeatureState
+ */
+class FeatureStateTest extends TestCase
+{
+    /**
+     * @var FeatureContext
+     */
+    private $context;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->context = new FeatureContext();
+    }
+
+    public function testTypeAndValue()
+    {
+        $state = new FeatureState('foo', 2);
+
+        $this->assertEquals('foo', $state->getType());
+        $this->assertEquals(2, $state->getValue());
+    }
+
+    public function testInvalidValue()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('State must be >= 0');
+
+        $state = new FeatureState('foo', -1);
+    }
+
+    public function testFromFeature()
+    {
+        $state = FeatureState::fromFeature(ValidFeature::FLAG_1());
+
+        $this->assertEquals(ValidFeature::getType(), $state->getType());
+        $this->assertEquals(ValidFeature::FLAG_1, $state->getValue());
+    }
+
+    public function testNoMatchIfTypeDoesntMatch()
+    {
+        $state = new FeatureState('foo', ValidFeature::FLAG_1);
+
+        $this->assertFalse($state->isEnabled(ValidFeature::NONE(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::FLAG_0(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::FLAG_1(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::FLAG_2(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::FLAG_3(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::ALL(), $this->context));
+    }
+
+    public function testNoneIsCorrectlyHandled()
+    {
+        $state = FeatureState::fromFeature(ValidFeature::NONE());
+
+        $this->assertTrue($state->isEnabled(ValidFeature::NONE(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::FLAG_0(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::FLAG_1(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::FLAG_2(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::FLAG_3(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::ALL(), $this->context));
+    }
+
+    public function testSingleFlag()
+    {
+        $state = new FeatureState(ValidFeature::getType(), ValidFeature::FLAG_2);
+
+        $this->assertFalse($state->isEnabled(ValidFeature::NONE(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::FLAG_0(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::FLAG_1(), $this->context));
+        $this->assertTrue($state->isEnabled(ValidFeature::FLAG_2(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::FLAG_3(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::ALL(), $this->context));
+    }
+
+    public function testMultipleFlags()
+    {
+        $state = new FeatureState(ValidFeature::getType(), ValidFeature::FLAG_2 | ValidFeature::FLAG_3);
+
+        $this->assertFalse($state->isEnabled(ValidFeature::NONE(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::FLAG_0(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::FLAG_1(), $this->context));
+        $this->assertTrue($state->isEnabled(ValidFeature::FLAG_2(), $this->context));
+        $this->assertTrue($state->isEnabled(ValidFeature::FLAG_3(), $this->context));
+        $this->assertFalse($state->isEnabled(ValidFeature::ALL(), $this->context));
+    }
+
+    public function testAllFlags()
+    {
+        $state = new FeatureState(ValidFeature::getType(), ValidFeature::FLAG_0 | ValidFeature::FLAG_1 | ValidFeature::FLAG_2 | ValidFeature::FLAG_3);
+
+        $this->assertFalse($state->isEnabled(ValidFeature::NONE(), $this->context));
+        $this->assertTrue($state->isEnabled(ValidFeature::FLAG_0(), $this->context));
+        $this->assertTrue($state->isEnabled(ValidFeature::FLAG_1(), $this->context));
+        $this->assertTrue($state->isEnabled(ValidFeature::FLAG_2(), $this->context));
+        $this->assertTrue($state->isEnabled(ValidFeature::FLAG_3(), $this->context));
+        $this->assertTrue($state->isEnabled(ValidFeature::ALL(), $this->context));
+    }
+
+    public function testAllFlag()
+    {
+        $state = FeatureState::fromFeature(ValidFeature::ALL());
+
+        $this->assertFalse($state->isEnabled(ValidFeature::NONE(), $this->context));
+        $this->assertTrue($state->isEnabled(ValidFeature::FLAG_0(), $this->context));
+        $this->assertTrue($state->isEnabled(ValidFeature::FLAG_1(), $this->context));
+        $this->assertTrue($state->isEnabled(ValidFeature::FLAG_2(), $this->context));
+        $this->assertTrue($state->isEnabled(ValidFeature::FLAG_3(), $this->context));
+        $this->assertTrue($state->isEnabled(ValidFeature::ALL(), $this->context));
+    }
+}

--- a/pimcore/tests/unit/FeatureToggles/FeatureTest.php
+++ b/pimcore/tests/unit/FeatureToggles/FeatureTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Tests\Unit\FeatureToggles;
+
+use Pimcore\FeatureToggles\Feature;
+use Pimcore\Tests\Test\TestCase;
+use Pimcore\Tests\Unit\FeatureToggles\Fixtures\InvalidFeatureDuplicateValue;
+use Pimcore\Tests\Unit\FeatureToggles\Fixtures\InvalidFeatureExceedMaximumFlags;
+use Pimcore\Tests\Unit\FeatureToggles\Fixtures\InvalidFeatureInvalidValue;
+use Pimcore\Tests\Unit\FeatureToggles\Fixtures\InvalidFeatureRedefined0;
+use Pimcore\Tests\Unit\FeatureToggles\Fixtures\InvalidFeatureRedefinedNone;
+use Pimcore\Tests\Unit\FeatureToggles\Fixtures\ValidFeature;
+use Pimcore\Tests\Unit\FeatureToggles\Fixtures\ValidFeatureMaximumFlags;
+
+require_once __DIR__ . '/Fixtures/Features.php';
+
+/**
+ * @covers \Pimcore\FeatureToggles\Feature
+ */
+class FeatureTest extends TestCase
+{
+    public function testFromName()
+    {
+        $flag = ValidFeature::fromName('FLAG_1');
+
+        $this->assertEquals('FLAG_1', $flag->getKey());
+        $this->assertEquals(2, $flag->getValue());
+    }
+
+    public function testValidFeature()
+    {
+        $values = ValidFeature::values();
+
+        $this->assertCount(6, $values);
+
+        $this->assertTrue(array_key_exists('NONE', $values));
+        $this->assertTrue(array_key_exists('FLAG_0', $values));
+        $this->assertTrue(array_key_exists('FLAG_1', $values));
+        $this->assertTrue(array_key_exists('FLAG_2', $values));
+        $this->assertTrue(array_key_exists('FLAG_3', $values));
+        $this->assertTrue(array_key_exists('ALL', $values));
+
+        $this->assertEquals(0, $values['NONE']->getValue());
+        $this->assertEquals(1, $values['FLAG_0']->getValue());
+        $this->assertEquals(2, $values['FLAG_1']->getValue());
+        $this->assertEquals(4, $values['FLAG_2']->getValue());
+        $this->assertEquals(8, $values['FLAG_3']->getValue());
+        $this->assertEquals(15, $values['ALL']->getValue());
+    }
+
+    public function testMaximumFlags()
+    {
+        $values = ValidFeatureMaximumFlags::values();
+
+        $this->assertCount(33, $values);
+        $this->assertEquals(2147483647, $values['ALL']->getValue());
+    }
+
+    /**
+     * @dataProvider invalidFeatureProvider
+     *
+     * @param Feature $featureClass
+     * @param string $exceptionMessage
+     */
+    public function testInvalidFeatures($featureClass, string $exceptionMessage)
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage($exceptionMessage);
+
+        $featureClass::toArray();
+    }
+
+    public function invalidFeatureProvider()
+    {
+        return [
+            [
+                InvalidFeatureRedefined0::class,
+                'The constant INVALID tries to re-define the bit mask 0 which is reserved for the NONE value.',
+            ],
+            [
+                InvalidFeatureRedefinedNone::class,
+                'The constant NONE is overwritten with value 4, but NONE needs to be 0.',
+            ],
+            [
+                InvalidFeatureInvalidValue::class,
+                'The mask 5 for constant FLAG_3 is not a power of 2.',
+            ],
+            [
+                InvalidFeatureDuplicateValue::class,
+                'The bit value 4 for constant FLAG_3 is already defined by FLAG_2. Please use distinct values for every feature.',
+            ],
+            [
+                InvalidFeatureExceedMaximumFlags::class,
+                'A feature can have a maximum of 31 flags excluding NONE and ALL.',
+            ],
+        ];
+    }
+}

--- a/pimcore/tests/unit/FeatureToggles/Fixtures/Features.php
+++ b/pimcore/tests/unit/FeatureToggles/Fixtures/Features.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Tests\Unit\FeatureToggles\Fixtures;
+
+use Pimcore\FeatureToggles\Feature;
+
+/**
+ * @method static ValidFeature FLAG_0()
+ * @method static ValidFeature FLAG_1()
+ * @method static ValidFeature FLAG_2()
+ * @method static ValidFeature FLAG_3()
+ */
+class ValidFeature extends Feature
+{
+    const FLAG_0 = 1;
+    const FLAG_1 = 2;
+    const FLAG_2 = 4;
+    const FLAG_3 = 8;
+
+    public static function getType(): string
+    {
+        return 'valid_feature';
+    }
+}
+
+class ValidFeatureMaximumFlags extends Feature
+{
+    const FLAG_0  = 1;
+    const FLAG_1  = 2;
+    const FLAG_2  = 4;
+    const FLAG_3  = 8;
+    const FLAG_4  = 16;
+    const FLAG_5  = 32;
+    const FLAG_6  = 64;
+    const FLAG_7  = 128;
+    const FLAG_8  = 256;
+    const FLAG_9  = 512;
+    const FLAG_10 = 1024;
+    const FLAG_11 = 2048;
+    const FLAG_12 = 4096;
+    const FLAG_13 = 8192;
+    const FLAG_14 = 16384;
+    const FLAG_15 = 32768;
+    const FLAG_16 = 65536;
+    const FLAG_17 = 131072;
+    const FLAG_18 = 262144;
+    const FLAG_19 = 524288;
+    const FLAG_20 = 1048576;
+    const FLAG_21 = 2097152;
+    const FLAG_22 = 4194304;
+    const FLAG_23 = 8388608;
+    const FLAG_24 = 16777216;
+    const FLAG_25 = 33554432;
+    const FLAG_26 = 67108864;
+    const FLAG_27 = 134217728;
+    const FLAG_28 = 268435456;
+    const FLAG_29 = 536870912;
+    const FLAG_30 = 1073741824;
+
+    public static function getType(): string
+    {
+        return 'valid_feature_maximum_flags';
+    }
+}
+
+class InvalidFeatureRedefined0 extends Feature
+{
+    const INVALID = 0;
+    const FLAG_0  = 1;
+    const FLAG_1  = 2;
+
+    public static function getType(): string
+    {
+        return 'invalid_feature_redefined_0';
+    }
+}
+
+class InvalidFeatureRedefinedNone extends Feature
+{
+    const FLAG_0 = 1;
+    const FLAG_1 = 2;
+    const NONE   = 4;
+
+    public static function getType(): string
+    {
+        return 'invalid_feature_redefined_none';
+    }
+}
+
+class InvalidFeatureInvalidValue extends Feature
+{
+    const FLAG_0 = 1;
+    const FLAG_1 = 2;
+    const FLAG_2 = 4;
+    const FLAG_3 = 5;
+
+    public static function getType(): string
+    {
+        return 'invalid_feature_invalid_value';
+    }
+}
+
+class InvalidFeatureDuplicateValue extends Feature
+{
+    const FLAG_0 = 1;
+    const FLAG_1 = 2;
+    const FLAG_2 = 4;
+    const FLAG_3 = 4;
+
+    public static function getType(): string
+    {
+        return 'invalid_feature_duplicate_value';
+    }
+}
+
+class InvalidFeatureExceedMaximumFlags extends ValidFeatureMaximumFlags
+{
+    const FLAG_31 = 2147483648;
+
+    public static function getType(): string
+    {
+        return 'invalid_feature_exceed_maximum_flags';
+    }
+}

--- a/pimcore/tests/unit/FeatureToggles/Initializers/ClosureInitializerTest.php
+++ b/pimcore/tests/unit/FeatureToggles/Initializers/ClosureInitializerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Tests\Unit\FeatureToggles\Initializers;
+
+use Pimcore\FeatureToggles\FeatureContext;
+use Pimcore\FeatureToggles\FeatureState;
+use Pimcore\FeatureToggles\FeatureStateInterface;
+use Pimcore\FeatureToggles\Initializers\ClosureInitializer;
+use Pimcore\Tests\Test\TestCase;
+
+/**
+ * @covers \Pimcore\FeatureToggles\Initializers\ClosureInitializer
+ */
+class ClosureInitializerTest extends TestCase
+{
+    public function testTypeIsSet()
+    {
+        $initializer = new ClosureInitializer('foo', function () {
+        });
+
+        $this->assertEquals('foo', $initializer->getType());
+    }
+
+    public function testClosureIsCalled()
+    {
+        // TODO find a more concise way of testing if a closure was called
+        $state         = new \stdClass();
+        $state->called = false;
+
+        $initializer = new ClosureInitializer('foo', function () use ($state) {
+            $state->called = true;
+        });
+
+        $this->assertFalse($state->called);
+
+        $initializer->getState(new FeatureContext());
+
+        $this->assertTrue($state->called);
+    }
+
+    public function testContextIsPassed()
+    {
+        $state         = new \stdClass();
+        $state->called = false;
+
+        $context = new FeatureContext();
+
+        $initializer = new ClosureInitializer('foo', function (FeatureContext $givenContext) use ($state, $context) {
+            $state->called = true;
+
+            $this->assertSame($context, $givenContext);
+        });
+
+        $this->assertFalse($state->called);
+
+        $initializer->getState($context);
+
+        $this->assertTrue($state->called);
+    }
+
+    public function testPreviousStateCanBeNull()
+    {
+        $state         = new \stdClass();
+        $state->called = false;
+
+        $initializer = new ClosureInitializer('foo', function (FeatureContext $givenContext, FeatureStateInterface $givenPreviousState = null) use ($state) {
+            $state->called = true;
+
+            $this->assertNull($givenPreviousState);
+        });
+
+        $this->assertFalse($state->called);
+
+        $initializer->getState(new FeatureContext());
+
+        $this->assertTrue($state->called);
+    }
+
+    public function testPreviousStateIsPassed()
+    {
+        $state         = new \stdClass();
+        $state->called = false;
+
+        $previousState = new FeatureState('foo', 0);
+
+        $initializer = new ClosureInitializer('foo', function (FeatureContext $givenContext, FeatureStateInterface $givenPreviousState = null) use ($state, $previousState) {
+            $state->called = true;
+
+            $this->assertSame($previousState, $givenPreviousState);
+        });
+
+        $this->assertFalse($state->called);
+
+        $initializer->getState(new FeatureContext(), $previousState);
+
+        $this->assertTrue($state->called);
+    }
+}

--- a/web/pimcore/static6/js/pimcore/document/edit.js
+++ b/web/pimcore/static6/js/pimcore/document/edit.js
@@ -25,7 +25,7 @@ pimcore.document.edit = Class.create({
             + pimcore.settings.language+'&_dc=' + date.getTime();
 
         if (pimcore.settings.disableMinifyJs) {
-            link += "&disable_minify_js";
+            link += "&unminified_js";
         }
 
         if(this.targetGroup && this.targetGroup.getValue()) {

--- a/web/pimcore/static6/js/pimcore/settings/system.js
+++ b/web/pimcore/static6/js/pimcore/settings/system.js
@@ -377,7 +377,13 @@ pimcore.settings.system = Class.create({
                                 xtype: "displayfield",
                                 hideLabel: true,
                                 width: 600,
-                                value: t("debug_description"),
+                                value: t("debug_description")
+                            },
+                            {
+                                xtype: "displayfield",
+                                hideLabel: true,
+                                width: 600,
+                                value: t("debug_override_warning"),
                                 cls: "pimcore_extra_label_bottom"
                             },
                             {


### PR DESCRIPTION
Implements #2269 (and is related to #2203). Instead of handling debug/dev mode as booleans, they are handled as bit fields which can be queried in a granular fashion. The implementation is not limited to debug and dev mode, but can be used to add any kind of feature flag by adding a feature enum class. The `Feature` enum initializes 2 special values `NONE` (equals to 0)  and `ALL` (is calculated to include all features from the enum) which can be set to completely enable or disable a feature set.

The actual state is represented by a `FeatureState` object which contains the type (e.g. `debug_mode`) and the actual bit field value to check against. At the moment this is just an in-memory object, but additional implementations of the `FeatureStateInterface` could add more sophisticated state handling, for example to persist its state or by enabling certain features on demand (see [Togglz Activation Strategies](https://www.togglz.org/documentation/activation-strategies.html) as an example).

Basic usage:

```php
<?php

use Pimcore\FeatureToggles\Features\DebugMode;
use Pimcore\FeatureToggles\Features\DevMode;
use Pimcore\FeatureToggles\FeatureState;

$featureManager = Pimcore::getFeatureManager(); // or inject FeatureManagerInterface in a DI context

// enable selected features
$featureManager->setState(new FeatureState(
    DebugMode::getType(),
    DebugMode::MAGIC_PARAMS | DebugMode::ERROR_REPORTING | DebugMode::RENDER_DOCUMENT_TAG_ERRORS
));

// enable everything, but exclude selected features
// ALL is dynamic, so instead of the constant, the magic method to build the enum
// instance needs to be used
$featureManager->setState(new FeatureState(
    DebugMode::getType(),
    DebugMode::ALL()->getValue() & ~DebugMode::DISABLE_HTTP_CACHE & ~DebugMode::MAGIC_PARAMS
));

// enable a single feature (this will overwrite previous calls)
$featureManager->setState(FeatureState::fromFeature(DebugMode::MAGIC_PARAMS()));

// enable all flags by using the special ALL enum member
$featureManager->setState(FeatureState::fromFeature(DebugMode::ALL()));

// disable all flags by using the special NONE enum member
$featureManager->setState(FeatureState::fromFeature(DebugMode::NONE()));

// same logic applies to other feature sets
$featureManager->setState(FeatureState::fromFeature(DevMode::ALL()));

// query for a specific feature
$featureManager->isEnabled(DebugMode::MAGIC_PARAMS());

// alternative method to build the feature instance (see https://github.com/myclabs/php-enum)
$featureManager->isEnabled(new DebugMode(DebugMode::MAGIC_PARAMS));

// get the current flag value (e.g. for merging)
$featureManager->getState(DebugMode::getType())->getValue();

// pimcore shortcuts to check for debug and dev flags
Pimcore::inDebugMode(DebugMode::MAGIC_PARAMS);
Pimcore::inDevMode(DevMode::UNMINIFIED_JS);
```