### PR TITLE
Fix: When creating folder by path multiple warnings are logged

### DIFF
--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -760,53 +760,53 @@ class Service extends Model\AbstractModel
             $sanitizedPath = $sanitizedPath . self::getValidKey($part, $itemType) . '/';
         }
 
-        if (!($foundElement = $type::getByPath($sanitizedPath))) {
-            foreach ($parts as $part) {
-                $pathPart = $pathsArray[count($pathsArray) - 1] ?? '';
-                $pathsArray[] = $pathPart . '/' . self::getValidKey($part, $itemType);
-            }
+        if (self::pathExists($sanitizedPath, $itemType)) {
+            return $type::getByPath($sanitizedPath);
+        }
 
-            for ($i = 0; $i < count($pathsArray); $i++) {
-                $currentPath = $pathsArray[$i];
-                if (!($type::getByPath($currentPath) instanceof $type)) {
-                    $parentFolderPath = ($i == 0) ? '/' : $pathsArray[$i - 1];
+        foreach ($parts as $part) {
+            $pathPart = $pathsArray[count($pathsArray) - 1] ?? '';
+            $pathsArray[] = $pathPart . '/' . self::getValidKey($part, $itemType);
+        }
 
-                    $parentFolder = $type::getByPath($parentFolderPath);
+        for ($i = 0; $i < count($pathsArray); $i++) {
+            $currentPath = $pathsArray[$i];
+            if (!self::pathExists($currentPath, $itemType)) {
+                $parentFolderPath = ($i == 0) ? '/' : $pathsArray[$i - 1];
 
-                    $folder = new $folderType();
-                    $folder->setParent($parentFolder);
-                    if ($parentFolder) {
-                        $folder->setParentId($parentFolder->getId());
-                    } else {
-                        $folder->setParentId(1);
-                    }
+                $parentFolder = $type::getByPath($parentFolderPath);
 
-                    $key = substr($currentPath, strrpos($currentPath, '/') + 1, strlen($currentPath));
-
-                    if (method_exists($folder, 'setKey')) {
-                        $folder->setKey($key);
-                    }
-
-                    if (method_exists($folder, 'setFilename')) {
-                        $folder->setFilename($key);
-                    }
-
-                    if (method_exists($folder, 'setType')) {
-                        $folder->setType('folder');
-                    }
-
-                    $folder->setPath($currentPath);
-                    $folder->setUserModification(0);
-                    $folder->setUserOwner(1);
-                    $folder->setCreationDate(time());
-                    $folder->setModificationDate(time());
-                    $folder->setValues($options);
-                    $folder->save();
-                    $lastFolder = $folder;
+                $folder = new $folderType();
+                $folder->setParent($parentFolder);
+                if ($parentFolder) {
+                    $folder->setParentId($parentFolder->getId());
+                } else {
+                    $folder->setParentId(1);
                 }
+
+                $key = substr($currentPath, strrpos($currentPath, '/') + 1, strlen($currentPath));
+
+                if (method_exists($folder, 'setKey')) {
+                    $folder->setKey($key);
+                }
+
+                if (method_exists($folder, 'setFilename')) {
+                    $folder->setFilename($key);
+                }
+
+                if (method_exists($folder, 'setType')) {
+                    $folder->setType('folder');
+                }
+
+                $folder->setPath($currentPath);
+                $folder->setUserModification(0);
+                $folder->setUserOwner(1);
+                $folder->setCreationDate(time());
+                $folder->setModificationDate(time());
+                $folder->setValues($options);
+                $folder->save();
+                $lastFolder = $folder;
             }
-        } else {
-            return $foundElement;
         }
 
         return $lastFolder;


### PR DESCRIPTION
## Additional info  

Bug can be reproduced with the following command:
```
<?php

namespace AppBundle\Command;

use Pimcore\Console\AbstractCommand;
use Pimcore\Model\Asset\Service;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;

class TestCommand extends AbstractCommand
{
    protected function configure()
    {
        $this->setName('test');
    }

    protected function execute(InputInterface $input, OutputInterface $output)
    {
        $folder = Service::createFolderByPath('/Test/Test2');
    }
}
```
Command:
`php bin/console test`

Output:
```
13:44:05 WARNING   [pimcore] asset with path: /Test/Test2 doesn't exist [] []
13:44:07 WARNING   [pimcore] asset with path: /Test doesn't exist [] []
13:44:07 WARNING   [pimcore] asset with path: /Test/Test2 doesn't exist [] []
```