### PR TITLE
Fixes serp preview with subdomains

### DIFF
--- a/web/pimcore/static6/js/pimcore/document/pages/settings.js
+++ b/web/pimcore/static6/js/pimcore/document/pages/settings.js
@@ -203,8 +203,25 @@ pimcore.document.pages.settings = Class.create(pimcore.document.settings_abstrac
                 return true;
             }.bind(this);
 
-            var serpAbsoluteUrl = window.location.protocol + '//' + window.location.hostname + this.document.data.path + this.document.data.key;
+            var urlPath = this.document.data.path + this.document.data.key;
+            var serpAbsoluteUrl = window.location.protocol + '//' + window.location.hostname + urlPath;
 
+            var subSites = pimcore.globalmanager.get('sites').data.items;
+            if (typeof subSites === 'array' && subSites.length) {
+                var idPath = this.document.data.idPath.replace(/^\/+/g, '');
+                var splitPath = idPath.split('/');
+
+                if (typeof splitPath[1] !== 'undefined') {
+                    var subSiteId = parseInt(splitPath[1], 10);
+
+                    subSites.forEach(function(item) {
+                        if (item.data.rootId === subSiteId) {
+                            urlPath = urlPath.replace(item.data.rootPath, '');
+                            serpAbsoluteUrl = item.data.domain + urlPath;
+                        }
+                    });
+                }
+            }
             // create layout
             this.layout = new Ext.FormPanel({
                 title: t('settings'),


### PR DESCRIPTION
Currently when using subsites the Serp preview shows the main domain + path, so this looks very strange (for example): `site.com/site.de/contact` because site.com is the main domain.

Checks for subsites and if the second idPath is equal to `subsites.data.rootId` then change the url to `subsite.data.domain` instead of `window.location.protocol + '//' + window.location.hostname`
This will look like: `site.de/contact` instead of `site.com/site.de/contact`
  
## Fixes Issue #
Strange url's in Serp preview when using subsites.

## Changes in this pull request  
`web/pimcore/static6/js/pimcore/document/pages/settings.js`

## Additional info  
When there are no subsites or the second idPath is not in subsites then it just uses the normal URL: `window.location.protocol + '//' + window.location.hostname`. As it was before.
