### PR TITLE
Integration of Pimcore asset metadata in the versions view of an Image 

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/views/Admin/Asset/showVersionImage.html.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Resources/views/Admin/Asset/showVersionImage.html.php
@@ -22,6 +22,7 @@
 
 
     </style>
+    <link rel="stylesheet" type="text/css" href="/pimcore/static6/css/object_versions.css"/>
 
 </head>
 
@@ -44,6 +45,69 @@
     <tr>
         <td align="center">
             <img src="<?= $dataUri ?>"/>
+              <table class="preview" border="0" cellpadding="0" cellspacing="0">
+                        <tbody>
+                            <tr class="odd">
+                                <th>Name</th>
+                                <th>Value</th>
+                            </tr>
+                            <tr>
+                                <td>Name</td>
+                                <td><?php echo $this->asset->getFileName(); ?></td>
+                            </tr>
+                            <tr>
+                                <td>Creation Date</td>
+                                <td><?php echo date('m/d/Y H:i:s', $this->asset->getCreationDate()); ?></td>
+                            </tr>
+                            <tr>
+                                <td>Modification Date</td>
+                                <td><?php echo date('m/d/Y H:i:s', $this->asset->getModificationDate()); ?></td>
+                            </tr>
+                            <tr>
+                                <td>File Size</td>
+                                <td><?php echo $this->asset->getFileSize("kb"); ?> </td>
+                            </tr>
+                            <tr>
+                                <td>Mime Type</td>
+                                <td><?php echo $this->asset->getMimetype(); ?></td>
+                            </tr>
+                            <tr>
+                                <td>Dimensions</td>
+                                <td><?php
+                                    if (is_array($this->asset->getDimensions())) {
+                                        echo $this->asset->getDimensions()["width"] . " X " . $this->asset->getDimensions()["height"];
+                                    }
+                                    ?></td>
+                            </tr>
+                            <?php
+                            if ($this->asset->getHasMetadata()) {
+                                ?>
+                                <?php
+                                $metaData = $this->asset->getMetadata();
+                                if (is_array($metaData) && count($metaData) > 0) {
+                                    foreach ($metaData as $data) {
+                                        ?>
+                                        <tr>
+                                            <td><?php echo $data['name']; ?>
+                                                (<?php echo $data['type']; ?>)
+                                            </td>
+                                            <td><?php if($data['type'] == 'date') {
+                                            echo date('m/d/Y H:i:s', $data['data']); ?>
+                                            <?php } else {
+                                            echo $data['data']; } ?>
+                                            </td>
+                                            <?php ?>
+                                        </tr>
+
+                                        <?php
+                                    }
+                                }
+                                ?>
+                            <?php }
+                            ?>
+                        </tbody>
+                    </table>
+
         </td>
     </tr>
 </table>


### PR DESCRIPTION

 ## Changes in this pull request  
Assets Metadata will be shown in the version views ( Image Assets only for now).

![version](https://user-images.githubusercontent.com/38214985/40488144-afb49d04-5f83-11e8-84b0-42ccb78cea46.png)



