### PR TITLE
Documents paste as language variant

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -879,6 +879,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
                     'sourceId' => $request->get('sourceId'),
                     'targetId' => $request->get('targetId'),
                     'type' => $request->get('type'),
+                    'language' => $request->get('language'),
                     'enableInheritance' => $request->get('enableInheritance'),
                     'transactionId' => $transactionId,
                     'resetIndex' => ($request->get('type') == 'child')
@@ -975,9 +976,10 @@ class DocumentController extends ElementControllerBase implements EventedControl
                 if ($source != null) {
                     if ($request->get('type') == 'child') {
                         $enableInheritance = ($request->get('enableInheritance') == 'true') ? true : false;
+                        $language = $request->get('language', false);
                         $resetIndex = ($request->get('resetIndex') == 'true') ? true : false;
 
-                        $newDocument = $this->_documentService->copyAsChild($target, $source, $enableInheritance, $resetIndex);
+                        $newDocument = $this->_documentService->copyAsChild($target, $source, $enableInheritance, $resetIndex, $language);
 
                         $sessionBag['idMapping'][(int)$source->getId()] = (int)$newDocument->getId();
 

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -829,5 +829,8 @@
   "list_thumbnail_in_download_section_on_image_detail_view": "List as option in download section on image detail view",
   "there_are_more_items": "There are more items than displayed",
   "unit_width": "Width Unit",
-  "permission_missing": "You need the '%s' permission to perform this action"
+  "permission_missing": "You need the '%s' permission to perform this action",
+  "paste_as_language_variant": "Paste as new language variant",
+  "select_language_for_new_document": "Select language for New Document",
+  "source_document_language_missing": "Set Language(Properties) in Source Document"
 }

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -215,7 +215,7 @@ class Service extends Model\Element\Service
      *
      * @throws \Exception
      */
-    public function copyAsChild($target, $source, $enableInheritance = false, $resetIndex = false)
+    public function copyAsChild($target, $source, $enableInheritance = false, $resetIndex = false, $language = false)
     {
         if (method_exists($source, 'getElements')) {
             $source->getElements();
@@ -248,9 +248,18 @@ class Service extends Model\Element\Service
             $new->setContentMasterDocumentId($source->getId());
         }
 
+        if ($language) {
+            $new->setProperty('language', 'text', $language, false);
+        }
+
         $new->save();
 
         $this->updateChilds($target, $new);
+
+        //link translated document
+        if ($language) {
+            $this->addTranslation($source, $new, $language);
+        }
 
         // triggers actions after the complete document cloning
         \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_COPY, new DocumentEvent($new, [


### PR DESCRIPTION
## Changes in this pull request  
Resolves #3231

Added new feature "Paste as new language variant"
---------------------------------------------------------------------
Copy Element
![language0](https://user-images.githubusercontent.com/5137917/47562999-09c67180-d93e-11e8-8abe-267f37cdfd40.png)


Select Paste/Paste(inheritance) -> Paste as new language variant
![language1](https://user-images.githubusercontent.com/5137917/47563006-0d59f880-d93e-11e8-84fe-4a08a84dfe3f.png)


Select Language &  Apply
![language2](https://user-images.githubusercontent.com/5137917/47563046-2793d680-d93e-11e8-8247-8fdee0cf0927.png)

This option creates a new copy document with selected language & interlink with source document.
## Additional info  

