### PR TITLE
option was set by .env or argv, should skip asking

### DIFF
--- a/bundles/InstallBundle/Command/InstallCommand.php
+++ b/bundles/InstallBundle/Command/InstallCommand.php
@@ -226,7 +226,7 @@ class InstallCommand extends Command
             $value = $input->getOption($name);
             $isDefaultValue = isset($config['default']) && $value === $config['default'];
 
-            if ($value && !$isDefaultValue) {
+            if ($value || $isDefaultValue) {
                 continue;
             }
 


### PR DESCRIPTION
When I set the .env var `PIMCORE_INSTALL_MYSQL_HOST_SOCKET` or the command line argument: `--mysql-host-socket`, it should not ask for it again. It also happens when setting the port. So, I changed the validation rule in such a way that:
* if there is a default value (true, for host and port), **OR**
* the user supplied a value by arguments or dotenv file **THEN**
* skip asking the user

<!--
## Please make sure your PR complies with all of the following points: 
- [OK] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [OK] Features need to be proper documented in `doc/`
- [OK] Bugfixes need a short guide how to reproduce them. 
- [OK] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [OK] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
 