### PR TITLE
[CSV import] always pass the "target" to Field Definitions' `getFromCsvImport` method

### DIFF
--- a/lib/DataObject/Import/ColumnConfig/Value/DefaultValue.php
+++ b/lib/DataObject/Import/ColumnConfig/Value/DefaultValue.php
@@ -93,7 +93,7 @@ class DefaultValue extends AbstractConfigElement implements ValueInterface
         }
 
         if ($this->mode != 'direct') {
-            $data = $fd->getFromCsvImport($data);
+            $data = $fd->getFromCsvImport($data, $target);
         }
 
         $setter = 'set' . ucfirst($realAttribute);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #3363
