### PR TITLE
Fix: Imagick couldn't load images with colon in path

### DIFF
--- a/pimcore/lib/Pimcore/Image/Adapter/Imagick.php
+++ b/pimcore/lib/Pimcore/Image/Adapter/Imagick.php
@@ -102,7 +102,7 @@ class Imagick extends Adapter
                 $i->setResolution($options['resolution']['x'], $options['resolution']['y']);
             }
 
-            $imagePathLoad = $imagePath;
+            $imagePathLoad = ':' . $imagePath;
             if (!defined('HHVM_VERSION')) {
                 $imagePathLoad .= '[0]'; // not supported by HHVM implementation - selects the first layer/page in layered/pages file formats
             }


### PR DESCRIPTION
If the path (folder or filename) has a colon (:), Imagick couldn't load the image.

Reason is: Imagick use the colon to specify the type of the image.
https://stackoverflow.com/questions/45878100/handle-colon-in-filename-with-imagemagick


## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
  
  
## Fixes Issue #

## Changes in this pull request  

## Additional info  

