### PR TITLE
[XLIFF export/import] Refactor to make it extendable and reusable

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -42,23 +42,6 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  */
 class TranslationController extends AdminController
 {
-    const SELFCLOSING_TAGS = ['area',
-        'base',
-        'br',
-        'col',
-        'command',
-        'embed',
-        'hr',
-        'img',
-        'input',
-        'keygen',
-        'link',
-        'meta',
-        'param',
-        'source',
-        'track',
-        'wbr'];
-
     /**
      * @Route("/import")
      * @Method({"POST"})
@@ -714,6 +697,7 @@ class TranslationController extends AdminController
 
     /**
      * @Route("/xliff-export")
+     * @Method({"POST"})
      *
      * @param Request $request
      * @param ExportServiceInterface $exportService
@@ -745,6 +729,7 @@ class TranslationController extends AdminController
 
     /**
      * @Route("/xliff-export-download")
+     * @Method({"GET"})
      *
      * @param Request $request
      * @param ExporterInterface $translationExporter
@@ -766,6 +751,7 @@ class TranslationController extends AdminController
 
     /**
      * @Route("/xliff-import-upload")
+     * @Method({"POST"})
      *
      * @param Request $request
      * @param ImportDataExtractorInterface $importDataExtractor
@@ -786,6 +772,7 @@ class TranslationController extends AdminController
         for ($i=0; $i < $steps; $i++) {
             $jobs[] = [[
                 'url' => '/admin/translation/xliff-import-element',
+                'method' => 'POST',
                 'params' => [
                     'id' => $id,
                     'step' => $i
@@ -807,6 +794,7 @@ class TranslationController extends AdminController
 
     /**
      * @Route("/xliff-import-element")
+     * @Method({"POST"})
      *
      * @param Request $request
      * @param ImportDataExtractorInterface $importDataExtractor

--- a/bundles/AdminBundle/DependencyInjection/Compiler/TranslationServicesPass.php
+++ b/bundles/AdminBundle/DependencyInjection/Compiler/TranslationServicesPass.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\AdminBundle\DependencyInjection\Compiler;
+
+
+use Pimcore\Translation\ExportDataExtractorService\ExportDataExtractorServiceInterface;
+use Pimcore\Translation\ImporterService\ImporterServiceInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class TranslationServicesPass implements CompilerPassInterface
+{
+    /**
+     * Registers each service with tag pimcore.translation.data-extractor as data extractor for the translations export data extractor service.
+     * Registers each service with tag pimcore.translation.importer as importer for the translations importer service.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $providers = $container->findTaggedServiceIds('pimcore.translation.data-extractor');
+
+        foreach ($providers as $id => $tags) {
+            foreach($tags as $attributes) {
+
+                if(empty($attributes['type'])) {
+                    throw new \Exception('service with tag "pimcore.translation.data-extractor" but without type registered');
+                }
+                $definition = $container->getDefinition(ExportDataExtractorServiceInterface::class);
+                $definition->addMethodCall('registerDataExtractor', [$attributes['type'], new Reference($id)]);
+            }
+        }
+
+
+        $providers = $container->findTaggedServiceIds('pimcore.translation.importer');
+
+        foreach ($providers as $id => $tags) {
+            foreach($tags as $attributes) {
+
+                if(empty($attributes['type'])) {
+                    throw new \Exception('service with tag "pimcore.translation.data-extractor" but without type registered');
+                }
+                $definition = $container->getDefinition(ImporterServiceInterface::class);
+                $definition->addMethodCall('registerImporter', [$attributes['type'], new Reference($id)]);
+            }
+        }
+    }
+}

--- a/bundles/AdminBundle/PimcoreAdminBundle.php
+++ b/bundles/AdminBundle/PimcoreAdminBundle.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\AdminBundle;
 use Pimcore\Bundle\AdminBundle\DependencyInjection\Compiler\GDPRDataProviderPass;
 use Pimcore\Bundle\AdminBundle\DependencyInjection\Compiler\ImportExportLocatorsPass;
 use Pimcore\Bundle\AdminBundle\DependencyInjection\Compiler\SerializerPass;
+use Pimcore\Bundle\AdminBundle\DependencyInjection\Compiler\TranslationServicesPass;
 use Pimcore\Bundle\AdminBundle\GDPR\DataProvider\DataProviderInterface;
 use Pimcore\Bundle\AdminBundle\Security\Factory\PreAuthenticatedAdminSessionFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
@@ -38,6 +39,7 @@ class PimcoreAdminBundle extends Bundle
         $container->addCompilerPass(new SerializerPass());
         $container->addCompilerPass(new GDPRDataProviderPass());
         $container->addCompilerPass(new ImportExportLocatorsPass());
+        $container->addCompilerPass(new TranslationServicesPass());
 
         /** @var SecurityExtension $extension */
         $extension = $container->getExtension('security');

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -80,6 +80,28 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+
+                        ->arrayNode('data_object')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->arrayNode('translation_extractor')
+                                    ->children()
+                                        ->arrayNode('attributes')
+                                            ->info('Can be used to restrict the extracted localized fields (e.g. used by XLIFF exporter in the Pimcore backend)')
+                                            ->prototype('array')
+                                                ->prototype('scalar')->end()
+                                            ->end()
+                                            ->example(
+                                                [
+                                                    'Product' => ['name', 'description'],
+                                                    'Brand' => ['name'],
+                                                ]
+                                            )
+                                        ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
                     ->end()
                 ->end()
                 ->arrayNode('maps')

--- a/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -30,6 +30,7 @@ use Pimcore\Sitemap\EventListener\SitemapGeneratorListener;
 use Pimcore\Targeting\ActionHandler\DelegatingActionHandler;
 use Pimcore\Targeting\DataLoaderInterface;
 use Pimcore\Targeting\Storage\TargetingStorageInterface;
+use Pimcore\Translation\ExportDataExtractorService\DataExtractor\DataObjectDataExtractor;
 use Pimcore\Translation\Translator;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -305,6 +306,11 @@ class PimcoreCoreExtension extends ConfigurableExtension implements PrependExten
         } else {
             $definition = $container->getDefinition(TranslationDebugListener::class);
             $definition->setArgument('$parameterName', $parameter);
+        }
+
+        if(!empty($config['data_object']['translation_extractor']['attributes'])) {
+            $definition = $container->getDefinition(DataObjectDataExtractor::class);
+            $definition->setArgument('$exportAttributes', $config['data_object']['translation_extractor']['attributes']);
         }
     }
 

--- a/bundles/CoreBundle/Resources/config/services.yml
+++ b/bundles/CoreBundle/Resources/config/services.yml
@@ -152,3 +152,33 @@ services:
     # DataObject Consent Service
     Pimcore\DataObject\Consent\Service:
         public: true
+
+    Pimcore\Translation\ExportDataExtractorService\ExportDataExtractorServiceInterface:
+        class:  Pimcore\Translation\ExportDataExtractorService\ExportDataExtractorService
+
+    Pimcore\Translation\ExportService\ExportServiceInterface:
+        class:  Pimcore\Translation\ExportService\ExportService
+
+    Pimcore\Translation\ExportDataExtractorService\DataExtractor\DataObjectDataExtractor:
+        tags: [{name:pimcore.translation.data-extractor, type:object}]
+
+    Pimcore\Translation\ExportDataExtractorService\DataExtractor\DocumentDataExtractor:
+        tags: [{name:pimcore.translation.data-extractor, type:document}]
+
+    Pimcore\Translation\ExportService\Exporter\ExporterInterface:
+        class: Pimcore\Translation\ExportService\Exporter\Xliff12Exporter
+
+    Pimcore\Translation\ImporterService\ImporterServiceInterface:
+        class: Pimcore\Translation\ImporterService\ImporterService
+
+    Pimcore\Translation\ImporterService\Importer\DataObjectImporter:
+        tags: [{name:pimcore.translation.importer, type:object}]
+
+    Pimcore\Translation\ImporterService\Importer\DocumentImporter:
+        tags: [{name:pimcore.translation.importer, type:document}]
+
+    Pimcore\Translation\ImportDataExtractor\ImportDataExtractorInterface:
+        class: Pimcore\Translation\ImportDataExtractor\Xliff12DataExtractor
+
+    Pimcore\Translation\ImportDataExtractor\TranslationItemResolver\TranslationItemResolverInterface:
+        class: Pimcore\Translation\ImportDataExtractor\TranslationItemResolver\TranslationItemResolver

--- a/lib/Translation/AttributeSet/Attribute.php
+++ b/lib/Translation/AttributeSet/Attribute.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\AttributeSet;
+
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\Element;
+
+class Attribute {
+
+    const TYPE_PROPERTY = 'property';
+    const TYPE_TAG = 'tag';
+    const TYPE_SETTINGS = 'settings';
+    const TYPE_LOCALIZED_FIELD = 'localizedfield';
+    const TYPE_BRICK_LOCALIZED_FIELD = 'localizedbrick';
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $content;
+
+    /**
+     * @var bool
+     */
+    private $isReadonly;
+
+    /**
+     * DataExtractorResultAttribute constructor.
+     * @param string $type
+     * @param string $name
+     * @param string $content
+     * @param bool $isReadonly
+     */
+    public function __construct(string $type, string $name, string $content, bool $isReadonly = false)
+    {
+        $this->type = $type;
+        $this->name = $name;
+        $this->content = $content;
+        $this->isReadonly = $isReadonly;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    /**
+     * Readonly attributes should not be translated - relevant for information purposes only.
+     *
+     * @return bool
+     */
+    public function isReadonly(): bool
+    {
+        return $this->isReadonly;
+    }
+
+}

--- a/lib/Translation/AttributeSet/AttributeSet.php
+++ b/lib/Translation/AttributeSet/AttributeSet.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\AttributeSet;
+
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\Element;
+use Pimcore\Translation\TranslationItemCollection\TranslationItem;
+
+class AttributeSet {
+
+    /**
+     * @var TranslationItem
+     */
+    private $translationItem;
+
+    /**
+     * @var string
+     */
+    private $sourceLanguage = '';
+
+    /**
+     * @var string[]
+     */
+    private $targetLanguages = [];
+
+    /**
+     * @var Attribute[];
+     */
+    private $attributes = [];
+
+    /**
+     * DataExtractorResult constructor.
+     * @param TranslationItem $element
+     */
+    public function __construct(TranslationItem $translationItem)
+    {
+        $this->translationItem = $translationItem;
+    }
+
+    /**
+     * @return TranslationItem
+     */
+    public function getTranslationItem(): TranslationItem
+    {
+        return $this->translationItem;
+    }
+
+    /**
+     * @param ElementInterface $translationItem
+     * @return AttributeSet
+     */
+    public function setTranslationItem(ElementInterface $translationItem): AttributeSet
+    {
+        $this->translationItem = $translationItem;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSourceLanguage(): string
+    {
+        return $this->sourceLanguage;
+    }
+
+    /**
+     * @param string $sourceLanguage
+     * @return AttributeSet
+     */
+    public function setSourceLanguage(string $sourceLanguage): AttributeSet
+    {
+        $this->sourceLanguage = $sourceLanguage;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getTargetLanguages(): array
+    {
+        return $this->targetLanguages;
+    }
+
+    /**
+     * @param string[] $targetLanguages
+     * @return AttributeSet
+     */
+    public function setTargetLanguages(array $targetLanguages): AttributeSet
+    {
+        $this->targetLanguages = $targetLanguages;
+
+        return $this;
+    }
+
+    /**
+     * @return Attribute[]
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    public function isEmpty(): bool
+    {
+        if(empty($this->attributes)) {
+            return true;
+        }
+
+        foreach ($this->attributes as $attribute) {
+            if(!$attribute->isReadonly()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string $type
+     * @param string $name
+     * @param string $content
+     * @param bool $isReadonly
+     * @return AttributeSet
+     */
+    public function addAttribute(string $type, string $name, string $content, bool $isReadonly = false): AttributeSet
+    {
+        $this->attributes[] = new Attribute($type, $name, $content, $isReadonly);
+
+        return $this;
+    }
+
+}

--- a/lib/Translation/Escaper/Xliff12Escaper.php
+++ b/lib/Translation/Escaper/Xliff12Escaper.php
@@ -1,9 +1,15 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: mmoser
- * Date: 03/05/2018
- * Time: 18:15
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
 namespace Pimcore\Translation\Escaper;

--- a/lib/Translation/Escaper/Xliff12Escaper.php
+++ b/lib/Translation/Escaper/Xliff12Escaper.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mmoser
+ * Date: 03/05/2018
+ * Time: 18:15
+ */
+
+namespace Pimcore\Translation\Escaper;
+
+
+class Xliff12Escaper
+{
+    const SELFCLOSING_TAGS = ['area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input', 'keygen', 'link', 'meta', 'param', 'source', 'track', 'wbr'];
+
+    /**
+     * @param string $content
+     *
+     * @return string
+     */
+    public function escapeXliff(string $content): string
+    {
+        $count = 1;
+        $openTags = [];
+        $final = [];
+
+        // remove nasty device control characters
+        $content = preg_replace('/[\x00-\x09\x0B\x0C\x0E-\x1F\x7F]/', '', $content);
+
+        $replacement = ['%_%_%lt;%_%_%', '%_%_%gt;%_%_%'];
+        $content = str_replace(['&lt;', '&gt;'], $replacement, $content);
+        $content = html_entity_decode($content, null, 'UTF-8');
+
+        if (!preg_match_all('/<([^>]+)>([^<]+)?/', $content, $matches)) {
+            // return original content if it doesn't contain HTML tags
+            return $this->toCData($content);
+        }
+
+        // Handle text before the first HTML tag
+        $firstTagPosition = strpos($content, '<');
+        $preText = ($firstTagPosition > 0) ? $this->toCData(substr($content, 0, $firstTagPosition)) : '';
+
+        foreach ($matches[0] as $match) {
+            $parts = explode('>', $match);
+            $parts[0] .= '>';
+            foreach ($parts as $part) {
+                $part = trim($part);
+                if (!empty($part)) {
+                    if (preg_match("/<([a-z0-9\/]+)/", $part, $tag)) {
+                        $tagName = str_replace('/', '', $tag[1]);
+                        if (in_array($tagName, self::SELFCLOSING_TAGS)) {
+                            $part = '<ph id="' . $count . '">' . $this->toCData($part) . '</ph>';
+
+                            $count++;
+                        } elseif (strpos($tag[1], '/') === false) {
+                            $openTags[$count] = ['tag' => $tagName, 'id' => $count];
+                            $part = '<bpt id="' . $count . '">' . $this->toCData($part) . '</bpt>';
+
+                            $count++;
+                        } else {
+                            $closingTag = array_pop($openTags);
+                            $part = '<ept id="' . $closingTag['id'] . '">' . $this->toCData($part) . '</ept>';
+                        }
+                    } else {
+                        $part = str_replace($replacement, ['<', '>'], $part);
+                        $part = $this->toCData($part);
+                    }
+
+                    if (!empty($part)) {
+                        $final[] = $part;
+                    }
+                }
+            }
+        }
+
+        $content = $preText . implode('', $final);
+
+        return $content;
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return string
+     */
+    public function unescapeXliff(string $content): string
+    {
+        $content = preg_replace("/<\/?(target|mrk)([^>.]+)?>/i", '', $content);
+        // we have to do this again but with html entities because of CDATA content
+        $content = preg_replace("/&lt;\/?(target|mrk)((?!&gt;).)*&gt;/i", '', $content);
+
+        if (preg_match("/<\/?(bpt|ept)/", $content)) {
+            include_once(PIMCORE_PATH . '/lib/simple_html_dom.php');
+            $xml = str_get_html($content);
+            if ($xml) {
+                $els = $xml->find('bpt,ept,ph');
+                foreach ($els as $el) {
+                    $content = html_entity_decode($el->innertext, null, 'UTF-8');
+                    $el->outertext = $content;
+                }
+            }
+            $content = $xml->save();
+        }
+
+        return $content;
+    }
+
+    private function toCData(string $data): string
+    {
+        return sprintf('<![CDATA[%s]]>', $data);
+    }
+}

--- a/lib/Translation/ExportDataExtractorService/DataExtractor/AbstractElementDataExtractor.php
+++ b/lib/Translation/ExportDataExtractorService/DataExtractor/AbstractElementDataExtractor.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ExportDataExtractorService\DataExtractor;
+
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\Property;
+use Pimcore\Translation\AttributeSet\Attribute;
+use Pimcore\Translation\AttributeSet\AttributeSet;
+use Pimcore\Translation\TranslationItemCollection\TranslationItem;
+
+abstract class AbstractElementDataExtractor implements DataExtractorInterface {
+
+    protected function createResultInstance(TranslationItem $translationItem): AttributeSet
+    {
+        return new AttributeSet($translationItem);
+    }
+
+    /**
+     * @param TranslationItem $translationItem
+     * @param string $sourceLanguage
+     * @param string[] $targetLanguages
+     * @return AttributeSet
+     *
+     * @throws \Exception
+     */
+    public function extract(TranslationItem $translationItem, string $sourceLanguage, array $targetLanguages): AttributeSet
+    {
+        $element = $translationItem->getElement();
+
+        if(!$element instanceof ElementInterface) {
+            throw new \Exception('only pimcore elements allowed');
+        }
+
+        $result = $this
+                    ->createResultInstance($translationItem)
+                    ->setSourceLanguage($sourceLanguage)
+                    ->setTargetLanguages($targetLanguages);
+
+        $this->addProperties($element, $result);
+
+        return $result;
+    }
+
+    protected function doExportProperty(Property $property): bool
+    {
+        return $property->getType() === 'text' && !$property->isInherited() && !empty($property->getData());
+    }
+
+    protected function addProperties(ElementInterface $element, AttributeSet $result)
+    {
+        foreach ($element->getProperties() ?: [] as $property) {
+            if ($this->doExportProperty($property)) {
+                $result->addAttribute(Attribute::TYPE_PROPERTY, $property->getName(), $property->getData());
+            }
+        }
+    }
+}

--- a/lib/Translation/ExportDataExtractorService/DataExtractor/DataExtractorInterface.php
+++ b/lib/Translation/ExportDataExtractorService/DataExtractor/DataExtractorInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ExportDataExtractorService\DataExtractor;
+
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Translation\AttributeSet\AttributeSet;
+use Pimcore\Translation\TranslationItemCollection\TranslationItem;
+
+interface DataExtractorInterface  {
+
+    /**
+     * @param TranslationItem $translationItem
+     * @param string $sourceLanguage
+     * @param string[] $targetLanguages
+     * @return AttributeSet
+     *
+     * @throws \Exception
+     */
+    public function extract(TranslationItem $translationItem, string $sourceLanguage, array $targetLanguages): AttributeSet;
+}

--- a/lib/Translation/ExportDataExtractorService/DataExtractor/DataObjectDataExtractor.php
+++ b/lib/Translation/ExportDataExtractorService/DataExtractor/DataObjectDataExtractor.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ExportDataExtractorService\DataExtractor;
+
+use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\ClassDefinition\Data;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields;
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Tool;
+use Pimcore\Translation\AttributeSet\Attribute;
+use Pimcore\Translation\AttributeSet\AttributeSet;
+use Pimcore\Translation\TranslationItemCollection\TranslationItem;
+
+class DataObjectDataExtractor extends AbstractElementDataExtractor {
+
+    const EXPORTABLE_TAGS = ['input', 'textarea', 'wysiwyg'];
+
+    const BRICK_DELIMITER = '|';
+
+    /**
+     * @var array
+     */
+    protected $exportAttributes;
+
+    public function __construct(array $exportAttributes = [])
+    {
+        $this->exportAttributes = $exportAttributes;
+    }
+
+    /**
+     * @param TranslationItem $translationItem
+     * @param string $sourceLanguage
+     * @param string[] $targetLanguages
+     * @return AttributeSet
+     *
+     * @throws \Exception
+     */
+    public function extract(TranslationItem $translationItem, string $sourceLanguage, array $targetLanguages, array $exportAttributes = null): AttributeSet
+    {
+        $notInheritedSet = $this->extractRawAttributeSet($translationItem, $sourceLanguage, $targetLanguages, $exportAttributes, false);
+        $inheritedSet = $this->extractRawAttributeSet($translationItem, $sourceLanguage, $targetLanguages, $exportAttributes, true);
+
+        foreach($inheritedSet->getAttributes() as $attribute) {
+            if(!$this->isAttributeIncluded($notInheritedSet, $attribute)) {
+                $notInheritedSet->addAttribute($attribute->getType(), $attribute->getName(), $attribute->getContent(), true);
+            }
+        }
+
+        return $notInheritedSet;
+    }
+
+    /**
+     * used to extract data either with enabled or disabled inheritance
+     *
+     * @param TranslationItem $translationItem
+     * @param string $sourceLanguage
+     * @param string[] $targetLanguages
+     * @return AttributeSet
+     *
+     * @throws \Exception
+     */
+    private function extractRawAttributeSet(TranslationItem $translationItem, string $sourceLanguage, array $targetLanguages, array $exportAttributes = null, bool $inherited): AttributeSet
+    {
+        $inheritedBackup = DataObject\AbstractObject::getGetInheritedValues();
+        DataObject\AbstractObject::setGetInheritedValues($inherited);
+
+        $result = parent::extract($translationItem, $sourceLanguage, $targetLanguages);
+
+        $object = $translationItem->getElement();
+
+        if(!$object instanceof DataObject\Concrete) {
+            throw new \Exception('only data objects allowed');
+        }
+
+        $this->addLocalizedFields($object, $result, $exportAttributes)
+              ->addLocalizedFieldsInBricks($object, $result, $exportAttributes);
+
+        DataObject\AbstractObject::setGetInheritedValues($inheritedBackup);
+
+        return $result;
+    }
+
+    private function isAttributeIncluded(AttributeSet $attributeSet, Attribute $attribute): bool
+    {
+        foreach($attributeSet->getAttributes() as $_attribute) {
+            if($_attribute->getType() === $attribute->getType() && $_attribute->getContent() === $attribute->getContent()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param (DataObject\Concrete $document
+     * @param AttributeSet $result
+     * @return DataObjectDataExtractor
+     *
+     * @throws \Exception
+     */
+    protected function addLocalizedFields(DataObject\Concrete $object, AttributeSet $result, array $exportAttributes = null): DataObjectDataExtractor
+    {
+        /**
+         * @var Localizedfields $fd
+         */
+        if ($fd = $object->getClass()->getFieldDefinition('localizedfields')) {
+            $definitions = $fd->getFielddefinitions();
+
+            $locale = str_replace('-', '_', $result->getSourceLanguage());
+            if (!Tool::isValidLanguage($locale)) {
+                $locale = \Locale::getPrimaryLanguage($locale);
+            }
+
+            /**
+             * @var Data $definition
+             */
+            foreach ($definitions as $definition) {
+
+                if (!$this->isFieldExportable($object->getClassName(), $definition, $exportAttributes)) {
+                    continue;
+                }
+
+                $content = $object->{'get' . ucfirst($definition->getName())}($locale);
+
+                if (!empty($content)) {
+                    $result->addAttribute(Attribute::TYPE_LOCALIZED_FIELD, $definition->getName(), $content);
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param DataObject\Concrete $object
+     * @param AttributeSet $result
+     * @param array|null $exportAttributes
+     * @return DataObjectDataExtractor
+     *
+     * @throws \Exception
+     */
+    protected function addLocalizedFieldsInBricks(DataObject\Concrete $object, AttributeSet $result, array $exportAttributes = null): DataObjectDataExtractor
+    {
+        $locale = str_replace('-', '_', $result->getSourceLanguage());
+        if (!Tool::isValidLanguage($locale)) {
+            $locale = \Locale::getPrimaryLanguage($locale);
+        }
+
+        if ($fieldDefinitions = $object->getClass()->getFieldDefinitions()) {
+            foreach($fieldDefinitions as $fieldDefinition) {
+                if(!$fieldDefinition instanceof Data\Objectbricks) {
+                    continue;
+                }
+
+                $brickContainerGetter = 'get' . ucfirst($fieldDefinition->getName());
+                if(!$brickContainer = $object->$brickContainerGetter()) {
+                    continue;
+                }
+
+                foreach($fieldDefinition->getAllowedTypes() ?: [] as $brickType) {
+                    $brickGetter = 'get' . ucfirst($brickType);
+
+                    /**
+                     * @var DataObject\Objectbrick\Data\AbstractData $brick
+                     */
+                    if(!$brick = $brickContainer->$brickGetter()) {
+                        continue;
+                    }
+
+                    $brickDefinition = DataObject\Objectbrick\Definition::getByKey($brickType);
+
+                    if(!$localizedFieldsDefinition = $brickDefinition->getFieldDefinition('localizedfields') ) {
+                        continue;
+                    }
+
+                    if(!$localizedFields = $brick->getLocalizedfields()) {
+                        continue;
+                    }
+
+                    foreach($localizedFieldsDefinition->getFieldDefinitions() ?: [] as $fd) {
+                        $content = $localizedFields->getLocalizedValue($fd->getName(), $locale);
+
+
+                        if (!empty($content)) {
+                            $name = $fieldDefinition->getName() . self::BRICK_DELIMITER . $brickType . self::BRICK_DELIMITER . $fd->getName();
+                            $result->addAttribute(Attribute::TYPE_BRICK_LOCALIZED_FIELD, $name, $content);
+                        }
+                    }
+
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    protected function isFieldExportable(string $className, Data $definition, array $exportAttributes = null): bool
+    {
+        // check allowed datatypes
+        if (!in_array($definition->getFieldtype(), self::EXPORTABLE_TAGS)) {
+           return false;
+        }
+
+        if(is_null($exportAttributes) && isset($this->exportAttributes[$className])) {
+            $exportAttributes = $this->exportAttributes[$className];
+        }
+
+        if(!empty($exportAttributes) && !in_array($definition->getName(), $exportAttributes)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/lib/Translation/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
+++ b/lib/Translation/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ExportDataExtractorService\DataExtractor;
+
+use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\Document;
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\Property;
+use Pimcore\Translation\AttributeSet\Attribute;
+use Pimcore\Translation\AttributeSet\AttributeSet;
+use Pimcore\Translation\TranslationItemCollection\TranslationItem;
+
+class DocumentDataExtractor extends AbstractElementDataExtractor {
+
+    const EXPORTABLE_TAGS = ['wysiwyg', 'input', 'textarea', 'image', 'link'];
+
+    /**
+     * @param Document $document
+     * @param string $sourceLanguage
+     * @param string[] $targetLanguages
+     * @return AttributeSet
+     *
+     * @throws \Exception
+     */
+    public function extract(TranslationItem $translationItem, string $sourceLanguage, array $targetLanguages): AttributeSet
+    {
+        $document = $translationItem->getElement();
+
+        $result = parent::extract($translationItem, $sourceLanguage, $targetLanguages);
+
+        if(!$document instanceof Document) {
+            throw new \Exception('only documents allowed');
+        }
+
+        $this
+            ->addDoumentTags($document, $result)
+            ->addSettings($document, $result);
+
+        return $result;
+    }
+
+    /**
+     * @param Document $document
+     * @param AttributeSet $result
+     * @return DocumentDataExtractor
+     * @throws \Exception
+     */
+    protected function addDoumentTags(Document $document, AttributeSet $result): DocumentDataExtractor
+    {
+        $doc = $document;
+
+        $elements = [];
+
+        // get also content of inherited document elements
+        while ($doc) {
+            if (method_exists($doc, 'getElements')) {
+                $elements = array_merge($doc->getElements(), $elements);
+            }
+
+            if (method_exists($doc, 'getContentMasterDocument')) {
+                $doc = $doc->getContentMasterDocument();
+            } else {
+                $doc = null;
+            }
+        }
+
+        foreach ($elements as $tag) {
+            if (in_array($tag->getType(),self::EXPORTABLE_TAGS)) {
+                if (in_array($tag->getType(), ['image', 'link'])) {
+                    $content = $tag->getText();
+                } else {
+                    $content = $tag->getData();
+                }
+
+                if (is_string($content)) {
+                    $contentCheck = trim(strip_tags($content));
+                    if (!empty($contentCheck)) {
+                        $result->addAttribute(Attribute::TYPE_TAG, $tag->getName(), $content);
+                    }
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param Document $document
+     * @param AttributeSet $result
+     * @return DocumentDataExtractor
+     */
+    protected function addSettings(Document $document, AttributeSet $result): DocumentDataExtractor
+    {
+        if ($document instanceof Document\Page) {
+            $data = [
+                'title' => $document->getTitle(),
+                'description' => $document->getDescription()
+            ];
+
+            foreach ($data as $key => $content) {
+                if (!empty(trim($content))) {
+                    $result->addAttribute(Attribute::TYPE_SETTINGS, $key, $content);
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    protected function doExportProperty(Property $property): bool
+    {
+        return parent::doExportProperty($property) && !in_array($property->getName(), [
+                    'language',
+                    'navigation_target',
+                    'navigation_exclude',
+                    'navigation_class',
+                    'navigation_anchor',
+                    'navigation_parameters',
+                    'navigation_relation',
+                    'navigation_accesskey',
+                    'navigation_tabindex'
+                ]);
+    }
+}

--- a/lib/Translation/ExportDataExtractorService/ExportDataExtractorService.php
+++ b/lib/Translation/ExportDataExtractorService/ExportDataExtractorService.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ExportDataExtractorService;
+
+use Pimcore\Model\DataObject;
+use Pimcore\Model\Document;
+use Pimcore\Translation\AttributeSet\AttributeSet;
+use Pimcore\Translation\ExportDataExtractorService\DataExtractor\DataExtractorInterface;
+use Pimcore\Translation\TranslationItemCollection\TranslationItem;
+
+class ExportDataExtractorService implements ExportDataExtractorServiceInterface {
+
+    /**
+     * @var DataExtractorInterface[]
+     */
+    private $dataExtractors;
+
+    public function extract(TranslationItem $translationItem, string $sourceLanguage, array $targetLanguages): AttributeSet
+    {
+        return $this->getDataExtractor($translationItem->getType())->extract($translationItem, $sourceLanguage, $targetLanguages);
+    }
+
+    /**
+     * @param DataExtractorInterface $dataExtractor
+     * @return $this
+     */
+    public function registerDataExtractor(string $type, DataExtractorInterface $dataExtractor): ExportDataExtractorServiceInterface
+    {
+        $this->dataExtractors[$type] = $dataExtractor;
+
+        return $this;
+    }
+
+    /**
+     * @param DataExtractorInterface $dataExtractor
+     * @return DataExtractorInterface
+     *
+     * @throws \Exception
+     */
+    public function getDataExtractor(string $type): DataExtractorInterface
+    {
+        if(isset($this->dataExtractors[$type])) {
+            return $this->dataExtractors[$type];
+        }
+
+        throw new \Exception(sprintf('no data extractor for type "%s" registered', $type));
+    }
+}

--- a/lib/Translation/ExportDataExtractorService/ExportDataExtractorServiceInterface.php
+++ b/lib/Translation/ExportDataExtractorService/ExportDataExtractorServiceInterface.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ExportDataExtractorService;
+
+use Pimcore\Translation\AttributeSet\AttributeSet;
+use Pimcore\Translation\ExportDataExtractorService\DataExtractor\DataExtractorInterface;
+use Pimcore\Translation\TranslationItemCollection\TranslationItem;
+
+interface ExportDataExtractorServiceInterface {
+
+    /**
+     * @param TranslationItem $translationItem
+     * @param string $sourceLanguage
+     * @param string[] $targetLanguages
+     * @return AttributeSet
+     *
+     * @throws \Exception
+     */
+    public function extract(TranslationItem $translationItem, string $sourceLanguage, array $targetLanguages): AttributeSet;
+
+    /**
+     * @param DataExtractorInterface $dataExtractor
+     * @return $this
+     */
+    public function registerDataExtractor(string $type, DataExtractorInterface $dataExtractor): ExportDataExtractorServiceInterface;
+
+    /**
+     * @param DataExtractorInterface $dataExtractor
+     * @return DataExtractorInterface
+     *
+     * @throws \Exception
+     */
+    public function getDataExtractor(string $type): DataExtractorInterface;
+}

--- a/lib/Translation/ExportService/ExportService.php
+++ b/lib/Translation/ExportService/ExportService.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mmoser
+ * Date: 09/05/2018
+ * Time: 12:49
+ */
+
+namespace Pimcore\Translation\ExportService;
+
+use Pimcore\Translation\ExportService\Exporter\ExporterInterface;
+use Pimcore\Translation\ExportDataExtractorService\ExportDataExtractorServiceInterface;
+use Pimcore\Translation\TranslationItemCollection\TranslationItemCollection;
+
+class ExportService implements ExportServiceInterface
+{
+
+    /**
+     * @var ExportDataExtractorServiceInterface
+     */
+    private $exportDataExtractorService;
+
+    /**
+     * @var ExporterInterface
+     */
+    private $translationExporter;
+
+    /**
+     * ExportService constructor.
+     * @param ExportDataExtractorServiceInterface $exportDataExtractorService
+     * @param ExporterInterface $translationExporter
+     */
+    public function __construct(
+        ExportDataExtractorServiceInterface $exportDataExtractorService,
+        ExporterInterface $translationExporter
+    ) {
+        $this->exportDataExtractorService = $exportDataExtractorService;
+        $this->translationExporter = $translationExporter;
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    public function exportTranslationItems(TranslationItemCollection $translationItems, string $sourceLanguage, array $targetLanguages, string $exportId = null): string
+    {
+        $exportId = empty($exportId) ? uniqid() : $exportId;
+
+        foreach($translationItems->getItems() as $item) {
+            $attributeSet = $this->getExportDataExtractorService()->extract($item, $sourceLanguage, $targetLanguages);
+            $this->getTranslationExporter()->export($attributeSet, $exportId);
+        }
+
+        return $exportId;
+    }
+
+    /**
+     * @return ExportDataExtractorServiceInterface
+     */
+    public function getExportDataExtractorService(): ExportDataExtractorServiceInterface
+    {
+        return $this->exportDataExtractorService;
+    }
+
+    /**
+     * @param ExportDataExtractorServiceInterface $exportDataExtractorService
+     * @return ExportService
+     */
+    public function setExportDataExtractorService(ExportDataExtractorServiceInterface $exportDataExtractorService): ExportService {
+        $this->exportDataExtractorService = $exportDataExtractorService;
+
+        return $this;
+    }
+
+    /**
+     * @return ExporterInterface
+     */
+    public function getTranslationExporter(): ExporterInterface
+    {
+        return $this->translationExporter;
+    }
+
+    /**
+     * @param ExporterInterface $translationExporter
+     * @return ExportService
+     */
+    public function setTranslationExporter(ExporterInterface $translationExporter): ExportService
+    {
+        $this->translationExporter = $translationExporter;
+
+        return $this;
+    }
+
+
+}

--- a/lib/Translation/ExportService/ExportService.php
+++ b/lib/Translation/ExportService/ExportService.php
@@ -1,9 +1,15 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: mmoser
- * Date: 09/05/2018
- * Time: 12:49
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
 namespace Pimcore\Translation\ExportService;

--- a/lib/Translation/ExportService/ExportServiceInterface.php
+++ b/lib/Translation/ExportService/ExportServiceInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mmoser
+ * Date: 09/05/2018
+ * Time: 12:49
+ */
+
+namespace Pimcore\Translation\ExportService;
+
+use Pimcore\Translation\ExportService\Exporter\ExporterInterface;
+use Pimcore\Translation\TranslationItemCollection\TranslationItemCollection;
+
+interface ExportServiceInterface
+{
+    /**
+     * @param TranslationItemCollection $translationItems
+     * @param string $sourceLanguage
+     * @param array $targetLanguages
+     * @param string|null $exportId
+     * @return string
+     *
+     * @throws \Exception
+     */
+    public function exportTranslationItems(TranslationItemCollection $translationItems, string $sourceLanguage, array $targetLanguages, string $exportId = null): string;
+
+    /**
+     * @return ExporterInterface
+     */
+    public function getTranslationExporter(): ExporterInterface;
+
+}

--- a/lib/Translation/ExportService/ExportServiceInterface.php
+++ b/lib/Translation/ExportService/ExportServiceInterface.php
@@ -1,9 +1,15 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: mmoser
- * Date: 09/05/2018
- * Time: 12:49
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
 namespace Pimcore\Translation\ExportService;

--- a/lib/Translation/ExportService/Exporter/ExporterInterface.php
+++ b/lib/Translation/ExportService/Exporter/ExporterInterface.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ExportService\Exporter;
+
+use Pimcore\Translation\AttributeSet\AttributeSet;
+
+interface ExporterInterface {
+
+    /**
+     * @param AttributeSet $attributeSet
+     * @param string|null $exportId
+     * @return string
+     */
+    public function export(AttributeSet $attributeSet, string $exportId = null): string;
+
+    /**
+     * @param string $exportId
+     * @return string
+     */
+    public function getExportFilePath(string $exportId): string;
+
+    /**
+     * @return string
+     */
+    public function getContentType(): string;
+}

--- a/lib/Translation/ExportService/Exporter/Xliff12Exporter.php
+++ b/lib/Translation/ExportService/Exporter/Xliff12Exporter.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ExportService\Exporter;
+
+use Pimcore\File;
+use Pimcore\Translation\AttributeSet\AttributeSet;
+use Pimcore\Translation\Escaper\Xliff12Escaper;
+
+class Xliff12Exporter implements ExporterInterface {
+
+    const DELIMITER = '~-~';
+
+    /**
+     * @var Xliff12Escaper
+     */
+    private $xliffEscaper;
+
+    public function __construct(Xliff12Escaper $xliffEscaper)
+    {
+        $this->xliffEscaper = $xliffEscaper;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function export(AttributeSet $attributeSet, string $exportId = null): string
+    {
+        $exportId = $exportId ?: uniqid();
+
+        $exportFile = $this->getExportFilePath($exportId);
+
+        if($attributeSet->isEmpty()) {
+            return $exportFile;
+        }
+
+        $xliff = simplexml_load_file($exportFile, null, LIBXML_NOCDATA);
+
+        foreach($attributeSet->getTargetLanguages() as $targetLanguage) {
+            $file = $xliff->addChild('file');
+            $file->addAttribute('original', $attributeSet->getTranslationItem()->getType() . '-' . $attributeSet->getTranslationItem()->getId());
+            $file->addAttribute('source-language', $attributeSet->getSourceLanguage());
+            $file->addAttribute('target-language', $targetLanguage);
+            $file->addAttribute('datatype', 'html');
+            $file->addAttribute('tool', 'pimcore');
+            $file->addAttribute('category', $attributeSet->getTranslationItem()->getType());
+
+            $file->addChild('header');
+
+            $body = $file->addChild('body');
+
+            foreach ($attributeSet->getAttributes() as $attribute) {
+
+                if($attribute->isReadonly()) {
+                    continue;
+                }
+
+                $this->addTransUnitNode($body, $attribute->getType() . self::DELIMITER . $attribute->getName(), $attribute->getContent(), $attributeSet->getSourceLanguage());
+            }
+
+        }
+
+
+        $xliff->asXML($exportFile);
+
+        return $exportFile;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getExportFilePath(string $exportId): string
+    {
+        $exportFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/' . $exportId . '.xliff';
+        if (!is_file($exportFile)) {
+            // create initial xml file structure
+            File::put($exportFile, '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL . '<xliff version="1.2"></xliff>');
+        }
+
+        return $exportFile;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getContentType(): string
+    {
+        return 'application/x-xliff+xml';
+    }
+
+
+    /**
+     * @param $xml
+     * @param $name
+     * @param $content
+     * @param $source
+     */
+    protected function addTransUnitNode(\SimpleXMLElement $xml, $name, $content, $source)
+    {
+        $transUnit = $xml->addChild('trans-unit');
+        $transUnit->addAttribute('id', htmlentities($name));
+
+        $sourceNode = $transUnit->addChild('source');
+        $sourceNode->addAttribute('xmlns:xml:lang', $source);
+
+        $node = dom_import_simplexml($sourceNode);
+        $no = $node->ownerDocument;
+        $f = $no->createDocumentFragment();
+        $f->appendXML($this->xliffEscaper->escapeXliff($content));
+        @$node->appendChild($f);
+    }
+
+
+}

--- a/lib/Translation/ImportDataExtractor/ImportDataExtractorInterface.php
+++ b/lib/Translation/ImportDataExtractor/ImportDataExtractorInterface.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ImportDataExtractor;
+
+use Pimcore\Model\DataObject;
+use Pimcore\Model\Document;
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Translation\AttributeSet\AttributeSet;
+use Pimcore\Translation\ExportDataExtractorService\DataExtractor\DataObjectDataExtractor;
+use Pimcore\Translation\ExportDataExtractorService\DataExtractor\DocumentDataExtractor;
+
+interface ImportDataExtractorInterface  {
+
+    /**
+     * @param string $importId
+     * @param int $stepId
+     * @return ?AttributeSet
+     *
+     * @throws \Exception
+     */
+    public function extractElement(string $importId, int $stepId): AttributeSet;
+
+    /**
+     * @param string $importId
+     * @return string
+     */
+    public function getImportFilePath(string $importId): string;
+
+    /**
+     * @param string $importId
+     * @return int
+     * @throws \Exception
+     */
+    public function countSteps(string $importId): int;
+}

--- a/lib/Translation/ImportDataExtractor/TranslationItemResolver/TranslationItemResolver.php
+++ b/lib/Translation/ImportDataExtractor/TranslationItemResolver/TranslationItemResolver.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ImportDataExtractor\TranslationItemResolver;
+
+use Pimcore\Translation\TranslationItemCollection\TranslationItem;
+use Pimcore\Model\Element;
+
+class TranslationItemResolver implements  TranslationItemResolverInterface
+{
+    public function resolve(string $type, string $id): ?TranslationItem
+    {
+        if(!$element = Element\Service::getElementById($type, $id)) {
+            return null;
+        }
+
+        return new TranslationItem($type, $id, $element);
+    }
+}

--- a/lib/Translation/ImportDataExtractor/TranslationItemResolver/TranslationItemResolverInterface.php
+++ b/lib/Translation/ImportDataExtractor/TranslationItemResolver/TranslationItemResolverInterface.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ImportDataExtractor\TranslationItemResolver;
+
+use Pimcore\Translation\TranslationItemCollection\TranslationItem;
+
+interface TranslationItemResolverInterface
+{
+    public function resolve(string $type, string $id): ?TranslationItem;
+}

--- a/lib/Translation/ImportDataExtractor/Xliff12DataExtractor.php
+++ b/lib/Translation/ImportDataExtractor/Xliff12DataExtractor.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mmoser
+ * Date: 08/05/2018
+ * Time: 10:22
+ */
+
+namespace Pimcore\Translation\ImportDataExtractor;
+
+
+use Pimcore\Model\Element;
+use Pimcore\Tool;
+use Pimcore\Translation\AttributeSet\AttributeSet;
+use Pimcore\Translation\ExportService\Exporter\Xliff12Exporter;
+use Pimcore\Translation\Escaper\Xliff12Escaper;
+use Pimcore\Translation\ImportDataExtractor\TranslationItemResolver\TranslationItemResolverInterface;
+
+class Xliff12DataExtractor implements ImportDataExtractorInterface
+{
+    /**
+     * @var Xliff12Escaper
+     */
+    protected $xliffEscaper;
+
+    /**
+     * @var TranslationItemResolver\
+     */
+    protected $translationItemResolver;
+
+
+    public function __construct(Xliff12Escaper $xliffEscaper, TranslationItemResolverInterface $translationItemResolver)
+    {
+        $this->xliffEscaper = $xliffEscaper;
+        $this->translationItemResolver = $translationItemResolver;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function extractElement(string $importId, int $stepId): AttributeSet
+    {
+        $xliff = $this->loadFile($importId);
+
+        $file = $xliff->file[$stepId];
+
+        $target = $file['target-language'];
+
+        // see https://en.wikipedia.org/wiki/IETF_language_tag
+        $target = str_replace('-', '_', $target);
+        if (!Tool::isValidLanguage($target)) {
+            $target = \Locale::getPrimaryLanguage($target);
+        }
+        if (!Tool::isValidLanguage($target)) {
+            throw new \Exception(sprintf('invalid language %s', $file['target-language']));
+        }
+
+
+        list($type, $id) = explode('-', $file['original']);
+
+        $translationItem = $this->translationItemResolver->resolve($type, $id);
+
+        if(empty($translationItem)) {
+            throw new \Exception('Could not resolve element ' . $file['original']);
+        }
+
+        $attributeSet = new AttributeSet($translationItem);
+        $attributeSet->setTargetLanguages([$target]);
+        if(!empty($file['source-language'])) {
+            $attributeSet->setSourceLanguage($file['source-language']);
+        }
+
+        foreach ($file->body->{'trans-unit'} as $transUnit) {
+            list($type, $name) = explode(Xliff12Exporter::DELIMITER, $transUnit['id']);
+            $content = $transUnit->target->asXml();
+            $content = $this->xliffEscaper->unescapeXliff($content);
+
+            $attributeSet->addAttribute($type, $name, $content);
+        }
+
+        return $attributeSet;
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    public function getImportFilePath(string $importId): string
+    {
+        return PIMCORE_SYSTEM_TEMP_DIRECTORY . '/' . $importId . '.xliff';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function countSteps(string $importId): int
+    {
+        $xliff = $this->loadFile($importId);
+        return count($xliff->file);
+    }
+
+    /**
+     * @param string $importId
+     * @return \SimpleXMLElement
+     * @throws \Exception
+     */
+    private function loadFile(string $importId): \SimpleXMLElement
+    {
+        return simplexml_load_file($this->getImportFilePath($importId), null, LIBXML_NOCDATA);
+    }
+}

--- a/lib/Translation/ImportDataExtractor/Xliff12DataExtractor.php
+++ b/lib/Translation/ImportDataExtractor/Xliff12DataExtractor.php
@@ -1,9 +1,15 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: mmoser
- * Date: 08/05/2018
- * Time: 10:22
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
 namespace Pimcore\Translation\ImportDataExtractor;

--- a/lib/Translation/ImporterService/Importer/AbstractElementImporter.php
+++ b/lib/Translation/ImporterService/Importer/AbstractElementImporter.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ImporterService\Importer;
+
+use Pimcore\Model\DataObject;
+use Pimcore\Model\Document;
+use Pimcore\Model\Element;
+use Pimcore\Translation\AttributeSet\Attribute;
+use Pimcore\Translation\AttributeSet\AttributeSet;
+
+class AbstractElementImporter implements ImporterInterface {
+
+    /**
+     * @inheritdoc
+     */
+    public function import(AttributeSet $attributeSet, bool $saveElement = true)
+    {
+        $translationItem = $attributeSet->getTranslationItem();
+        $element = $translationItem->getElement();
+
+        if(!$element instanceof Element\ElementInterface || $attributeSet->isEmpty()) {
+            return;
+        }
+
+        foreach($attributeSet->getAttributes() as $attribute) {
+            $targetLanguage = $attributeSet->getTargetLanguages()[0];
+            $this->importAttribute($element, $targetLanguage, $attribute);
+        }
+
+        if($saveElement) {
+            $this->saveElement($element);
+        }
+
+    }
+
+    /**
+     * @param Document|DataObject\Concrete $element
+     * @param string $targetLanguage
+     * @param Attribute $attribute
+     *
+     * @throws \Exception
+     */
+    protected function importAttribute(Element\ElementInterface $element, string $targetLanguage, Attribute $attribute)
+    {
+        if ($attribute->getType() === Attribute::TYPE_PROPERTY) {
+            $property = $element->getProperty($attribute->getName(), true);
+            if ($property) {
+                $property->setData($attribute->getContent());
+            } else {
+                $element->setProperty($attribute->getName(), 'text', $attribute->getContent());
+            }
+        }
+    }
+
+    /**
+     * @param Document|DataObject\Concrete $element
+     * @throws \Exception
+     */
+    protected function saveElement(Element\ElementInterface $element)
+    {
+        try {
+            $element->save();
+        } catch (\Exception $e) {
+            throw new \Exception('Unable to save ' . Element\Service::getElementType($element) . ' with id ' . $element->getId() . ' because of the following reason: ' . $e->getMessage());
+        }
+    }
+
+}

--- a/lib/Translation/ImporterService/Importer/DataObjectImporter.php
+++ b/lib/Translation/ImporterService/Importer/DataObjectImporter.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ImporterService\Importer;
+
+use Pimcore\Model\DataObject;
+use Pimcore\Model\Document;
+use Pimcore\Model\Element;
+use Pimcore\Translation\AttributeSet\Attribute;
+use Pimcore\Translation\ExportDataExtractorService\DataExtractor\DataObjectDataExtractor;
+
+class DataObjectImporter extends AbstractElementImporter {
+
+    /**
+     * @param Element\ElementInterface $element
+     * @param string $targetLanguage
+     * @param Attribute $attribute
+     * @throws \Exception
+     */
+    protected function importAttribute(Element\ElementInterface $element, string $targetLanguage, Attribute $attribute)
+    {
+        parent::importAttribute($element, $targetLanguage, $attribute);
+
+        if ($attribute->getType() === Attribute::TYPE_LOCALIZED_FIELD) {
+            $setter = 'set' . ucfirst($attribute->getName());
+            if (method_exists($element, $setter)) {
+                $element->$setter($attribute->getContent(), $targetLanguage);
+            }
+        }
+
+        if ($attribute->getType() === Attribute::TYPE_BRICK_LOCALIZED_FIELD) {
+            list($brickField, $brick, $field) = explode(DataObjectDataExtractor::BRICK_DELIMITER, $attribute->getName());
+
+            $brickContainerGetter = 'get' . ucfirst($brickField);
+            if($brickContainer = $element->$brickContainerGetter()) {
+                $brickGetter = 'get' . ucfirst($brick);
+            }
+
+            if(method_exists($brickContainer, $brickGetter) && ($brick = $brickContainer->$brickGetter())) {
+                /**
+                 * @var DataObject\Localizedfield $localizedFields
+                 */
+                if(method_exists($brick, 'getLocalizedfields') && ($localizedFields = $brick->getLocalizedfields())){
+
+                    $localizedFields->setLocalizedValue($field, $attribute->getContent(), $targetLanguage);
+                }
+            }
+        }
+    }
+
+
+    /**
+     * @param DataObject\Concrete $element
+     * @throws \Exception
+     */
+    protected function saveElement(Element\ElementInterface $element)
+    {
+        $element->setOmitMandatoryCheck(true);
+        parent::saveElement($element);
+    }
+
+
+}

--- a/lib/Translation/ImporterService/Importer/DocumentImporter.php
+++ b/lib/Translation/ImporterService/Importer/DocumentImporter.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ImporterService\Importer;
+
+use Pimcore\Model\Document;
+use Pimcore\Model\Element;
+use Pimcore\Translation\AttributeSet\Attribute;
+
+class DocumentImporter extends AbstractElementImporter {
+
+    /**
+     * @inheritdoc
+     */
+    protected function importAttribute(Element\ElementInterface $element, string $targetLanguage, Attribute $attribute)
+    {
+        parent::importAttribute($element, $targetLanguage, $attribute);
+
+        if ($attribute->getType() === Attribute::TYPE_TAG && method_exists($element, 'getElement')) {
+            $tag = $element->getElement($attribute->getName());
+            if ($tag) {
+                if (in_array($tag->getType(), ['image', 'link'])) {
+                    $tag->setText($attribute->getContent());
+                } else {
+                    $tag->setDataFromEditmode($attribute->getContent());
+                }
+
+                $tag->setInherited(false);
+                $element->setElement($tag->getName(), $tag);
+            }
+        }
+
+        if ($attribute->getType() === Attribute::TYPE_SETTINGS && $element instanceof Document\Page) {
+            $setter = 'set' . ucfirst($attribute->getName());
+            if (method_exists($element, $setter)) {
+                $element->$setter($attribute->getContent());
+            }
+        }
+    }
+
+}

--- a/lib/Translation/ImporterService/Importer/ImporterInterface.php
+++ b/lib/Translation/ImporterService/Importer/ImporterInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ImporterService\Importer;
+
+use Pimcore\Translation\AttributeSet\AttributeSet;
+
+interface ImporterInterface {
+
+    /**
+     * @param AttributeSet $attributeSet
+     * @param bool $saveElement
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function import(AttributeSet $attributeSet, bool $saveElement = true);
+}

--- a/lib/Translation/ImporterService/ImporterService.php
+++ b/lib/Translation/ImporterService/ImporterService.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ImporterService;
+
+use Pimcore\Model\DataObject;
+use Pimcore\Model\Document;
+use Pimcore\Model\Element;
+use Pimcore\Translation\AttributeSet\Attribute;
+use Pimcore\Translation\AttributeSet\AttributeSet;
+use Pimcore\Translation\ImporterService\Importer\DataObjectImporter;
+use Pimcore\Translation\ImporterService\Importer\DocumentImporter;
+use Pimcore\Translation\ImporterService\Importer\ImporterInterface;
+
+class ImporterService implements ImporterServiceInterface {
+
+    /**
+     * @var ImporterInterface[]
+     */
+    private $importers = [];
+
+    /**
+     * @inheritdoc
+     */
+    public function import(AttributeSet $attributeSet, bool $saveElement = true)
+    {
+        $this->getImporter($attributeSet->getTranslationItem()->getType())->import($attributeSet, $saveElement);
+    }
+
+    public function registerImporter(string $type, ImporterInterface $importer): ImporterServiceInterface
+    {
+        $this->importers[$type] = $importer;
+
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getImporter(string $type): ImporterInterface
+    {
+        if(isset($this->importers[$type])) {
+            return $this->importers[$type];
+        }
+
+        throw new \Exception(sprintf('no importer for type "%s" registered', $type));
+    }
+
+
+}

--- a/lib/Translation/ImporterService/ImporterServiceInterface.php
+++ b/lib/Translation/ImporterService/ImporterServiceInterface.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Translation\ImporterService;
+
+use Pimcore\Translation\AttributeSet\AttributeSet;
+use Pimcore\Translation\ImporterService\Importer\ImporterInterface;
+
+interface ImporterServiceInterface {
+
+    /**
+     * @param AttributeSet $attributeSet
+     * @param bool $saveElement
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function import(AttributeSet $attributeSet, bool $saveElement = true);
+
+    /**
+     * @param string $type
+     * @param ImporterInterface $importer
+     * @return ImporterServiceInterface
+     */
+    public function registerImporter(string $type, ImporterInterface $importer): ImporterServiceInterface;
+
+    /**
+     * @param string $type
+     * @return ImporterInterface
+     *
+     * @throws \Exception
+     */
+    public function getImporter(string $type): ImporterInterface;
+}

--- a/lib/Translation/TranslationItemCollection/TranslationItem.php
+++ b/lib/Translation/TranslationItemCollection/TranslationItem.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mmoser
+ * Date: 08/05/2018
+ * Time: 14:55
+ */
+
+namespace Pimcore\Translation\TranslationItemCollection;
+
+class TranslationItem
+{
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var
+     */
+    private $element;
+
+
+    /**
+     * TranslationItem constructor.
+     * @param string $type
+     * @param string $id
+     * @param object $element
+     */
+    public function __construct(string $type, string $id, $element)
+    {
+        $this->type = $type;
+        $this->id = $id;
+        $this->element = $element;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return object
+     */
+    public function getElement()
+    {
+        return $this->element;
+    }
+
+
+}

--- a/lib/Translation/TranslationItemCollection/TranslationItem.php
+++ b/lib/Translation/TranslationItemCollection/TranslationItem.php
@@ -1,9 +1,15 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: mmoser
- * Date: 08/05/2018
- * Time: 14:55
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
 namespace Pimcore\Translation\TranslationItemCollection;

--- a/lib/Translation/TranslationItemCollection/TranslationItemCollection.php
+++ b/lib/Translation/TranslationItemCollection/TranslationItemCollection.php
@@ -1,9 +1,15 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: mmoser
- * Date: 08/05/2018
- * Time: 14:55
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
 namespace Pimcore\Translation\TranslationItemCollection;

--- a/lib/Translation/TranslationItemCollection/TranslationItemCollection.php
+++ b/lib/Translation/TranslationItemCollection/TranslationItemCollection.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mmoser
+ * Date: 08/05/2018
+ * Time: 14:55
+ */
+
+namespace Pimcore\Translation\TranslationItemCollection;
+
+use Pimcore\Model\Element;
+use Pimcore\Model\Element\ElementInterface;
+
+
+class TranslationItemCollection
+{
+    /**
+     * @var TranslationItem[]
+     */
+    private $items = [];
+
+    /**
+     * @param string $type
+     * @param string $id
+     * @param object $element
+     * @return TranslationItemCollection
+     */
+    public function add(string $type, string $id, $element): TranslationItemCollection
+    {
+        $this->items[] = new TranslationItem($type, $id, $element);
+
+        return $this;
+    }
+
+    public function addItem(TranslationItem $item): TranslationItemCollection
+    {
+        $this->items[] = $item;
+
+        return $this;
+    }
+
+    public function addPimcoreElement(ElementInterface $element): TranslationItemCollection
+    {
+        $this->items[] = new TranslationItem(Element\Service::getElementType($element), $element->getId(), $element);
+
+        return $this;
+    }
+
+    /**
+     * @return TranslationItem[]
+     */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    public function toArray(): array
+    {
+        $elementsArray = [];
+        foreach($this->getItems() as $element) {
+
+            $elementsArray[$element->getType()] = $elementsArray[$element->getType()] ?? [];
+            $elementsArray[$element->getType()][] = $element->getId();
+        }
+
+        return $elementsArray;
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->items);
+    }
+}

--- a/lib/Translation/XliffEscaper.php
+++ b/lib/Translation/XliffEscaper.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mmoser
+ * Date: 03/05/2018
+ * Time: 18:15
+ */
+
+namespace Pimcore\Translation;
+
+
+class XliffEscaper
+{
+    const SELFCLOSING_TAGS = ['area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input', 'keygen', 'link', 'meta', 'param', 'source', 'track', 'wbr'];
+
+    /**
+     * @param string $content
+     *
+     * @return string
+     */
+    public function escapeXliff($content)
+    {
+        $count = 1;
+        $openTags = [];
+        $final = [];
+
+        // remove nasty device control characters
+        $content = preg_replace('/[\x00-\x09\x0B\x0C\x0E-\x1F\x7F]/', '', $content);
+
+        $replacement = ['%_%_%lt;%_%_%', '%_%_%gt;%_%_%'];
+        $content = str_replace(['&lt;', '&gt;'], $replacement, $content);
+        $content = html_entity_decode($content, null, 'UTF-8');
+
+        if (!preg_match_all('/<([^>]+)>([^<]+)?/', $content, $matches)) {
+            // return original content if it doesn't contain HTML tags
+            return '<![CDATA[' . $content . ']]>';
+        }
+
+        // Handle text before the first HTML tag
+        $firstTagPosition = strpos($content, '<');
+        $preText = ($firstTagPosition > 0) ? '<![CDATA[' . substr($content, 0, $firstTagPosition) . ']]>' : '';
+
+        foreach ($matches[0] as $match) {
+            $parts = explode('>', $match);
+            $parts[0] .= '>';
+            foreach ($parts as $part) {
+                $part = trim($part);
+                if (!empty($part)) {
+                    if (preg_match("/<([a-z0-9\/]+)/", $part, $tag)) {
+                        $tagName = str_replace('/', '', $tag[1]);
+                        if (in_array($tagName, self::SELFCLOSING_TAGS)) {
+                            $part = '<ph id="' . $count . '"><![CDATA[' . $part . ']]></ph>';
+
+                            $count++;
+                        } elseif (strpos($tag[1], '/') === false) {
+                            $openTags[$count] = ['tag' => $tagName, 'id' => $count];
+                            $part = '<bpt id="' . $count . '"><![CDATA[' . $part . ']]></bpt>';
+
+                            $count++;
+                        } else {
+                            $closingTag = array_pop($openTags);
+                            $part = '<ept id="' . $closingTag['id'] . '"><![CDATA[' . $part . ']]></ept>';
+                        }
+                    } else {
+                        $part = str_replace($replacement, ['<', '>'], $part);
+                        $part = '<![CDATA[' . $part . ']]>';
+                    }
+
+                    if (!empty($part)) {
+                        $final[] = $part;
+                    }
+                }
+            }
+        }
+
+        $content = $preText . implode('', $final);
+
+        return $content;
+    }
+}

--- a/lib/Translation/XliffEscaper.php
+++ b/lib/Translation/XliffEscaper.php
@@ -1,9 +1,15 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: mmoser
- * Date: 03/05/2018
- * Time: 18:15
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
 namespace Pimcore\Translation;


### PR DESCRIPTION
Currently the XLIFF export/import feature is handled directly in the controller. This makes it impossible to reuse and extend the logic. 

This pull request separates the export/import process into several components:

- **Export data extractor**: extracts the localized field data from the pimcore elements into a neutral representation (AttributeSet). 

- **Translation exporter**: takes the AttributeSet and creates the desired target format/export file (XLIFF by default)

- **Import data extractor**: takes an import file of a given format (XLIFF), parses the data and returns again an AttributeSet representation of the data

- **Importer**: takes the AttributeSet and actually import/save it to the target Pimcore elements

Additionally to this refactoring it adds a configuration option to export only certain data object attributes into the Pimcore configuration tree.

#### Example:
```yaml
pimcore:
    translations:
        data_object:
           translation_extractor:
              attributes:
                  Product:
                     - description
```

Another improvement is that now localized fields in bricks are supported by the export/import feature.