### PR TITLE
Removes void return in EncryptedField.php

### DIFF
--- a/pimcore/models/DataObject/Data/EncryptedField.php
+++ b/pimcore/models/DataObject/Data/EncryptedField.php
@@ -63,7 +63,7 @@ class EncryptedField
     /**
      * @param Data $delegate
      */
-    public function setDelegate(Data $delegate): void
+    public function setDelegate(Data $delegate)
     {
         $this->delegate = $delegate;
     }
@@ -79,7 +79,7 @@ class EncryptedField
     /**
      * @param mixed $plain
      */
-    public function setPlain($plain): void
+    public function setPlain($plain)
     {
         $this->plain = $plain;
     }


### PR DESCRIPTION
Removes `: void` as it's not supported in PHP 7.0


## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
  
  
## Fixes Issue #
phpcs is not failing anymore.

## Changes in this pull request  
Removes void return type.

## Additional info  
phpcs is failing because of the the return type void:
```
FILE: /var/www/consumer-cms/pimcore/models/DataObject/Data/EncryptedField.php
-----------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
-----------------------------------------------------------------------------
 66 | ERROR | void return type is not present in PHP version 7.0 or earlier
 82 | ERROR | void return type is not present in PHP version 7.0 or earlier
-----------------------------------------------------------------------------
```


