### PR TITLE
serpAbsoluteUrl fix for use case when site is not in the 1st level

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/pages/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/pages/settings.js
@@ -125,14 +125,19 @@ pimcore.document.pages.settings = Class.create(pimcore.document.settings_abstrac
             if (typeof subSites === 'object' && subSites.length) {
                 var idPath = this.document.data.idPath.replace(/^\/+/g, '');
                 var splitPath = idPath.split('/');
+                var siteKey = 1;
+                if (this.document.data.path === "/") {
+                    siteKey = splitPath.length - 1;
+                }
 
-                if (typeof splitPath[1] !== 'undefined') {
-                    var subSiteId = parseInt(splitPath[1], 10);
+                if (typeof splitPath[siteKey] !== 'undefined') {
+                    var subSiteId = parseInt(splitPath[siteKey], 10);
 
                     subSites.forEach(function(item) {
                         if (item.data.rootId === subSiteId) {
+                            urlPath = urlPath.substring(urlPath.indexOf(item.data.rootPath), urlPath.length);
                             urlPath = urlPath.replace(item.data.rootPath, '');
-                            serpAbsoluteUrl = item.data.domain + urlPath;
+                            serpAbsoluteUrl = window.location.protocol + '//' + item.data.domain + urlPath;
                         }
                     });
                 }


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Fixes for situation described in https://talk.pimcore.org/t/multisites-and-problem-with-path-key-realurl-uri-preview/1374

## Additional info  
If sites are not on 1st level tree then their serpAbsoluteUrl is wrong (default window data is used)
