### PR TITLE
[DOCS] Additional config info for Matomo iframe

### DIFF
--- a/doc/Development_Documentation/18_Tools_and_Features/28_Marketing_Settings/07_Piwik.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/28_Marketing_Settings/07_Piwik.md
@@ -50,6 +50,9 @@ functionality. To use this integration, you need to configure the Matomo usernam
 of its password (not the plain text password itself!). Similar to the report token, you should use a user with **view only**
 permissions here. 
 
+Further more, you might need to enable the setting `enable_framed_pages` in the Matomo config (see
+[Matomo FAQ](https://matomo.org/faq/troubleshooting/faq_147/)) to allow the iframe to be displayed.
+
 After the iframe integration is configured, you'll find a new menu entry in the marketing menu:
 
 ![Matomo Iframe integration](../../img/piwik_iframe_integration.png)


### PR DESCRIPTION
The default configuration of Matomo prevents the inclusion via IFrame.
See: https://matomo.org/faq/troubleshooting/faq_147/