### PR TITLE
[Workflow] Don't overwrite symfony registered services

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Compiler/WorkflowPass.php
+++ b/bundles/CoreBundle/DependencyInjection/Compiler/WorkflowPass.php
@@ -38,7 +38,7 @@ class WorkflowPass implements CompilerPassInterface
     {
         $loader = new YamlFileLoader(
             $container,
-            new FileLocator(__DIR__.'..//../Resources/config')
+            new FileLocator(__DIR__.'/../../Resources/config')
         );
 
         $workflowManagerDefinition = $container->getDefinition(Manager::class);

--- a/bundles/CoreBundle/DependencyInjection/Compiler/WorkflowPass.php
+++ b/bundles/CoreBundle/DependencyInjection/Compiler/WorkflowPass.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Pimcore\Workflow\Manager;
+use Pimcore\Workflow\Transition;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Workflow;
+use Symfony\Component\Workflow\Exception\LogicException;
+
+class WorkflowPass implements CompilerPassInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $loader = new YamlFileLoader(
+            $container,
+            new FileLocator(__DIR__.'..//../Resources/config')
+        );
+
+        $workflowManagerDefinition = $container->getDefinition(Manager::class);
+
+        if (!$container->hasDefinition('workflow.registry')) {
+            $loader->load('services_symfony_workflow.yml');
+        }
+
+        $config = $container->getParameter('pimcore.workflow');
+
+        foreach ($config as $workflowName => $workflowConfig) {
+            if (!$workflowConfig['enabled']) {
+                continue;
+            }
+
+            $type = $workflowConfig['type'] ?? 'workflow';
+
+            $workflowManagerDefinition->addMethodCall(
+                'registerWorkflow',
+                [
+                    $workflowName,
+                    [
+                        'label' => $workflowConfig['label'],
+                        'priority' => $workflowConfig['priority'],
+                        'type' => $type,
+                    ],
+                ]
+            );
+
+            $transitions = [];
+            foreach ($workflowConfig['transitions'] as $transitionName => $transitionConfig) {
+                if ('workflow' === $type) {
+                    $transitions[] = new Definition(
+                        Transition::class,
+                        [
+                            $transitionName,
+                            $transitionConfig['from'],
+                            $transitionConfig['to'],
+                            $transitionConfig['options'],
+                        ]
+                    );
+                } elseif ('state_machine' === $type) {
+                    foreach ($transitionConfig['from'] as $from) {
+                        foreach ($transitionConfig['to'] as $to) {
+                            $transitions[] = new Definition(
+                                Transition::class,
+                                [$transitionName, $from, $to, $transitionConfig['options']]
+                            );
+                        }
+                    }
+                }
+            }
+
+            $places = [];
+            foreach ($workflowConfig['places'] as $place => $placeConfig) {
+                $places[] = $place;
+
+                $workflowManagerDefinition->addMethodCall('addPlaceConfig', [$workflowName, $place, $placeConfig]);
+            }
+
+            foreach ($workflowConfig['globalActions'] ?? [] as $action => $actionConfig) {
+                $workflowManagerDefinition->addMethodCall('addGlobalAction', [$workflowName, $action, $actionConfig]);
+            }
+
+            $markingStoreType = $workflowConfig['marking_store']['type'] ?? null;
+            $markingStoreService = $workflowConfig['marking_store']['service'] ?? null;
+            if (is_null($markingStoreService) && is_null($markingStoreType)) {
+                $markingStoreType = 'state_table';
+            }
+
+            // Create a Definition
+            $definitionDefinition = new Definition(Workflow\Definition::class);
+            $definitionDefinition->setPublic(false);
+            $definitionDefinition->addArgument($places);
+            $definitionDefinition->addArgument($transitions);
+            $definitionDefinition->addTag(
+                'workflow.definition',
+                [
+                    'name' => $workflowName,
+                    'type' => $type,
+                    'marking_store' => $markingStoreType,
+                ]
+            );
+
+            if (isset($workflowConfig['initial_place'])) {
+                $definitionDefinition->addArgument($workflowConfig['initial_place']);
+            }
+
+            // Create MarkingStore
+            if (!is_null($markingStoreType)) {
+                $markingStoreDefinition = new ChildDefinition('workflow.marking_store.'.$markingStoreType);
+
+                if ($markingStoreType === 'state_table' || $markingStoreType === 'data_object_splitted_state') {
+                    $markingStoreDefinition->addArgument($workflowName);
+                }
+
+                if ($markingStoreType === 'data_object_splitted_state') {
+                    $markingStoreDefinition->addArgument($places);
+                }
+
+                foreach ($workflowConfig['marking_store']['arguments'] ?? [] as $argument) {
+                    $markingStoreDefinition->addArgument($argument);
+                }
+            } elseif (!is_null($markingStoreService)) {
+                $markingStoreDefinition = new Reference($markingStoreService);
+            }
+
+            // Create Workflow
+            $workflowId = sprintf('%s.%s', $type, $workflowName);
+            $workflowDefinition = new ChildDefinition(sprintf('%s.abstract', $type));
+            $workflowDefinition->replaceArgument(0, new Reference(sprintf('%s.definition', $workflowId)));
+            if (isset($markingStoreDefinition)) {
+                $workflowDefinition->replaceArgument(1, $markingStoreDefinition);
+            }
+            $workflowDefinition->replaceArgument(3, $workflowName);
+
+            // Store to container
+            $container->setDefinition($workflowId, $workflowDefinition);
+            $container->setDefinition(sprintf('%s.definition', $workflowId), $definitionDefinition);
+
+            $registryDefinition = $container->getDefinition('workflow.registry');
+            // Add workflow to Registry
+            if ($workflowConfig['supports']) {
+                foreach ((array)$workflowConfig['supports'] as $supportedClassName) {
+                    $strategyDefinition = new Definition(
+                        Workflow\SupportStrategy\ClassInstanceSupportStrategy::class,
+                        [$supportedClassName]
+                    );
+                    $strategyDefinition->setPublic(false);
+                    $registryDefinition->addMethodCall('add', [new Reference($workflowId), $strategyDefinition]);
+                }
+            } elseif (isset($workflowConfig['support_strategy'])) {
+                $supportStrategyType = $workflowConfig['support_strategy']['type'] ?? null;
+
+                if (!is_null($supportStrategyType)) {
+                    $supportStrategyDefinition = new ChildDefinition('workflow.support_strategy.'.$supportStrategyType);
+
+                    foreach ($workflowConfig['support_strategy']['arguments'] ?? [] as $argument) {
+                        $supportStrategyDefinition->addArgument($argument);
+                    }
+                    $registryDefinition->addMethodCall('add', [new Reference($workflowId), $supportStrategyDefinition]);
+                } elseif (isset($workflowConfig['support_strategy']['service'])) {
+                    $registryDefinition->addMethodCall(
+                        'add',
+                        [new Reference($workflowId), new Reference($workflowConfig['support_strategy']['service'])]
+                    );
+                }
+            }
+
+            // Enable the AuditTrail
+            if ($workflowConfig['audit_trail']['enabled']) {
+                $listener = new Definition(Workflow\EventListener\AuditTrailListener::class);
+                $listener->setPrivate(true);
+                $listener->addTag('monolog.logger', ['channel' => 'workflow']);
+                $listener->addTag(
+                    'kernel.event_listener',
+                    ['event' => sprintf('workflow.%s.leave', $workflowName), 'method' => 'onLeave']
+                );
+                $listener->addTag(
+                    'kernel.event_listener',
+                    ['event' => sprintf('workflow.%s.transition', $workflowName), 'method' => 'onTransition']
+                );
+                $listener->addTag(
+                    'kernel.event_listener',
+                    ['event' => sprintf('workflow.%s.enter', $workflowName), 'method' => 'onEnter']
+                );
+                $listener->addArgument(new Reference('logger'));
+                $container->setDefinition(sprintf('%s.listener.audit_trail', $workflowId), $listener);
+            }
+
+            // Add Guard Listener
+            $guard = new Definition(Workflow\EventListener\GuardListener::class);
+            $guard->setPrivate(true);
+            $configuration = [];
+            foreach ($workflowConfig['transitions'] as $transitionName => $config) {
+                if (!isset($config['guard'])) {
+                    continue;
+                }
+
+                if (!class_exists(ExpressionLanguage::class)) {
+                    throw new LogicException(
+                        'Cannot guard workflows as the ExpressionLanguage component is not installed.'
+                    );
+                }
+
+                if (!class_exists(Security::class)) {
+                    throw new LogicException('Cannot guard workflows as the Security component is not installed.');
+                }
+
+                $eventName = sprintf('workflow.%s.guard.%s', $workflowName, $transitionName);
+                $guard->addTag('kernel.event_listener', ['event' => $eventName, 'method' => 'onTransition']);
+                $configuration[$eventName] = $config['guard'];
+            }
+            if ($configuration) {
+                $guard->setArguments(
+                    [
+                        $configuration,
+                        new Reference('workflow.security.expression_language'),
+                        new Reference('security.token_storage'),
+                        new Reference('security.authorization_checker'),
+                        new Reference('security.authentication.trust_resolver'),
+                        new Reference('security.role_hierarchy'),
+                        new Reference('validator', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                    ]
+                );
+
+                $container->setDefinition(sprintf('%s.listener.guard', $workflowId), $guard);
+                $container->setParameter('workflow.has_guard_listeners', true);
+            }
+        }
+    }
+}

--- a/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -32,13 +32,9 @@ use Pimcore\Targeting\DataLoaderInterface;
 use Pimcore\Targeting\Storage\TargetingStorageInterface;
 use Pimcore\Translation\ExportDataExtractorService\DataExtractor\DataObjectDataExtractor;
 use Pimcore\Translation\Translator;
-use Pimcore\Workflow\Manager;
-use Pimcore\Workflow\Transition;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -46,10 +42,6 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
-use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
-use Symfony\Component\Security\Core\Security;
-use Symfony\Component\Workflow;
-use Symfony\Component\Workflow\Exception\LogicException;
 
 class PimcoreCoreExtension extends ConfigurableExtension implements PrependExtensionInterface
 {
@@ -127,7 +119,8 @@ class PimcoreCoreExtension extends ConfigurableExtension implements PrependExten
         $this->configureMigrations($container, $config['migrations']);
         $this->configureGoogleAnalyticsFallbackServiceLocator($container);
         $this->configureSitemaps($container, $config['sitemaps']);
-        $this->configureWorkflows($container, $config['workflows']);
+
+        $container->setParameter('pimcore.workflow', $config['workflows']);
 
         // load engine specific configuration only if engine is active
         $configuredEngines = ['twig', 'php'];
@@ -498,173 +491,6 @@ class PimcoreCoreExtension extends ConfigurableExtension implements PrependExten
 
         foreach ($config as $context => $contextConfig) {
             $guesser->addMethodCall('addContextRoutes', [$context, $contextConfig['routes']]);
-        }
-    }
-
-    private function configureWorkflows(ContainerBuilder $container, array $config)
-    {
-        $workflowManagerDefinition = $container->getDefinition(Manager::class);
-
-        foreach ($config as $workflowName => $workflowConfig) {
-            if (!$workflowConfig['enabled']) {
-                continue;
-            }
-
-            $type = $workflowConfig['type'] ?? 'workflow';
-
-            $workflowManagerDefinition->addMethodCall('registerWorkflow', [$workflowName, [
-                'label' => $workflowConfig['label'],
-                'priority' => $workflowConfig['priority'],
-                'type' => $type
-            ]]);
-
-            $transitions = [];
-            foreach ($workflowConfig['transitions'] as $transitionName => $transitionConfig) {
-                if ('workflow' === $type) {
-                    $transitions[] = new Definition(Transition::class, [$transitionName, $transitionConfig['from'], $transitionConfig['to'], $transitionConfig['options']]);
-                } elseif ('state_machine' === $type) {
-                    foreach ($transitionConfig['from'] as $from) {
-                        foreach ($transitionConfig['to'] as $to) {
-                            $transitions[] = new Definition(Transition::class, [$transitionName, $from, $to, $transitionConfig['options']]);
-                        }
-                    }
-                }
-            }
-
-            $places = [];
-            foreach ($workflowConfig['places'] as $place => $placeConfig) {
-                $places[] = $place;
-
-                $workflowManagerDefinition->addMethodCall('addPlaceConfig', [$workflowName, $place, $placeConfig]);
-            }
-
-            foreach ($workflowConfig['globalActions'] ?? [] as $action => $actionConfig) {
-                $workflowManagerDefinition->addMethodCall('addGlobalAction', [$workflowName, $action, $actionConfig]);
-            }
-
-            $markingStoreType = $workflowConfig['marking_store']['type'] ?? null;
-            $markingStoreService = $workflowConfig['marking_store']['service'] ?? null;
-            if (is_null($markingStoreService) && is_null($markingStoreType)) {
-                $markingStoreType = 'state_table';
-            }
-
-            // Create a Definition
-            $definitionDefinition = new Definition(Workflow\Definition::class);
-            $definitionDefinition->setPublic(false);
-            $definitionDefinition->addArgument($places);
-            $definitionDefinition->addArgument($transitions);
-            $definitionDefinition->addTag('workflow.definition', [
-                'name' => $workflowName,
-                'type' => $type,
-                'marking_store' => $markingStoreType,
-            ]);
-
-            if (isset($workflowConfig['initial_place'])) {
-                $definitionDefinition->addArgument($workflowConfig['initial_place']);
-            }
-
-            // Create MarkingStore
-            if (!is_null($markingStoreType)) {
-                $markingStoreDefinition = new ChildDefinition('workflow.marking_store.'.$markingStoreType);
-
-                if ($markingStoreType === 'state_table' || $markingStoreType === 'data_object_splitted_state') {
-                    $markingStoreDefinition->addArgument($workflowName);
-                }
-
-                if ($markingStoreType === 'data_object_splitted_state') {
-                    $markingStoreDefinition->addArgument($places);
-                }
-
-                foreach ($workflowConfig['marking_store']['arguments'] ?? [] as $argument) {
-                    $markingStoreDefinition->addArgument($argument);
-                }
-            } elseif (!is_null($markingStoreService)) {
-                $markingStoreDefinition = new Reference($markingStoreService);
-            }
-
-            // Create Workflow
-            $workflowId = sprintf('%s.%s', $type, $workflowName);
-            $workflowDefinition = new ChildDefinition(sprintf('%s.abstract', $type));
-            $workflowDefinition->replaceArgument(0, new Reference(sprintf('%s.definition', $workflowId)));
-            if (isset($markingStoreDefinition)) {
-                $workflowDefinition->replaceArgument(1, $markingStoreDefinition);
-            }
-            $workflowDefinition->replaceArgument(3, $workflowName);
-
-            // Store to container
-            $container->setDefinition($workflowId, $workflowDefinition);
-            $container->setDefinition(sprintf('%s.definition', $workflowId), $definitionDefinition);
-
-            $registryDefinition = $container->getDefinition('workflow.registry');
-            // Add workflow to Registry
-            if ($workflowConfig['supports']) {
-                foreach ((array) $workflowConfig['supports'] as $supportedClassName) {
-                    $strategyDefinition = new Definition(Workflow\SupportStrategy\ClassInstanceSupportStrategy::class, [$supportedClassName]);
-                    $strategyDefinition->setPublic(false);
-                    $registryDefinition->addMethodCall('add', [new Reference($workflowId), $strategyDefinition]);
-                }
-            } elseif (isset($workflowConfig['support_strategy'])) {
-                $supportStrategyType = $workflowConfig['support_strategy']['type'] ?? null;
-
-                if (!is_null($supportStrategyType)) {
-                    $supportStrategyDefinition = new ChildDefinition('workflow.support_strategy.' . $supportStrategyType);
-
-                    foreach ($workflowConfig['support_strategy']['arguments'] ?? [] as $argument) {
-                        $supportStrategyDefinition->addArgument($argument);
-                    }
-                    $registryDefinition->addMethodCall('add', [new Reference($workflowId), $supportStrategyDefinition]);
-                } elseif (isset($workflowConfig['support_strategy']['service'])) {
-                    $registryDefinition->addMethodCall('add', [new Reference($workflowId), new Reference($workflowConfig['support_strategy']['service'])]);
-                }
-            }
-
-            // Enable the AuditTrail
-            if ($workflowConfig['audit_trail']['enabled']) {
-                $listener = new Definition(Workflow\EventListener\AuditTrailListener::class);
-                $listener->setPrivate(true);
-                $listener->addTag('monolog.logger', ['channel' => 'workflow']);
-                $listener->addTag('kernel.event_listener', ['event' => sprintf('workflow.%s.leave', $workflowName), 'method' => 'onLeave']);
-                $listener->addTag('kernel.event_listener', ['event' => sprintf('workflow.%s.transition', $workflowName), 'method' => 'onTransition']);
-                $listener->addTag('kernel.event_listener', ['event' => sprintf('workflow.%s.enter', $workflowName), 'method' => 'onEnter']);
-                $listener->addArgument(new Reference('logger'));
-                $container->setDefinition(sprintf('%s.listener.audit_trail', $workflowId), $listener);
-            }
-
-            // Add Guard Listener
-            $guard = new Definition(Workflow\EventListener\GuardListener::class);
-            $guard->setPrivate(true);
-            $configuration = [];
-            foreach ($workflowConfig['transitions'] as $transitionName => $config) {
-                if (!isset($config['guard'])) {
-                    continue;
-                }
-
-                if (!class_exists(ExpressionLanguage::class)) {
-                    throw new LogicException('Cannot guard workflows as the ExpressionLanguage component is not installed.');
-                }
-
-                if (!class_exists(Security::class)) {
-                    throw new LogicException('Cannot guard workflows as the Security component is not installed.');
-                }
-
-                $eventName = sprintf('workflow.%s.guard.%s', $workflowName, $transitionName);
-                $guard->addTag('kernel.event_listener', ['event' => $eventName, 'method' => 'onTransition']);
-                $configuration[$eventName] = $config['guard'];
-            }
-            if ($configuration) {
-                $guard->setArguments([
-                    $configuration,
-                    new Reference('workflow.security.expression_language'),
-                    new Reference('security.token_storage'),
-                    new Reference('security.authorization_checker'),
-                    new Reference('security.authentication.trust_resolver'),
-                    new Reference('security.role_hierarchy'),
-                    new Reference('validator', ContainerInterface::NULL_ON_INVALID_REFERENCE),
-                ]);
-
-                $container->setDefinition(sprintf('%s.listener.guard', $workflowId), $guard);
-                $container->setParameter('workflow.has_guard_listeners', true);
-            }
         }
     }
 

--- a/bundles/CoreBundle/PimcoreCoreBundle.php
+++ b/bundles/CoreBundle/PimcoreCoreBundle.php
@@ -31,6 +31,7 @@ use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\TargetingOverrideHand
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\TemplateVarsProviderPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\TemplatingEngineAwareHelperPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\WebDebugToolbarListenerPass;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\WorkflowPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -80,5 +81,6 @@ class PimcoreCoreBundle extends Bundle
         $container->addCompilerPass(new MonologPsrLogMessageProcessorPass());
         $container->addCompilerPass(new DebugStopwatchPass());
         $container->addCompilerPass(new LongRunningHelperPass());
+        $container->addCompilerPass(new WorkflowPass());
     }
 }

--- a/bundles/CoreBundle/Resources/config/services_symfony_workflow.yml
+++ b/bundles/CoreBundle/Resources/config/services_symfony_workflow.yml
@@ -1,0 +1,39 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    workflow.abstract:
+        class: Symfony\Component\Workflow\Workflow
+        abstract: true
+        public: true
+        arguments:
+            - ~
+            - null
+            - '@event_dispatcher'
+            - ~
+    state_machine.abstract:
+        class: Symfony\Component\Workflow\StateMachine
+        abstract: true
+        public: true
+        arguments:
+            - ~
+            - null
+            - '@event_dispatcher'
+            - ~
+    workflow.marking_store.multiple_state:
+        class: Symfony\Component\Workflow\MarkingStore\MultipleStateMarkingStore
+        abstract: true
+    workflow.marking_store.single_state:
+        class: Symfony\Component\Workflow\MarkingStore\SingleStateMarkingStore
+        abstract: true
+
+    workflow.registry:
+        class: Symfony\Component\Workflow\Registry
+
+    Symfony\Component\Workflow\Registry:
+        alias: workflow.registry
+
+    workflow.security.expression_language:
+        class: Symfony\Component\Workflow\EventListener\ExpressionLanguage

--- a/bundles/CoreBundle/Resources/config/services_workflow.yml
+++ b/bundles/CoreBundle/Resources/config/services_workflow.yml
@@ -13,34 +13,6 @@ services:
     Pimcore\Workflow\NotificationEmail\NotificationEmailService:
         public: true
 
-    workflow.abstract:
-        class: Symfony\Component\Workflow\Workflow
-        abstract: true
-        public: true
-        arguments:
-            - ~
-            - null
-            - '@event_dispatcher'
-            - ~
-
-    state_machine.abstract:
-        class: Symfony\Component\Workflow\StateMachine
-        abstract: true
-        public: true
-        arguments:
-            - ~
-            - null
-            - '@event_dispatcher'
-            - ~
-
-    workflow.marking_store.multiple_state:
-        class: Symfony\Component\Workflow\MarkingStore\MultipleStateMarkingStore
-        abstract: true
-
-    workflow.marking_store.single_state:
-        class: Symfony\Component\Workflow\MarkingStore\SingleStateMarkingStore
-        abstract: true
-
     workflow.marking_store.state_table:
         class: Pimcore\Workflow\MarkingStore\StateTableMarkingStore
         abstract: true
@@ -71,21 +43,11 @@ services:
             - '@validator'
         public: true
 
-    workflow.registry:
-        class: Symfony\Component\Workflow\Registry
-
-    Symfony\Component\Workflow\Registry:
-        alias: workflow.registry
-
     Pimcore\Workflow\EventSubscriber\NotificationEmailSubscriber: ~
 
     Pimcore\Workflow\EventSubscriber\NotesSubscriber: ~
 
     Pimcore\Workflow\EventSubscriber\ChangePublishedStateSubscriber: ~
-
-    workflow.security.expression_language:
-        class: Symfony\Component\Workflow\EventListener\ExpressionLanguage
-
     pimcore.workflow.place-options-provider:
         class: Pimcore\Workflow\Place\OptionsProvider
         public: true


### PR DESCRIPTION
this causes issues with other services that already extend it or use it -> for example if you manually define a symfony workflow -> registering that again will cause to lose all of its configuration and therefore fail. even if it is configured properly.

this is quite urgent and has to be merged before 5.5, since this breaks default symfony behaviour in workflows.