### PR TITLE
Fixes the problem with the escaping "save" button

### DIFF
--- a/pimcore/models/DataObject/ClassDefinition/Helper/Dao.php
+++ b/pimcore/models/DataObject/ClassDefinition/Helper/Dao.php
@@ -32,7 +32,7 @@ trait Dao
 
         $prefixes = [
             'p_index_' => ['enabled' => $field->getIndex() && ! $field->getUnique(), 'unique' => false],
-            'u_index_' => ['enabled' => $field->getUnique(), 'unique' => true]
+            'u_index_' => ['enabled' => $considerUniqueIndex && $field->getUnique(), 'unique' => true]
 
         ];
 

--- a/update-scripts/277/postupdate.php
+++ b/update-scripts/277/postupdate.php
@@ -1,0 +1,12 @@
+<?php
+
+$classList = new \Pimcore\Model\DataObject\ClassDefinition\Listing();
+$classes = $classList->load();
+foreach ($classes as $ckey => $class) {
+   foreach ($class->getFieldDefinitions() as $fkey => $field) {
+       if ($field->getUnique()) {
+            $class->save(); //save class to remove unique constraint form query table
+            break;
+       }
+   } 
+}


### PR DESCRIPTION
When performing mass actions on the grid there is a problem with the "save" button when adding many elements, eg to a multihref
<!--
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Add autoscroll to Window in gridTabAbstract

## Additional info  

