### PR TITLE
avoid 500 when doing GET on /admin/login/login

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Security/Guard/AdminAuthenticator.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Security/Guard/AdminAuthenticator.php
@@ -141,7 +141,8 @@ class AdminAuthenticator extends AbstractGuardAuthenticator implements LoggerAwa
         $credentials = null;
 
         if ($request->attributes->get('_route') === 'pimcore_admin_login_check') {
-            if (!null === $username = $request->get('username')) {
+            $username = $request->get('username');
+            if (null === $username) {
                 throw new AuthenticationException('Missing username');
             }
 


### PR DESCRIPTION
When you are directly going to /admin/login/login you get a 500 error.

Type error: Argument 2 passed to Pimcore\Event\Admin\Login\LoginCredentialsEvent::__construct() must be of the type array,
null given,
called in /phpapp/pimcore/lib/Pimcore/Bundle/AdminBundle/Security/Guard/AdminAuthenticator.php on line 157

The desired result should be to get the login form again when not logged
in, or the admin interface when you were already logged in.

There was already a check to verify if there was a username passed, but
it contained an always invalid condition so the exception was never
triggered.

if (!null === $username = $request->get('username')) { <-- never true
    throw new AuthenticationException('Missing username');
}

If the $username check is changed to throw an exception when no username
is given, the behaviour is correct.

$username = $request->get('username');
if (null === $username) {
    throw new AuthenticationException('Missing username');
}

Signed-off-by: BlackEagle <ike.devolder@gmail.com>

