### PR TITLE
Raise document.description to 383 (255+128) chars

### DIFF
--- a/pimcore/lib/Pimcore/Install/Resources/install.sql
+++ b/pimcore/lib/Pimcore/Install/Resources/install.sql
@@ -203,7 +203,7 @@ CREATE TABLE `documents_page` (
   `action` varchar(255) DEFAULT NULL,
   `template` varchar(255) DEFAULT NULL,
   `title` varchar(255) DEFAULT NULL,
-  `description` varchar(255) DEFAULT NULL,
+  `description` varchar(383) DEFAULT NULL,
   `metaData` text,
   `prettyUrl` varchar(190) DEFAULT NULL,
   `contentMasterDocumentId` int(11) DEFAULT NULL,

--- a/pimcore/lib/Pimcore/Version.php
+++ b/pimcore/lib/Pimcore/Version.php
@@ -24,7 +24,7 @@ class Version
     /**
      * @var int
      */
-    public static $revision = 223;
+    public static $revision = 224;
 
     /**
      * @var string

--- a/pimcore/lib/Pimcore/Version.php
+++ b/pimcore/lib/Pimcore/Version.php
@@ -24,7 +24,7 @@ class Version
     /**
      * @var int
      */
-    public static $revision = 224;
+    public static $revision = 223;
 
     /**
      * @var string

--- a/update-scripts/224/postupdate.php
+++ b/update-scripts/224/postupdate.php
@@ -1,0 +1,5 @@
+<?php
+
+$db = \Pimcore\Db::get();
+
+$db->query("ALTER TABLE `documents_page` CHANGE COLUMN `description` `description` VARCHAR(383) NULL DEFAULT NULL;");

--- a/web/pimcore/static6/js/pimcore/document/pages/settings.js
+++ b/web/pimcore/static6/js/pimcore/document/pages/settings.js
@@ -259,7 +259,7 @@ pimcore.document.pages.settings = Class.create(pimcore.document.settings_abstrac
                             },
                             {
                                 fieldLabel: t('description') + " (" + this.document.data.description.length + ")",
-                                maxLength: 255,
+                                maxLength: 350,
                                 height: 51,
                                 width: 700,
                                 name: 'description',


### PR DESCRIPTION
Major Search engines (aka Google) raised their limit for the META-Description. This patch allows Texts up to 383 (255+128) bytes.

See: https://moz.com/blog/googles-longer-snippets

Fixes #2619 

