### PR TITLE
Added is_object check, to prevent fatal error on backend search.

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Date.php
+++ b/models/DataObject/ClassDefinition/Data/Date.php
@@ -196,7 +196,7 @@ class Date extends Model\DataObject\ClassDefinition\Data
      */
     public function getDataForGrid($data, $object = null, $params = [])
     {
-        if ($data) {
+        if ($data && is_object($data)) {
             return $data->getTimestamp();
         } else {
             return null;

--- a/models/DataObject/ClassDefinition/Data/Datetime.php
+++ b/models/DataObject/ClassDefinition/Data/Datetime.php
@@ -195,7 +195,7 @@ class Datetime extends Model\DataObject\ClassDefinition\Data
      */
     public function getDataForGrid($data, $object = null, $params = [])
     {
-        if ($data) {
+        if ($data && is_object($data)) {
             return $data->getTimestamp();
         } else {
             return null;


### PR DESCRIPTION
Sometimes $data is a string and not object:

object(Carbon\Carbon)#11507 (3) {
  ["date"]=>
  string(26) "2017-03-09 00:00:00.000000"
  ["timezone_type"]=>
  int(3)
  ["timezone"]=>
  string(13) "Europe/Berlin"
}

string(13) "NOT SUPPORTED"

This causes fatal error:
Call to a member function getTimestamp() on string {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Call to a member function getTimestamp() on string at pimcore/models/DataObject/ClassDefinition/Data/Date.php:200)"} []

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

