### PR TITLE
Add objects with meta data date column support

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/multihrefMetadata.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/multihrefMetadata.js
@@ -424,7 +424,7 @@ pimcore.object.classes.data.multihrefMetadata = Class.create(pimcore.object.clas
             var types = {
                 number: t("objectsMetadata_type_number"),
                 text: t("objectsMetadata_type_text"),
-                date: t("objectsMetadata_type_date"),
+                date: t("date"),
                 select: t("objectsMetadata_type_select"),
                 bool: t("objectsMetadata_type_bool"),
                 columnbool: t("objectsMetadata_type_columnbool"),

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/multihrefMetadata.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/multihrefMetadata.js
@@ -424,6 +424,7 @@ pimcore.object.classes.data.multihrefMetadata = Class.create(pimcore.object.clas
             var types = {
                 number: t("objectsMetadata_type_number"),
                 text: t("objectsMetadata_type_text"),
+                date: t("objectsMetadata_type_date"),
                 select: t("objectsMetadata_type_select"),
                 bool: t("objectsMetadata_type_bool"),
                 columnbool: t("objectsMetadata_type_columnbool"),
@@ -445,6 +446,7 @@ pimcore.object.classes.data.multihrefMetadata = Class.create(pimcore.object.clas
                     data: [
                         ['number', types.number],
                         ['text', types.text],
+                        ['date', types.date],
                         ['select', types.select],
                         ['bool', types.bool],
                         ['columnbool', types.columnbool],

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/objectsMetadata.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/objectsMetadata.js
@@ -248,7 +248,7 @@ pimcore.object.classes.data.objectsMetadata = Class.create(pimcore.object.classe
             var types = {
                 number: t("objectsMetadata_type_number"),
                 text: t("objectsMetadata_type_text"),
-                date: t("objectsMetadata_type_date"),
+                date: t("date"),
                 select: t("objectsMetadata_type_select"),
                 bool: t("objectsMetadata_type_bool"),
                 multiselect: t("objectsMetadata_type_multiselect")

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/objectsMetadata.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/objectsMetadata.js
@@ -248,6 +248,7 @@ pimcore.object.classes.data.objectsMetadata = Class.create(pimcore.object.classe
             var types = {
                 number: t("objectsMetadata_type_number"),
                 text: t("objectsMetadata_type_text"),
+                date: t("objectsMetadata_type_date"),
                 select: t("objectsMetadata_type_select"),
                 bool: t("objectsMetadata_type_bool"),
                 multiselect: t("objectsMetadata_type_multiselect")
@@ -265,8 +266,8 @@ pimcore.object.classes.data.objectsMetadata = Class.create(pimcore.object.classe
                         'value',
                         'label'
                     ],
-                    data: [['number', types.number], ['text', types.text], ['select', types.select],
-                        ['bool', types.bool], ['multiselect', types.multiselect]]
+                    data: [['number', types.number], ['text', types.text], ['date', types.date],
+                        ['select', types.select], ['bool', types.bool], ['multiselect', types.multiselect]]
                 }),
                 valueField: 'value',
                 displayField: 'label'

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multihrefMetadata.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multihrefMetadata.js
@@ -116,7 +116,10 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                 };
             } else if (this.fieldConfig.columns[i].type == "date" && !readOnly) {
                 cellEditor = function() {
-                    return new Ext.form.DateField({});
+                    return new Ext.form.DateField({
+                        format: 'Y-m-d',
+                        xtype: 'datefield'
+                    });
                 };
             } else if(this.fieldConfig.columns[i].type == "select" && !readOnly) {
                 var selectData = [];
@@ -201,6 +204,11 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
             if(this.fieldConfig.columns[i].type == "select") {
                 renderer = function (value, metaData, record, rowIndex, colIndex, store) {
                     return ts(value);
+                }
+            }
+            if(this.fieldConfig.columns[i].type == "date") {
+                renderer = function (value, metaData, record, rowIndex, colIndex, store) {
+                    return Ext.Date.format(new Date(value), 'Y-m-d')
                 }
             }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multihrefMetadata.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multihrefMetadata.js
@@ -118,7 +118,6 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                 cellEditor = function() {
                     return new Ext.form.DateField({});
                 };
-            }
             } else if(this.fieldConfig.columns[i].type == "select" && !readOnly) {
                 var selectData = [];
                 if (this.fieldConfig.columns[i].value) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multihrefMetadata.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multihrefMetadata.js
@@ -114,6 +114,11 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                 cellEditor = function() {
                     return new Ext.form.TextField({});
                 };
+            } else if (this.fieldConfig.columns[i].type == "date" && !readOnly) {
+                cellEditor = function() {
+                    return new Ext.form.DateField({});
+                };
+            }
             } else if(this.fieldConfig.columns[i].type == "select" && !readOnly) {
                 var selectData = [];
                 if (this.fieldConfig.columns[i].value) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectsMetadata.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectsMetadata.js
@@ -138,7 +138,7 @@ pimcore.object.tags.objectsMetadata = Class.create(pimcore.object.tags.objects, 
                     return new Ext.form.NumberField({});
                 }.bind();
             } else if (this.fieldConfig.columns[i].type == "text" && !readOnly) {
-                cellEditor = function () {
+                cellEditor = function() {
                     return new Ext.form.TextField({});
                 };
             } else if (this.fieldConfig.columns[i].type == "date" && !readOnly) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectsMetadata.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectsMetadata.js
@@ -142,10 +142,9 @@ pimcore.object.tags.objectsMetadata = Class.create(pimcore.object.tags.objects, 
                     return new Ext.form.TextField({});
                 };
             } else if (this.fieldConfig.columns[i].type == "date" && !readOnly) {
-                    cellEditor = function() {
-                        return new Ext.form.DateField({});
-                    };
-                }
+                cellEditor = function() {
+                    return new Ext.form.DateField({});
+                };
             } else if (this.fieldConfig.columns[i].type == "select" && !readOnly) {
                var selectData = [];
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectsMetadata.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectsMetadata.js
@@ -138,9 +138,14 @@ pimcore.object.tags.objectsMetadata = Class.create(pimcore.object.tags.objects, 
                     return new Ext.form.NumberField({});
                 }.bind();
             } else if (this.fieldConfig.columns[i].type == "text" && !readOnly) {
-                cellEditor = function() {
+                cellEditor = function () {
                     return new Ext.form.TextField({});
                 };
+            } else if (this.fieldConfig.columns[i].type == "date" && !readOnly) {
+                    cellEditor = function() {
+                        return new Ext.form.DateField({});
+                    };
+                }
             } else if (this.fieldConfig.columns[i].type == "select" && !readOnly) {
                var selectData = [];
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectsMetadata.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectsMetadata.js
@@ -142,9 +142,11 @@ pimcore.object.tags.objectsMetadata = Class.create(pimcore.object.tags.objects, 
                     return new Ext.form.TextField({});
                 };
             } else if (this.fieldConfig.columns[i].type == "date" && !readOnly) {
-                cellEditor = function() {
-                    return new Ext.form.DateField({});
-                };
+                if(this.fieldConfig.columns[i].type == "date") {
+                    renderer = function (value, metaData, record, rowIndex, colIndex, store) {
+                        return Ext.Date.format(new Date(value), 'Y-m-d')
+                    }
+                }
             } else if (this.fieldConfig.columns[i].type == "select" && !readOnly) {
                var selectData = [];
 
@@ -211,6 +213,11 @@ pimcore.object.tags.objectsMetadata = Class.create(pimcore.object.tags.objects, 
             if(this.fieldConfig.columns[i].type == "select") {
                 renderer = function (value, metaData, record, rowIndex, colIndex, store) {
                     return ts(value);
+                }
+            }
+            if(this.fieldConfig.columns[i].type == "date") {
+                renderer = function (value, metaData, record, rowIndex, colIndex, store) {
+                    return Ext.Date.format(new Date(value), 'Y-m-d')
                 }
             }
 


### PR DESCRIPTION
## Add date type info objects metadata and multihref with metadata.
This pull requests adds new type into supported types of meta columns.
![image](https://user-images.githubusercontent.com/31479820/46905939-2359c900-cefb-11e8-9c00-706b8e90163b.png)
![image](https://user-images.githubusercontent.com/31479820/46905941-2bb20400-cefb-11e8-877d-d597f206209d.png)
![image](https://user-images.githubusercontent.com/31479820/46905945-38cef300-cefb-11e8-9475-62e5dc72e281.png)

## Additional info  

