### PR TITLE
Custom Reports: Fixed headers exporting CSV ","

### DIFF
--- a/bundles/AdminBundle/Controller/Reports/CustomReportController.php
+++ b/bundles/AdminBundle/Controller/Reports/CustomReportController.php
@@ -392,7 +392,7 @@ class CustomReportController extends ReportsControllerBase implements EventedCon
         $fp = fopen($exportFile, 'w');
 
         if ($includeHeaders) {
-            fputcsv($fp, $fields);
+            fputcsv($fp, $fields, ';');
         }
 
         foreach ($result['data'] as $row) {


### PR DESCRIPTION
When you select to include the headers in a custom report, they are exported as CSV (,), while the rest of the report is semi-colon separated.
