### PR TITLE
[WebDAV fix] Mime detection: check for 0Byte files

### DIFF
--- a/lib/Tool/Mime.php
+++ b/lib/Tool/Mime.php
@@ -30,31 +30,33 @@ class Mime
             throw new \Exception('File ' . $file . " doesn't exist");
         }
 
-        if (!$filename) {
-            $filename = basename($file);
-        }
-
-        $extensionMapping = \Pimcore::getContainer()->getParameter('pimcore.mime.extensions');
-
-        // check for an extension mapping first
-        if ($filename) {
-            $extension = \Pimcore\File::getFileExtension($filename);
-            if (array_key_exists($extension, $extensionMapping)) {
-                return $extensionMapping[$extension];
-            }
-        }
-
-        // check with fileinfo, if there's no extension mapping
-        $finfo = finfo_open(FILEINFO_MIME);
-        $type = finfo_file($finfo, $file);
-        finfo_close($finfo);
-
-        if ($type !== false && !empty($type)) {
-            if (strstr($type, ';')) {
-                $type = substr($type, 0, strpos($type, ';'));
+        if (filesize($file) !== 0) {
+            if (!$filename) {
+                $filename = basename($file);
             }
 
-            return $type;
+            $extensionMapping = \Pimcore::getContainer()->getParameter('pimcore.mime.extensions');
+
+            // check for an extension mapping first
+            if ($filename) {
+                $extension = \Pimcore\File::getFileExtension($filename);
+                if (array_key_exists($extension, $extensionMapping)) {
+                    return $extensionMapping[$extension];
+                }
+            }
+
+            // check with fileinfo, if there's no extension mapping
+            $finfo = finfo_open(FILEINFO_MIME);
+            $type = finfo_file($finfo, $file);
+            finfo_close($finfo);
+
+            if ($type !== false && !empty($type)) {
+                if (strstr($type, ';')) {
+                    $type = substr($type, 0, strpos($type, ';'));
+                }
+
+                return $type;
+            }
         }
 
         // return default mime-type if we're unable to detect it


### PR DESCRIPTION
Some WebDAV clients create 0B files (zero byte files), e.g. as a mechanism for locking. 
For details, see http://sabre.io/dav/0bytes/.

This PR ensures that 0B files will always have type `application/octet-stream`.

Prior to this fix, when a file was detected e.g. as an image, it would become an `Image`, and tasks like dimension calculation (width/height) or thumbnail creation would fail.

## Additional info  

If I push a 0B file to `dir/img.jpg`, I'll get the following error in the log:

```
[2018-10-11 10:16:41] pimcore.ERROR: ImagickException: insufficient image data in file `/var/www/pimcore/var/tmp/asset-temporary/asset_65_f1683f4c46a775391018314af9e99be4__img.jpg' @ error/jpeg.c/ReadJPEGImage/1039 in /var/www/pimcore/vendor/pimcore/pimcore/lib/Image/Adapter/Imagick.php:117
Stack trace:
#0 /var/www/pimcore/vendor/pimcore/pimcore/lib/Image/Adapter/Imagick.php(117): Imagick->readimage('/var/www/pimcor...')
#1 /var/www/pimcore/vendor/pimcore/pimcore/models/Asset/Image.php(409): Pimcore\Image\Adapter\Imagick->load('/var/www/pimcor...', Array)
#2 /var/www/pimcore/vendor/pimcore/pimcore/models/Asset/Image.php(50): Pimcore\Model\Asset\Image->getDimensions('/var/www/pimcor...', true)
#3 /var/www/pimcore/vendor/pimcore/pimcore/models/Asset.php(501): Pimcore\Model\Asset\Image->update(Array)
#4 /var/www/pimcore/vendor/pimcore/pimcore/models/Asset.php(355): Pimcore\Model\Asset->save()
#5 /var/www/pimcore/vendor/pimcore/pimcore/models/Asset/WebDAV/Folder.php(130): Pimcore\Model\Asset::create(8, Array)
#6 /var/www/pimcore/vendor/sabre/dav/lib/DAV/Server.php(1095): Pimcore\Model\Asset\WebDAV\Folder->createFile('img.jpg', Resource id #29)
#7 /var/www/pimcore/vendor/sabre/dav/lib/DAV/Locks/Plugin.php(247): Sabre\DAV\Server->createFile('dir/img.jpg', Resource id #29)
#8 [internal function]: Sabre\DAV\Locks\Plugin->httpLock(Object(Sabre\HTTP\Request), Object(Sabre\HTTP\Response))
#9 /var/www/pimcore/vendor/sabre/event/lib/EventEmitterTrait.php(105): call_user_func_array(Array, Array)
#10 /var/www/pimcore/vendor/sabre/dav/lib/DAV/Server.php(479): Sabre\Event\EventEmitter->emit('method:LOCK', Array)
#11 /var/www/pimcore/vendor/sabre/dav/lib/DAV/Server.php(254): Sabre\DAV\Server->invokeMethod(Object(Sabre\HTTP\Request), Object(Sabre\HTTP\Response))
#12 /var/www/pimcore/vendor/pimcore/pimcore/bundles/AdminBundle/Controller/Admin/AssetController.php(966): Sabre\DAV\Server->exec()
#13 /var/www/pimcore/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(151): Pimcore\Bundle\AdminBundle\Controller\Admin\AssetController->webdavAction(Object(Symfony\Component\HttpFoundation\Request))
#14 /var/www/pimcore/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(68): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#15 /var/www/pimcore/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php(200): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#16 /var/www/pimcore/web/app.php(42): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#17 {main} [] []
```