### PR TITLE
Added phpDoc

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/OrderManager/OrderManager.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/OrderManager/OrderManager.php
@@ -218,6 +218,9 @@ class OrderManager implements IOrderManager
         ));
     }
 
+    /**
+     * @return Folder
+     */
     protected function getOrderParentFolder()
     {
         if (empty($this->orderParentFolder)) {


### PR DESCRIPTION
Added phpDoc for getOrderParentFolder() to avoid false assumption of returning a static, as defined in AbstractObject::getById()

