### PR TITLE
Add parent class and traits for listing data object model

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
@@ -724,6 +724,20 @@ pimcore.object.classes.klass = Class.create({
                 },
                 {
                     xtype: "textfield",
+                    fieldLabel: t("listing_parent_php_class"),
+                    name: "listingParentClass",
+                    width: 600,
+                    value: this.data.listingParentClass
+                },
+                {
+                    xtype: "textfield",
+                    fieldLabel: t("listing_use_traits"),
+                    name: "listingUseTraits",
+                    width: 600,
+                    value: this.data.listingUseTraits
+                },
+                {
+                    xtype: "textfield",
                     fieldLabel: t("link_generator_reference"),
                     name: "linkGeneratorReference",
                     width: 600,

--- a/bundles/CoreBundle/Resources/translations/en.extended.json
+++ b/bundles/CoreBundle/Resources/translations/en.extended.json
@@ -685,5 +685,7 @@
   "unlock": "Unlock",
   "lock_and_propagate_to_childs": "Lock and propagate to children",
   "unlock_and_propagate_to_children": "Unlock and propagate to children",
-  "data_cache": "Data Cache"
+  "data_cache": "Data Cache",
+  "listing_use_traits": "Listing Use (traits)",
+  "listing_parent_php_class": "Listing Parent PHP Class"
 }

--- a/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_FilterDefinition_export.json
+++ b/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_FilterDefinition_export.json
@@ -1,7 +1,9 @@
 {
 	"description":null,
 	"parentClass":"\\Pimcore\\Bundle\\EcommerceFrameworkBundle\\Model\\AbstractFilterDefinition",
+	"listingParentClass":null,
 	"useTraits":null,
+	"listingUseTraits":null,
 	"allowInherit":true,
 	"allowVariants":false,
 	"showVariants":false,

--- a/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OfferToolCustomProduct_export.json
+++ b/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OfferToolCustomProduct_export.json
@@ -1,7 +1,9 @@
 {
     "description": null,
     "parentClass": "\\Pimcore\\Bundle\\EcommerceFrameworkBundle\\OfferTool\\AbstractOfferToolProduct",
-    "useTraits": null,
+    "listingParentClass":null,
+    "useTraits":null,
+    "listingUseTraits":null,
     "allowInherit": false,
     "allowVariants": false,
     "showVariants": false,

--- a/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OfferToolOfferItem_export.json
+++ b/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OfferToolOfferItem_export.json
@@ -1,7 +1,9 @@
 {
     "description": null,
     "parentClass": "\\Pimcore\\Bundle\\EcommerceFrameworkBundle\\OfferTool\\AbstractOfferItem",
-    "useTraits": null,
+    "listingParentClass":null,
+    "useTraits":null,
+    "listingUseTraits":null,
     "allowInherit": false,
     "allowVariants": false,
     "showVariants": false,

--- a/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OfferToolOffer_export.json
+++ b/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OfferToolOffer_export.json
@@ -1,7 +1,9 @@
 {
     "description": null,
     "parentClass": "\\Pimcore\\Bundle\\EcommerceFrameworkBundle\\OfferTool\\AbstractOffer",
-    "useTraits": null,
+    "listingParentClass":null,
+    "useTraits":null,
+    "listingUseTraits":null,
     "allowInherit": false,
     "allowVariants": false,
     "showVariants": false,

--- a/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopOrderItem_export.json
+++ b/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopOrderItem_export.json
@@ -1,7 +1,9 @@
 {
     "description": null,
     "parentClass": "\\Pimcore\\Bundle\\EcommerceFrameworkBundle\\Model\\AbstractOrderItem",
-    "useTraits": null,
+    "listingParentClass":null,
+    "useTraits":null,
+    "listingUseTraits":null,
     "allowInherit": false,
     "allowVariants": false,
     "showVariants": false,

--- a/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopOrder_export.json
+++ b/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopOrder_export.json
@@ -1,7 +1,9 @@
 {
   "description": null,
   "parentClass": "\\Pimcore\\Bundle\\EcommerceFrameworkBundle\\Model\\AbstractOrder",
-  "useTraits": null,
+  "listingParentClass":null,
+  "useTraits":null,
+  "listingUseTraits":null,
   "allowInherit": false,
   "allowVariants": false,
   "showVariants": false,

--- a/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopTaxClass_export.json
+++ b/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopTaxClass_export.json
@@ -1,7 +1,9 @@
 {
 	"description":null,
 	"parentClass":null,
+	"listingParentClass":null,
 	"useTraits":null,
+	"listingUseTraits":null,
 	"allowInherit":false,
 	"allowVariants":false,
 	"showVariants":false,

--- a/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopVoucherSeries_export.json
+++ b/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopVoucherSeries_export.json
@@ -1,7 +1,9 @@
 {
 	"description":null,
 	"parentClass":"\\Pimcore\\Bundle\\EcommerceFrameworkBundle\\Model\\AbstractVoucherSeries",
+	"listingParentClass":null,
 	"useTraits":null,
+	"listingUseTraits":null,
 	"allowInherit":false,
 	"allowVariants":false,
 	"showVariants":false,

--- a/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopVoucherToken_export.json
+++ b/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopVoucherToken_export.json
@@ -1,7 +1,9 @@
 {
 	"description":null,
 	"parentClass":null,
+	"listingParentClass":null,
 	"useTraits":null,
+	"listingUseTraits":null,
 	"allowInherit":false,
 	"allowVariants":false,
 	"showVariants":false,

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/01_Inheritance.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/01_Inheritance.md
@@ -56,6 +56,8 @@ In order to maintain all Pimcore functionalities, it has to be ensured that the 
 above extends `Pimcore\Model\DataObject\Concrete` and that its methods don't override and clash in unexpected ways 
 with existing methods of `Pimcore\Model\DataObject\Concrete` or any magic functions of `Pimcore\Model\DataObject\Concrete`
 or its parent classes.
+
+Starting from Pimcore 5.4.0, it is also possible to use class inheritance and traits for listing data object model.
 </div>
 
 ### Hooks available when using class inheritance

--- a/doc/Development_Documentation/20_Extending_Pimcore/07_Parent_Class_for_Objects.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/07_Parent_Class_for_Objects.md
@@ -9,5 +9,8 @@ The class will then extend the given parent class.
 ![Parent Class Configuration](../img/parent-class.png)
 
 Please make sure, that your custom class itself extends `Pimcore\Model\DataObject\Concrete` at some point in its class hierarchy. 
-Otherwise the object class will not work. 
+Otherwise the object class will not work.
 
+Starting from Pimcore 5.4.0, it is also possible to make the object listing model extend a certain parent class too.
+To do so, define a `Listing Parent class` in the classes basic configuration. 
+The listing class will then extend the given listing parent class.

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -76,9 +76,21 @@ class ClassDefinition extends Model\AbstractModel
     public $parentClass;
 
     /**
+     * Name of the listing parent class if set
+     *
+     * @var string
+     */
+    public $listingParentClass;
+
+    /**
      * @var bool
      */
     public $useTraits;
+
+    /**
+     * @var bool
+     */
+    public $listingUseTraits;
 
     /**
      * @var bool
@@ -437,6 +449,13 @@ class ClassDefinition extends Model\AbstractModel
         }
         File::put($classFile, $cd);
 
+        // create class for object list
+        $extendListingClass = 'DataObject\\Listing\\Concrete';
+        if ($this->getListingParentClass()) {
+            $extendListingClass = $this->getListingParentClass();
+            $extendListingClass = '\\'.ltrim($extendListingClass, '\\');
+        }
+
         // create list class
         $cd = '<?php ';
 
@@ -450,8 +469,13 @@ class ClassDefinition extends Model\AbstractModel
         $cd .= ' * @method DataObject\\'.ucfirst($this->getName())."[] load()\n";
         $cd .= ' */';
         $cd .= "\n\n";
-        $cd .= 'class Listing extends DataObject\\Listing\\Concrete {';
+        $cd .= 'class Listing extends '.$extendListingClass.' {';
         $cd .= "\n\n";
+
+        if ($this->getListingUseTraits()) {
+            $cd .= 'use '.$this->getListingUseTraits().";\n";
+            $cd .= "\n";
+        }
 
         $cd .= 'public $classId = "'. $this->getId()."\";\n";
         $cd .= 'public $className = "'.$this->getName().'"'.";\n";
@@ -922,6 +946,14 @@ class ClassDefinition extends Model\AbstractModel
     /**
      * @return string
      */
+    public function getListingParentClass()
+    {
+        return $this->listingParentClass;
+    }
+
+    /**
+     * @return string
+     */
     public function getUseTraits()
     {
         return $this->useTraits;
@@ -935,6 +967,26 @@ class ClassDefinition extends Model\AbstractModel
     public function setUseTraits($useTraits)
     {
         $this->useTraits = $useTraits;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getListingUseTraits()
+    {
+        return $this->listingUseTraits;
+    }
+
+    /**
+     * @param string $listingUseTraits
+     *
+     * @return ClassDefinition
+     */
+    public function setListingUseTraits($listingUseTraits)
+    {
+        $this->listingUseTraits = $listingUseTraits;
 
         return $this;
     }
@@ -963,6 +1015,18 @@ class ClassDefinition extends Model\AbstractModel
     public function setParentClass($parentClass)
     {
         $this->parentClass = $parentClass;
+
+        return $this;
+    }
+
+    /**
+     * @param string $listingParentClass
+     *
+     * @return $this
+     */
+    public function setListingParentClass($listingParentClass)
+    {
+        $this->listingParentClass = $listingParentClass;
 
         return $this;
     }

--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -110,7 +110,9 @@ class Service
         $class->setAllowVariants($importData['allowVariants']);
         $class->setShowVariants($importData['showVariants']);
         $class->setParentClass($importData['parentClass']);
+        $class->setListingParentClass(isset($importData['listingParentClass']) ? $importData['listingParentClass'] : null);
         $class->setUseTraits($importData['useTraits']);
+        $class->setListingUseTraits(isset($importData['listingUseTraits']) ? $importData['listingUseTraits'] : null);
         $class->setPreviewUrl($importData['previewUrl']);
         $class->setPropertyVisibility($importData['propertyVisibility']);
         $class->setLinkGeneratorReference(isset($importData['linkGeneratorReference']) ? $importData['linkGeneratorReference'] : null);

--- a/models/Webservice/Data/ClassDefinition.php
+++ b/models/Webservice/Data/ClassDefinition.php
@@ -64,11 +64,25 @@ class ClassDefinition extends Model\Webservice\Data
     public $parentClass;
 
     /**
+     * Name of the parent listing class if set
+     *
+     * @var string
+     */
+    public $listingParentClass;
+
+    /**
      * Name of the traits to use if set
      *
      * @var string
      */
     public $useTraits;
+
+    /**
+     * Name of the listing traits to use if set
+     *
+     * @var string
+     */
+    public $listingUseTraits;
 
     /**
      * @var bool

--- a/tests/_support/Resources/objects/class-allfields.json
+++ b/tests/_support/Resources/objects/class-allfields.json
@@ -1,7 +1,9 @@
 {
 	"description":null,
 	"parentClass":null,
+	"listingParentClass":null,
 	"useTraits":null,
+	"listingUseTraits":null,
 	"allowInherit":false,
 	"allowVariants":false,
 	"showVariants":false,

--- a/tests/_support/Resources/objects/class-import.json
+++ b/tests/_support/Resources/objects/class-import.json
@@ -1,7 +1,9 @@
 {
 	"description":null,
 	"parentClass":null,
+	"listingParentClass":null,
 	"useTraits":null,
+	"listingUseTraits":null,
 	"allowInherit":false,
 	"allowVariants":false,
 	"showVariants":false,

--- a/tests/_support/Resources/objects/classificationstore.json
+++ b/tests/_support/Resources/objects/classificationstore.json
@@ -1,7 +1,9 @@
 {
 	"description":null,
 	"parentClass":null,
+	"listingParentClass":null,
 	"useTraits":null,
+	"listingUseTraits":null,
 	"allowInherit":false,
 	"allowVariants":false,
 	"showVariants":false,

--- a/tests/_support/Resources/objects/inheritance.json
+++ b/tests/_support/Resources/objects/inheritance.json
@@ -1,7 +1,9 @@
 {
     "description":null,
     "parentClass":null,
+    "listingParentClass":null,
     "useTraits":null,
+    "listingUseTraits":null,
     "allowInherit":true,
     "allowVariants":false,
     "showVariants":false,


### PR DESCRIPTION
Hello,

This PR add parent class and traits for listing data object model.

It resolve https://github.com/pimcore/pimcore/issues/1618 (1 year ago i know, long time to provide this PR ;-) ). But as we are going to Pimcore 5.4 i think it is good to release this feature in the same time.

It should not introduce any BC break and i tested import/export class too.

Documentation has been updated considering this feature will be available in Pimcore 5.4.0.

Thanks.