### PR TITLE
Include fastcgi_params vs. include fastcgi.conf

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
@@ -105,7 +105,7 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         # Check that the PHP script exists before passing it
         try_files $fastcgi_script_name =404;
-        include fastcgi.conf;
+        include fastcgi_params;
         # Bypass the fact that try_files resets $fastcgi_path_info
         # see: http://trac.nginx.org/nginx/ticket/321
         set $path_info $fastcgi_path_info;


### PR DESCRIPTION
Once you include fastcgi_params and later fastcgi.conf. Shouldn't this include the same file? Or how are they different?