### PR TITLE
Remove site if document is registered as one

### DIFF
--- a/models/Document.php
+++ b/models/Document.php
@@ -779,6 +779,11 @@ class Document extends Element\AbstractElement
             $service = new Document\Service;
             $service->removeTranslation($this);
 
+            // if document is registered as site remove it
+            if (($site = Site::getByRootId($this->getId())) instanceof Site) {
+                $site->delete();
+            }
+
             $this->getDao()->delete();
 
             // clear cache

--- a/models/Document.php
+++ b/models/Document.php
@@ -780,8 +780,12 @@ class Document extends Element\AbstractElement
             $service->removeTranslation($this);
 
             // if document is registered as site remove it
-            if (($site = Site::getByRootId($this->getId())) instanceof Site) {
-                $site->delete();
+            try {
+                if (($site = Site::getByRootId($this->getId())) instanceof Site) {
+                    $site->delete();
+                }
+            } catch (\Exception $e) {
+                Logger::warning($e->getMessage());
             }
 
             $this->getDao()->delete();

--- a/models/Site.php
+++ b/models/Site.php
@@ -179,6 +179,16 @@ class Site extends AbstractModel
     }
 
     /**
+     * Remove the site
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        $this->getDao()->delete();
+    }
+
+    /**
      * returns true if the current process/request is inside a site
      *
      * @static


### PR DESCRIPTION
## Changes in this pull request  
Resolves #3253 
When a document is registered as site and you remove it from the document tree, the site entry isn't deleted from the DB. This leads into a crash of the webpage.

This PR fixes this problem and checks whether the document is registered as site when you delete it.