### PR TITLE
Implement webservice import for videos in data objects.

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Video.php
+++ b/models/DataObject/ClassDefinition/Data/Video.php
@@ -477,8 +477,6 @@ class Video extends Model\DataObject\ClassDefinition\Data
                         $video->setDescription($data['description']);
                         if (is_int($id = $data['data'])) {
                             if ($idMapper) {
-                                // @TODO check implementation of id mapping
-                                throw new \Exception('cannot get object video data from web service import - id mapping is not implemented');
                                 $id = $idMapper->getMappedId( 'asset', $id);
                             }
                             if( $asset = Asset::getById($id)) {
@@ -493,8 +491,6 @@ class Video extends Model\DataObject\ClassDefinition\Data
                         }
                         if (is_int($id = $data['poster'])) {
                             if ($idMapper) {
-                                // @TODO check implementation of id mapping
-                                throw new \Exception('cannot get object video data from web service import - id mapping is not implemented');
                                 $id = $idMapper->getMappedId( 'asset', $id);
                             }
                             if( $poster = Asset::getById($id)) {

--- a/models/DataObject/ClassDefinition/Data/Video.php
+++ b/models/DataObject/ClassDefinition/Data/Video.php
@@ -463,7 +463,7 @@ class Video extends Model\DataObject\ClassDefinition\Data
                 return null;
             }
             $data = unserialize( $value);
-            if ($data == FALSE) {
+            if ($data === FALSE) {
                 throw new \Exception('cannot get object video data from web service import - value cannot be decoded');
             }
             if (is_array($data)) {


### PR DESCRIPTION
This patch for #3150 implements the webservice import for videos in data objects.

I tested this in Pimcore 5.4.0 for youtube, vimeo and dailymotion videos.
Asset based videos are tested when used without an idMapper.

I tried to put in code for the id mapper, but that is untested because I dont know how to trigger the use of an id mapper. 