### PR TITLE
Remove initial <p> on Translation Key WYSIWYG

### DIFF
--- a/web/pimcore/static6/js/pimcore/settings/translationEditor.js
+++ b/web/pimcore/static6/js/pimcore/settings/translationEditor.js
@@ -239,6 +239,7 @@ Ext.define('pimcore.settings.translationEditor', {
 
         //prevent override important settings!
         eConfig.resize_enabled = false;
+        eConfig.enterMode = CKEDITOR.ENTER_BR;
         eConfig.entities = false;
         eConfig.entities_greek = false;
         eConfig.entities_latin = false;


### PR DESCRIPTION
translationkeys should never wrappet in a <p> tag by default.