### PR TITLE
Allow no mysql password on cli install

### DIFF
--- a/bundles/InstallBundle/Command/InstallCommand.php
+++ b/bundles/InstallBundle/Command/InstallCommand.php
@@ -287,7 +287,8 @@ class InstallCommand extends Command
 
             $value = $input->getOption($name);
 
-            if ($value) {
+            // Empty MySQL password allowed
+            if ($value || $name === 'mysql-password') {
                 $param          = str_replace('-', '_', $name);
                 $params[$param] = $value;
             } else {


### PR DESCRIPTION
Hello,

This pull request allow command-line install without password (for instance for dev env, automation/qa, etc.)

It resolves https://github.com/pimcore/pimcore/issues/2975

There is no way to detect if $value is empty or not set (because option 'mysql-password' is required in any case), so the if condition has been modified to handle this special case by testing directly the option name (even if i found that it is not a very proper solution).

Maybe better solution would have been to add a new option parameter, like 'allow-empty':
```
            'mysql-password'    => [
                'description'  => 'MySQL password',
                'mode'         => InputOption::VALUE_REQUIRED,
                'insecure'     => true,
                'hidden-input' => true,
                'allow-empty' => true,
                'group'        => 'db_credentials',
            ],
```
And check in the if condition the value of 'allow-empty'.
But i don't know if it introduce some BC or problems in the installer (as it is based on Symfony Console component).
Another way would have been to change the mode to `InputOption::VALUE_OPTIONAL` but doing this mysql_password would not be mandatory on command line installer... (we want it mandatory but allowing empty).

Thanks.