### PR TITLE
Considers fallback languages in combination with empty values

### DIFF
--- a/pimcore/models/DataObject/Localizedfield/Dao.php
+++ b/pimcore/models/DataObject/Localizedfield/Dao.php
@@ -433,11 +433,13 @@ class Dao extends Model\Dao\AbstractDao
 
             // create query
             $sql = sprintf(
-                'ifnull(`%s`.`%s`, %s)',
-                $lang,
-                $field,
-                $fallback
+                'IF(`%s`.`%s` IS NULL OR `%s`.`%s` = "", %s, `%s`.`%s`)',
+                $lang, $field,
+                $lang, $field,
+                $fallback,
+                $lang, $field
             );
+
 
             return $fallback !== 'null'
                 ? $sql
@@ -467,7 +469,11 @@ class Dao extends Model\Dao\AbstractDao
                 $fallbackLanguages = array_unique(Tool::getFallbackLanguagesFor($language));
                 array_unshift($fallbackLanguages, $language);
                 foreach ($localizedColumns as $row) {
-                    $localizedFields[] = $getFallbackValue($row['Field'], $fallbackLanguages) . sprintf(' as "%s"', $row['Field']);
+                    if($row['Field'] == 'language' || $row['Field'] == 'ooo_id') {
+                        $localizedFields[] = $db->quoteIdentifier($language) . '.' . $db->quoteIdentifier($row['Field']);
+                    } else {
+                        $localizedFields[] = $getFallbackValue($row['Field'], $fallbackLanguages) . sprintf(' as "%s"', $row['Field']);
+                    }
                 }
 
                 // create view select fields

--- a/update-scripts/236/postupdate.php
+++ b/update-scripts/236/postupdate.php
@@ -1,0 +1,7 @@
+<?php
+
+$classList = new \Pimcore\Model\DataObject\ClassDefinition\Listing();
+$classes = $classList->load();
+foreach ($classes as $class) {
+    $class->save();
+}


### PR DESCRIPTION
fixes #2110 

we always treat null and empty as indicator for using fallback - so this also has to be considered in localized views. 

TODO: resave of classes necessary. 