### PR TITLE
Website setting empty icon don't work 

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/SettingsController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/SettingsController.php
@@ -1825,7 +1825,7 @@ class SettingsController extends AdminController
                                 if ($path != null) {
                                     $element = Element\Service::getElementByPath($setting->getType(), $path);
                                 }
-                                    $data['data'] = $element ? $element->getId() : null;
+                                $data['data'] = $element ? $element->getId() : null;
                             }
                             break;
                     }

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/SettingsController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/SettingsController.php
@@ -1811,6 +1811,7 @@ class SettingsController extends AdminController
                     $setting->delete();
 
                     return $this->adminJson(['success' => true, 'data' => []]);
+
                 } elseif ($request->get('xaction') == 'update') {
                     // save routes
                     $setting = WebsiteSetting::getById($data['id']);
@@ -1821,11 +1822,14 @@ class SettingsController extends AdminController
                         case 'object':
                             if (isset($data['data'])) {
                                 $path = $data['data'];
-                                $element = Element\Service::getElementByPath($setting->getType(), $path);
-                                $data['data'] = $element ? $element->getId() : null;
+                                if ($path != null) {
+                                    $element = Element\Service::getElementByPath($setting->getType(), $path);
+                                }
+                                    $data['data'] = $element ? $element->getId() : null;
                             }
                             break;
                     }
+
 
                     $setting->setValues($data);
 

--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/SettingsController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/SettingsController.php
@@ -1811,7 +1811,6 @@ class SettingsController extends AdminController
                     $setting->delete();
 
                     return $this->adminJson(['success' => true, 'data' => []]);
-
                 } elseif ($request->get('xaction') == 'update') {
                     // save routes
                     $setting = WebsiteSetting::getById($data['id']);
@@ -1830,9 +1829,7 @@ class SettingsController extends AdminController
                             break;
                     }
 
-
                     $setting->setValues($data);
-
                     $setting->save();
 
                     $data = $this->getWebsiteSettingForEditMode($setting);


### PR DESCRIPTION
 ## Fixes Issue #2800 

## Changes in this pull request  
Website settings empty icon is now setting empty path instead of "/".

## Additional info  

