### PR TITLE
Package timeout is not available

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/01_System_Requirements.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/01_System_Requirements.md
@@ -92,7 +92,7 @@ On Debian based systems, you can use the following command to install all requir
 - wkhtmltoimage / wkhtmltopdf (>= 0.12)
 - xvfb
 - [html2text (mbayer)](http://www.mbayer.de/html2text/)
-- timeout (GNU core utils)
+- coreutils (GNU core utils)
 - pdftotext (poppler utils)
 - inkscape
 - zopflipng


### PR DESCRIPTION
Package timeout is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it: coreutils

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

