### PR TITLE
Fix: getDataFromObjectParam for localized CS-Data

### DIFF
--- a/pimcore/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/pimcore/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -468,6 +468,7 @@ class Classificationstore extends Model\DataObject\ClassDefinition\Data
                     ];
 
                     foreach ($validLanguages as $language) {
+                        $context['language'] = $language;
                         $value = $fd->getForWebserviceExport($object, ['context' => $context, 'language' => $language]);
                         $groupResult[$language][] = [
                             'id' => $keyId,


### PR DESCRIPTION
## Calling the REST API does not return the values ​​of localized classification store attributes.

Reproduce:

- Create classification store
- Create classification store as attribute in class and select option "localized"
- Enter data
- REST call ([your.domain] / webservice / rest / object / id / ...)
- Result for all languages in JSON: `value: null`
 
Fix for PR #2875 in file Pimcore\Model\DataObject\ClassDefinition\Data\Classificationstore.php as proposed in https://github.com/pimcore/pimcore/pull/2875#issuecomment-393080149

Sorry for the delayed response! 