### PR TITLE
Fixed logs pagination for some databases

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/LogController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/LogController.php
@@ -117,8 +117,14 @@ class LogController extends AdminController implements EventedControllerInterfac
             $qb->andWhere('pid LIKE ' . $qb->createNamedParameter('%' . $pid . '%'));
         }
 
+        $totalQb = clone $qb;
+        $totalQb->setMaxResults(null)
+            ->setFirstResult(0)
+            ->select('COUNT(id) as count');
+        $total = $totalQb->execute()->fetch();
+        $total = (int) $total['count'];
+
         $stmt   = $qb->execute();
-        $total  = $stmt->rowCount();
         $result = $stmt->fetchAll();
 
         $logEntries = [];


### PR DESCRIPTION
## Fixes Issue #2656 

### Steps to reproduce  
1. Install PimCore on MariaDB
2. Insert 50 records into application_logs table
3. Go to Application Logger view and set a limit to 25
4. You are not able to switch to page 2.
