### PR TITLE
Fixed the checking for validation exceptions

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -1089,7 +1089,7 @@ class Localizedfields extends Model\DataObject\ClassDefinition\Data
             }
         }
 
-        if (count($validationExceptions)) {
+        if (count($validationExceptions) > 0) {
             $aggregatedExceptions = new Model\Element\ValidationException();
             $aggregatedExceptions->setSubItems($validationExceptions);
             throw $aggregatedExceptions;

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -1070,8 +1070,8 @@ class Localizedfields extends Model\DataObject\ClassDefinition\Data
         }
 
         $data = $this->getDataForValidity($data, $languages);
+        $validationExceptions = [];
         if (!$omitMandatoryCheck) {
-            $validationExceptions = [];
 
             foreach ($languages as $language) {
                 foreach ($this->getFieldDefinitions() as $fd) {
@@ -1089,7 +1089,7 @@ class Localizedfields extends Model\DataObject\ClassDefinition\Data
             }
         }
 
-        if ($validationExceptions) {
+        if (count($validationExceptions)) {
             $aggregatedExceptions = new Model\Element\ValidationException();
             $aggregatedExceptions->setSubItems($validationExceptions);
             throw $aggregatedExceptions;


### PR DESCRIPTION
So, it will not throw the notice below.
```Notice: Undefined variable: validationExceptions in /data/projects/kh-pimcore/vendor/pimcore/pimcore/models/DataObject/ClassDefinition/Data/Localizedfields.php on line 1084```

<!--
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
A notice warning when we are checking for validation exceptions on localized fields.

You can reproduce it by creating a script to import an object that has some localized fields and those fields don't have any errors.

## Additional info  

