### PR TITLE
Add a event handler before the logic is called

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/DataObjectController.php
@@ -340,6 +340,13 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         $objectFromVersion = $latestObject === $object ? false : true;
         $object = $latestObject;
 
+        // Hook for manipulating the object before loading the data
+        $event = new GenericEvent($this, [
+            'object' => $object,
+        ]);
+        $eventDispatcher->dispatch(AdminEvents::OBJECT_GET_PRE_LOAD_DATA, $event);
+        $object = $event->getArgument('object');
+
         if ($object->isAllowed('view')) {
             $objectData = [];
 

--- a/pimcore/lib/Pimcore/Event/AdminEvents.php
+++ b/pimcore/lib/Pimcore/Event/AdminEvents.php
@@ -290,7 +290,20 @@ final class AdminEvents
     const DOCUMENT_TREE_GET_CHILDREN_BY_ID_PRE_SEND_DATA = 'pimcore.admin.document.treeGetChildsById.preSendData';
 
     /**
-     * Fired before the request params are parsed.
+     * Fired before the object data is loaded.
+     *
+     * Subject: \Pimcore\Bundle\AdminBundle\Controller\Admin\DataObjectController
+     * Arguments:
+     *  - object | AbstractObject | the current object
+     *
+     * @Event("Pimcore\Event\Model\GenericEvent")
+     *
+     * @var string
+     */
+    const OBJECT_GET_PRE_LOAD_DATA = 'pimcore.admin.dataobject.get.preLoadData';
+
+    /**
+     * Fired before the object data is sent.
      *
      * Subject: \Pimcore\Bundle\AdminBundle\Controller\Admin\DataObjectController
      * Arguments:


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/` (event documentation in file)
**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
The problem was that we only had influence on the 'data' array, which was the result of lots of logic, so I added a event handler before the logic is called, so i can have influence from object level.

