### PR TITLE
Add mute option to embedded video elements.

### DIFF
--- a/models/Document/Tag/Video.php
+++ b/models/Document/Tag/Video.php
@@ -538,13 +538,15 @@ class Video extends Model\Document\Tag
             'listType',
             'loop',
             'modestbranding',
+			'mute',
             'origin',
             'playerapiid',
             'playlist',
             'rel',
             'showinfo',
             'start',
-            'theme'];
+            'theme'
+			];
         $additional_params = '';
 
         $clipConfig = [];
@@ -613,9 +615,12 @@ class Video extends Model\Document\Tag
                 $height = $options['height'];
             }
 
-            $valid_vimeo_prams = [
+            $valid_vimeo_prams = [         
                 'autoplay',
-                'loop'];
+				'background',
+                'loop',
+				'muted'
+				];
 
             $additional_params = '';
 
@@ -691,7 +696,8 @@ class Video extends Model\Document\Tag
 
             $valid_dailymotion_prams = [
                 'autoplay',
-                'loop'];
+                'loop',
+				'mute'];
 
             $additional_params = '';
 


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
* add `mute` and `muted` (depending on the video source) to valid video tag parameter for embedded videos
* add `background` to the valid dailymotion parameters. This hides the control panel and automatically mutes the video  

## Additional info  
Google Chrome blocks autoplay of video with audio, while muted autoplay is always allowed. [Source](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes)

## Example
```php
 <?= $this->video('background-video', [
    "youtube" => ['mute' => true, 'autoplay' => true],
    "vimeo" => ['autoplay' => true, 'background' => true, 'muted' => true],
    "dailymotion" => ['autoplay' => true, 'mute' => true]
]) ?>
````

