### PR TITLE
Fixed syntax error in classificationstore

### DIFF
--- a/pimcore/models/DataObject/Classificationstore/KeyConfig/Listing/Dao.php
+++ b/pimcore/models/DataObject/Classificationstore/KeyConfig/Listing/Dao.php
@@ -75,7 +75,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     protected function getCondition()
     {
-        $condition = $this->model->getIncludeDisabled() ? 'enabled is null or enabled is 0' : 'enabled = 1';
+        $condition = $this->model->getIncludeDisabled() ? '(enabled is null or enabled = 0)' : 'enabled = 1';
 
         $cond = $this->model->getCondition();
         if ($cond) {


### PR DESCRIPTION
![screenshot from 2018-07-25 11-05-48](https://user-images.githubusercontent.com/16477689/43195093-579c4dae-9004-11e8-86e1-0e85e2e4c9c8.png)

Changed "is 0" to "= 0". Added parenthesis because of AND operator having higher precedence