### PR TITLE
Filterable Admin Languages

### DIFF
--- a/pimcore/lib/Pimcore/Event/AdminEvents.php
+++ b/pimcore/lib/Pimcore/Event/AdminEvents.php
@@ -353,4 +353,15 @@ final class AdminEvents
      * @var string
      */
     const QUICKSEARCH_LIST_AFTER_LIST_LOAD = 'pimcore.admin.quickSearch.list.afterListLoad';
+
+    /**
+     * Subject: null
+     * Arguments:
+     *  - languages | array | the list of available languages
+     *
+     * @Event("Pimcore\Event\Model\GenericEvent")
+     *
+     * @var string
+     */
+    const SETTINGS_GET_AVAILABLE_ADMIN_LANGUAGES = "pimcore.admin.settings.getAvailableLanguages";
 }

--- a/pimcore/lib/Pimcore/Event/AdminEvents.php
+++ b/pimcore/lib/Pimcore/Event/AdminEvents.php
@@ -355,6 +355,8 @@ final class AdminEvents
     const QUICKSEARCH_LIST_AFTER_LIST_LOAD = 'pimcore.admin.quickSearch.list.afterListLoad';
 
     /**
+     * Allows to modify the list of admin languages to reduce the amount of languages if not all are needed.
+     *
      * Subject: null
      * Arguments:
      *  - languages | array | the list of available languages

--- a/pimcore/lib/Pimcore/Tool/Admin.php
+++ b/pimcore/lib/Pimcore/Tool/Admin.php
@@ -76,7 +76,11 @@ class Admin
 
         $eventDispatcher->dispatch(AdminEvents::SETTINGS_GET_AVAILABLE_ADMIN_LANGUAGES, $event);
 
-        return $event->getArgument("languages");
+        if (!empty($event->getArgument("languages"))) {
+            return $event->getArgument("languages");
+        }
+
+        return $languages;
     }
 
     /**

--- a/pimcore/lib/Pimcore/Tool/Admin.php
+++ b/pimcore/lib/Pimcore/Tool/Admin.php
@@ -15,10 +15,12 @@
 namespace Pimcore\Tool;
 
 use Pimcore\Bundle\AdminBundle\Security\User\TokenStorageUserResolver;
+use Pimcore\Event\AdminEvents;
 use Pimcore\Event\SystemEvents;
 use Pimcore\File;
 use Pimcore\Model\User;
 use Pimcore\Tool\Text\Csv;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Admin
 {
@@ -69,7 +71,12 @@ class Admin
             }
         }
 
-        return $languages;
+        $eventDispatcher = \Pimcore::getContainer()->get("event_dispatcher");
+        $event = new GenericEvent(null, ["languages" => $languages]);
+
+        $eventDispatcher->dispatch(AdminEvents::SETTINGS_GET_AVAILABLE_ADMIN_LANGUAGES, $event);
+
+        return $event->getArgument("languages");
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
This PR makes the list of admin languages filterable via an event. This can be used to reduce the amount of languages visible in the backend, if not all languages are necessary.