### PR TITLE
QuantityValue webservice bugfix

### DIFF
--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -426,7 +426,7 @@ class QuantityValue extends Model\DataObject\ClassDefinition\Data
         if ($data instanceof \Pimcore\Model\DataObject\Data\QuantityValue) {
             return [
                 'value' => $data->getValue(),
-                'unit' => $data->getUnitId(),
+                'unit' => is_object($data->getUnit()) ? $data->getUnit()->getId() : null,
                 'unitAbbreviation' => is_object($data->getUnit()) ? $data->getUnit()->getAbbreviation() : ''
             ];
         } else {


### PR DESCRIPTION
A check is needed whether the unit actually exists otherwise a problem will result if units get deleted as the unit ID might be still in the database.
