### PR TITLE
Classification Store: Removed erroneous check for localized fields

### DIFF
--- a/pimcore/models/DataObject/Classificationstore.php
+++ b/pimcore/models/DataObject/Classificationstore.php
@@ -341,14 +341,11 @@ class Classificationstore extends Model\AbstractModel
 
                     if ($parent && ($parent->getType() == 'object' || $parent->getType() == 'variant')) {
                         if ($parent->getClassId() == $object->getClassId()) {
-                            $method = 'getLocalizedfields';
-                            if (method_exists($parent, $method)) {
-                                $getter = 'get' . ucfirst($this->fieldname);
-                                $classificationStore = $parent->$getter();
-                                if ($classificationStore instanceof Classificationstore) {
-                                    if ($classificationStore->object->getId() != $this->object->getId()) {
-                                        $data = $classificationStore->getLocalizedKeyValue($groupId, $keyId, $language, false);
-                                    }
+                            $getter = 'get' . ucfirst($this->fieldname);
+                            $classificationStore = $parent->$getter();
+                            if ($classificationStore instanceof Classificationstore) {
+                                if ($classificationStore->object->getId() != $this->object->getId()) {
+                                    $data = $classificationStore->getLocalizedKeyValue($groupId, $keyId, $language, false);
                                 }
                             }
                         }


### PR DESCRIPTION
When calling getLocalizedKeyValue() inherited values were only used if
the store's object had a Localized Fields data component. However, the
classification store itself has the option to be localized.

As a workaround it was possible to add an empty Localized Fields to the
object and the values were inherited as expected. This commit removes
the unnecessary check.