### PR TITLE
Set Branch Alias for dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -173,6 +173,9 @@
       "merge-extra": false,
       "merge-extra-deep": false,
       "merge-scripts": false
+    },
+    "branch-alias": {
+      "dev-master": "5.2.x-dev"
     }
   }
 }


### PR DESCRIPTION
I want set a composer require of a bundle for pimcore because of testing.
e. g.
```
"require": {
  "pimcore/pimcore": "^5.2"
}
```

Than i have the problem that the bundle isn't be able to install in a normal pimcore installation.
Because dev-master has no version. With a branch alias it will be work.