### PR TITLE
Support comma as separation symbol for floating-point numbers

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/QPay.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/QPay.php
@@ -344,9 +344,8 @@ class QPay extends AbstractPayment
 
         // restore price object for payment status
         $decimal = Decimal::zero();
-        if ($amount = $authorizedData['amount']) {
-            $amount = str_replace(",", ".", $amount);
-            $decimal = Decimal::create($amount);
+        if ($authorizedData['amount']) {
+            $decimal = Decimal::create($authorizedData['amount']);
         }
         $price = new Price($decimal, new Currency($authorizedData['currency']));
 

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/QPay.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/QPay.php
@@ -344,8 +344,9 @@ class QPay extends AbstractPayment
 
         // restore price object for payment status
         $decimal = Decimal::zero();
-        if ($authorizedData['amount']) {
-            $decimal = Decimal::create($authorizedData['amount']);
+        if ($amount = $authorizedData['amount']) {
+            $amount = str_replace(",", ".", $amount);
+            $decimal = Decimal::create($amount);
         }
         $price = new Price($decimal, new Currency($authorizedData['currency']));
 

--- a/tests/ecommerce/Type/DecimalTest.php
+++ b/tests/ecommerce/Type/DecimalTest.php
@@ -584,6 +584,7 @@ class DecimalTest extends TestCase
         return [
             [15.99, '16.0000'],
             ['15.99', '16.0000'],
+            ['15,99', '16.0000'],
             [Decimal::fromRawValue(159900, 4), '16.0000'],
         ];
     }


### PR DESCRIPTION
If the amount gets passes with a comma "," as separation symbol for floating-point numbers in the `initPayment` call, the amount will be returned in the same format, which results in an Exception in the `Decimal::create(..)` call in the `handleResponse` function.

Solution: `Decimal::create(..)`  also accepts "," as separation symbol