### PR TITLE
[assets] getChildren() performance improvement and php doc fixes for asset DAO

### DIFF
--- a/models/Asset/Dao.php
+++ b/models/Asset/Dao.php
@@ -329,7 +329,7 @@ class Dao extends Model\Element\Dao
      */
     public function hasChildren()
     {
-        $c = $this->db->fetchOne('SELECT id FROM assets WHERE parentId = ?', $this->model->getId());
+        $c = $this->db->fetchOne('SELECT id FROM assets WHERE parentId = ? LIMIT 1', $this->model->getId());
 
         return (bool)$c;
     }
@@ -405,7 +405,7 @@ class Dao extends Model\Element\Dao
      *
      * @param bool $force
      *
-     * @return array
+     * @return Model\Version|null
      */
     public function getLatestVersion($force = false)
     {
@@ -419,12 +419,12 @@ class Dao extends Model\Element\Dao
             }
         }
 
-        return;
+        return null;
     }
 
     /**
      * @param $type
-     * @param $user
+     * @param Model\User $user
      *
      * @return bool
      */


### PR DESCRIPTION
The main improvement of this pull request is that now the `hasChildren()` method is faster because of the added `LIMIT 1` especially for folders with many assets in it. 

Additionally I've added some PHP doc fixes.