### PR TITLE
fix: added variant object type to BatchJobs

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
@@ -2233,7 +2233,13 @@ class DataObjectHelperController extends AdminController
         $list->setOrderKey('o_id');
 
         if ($request->get('objecttype')) {
-            $list->setObjectTypes([$request->get('objecttype')]);
+            $objectTypes = [$request->get('objecttype')];
+
+            if ($class->getShowVariants()) {
+                $objectTypes[] = DataObject\AbstractObject::OBJECT_TYPE_VARIANT;
+            }
+
+            $list->setObjectTypes($objectTypes);
         }
 
         $jobs = $list->loadIdList();


### PR DESCRIPTION
How to reproduce an issue:
`objecttype` `variant` is ignored during `Batch edit all` objects in the grid's column

