### PR TITLE
Add object open listener on ID & Path columns in object grid

### DIFF
--- a/web/pimcore/static6/js/pimcore/object/folder/search.js
+++ b/web/pimcore/static6/js/pimcore/object/folder/search.js
@@ -309,6 +309,15 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
                 forceFit: false,
                 xtype: 'patchedgridview'
             },
+            listeners: {
+                celldblclick: function(grid, td, cellIndex, record, tr, rowIndex, e, eOpts) {
+                    var columnName = grid.ownerGrid.getColumns();
+                    if(columnName[cellIndex].text == 'ID' || columnName[cellIndex].text == 'Path') {
+                        var data = this.store.getAt(rowIndex);
+                        pimcore.helpers.openObject(data.get("id"), data.get("type"));
+                    }
+                }
+            },
             cls: 'pimcore_object_grid_panel',
             tbar: [this.languageInfo, "-", this.toolbarFilterInfo, this.clearFilterButton, "->", this.checkboxOnlyDirectChildren, "-", this.sqlEditor, this.sqlButton, "-", {
                 text: t("search_and_move"),


### PR DESCRIPTION
## Fixes #1359

## Changes in this pull request  
Added double click listener on "ID" & "Path" column to open object on grid.
## Additional info  

