### PR TITLE
Fix cover transformation when focal point near edge

### DIFF
--- a/lib/Image/Adapter.php
+++ b/lib/Image/Adapter.php
@@ -256,9 +256,11 @@ abstract class Adapter
             $focalPointYCoordinate = $orientation['y'] / 100 * $this->getHeight();
 
             $cropY = $focalPointYCoordinate - ($height / 2);
+            $cropY = min($cropY, $this->height() - $height);
             $cropY = max($cropY, 0);
 
             $cropX = $focalPointXCoordinate - ($width / 2);
+            $cropX = min($cropX, $this->width() - $width);
             $cropX = max($cropX, 0);
         } else {
             $cropX = null;


### PR DESCRIPTION
If an image has a focal point too close to the right edge or the bottom, the cover transformation will end up cropping the image too much, leaving the resulting thumbnail narrower or shorter than it's supposed to be. This fix puts a ceiling on the cropX and cropY values in order to preserve the desired height and width of the thumbnail.
