### PR TITLE
Fix _toString returning null instead of ''

### DIFF
--- a/pimcore/models/DataObject/Data/ExternalImage.php
+++ b/pimcore/models/DataObject/Data/ExternalImage.php
@@ -53,6 +53,6 @@ class ExternalImage
      */
     public function __toString()
     {
-        return $this->url;
+        return (is_null($this->url)) ? '' : $this->url;
     }
 }


### PR DESCRIPTION
When you try to see the history of an object that has an external image that was empty the system prints an error message.


## Please make sure your PR complies with all of the following points: 
- [X] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [X] Features need to be proper documented in `doc/`
- [X] Bugfixes need a short guide how to reproduce them. 
- [X] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [X] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
  
  
## Fixes Issue #
When you try to see the history of an object that has an external image that is empty you will get an exception that will be shown on the screen.
Examples:
[demo.pimcore](https://i.imgur.com/7X00YoD.png)
[localhost](https://i.imgur.com/wGNmjoo.png)
## Changes in this pull request  
Changed the method __toString of the class ExternalImage, to return an empty string '', instead of null.

## Additional info  

