### PR TITLE
Removed injecting javascript from potential spoofed external source

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/views/Admin/Login/login.html.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/views/Admin/Login/login.html.php
@@ -147,6 +147,4 @@ $config = $this->config;
         $("#username").select();
     </script>
 
-    <script type="text/javascript" src="https://liveupdate.pimcore.org/imageservice"></script>
-
 <?php $view->slots()->stop() ?>


### PR DESCRIPTION
Pimcore is injecting javascript from an external source, this is not used and is loaded with an empty comment.

```
    <script type="text/javascript" src="https://liveupdate.pimcore.org/imageservice"></script>
```

When the server `liveupdate.pimcore.org` is spoofed (because there is no DNSSEC) you could potentially hijack all customers admin login page and inject it with javascript.

## Fixes Issue #

- Possible hijack of all customers admin login page.

## Changes in this pull request  

- The removed external source that is not used.
