### PR TITLE
Do not disable already disabled redirects

### DIFF
--- a/models/Redirect.php
+++ b/models/Redirect.php
@@ -316,7 +316,7 @@ class Redirect extends AbstractModel
     public static function maintenanceCleanUp()
     {
         $list = new Redirect\Listing();
-        $list->setCondition('expiry < ' . time() . " AND expiry IS NOT NULL AND expiry != ''");
+        $list->setCondition('active = 1 AND expiry < ' . time() . " AND expiry IS NOT NULL AND expiry != ''");
         $list->load();
 
         foreach ($list->getRedirects() as $redirect) {


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [x ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x ] Features need to be proper documented in `doc/`
- [x ] Bugfixes need a short guide how to reproduce them. 
- [ x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
Redirects cache being blown for already delt with entries.
## Additional info  

When running the maintenance job there query that is being used does not consider if the redirect is already disabled. Disabled redirects are disabled again causing the cache to be invalidated and affecting the performance for the web site.

To reproduce:

- Create a redirect with expiration date set to yesterday.
- Open a page on the web site.
- Run the Pimcore maintenance job.
  => Redirect is disabled
  => Cache is gone
- Reload the page (make sure it's not coming from cache, add a query parameter or something).
  => Redirects are saved to cache again.
- Run maintenance job again
 => Redirect is disabled again even though its already disabled
 => BAD Cache is gone
- Reload the page again (make sure it's not coming from cache, add a query parameter or something).
 => BAD: redirects are saved to cache once again.

In our case there are 26000 redirects which greately affects performance. 