### PR TITLE
Issue in custom layouts import/export

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ClassController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/ClassController.php
@@ -442,7 +442,7 @@ class ClassController extends AdminController implements EventedControllerInterf
     }
 
     /**
-     * @Route("/import-custom-layout")
+     * @Route("/import-custom-layout-definition")
      *
      * @param Request $request
      *
@@ -582,7 +582,7 @@ class ClassController extends AdminController implements EventedControllerInterf
     }
 
     /**
-     * @Route("/export-custom-layout-definitions")
+     * @Route("/export-custom-layout-definition")
      *
      * @param Request $request
      *


### PR DESCRIPTION

## Fixes Issue #
Custom layouts import and export not working because of routing mismatch.

## Changes in this pull request  
Import route has been changed from '/import-custom-layout' to '/import-custom-layout-definition'.
Export route has been changed from '/export-custom-layout-definitions' to '/export-custom-layout-definition'.

## Steps to reproduce
- Open a custom layout created for any class.
- Click on Export button. 
- This action is broken due to route mismatch.
- Likewise import action also have the same issue.

