### PR TITLE
[Ecommerce] WirecardSeamless payment provider - updated setting payment state to PENDING

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PaymentManager/Payment/WirecardSeamless.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/PaymentManager/Payment/WirecardSeamless.php
@@ -536,8 +536,8 @@ class WirecardSeamless extends AbstractPayment
                 $orderIdent,
                 $response['orderNumber'],
                 $response['avsResponseMessage'],
-                $response['orderNumber'] !== null && $response['paymentState'] == 'SUCCESS'
-                    ? IStatus::STATUS_CANCELLED
+                $response['orderNumber'] !== null && $response['paymentState'] == 'PENDING'
+                    ? IStatus::STATUS_PENDING
                     : IStatus::STATUS_CANCELLED,
                 [
                     'seamless_amount'       => '',


### PR DESCRIPTION
It seems like this line was copied from below. As it results in `IStatus::STATUS_CANCELLED` in either case, we can get rid of the condition.

The condition would never evaluate to `true` anyway, because the `$response['paymentState']` is already checked above and thus can never contain the corresponding value.

---

**Note**: I'm not entirely sure this is the correct fix. Maybe we shouldn't remove the condition but check `$response['paymentState']` for `PENDING` instead and set the status to `IStatus::STATUS_PENDING` in this case?