### PR TITLE
FFMPEG transformation fails if folder path of video contains umlaute 

### DIFF
--- a/pimcore/lib/Pimcore/Video/Adapter/Ffmpeg.php
+++ b/pimcore/lib/Pimcore/Video/Adapter/Ffmpeg.php
@@ -117,7 +117,7 @@ class Ffmpeg extends Adapter
             // add some global arguments
             $arguments = '-threads 0 ' . $arguments;
 
-            $cmd = self::getFfmpegCli() . ' -i ' . escapeshellarg(realpath($this->file)) . ' ' . $arguments . ' ' . escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, $this->getDestinationFile()));
+            $cmd = self::getFfmpegCli() . ' -i ' . realpath($this->file) . ' ' . $arguments . ' ' . str_replace('/', DIRECTORY_SEPARATOR, $this->getDestinationFile());
 
             Logger::debug('Executing FFMPEG Command: ' . $cmd);
 
@@ -163,7 +163,7 @@ class Ffmpeg extends Adapter
             $file = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/ffmpeg-tmp-' . uniqid() . '.' . File::getFileExtension($file);
         }
 
-        $cmd = self::getFfmpegCli() . ' -i ' . escapeshellarg(realpath($this->file)) . ' -vcodec png -vframes 1 -vf scale=iw*sar:ih -ss ' . $timeOffset . ' ' . escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, $file));
+        $cmd = self::getFfmpegCli() . ' -i ' . realpath($this->file) . ' -vcodec png -vframes 1 -vf scale=iw*sar:ih -ss ' . $timeOffset . ' ' . escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, $file));
         Console::exec($cmd, null, 60);
 
         if ($realTargetPath) {

--- a/pimcore/models/Asset/Video/Thumbnail/Processor.php
+++ b/pimcore/models/Asset/Video/Thumbnail/Processor.php
@@ -118,6 +118,7 @@ class Processor
 
             if (!is_dir(dirname($fsPath))) {
                 File::mkdir(dirname($fsPath));
+                @chmod($thumbDir, File::getDefaultMode());
             }
 
             if (is_file($fsPath)) {


### PR DESCRIPTION
resolves #2728 

## Changes in this pull request  
Changes in FFMPEG transformation if folder path of assets contains umlaute character.

## Additional info  
Support for umlaute chracters is already provided in Symfony core libraries and removes the use of escapeshellarg() function. Below is the link for more details:
https://github.com/PHP-FFMpeg/PHP-FFMpeg/issues/226
