### PR TITLE
[fix] Get class definition in ObjectsMetadata

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ObjectsMetadata.php
+++ b/models/DataObject/ClassDefinition/Data/ObjectsMetadata.php
@@ -897,7 +897,11 @@ class ObjectsMetadata extends Model\DataObject\ClassDefinition\Data\Objects
             return;
         }
 
-        $class = DataObject\ClassDefinition::getByName($classId);
+        if (is_string($classId)) {
+            $class = DataObject\ClassDefinition::getByName($classId);
+        } elseif (is_int($classId)) {
+            $class = DataObject\ClassDefinition::getById($classId);
+        }
 
         if (!$this->visibleFields) {
             return;

--- a/models/DataObject/ClassDefinition/Data/ObjectsMetadata.php
+++ b/models/DataObject/ClassDefinition/Data/ObjectsMetadata.php
@@ -897,10 +897,10 @@ class ObjectsMetadata extends Model\DataObject\ClassDefinition\Data\Objects
             return;
         }
 
-        if (is_string($classId)) {
-            $class = DataObject\ClassDefinition::getByName($classId);
-        } elseif (is_int($classId)) {
+        if (is_numeric($classId)) {
             $class = DataObject\ClassDefinition::getById($classId);
+        } else {
+            $class = DataObject\ClassDefinition::getByName($classId);
         }
 
         if (!$this->visibleFields) {


### PR DESCRIPTION
## bug #

In the older version in class definition for field `objectsMetadata` in attribute `allowedClassId` was saved class id instead of class name.

Tested on pimcore 5.23.