### PR TITLE
Added option to customize object add dialog box 

### DIFF
--- a/web/pimcore/static6/js/pimcore/object/tree.js
+++ b/web/pimcore/static6/js/pimcore/object/tree.js
@@ -929,7 +929,13 @@ pimcore.object.tree = Class.create({
             dialogText =  t('please_enter_the_name_of_the_new_object');
         }
 
-        Ext.MessageBox.prompt(sprintf(t('add_object_mbx_title'), ts(className)), dialogText,
+        var dialogTitle = t("object_add_dialog_custom_title" + "." + className);
+
+        if (dialogTitle == "object_add_dialog_custom_title" + "." + className) {
+            dialogTitle =  sprintf(t('add_object_mbx_title'), ts(className));
+        }
+
+        Ext.MessageBox.prompt(dialogTitle, dialogText,
             this.addObjectCreate.bind(this, classId, className, tree, record));
     },
 

--- a/web/pimcore/static6/js/pimcore/object/tree.js
+++ b/web/pimcore/static6/js/pimcore/object/tree.js
@@ -923,7 +923,13 @@ pimcore.object.tree = Class.create({
     },
 
     addObject: function (classId, className, tree, record) {
-        Ext.MessageBox.prompt(sprintf(t('add_object_mbx_title'), ts(className)), t('please_enter_the_name_of_the_new_object'),
+        var dialogText = t("object_add_dialog_custom_text" + "." + className);
+
+        if (dialogText == "object_add_dialog_custom_text" + "." + className) {
+            dialogText =  t('please_enter_the_name_of_the_new_object');
+        }
+
+        Ext.MessageBox.prompt(sprintf(t('add_object_mbx_title'), ts(className)), dialogText,
             this.addObjectCreate.bind(this, classId, className, tree, record));
     },
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #2772

## Additional info  
Keys will show up in Admin Translations for each class, after displaying dialog for the first time:
![screenshot_20180709_143500](https://user-images.githubusercontent.com/1809664/42450722-66ac5ed2-8385-11e8-8429-202f06605a6f.png)

If it's translated it will replace object add dialog (after ui reload):
![screenshot_20180709_143525](https://user-images.githubusercontent.com/1809664/42450736-6d4bdace-8385-11e8-9feb-4ce51f9d49e6.png)
