### PR TITLE
pimcore4 Delete Asset Syntax error

### DIFF
--- a/pimcore/modules/admin/controllers/AssetController.php
+++ b/pimcore/modules/admin/controllers/AssetController.php
@@ -473,7 +473,7 @@ class Admin_AssetController extends \Pimcore\Controller\Action\Admin\Element
                 if ($hasChilds) {
                     // get amount of childs
                     $list = new Asset\Listing();
-                    $list->setCondition("path LIKE ", [$asset->getRealFullPath() . "/%"]);
+                    $list->setCondition("path LIKE ?", [$asset->getRealFullPath() . "/%"]);
                     $childs = $list->getTotalCount();
                     $totalChilds += $childs;
 


### PR DESCRIPTION
Steps to reproduce:
Create 1 asset folder, then another one inside the first one, then try to delete the first one.

