### PR TITLE
Application Logger: Properly escape log message

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/log/admin.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/log/admin.js
@@ -191,7 +191,10 @@ pimcore.log.admin = Class.create({
                     text: t("log_message"),
                     dataIndex: 'message',
                     flex: 220,
-                    sortable: true
+                    sortable: true,
+                    renderer: function (s) {
+                        return Ext.util.Format.htmlEncode(s);
+                    }
                 },{
                     text: t("log_type"),
                     dataIndex: 'priority',


### PR DESCRIPTION
Messages with markup (e.g. <?xml version='1.0' encoding='UTF-8' standalone='no' ?>)
break the entire listing and other prepared content can lead to XSS.