### PR TITLE
[DOCS] Update urls in documentation pointing to the wrong location 

### DIFF
--- a/doc/Development_Documentation/03_Documents/02_Document_Types/15_Print_Documents.md
+++ b/doc/Development_Documentation/03_Documents/02_Document_Types/15_Print_Documents.md
@@ -67,7 +67,7 @@ For details of settings please see section below or renderer documentation.
 They can be activated by the printermarks rendering setting. Technically they are implemented by an additional CSS-file which needs to be included.
 For Details, check links below:
 
-* [view-script](https://github.com/pimcore/pimcore/blob/master/install-profiles/demo-basic/app/Resources/views/Web2print/default.html.php#L102-L102)
+* [view-script](https://github.com/pimcore/demo-basic/blob/master/app/Resources/views/Web2print/default.html.php#L102-L102)
 * [css-file](https://github.com/pimcore/pimcore/blob/master/bundles/AdminBundle/Resources/public/css/print/print-printermarks.css)
 
 ## Settings

--- a/doc/Development_Documentation/03_Documents/02_Document_Types/15_Print_Documents.md
+++ b/doc/Development_Documentation/03_Documents/02_Document_Types/15_Print_Documents.md
@@ -68,7 +68,7 @@ They can be activated by the printermarks rendering setting. Technically they ar
 For Details, check links below:
 
 * [view-script](https://github.com/pimcore/pimcore/blob/master/install-profiles/demo-basic/app/Resources/views/Web2print/default.html.php#L102-L102)
-* [css-file](https://github.com/pimcore/pimcore/blob/master/web/bundles/pimcoreadmin/css/print/print-printermarks.css)
+* [css-file](https://github.com/pimcore/pimcore/blob/master/bundles/AdminBundle/Resources/public/css/print/print-printermarks.css)
 
 ## Settings
 In the web-to-print settings, the used PDF renderer is specified. Depending on the renderer, there are additional settings to be made. 


### PR DESCRIPTION
Update the location of the urls, they where pointing to the old location.