### PR TITLE
[Bugfix] Getting value of localized field of newly created field collection should return null

### DIFF
--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -280,7 +280,7 @@ class Localizedfield extends Model\AbstractModel
             $allowInheritance = false;
         }
 
-        if ($fieldDefinition->isEmpty($data) && $doGetInheritedValues && $allowInheritance) {
+        if ($fieldDefinition->isEmpty($data) && $doGetInheritedValues && $allowInheritance && $this->getObject() instanceof Concrete) {
             $object = $this->getObject();
             $class = $object->getClass();
             $allowInherit = $class->getAllowInherit();


### PR DESCRIPTION
### Expected behavior 
Getter of localized fields should return null on newly created field collection objects
  
### Actual behavior  
Error: Call to a member function getClass() on null

### Steps to reproduce  
1. Create field collection named `XYZ` with a localized field `test`
1. Anywhere in the code write:
```php
$fieldCollectionItem = new \Pimcore\Model\DataObject\Fieldcollection\Data\XYZ();
$fieldCollectionItem->getTest('en');
```
It happens because the field collection does not know which object it belongs to and nevertheless tries to get an inherited value.