### PR TITLE
Fix unique constraint error

### DIFF
--- a/models/DataObject/Data/ObjectMetadata/Dao.php
+++ b/models/DataObject/Data/ObjectMetadata/Dao.php
@@ -51,7 +51,7 @@ class Dao extends Model\Dao\AbstractDao
             $data = $dataTemplate;
             $data['column'] = $column;
             $data['data'] = $this->model->$getter();
-            $this->db->insert($table, $data);
+            $this->db->insertOrUpdate($table, $data);
         }
     }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #3527 
When a save() method is called on existing, but modified objectMetadata it might rise An exception " Integrity constraint violation: 1062 Duplicate entry".
It should use insertOrUpdate() instead of insert()

