### PR TITLE
Flush the container of a ObjectBrick on delete of a brick

### DIFF
--- a/pimcore/models/DataObject/Objectbrick/Data/AbstractData.php
+++ b/pimcore/models/DataObject/Objectbrick/Data/AbstractData.php
@@ -93,8 +93,9 @@ abstract class AbstractData extends Model\AbstractModel
      */
     public function setDoDelete($doDelete)
     {
+        $this->flushContainer();
         $this->doDelete = $doDelete;
-
+       
         return $this;
     }
 
@@ -121,8 +122,25 @@ abstract class AbstractData extends Model\AbstractModel
     {
         $this->doDelete = true;
         $this->getDao()->delete($object);
+        $this->flushContainer();
     }
 
+    /**
+     * Flushes the already collected items of the container object
+     */
+    protected function flushContainer()
+    {
+        $object = $this->getObject();
+        if ($object) {
+            $containerGetter = "get" . ucfirst($this->fieldname);
+
+            $container = $object->$containerGetter();
+            if ($container instanceof Object\Objectbrick) {
+                $container->setItems([]);
+            }
+        }
+    }
+    
     /**
      * @param $key
      *


### PR DESCRIPTION
The ObjectBrick container[ caches the result](https://github.com/pimcore/pimcore/blob/master/pimcore/models/DataObject/Objectbrick.php#L82) of getItems().
This resets the result to the initial value when a brick gets deleted.