### PR TITLE
Add "not editable" check for advance multihref remove context menu

### DIFF
--- a/web/pimcore/static6/js/pimcore/object/tags/multihrefMetadata.js
+++ b/web/pimcore/static6/js/pimcore/object/tags/multihrefMetadata.js
@@ -659,11 +659,14 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
         var menu = new Ext.menu.Menu();
         var data = record;
 
-        menu.add(new Ext.menu.Item({
-            text: t('remove'),
-            iconCls: "pimcore_icon_delete",
-            handler: this.removeElement.bind(this, rowIndex)
-        }));
+         // check if field noteditable property is false
+        if(this.fieldConfig.noteditable == false) {
+            menu.add(new Ext.menu.Item({
+                text: t('remove'),
+                iconCls: "pimcore_icon_delete",
+                handler: this.removeElement.bind(this, rowIndex)
+            }));
+        }
 
         menu.add(new Ext.menu.Item({
             text: t('open'),


### PR DESCRIPTION
## Fixes Issue #
Fixes #1609 

## Changes in this pull request  
Added "not-editable" check for remove option in context menu of Advance Multihref Data Object field
## Additional info  

