### PR TITLE
Autoreload object view/edit tab on save.

### DIFF
--- a/web/pimcore/static6/js/pimcore/object/object.js
+++ b/web/pimcore/static6/js/pimcore/object/object.js
@@ -729,6 +729,8 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
 
                                 // for internal use ID.
                                 pimcore.eventDispatcher.fireEvent("postSaveObject", this, task);
+
+                                this.reload(this.layoutId);
                             }
                             else {
                                 pimcore.helpers.showPrettyError(rdata.type, t("error"), t("error_saving_object"),


### PR DESCRIPTION
This PR contains new feature, that auto reloads object tab on save.
Why? Sometimes object contains calculated value fields.