### PR TITLE
in checkValidity changed exception type into ValidationException

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -302,16 +302,16 @@ class Multiselect extends Model\DataObject\ClassDefinition\Data
      * @param mixed $data
      * @param bool $omitMandatoryCheck
      *
-     * @throws \Exception
+     * @throws Model\Element\ValidationException
      */
     public function checkValidity($data, $omitMandatoryCheck = false)
     {
         if (!$omitMandatoryCheck and $this->getMandatory() and empty($data)) {
-            throw new \Exception('Empty mandatory field [ '.$this->getName().' ]');
+            throw new Model\Element\ValidationException('Empty mandatory field [ '.$this->getName().' ]');
         }
 
         if (!is_array($data) and !empty($data)) {
-            throw new \Exception('Invalid multiselect data');
+            throw new Model\Element\ValidationException('Invalid multiselect data');
         }
     }
 


### PR DESCRIPTION
Pimcore\Model\DataObject\ClassDefinition\Data\Multiselect::checkValidity(...) method throws \Exception while other Pimcore\Model\DataObject\ClassDefinition\Data throws ValidationException. It is inconsistent and, moreover, caused errors in our special validator.
<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

