### PR TITLE
ApplicationLogger set wrong relatedObjectType

### DIFF
--- a/pimcore/lib/Pimcore/Log/ApplicationLogger.php
+++ b/pimcore/lib/Pimcore/Log/ApplicationLogger.php
@@ -177,10 +177,16 @@ class ApplicationLogger implements LoggerInterface
         }
 
         if ($relatedObject) {
-            if ($relatedObject instanceof \Pimcore\Model\DataObject\AbstractObject or $relatedObject instanceof \Pimcore\Model\Document or $relatedObject instanceof \Pimcore\Model\Asset) {
-                $relatedObject = $relatedObject->getId();
-            }
-            if (is_numeric($relatedObject)) {
+            if ($relatedObject instanceof \Pimcore\Model\DataObject\AbstractObject) {
+                $context['relatedObject'] = $relatedObject->getId();
+                $context['relatedObjectType'] = 'object';
+            } elseif ($relatedObject instanceof \Pimcore\Model\Document) {
+                $context['relatedObject'] = $relatedObject->getId();
+                $context['relatedObjectType'] = 'document';
+            } elseif ($relatedObject instanceof \Pimcore\Model\Asset) {
+                $context['relatedObject'] = $relatedObject->getId();
+                $context['relatedObjectType'] = 'asset';
+            } elseif (is_numeric($relatedObject)) {
                 $context['relatedObject'] = $relatedObject;
                 $context['relatedObjectType'] = $this->relatedObjectType;
             }


### PR DESCRIPTION
If I use the ApplicationLogger direct without MonoLog, the ApplicationLogger always set "object" as relatedObjectType.

e. g.:

```
namespace TestNamespace;

use Pimcore\Log\ApplicationLogger;
use Pimcore\Model\Asset;

class ExampleClass
{
    /** @var \Pimcore\Log\ApplicationLogger */
    protected $applicationLogger;

    public function __construct(ApplicationLogger $applicationLogger)
    {
        $this->applicationLogger = $applicationLogger;
    }

    public function test()
    {
        $asset = Asset::getByPath('/Test.jpg')
        $this->applicationLogger->info(
            'Test',
            [
                'relatedObject' => $asset,
            ]
    }
}
```