### PR TITLE
Removed return type void because this is not present in PHP 7.0

### DIFF
--- a/pimcore/models/DataObject/Data/EncryptedField.php
+++ b/pimcore/models/DataObject/Data/EncryptedField.php
@@ -63,7 +63,7 @@ class EncryptedField
     /**
      * @param Data $delegate
      */
-    public function setDelegate(Data $delegate): void
+    public function setDelegate(Data $delegate)
     {
         $this->delegate = $delegate;
     }
@@ -79,7 +79,7 @@ class EncryptedField
     /**
      * @param mixed $plain
      */
-    public function setPlain($plain): void
+    public function setPlain($plain)
     {
         $this->plain = $plain;
     }


### PR DESCRIPTION
Return type void is not supported in php 7.0:

```
phpcs -p -n --standard=PHPCompatibility --exclude=PHPCompatibility.PHP.DefaultTimezoneRequired --ignore="vendor" --extensions=php --runtime-set testVersion $(php -r "echo phpversion();" | cut -d"." -f1,2) .
```

```
pimcore/models/DataObject/Data/EncryptedField.php
----------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------
 66 | ERROR | void return type is not present in PHP version 7.0 or
    |       | earlier
 82 | ERROR | void return type is not present in PHP version 7.0 or
    |       | earlier
----------------------------------------------------------------------
```

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.
  
  
## Fixes Issue #

- Void return type is not present in PHP version 7.0

## Changes in this pull request  

- Removed void return types

## Additional info  

To reproduce use phpcs with PHP 7.0:
```
phpcs -p -n --standard=PHPCompatibility --exclude=PHPCompatibility.PHP.DefaultTimezoneRequired --ignore="vendor" --extensions=php --runtime-set testVersion $(php -r "echo phpversion();" | cut -d"." -f1,2) .
```