### PR TITLE
Mark class tree item whose tab has focus

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
@@ -110,7 +110,6 @@ pimcore.object.klass = Class.create({
             params: {
             },
             success: function (response) {
-
                 var classes = Ext.decode(response.responseText);
                 this.addClass(classes);
             }.bind(this)
@@ -129,7 +128,18 @@ pimcore.object.klass = Class.create({
                             showCloseOthers: true
                         }),
                         Ext.create('Ext.ux.TabReorderer', {})
-                    ]
+                    ],
+                listeners: {
+                    'tabchange': function (tabpanel, tab) {
+                        var classId = tab.id.substr("pimcore_class_editor_panel_".length);
+                        var tree = this.tree;
+                        this.tree.getRootNode().cascade(function () {
+                            if (this.id.toString() === classId) {
+                                tree.setSelection(this);
+                            }
+                        });
+                    }.bind(this)
+                }
             });
         }
 


### PR DESCRIPTION
In the past it happened multiple times that our customers wanted to import a class definition from their test system. They exported it to a JSON file and went to classes configuration. Because they had some other changes to do they opened multiple classes. Then they wanted to overwrite the existing class with the import. They looked which class was marked with yellow background in the tree and clicked the import button. They imported the JSON file, saved - and boom, a lot of data was deleted.

What happened? They did not look which tab has focus but only which tree item is marked. In the current implementation this does not get synchronized. Consequently they imported the class definition to another class than was marked in the tree - and so they deleted all data of the belinging data objects.

With this PR the corresponding tree item gets marked when you change the tab focus.