### PR TITLE
fix WebDAV of the suggested Nginx config

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
@@ -74,8 +74,8 @@ server {
 
     # Assets
     # Still use a whitelist approach to prevent each and every missing asset to go through the PHP Engine.
-    location ~* (.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|ogg|ogv|webm|pdf|docx?|xlsx?|pptx?)$ {
-        try_files /var/assets$uri $uri =404;
+    location ~* ^(?:/admin/asset/webdav(?=/))?(?<actual_path>(.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|ogg|ogv|webm|pdf|docx?|xlsx?|pptx?))$ {
+        try_files /var/assets$actual_path $actual_path =404;
         expires 2w;
         access_log off;
         log_not_found off;


### PR DESCRIPTION
## Issue description

When using the [suggested Nginx configuration](https://pimcore.com/docs/5.x/Development_Documentation/Installation_and_Upgrade/System_Setup_and_Hosting/Nginx_Configuration.html), requesting files ending with (regex)

    \.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|ogg|ogv|webm|pdf|docx?|xlsx?|pptx?)

results in a `404` error. This happens for both `http` and `webdav` protocols:

* `http://pimcore.mysite.localhost/admin/asset/webdav/pimcore-logo-2013-grau.png`
* `webdav://pimcore.mysite.localhost/admin/asset/webdav/pimcore-logo-2013-grau.png`

When requesting the http URI (with a web browser or with curl), the returned page indicates that the 404 was caused by Nginx.

## Changes in this pull request

The prefix

    /admin/asset/webdav(?=/)

is trimmed from `$uri` for the `try_files` check.

## Additional info

I've verified that requesting

    http://pimcore.mysite.localhost/var/assets/pimcore-logo-2013-grau.png

still works.