### PR TITLE
Typo in setForceImmediateWrite()

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/09_Cache/README.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/09_Cache/README.md
@@ -151,7 +151,7 @@ if(!$data = \Pimcore\Cache::load($cacheKey)) {
 \Pimcore\Cache::clearAll();
  
 // disable the queue and limit and write immediately
-\Pimcore\Cache::setForceImmendiateWrite(true);
+\Pimcore\Cache::setForceImmediateWrite(true);
 ```
 
 #### Disable the Cache for a Single Request


### PR DESCRIPTION
Typo in `setForceImmediateWrite()`.

Changed `setForceImmendiateWrite()` to `setForceImmediateWrite()`.