### PR TITLE
Fixed localized fields filtering on custom layout change.

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObjectController.php
@@ -464,9 +464,6 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 $objectData['currentLayoutId'] = $currentLayoutId;
             }
 
-            $objectData = $this->filterLocalizedFields($object, $objectData);
-            DataObject\Service::enrichLayoutDefinition($objectData['layout'], $object);
-
             //Hook for modifying return value - e.g. for changing permissions based on object data
             //data need to wrapped into a container in order to pass parameter to event listeners by reference so that they can change the values
             $event = new GenericEvent($this, [

--- a/bundles/AdminBundle/Controller/Admin/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObjectController.php
@@ -476,6 +476,9 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             $eventDispatcher->dispatch(AdminEvents::OBJECT_GET_PRE_SEND_DATA, $event);
             $data = $event->getArgument('data');
 
+            $data = $this->filterLocalizedFields($object, $data);
+            DataObject\Service::enrichLayoutDefinition($data['layout'], $object);
+
             DataObject\Service::removeObjectFromSession($object->getId());
 
             return $this->adminJson($data);


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Fixed localized fields filtering on layout change via event: https://pimcore.com/docs/5.x/Development_Documentation/Best_Practice/Showing_Custom_Layouts_based_on_Object_Data.html

## Additional info  
How to reproduce:
1. Create custom layout
2. Restrict localized fields via workspace settings
3. Define event like here described: https://pimcore.com/docs/5.x/Development_Documentation/Best_Practice/Showing_Custom_Layouts_based_on_Object_Data.html
4. Change layout programmatically
5. On the first open of object you will see all possible languages in localized fields
6. After reload of object they are restricted to your workspace configuration

The bug appears because there is no localized fields filtering, if layout is changed via event.
