### PR TITLE
add preSendData event for fieldcollectionList

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
@@ -857,6 +857,13 @@ class ClassController extends AdminController implements EventedControllerInterf
             $definitions[] = $group;
         }
 
+        $event = new GenericEvent($this, [
+            'list' => $definitions,
+            'objectId' => $request->get('object_id')
+        ]);
+        \Pimcore::getEventDispatcher()->dispatch(AdminEvents::CLASS_FIELDCOLLECTION_LIST_PRE_SEND_DATA, $event);
+        $definitions = $event->getArgument('list');
+
         if ($forObjectEditor) {
             return $this->adminJson(['fieldcollections' => $definitions, 'layoutDefinitions' => $layoutDefinitions]);
         } else {
@@ -907,6 +914,13 @@ class ClassController extends AdminController implements EventedControllerInterf
 
             $list = $filteredList;
         }
+
+        $event = new GenericEvent($this, [
+            'list' => $list,
+            'objectId' => $request->get('object_id')
+        ]);
+        \Pimcore::getEventDispatcher()->dispatch(AdminEvents::CLASS_FIELDCOLLECTION_LIST_PRE_SEND_DATA, $event);
+        $list = $event->getArgument('list');
 
         return $this->adminJson(['fieldcollections' => $list]);
     }

--- a/lib/Event/AdminEvents.php
+++ b/lib/Event/AdminEvents.php
@@ -317,6 +317,18 @@ final class AdminEvents
     /**
      * Subject: \Pimcore\Bundle\AdminBundle\Controller\Admin\ClassController
      * Arguments:
+     *  - list | array | the list of field collections
+     *  - objectId | int | id of the origin object
+     *
+     * @Event("Pimcore\Event\Model\GenericEvent")
+     *
+     * @var string
+     */
+    const CLASS_FIELDCOLLECTION_LIST_PRE_SEND_DATA = 'pimcore.admin.class.fieldcollectionList.preSendData';
+
+    /**
+     * Subject: \Pimcore\Bundle\AdminBundle\Controller\Admin\ClassController
+     * Arguments:
      *  - list | array | the list of object bricks
      *  - objectId | int | id of the origin object
      *


### PR DESCRIPTION
This pull requests adds basically the same event as **\Pimcore\Event\AdminEvents::CLASS_OBJECTBRICK_LIST_PRE_SEND_DATA** 
just for Fieldcollections

Adapted both usages from objectbrickbricks in 
- \Pimcore\Bundle\AdminBundle\Controller\Admin\DataObject\ClassController::objectbrickListAction:1315
- \Pimcore\Bundle\AdminBundle\Controller\Admin\DataObject\ClassController::objectbrickTreeAction:1245