### PR TITLE
Skip linking glossary terms that match custom routes

### DIFF
--- a/pimcore/lib/Pimcore/Tool/Glossary/Processor.php
+++ b/pimcore/lib/Pimcore/Tool/Glossary/Processor.php
@@ -102,6 +102,7 @@ class Processor
 
         // get initial document from request (requested document, if it was a "document" request)
         $currentDocument = $this->documentResolver->getDocument();
+        $currentUri = $this->requestHelper->getMasterRequest()->getRequestUri();
 
         foreach ($data as $entry) {
             if ($currentDocument && $currentDocument instanceof Document) {
@@ -114,6 +115,11 @@ class Processor
                 if ($currentDocument->getFullPath() == rtrim($entry['linkTarget'], ' /')) {
                     continue;
                 }
+            }
+
+            // check if the current URI is the target link (path check)
+            if ($currentUri == rtrim($entry['linkTarget'], ' /')) {
+                continue;
             }
 
             $tmpData['search'][]  = $entry['search'];


### PR DESCRIPTION
Right now glossary terms skip self-linking on matching documents, which doesn't work if using glossary functionality on dynamic content (no underlying document).