### PR TITLE
[fix] re-throwing: ErrorException has 6 parameters rather than 3

### DIFF
--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -195,14 +195,22 @@ class Concrete extends AbstractObject
                                     throw $e;
                                 }
                                 $exceptionClass = get_class($e);
-                                throw new $exceptionClass($e->getMessage() . ' fieldname=' . $fd->getName(), $e->getCode(), $e->getPrevious());
+                                $new_message = $e->getMessage() . ' fieldname=' . $fd->getName();
+                                if ($e instanceof \ErrorException) {
+                                    throw new $exceptionClass($new_message, $e->getCode(), $e->getSeverity(), $e->getFile(), $e->getLine(), $e);
+                                }
+                                throw new $exceptionClass($new_message, $e->getCode(), $e);
                             }
                         } else {
-                            $exceptionClass = get_class($e);
                             if ($e instanceof Model\Element\ValidationException) {
                                 throw $e;
                             }
-                            throw new $exceptionClass($e->getMessage() . ' fieldname=' . $fd->getName(), $e->getCode(), $e);
+                            $exceptionClass = get_class($e);
+                            $new_message = $e->getMessage() . ' fieldname=' . $fd->getName();
+                            if ($e instanceof \ErrorException) {
+                                throw new $exceptionClass($new_message, $e->getCode(), $e->getSeverity(), $e->getFile(), $e->getLine(), $e);
+                            }
+                            throw new $exceptionClass($new_message, $e->getCode(), $e);
                         }
                     }
                 }


### PR DESCRIPTION
## Changes in this pull request  

- Pass `$e` rather than `$e->getPrevious()` to the [`Exception`](https://secure.php.net/manual/en/class.exception.php) constructor (parameter `Throwable $previous`). See my comment in commit https://github.com/pimcore/pimcore/commit/873cb55787241d58be8e6b51af5b19c6fac035d7#r30577890.
- The [`ErrorException`](https://secure.php.net/manual/en/class.errorexception.php) constructor accepts 6 parameters rather than 3. The Symphony (deprecated) [`ContextErrorException`](https://api.symfony.com/3.4/Symfony/Component/Debug/Exception/ContextErrorException.html) constructor _requires_ those parameters.

## Additional info  

Those six lines (197 to 202 and 208 to 213) can be deduplicated into a function.