### PR TITLE
fix button ordering for video editmode panel

### DIFF
--- a/web/pimcore/static6/js/pimcore/helpers.js
+++ b/web/pimcore/static6/js/pimcore/helpers.js
@@ -2135,18 +2135,18 @@ pimcore.helpers.editmode.openVideoEditPanel = function (data, callback) {
         }],
         buttons: [
             {
-                text: t("cancel"),
-                iconCls: "pimcore_icon_cancel",
-                listeners: {
-                    "click": callback["cancel"]
-                }
-            },
-            {
                 text: t("save"),
                 listeners: {
                     "click": callback["save"]
                 },
                 iconCls: "pimcore_icon_save"
+            },
+            {
+                text: t("cancel"),
+                iconCls: "pimcore_icon_cancel",
+                listeners: {
+                    "click": callback["cancel"]
+                }
             }
         ]
     });


### PR DESCRIPTION
Video Edit UI is not consistent with brick editmode UI:

![bildschirmfoto 2018-07-23 um 11 32 57](https://user-images.githubusercontent.com/5981845/43069047-6325646a-8e6c-11e8-8127-dd61ff099159.png)

With this PR, it looks like this, so button ordering is the same:

![bildschirmfoto 2018-07-23 um 11 33 20](https://user-images.githubusercontent.com/5981845/43069054-681fe166-8e6c-11e8-9aaf-a5db7de292f0.png)
