### PR TITLE
Date component breaks view layout randomly fix

### DIFF
--- a/web/pimcore/static6/js/pimcore/overrides.js
+++ b/web/pimcore/static6/js/pimcore/overrides.js
@@ -939,3 +939,21 @@ Ext.define('pimcore.Ext.form.field.Date', {
         this.picker.setValue(Ext.isDate(value) ? value : null);
     }
 });
+
+//Fix - Date picker does not align to component in scrollable container and breaks view layout randomly.
+Ext.override(Ext.picker.Date, {
+        afterComponentLayout: function (width, height, oldWidth, oldHeight) {
+        var field = this.pickerField;
+        this.callParent([
+            width,
+            height,
+            oldWidth,
+            oldHeight
+        ]);
+        // Bound list may change size, so realign on layout
+        // **if the field is an Ext.form.field.Picker which has alignPicker!**
+        if (field && field.alignPicker) {
+            field.alignPicker();
+        }
+    }
+});


### PR DESCRIPTION
Resolves #2739
## Changes in this pull request  
Date component was breaking view layout randomly. Whenever date component was being used in scrollable container, screen was getting off randomly after clicking on date picker. Now date component works fine and displays date picker at correct position.


## Additional info  

