### PR TITLE
Remove superfluous cast to boolean

### DIFF
--- a/pimcore/lib/Pimcore/Controller/Traits/TemplateControllerTrait.php
+++ b/pimcore/lib/Pimcore/Controller/Traits/TemplateControllerTrait.php
@@ -27,8 +27,6 @@ trait TemplateControllerTrait
      */
     public function setViewAutoRender(Request $request, bool $autoRender, string $engine = null)
     {
-        $autoRender = (bool)$autoRender;
-
         if ($autoRender) {
             $request->attributes->set(TemplateControllerInterface::ATTRIBUTE_AUTO_RENDER, $autoRender);
 


### PR DESCRIPTION
`$autoRender` is already a boolean as per the method signature. There's no need to cast it again.