### PR TITLE
System thumbnail generation

### DIFF
--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -79,6 +79,9 @@ class ThumbnailsImageCommand extends AbstractCommand
         }
 
         if ($input->getOption('system')) {
+            if(!$input->getOption('thumbnails')){
+                $thumbnailsToGenerate = [];
+            }
             $thumbnailsToGenerate[] = 'system';
         }
 


### PR DESCRIPTION
Only generate system thumbnails if "--system" option is provided an no thumbnails are passed to generate

e.g: php www/bin/console pimcore:thumbnails:image --system
