### PR TITLE
Object Grid Improvements

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
@@ -786,6 +786,7 @@ class DataObjectHelperController extends AdminController
                 $calculatedColumnConfig['position'] = $config['position'];
                 $calculatedColumnConfig['isOperator'] = true;
                 $calculatedColumnConfig['attributes'] = $config['fieldConfig']['attributes'];
+                $calculatedColumnConfig['width'] = $config['width'];
 
                 $existingColumns = $session->get('helpercolumns', []);
 

--- a/pimcore/lib/Pimcore/DataObject/GridColumnConfig/Value/DefaultValue.php
+++ b/pimcore/lib/Pimcore/DataObject/GridColumnConfig/Value/DefaultValue.php
@@ -18,14 +18,91 @@
 namespace Pimcore\DataObject\GridColumnConfig\Value;
 
 use Pimcore\Model\DataObject\AbstractObject;
-use Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields;
 use Pimcore\Model\DataObject\Concrete;
-use Pimcore\Model\DataObject\Objectbrick\Definition;
+use Pimcore\Model\DataObject\Objectbrick;
 use Pimcore\Model\DataObject\Service;
 use Pimcore\Model\Element\ElementInterface;
 
 class DefaultValue extends AbstractValue
 {
+    /**
+     * @param $object
+     * @param $key
+     * @param null $brickType
+     * @param null $brickKey
+     * @param null $fieldDefinition
+     * @return \stdClass
+     *
+     * @throws \Exception
+     */
+    private function getValueForObject($object, $key, $brickType = null, $brickKey = null, $fieldDefinition = null)
+    {
+        $getter = 'get' . ucfirst($key);
+        $value = $object->$getter();
+
+        if (!empty($value) && !empty($brickType)) {
+            $getBrickType = 'get' . ucfirst($brickType);
+            $value = $value->$getBrickType();
+
+            if (!empty($value) && !empty($brickKey)) {
+                $brickGetter = 'get' . ucfirst($brickKey);
+                $value = $value->$brickGetter();
+            }
+        }
+
+        if (!$fieldDefinition) {
+            $fieldDefinition = $object->getClass()->getFieldDefinition($key);
+
+            if (!$fieldDefinition && ($localizedFields = $object->getClass()->getFieldDefinition("localizedfields"))) {
+                $fieldDefinition = $localizedFields->getFieldDefinition($key);
+            }
+        }
+
+        if (!empty($brickType) && !empty($brickKey)) {
+            $brickClass = Objectbrick\Definition::getByKey($brickType);
+            $context = ['object' => $object, 'outerFieldname' => $key];
+            $fieldDefinition = $brickClass->getFieldDefinition($brickKey, $context);
+        }
+
+        if ($fieldDefinition->isEmpty($value)) {
+            $parent = Service::hasInheritableParentObject($object);
+
+            if (!empty($parent)) {
+                return $this->getValueForObject($parent, $key, $brickType, $brickKey, $fieldDefinition);
+            }
+        }
+
+        $result = new \stdClass();
+        $result->value = $value;
+        $result->label = $fieldDefinition->getTitle();
+        $result->def = $fieldDefinition;
+        $result->empty = $fieldDefinition->isEmpty($value);
+        $result->objectid = $object->getId();
+
+        return $result;
+    }
+
+    /**
+     * @param $value
+     *
+     * @return \stdClass
+     */
+    private function getDefaultValue($value)
+    {
+        $result = new \stdClass();
+        $result->value = $value;
+        $result->label = $this->label;
+        $result->def = null;
+
+        if (empty($value) || (is_object($value) && method_exists($value, 'isEmpty') && $value->isEmpty())) {
+            $result->empty = true;
+        } else {
+            $result->empty = false;
+        }
+
+        return $result;
+    }
+
     /**
      * @param ElementInterface|Concrete $element
      *
@@ -35,75 +112,28 @@ class DefaultValue extends AbstractValue
     {
         /** @var Concrete $element */
         $attributeParts = explode('~', $this->attribute);
-        $label = $this->label;
 
         $getter = 'get' . ucfirst($this->attribute);
+        $brickType = null;
+        $brickKey = null;
 
         if (substr($this->attribute, 0, 1) == '~') {
             // key value, ignore for now
         } elseif (count($attributeParts) > 1) {
             $brickType = $attributeParts[0];
             $brickKey = $attributeParts[1];
-
-            $getter = 'get' . Service::getFieldForBrickType($element->getClass(), $brickType);
-            $brickTypeGetter = 'get' . ucfirst($brickType);
-            $brickGetter = 'get' . ucfirst($brickKey);
         }
+
         if (method_exists($element, $getter)) {
-            $value = $element->$getter();
-
             if ($element instanceof AbstractObject) {
-                $def = $element->getClass()->getFieldDefinition($this->attribute);
-                if (!$def) {
-                    /**
-                     * @var Localizedfields $lf
-                     */
-                    $lf = $element->getClass()->getFieldDefinition('localizedfields');
-                    if ($lf) {
-                        $def = $lf->getFieldDefinition($this->attribute);
-                    }
+                try {
+                    $result = $this->getValueForObject($element, $this->attribute, $brickType, $brickKey);
+                } catch(\Exception $e) {
+                    $result = $this->getDefaultValue($element->$getter());
                 }
-
-                if (empty($label)) {
-                    if ($def) {
-                        $label =  $def->getTitle();
-                    }
-                }
-
-                if (!empty($value) && !empty($brickGetter)) {
-                    $def = Definition::getByKey($brickType);
-                    $def = $def->getFieldDefinition($brickKey);
-                    if (empty($label) && !empty($value)) {
-                        if ($def) {
-                            $label = $def->getTitle();
-                        }
-                    }
-
-                    if (is_object($value) && method_exists($value, $brickTypeGetter)) {
-                        $value = $value->$brickTypeGetter();
-
-                        if (is_object($value) && method_exists($value, $brickGetter)) {
-                            $value = $value->$brickGetter();
-                        } else {
-                            $value = null;
-                        }
-                    } else {
-                        $value = null;
-                    }
-                }
-            }
-
-            $result = new \stdClass();
-            $result->value = $value;
-            $result->label = $label;
-
-            if (empty($value) || (is_object($value) && method_exists($value, 'isEmpty') && $value->isEmpty())) {
-                $result->empty = true;
             } else {
-                $result->empty = false;
+                $result = $this->getDefaultValue($element->$getter());
             }
-
-            $result->def = $def;
 
             return $result;
         }

--- a/pimcore/lib/Pimcore/DataObject/GridColumnConfig/Value/Href.php
+++ b/pimcore/lib/Pimcore/DataObject/GridColumnConfig/Value/Href.php
@@ -17,19 +17,37 @@
 
 namespace Pimcore\DataObject\GridColumnConfig\Value;
 
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Service;
+
 class Href extends AbstractValue
 {
+    private function getValue($element)
+    {
+        $getter = 'get' . ucfirst($this->attribute);
+
+        if (method_exists($element, $getter)) {
+            $value = $element->$getter();
+
+            if (
+                $element instanceof Concrete &&
+                !$value &&
+                ($parent = Service::hasInheritableParentObject($element))
+            ) {
+                $value = $this->getValue($parent);
+            }
+
+            return $value;
+        }
+
+        return null;
+    }
+
     public function getLabeledValue($element)
     {
         $result = new \stdClass();
         $result->label = $this->label;
-
-        $getter = 'get' . ucfirst($this->attribute);
-        if (method_exists($element, $getter)) {
-            $result->value = $element->$getter();
-
-            return $result;
-        }
+        $result->value = $this->getValue($element);
 
         return $result;
     }

--- a/web/pimcore/static6/js/pimcore/object/helpers/grid.js
+++ b/web/pimcore/static6/js/pimcore/object/helpers/grid.js
@@ -252,7 +252,7 @@ pimcore.object.helpers.grid = Class.create({
                     }/*, hidden: !propertyVisibility.modificationDate*/});
             } else {
                 if (fields[i].isOperator) {
-                    var operatorColumnConfig = {text: field.attributes.label ? field.attributes.label : field.attributes.key, width: 200, sortable: false,
+                    var operatorColumnConfig = {text: field.attributes.label ? field.attributes.label : field.attributes.key, width: field.width ? field.width : 200, sortable: false,
                         dataIndex: fields[i].key, editable: false};
 
                     if (field.attributes.renderer && pimcore.object.tags[field.attributes.renderer]) {

--- a/web/pimcore/static6/js/pimcore/object/helpers/gridConfigDialog.js
+++ b/web/pimcore/static6/js/pimcore/object/helpers/gridConfigDialog.js
@@ -14,6 +14,7 @@
 pimcore.registerNS("pimcore.object.helpers.gridConfigDialog");
 pimcore.object.helpers.gridConfigDialog = Class.create({
 
+    showFieldname: true,
     data: {},
     brickKeys: [],
 
@@ -336,7 +337,7 @@ pimcore.object.helpers.gridConfigDialog = Class.create({
 
                 } else {
                     obj.key = child.data.key;
-                    obj.label = child.data.text;
+                    obj.label = child.data.layout ? child.data.layout.title : child.data.text;
                     obj.type = child.data.dataType;
                     obj.layout = child.data.layout;
                     if (child.data.width) {
@@ -485,8 +486,14 @@ pimcore.object.helpers.gridConfigDialog = Class.create({
                     child = child[0];
                     child.renderer = nodeConf.attributes.renderer;
                 } else {
+                    var text = nodeConf.label;
+
+                    if (nodeConf.dataType !== "system" && this.showFieldname && nodeConf.key) {
+                        text = text + " (" + nodeConf.key.replace("~", ".") + ")";
+                    }
+
                     var child = {
-                        text: nodeConf.label,
+                        text: text,
                         key: nodeConf.key,
                         type: "data",
                         dataType: nodeConf.dataType,
@@ -813,7 +820,7 @@ pimcore.object.helpers.gridConfigDialog = Class.create({
 
     getClassTree: function (url, classId, objectId) {
 
-        var classTreeHelper = new pimcore.object.helpers.classTree(true);
+        var classTreeHelper = new pimcore.object.helpers.classTree(this.showFieldname);
         var tree = classTreeHelper.getClassTree(url, classId, objectId);
 
         tree.addListener("itemdblclick", function (tree, record, item, index, e, eOpts) {


### PR DESCRIPTION
## Changes in this pull request 
This pull requests fixes some minor issues with the object grid. 

First of all the fieldnames are not displayed in brackets in the object grid anymore to keep it compact. They are still displayed in the configuration panel, and for all columns except system columns. Previously columns that were displayed due to configuration in the class definition itself, did not contain the fieldname either. Consistency.

Second inherited values are used in the object grid for operators as well which resolves #2873.

Third the widths for columns could be saved in configurations. Operator columns were ignored and always returned to 200 pixels. They are now saved as well.

