### PR TITLE
fix links to *.example.php files

### DIFF
--- a/doc/Development_Documentation/01_Getting_Started/03_Configuration.md
+++ b/doc/Development_Documentation/01_Getting_Started/03_Configuration.md
@@ -54,7 +54,9 @@ at AWS S3 you have multiple ways to do so:
   component if it exists. Environment variables defined here will have the same effect as "real" environment variables.
 
 
-An example file (`constants.example.php`) is shipped with Pimcore installation and could look like: 
+The [Pimcore Skeleton](https://github.com/pimcore/skeleton) repository contains an example file,
+[`constants.example.php`](https://github.com/pimcore/skeleton/blob/master/app/constants.example.php).
+The following file is an example to overwrite some locations:
 
 ```php
 <?php

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/11_Custom_Views.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/11_Custom_Views.md
@@ -10,7 +10,7 @@ Note that the ID is mandatory and must be unique!
 
 ![Custom Views](../../../img/classes-custom-views1.png)
 
-For a sample configuration file have a look at the [sample configuration file](https://github.com/pimcore/pimcore/blob/master/app/config/pimcore/customviews.example.php) 
+For a sample configuration file have a look at the [sample configuration file](https://github.com/pimcore/skeleton/blob/master/app/config/pimcore/customviews.example.php) 
 that ships with Pimcore and its comments. 
 
 ## Advanced Features / Configurations
@@ -24,7 +24,7 @@ The main idea for this configuration is to
 
 ```php
 <?php
-// app/config/pimcore/customviews.example.php
+// https://github.com/pimcore/skeleton/blob/master/app/config/pimcore/customviews.example.php
  
 return [
     "views" => [

--- a/doc/Development_Documentation/07_Workflow_Management/README.md
+++ b/doc/Development_Documentation/07_Workflow_Management/README.md
@@ -33,8 +33,8 @@ These hold together States, Status & Actions into a complete workflow configurat
 
 ## Configuration
 
-Pimcore ships with a sample configuration file at `/app/config/pimcore/workflowmanagement.example.php`. 
-[See that file on GitHub](https://github.com/pimcore/pimcore/blob/master/app/config/pimcore/workflowmanagement.example.php).
+The [Pimcore Skeleton](https://github.com/pimcore/skeleton) repository contains a sample configuration file
+at [`app/config/pimcore/workflowmanagement.example.php`](https://github.com/pimcore/skeleton/blob/master/app/config/pimcore/workflowmanagement.example.php).
 This file should give you getting started in workflow configuration. 
 
 For details of configuration options see comments in that file or [Configuration Details](./01_Configuration_Details.md).

--- a/doc/Development_Documentation/18_Tools_and_Features/13_Perspectives.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/13_Perspectives.md
@@ -33,7 +33,7 @@ You can restrict the access to certain perspectives via the user settings.
 
 ## The Configuration File
 
-Please refer to the [Example File](https://github.com/pimcore/pimcore/blob/master/app/config/pimcore/perspectives.example.php) 
+Please refer to the [Example File](https://github.com/pimcore/skeleton/blob/master/app/config/pimcore/perspectives.example.php) 
 for further details on how this can be set up.
 
 You can find out there how the default view is prepared and how to add a special perspective.
@@ -55,7 +55,7 @@ The table below, describes the most useful of available options in the configura
 
 ## Simple example
 
-In the [Example File](https://github.com/pimcore/pimcore/blob/master/app/config/pimcore/perspectives.example.php) you 
+In the [Example File](https://github.com/pimcore/skeleton/blob/master/app/config/pimcore/perspectives.example.php) you 
 can find advance usage. Below, I showed how to create the simple structure which would be use for catalog administrators.
 
 We need only to see 

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/06_Additional_Tools_Installation.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/06_Additional_Tools_Installation.md
@@ -6,7 +6,7 @@ The installation of some of the tools is covered in this guide and should work a
 For other Linux distributions you might have to adopt some commands to your platform-specific environment, but we try to use as many statically linked software as possible, that can be used on any x64 Linux platform.  
 
 > It's important that all tools (incl. `composer`) are added to the `$PATH` env. variable, so that Pimcore is able to find the executables. 
-If you're not able to control the `$PATH` variable, you can also [manually configure the paths for each application](https://github.com/pimcore/pimcore/blob/master/app/config/parameters.example.yml).
+If you're not able to control the `$PATH` variable, you can also [manually configure the paths for each application](https://github.com/pimcore/skeleton/blob/master/app/config/parameters.example.yml).
 
 
 ## Composer 


### PR DESCRIPTION
## Changes in this pull request
fix links in the docs to `*.example.php` files

## Additional info  
it's a fixup for commit ee419f1633 (PR #3121)

In doc/Development_Documentation/01_Getting_Started/03_Configuration.md`, the link to the example + the inline example are somewhat redundant, but I kept the inline example as is.