### PR TITLE
Fix/ecommerce switch index alias elasticsearch

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/IndexService/Worker/DefaultElasticSearch.php
+++ b/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/IndexService/Worker/DefaultElasticSearch.php
@@ -699,6 +699,8 @@ class DefaultElasticSearch extends AbstractMockupCacheWorker implements IBatchPr
                         'index' => '*',
                         'alias' => $this->indexName,
                     ],
+                ],
+                [
                     'add' => [
                         'index' => $this->getIndexNameVersion(),
                         'alias' => $this->indexName,


### PR DESCRIPTION
You can't mix in one action array `remove` and `add` operations, see https://www.elastic.co/guide/en/elasticsearch/reference/5.6/indices-aliases.html

Right now it gets 400 error from elasticsearch.