### PR TITLE
Removed ; in documentation for Twig

### DIFF
--- a/doc/Development_Documentation/03_Documents/01_Editables/16_Input.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/16_Input.md
@@ -36,7 +36,7 @@ For a multi-line alternative have a look at the [textarea editable](./36_Textare
 
 ```twig
 <h2>
- {{ pimcore_input("myHeadline"); }}
+ {{ pimcore_input("myHeadline") }}
 </h2>
 ```
 </div>


### PR DESCRIPTION
Twig does not support `;` so we need to remove this.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
  
  
## Fixes Issue #

- Input breaks on `;`

## Changes in this pull request  

- Removed `;` for Twig

