### PR TITLE
display version publish errors to the user

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/versions.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/versions.js
@@ -260,11 +260,15 @@ pimcore.object.versions = Class.create({
             method: "POST",
             params: {id: versionId},
             success: function(response) {
-                this.object.reload();
-
                 var rdata = Ext.decode(response.responseText);
-                if (rdata && rdata.success) {
+
+                if (rdata.success) {
+                    this.object.reload();
+
                     pimcore.helpers.updateObjectStyle(this.object.id, rdata.treeData);
+                }
+                else {
+                    Ext.MessageBox.alert(t("error"), rdata.message);
                 }
 
             }.bind(this)


### PR DESCRIPTION
Otherwise the object just reloads and you have no clue that it actually failed.