### PR TITLE
Amazon AWS S3 setup

### DIFF
--- a/pimcore/lib/Pimcore/Image/Adapter/Imagick.php
+++ b/pimcore/lib/Pimcore/Image/Adapter/Imagick.php
@@ -103,7 +103,7 @@ class Imagick extends Adapter
             }
 
             $imagePathLoad = $imagePath;
-            if (!defined('HHVM_VERSION')) {
+            if (!defined('HHVM_VERSION') && !defined('STREAMS_API')) {
                 $imagePathLoad .= '[0]'; // not supported by HHVM implementation - selects the first layer/page in layered/pages file formats
             }
 
@@ -235,8 +235,8 @@ class Imagick extends Adapter
             $path = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/imagick-tmp-' . uniqid() . '.' . File::getFileExtension($path);
         }
 
-        if (defined('HHVM_VERSION')) {
-            $success = $i->writeImage($path);
+        if (defined('HHVM_VERSION') || defined('STREAMS_API')) {
+            $success = file_put_contents($path, $i->getImageblob());
         } else {
             $success = $i->writeImage($format . ':' . $path);
         }


### PR DESCRIPTION
We wanted to use Amazon AWS S3 in a simple way. But in pimcore we have our own asset management instead of the Symfony one. @mjrider and I created a workaround so we can use Amazon AWS S3 with the usage of file streams.

- Fixed file streams issue in Imagick. `stream://`
- Added Amazon AWS S3 setup

# Installation instructions without file lookup caching:

Composer packages:
```
composer require league/flysystem-aws-s3-v3 mjrider/flysystem-factory twistor/flysystem-stream-wrapper
```

Create .env vars:
```
AMAZON_S3_URL="s3://accesstoken:secretkey@region/bucketname/"
PIMCORE_ASSET_DIRECTORY="fly://assetdirectory"
PIMCORE_TEMPORARY_DIRECTORY="fly://tempdirectory"
```

Add a `constants.php` to `app/` with contents:
```
<?php
// Initialize flysystem stream wrapper
use League\Flysystem\Adapter\Local;
use League\Flysystem\Filesystem;
use Twistor\FlysystemStreamWrapper;

$filesystem = \MJRider\FlysystemFactory\create(getenv('AMAZON_S3_URL'));

FlysystemStreamWrapper::register('fly', $filesystem);
$manager = new League\Flysystem\MountManager([
    'fly' => $filesystem
]);

define('STREAMS_API', 1);

if (PHP_SAPI != 'cli') {
    $pimcoreFiles = [
        PIMCORE_ASSET_DIRECTORY . $_SERVER['REQUEST_URI'],
        PIMCORE_TEMPORARY_DIRECTORY . $_SERVER['REQUEST_URI']
    ];

    foreach ($pimcoreFiles as $file) {
        if (!empty($file) && file_exists($file) && ($fileSize = filesize($file))) {
            header("Content-Length: " . $fileSize);

            $contentType = $manager->getMimeType($file);
            header('Content-Type: ' . $contentType);
            if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                $stream = $manager->readStream($file);
                if (!$stream) {
                    stream_copy_to_stream($stream, fopen('php://output', 'wb'));
                }
            }
            exit;
        }
    }
}
```

# Installation instructions with file lookup caching:

Composer packages:
```
composer require league/flysystem-aws-s3-v3 mjrider/flysystem-factory twistor/flysystem-stream-wrapper predis/predis
```

Create .env vars:
```
REDIS_URL="predis-tcp://127.0.0.1/?expire=3600"
AMAZON_S3_URL="s3://accesstoken:secretkey@region/bucketname/"
PIMCORE_ASSET_DIRECTORY="fly://assetdirectory"
PIMCORE_TEMPORARY_DIRECTORY="fly://tempdirectory"
```

Add a `constants.php` to `app/` with contents:
```
<?php
// Initialize flysystem stream wrapper
use League\Flysystem\Adapter\Local;
use League\Flysystem\Filesystem;
use Twistor\FlysystemStreamWrapper;

$cache = getenv('REDIS_URL');
$filesystem = \MJRider\FlysystemFactory\create(getenv('AMAZON_S3_URL'));
if ($cache !== false) {
    $filesystem = \MJRider\FlysystemFactory\cache($cache, $filesystem);
}

FlysystemStreamWrapper::register('fly', $filesystem);
$manager = new League\Flysystem\MountManager([
    'fly' => $filesystem
]);

define('STREAMS_API', 1);

if (PHP_SAPI != 'cli') {
    $pimcoreFiles = [
        PIMCORE_ASSET_DIRECTORY . $_SERVER['REQUEST_URI'],
        PIMCORE_TEMPORARY_DIRECTORY . $_SERVER['REQUEST_URI']
    ];

    foreach ($pimcoreFiles as $file) {
        if (!empty($file) && file_exists($file) && ($fileSize = filesize($file))) {
            header("Content-Length: " . $fileSize);

            $contentType = $manager->getMimeType($file);
            header('Content-Type: ' . $contentType);
            if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                $stream = $manager->readStream($file);
                if (!$stream) {
                    stream_copy_to_stream($stream, fopen('php://output', 'wb'));
                }
            }
            exit;
        }
    }
}
```

# PR

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.
  
## Fixes Issue #

- Fixed file stream handling
- Added Amazon AWS S3 usage in PR (needs to be documented in the future)

## Changes in this pull request  

- Fixed file streams

## Additional info  

When using file streams with our test.php you can see the file streams break with the current imagick code:
```
<?php

require 'vendor/autoload.php';

// Initialize flysystem stream wrapper
use League\Flysystem\Adapter\Local;
use League\Flysystem\Filesystem;
use Twistor\FlysystemStreamWrapper;

$filesystem = new Filesystem(new Local('/tmp/pimcoreassets'));

FlysystemStreamWrapper::register('fly', $filesystem);
$manager = new League\Flysystem\MountManager([
    'fly' => $filesystem
]);

$i = new \Imagick();
try {
    $i->readImage('fly://assetdirectory/logo.jpg');
    file_put_contents('fly://assetdirectory/logo-2.jpg', $i->getImageblob());
    $i->writeImage('fly://assetdirectory/logo-3.jpg'); // WILL RETURN AN ERROR
} catch (Exception $e) {
    var_dump($e);
}
```
The Imagick `writeImage` will fail because the file does not exist that's why we need to use:
```
file_put_contents('fly://assetdirectory/logo-2.jpg', $i->getImageblob());
```

