### PR TITLE
Remove broken Array.from monkey patch

### DIFF
--- a/web/pimcore/static6/js/lib/prototype-light.js
+++ b/web/pimcore/static6/js/lib/prototype-light.js
@@ -330,10 +330,6 @@ function $w(string) {
     return string ? string.split(/\s+/) : [];
 }
 
-Array.from = $A;
-
-Array.from = $A;
-
 (function() {
     var arrayProto = Array.prototype, slice = arrayProto.slice, _each = arrayProto.forEach; // use
                                                                                             // native


### PR DESCRIPTION
## Changes in this pull request  
Resolves #2968 

Array.from is a well supported feature in all browsers that Pimcore supports so dropping a faulty monkey patch should not cause any issues.

### Steps to reproduce  

Visit https://demo-basic.pimcore.org/error?pimcore_editmode=true in Mozilla Firefox and paste the following code into your developer console;

```js
Array.from([0, 1, 2], (d) => d*2);
```

Expected output: `[ 0, 2, 4 ]`

Actual output: `[ 0, 1, 2 ]`
