### PR TITLE
An exception is thrown for users without permission in the GDPR Data Extractor

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/gdpr/dataproviders/sentMail.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/gdpr/dataproviders/sentMail.js
@@ -20,12 +20,12 @@ pimcore.settings.gdpr.dataproviders.sentMail = Class.create({
     initialize: function (searchParams) {
         this.searchParams = searchParams;
         this.getPanel();
-        this.user = pimcore.globalmanager.get("user");
     },
 
     getPanel: function () {
 
-        if(!this.panel && this.user && this.user.isAllowed("emails")) {
+        var user = pimcore.globalmanager.get("user");
+        if(!this.panel && user && user.isAllowed("emails")) {
 
             this.panel = new Ext.Panel({
                 title: t("gdpr_dataSource_sentMail"),

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/gdpr/dataproviders/sentMail.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/gdpr/dataproviders/sentMail.js
@@ -15,7 +15,6 @@ pimcore.registerNS("pimcore.settings.gdpr.dataproviders.sentMail");
 pimcore.settings.gdpr.dataproviders.sentMail = Class.create({
 
     searchParams: [],
-    user: null,
 
     initialize: function (searchParams) {
         this.searchParams = searchParams;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/gdpr/dataproviders/sentMail.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/gdpr/dataproviders/sentMail.js
@@ -15,15 +15,17 @@ pimcore.registerNS("pimcore.settings.gdpr.dataproviders.sentMail");
 pimcore.settings.gdpr.dataproviders.sentMail = Class.create({
 
     searchParams: [],
+    user: null,
 
     initialize: function (searchParams) {
         this.searchParams = searchParams;
         this.getPanel();
+        this.user = pimcore.globalmanager.get("user");
     },
 
     getPanel: function () {
 
-        if(!this.panel) {
+        if(!this.panel && this.user && this.user.isAllowed("emails")) {
 
             this.panel = new Ext.Panel({
                 title: t("gdpr_dataSource_sentMail"),


### PR DESCRIPTION
Opening the **GDPR Data Extractor** and searching for *any* value will trigger a popup window. This window shows an exception for users without the **emails** permission.

## Changes in this pull request  
Added a check for user permissions before rendering the *Sent Emails* Panel in the GDPR Data Extractor.
If the permission is not given the user will simply not see the *Sent Emails* tab.

## How to reproduce

1. Configure the GDPR Data Extractor as documented [here](https://pimcore.com/docs/5.x/Development_Documentation/Tools_and_Features/GDPR_Data_Extractor.html).
2. Create a new user without *emails* permission.
3. Log in with the newly created user.
4. Use the GDPR Data Extractor to search for anything.
5. When the *Sent Emails* tab is to be loaded an exception will be thrown in [EmailController.php](https://github.com/pimcore/pimcore/blob/master/bundles/AdminBundle/Controller/Admin/EmailController.php) (which will be shown in a popup window).