### PR TITLE
Fix a typo in the OGone payment provider

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PaymentManager/Payment/OGone.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PaymentManager/Payment/OGone.php
@@ -256,7 +256,7 @@ class OGone extends AbstractPayment
             'amount'            => $amount,
             'currency'          => $currency,
             'ip'                => $ip,
-            'customerName' >= $customerName
+            'customerName'      => $customerName
         ]);
 
         $responseStatus = new Status(


### PR DESCRIPTION
This patch will assign the `$customerName` to the `customerName` key in the authorized data array instead of adding a random boolean value to the key `0`.