### PR TITLE
Add name property to object textareas

### DIFF
--- a/web/pimcore/static6/js/pimcore/object/tags/textarea.js
+++ b/web/pimcore/static6/js/pimcore/object/tags/textarea.js
@@ -59,6 +59,7 @@ pimcore.object.tags.textarea = Class.create(pimcore.object.tags.abstract, {
         var labelWidth = this.fieldConfig.labelWidth ? this.fieldConfig.labelWidth : 100;
 
         var conf = {
+            name: this.fieldConfig.name,
             width: this.fieldConfig.width,
             height: this.fieldConfig.height,
             fieldLabel: this.fieldConfig.title,


### PR DESCRIPTION
## Changes in this pull request  
Set the name property for textareas to allow easier dom access. Input fields already have it, and this makes it easy to access their content from a custom handler script.

## Additional info  
Initially discussed with Christian Fasching
