### PR TITLE
set options and id before firing preOpen Event

### DIFF
--- a/web/pimcore/static6/js/pimcore/document/printabstract.js
+++ b/web/pimcore/static6/js/pimcore/document/printabstract.js
@@ -18,12 +18,12 @@ pimcore.document.printabstract = Class.create(pimcore.document.page_snippet, {
     type: "printabstract",
 
     initialize: function(id, options) {
-
+        this.id = intval(id);
         this.options = options;
+        
         pimcore.plugin.broker.fireEvent("preOpenDocument", this, this.getType());
 
         this.addLoadingPanel();
-        this.id = intval(id);
         this.getData();
     },
 

--- a/web/pimcore/static6/js/pimcore/object/object.js
+++ b/web/pimcore/static6/js/pimcore/object/object.js
@@ -15,12 +15,12 @@ pimcore.registerNS("pimcore.object.object");
 pimcore.object.object = Class.create(pimcore.object.abstract, {
 
     initialize: function (id, options) {
+        this.id = intval(id);
+        this.options = options;
+        
         pimcore.plugin.broker.fireEvent("preOpenObject", this, "object");
 
-        this.id = intval(id);
         this.addLoadingPanel();
-
-        this.options = options;
 
         var user = pimcore.globalmanager.get("user");
 


### PR DESCRIPTION
Setting ID, Options before preOpen Event, otherwise the event has no sense for objects. Also did it for print documents.