### PR TITLE
Prevent warning array_keys() expects parameter 1 to be array, null given

### DIFF
--- a/models/Workflow.php
+++ b/models/Workflow.php
@@ -406,6 +406,10 @@ class Workflow extends AbstractModel
      */
     public function getValidActionsForStatus($statusName)
     {
+        if (!is_array($this->transitionDefinitions[$statusName]['validActions'])) {
+            return [];
+        }
+        
         return array_keys($this->transitionDefinitions[$statusName]['validActions']);
     }
 


### PR DESCRIPTION
Prevent Warning: array_keys() expects parameter 1 to be array, null given