### PR TITLE
Add setter for maxWriteToCacheItems

### DIFF
--- a/lib/Cache/Core/CoreHandler.php
+++ b/lib/Cache/Core/CoreHandler.php
@@ -242,10 +242,14 @@ class CoreHandler implements LoggerAwareInterface, CoreHandlerInterface
     
     /**
      * @param int $maxWriteToCacheItems
+     *
+     * @return $this
      */
     public function setMaxWriteToCacheItems($maxWriteToCacheItems)
     {
         $this->maxWriteToCacheItems = (int)$maxWriteToCacheItems;
+        
+        return $this;
     }
 
     /**

--- a/lib/Cache/Core/CoreHandler.php
+++ b/lib/Cache/Core/CoreHandler.php
@@ -239,6 +239,14 @@ class CoreHandler implements LoggerAwareInterface, CoreHandlerInterface
 
         return $this;
     }
+    
+    /**
+     * @param int $maxWriteToCacheItems
+     */
+    public function setMaxWriteToCacheItems($maxWriteToCacheItems)
+    {
+        $this->maxWriteToCacheItems = (int)$maxWriteToCacheItems;
+    }
 
     /**
      * Load data from cache (retrieves data from cache item)

--- a/lib/Cache/Core/CoreHandlerInterface.php
+++ b/lib/Cache/Core/CoreHandlerInterface.php
@@ -55,13 +55,6 @@ interface CoreHandlerInterface
      * @return $this
      */
     public function setHandleCli($handleCli);
-    
-    /**
-     * @param int $maxWriteToCacheItems
-     
-     * @return $this
-     */
-    public function setMaxWriteToCacheItems($maxWriteToCacheItems)
 
     /**
      * @return bool

--- a/lib/Cache/Core/CoreHandlerInterface.php
+++ b/lib/Cache/Core/CoreHandlerInterface.php
@@ -55,6 +55,13 @@ interface CoreHandlerInterface
      * @return $this
      */
     public function setHandleCli($handleCli);
+    
+    /**
+     * @param int $maxWriteToCacheItems
+     
+     * @return $this
+     */
+    public function setMaxWriteToCacheItems($maxWriteToCacheItems)
 
     /**
      * @return bool


### PR DESCRIPTION
During a CLI mass import we want to be able to add items to the cache. Currently this fails if there are more than 50 objects / assets related in the currently imported object (hard coded limit in CoreHandler). This PR adds a setter for this field. 