### PR TITLE
Documentation: typo "includeRelations" vs "includedRelations"

### DIFF
--- a/doc/Development_Documentation/18_Tools_and_Features/35_GDPR_Data_Extractor.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/35_GDPR_Data_Extractor.md
@@ -30,7 +30,7 @@ pimcore_admin:
                 #     MY_CLASS_NAME: 
                 #               include: true
                 #               allowDelete: false
-                #               includeRelations:
+                #               includedRelations:
                 #                       - manualSegemens
                 #                       - calculatedSegments
                 #                         


### PR DESCRIPTION
Documentation: typo "includeRelations" vs "includedRelations"