### PR TITLE
Fix newsletter test send fails when address source is empty

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/NewsletterController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/NewsletterController.php
@@ -338,6 +338,11 @@ class NewsletterController extends DocumentControllerBase
         $document = Document\Newsletter::getById($request->get('id'));
         $addressSourceAdapterName = $request->get('addressAdapterName');
         $adapterParams = json_decode($request->get('adapterParams'), true);
+        $testMailAddress = $request->get('testMailAddress');
+
+        if(empty($testMailAddress)) {
+            return $this->adminJson(['success' => false, 'message' =>  'Please provide valid email address to send test newsletter']);
+        }
 
         $serviceLocator = $this->get('pimcore.newsletter.address_source_adapter.factories');
 
@@ -351,7 +356,7 @@ class NewsletterController extends DocumentControllerBase
         $addressAdapterFactory = $serviceLocator->get($addressSourceAdapterName);
         $addressAdapter = $addressAdapterFactory->create($adapterParams);
 
-        $sendingContainer = $addressAdapter->getParamsForTestSending($request->get('testMailAddress'));
+        $sendingContainer = $addressAdapter->getParamsForTestSending($testMailAddress);
 
         $mail = \Pimcore\Tool\Newsletter::prepareMail($document);
         \Pimcore\Tool\Newsletter::sendNewsletterDocumentBasedMail($mail, $sendingContainer);

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/NewsletterController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/NewsletterController.php
@@ -341,7 +341,7 @@ class NewsletterController extends DocumentControllerBase
         $testMailAddress = $request->get('testMailAddress');
 
         if(empty($testMailAddress)) {
-            return $this->adminJson(['success' => false, 'message' =>  'Please provide valid email address to send test newsletter']);
+            return $this->adminJson(['success' => false, 'message' =>  'Please provide a valid email address to send test newsletter']);
         }
 
         $serviceLocator = $this->get('pimcore.newsletter.address_source_adapter.factories');

--- a/web/pimcore/static6/js/pimcore/document/newsletters/addressSourceAdapters/report.js
+++ b/web/pimcore/static6/js/pimcore/document/newsletters/addressSourceAdapters/report.js
@@ -62,7 +62,17 @@ pimcore.document.newsletters.addressSourceAdapters.report = Class.create({
                         id: "pimcore_newsletter_send_report_" + this.document.id,
                         width: 600,
                         displayField: 'text',
-                        valueField: 'id'
+                        valueField: 'id',
+                        listeners: {
+                            "change": function (el) {
+                                Ext.getCmp("email_field_name_" + this.document.id).clearValue();
+                                Ext.getCmp("email_field_name_" + this.document.id).getStore().reload({
+                                    params: {
+                                        reportId: el.getValue()
+                                    }
+                                });
+                            }.bind(this)
+                        }
                     },{
                         xtype:'combo',
                         name: "emailFieldName",
@@ -79,21 +89,20 @@ pimcore.document.newsletters.addressSourceAdapters.report = Class.create({
                                     rootProperty: 'data'
                                 }
                             },
+                            listeners: {
+                                beforeload : function(store, options) {
+                                    store.getProxy().extraParams = {
+                                        reportId: Ext.getCmp("pimcore_newsletter_send_report_"
+                                            + this.document.id).getValue()
+                                    };
+                                }.bind(this)
+                            },
                             fields: ["name"]
                         }),
                         width: 600,
                         displayField: 'name',
                         valueField: 'name',
-                        listeners: {
-                            "focus": function (el) {
-                                el.getStore().reload({
-                                    params: {
-                                        reportId: Ext.getCmp("pimcore_newsletter_send_report_"
-                                            + this.document.id).getValue()
-                                    }
-                                });
-                            }.bind(this)
-                        }
+                        id: "email_field_name_" + this.document.id,
                     }
                 ]
             });

--- a/web/pimcore/static6/js/pimcore/document/newsletters/sendingPanel.js
+++ b/web/pimcore/static6/js/pimcore/document/newsletters/sendingPanel.js
@@ -230,7 +230,8 @@ pimcore.document.newsletters.sendingPanel = Class.create({
                 if(res.success) {
                     Ext.MessageBox.alert(t("info"), t("newsletter_test_sent_message"))
                 } else {
-                    Ext.MessageBox.alert(t("error"), t("newsletter_send_error"))
+                    var message = (res.message ? res.message : t("newsletter_send_error"));
+                    Ext.MessageBox.alert(t("error"), message)
                 }
             }
         });


### PR DESCRIPTION
## Fixes Issue #
Fixes #1344
## Changes in this pull request  
1. Fixed email field load issue when selecting report in Newsletter sending panel.
2. Added a check for empty email address for test send newsletter
## Additional info  

