### PR TITLE
[ecommmerce][elasticsearch] delete moved variants from old parents

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/DefaultElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/DefaultElasticSearch.php
@@ -541,8 +541,12 @@ class DefaultElasticSearch extends AbstractMockupCacheWorker implements IBatchPr
 
         foreach($hits as $hit) {
             if($hit['_parent'] != $indexSystemData['o_virtualProductId']) {
-                $params = ['index' => $this->getIndexNameVersion(), 'type' => IProductList::PRODUCT_TYPE_VARIANT, 'id' => $indexSystemData['o_id']];
-                $params['parent'] = $hit['_parent'];
+                $params = [
+                    'index' => $this->getIndexNameVersion(),
+                    'type' => IProductList::PRODUCT_TYPE_VARIANT,
+                    'id' => $indexSystemData['o_id'],
+                    'parent' => $hit['_parent']
+                ];
                 $esClient->delete($params);
             }
         }


### PR DESCRIPTION
If a variant is moved from one parent to another one the original document needs to be deleted as otherwise the variant will be stored twice in the index.

A proposed solution is added to this pull request.