### PR TITLE
Bugfix: Cart price modificated twice

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
@@ -301,6 +301,7 @@ class Configuration implements ConfigurationInterface
                                     ->append($this->buildOptionsNode('factory_options'))
                                     ->arrayNode('modificators')
                                         ->info('List price modificators for cart, e.g. for shipping-cost, special discounts, etc. Key is name of modificator.')
+                                        ->useAttributeAsKey('name')
                                         ->prototype('array')
                                             ->children()
                                                 ->scalarNode('class')->isRequired()->end()


### PR DESCRIPTION
The cart price modificators are collected twice by PimcoreEcommerceFrameworkExtension::registerCartManagerConfiguration().
This fixes it.

Currently the read configuration results in an array like this:
![auswahl_187](https://user-images.githubusercontent.com/1055202/39034648-718297f6-4477-11e8-835a-84fe6368aecc.png)
The modificators are read twice, with their names as key and a numeric value.
This results in them being applied twice to the cart price.

This fix to the configuration definition results in omitting the numeric index:
![auswahl_186](https://user-images.githubusercontent.com/1055202/39034703-a347c70c-4477-11e8-9cfc-4e35aa3ac752.png)

