### PR TITLE
Prevent warning when trying to create a hardlink

### DIFF
--- a/pimcore/models/Version.php
+++ b/pimcore/models/Version.php
@@ -195,7 +195,7 @@ class Version extends AbstractModel
                 // inodes get overwritten but creates new inodes if the content changes. This is done by deleting the
                 // old file first before opening a new stream -> see Asset::update()
                 if (stream_is_local($this->getBinaryFilePath()) && stream_is_local($data->getFileSystemPath())) {
-                    $linked = link($data->getFileSystemPath(), $this->getBinaryFilePath());
+                    $linked = @link($data->getFileSystemPath(), $this->getBinaryFilePath());
                 }
 
                 if (!$linked) {


### PR DESCRIPTION
Trying to create a link across filesystems creates a unhandled warning which let's the whole process fail. Thus suppressing the warning with this change since a failed link is handled by creating a copy.

