### PR TITLE
Updated best practice for custom layouts

### DIFF
--- a/doc/Development_Documentation/26_Best_Practice/04_Showing_Custom_Layouts_based_on_Object_Data.md
+++ b/doc/Development_Documentation/26_Best_Practice/04_Showing_Custom_Layouts_based_on_Object_Data.md
@@ -59,13 +59,13 @@ class MyEventListener {
 
             switch ($hierarchyLevel) {
                 case "Article":
-                    $data = $this->doModifyCustomLayouts($data, 2, [0, 1]);
+                    $data = $this->doModifyCustomLayouts($data, $object, 2, [0, 1]);
                     break;
                 case "Color Variant":
-                    $data = $this->doModifyCustomLayouts($data, 1, [0, 2]);
+                    $data = $this->doModifyCustomLayouts($data, $object, 1, [0, 2]);
                     break;
                 default:
-                    $data = $this->doModifyCustomLayouts($data, 0, [1, 2]);
+                    $data = $this->doModifyCustomLayouts($data, $object, 0, [1, 2]);
                     break;
             }
             
@@ -77,14 +77,14 @@ class MyEventListener {
     /**
     * 
     */
-    private function doModifyCustomLayouts($data, $customLayoutToSelect = null, $layoutsToRemove = []) {
+    private function doModifyCustomLayouts($data, $object, $customLayoutToSelect = null, $layoutsToRemove = []) {
         
         if($customLayoutToSelect != null) {
             //set current layout to subcategory layout
             $data['currentLayoutId'] = $customLayoutToSelect;
             $customLayout = CustomLayout::getById($customLayoutToSelect);
             $data['layout'] = $customLayout->getLayoutDefinitions();
-            Service::enrichLayoutDefinition($data["layout"]);            
+            Service::enrichLayoutDefinition($data["layout"], $object);            
         }
         
         if(!empty($layoutsToRemove)) {


### PR DESCRIPTION
I found an edge case using the example provided where if you have a custom layout containing an additional layout item, such as a text box, and then you attach a custom renderer to that text box, this example passes null through as the object (and context).

Adding the $object parameter in here catches this edge case :)

