### PR TITLE
[DOC] Update documentation example, use the defaultValue

### DIFF
--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/08_Dynamic_Select_Types.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/08_Dynamic_Select_Types.md
@@ -63,12 +63,13 @@ class OptionsProvider implements SelectOptionsProviderInterface
     }
 
     /**
+     * Returns the value which is defined in the 'Default value' field  
      * @param $context array
      * @param $fieldDefinition Data
      * @return mixed
      */
     public function getDefaultValue($context, $fieldDefinition) {
-        return 4;
+        return $fieldDefinition->getDefaultValue();
     }
 
     /**


### PR DESCRIPTION
Updated the code example to explain how to get the default value back from the fielddefinition.
