### PR TITLE
Add option to disable useIds only 

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFactFinder.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFactFinder.php
@@ -145,6 +145,11 @@ class DefaultFactFinder implements IProductList
     protected $logger;
 
     /**
+     * @var bool
+     */
+    protected $useIdsOnly = true;
+
+    /**
      * @return bool
      */
     public function getTransmitSessionId()
@@ -161,6 +166,24 @@ class DefaultFactFinder implements IProductList
     {
         $this->transmitSessionId = $transmitSessionId;
 
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getUseIdsOnly()
+    {
+        return $this->useIdsOnly;
+    }
+
+    /**
+     * @param boolean $useIdsOnly
+     * @return $this
+     */
+    public function setUseIdsOnly($useIdsOnly)
+    {
+        $this->useIdsOnly = $useIdsOnly;
         return $this;
     }
 
@@ -819,7 +842,9 @@ class DefaultFactFinder implements IProductList
             $params['page'] = ceil($this->getOffset() / $this->getLimit()) + 1;
         }
         $params['productsPerPage'] = $this->getLimit();
-        $params['idsOnly'] = 'true';
+        if($this->getUseIdsOnly()){
+            $params['idsOnly'] = 'true';
+        }
         // $params['navigation'] = 'true';
         $params['useAsn'] = $this->getUseAsn() ? 'true' : 'false';
         if ($this->getFollowSearchParam()) {


### PR DESCRIPTION
Add option to disable useIds only parameter (required in special situation where you need e.g. the variant ids in the response)
