### PR TITLE
htmlspecialchars default value

### DIFF
--- a/pimcore/models/Document/Tag/Input.php
+++ b/pimcore/models/Document/Tag/Input.php
@@ -61,7 +61,7 @@ class Input extends Model\Document\Tag
         $options = $this->getOptions();
 
         $text = $this->text;
-        if (!isset($options['htmlspecialchars']) or $options['htmlspecialchars'] !== false) {
+        if (!isset($options['htmlspecialchars']) || $options['htmlspecialchars'] !== false) {
             $text = htmlspecialchars($this->text);
         }
 

--- a/pimcore/models/Document/Tag/Input.php
+++ b/pimcore/models/Document/Tag/Input.php
@@ -61,7 +61,7 @@ class Input extends Model\Document\Tag
         $options = $this->getOptions();
 
         $text = $this->text;
-        if (isset($options['htmlspecialchars']) and $options['htmlspecialchars'] !== false) {
+        if (!isset($options['htmlspecialchars']) or $options['htmlspecialchars'] !== false) {
             $text = htmlspecialchars($this->text);
         }
 


### PR DESCRIPTION
According to the documentation (https://pimcore.com/docs/5.0.x/Development_Documentation/Documents/Editables/Input.html) the default value of "htmlspecialchars" is true, this does not seem to match the logic of the frontend method.
