### PR TITLE
 Fix: getByPath() special chars

### DIFF
--- a/pimcore/models/DataObject/AbstractObject.php
+++ b/pimcore/models/DataObject/AbstractObject.php
@@ -24,7 +24,6 @@ use Pimcore\Event\Model\DataObjectEvent;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Element;
-use Pimcore\Tool;
 
 /**
  * @method \Pimcore\Model\DataObject\AbstractObject\Dao getDao()

--- a/pimcore/models/DataObject/AbstractObject.php
+++ b/pimcore/models/DataObject/AbstractObject.php
@@ -330,11 +330,9 @@ class AbstractObject extends Model\Element\AbstractElement
         try {
             $object = new self();
 
-            if (Tool::isValidPath($path)) {
-                $object->getDao()->getByPath($path);
+            $object->getDao()->getByPath($path);
 
-                return self::getById($object->getId(), $force);
-            }
+            return self::getById($object->getId(), $force);
         } catch (\Exception $e) {
             Logger::warning($e->getMessage());
         }


### PR DESCRIPTION
When creating an object path (key), only a limited character check is performed (eliminating 4 byte unicode letters, points, etc.). Calling DataObject :: getByPath () applies a more stringent check (Tool :: isValidPath ()) so that extended character set objects / folders are no longer found by this method.