### PR TITLE
throwing up the error instead of hiding it

### DIFF
--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -151,7 +151,7 @@ class Dao extends Model\Dao\AbstractDao
                     $this->createUpdateTable();
                     throw new \Exception('missing table created, start next run ... ;-)');
                 }
-                throw new \Exception('passing it on ...');
+                throw $e;
             }
 
             if ($container instanceof DataObject\ClassDefinition || $container instanceof DataObject\Objectbrick\Definition) {


### PR DESCRIPTION
The Exception "passing it on ..." is not good, it hides the problem

<!--
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
Showing meaningless message while trying to save an object
## Additional info  
if you remove one column from the localized fields table and tries to save instead of saying that the column does not exist it says "passing it on..." but does not passes anything. 
