### PR TITLE
Fixes check on array in settings.js

### DIFF
--- a/web/pimcore/static6/js/pimcore/document/pages/settings.js
+++ b/web/pimcore/static6/js/pimcore/document/pages/settings.js
@@ -207,7 +207,7 @@ pimcore.document.pages.settings = Class.create(pimcore.document.settings_abstrac
             var serpAbsoluteUrl = window.location.protocol + '//' + window.location.hostname + urlPath;
 
             var subSites = pimcore.globalmanager.get('sites').data.items;
-            if (typeof subSites === 'array' && subSites.length) {
+            if (typeof subSites === 'object' && subSites.length) {
                 var idPath = this.document.data.idPath.replace(/^\/+/g, '');
                 var splitPath = idPath.split('/');
 


### PR DESCRIPTION
Fixes check on array. 
It checks on `typeof subSites === 'array'` but should be `object` because typeof would not return array but object.

## Fixes Issue #
This fixes the subdomain show correctly instead of maindomain/subsite.

## Changes in this pull request  
Changes the check on array must be `typeof subSites === 'object'`

## Additional info  
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#examples
