### PR TITLE
Allow usage of the DataObject/Service::getUniqueKey method variants

### DIFF
--- a/pimcore/models/DataObject/Service.php
+++ b/pimcore/models/DataObject/Service.php
@@ -1501,6 +1501,7 @@ class Service extends Model\Element\Service
     {
         $list = new Listing();
         $list->setUnpublished(true);
+        $list->setObjectTypes([AbstractObject::OBJECT_TYPE_OBJECT, AbstractObject::OBJECT_TYPE_FOLDER, AbstractObject::OBJECT_TYPE_VARIANT]);
         $key = Element\Service::getValidKey($item->getKey(), 'object');
         if (!$key) {
             throw new \Exception('No item key set.');


### PR DESCRIPTION
The list used in this method did not take variants into account when checking if a key is already is use. I've added the variant type to the list as well.