### PR TITLE
Fix cover transformation when focal point too close to edge

### DIFF
--- a/lib/Image/Adapter.php
+++ b/lib/Image/Adapter.php
@@ -256,9 +256,11 @@ abstract class Adapter
             $focalPointYCoordinate = $orientation['y'] / 100 * $this->getHeight();
 
             $cropY = $focalPointYCoordinate - ($height / 2);
+            $cropY = min($cropY, $this->getHeight() - $height);
             $cropY = max($cropY, 0);
 
             $cropX = $focalPointXCoordinate - ($width / 2);
+            $cropX = min($cropX, $this->getWidth() - $width);
             $cropX = max($cropX, 0);
         } else {
             $cropX = null;


### PR DESCRIPTION
If a focal point is set too close to the right edge or the  bottom of an image, the cover thumbnail transformation will crop the  image too much. The resulting thumbnail will be either narrower or  shorter than it's supposed to be. This fix puts a ceiling on the cropX  and cropY values so that cropX won't be too close to the right edge, and  cropY won't be too close to the bottom. 



