### PR TITLE
Fix keyboard shortcuts

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -868,6 +868,7 @@ class User extends User\UserRole
                 [
                     'action' => 'glossary',
                     'key' => ord('G'),
+                    'shift' => true,
                     'alt' => true
                 ],
                 [

--- a/models/User.php
+++ b/models/User.php
@@ -873,6 +873,7 @@ class User extends User\UserRole
                 [
                     'action' => 'redirects',
                     'key' => ord('R'),
+                    'ctrl' => false,
                     'alt' => true
                 ],
                 [
@@ -956,11 +957,13 @@ class User extends User\UserRole
                 [
                     'action' => 'clearAllCaches',
                     'key' => ord('Q'),
+                    'ctrl' => false,
                     'alt' => true
                 ],
                 [
                     'action' => 'clearDataCache',
                     'key' => ord('C'),
+                    'ctrl' => false,
                     'alt' => true
                 ],
                 [


### PR DESCRIPTION
## Changes in this pull request  
Resolves #3390

## Additional info  
Default keyboard shortcut for "Glossary" updated from **ALT+G** to **ALT+Shift+G**
