### PR TITLE
Prevent JS error when adding predefined metadata 

### DIFF
--- a/web/pimcore/static6/js/pimcore/asset/metadata.js
+++ b/web/pimcore/static6/js/pimcore/asset/metadata.js
@@ -394,7 +394,7 @@ pimcore.asset.metadata = Class.create({
         // check for duplicate name
         var dublicateIndex = store.findBy(function (record, id) {
             if (record.data.name.toLowerCase() == key.toLowerCase()) {
-                if(record.data.language.toLowerCase() == language.toLowerCase()) {
+                if(String(record.data.language).toLowerCase() == language.toLowerCase()) {
                     return true;
                 }
             }
@@ -532,7 +532,7 @@ pimcore.asset.metadata = Class.create({
 
             var dublicateIndex = store.findBy(function (record, id) {
                 if (record.data.name.toLowerCase() == key.toLowerCase()) {
-                    if(record.data.language.toLowerCase() == language.toLowerCase()) {
+                    if(String(record.data.language).toLowerCase() == language.toLowerCase()) {
                         return true;
                     }
                 }


### PR DESCRIPTION
# Prevent JS error when adding predefined metadata while asset already has programmatically added metadata with language=null

## Reproduction:
1. Create predefined metadata with field foo
1. Add metadata bar with Asset::addMetadata('bar', '', $data = '', null) // last parameter is language
1. Open asset with metadata bar in Pimcore backend, go to metadata tab and click "Add predefined definitions"
1. JS error occurs because in https://github.com/pimcore/pimcore/blob/9d71c0812fd3256a6a670d04597d326f85ff2717/web/pimcore/static6/js/pimcore/asset/metadata.js#L535 and https://github.com/pimcore/pimcore/blob/9d71c0812fd3256a6a670d04597d326f85ff2717/web/pimcore/static6/js/pimcore/asset/metadata.js#L397 toLowerCase() is executed on null.
