### PR TITLE
Minor payment refactorings

### DIFF
--- a/bundles/CoreBundle/Resources/migrations/Version20180830113528.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20180830113528.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+use Pimcore\Model\DataObject\Fieldcollection\Definition;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180830113528 extends AbstractPimcoreMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->writeMessage("Updating field collection definition 'paymentState' - adding additional paymentState");
+
+        try {
+            $definition = Definition::getByKey('PaymentInfo');
+        } catch (\Exception $e) {
+        }
+
+        if($definition) {
+            $fieldDefinition = $definition->getFieldDefinition('paymentState');
+
+            if($fieldDefinition) {
+                $options = $fieldDefinition->getOptions();
+                $options[] = [
+                    'value' => 'abortedButResponseReceived',
+                    'key' => 'Aborted but Response Received'
+                ];
+                $fieldDefinition->setOptions($options);
+
+
+                $this->writeMessage(" ... saving field collection definition 'paymentState'");
+                if(!$this->isDryRun()) {
+                    $definition->save();
+                }
+            }
+        } else {
+            $this->writeMessage(" ... nothing to do because field collection definition does not exist.");
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->writeMessage("Updating field collection definition 'paymentState' - removing additional paymentState");
+
+        try {
+            $definition = Definition::getByKey('PaymentInfo');
+        } catch (\Exception $e) {
+        }
+
+        if($definition) {
+            $fieldDefinition = $definition->getFieldDefinition('paymentState');
+
+            if($fieldDefinition) {
+                $options = $fieldDefinition->getOptions();
+
+                $indexToDelete = null;
+                foreach($options as $index => $option) {
+                    if($option['value'] == 'abortedButResponseReceived') {
+                        $indexToDelete = $index;
+                    }
+                }
+
+                if($indexToDelete !== null) {
+                    unset($options[$indexToDelete]);
+                }
+
+                $fieldDefinition->setOptions($options);
+
+                $this->writeMessage(" ... saving field collection definition 'paymentState'");
+                if(!$this->isDryRun()) {
+                    $definition->save();
+                }
+            }
+
+        } else {
+            $this->writeMessage(" ... nothing to do because field collection definition does not exist.");
+        }
+
+    }
+}

--- a/bundles/CoreBundle/Resources/migrations/Version20180830113528.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20180830113528.php
@@ -6,9 +6,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
 use Pimcore\Model\DataObject\Fieldcollection\Definition;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
+
 class Version20180830113528 extends AbstractPimcoreMigration
 {
     /**
@@ -43,6 +41,9 @@ class Version20180830113528 extends AbstractPimcoreMigration
         } else {
             $this->writeMessage(" ... nothing to do because field collection definition does not exist.");
         }
+
+
+
     }
 
     /**

--- a/bundles/CoreBundle/Resources/migrations/Version20180830122128.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20180830122128.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+use Pimcore\Model\DataObject\ClassDefinition;
+
+class Version20180830122128 extends AbstractPimcoreMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->writeMessage("Updating class definition 'OnlineShopOrder' - adding index to cartId");
+
+        $classDefinition = ClassDefinition::getByName('OnlineShopOrder');
+
+        if($classDefinition) {
+            $fieldDefinition = $classDefinition->getFieldDefinition('cartId');
+
+            if($fieldDefinition) {
+                $fieldDefinition->setIndex(true);
+
+                $this->writeMessage(" ... saving class definition 'OnlineShopOrder'");
+                if(!$this->isDryRun()) {
+                    $classDefinition->save();
+                }
+            }
+        } else {
+            $this->writeMessage(" ... nothing to do because class definition does not exist.");
+        }
+
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->writeMessage("Updating class definition 'OnlineShopOrder' - removing index to cartId");
+
+        $classDefinition = ClassDefinition::getByName('OnlineShopOrder');
+
+        if($classDefinition) {
+            $fieldDefinition = $classDefinition->getFieldDefinition('cartId');
+
+            if($fieldDefinition) {
+                $fieldDefinition->setIndex(false);
+
+                $this->writeMessage(" ... saving class definition 'OnlineShopOrder'");
+                if(!$this->isDryRun()) {
+                    $classDefinition->save();
+                }
+            }
+        } else {
+            $this->writeMessage(" ... nothing to do because class definition does not exist.");
+        }
+
+    }
+}

--- a/bundles/EcommerceFrameworkBundle/CheckoutManager/CheckoutManager.php
+++ b/bundles/EcommerceFrameworkBundle/CheckoutManager/CheckoutManager.php
@@ -287,10 +287,6 @@ class CheckoutManager implements ICheckoutManager
             throw new UnsupportedException('Payment is not activated');
         }
 
-        if ($this->isCommitted()) {
-            throw new UnsupportedException('Order is already committed.');
-        }
-
         if (!$this->isFinished()) {
             throw new UnsupportedException('Checkout is not finished yet.');
         }

--- a/bundles/EcommerceFrameworkBundle/CheckoutManager/CommitOrderProcessor.php
+++ b/bundles/EcommerceFrameworkBundle/CheckoutManager/CommitOrderProcessor.php
@@ -136,9 +136,7 @@ class CommitOrderProcessor implements ICommitOrderProcessor
                         if ($paymentInfo->getPaymentState() == $paymentStatus->getStatus()) {
                             return $order;
                         } else {
-                            $message = 'Payment state of order ' . $order->getId() . ' does not match with new request!';
-                            Logger::error($message);
-                            throw new \Exception($message);
+                            Logger::warning('Payment state of order ' . $order->getId() . ' does not match with new request!');
                         }
                     }
                 }

--- a/bundles/EcommerceFrameworkBundle/CheckoutManager/CommitOrderProcessor.php
+++ b/bundles/EcommerceFrameworkBundle/CheckoutManager/CommitOrderProcessor.php
@@ -180,11 +180,15 @@ class CommitOrderProcessor implements ICommitOrderProcessor
             $order = $this->commitOrder($order);
         } elseif ($order->getOrderState() == $order::ORDER_STATE_COMMITTED) {
 
+            // only when we receive an unsuccessful payment request after order is already committed
             // do not overwrite status if order is already committed. normally this shouldn't happen at all.
             $logger = ApplicationLogger::getInstance(self::LOGGER_NAME, true);
-            $logger->setRelatedObject($order);
-            $logger->setFileObject(new FileObject(print_r($paymentStatus, true)));
-            $logger->critical('Order with ID ' . $order->getId() . ' got payment status after it was already committed.');
+            $logger->critical('Order with ID ' . $order->getId() . ' got payment status after it was already committed.',
+                [
+                    'fileObject' => new FileObject(print_r($paymentStatus, true)),
+                    'relatedObject' => $order
+                ]
+            );
         } else {
             $order->setOrderState(null);
             $order->save();

--- a/bundles/EcommerceFrameworkBundle/Model/AbstractOrder.php
+++ b/bundles/EcommerceFrameworkBundle/Model/AbstractOrder.php
@@ -27,6 +27,7 @@ class AbstractOrder extends \Pimcore\Model\DataObject\Concrete
     const ORDER_STATE_PAYMENT_PENDING = 'paymentPending';
     const ORDER_STATE_PAYMENT_AUTHORIZED = 'paymentAuthorized';
     const ORDER_STATE_ABORTED = 'aborted';
+    const ORDER_PAYMENT_STATE_ABORTED_BUT_RESPONSE = 'abortedButResponseReceived';
 
     /**
      * @return string

--- a/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopOrder_export.json
+++ b/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopOrder_export.json
@@ -567,7 +567,7 @@
                     "tooltip": "",
                     "mandatory": false,
                     "noteditable": true,
-                    "index": false,
+                    "index": true,
                     "locked": false,
                     "style": "",
                     "permissions": null,

--- a/bundles/EcommerceFrameworkBundle/Resources/install/fieldcollection_sources/fieldcollection_PaymentInfo_export.json
+++ b/bundles/EcommerceFrameworkBundle/Resources/install/fieldcollection_sources/fieldcollection_PaymentInfo_export.json
@@ -121,6 +121,10 @@
 							{
 								"key":"Aborted",
 								"value":"aborted"
+							},
+							{
+								"key": "Aborted but Response Received",
+								"value": "abortedButResponseReceived"
 							}
 						],
 						"width":500,


### PR DESCRIPTION
- fixes #2248 
- makes sure that payment is processed even if order is already committed - in order to have logs
- sets index or OnlineShopOrder:cartId