### PR TITLE
Fixed PHPDoc for type

### DIFF
--- a/pimcore/models/DataObject/ClassDefinition/Data/Block.php
+++ b/pimcore/models/DataObject/ClassDefinition/Data/Block.php
@@ -88,7 +88,7 @@ class Block extends Model\DataObject\ClassDefinition\Data
      *
      * @var string
      */
-    public $phpdocType = '\\Pimcore\\Model\\DataObject\\Data\\Block';
+    public $phpdocType = '\\Pimcore\\Model\\DataObject\\Data\\BlockElement[][]';
 
     /**
      * @var array


### PR DESCRIPTION
get() on a Block element in a DataObject doesn't return Data\Block but Data\BlockElement, and to be more specific an array of an array of BlockElements.

It's possible to specify that as FooBar[][], which as notation will be accepted by e.g. PhpStorm:

![auswahl_182](https://user-images.githubusercontent.com/1055202/38982529-5b99c122-43c2-11e8-8fc3-90fdbfd4d039.png)

For testing this: unfortunately there's apparantly a bug in PhpStorm since the return hint won't suffice:
![auswahl_183](https://user-images.githubusercontent.com/1055202/38982606-9a0a54e4-43c2-11e8-8748-1a2d5ca641ed.png)
![auswahl_184](https://user-images.githubusercontent.com/1055202/38982731-e9af8ee2-43c2-11e8-8ee6-b2f1b3cb769c.png)

I'll file a bug report with PhpStorm as soon as possible.