### PR TITLE
Fix for CSV export.

### DIFF
--- a/pimcore/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/pimcore/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -352,10 +352,9 @@ class QuantityValue extends Model\DataObject\ClassDefinition\Data
      */
     public function getForCsvExport($object, $params = [])
     {
-        $key = $this->getName();
-        $getter = 'get'.ucfirst($key);
-        if ($object->$getter() instanceof \Pimcore\Model\DataObject\Data\QuantityValue) {
-            return $object->$getter()->getValue() . '_' . $object->$getter()->getUnitId();
+        $data = $this->getDataFromObjectParam($object, $params);
+        if ($data instanceof \Pimcore\Model\DataObject\Data\QuantityValue) {
+            return $data->getValue() . '_' . $data->getUnitId();
         } else {
             return null;
         }


### PR DESCRIPTION
## Fixes Issue
An error exists when you're exporting into csv file any field of type QuantityValue which is located under classification store. This PR resolves it.

## How to reproduce the issue
Add classification store field with QuantityValue key to class. Try to export objects into csv file. You should get "Internal Server Error".

## Changes in this pull request  
This PR fixes QuantityValue::getForCsvExport() method.