### PR TITLE
Use admin translations for rendering meta column value

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multihrefMetadata.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multihrefMetadata.js
@@ -193,7 +193,7 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                 }.bind(this, this.fieldConfig.columns[i].type, readOnly);
             }
             
-            if(this.fieldConfig.columns[i].type == "multiselect" || this.fieldConfig.columns[i].type == "select") {
+            if(this.fieldConfig.columns[i].type == "select") {
                 renderer = function (value, metaData, record, rowIndex, colIndex, store) {
                     return ts(value);
                 }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multihrefMetadata.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multihrefMetadata.js
@@ -192,6 +192,12 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                     return editor;
                 }.bind(this, this.fieldConfig.columns[i].type, readOnly);
             }
+            
+            if(this.fieldConfig.columns[i].type == "multiselect" || this.fieldConfig.columns[i].type == "select") {
+                renderer = function (value, metaData, record, rowIndex, colIndex, store) {
+                    return ts(value);
+                }
+            }
 
             var columnConfig = {
                 text: ts(this.fieldConfig.columns[i].label),


### PR DESCRIPTION
When you have a multihref with metadata field which has a select or multiselect metadata column its values should be translated.

Reproduce:
1. Create multihref with metadata field in a data object class
1. Add meta column "test" of type "select" and add some options
1. Add admin translations with key=option key
1. go to an object and set value -> admin translations are not used

With this PR admin translations get used to display selected option.