### PR TITLE
Fixed custom report column view breaks with html content

### DIFF
--- a/web/pimcore/static6/js/pimcore/report/custom/report.js
+++ b/web/pimcore/static6/js/pimcore/report/custom/report.js
@@ -73,6 +73,16 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
                 this.gridfilters[colConfig["name"]] = colConfig["filter"];
             }
 
+            if (colConfig["displayType"] == "text") {
+                gridColConfig["renderer"] = function (key, value, metaData, record) {
+                    if (value && Ext.String.hasHtmlCharacters(value)) {
+                        return Ext.util.Format.htmlEncode(value);
+                    } else {
+                        return value;
+                    }
+                }.bind(this, colConfig["name"]);
+            }
+
             if (colConfig["displayType"] == "date") {
                 gridColConfig["renderer"] = function (key, value, metaData, record) {
                     if (value) {


### PR DESCRIPTION
## Fixes Issue #
Fixes #2695 
## Changes in this pull request  
Added render for html content in custom report text column
## Additional info  

