### PR TITLE
Make layout information available in renderer

### DIFF
--- a/pimcore/models/DataObject/ClassDefinition/Layout/Text.php
+++ b/pimcore/models/DataObject/ClassDefinition/Layout/Text.php
@@ -106,7 +106,7 @@ class Text extends Model\DataObject\ClassDefinition\Layout
         if (Tool::classExists($renderingClass)) {
             if (method_exists($renderingClass, 'renderLayoutText')) {
                 $context['fieldname'] = $this->getName();
-
+                $context['layout'] = $this;
                 $result = call_user_func($renderingClass . '::renderLayoutText', $this->renderingData, $object, $context);
                 $this->html = $result;
             }


### PR DESCRIPTION
By passing the layout information, the HTML of the text element is available and can be styled individually, for instance as a message output.