### PR TITLE
Fix findByType not available in system settings

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/system.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/system.js
@@ -1334,7 +1334,7 @@ pimcore.settings.system = Class.create({
             smtpFieldSet.show();
         } else {
             smtpFieldSet.hide();
-            Ext.each(smtpFieldSet.findByType("textfield"), function (item) {
+            Ext.each(smtpFieldSet.query("textfield"), function (item) {
                 item.setValue("");
             });
         }


### PR DESCRIPTION
`findByType` is not available since ExtJs 4 anymore.... it was replaced with `query` in ExtJs 4