### PR TITLE
Secure generateRandomSymfonySecret

### DIFF
--- a/pimcore/lib/helper-functions.php
+++ b/pimcore/lib/helper-functions.php
@@ -637,5 +637,5 @@ function to_php_data_file_format($contents)
  */
 function generateRandomSymfonySecret()
 {
-    return bin2hex(random_bytes(20));
+    return base64_encode(random_bytes(24));
 }

--- a/pimcore/lib/helper-functions.php
+++ b/pimcore/lib/helper-functions.php
@@ -637,9 +637,5 @@ function to_php_data_file_format($contents)
  */
 function generateRandomSymfonySecret()
 {
-    if (function_exists('openssl_random_pseudo_bytes')) {
-        return hash('sha1', openssl_random_pseudo_bytes(23));
-    }
-
-    return hash('sha1', uniqid(mt_rand(), true));
+    return bin2hex(random_bytes(20));
 }


### PR DESCRIPTION
This gives the same result as the previous 2 implementations without using a insecure source of random data

```
php > echo bin2hex(random_bytes(20));
191193afb3317e37c44df8b24c8fb70164a8d6c7
php > echo hash('sha1', openssl_random_pseudo_bytes(23));
b82291dc5a4de7861f4a494eba5a8c7fb52c6fc4
php > echo hash('sha1', uniqid(mt_rand(), true));
1ece0f9bbd0db3769aa7576438a8fc673f45e9b1
```


## Please make sure your PR complies with all of the following points: 
- [X] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [N/A] Features need to be proper documented in `doc/`
- [X] Bugfixes need a short guide how to reproduce them. 
- [X] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [X] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
  
  
## Fixes Issue #
insecure generation of symfony tokens with `uniqid` or `openssl_random_pseudo_bytes`

## Changes in this pull request 
- use random_bytes to get random data
- use bin2hex instead of sha1 to

## Additional info  

a even better implementation would be
`base64_encode(random_bytes(24))`, this matches with the Symfony documentation about generating token with a length of 32 chars, but i do not know if Pimcore has additional requirements for the contents of the token. that is why i choice this version in this PR

examples:
```
 php > echo bin2hex(random_bytes(20));
5a3f93e6b5c6e60f620dac5014ffcdc19f45d55d

php > echo base64_encode(random_bytes(24));
UeEdAREPPX3D1sPAy5rlYX/+gAbDBoBx

php > echo base64_encode(random_bytes(30));
JUizIB/wlPUKrjxY0/pk9wGoJxfHDpSmrKvtpAQO

php > echo hash('sha1', openssl_random_pseudo_bytes(23));
a546c2090ad8b07e18a7eee68d3b44c44eb5c954

php > echo hash('sha1', uniqid(mt_rand(), true));
9d2d4cf19874ed519e70fa12463788e5770cd468
```
