### PR TITLE
Bugfix: Lost version data on index update

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObjectController.php
@@ -1207,10 +1207,16 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             if (method_exists($sibling, 'setOmitMandatoryCheck')) {
                 $sibling->setOmitMandatoryCheck(true);
             }
-            $sibling
-                ->setIndex($index)
-                ->save();
-            $index++;
+            if($sibling instanceof DataObject\Concrete && $latestVersion = $sibling->getLatestVersion()) {
+                $sibling = $latestVersion->loadData();
+                $sibling->setIndex($index)
+                    ->saveVersion();
+            } else {
+                $sibling
+                    ->setIndex($index)
+                    ->save();
+                $index++;
+            }
         }
     }
 


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [X] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [X] Features need to be proper documented in `doc/`
- [X] Bugfixes need a short guide how to reproduce them. 
- [X] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [X] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
With 5.2.2 the functionality of sorting tree-objects by key (position in tree) was implemented.
https://github.com/pimcore/pimcore/pull/2501

The implementation leads to a problem when moving objects into a folder. 
All siblings of the moved object get their index value updated to keep the index up to date, regardless if the sibling is only saved as an unpublished version. (DataObjectController::updateIndexesOfObjectSiblings).
The modification timestamp of the object is changed and therefore the link to the version file is lost.
This may lead to dataloss when using unpublished versions

The provided fix saves objects only as versions if there is an unpublished version for that object.
Side effect here is that the index of that particular object is updated only inside the version on the file system and therefore the sorting may not work as expected.
But it's less dangerous than to lose version contents.

## Additional info  
Steps to reproduce:
1) Create folder "foo"
2) Create folder "bar" inside "foo"
3) Create object "foobar" inside "foo"
4) Create object "barfoo" inside "bar"
5) Edit object "barfoo" and save as version
6) Move "foobar" into "bar"

The edited changes from step 5 in "barfoo" are lost.

