### PR TITLE
Fix "Unknown key for a VALUE_NULL in [from]"

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/IndexService/ProductList/DefaultElasticSearch.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/IndexService/ProductList/DefaultElasticSearch.php
@@ -89,7 +89,7 @@ class DefaultElasticSearch implements IProductList
     /**
      * @var int
      */
-    protected $offset;
+    protected $offset = 0;
 
     /**
      * @var AbstractCategory


### PR DESCRIPTION
Filter MultiSelectRelation (`Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\FilterType\ElasticSearch\MultiSelectRelation`) doesn't work in admin panel with elasticsearch configuration. 
It doesn't show any value, instead of that there's msg like this in ajax response:
```
"{"error":{"root_cause":[{"type":"parsing_exception","reason":"Unknown key for a VALUE_NULL in [from].","line":1,"col":34}],"type":"parsing_exception","reason":"Unknown key for a VALUE_NULL in [from].","line":1,"col":34},"status":400}"
```

It sends request to es with `from = null` instead of `from = 0`.