### PR TITLE
Additional mapping type for doctrine

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/default.yml
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/config/pimcore/default.yml
@@ -54,6 +54,7 @@ doctrine:
                     collate: utf8mb4_unicode_ci
                 mapping_types:
                     enum: string
+                    bit: boolean
 
 # Monolog Configuration
 monolog:


### PR DESCRIPTION
## Scenario
- Go to extensions
- Install EcommerceFrameworkBundle
- Error message appears in popup

## Error Message
Unknown database type bit requested, Doctrine\DBAL\Platforms\MysqlPlatform may not support it.

## Changes in this pull request  
Added the required mapping type as found [here](https://stackoverflow.com/questions/9744629/doctrine2-workaround-for-mapping-mysql-bit-data-type) (not marked as answer).

## Additional Information

- Pimcore Version: 5.2.2
- Symfony Version: 3.4.6