### PR TITLE
Prevent duplicates in CheckoutStepOrder

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
@@ -658,6 +658,7 @@ class Configuration implements ConfigurationInterface
                             ->arrayNode('steps')
                                 ->info('Define different checkout steps which need to be committed before commit of order is possible')
                                 ->requiresAtLeastOneElement()
+                                ->useAttributeAsKey('name')
                                 ->prototype('array')
                                     ->children()
                                         ->scalarNode('class')


### PR DESCRIPTION
Fixes [adding a checkout-step](https://github.com/pimcore/pimcore/blob/master/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/CheckoutManager/CheckoutManager.php#L137) to $checkoutStepOrder[] more than once.
