### PR TITLE
workflow state grid operator: do not output html content in csv export

### DIFF
--- a/lib/DataObject/GridColumnConfig/Operator/WorkflowState.php
+++ b/lib/DataObject/GridColumnConfig/Operator/WorkflowState.php
@@ -31,7 +31,15 @@ class WorkflowState extends AbstractOperator
         $result = new \stdClass();
         $result->label = $this->label;
 
-        $result->value = $this->statusInfo->getAllPalacesHtml($element);
+        $context = $this->getContext();
+        $purpose = $context['purpose'] ?? null;
+
+        if($purpose === 'gridview') {
+            $result->value = $this->statusInfo->getAllPalacesHtml($element);
+        } else {
+            $result->value = $this->statusInfo->getAllPlacesForCsv($element);
+        }
+
 
         return $result;
     }

--- a/lib/Workflow/Place/StatusInfo.php
+++ b/lib/Workflow/Place/StatusInfo.php
@@ -68,6 +68,18 @@ class StatusInfo
         );
     }
 
+    public function getAllPlacesForCsv($subject, string $workflowName = null): string
+    {
+        $places = $this->getAllPlaces($subject, false, $workflowName);
+        $result = [];
+
+        foreach($places as $place) {
+            $result[] = $place->getLabel();
+        }
+
+        return implode(', ', $result);
+    }
+
     /**
      * @param $subject
      * @param bool $visibleInHeaderOnly


### PR DESCRIPTION
This pull request outputs the workflow state as html in the object grid and as simple text-list in the CSV export.

(see #3538)