### PR TITLE
Add cleanup command for email logs

### DIFF
--- a/doc/User_Documentation/10_Administration_of_Pimcore/01_Data_Protection_and_GDPR.md
+++ b/doc/User_Documentation/10_Administration_of_Pimcore/01_Data_Protection_and_GDPR.md
@@ -55,6 +55,11 @@ Also in terms of erasure of information, Pimcores single source publishing comes
 object) is deleted, Pimcore automatically cleans up all related data (e.g. versions, etc.) and updates the places where  
 it used. 
 
+For email logs cleanup use Pimcore Console command `pimcore:email:cleanup` with required option `older-than-days` to delete the logs older than x days
+```bash
+./bin/console pimcore:email:cleanup --older-than-days=12
+```
+
 > Of course Pimcore cannot cleanup external data copies or backups. This has to be taken care of by the owner of the actual solution. 
 
 

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/EmailLogsCleanupCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/EmailLogsCleanupCommand.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Command;
+
+use Pimcore\Console\AbstractCommand;
+use Pimcore\Model\Tool\Email;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class EmailLogsCleanupCommand extends AbstractCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('pimcore:email:cleanup')
+            ->setAliases(['email:cleanup'])
+            ->setDescription('Cleanup email logs')
+            ->addOption(
+                'older-than-days',
+                'days',
+                InputOption::VALUE_REQUIRED,
+                'Older than X Days to delete email logs'
+            );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $daysAgo = $input->getOption('older-than-days');
+
+        if (!is_numeric($daysAgo)) {
+            throw new \Exception('The "--older-than-days" option value should be numeric');
+        }
+
+        $date = new \DateTime("-{$daysAgo} days");
+        $dateTimestamp = $date->getTimestamp();
+        $emailLogs = new Email\Log\Listing();
+        $emailLogs->setCondition("sentDate < $dateTimestamp");
+
+        foreach ($emailLogs->load() as $ekey => $emailLog) {
+            $emailLog->delete();
+        }
+
+        $this->output->writeln('Email logs cleanup done!');
+    }
+}

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/EmailLogsCleanupCommand.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Command/EmailLogsCleanupCommand.php
@@ -43,7 +43,9 @@ class EmailLogsCleanupCommand extends AbstractCommand
     {
         $daysAgo = $input->getOption('older-than-days');
 
-        if (!is_numeric($daysAgo)) {
+        if(!isset($daysAgo)) {
+            throw new \Exception('Missing option "--older-than-days"');
+        } elseif (!is_numeric($daysAgo)) {
             throw new \Exception('The "--older-than-days" option value should be numeric');
         }
 


### PR DESCRIPTION
## Fixes Issue #
Fixes #2649 
## Changes in this pull request  
Added new command for email sent logs cleanup from db and file system. Required parameter "--older-than-days" to delete logs older than X days.
## Additional info  

