### PR TITLE
refactor preview for objects

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectHelperController.php
@@ -2281,29 +2281,6 @@ class DataObjectHelperController extends AdminController
     }
 
     /**
-     * @Route("/generate-link")
-     * @Method({"GET"})
-     *
-     * @param Request $request
-     *
-     * @return JsonResponse
-     */
-    public function generateLink(Request $request)
-    {
-        $id = $request->get('id');
-        $object = DataObject\Concrete::getById($id);
-        if (!$object) {
-            return $this->adminJson(['success' => false]);
-        }
-
-        $class = $object->getClass();
-        $generator = DataObject\ClassDefinition\Helper\LinkGeneratorResolver::resolveGenerator($class->getLinkGeneratorReference());
-        $link = $generator->generate($object, []);
-
-        return $this->adminJson(['success' => true, 'link' => $link]);
-    }
-
-    /**
      * @Route("/batch")
      * @Method({"PUT"})
      *

--- a/web/pimcore/static6/js/pimcore/object/object.js
+++ b/web/pimcore/static6/js/pimcore/object/object.js
@@ -17,7 +17,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
     initialize: function (id, options) {
         this.id = intval(id);
         this.options = options;
-        
+
         pimcore.plugin.broker.fireEvent("preOpenObject", this, "object");
 
         this.addLoadingPanel();
@@ -232,7 +232,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
         //    console.log(e);
         //}
 
-        if (!empty(this.data.previewUrl)) {
+        if (this.data.hasPreview) {
             try {
                 items.push(this.preview.getLayout());
             } catch (e) {
@@ -466,27 +466,18 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
             });
 
 
-            if (this.data.general.linkGeneratorReference) {
+            if (this.data.hasPreview) {
                 buttons.push("-");
                 buttons.push({
                     tooltip: t("open"),
                     iconCls: "pimcore_icon_open",
                     scale: "medium",
                     handler: function () {
-                        Ext.Ajax.request({
-                            url: "/admin/object-helper/generate-link",
-                            params: {
-                                id: this.id
-                            },
-                            success: function (response) {
-                                var res = Ext.decode(response.responseText);
-                                if (res["success"]) {
-                                    window.open(res["link"]);
-                                }
-
-                            }.bind(this)
+                        var date = new Date();
+                        var path = "/admin/object/preview?id=" + this.data.general.o_id + "&time=" + date.getTime();
+                        this.saveToSession(function () {
+                            window.open(path);
                         });
-
                     }.bind(this)
                 });
             }


### PR DESCRIPTION
- Use the LinkGenerator for the preview-tab if no specific 'Preview Url' is set.

- The 'preview-tab' and the 'open-button' now use the same logik 