### PR TITLE
urlencode double quotes (") for anchors in link editable

### DIFF
--- a/pimcore/models/Document/Tag/Link.php
+++ b/pimcore/models/Document/Tag/Link.php
@@ -150,7 +150,9 @@ class Link extends Model\Document\Tag
         }
 
         if (strlen($this->data["anchor"]) > 0) {
-            $url .= "#" . str_replace("#", "", $this->getAnchor());
+            $anchor = $this->getAnchor();
+            $anchor = str_replace('"', urlencode('"'), $anchor);
+            $url .= "#" . str_replace("#", "", $anchor);
         }
 
         return $url;


### PR DESCRIPTION
# Anchors with " will break link

## Expected behavior
When I add an anchor to a ‚link‘ editable the double quotes (") should be urlencoded, so that a link does not break at the first double quote.
For some JS links you have, e.g. www.domain.de/page#{"selectedFilters"%3A[]}.
This is a Json String.

## Actual behavior
Double quotes in an anchor of a ‚link‘ editable will break the link.

## Steps to reproduce
Add an anchor to a ‚link‘ editable with double quotes like ‚#{„selectedFilters"%3A[]}‘.
Check the link which is rendered in the frontend.

You can check this with the element ‚Icon teaser‘ link on the following demo page.
https://demo-basic.pimcore.org/en/basic-examples/content-page
You will see the rendered link is https://demo-basic.pimcore.org/en/basic-examples/html5-video#{