### PR TITLE
Key shouldn't have a Slash

### DIFF
--- a/pimcore/models/Element/Service.php
+++ b/pimcore/models/Element/Service.php
@@ -875,6 +875,8 @@ class Service extends Model\AbstractModel
 
         // replace all 4 byte unicode characters
         $key = preg_replace('/[\x{10000}-\x{10FFFF}]/u', '-', $key);
+        
+        $key = str_replace('/', '-', $key);
 
         if ($type == 'document') {
             // no spaces & utf8 for documents / clean URLs


### PR DESCRIPTION
I think a key shouldn't have a Slash (/).

Assets and Folder disappear in WebDAV and it could have problems with paths.