### PR TITLE
Google api client updated to latest version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     "egulias/email-validator": "*",
     "endroid/qr-code": "~2.2",
     "geoip2/geoip2": "~2",
-    "google/apiclient": "~1",
+    "google/apiclient": "^2.0",
     "guzzlehttp/guzzle": "~6.0",
     "hybridauth/hybridauth": "~2",
     "lcobucci/jwt": "^3.2",

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/translations/en.json
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/Resources/translations/en.json
@@ -335,7 +335,7 @@
   "fields": "Fields",
   "events": "Events",
   "analytics_settings_description": "To use the complete Google Analytics integration, please configure the Google API Service Account in System Settings",
-  "google_api_key_missing": "Google API private key is missing (p12 file from API Console), please put it into the following location:",
+  "google_api_key_missing": "Google API private key is missing (JSON file from API Console), please put it into the following location:",
   "google_api_private_key_installed": "Your Google API private key is installed correctly",
   "google_api_access_description": "This is required for the Google API integrations. Only use a `Service Account´ from the Google API Console.",
   "not_possible_with_paging": "Sorry, this is not possible in elements which are paged, try to restructure your data to avoid pages in the tree",

--- a/pimcore/lib/Pimcore/Google/Api.php
+++ b/pimcore/lib/Pimcore/Google/Api.php
@@ -114,6 +114,10 @@ class Api
         }
 
         $client = new \Google_Client();
+
+        $cache = \Pimcore::getContainer()->get('pimcore.cache.core.pool');
+        $client->setCache($cache);
+
         $client->setApplicationName('pimcore CMF');
         $json = self::getPrivateKeyPath();
         $client->setAuthConfig($json);
@@ -155,6 +159,10 @@ class Api
         }
 
         $client = new \Google_Client();
+
+        $cache = \Pimcore::getContainer()->get('pimcore.cache.core.pool');
+        $client->setCache($cache);
+
         $client->setApplicationName('pimcore CMF');
         $client->setDeveloperKey(Config::getSystemConfig()->services->google->simpleapikey);
 

--- a/pimcore/lib/Pimcore/Google/Api.php
+++ b/pimcore/lib/Pimcore/Google/Api.php
@@ -26,7 +26,7 @@ class Api
      */
     public static function getPrivateKeyPath()
     {
-        $path = \Pimcore\Config::locateConfigFile('google-api-private-key.p12');
+        $path = \Pimcore\Config::locateConfigFile('google-api-private-key.json');
 
         return $path;
     }
@@ -113,20 +113,12 @@ class Api
             $scope = ['https://www.googleapis.com/auth/analytics.readonly'];
         }
 
-        $clientConfig = new \Google_Config();
-        $clientConfig->setClassConfig('Google_Cache_File', 'directory', PIMCORE_CACHE_DIRECTORY);
-
-        $client = new \Google_Client($clientConfig);
+        $client = new \Google_Client();
         $client->setApplicationName('pimcore CMF');
+        $json = self::getPrivateKeyPath();
+        $client->setAuthConfig($json);
 
-        $key = file_get_contents(self::getPrivateKeyPath());
-        $client->setAssertionCredentials(
-            new \Google_Auth_AssertionCredentials(
-            $config->email,
-            $scope,
-            $key
-        )
-        );
+        $client->setScopes($scope);
 
         $client->setClientId($config->client_id);
 
@@ -141,9 +133,9 @@ class Api
         }
 
         if (!$token) {
-            $client->getAuth()->refreshTokenWithAssertion();
-            $token = $client->getAuth()->getAccessToken();
-
+            $client->refreshTokenWithAssertion();
+            $token = json_encode($client->getAccessToken());
+            
             // 1 hour (3600s) is the default expiry time
             TmpStore::add($tokenId, $token, null, 3600);
         }
@@ -162,10 +154,7 @@ class Api
             return false;
         }
 
-        $clientConfig = new \Google_Config();
-        $clientConfig->setClassConfig('Google_Cache_File', 'directory', PIMCORE_CACHE_DIRECTORY);
-
-        $client = new \Google_Client($clientConfig);
+        $client = new \Google_Client();
         $client->setApplicationName('pimcore CMF');
         $client->setDeveloperKey(Config::getSystemConfig()->services->google->simpleapikey);
 


### PR DESCRIPTION
fixes #1209
## Changes in this pull request  

- Google api client library updated to latest version 2.x

- Google API private key should be json now placed as /var/config/google-api-private-key.json
`Note: P12s are deprecated in favor of service account JSON, which can be generated in the Credentials section of Google Developer Console`

## Additional info  

