### PR TITLE
Unified name of the "client_params" option for ElasticSearch indices

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
@@ -86,7 +86,7 @@ class ElasticSearch extends AbstractConfig implements IMockupConfig, IElasticSea
         // TODO validate client config and other settings/params?
         $this->clientConfig = $options['client_config'];
         $this->indexSettings = $options['index_settings'];
-        $this->elasticSearchClientParams = $options['elastic_search_client_params'];
+        $this->elasticSearchClientParams = $options['es_client_params'];
     }
 
     protected function configureOptionsResolver(string $resolverName, OptionsResolver $resolver)
@@ -94,7 +94,7 @@ class ElasticSearch extends AbstractConfig implements IMockupConfig, IElasticSea
         $arrayFields = [
             'client_config',
             'index_settings',
-            'elastic_search_client_params',
+            'es_client_params',
             'mapping'
         ];
 

--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
@@ -94,7 +94,7 @@ class ElasticSearch extends AbstractConfig implements IMockupConfig, IElasticSea
         $arrayFields = [
             'client_config',
             'index_settings',
-            'es_client_params',
+            'elastic_search_client_params',
             'mapping'
         ];
 


### PR DESCRIPTION
It was not possible to specify any "client_params" for Elasticsearch, since the option name differed in two pieces of code:

https://github.com/pimcore/pimcore/blob/b6ad9535cb95bc1ee4ae77fc27a9b1460c36f684/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php#L89-L99