### PR TITLE
[ECOMMERCE/INDEXSERVICE/ELASTICSEARCH]: Use bool-Query instead of filtered-Query

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/IndexService/ProductList/DefaultElasticSearch.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/IndexService/ProductList/DefaultElasticSearch.php
@@ -691,15 +691,15 @@ class DefaultElasticSearch implements IProductList
     protected function buildQuery(array $params, array $boolFilters, array $queryFilters)
     {
         if ($this->getVariantMode() == IProductList::VARIANT_MODE_INCLUDE_PARENT_OBJECT) {
-            $params['body']['query']['filtered']['query']['has_child']['type'] = self::PRODUCT_TYPE_VARIANT;
-            $params['body']['query']['filtered']['query']['has_child']['score_mode'] = 'avg';
-            $params['body']['query']['filtered']['query']['has_child']['query']['bool']['must'] = $queryFilters;
+            $params['body']['query']['bool']['must']['has_child']['type'] = self::PRODUCT_TYPE_VARIANT;
+            $params['body']['query']['bool']['must']['has_child']['score_mode'] = 'avg';
+            $params['body']['query']['bool']['must']['has_child']['query']['bool']['must'] = $queryFilters;
 
-            $params['body']['query']['filtered']['filter']['has_child']['type'] = self::PRODUCT_TYPE_VARIANT;
-            $params['body']['query']['filtered']['filter']['has_child']['filter']['bool']['must'] = $boolFilters;
+            $params['body']['query']['bool']['filter']['has_child']['type'] = self::PRODUCT_TYPE_VARIANT;
+            $params['body']['query']['bool']['filter']['has_child']['filter']['bool']['must'] = $boolFilters;
         } else {
-            $params['body']['query']['filtered']['query']['bool']['must'] = $queryFilters;
-            $params['body']['query']['filtered']['filter']['bool']['must'] = $boolFilters;
+            $params['body']['query']['bool']['must']['bool']['must'] = $queryFilters;
+            $params['body']['query']['bool']['filter']['bool']['must'] = $boolFilters;
         }
 
         return $params;


### PR DESCRIPTION
Compat-fix for Elasticsearch 5.x. The filtered-Query has been deprecated
since 2.0.0-beta1 and has been removed in 5.x.

See:
* https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-filtered-query.html
* https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-filtered-query.html
