### PR TITLE
Portlet Bugfix - move condition to list statement

### DIFF
--- a/pimcore/modules/admin/controllers/PortalController.php
+++ b/pimcore/modules/admin/controllers/PortalController.php
@@ -247,7 +247,8 @@ class Admin_PortalController extends \Pimcore\Controller\Action\Admin
         $list = Document::getList([
             "limit" => 10,
             "order" => "DESC",
-            "orderKey" => "modificationDate"
+            "orderKey" => "modificationDate",
+            "condition" => "userModification = '".$this->getUser()->getId()."'"
         ]);
 
 
@@ -260,7 +261,6 @@ class Admin_PortalController extends \Pimcore\Controller\Action\Admin
                 "type" => $doc->getType(),
                 "path" => $doc->getRealFullPath(),
                 "date" => $doc->getModificationDate(),
-                "condition" => "userModification = '".$this->getUser()->getId()."'"
             ];
         }
 
@@ -272,7 +272,8 @@ class Admin_PortalController extends \Pimcore\Controller\Action\Admin
         $list = Asset::getList([
             "limit" => 10,
             "order" => "DESC",
-            "orderKey" => "modificationDate"
+            "orderKey" => "modificationDate",
+            "condition" => "userModification = '".$this->getUser()->getId()."'"
         ]);
 
 
@@ -285,7 +286,6 @@ class Admin_PortalController extends \Pimcore\Controller\Action\Admin
                 "type" => $doc->getType(),
                 "path" => $doc->getRealFullPath(),
                 "date" => $doc->getModificationDate(),
-                "condition" => "userModification = '".$this->getUser()->getId()."'"
             ];
         }
 


### PR DESCRIPTION
Move the condition for the Document/Asset portlet to the list statement (otherwise documents... appear which are not editable).

It should also be fixed in the pimcore 5 version but there we may also check if the user is still allowed to edit the document. Otherwise the User gets an error each time pimcore is opened because the document is in the "remembered Tabs" - and the user is not allowed to view the document.