### PR TITLE
Fixed web2print with svg not working

### DIFF
--- a/pimcore/models/Asset/Image/Thumbnail/Processor.php
+++ b/pimcore/models/Asset/Image/Thumbnail/Processor.php
@@ -127,7 +127,7 @@ class Processor
                     }
                 }
             } elseif ($format == 'svg') {
-                return str_replace(PIMCORE_WEB_ROOT, '', $fileSystemPath);
+                return $asset->getFullPath();
             }
         } elseif ($format == 'tiff') {
             if (\Pimcore\Tool::isFrontentRequestByAdmin()) {

--- a/pimcore/models/Asset/Image/Thumbnail/Processor.php
+++ b/pimcore/models/Asset/Image/Thumbnail/Processor.php
@@ -111,7 +111,7 @@ class Processor
         if ($format == 'print') {
             $format = self::getAllowedFormat($fileExt, ['svg', 'jpeg', 'png', 'tiff'], 'png');
 
-            if (($format == 'tiff' || $format == 'svg') && \Pimcore\Tool::isFrontentRequestByAdmin()) {
+            if (($format == 'tiff') && \Pimcore\Tool::isFrontentRequestByAdmin()) {
                 // return a webformat in admin -> tiff cannot be displayed in browser
                 $format = 'png';
                 $deferred = false; // deferred is default, but it's not possible when using isFrontentRequestByAdmin()
@@ -127,7 +127,7 @@ class Processor
                     }
                 }
             } elseif ($format == 'svg') {
-                return self::returnPath($fileSystemPath, $returnAbsolutePath);
+                return str_replace(PIMCORE_WEB_ROOT, '', $fileSystemPath);
             }
         } elseif ($format == 'tiff') {
             if (\Pimcore\Tool::isFrontentRequestByAdmin()) {


### PR DESCRIPTION
resolves #2789

## Changes in this pull request  
Replaced absolute path of svg file to render image when thumbnail type is "print"
## Additional info  

