### PR TITLE
Retrieve getChildren() listing by index or key sort order

### DIFF
--- a/pimcore/models/DataObject/AbstractObject.php
+++ b/pimcore/models/DataObject/AbstractObject.php
@@ -436,7 +436,7 @@ class AbstractObject extends Model\Element\AbstractElement
             $list = new Listing();
             $list->setUnpublished($unpublished);
             $list->setCondition('o_parentId = ?', $this->getId());
-            $list->setOrderKey('o_' . $this->getChildrenSortBy());
+            $list->setOrderKey(sprintf('o_%s', $this->getChildrenSortBy()));
             $list->setOrder('asc');
             $list->setObjectTypes($objectTypes);
             $this->o_childs = $list->load();

--- a/pimcore/models/DataObject/AbstractObject.php
+++ b/pimcore/models/DataObject/AbstractObject.php
@@ -436,7 +436,7 @@ class AbstractObject extends Model\Element\AbstractElement
             $list = new Listing();
             $list->setUnpublished($unpublished);
             $list->setCondition('o_parentId = ?', $this->getId());
-            $list->setOrderKey('o_key');
+            $list->setOrderKey('o_' . $this->getChildrenSortBy());
             $list->setOrder('asc');
             $list->setObjectTypes($objectTypes);
             $this->o_childs = $list->load();


### PR DESCRIPTION
We're setting the sort order in Pimcore, we should retrieve getChildren() listing by the same order.