### PR TITLE
fix sql error in element_workflow_state

### DIFF
--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -873,7 +873,7 @@ CREATE TABLE `element_workflow_state` (
   `cid` int(10) NOT NULL DEFAULT '0',
   `ctype` enum('document','asset','object') NOT NULL,
   `place` varchar(255) DEFAULT NULL,
-  `workflow` varchar(100) DEFAULT '',
+  `workflow` varchar(100) NOT NULL,
   PRIMARY KEY (`cid`,`ctype`,`workflow`)
 ) DEFAULT CHARSET=utf8mb4;
 


### PR DESCRIPTION
And also make the schema end up like one would have migrated.

When you migrate from 5.4.x to 5.5.0 you get additional columns which are
described in doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5/05_Workflow_Management.md
in element_workflow_state. The install.sql script does not properly
reflect the requirement of workflow which should end up as NOT NULL.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

This makes sure the upgraded schema and the clean install schema are more alike
