### PR TITLE
[fix] SabreDAV: surround ETag by double-quotes

### DIFF
--- a/models/Asset/WebDAV/File.php
+++ b/models/Asset/WebDAV/File.php
@@ -154,7 +154,7 @@ class File extends DAV\File
      */
     public function getETag()
     {
-        return md5_file($this->asset->getFileSystemPath());
+        return '"' . md5_file($this->asset->getFileSystemPath()) . '"';
     }
 
     /**


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
## the bug
### how to reproduce:

* install and set up pimcore
* mount `http://pimcore.test/admin/asset/webdav/` to `/mnt/` using `mount.davfs` (https://savannah.nongnu.org/projects/davfs2, https://en.wikipedia.org/wiki/Davfs2)
* `echo foo > /mnt/testfile`

### observation:

the `testfile` is created, but it will stay empty. `foo` will never be put into the file. davfs2 will move the `testfile` containing `foo` into a local `lost+found` directory, right after the failed http `PUT`.

### more in-depth:

The SabreDAV server creates the file (0 Bytes in size) because davfs2 **locks** ( http `LOCK`) the not-yet-existing file. Every few seconds, davfs2 pushes its cache to the server. The `PUT` request contains an `If-Match` header with a hash in double-quotes, like this: `If-Match: "d41d8cd..."`. SabreDAV will respond `HTTP/1.1 412 Precondition failed` with the message `An If-Match header was specified, but none of the specified ETags matched.` (thrown [here](https://github.com/sabre-io/dav/blob/fb6991ce451c246cbd968e16112ec13b68b8ad44/lib/DAV/Server.php#L1339)).

It turned out that SabreDAV will compare `'d41d8cd...' === '"d41d8cd..."'` (in [this line of code](https://github.com/sabre-io/dav/blob/fb6991ce451c246cbd968e16112ec13b68b8ad44/lib/DAV/Server.php#L1326)) in this case, which will always be false (note the double quotes).

SabreDAV requires `getETag` to return values in double-quotes since https://github.com/sabre-io/dav/commit/f74fba8ffeacaf712ca77bb84816545cd9d3c4e0 (v1.3.0).

## Changes in this pull request  
Resolve the above issue
