### PR TITLE
[ecommerce][index service] Elasticsearch delete from index bugfix in combination with virtual product ids

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/DefaultElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/DefaultElasticSearch.php
@@ -395,7 +395,7 @@ class DefaultElasticSearch extends AbstractMockupCacheWorker implements IBatchPr
             try {
                 $params = ['index' => $this->getIndexNameVersion(), 'type' => $object->getOSIndexType(), 'id' => $objectId];
                 if ($object->getOSIndexType() == IProductList::PRODUCT_TYPE_VARIANT) {
-                    $params['parent'] = $object->getOSParentId();
+                    $params['parent'] = $this->tenantConfig->createVirtualParentIdForSubId($object, $objectId);
                 }
                 $esClient->delete($params);
 


### PR DESCRIPTION
It's not a good idea to delete items from the elastic search based on the osParentId if they are added based on the virtual product ID. Depending on the use cases this could be a big difference and will result in undeleted items in the elasticsearch index.