### PR TITLE
DataObject: Late binding return typehint

### DIFF
--- a/pimcore/models/DataObject/AbstractObject.php
+++ b/pimcore/models/DataObject/AbstractObject.php
@@ -320,7 +320,7 @@ class AbstractObject extends Model\Element\AbstractElement
      * @param string $path
      * @param bool $force
      *
-     * @return self
+     * @return static
      */
     public static function getByPath($path, $force = false)
     {


### PR DESCRIPTION
Changed return typehint of static method AbstractObject::getByPath() from "self" to "static" in order to make use of IDE completion by using late binding.

Before one had to explicitly write a variable typehint:
```
/** @var DataObject\Foo $foo */
$foo = DataObject\Foo::getByPath('/path/to/object');
$foo->getMemberOfFoo();
```

After just:
```
$foo = DataObject\Foo::getByPath('/path/to/object');
$foo->getMemberOfFoo();
```


## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
  
  

## Changes in this pull request  
Resolves #

## Additional info  

