### PR TITLE
Fix #3152: When creating a new class definition an error is logged

### DIFF
--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -273,6 +273,16 @@ class ClassDefinition extends Model\AbstractModel
     }
 
     /**
+     * @return bool
+     */
+    public function exists()
+    {
+        $name = $this->getDao()->getNameById($this->getId());
+
+        return is_string($name);
+    }
+
+    /**
      * @param bool $saveDefinitionFile
      *
      * @throws \Exception
@@ -285,9 +295,8 @@ class ClassDefinition extends Model\AbstractModel
             $this->setId($maxId ? $maxId + 1 : 1);
         }
 
-        $existingDefinition = ClassDefinition::getById($this->getId());
+        $isUpdate = $this->exists();
 
-        $isUpdate = !is_null($existingDefinition);
         if (!$isUpdate) {
             \Pimcore::getEventDispatcher()->dispatch(
                 DataObjectClassDefinitionEvents::PRE_ADD,


### PR DESCRIPTION
## Changes in this pull request  
Resolves #3152

## Additional info  

Bug can be reproduced with the following command:

```
<?php

namespace AppBundle\Command;

use Pimcore\Console\AbstractCommand;
use Pimcore\Model\DataObject\ClassDefinition;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;

class TestCommand extends AbstractCommand
{
    protected function configure()
    {
        $this->setName('test');
    }

    protected function execute(InputInterface $input, OutputInterface $output)
    {
        $class = new ClassDefinition();
        $class->setName('Test');
        $class->save();
    }
}
```

Command:
`php bin/console test` 

Output:
`09:53:12 ERROR     [pimcore] Exception: Class definition with name  or ID 9 does not exist in /var/www/blankse/pimcore-5.4.2/vendor/pimcore/pimcore/models/DataObject/ClassDefinition.php:193`