### PR TITLE
[Bugfix] Use Pimcore constant instead of hard-coded value

### DIFF
--- a/bundles/CoreBundle/EventListener/TemplateControllerListener.php
+++ b/bundles/CoreBundle/EventListener/TemplateControllerListener.php
@@ -107,7 +107,7 @@ class TemplateControllerListener implements EventSubscriberInterface
             $template->setEngine($engine);
             $templateReference = $guesser->guessTemplateName($controller, $request, $engine);
 
-            if ($templateReference->get('bundle') == 'AppBundle') {
+            if ($templateReference->get('bundle') === PIMCORE_SYMFONY_DEFAULT_BUNDLE) {
                 $templateReference->set('bundle', '');
             }
 


### PR DESCRIPTION
## Steps to reproduce
* Move the default AppBundle to an own namespace (e.g. AcmeAppBundle) by setting PIMCORE_SYMFONY_DEFAULT_BUNDLE
* Create a document with a default action
* An error will be thrown in the "Edit" tab since Symfony can not find the template
