### PR TITLE
Fixed asset gets processed as Document

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/ElementListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/ElementListener.php
@@ -118,7 +118,7 @@ class ElementListener implements EventSubscriberInterface, LoggerAwareInterface
             $user = $this->userLoader->getUser();
         }
 
-        if (!$document->isPublished() && !$user && !$request->attributes->get(self::FORCE_ALLOW_PROCESSING_UNPUBLISHED_ELEMENTS)) {
+        if (!$document->isPublished() && !$user && !$request->attributes->get(self::FORCE_ALLOW_PROCESSING_UNPUBLISHED_ELEMENTS) && empty($request->attributes->get('assetId'))) {
             $this->logger->warning('Denying access to document {document} as it is unpublished and there is no user in the session.', [
                 $document->getFullPath()
             ]);


### PR DESCRIPTION
## Fixes Issue #2704

## Changes in this pull request  
Added Asset Id empty check for unpublished document exception throw so that asset thumbnail will be generated
## Additional info  

