### PR TITLE
Fix position of closing parenthesis

### DIFF
--- a/pimcore/lib/Pimcore/Http/Request/Resolver/TemplateVarsResolver.php
+++ b/pimcore/lib/Pimcore/Http/Request/Resolver/TemplateVarsResolver.php
@@ -66,10 +66,10 @@ class TemplateVarsResolver extends AbstractRequestResolver
             if (!is_array($vars)) {
                 throw new \RuntimeException(
                     sprintf(
-                    'Expected TemplateVarsProvider %s to return an array (%s returned)'
-                ),
-                    get_class($provider),
-                    gettype($vars)
+                        'Expected TemplateVarsProvider %s to return an array (%s returned)',
+                        get_class($provider),
+                        gettype($vars)
+                    )
                 );
             }
         }


### PR DESCRIPTION
The parameters `get_class($provider)` and `gettype($vars)` were after the closing parenthesis of the `sprintf()` and thus were applied as the parameters `$code` and `$previous` of the `RuntimeException`, which is obviously wrong.