### PR TITLE
Added failed add/save/delete events

### DIFF
--- a/pimcore/lib/Pimcore/Event/AssetEvents.php
+++ b/pimcore/lib/Pimcore/Event/AssetEvents.php
@@ -31,6 +31,13 @@ final class AssetEvents
     const POST_ADD = 'pimcore.asset.postAdd';
 
     /**
+     * @Event("Pimcore\Event\Model\AssetEvent")
+     *
+     * @var string
+     */
+    const POST_ADD_FAILURE = 'pimcore.asset.postAddFailure';
+
+    /**
      * Arguments:
      *  - saveVersionOnly | is set if method saveVersion() was called instead of save()
      *
@@ -51,6 +58,16 @@ final class AssetEvents
     const POST_UPDATE = 'pimcore.asset.postUpdate';
 
     /**
+     * Arguments:
+     *  - saveVersionOnly | is set if method saveVersion() was called instead of save()
+     *
+     * @Event("Pimcore\Event\Model\AssetEvent")
+     *
+     * @var string
+     */
+    const POST_UPDATE_FAILURE = 'pimcore.asset.postUpdateFailure';
+
+    /**
      * @Event("Pimcore\Event\Model\AssetEvent")
      *
      * @var string
@@ -63,6 +80,13 @@ final class AssetEvents
      * @var string
      */
     const POST_DELETE = 'pimcore.asset.postDelete';
+
+    /**
+     * @Event("Pimcore\Event\Model\AssetEvent")
+     *
+     * @var string
+     */
+    const POST_DELETE_FAILURE = 'pimcore.asset.postDeleteFailure';
 
     /**
      * Arguments:

--- a/pimcore/lib/Pimcore/Event/DataObjectEvents.php
+++ b/pimcore/lib/Pimcore/Event/DataObjectEvents.php
@@ -82,6 +82,13 @@ final class DataObjectEvents
     const POST_DELETE = 'pimcore.dataobject.postDelete';
 
     /**
+     * @Event("Pimcore\Event\Model\DataObjectEvent")
+     *
+     * @var string
+     */
+    const POST_DELETE_FAILURE = 'pimcore.dataobject.postDeleteFailure';
+
+    /**
      * Arguments:
      *  - base_element | Pimcore\Model\Document | contains the base document used in copying process
      *

--- a/pimcore/lib/Pimcore/Event/DataObjectEvents.php
+++ b/pimcore/lib/Pimcore/Event/DataObjectEvents.php
@@ -31,6 +31,13 @@ final class DataObjectEvents
     const POST_ADD = 'pimcore.dataobject.postAdd';
 
     /**
+     * @Event("Pimcore\Event\Model\DataObjectEvent")
+     *
+     * @var string
+     */
+    const POST_ADD_FAILURE = 'pimcore.dataobject.postAddFailure';
+
+    /**
      * Arguments:
      *  - saveVersionOnly | is set if method saveVersion() was called instead of save()
      *
@@ -49,6 +56,16 @@ final class DataObjectEvents
      * @var string
      */
     const POST_UPDATE = 'pimcore.dataobject.postUpdate';
+
+    /**
+     * Arguments:
+     *  - saveVersionOnly | is set if method saveVersion() was called instead of save()
+     *
+     * @Event("Pimcore\Event\Model\DataObjectEvent")
+     *
+     * @var string
+     */
+    const POST_UPDATE_FAILURE = 'pimcore.dataobject.postUpdateFailure';
 
     /**
      * @Event("Pimcore\Event\Model\DataObjectEvent")

--- a/pimcore/lib/Pimcore/Event/DocumentEvents.php
+++ b/pimcore/lib/Pimcore/Event/DocumentEvents.php
@@ -31,6 +31,13 @@ final class DocumentEvents
     const POST_ADD = 'pimcore.document.postAdd';
 
     /**
+     * @Event("Pimcore\Event\Model\DocumentEvent")
+     *
+     * @var string
+     */
+    const POST_ADD_FAILURE = 'pimcore.document.postAddFailure';
+
+    /**
      * Arguments:
      *  - saveVersionOnly | is set if method saveVersion() was called instead of save()
      *
@@ -51,6 +58,16 @@ final class DocumentEvents
     const POST_UPDATE = 'pimcore.document.postUpdate';
 
     /**
+     * Arguments:
+     *  - saveVersionOnly | is set if method saveVersion() was called instead of save()
+     *
+     * @Event("Pimcore\Event\Model\DocumentEvent")
+     *
+     * @var string
+     */
+    const POST_UPDATE_FAILURE = 'pimcore.document.postUpdateFailure';
+
+    /**
      * @Event("Pimcore\Event\Model\DocumentEvent")
      *
      * @var string
@@ -63,6 +80,13 @@ final class DocumentEvents
      * @var string
      */
     const POST_DELETE = 'pimcore.document.postDelete';
+
+    /**
+     * @Event("Pimcore\Event\Model\DocumentEvent")
+     *
+     * @var string
+     */
+    const POST_DELETE_FAILURE = 'pimcore.document.postDeleteFailure';
 
     /**
      * Processor contains the processor object used to generate the PDF

--- a/pimcore/models/Asset.php
+++ b/pimcore/models/Asset.php
@@ -599,7 +599,7 @@ class Asset extends Element\AbstractElement
             $parent = Asset::getById($this->getParentId());
             if ($parent) {
                 // use the parent's path from the database here (getCurrentFullPath), to ensure the path really exists and does not rely on the path
-                // that is currently in the parent object (in memory), because this might have changed but wasn't not saved
+                // that is currently in the parent asset (in memory), because this might have changed but wasn't not saved
                 $this->setPath(str_replace('//', '/', $parent->getCurrentFullPath() . '/'));
             } else {
                 // parent document doesn't exist anymore, set the parent to to root
@@ -757,7 +757,7 @@ class Asset extends Element\AbstractElement
 
         $this->getDao()->update();
 
-        //set object to registry
+        //set asset to registry
         \Pimcore\Cache\Runtime::set('asset_' . $this->getId(), $this);
         if (get_class($this) == 'Asset' || $typeChanged) {
             // get concrete type of asset
@@ -802,7 +802,7 @@ class Asset extends Element\AbstractElement
         $version = null;
 
         // only create a new version if there is at least 1 allowed
-        // or if saveVersion() was called directly (it's a newer version of the object)
+        // or if saveVersion() was called directly (it's a newer version of the asset)
         if (Config::getSystemConfig()->assets->versions->steps
             || Config::getSystemConfig()->assets->versions->days
             || $setModificationDate) {
@@ -1032,10 +1032,10 @@ class Asset extends Element\AbstractElement
             // remove from resource
             $this->getDao()->delete();
 
-            // empty object cache
+            // empty asset cache
             $this->clearDependentCache();
 
-            //set object to registry
+            // clear asset from registry
             \Pimcore\Cache\Runtime::set('asset_' . $this->getId(), null);
         } catch (\Exception $e) {
             \Pimcore::getEventDispatcher()->dispatch(AssetEvents::POST_DELETE_FAILURE, new AssetEvent($this));
@@ -1832,12 +1832,12 @@ class Asset extends Element\AbstractElement
         $parentVars = parent::__sleep();
 
         if (isset($this->_fulldump)) {
-            // this is if we want to make a full dump of the object (eg. for a new version), including childs for recyclebin
+            // this is if we want to make a full dump of the asset (eg. for a new version), including childs for recyclebin
             $blockedVars = ['scheduledTasks', 'dependencies', 'userPermissions', 'hasChilds', 'versions', 'parent', 'stream'];
             $finalVars[] = '_fulldump';
             $this->removeInheritedProperties();
         } else {
-            // this is if we want to cache the object
+            // this is if we want to cache the asset
             $blockedVars = ['scheduledTasks', 'dependencies', 'userPermissions', 'hasChilds', 'versions', 'childs', 'properties', 'stream', 'parent'];
         }
 

--- a/pimcore/models/Asset.php
+++ b/pimcore/models/Asset.php
@@ -1040,6 +1040,7 @@ class Asset extends Element\AbstractElement
         } catch (\Exception $e) {
             \Pimcore::getEventDispatcher()->dispatch(AssetEvents::POST_DELETE_FAILURE, new AssetEvent($this));
             Logger::crit($e);
+            throw $e;
         }
 
         \Pimcore::getEventDispatcher()->dispatch(AssetEvents::POST_DELETE, new AssetEvent($this));

--- a/pimcore/models/DataObject/AbstractObject.php
+++ b/pimcore/models/DataObject/AbstractObject.php
@@ -565,6 +565,7 @@ class AbstractObject extends Model\Element\AbstractElement
         } catch (\Exception $e) {
             \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_DELETE_FAILURE, new DataObjectEvent($this));
             Logger::crit($e);
+            throw $e;
         }
 
         \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_DELETE, new DataObjectEvent($this));

--- a/pimcore/models/DataObject/AbstractObject.php
+++ b/pimcore/models/DataObject/AbstractObject.php
@@ -560,7 +560,7 @@ class AbstractObject extends Model\Element\AbstractElement
             // empty object cache
             $this->clearDependentCache();
 
-            //set object to registry
+            //clear object from registry
             \Pimcore\Cache\Runtime::set('object_' . $this->getId(), null);
         } catch (\Exception $e) {
             \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_DELETE_FAILURE, new DataObjectEvent($this));

--- a/pimcore/models/DataObject/AbstractObject.php
+++ b/pimcore/models/DataObject/AbstractObject.php
@@ -663,6 +663,12 @@ class AbstractObject extends Model\Element\AbstractElement
 
                     usleep($waitTime); // wait specified time until we restart the transaction
                 } else {
+                    if ($isUpdate) {
+                        \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_UPDATE_FAILURE, new DataObjectEvent($this));
+                    } else {
+                        \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_ADD_FAILURE, new DataObjectEvent($this));
+                    }
+                    
                     // if the transaction still fail after $maxRetries retries, we throw out the exception
                     Logger::error('Finally giving up restarting the same transaction again and again, last message: ' . $e->getMessage());
                     throw $e;

--- a/pimcore/models/Document.php
+++ b/pimcore/models/Document.php
@@ -605,7 +605,7 @@ class Document extends Element\AbstractElement
 
         $this->getDao()->update();
 
-        //set object to registry
+        //set document to registry
         \Pimcore\Cache\Runtime::set('document_' . $this->getId(), $this);
     }
 
@@ -819,7 +819,7 @@ class Document extends Element\AbstractElement
             // clear cache
             $this->clearDependentCache();
 
-            //set object to registry
+            //clear document from registry
             \Pimcore\Cache\Runtime::set('document_' . $this->getId(), null);
         } catch (\Exception $e) {
             \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_DELETE_FAILURE, new DocumentEvent($this));

--- a/pimcore/models/Document.php
+++ b/pimcore/models/Document.php
@@ -474,6 +474,11 @@ class Document extends Element\AbstractElement
 
                     usleep($waitTime); // wait specified time until we restart the transaction
                 } else {
+                    if ($isUpdate) {
+                        \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_UPDATE_FAILURE, new DocumentEvent($this));
+                    } else {
+                        \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_ADD_FAILURE, new DocumentEvent($this));
+                    }
                     // if the transaction still fail after $maxRetries retries, we throw out the exception
                     throw $e;
                 }
@@ -783,39 +788,42 @@ class Document extends Element\AbstractElement
     public function delete()
     {
         \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::PRE_DELETE, new DocumentEvent($this));
-
-        // remove childs
-        if ($this->hasChildren()) {
-            // delete also unpublished children
-            $unpublishedStatus = self::doHideUnpublished();
-            self::setHideUnpublished(false);
-            foreach ($this->getChildren(true) as $child) {
-                $child->delete();
+        try {
+            // remove childs
+            if ($this->hasChildren()) {
+                // delete also unpublished children
+                $unpublishedStatus = self::doHideUnpublished();
+                self::setHideUnpublished(false);
+                foreach ($this->getChildren(true) as $child) {
+                    $child->delete();
+                }
+                self::setHideUnpublished($unpublishedStatus);
             }
-            self::setHideUnpublished($unpublishedStatus);
+
+            // remove all properties
+            $this->getDao()->deleteAllProperties();
+
+            // remove permissions
+            $this->getDao()->deleteAllPermissions();
+
+            // remove dependencies
+            $d = $this->getDependencies();
+            $d->cleanAllForElement($this);
+
+            // remove translations
+            $service = new Document\Service;
+            $service->removeTranslation($this);
+
+            $this->getDao()->delete();
+
+            // clear cache
+            $this->clearDependentCache();
+
+            //set object to registry
+            \Pimcore\Cache\Runtime::set('document_' . $this->getId(), null);
+        } catch (\Exception $e) {
+            \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_DELETE_FAILURE, new DocumentEvent($this));
         }
-
-        // remove all properties
-        $this->getDao()->deleteAllProperties();
-
-        // remove permissions
-        $this->getDao()->deleteAllPermissions();
-
-        // remove dependencies
-        $d = $this->getDependencies();
-        $d->cleanAllForElement($this);
-
-        // remove translations
-        $service = new Document\Service;
-        $service->removeTranslation($this);
-
-        $this->getDao()->delete();
-
-        // clear cache
-        $this->clearDependentCache();
-
-        //set object to registry
-        \Pimcore\Cache\Runtime::set('document_' . $this->getId(), null);
 
         \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_DELETE, new DocumentEvent($this));
     }

--- a/pimcore/models/Document.php
+++ b/pimcore/models/Document.php
@@ -823,6 +823,8 @@ class Document extends Element\AbstractElement
             \Pimcore\Cache\Runtime::set('document_' . $this->getId(), null);
         } catch (\Exception $e) {
             \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_DELETE_FAILURE, new DocumentEvent($this));
+            Logger::error($e);
+            throw $e;
         }
 
         \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_DELETE, new DocumentEvent($this));


### PR DESCRIPTION
## Fixes #236

## Changes in this pull request  
Added events for failure handling:
- DataObjectEvents::POST_ADD_FAILURE
- DataObjectEvents::POST_UPDATE_FAILURE
- DataObjectEvents::POST_DELETE_FAILURE
- AssetEvents::POST_ADD_FAILURE
- AssetEvents::POST_UPDATE_FAILURE
- AssetEvents::POST_DELETE_FAILURE
- DocumentEvents::POST_ADD_FAILURE
- DocumentEvents::POST_UPDATE_FAILURE
- DocumentEvents::POST_DELETE_FAILURE

