### PR TITLE
Fixed small Javascript Issues

### DIFF
--- a/web/pimcore/static6/js/pimcore/element/abstract.js
+++ b/web/pimcore/static6/js/pimcore/element/abstract.js
@@ -118,12 +118,24 @@ pimcore.element.abstract = Class.create({
     resetChanges: function () {
         this.changeDetectorInitData = {};
 
-        this.tab.setTitle(this.tab.initialConfig.title);
-        this.startChangeDetector();
-        this.dirty = false;
+        try {
+            this.tab.setTitle(this.tab.initialConfig.title);
+            this.startChangeDetector();
+            this.dirty = false;
+        } catch(exception) {
+            // tab was closed to fast
+            console.error(exception);
+        }
     },
 
     checkForChanges: function () {
+        // tab was closed before first cycle
+        // stop change detector again
+        if(this.tab.destroyed) {
+            this.stopChangeDetector();
+            return;
+        }
+
         if (!this.changeDetectorInitData) {
             this.setupChangeDetector();
         }

--- a/web/pimcore/static6/js/pimcore/object/helpers/grid.js
+++ b/web/pimcore/static6/js/pimcore/object/helpers/grid.js
@@ -129,6 +129,7 @@ pimcore.object.helpers.grid = Class.create({
                 update  : this.url + glue  + "xaction=update",
                 destroy : this.url + glue  + "xaction=destroy"
             },
+            batchActions: false,
             actionMethods: {
                 create : 'POST',
                 read   : 'POST',

--- a/web/pimcore/static6/js/pimcore/object/tags/multihrefMetadata.js
+++ b/web/pimcore/static6/js/pimcore/object/tags/multihrefMetadata.js
@@ -93,6 +93,7 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
         columns.push({text: 'ID', dataIndex: 'id', width: 50});
         columns.push({text: t('reference'), dataIndex: 'path', flex: 1});
 
+        var visibleFieldsCount = columns.length;
 
         for (i = 0; i < this.fieldConfig.columns.length; i++) {
             var width = 100;
@@ -100,16 +101,18 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                 width = this.fieldConfig.columns[i].width;
             }
 
-            var editor = null;
             var cellEditor = null;
             var renderer = null;
             var listeners = null;
 
             if(this.fieldConfig.columns[i].type == "number" && !readOnly) {
-                editor = new Ext.form.NumberField({});
-
+                cellEditor = function() {
+                    return new Ext.form.NumberField({});
+                };
             } else if(this.fieldConfig.columns[i].type == "text" && !readOnly) {
-                editor = new Ext.form.TextField({});
+                cellEditor = function() {
+                    return new Ext.form.TextField({});
+                };
             } else if(this.fieldConfig.columns[i].type == "select" && !readOnly) {
                 var selectData = [];
                 if (this.fieldConfig.columns[i].value) {
@@ -119,23 +122,27 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                     }
                 }
 
-                editor = new Ext.form.ComboBox({
-                    typeAhead: true,
-                    forceSelection: true,
-                    triggerAction: 'all',
-                    lazyRender:true,
-                    mode: 'local',
+                cellEditor = function(selectData) {
+                    return new Ext.form.ComboBox({
+                        typeAhead: true,
+                        queryDelay: 0,
+                        queryMode: "local",
+                        forceSelection: true,
+                        triggerAction: 'all',
+                        lazyRender: false,
+                        mode: 'local',
 
-                    store: new Ext.data.ArrayStore({
-                        fields: [
-                            'value',
-                            'label'
-                        ],
-                        data: selectData
-                    }),
-                    valueField: 'value',
-                    displayField: 'label'
-                });
+                        store: new Ext.data.ArrayStore({
+                            fields: [
+                                'value',
+                                'label'
+                            ],
+                            data: selectData
+                        }),
+                        valueField: 'value',
+                        displayField: 'label'
+                    });
+                }.bind(this, selectData);
             } else if(this.fieldConfig.columns[i].type == "multiselect" && !readOnly) {
                 cellEditor =  function(fieldInfo) {
                     return new pimcore.object.helpers.metadataMultiselectEditor({
@@ -150,8 +157,6 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                         return '<div style="text-align: center"><div role="button" class="x-grid-checkcolumn" style=""></div></div>';
                     }
                 };
-                editor = Ext.create('Ext.form.field.Checkbox', {style: 'margin-top: 2px;'});
-
 
                 if(readOnly) {
                     columns.push(Ext.create('Ext.grid.column.Check'), {
@@ -163,24 +168,29 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                     continue;
                 }
 
-                if (!readOnly && this.fieldConfig.columns[i].type === "columnbool") {
-                    editor.addListener('change', function (el, newValue) {
-                        window.gridPanel = el.up('gridpanel');
-                        window.el = el;
-                        var gridPanel = el.up('gridpanel');
-                        var columnKey = el.up().column.dataIndex;
-                        if (newValue) {
-                            gridPanel.getStore().each(function (record) {
-                                if (!!record.get(columnKey)) {
-                                    // note, we don't need to check for the row here as the editor fires another change
-                                    // on blur, which updates the underlying record without a subsequent event being fired.
-                                    record.set(columnKey, false);
-                                }
-                            });
-                        }
-                    });
-                }
+                cellEditor = function(type, readOnly) {
+                    var editor = Ext.create('Ext.form.field.Checkbox', {style: 'margin-top: 2px;'});
 
+                    if (!readOnly && type === "columnbool") {
+                        editor.addListener('change', function (el, newValue) {
+                            window.gridPanel = el.up('gridpanel');
+                            window.el = el;
+                            var gridPanel = el.up('gridpanel');
+                            var columnKey = el.up().column.dataIndex;
+                            if (newValue) {
+                                gridPanel.getStore().each(function (record) {
+                                    if (!!record.get(columnKey)) {
+                                        // note, we don't need to check for the row here as the editor fires another change
+                                        // on blur, which updates the underlying record without a subsequent event being fired.
+                                        record.set(columnKey, false);
+                                    }
+                                });
+                            }
+                        });
+                    }
+
+                    return editor;
+                }.bind(this, this.fieldConfig.columns[i].type, readOnly);
             }
 
             var columnConfig = {
@@ -191,9 +201,7 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                 sortable: true,
                 width: width
             };
-            if (editor) {
-                columnConfig.editor = editor;
-            }
+
             if (cellEditor) {
                 columnConfig.getEditor = cellEditor;
             }
@@ -287,7 +295,23 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
 
 
         this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {
-            clicksToEdit: 1
+            clicksToEdit: 1,
+            listeners: {
+                beforeedit: function (editor, context, eOpts) {
+                    editor.editors.each(function (e) {
+                        try {
+                            // complete edit, so the value is stored when hopping around with TAB
+                            e.completeEdit();
+                            Ext.destroy(e);
+                        } catch (exception) {
+                            // garbage collector was faster
+                            // already destroyed
+                        }
+                    });
+
+                    editor.editors.clear();
+                }
+            }
         });
 
 
@@ -325,7 +349,7 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                     // probably a ExtJS 6.0 bug. withou this, dropdowns not working anymore if plugin is enabled
                     // TODO: investigate if there this is already fixed 6.2
                     cellmousedown: function (element, td, cellIndex, record, tr, rowIndex, e, eOpts) {
-                        if (cellIndex >= visibleFields.length) {
+                        if (cellIndex >= visibleFieldsCount) {
                             return false;
                         } else {
                             return true;
@@ -621,10 +645,10 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
         }
 
         pimcore.helpers.itemselector(true, this.addDataFromSelector.bind(this), {
-            type: allowedTypes,
-            subtype: allowedSubtypes,
-            specific: allowedSpecific
-        },
+                type: allowedTypes,
+                subtype: allowedSubtypes,
+                specific: allowedSpecific
+            },
             {
                 context: this.getContext()
             });
@@ -817,10 +841,10 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
         }
 
         pimcore.helpers.itemselector(true, this.addDataFromSelector.bind(this), {
-            type: allowedTypes,
-            subtype: allowedSubtypes,
-            specific: allowedSpecific
-        },
+                type: allowedTypes,
+                subtype: allowedSubtypes,
+                specific: allowedSpecific
+            },
             {
                 context: Ext.apply({scope: "objectEditor"}, this.getContext())
             });

--- a/web/pimcore/static6/js/pimcore/object/tags/objectsMetadata.js
+++ b/web/pimcore/static6/js/pimcore/object/tags/objectsMetadata.js
@@ -121,16 +121,18 @@ pimcore.object.tags.objectsMetadata = Class.create(pimcore.object.tags.objects, 
                 width = this.fieldConfig.columns[i].width;
             }
 
-            var editor = null;
             var cellEditor = null;
             var renderer = null;
             var listeners = null;
 
             if (this.fieldConfig.columns[i].type == "number" && !readOnly) {
-                editor = new Ext.form.NumberField({});
-
+                cellEditor = function() {
+                    return new Ext.form.NumberField({});
+                }.bind();
             } else if (this.fieldConfig.columns[i].type == "text" && !readOnly) {
-                editor = new Ext.form.TextField({});
+                cellEditor = function() {
+                    return new Ext.form.TextField({});
+                };
             } else if (this.fieldConfig.columns[i].type == "select" && !readOnly) {
                var selectData = [];
 
@@ -142,23 +144,27 @@ pimcore.object.tags.objectsMetadata = Class.create(pimcore.object.tags.objects, 
                     }
                 }
 
-                editor = new Ext.form.ComboBox({
-                    typeAhead: true,
-                    forceSelection: true,
-                    triggerAction: 'all',
-                    lazyRender: true,
-                    mode: 'local',
+                cellEditor = function(selectData) {
+                    return new Ext.form.ComboBox({
+                        typeAhead: true,
+                        queryDelay: 0,
+                        queryMode: "local",
+                        forceSelection: true,
+                        triggerAction: 'all',
+                        lazyRender: false,
+                        mode: 'local',
 
-                    store: new Ext.data.ArrayStore({
-                        fields: [
-                            'value',
-                            'label'
-                        ],
-                        data: selectData
-                    }),
-                    valueField: 'value',
-                    displayField: 'label'
-                });
+                        store: new Ext.data.ArrayStore({
+                            fields: [
+                                'value',
+                                'label'
+                            ],
+                            data: selectData
+                        }),
+                        valueField: 'value',
+                        displayField: 'label'
+                    });
+                }.bind(this, selectData);
             } else if(this.fieldConfig.columns[i].type == "multiselect" && !readOnly) {
                 cellEditor =  function(fieldInfo) {
                     return new pimcore.object.helpers.metadataMultiselectEditor({
@@ -198,9 +204,7 @@ pimcore.object.tags.objectsMetadata = Class.create(pimcore.object.tags.objects, 
                 sortable: true,
                 width: width
             };
-            if (editor) {
-                columnConfig.editor = editor;
-            }
+
             if (cellEditor) {
                 columnConfig.getEditor = cellEditor;
             }
@@ -285,7 +289,23 @@ pimcore.object.tags.objectsMetadata = Class.create(pimcore.object.tags.objects, 
 
 
         this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {
-            clicksToEdit: 1
+            clicksToEdit: 1,
+            listeners: {
+                beforeedit: function (editor, context, eOpts) {
+                    editor.editors.each(function (e) {
+                        try {
+                            // complete edit, so the value is stored when hopping around with TAB
+                            e.completeEdit();
+                            Ext.destroy(e);
+                        } catch (exception) {
+                            // garbage collector was faster
+                            // already destroyed
+                        }
+                    });
+
+                    editor.editors.clear();
+                }
+            }
         });
 
 


### PR DESCRIPTION
## Fixes following Issues

### Batch actions in object grid
When objects in the grid view are edited fast enought ExtJs would batch those changes, which the backend is not compliant with, resulting in an error. The batching process has been disabled for grids created with `pimcore.object.helpers.grid`.

### Multihref Advanced & Objects with Metadata
Both these tags had the issue that ExtJs's garbage collector would collect the cell editors if working long enought with the tag. Usually when adding / removing / sorting elements the garbage collector would destroy the cell editor leading to a javascript exception and disabling the layout rerender, which could only be fixed by refreshing the backend. By destroying and recreating the cell editors each time a cell is being edited, the issue could be fixed.

### Combobox delayed preselect
By recreating the combobox for the cell editor each time, the preselect of the current value is delayed. This behaviour was previously present as well, but only for the first time the combobox was rendered. Was fixed by switching to the local queryMode of the combobox store (only for typeahead stores).
