### PR TITLE
Correctly determine pagination direction when using "show in tree" function

### DIFF
--- a/web/pimcore/static6/js/pimcore/treenodelocator.js
+++ b/web/pimcore/static6/js/pimcore/treenodelocator.js
@@ -253,9 +253,9 @@ pimcore.treenodelocator.getDirectionForElementsSortedByKey = function (elementKe
     var direction = 0;
 
     if (eType == "folder") {
-        if (firstFolderChild && elementKey.toLowerCase() < firstFolderChild.data.text.toLowerCase()) {
+        if (firstFolderChild && elementKey.toUpperCase() < firstFolderChild.data.text.toUpperCase()) {
             direction = -1;
-        } else if (lastFolderChild && elementKey.toLowerCase() > lastFolderChild.data.text.toLowerCase()) {
+        } else if (lastFolderChild && elementKey.toUpperCase() > lastFolderChild.data.text.toUpperCase()) {
             direction = 1;
         } else if (firstElementChild) {
             direction = -1;
@@ -263,9 +263,9 @@ pimcore.treenodelocator.getDirectionForElementsSortedByKey = function (elementKe
     } else {
         if (lastFolderChild) {
             direction = 1;
-        } else if (firstElementChild && elementKey.toLowerCase() < firstElementChild.data.text.toLowerCase()) {
+        } else if (firstElementChild && elementKey.toUpperCase() < firstElementChild.data.text.toUpperCase()) {
             direction = -1;
-        } else if (lastElementChild && elementKey.toLowerCase() > lastElementChild.data.text.toLowerCase()) {
+        } else if (lastElementChild && elementKey.toUpperCase() > lastElementChild.data.text.toUpperCase()) {
             direction = 1;
         }
     }


### PR DESCRIPTION
## Fixes Issue #2530 #

### Steps to reproduce (without this PR's changes)
1. Create data object with key "aa" in folder x. Copy and paste it until tree items in folder x paginate and the last object on page 1 has a key "aa_*". 
1. Now create object with key "a_". Object gets opened
1. Go to page 1 in tree of folder x
1. click "show in tree" in object "a_"
1. Object does not get found in tree