### PR TITLE
[Bugfix] Class definition ids may now be alphanumeric

### DIFF
--- a/bundles/CoreBundle/Command/ClassesRebuildCommand.php
+++ b/bundles/CoreBundle/Command/ClassesRebuildCommand.php
@@ -72,7 +72,7 @@ class ClassesRebuildCommand extends AbstractCommand
                     $name = $class['name'];
 
                     $cls = new ClassDefinition();
-                    $cls->setId((int)$id);
+                    $cls->setId($id);
                     $definitionFile = $cls->getDefinitionFile($name);
 
                     if (!file_exists($definitionFile)) {


### PR DESCRIPTION
Since 5.4 class definition ids may be manually specified (alphanumeric) rather than being auto-generated (integer). In the ClassesRebuildCommand the id is casted to integer when deleting class definitions, which results in alphanumeric ids being set to "0".

## Steps to reproduce   
* Create a class with a manually specified identifier, e.g. "foo"
* Run `bin/console pimcore:deployment:classes-rebuild` with `--delete-classes` 
* See errors similar to this:
`[Doctrine\DBAL\Driver\PDOException (42S02)]
  SQLSTATE[42S02]: Base table or view not found: 1051 Unknown table 'pimcore.object_query_0'`
