### PR TITLE
Fix infinite recursion when get called on object with null param

### DIFF
--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1326,7 +1326,7 @@ class AbstractObject extends Model\Element\AbstractElement
      */
     public function get($fieldName, $language = null)
     {
-        return $this->{'get'.ucfirst($fieldName)}($language);
+        return $fieldName ? $this->{'get'.ucfirst($fieldName)}($language) : null;
     }
 
     /**

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1326,7 +1326,10 @@ class AbstractObject extends Model\Element\AbstractElement
      */
     public function get($fieldName, $language = null)
     {
-        return $fieldName ? $this->{'get'.ucfirst($fieldName)}($language) : null;
+        if (!$fieldName) {
+            throw new \Exception('Field name must not be empty.');
+        }
+        return $this->{'get'.ucfirst($fieldName)}($language);
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
When a get function is called with null or empty param it won't jump into infinite recursion.
Currently in works like:

```
public function get($fieldName, $language = null) // $fieldName = null $language = null
{
    return $this->{'get'.ucfirst($fieldName)}($language); // is transformed into $this->get($language) - infinite recursion when $language is null;
}


