### PR TITLE
Fixed wrong file creation mode

### DIFF
--- a/pimcore/lib/Pimcore/File.php
+++ b/pimcore/lib/Pimcore/File.php
@@ -161,7 +161,9 @@ class File
             $mode = self::$defaultMode;
         }
 
+        $oldMask = umask(0);
         $return = @mkdir($path, $mode, $recursive, self::getContext());
+        umask($oldMask);
 
         return $return;
     }


### PR DESCRIPTION
## Additional info  
The mkdir Method creates directories and files with wrong permissions.
How to reproduce:
1. Upload asset to some folder
2. Pimcore creates thumbnails in web/var/tmp
![image](https://user-images.githubusercontent.com/6016485/40174501-9d90d560-59d5-11e8-9543-924b8aa5b1a5.png)
The folder has no group rights
3. After bugfix the rights are correct
![image](https://user-images.githubusercontent.com/6016485/40174564-d1495a08-59d5-11e8-804f-6e0343e16669.png)

See also: https://stackoverflow.com/questions/7878784/php-mkdir-permissions
