### PR TITLE
Flush the container of a ObjectBrick on delete of a brick

### DIFF
--- a/pimcore/models/Object/Objectbrick/Data/AbstractData.php
+++ b/pimcore/models/Object/Objectbrick/Data/AbstractData.php
@@ -92,6 +92,7 @@ class AbstractData extends Model\AbstractModel
      */
     public function setDoDelete($doDelete)
     {
+        $this->flushContainer();
         $this->doDelete = $doDelete;
 
         return $this;
@@ -120,7 +121,25 @@ class AbstractData extends Model\AbstractModel
     {
         $this->doDelete = true;
         $this->getDao()->delete($object);
+        $this->flushContainer();
     }
+    
+    /**
+     * Flushes the already collected items of the container object
+     */
+    protected function flushContainer()
+    {
+        $object = $this->getObject();
+        if ($object) {
+            $containerGetter = "get" . ucfirst($this->fieldname);
+
+            $container = $object->$containerGetter();
+            if ($container instanceof Object\Objectbrick) {
+                $container->setItems([]);
+            }
+        }
+    }
+    
 
     /**
      * @param $key


### PR DESCRIPTION
The ObjectBrick container caches the result of getItems().
This resets the result to the initial value when a brick gets deleted.
