### PR TITLE
Updated imageEditor wait for images to load

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/views/Admin/Asset/imageEditor.html.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/views/Admin/Asset/imageEditor.html.php
@@ -74,7 +74,7 @@
 
 <img style="visibility: hidden" id='image' src='/admin/asset/get-image-thumbnail?id=<?= $this->asset->getId() ?>&width=1000&height=1000&contain=true'/>
 <script>
-    window.setTimeout(function () {
+    window.addEventListener('load', function (e) {
         var image = document.getElementById('image');
         window.Layers.insert({
             name: "<?= $this->asset->getFilename() ?>",
@@ -105,9 +105,7 @@
 
             return false;
         });
-    }, 2000);
-
-
+    }, false);
 </script>
 
 </body>


### PR DESCRIPTION
- When images load slow (5 seconds) this script will not wait 5 seconds but 2 seconds and this will result in a javascript error and a white blank image

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be properly documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

## Fixes Issue #

- Fixes slow images loading still editable with minipaint

## Changes in this pull request  

- Fixes slow images loading still editable with minipaint

## Additional info  

When images loading slowly the minipaint can not edit because of hardcoded timeout

