### PR TITLE
Fix CSV import with alphanumeric ID's

### DIFF
--- a/lib/DataObject/Import/Service.php
+++ b/lib/DataObject/Import/Service.php
@@ -173,7 +173,7 @@ class Service
         $db = Db::get();
 
         $query = 'select distinct c.id from importconfigs c, importconfig_shares s where '
-            . ' c.id = s.importConfigId and s.sharedWithUserId IN (' . $userIds . ') and c.classId = ' . $classId
+            . ' c.id = s.importConfigId and s.sharedWithUserId IN (' . $userIds . ') and c.classId = ' . $db->quote($classId)
                 . ' UNION distinct select c2.id from importconfigs c2 where shareGlobally = 1 and c2.classId = ' . $db->quote($classId);
 
         $ids = $this->db->fetchCol($query);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #
The problem arises if one uses alphanumeric ID's for the new DataObjects, and tries to import some of said DataObject through CSV import.

This will result the following error: 
Message: An exception occurred while executing 'select distinct c.id from importconfigs c, importconfig_shares s where  c.id = s.importConfigId and s.sharedWithUserId IN (2) and c.classId = 93d3afe3 UNION distinct select c2.id from importconfigs c2 where shareGlobally = 1 and c2.classId = '93d3afe3'':

SQLSTATE[42S22]: Column not found: 1054 Unknown column '93d1afe3' in 'where clause'

Where 93d3afe3 is the ID of the ObjectData class.
