### PR TITLE
Fix Double Nested Array in ObjectData Preview Url Generator

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -2336,7 +2336,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 }
             }
         } elseif ($linkGenerator = $object->getClass()->getLinkGenerator()) {
-            $url = $linkGenerator->generate($object, [['preview' => true, 'context' => $this]]);
+            $url = $linkGenerator->generate($object, ['preview' => true, 'context' => $this]);
         }
 
         if (!$url) {


### PR DESCRIPTION
Use `[]` instead of `[[]]` in link generator options.