### PR TITLE
Bugfix - Thumnail - return correct file system path if no config is passed

### DIFF
--- a/pimcore/models/Asset/Image/Thumbnail.php
+++ b/pimcore/models/Asset/Image/Thumbnail.php
@@ -137,7 +137,7 @@ class Thumbnail
         } elseif (!$this->filesystemPath) {
             // if no correct thumbnail config is given use the original image as thumbnail
             if (!$this->config) {
-                $this->filesystemPath = $this->asset->getRealFullPath();
+                $this->filesystemPath = $this->asset->getFileSystemPath();
             } else {
                 try {
                     $deferred = ($deferredAllowed && $this->deferred) ? true : false;


### PR DESCRIPTION
Return correct filesystem path if no config was provided.
The getRealFullPath() method doesn't return the Document_Root
