### PR TITLE
[Application Logger] shows html piece as "text/plain"

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/LogController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/LogController.php
@@ -258,7 +258,7 @@ class LogController extends AdminController implements EventedControllerInterfac
 
         if (file_exists($filePath)) {
             $response->setContent(file_get_contents($filePath));
-            if (strpos($response->getContent(), '</html>') > 0) {
+            if (strpos($response->getContent(), '</html>') > 0 || strpos($response->getContent(), '</pre>') > 0) {
                 $response->headers->set('Content-Type', 'text/html');
             }
         } else {


### PR DESCRIPTION
logged exceptions by the ApplicationLogger which are wrapped inside a `<pre>` tag were displayed as `text/plain`

Resolves #3133