### PR TITLE
Short hand for getters/setters on Objects 

### DIFF
--- a/pimcore/models/DataObject/AbstractObject.php
+++ b/pimcore/models/DataObject/AbstractObject.php
@@ -1287,4 +1287,26 @@ class AbstractObject extends Model\Element\AbstractElement
     {
         self::$doNotRestoreKeyAndPath = $doNotRestoreKeyAndPath;
     }
+
+    /**
+    * @param string $fieldName
+    * @param null $language
+    * @return mixed
+    */
+    public function get($fieldName, $language = null)
+    {
+        return $this->{"get".ucfirst($fieldName)}($language);
+    }
+
+    /**
+    * @param string $fieldName
+    * @param $value
+    * @param null $language
+    * @return mixed
+    */
+    public function set($fieldName, $value, $language = null)
+    {
+        return $this->{"set".ucfirst($fieldName)}($value, $language);
+
+    }
 }

--- a/pimcore/models/DataObject/Fieldcollection/Data/AbstractData.php
+++ b/pimcore/models/DataObject/Fieldcollection/Data/AbstractData.php
@@ -121,4 +121,26 @@ abstract class AbstractData extends Model\AbstractModel
     {
         return $this->object;
     }
+
+    /**
+    * @param string $fieldName
+    * @param null $language
+    * @return mixed
+    */
+    public function get($fieldName, $language = null)
+    {
+        return $this->{"get".ucfirst($fieldName)}($language);
+    }
+
+    /**
+    * @param string $fieldName
+    * @param $value
+    * @param null $language
+    * @return mixed
+    */
+    public function set($fieldName, $value, $language = null)
+    {
+        return $this->{"set".ucfirst($fieldName)}($value, $language);
+
+    }
 }

--- a/pimcore/models/DataObject/Objectbrick.php
+++ b/pimcore/models/DataObject/Objectbrick.php
@@ -288,4 +288,24 @@ class Objectbrick extends Model\AbstractModel
             }
         }
     }
+
+    /**
+    * @param string $fieldName
+    * @return mixed
+    */
+    public function get($fieldName)
+    {
+        return $this->{"get".ucfirst($fieldName)}();
+    }
+
+    /**
+    * @param string $fieldName
+    * @param $value
+    * @return mixed
+    */
+    public function set($fieldName, $value)
+    {
+        return $this->{"set".ucfirst($fieldName)}($value);
+
+    }
 }

--- a/pimcore/models/DataObject/Objectbrick/Data/AbstractData.php
+++ b/pimcore/models/DataObject/Objectbrick/Data/AbstractData.php
@@ -196,4 +196,24 @@ abstract class AbstractData extends Model\AbstractModel
 
         return false;
     }
+
+    /**
+    * @param string $fieldName
+    * @return mixed
+    */
+    public function get($fieldName)
+    {
+        return $this->{"get".ucfirst($fieldName)}();
+    }
+
+    /**
+    * @param string $fieldName
+    * @param $value
+    * @return mixed
+    */
+    public function set($fieldName, $value)
+    {
+        return $this->{"set".ucfirst($fieldName)}($value);
+
+    }
 }


### PR DESCRIPTION
## Fixes #1312 
## Changes in this pull request  
Added getters & setters short hand for Objects. 

Shorthand getter
`$value = $object->get($field);`

Shorthand setter
$language is optional. 
`$object->set($field, $value, $language);`
## Additional info  

