### PR TITLE
fix the suggested Nginx config: don't `try_files` on SabreDAV URLs

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
@@ -74,8 +74,8 @@ server {
 
     # Assets
     # Still use a whitelist approach to prevent each and every missing asset to go through the PHP Engine.
-    location ~* ^(?:/admin/asset/webdav(?=/))?(?<actual_path>(.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|ogg|ogv|webm|pdf|docx?|xlsx?|pptx?))$ {
-        try_files /var/assets$actual_path $actual_path =404;
+    location ~* ^(?!/admin/asset/webdav/)(.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|ogg|ogv|webm|pdf|docx?|xlsx?|pptx?)$ {
+        try_files /var/assets$uri $uri =404;
         expires 2w;
         access_log off;
         log_not_found off;


### PR DESCRIPTION
## Changes in this pull request  
Resolves #3386
Follow-up of #3291

## Additional info  
The solution is to disable the `location` section for webdav entirely, to avoid any further issues with SabreDAV.
