### PR TITLE
prevent endless loops when uploading a file without extension

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/AssetController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/AssetController.php
@@ -410,7 +410,9 @@ class AssetController extends ElementControllerBase implements EventedController
      */
     protected function getSafeFilename($targetPath, $filename)
     {
-        $originalFilename = $filename;
+        $pathinfo = pathinfo($filename);
+        $originalFilename = $pathinfo['filename'];
+        $originalFileextension = empty($pathinfo['extension']) ? '' : '.' . $pathinfo['extension'];
         $count = 1;
 
         if ($targetPath == '/') {
@@ -419,7 +421,7 @@ class AssetController extends ElementControllerBase implements EventedController
 
         while (true) {
             if (Asset\Service::pathExists($targetPath . '/' . $filename)) {
-                $filename = str_ireplace('.' . File::getFileExtension($originalFilename), '_' . $count . '.' . File::getFileExtension($originalFilename), $originalFilename);
+                $filename = $originalFilename . '_' . $count . $originalFileextension;
                 $count++;
             } else {
                 return $filename;


### PR DESCRIPTION
When uploading an asset, getSafeFilename will run in an endless loop if the file has no file extension as the str_ireplace() never matches.

Steps to reproduce:
- Upload an image without file extension
- Upload the same image again in the same folder
-> The upload dialog will stay open indefinitely as the server process gets stuck in getSafeFilename
  

## Changes in this pull request  
Instead of replacing the current extension, rebuild the whole filename with count and an optional extension part in each loop

## Additional info  
This was originally noticed when using the import-url feature with URLs from an asset service that doesn't add file extensions to the URLs
