### PR TITLE
Fix sorting variants

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1214,6 +1214,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             'o_parentId = ? AND o_id != ?',
             [$updatedObject->getParentId(), $updatedObject->getId()]
         );
+        $list->setObjectTypes([DataObject\AbstractObject::OBJECT_TYPE_OBJECT, DataObject\AbstractObject::OBJECT_TYPE_VARIANT, DataObject\AbstractObject::OBJECT_TYPE_FOLDER]);
         $list->setOrderKey('o_index');
         $list->setOrder('asc');
         $siblings = $list->load();


### PR DESCRIPTION
Fix bug when manually sorting objects in the tree. This was not working correctly for variants as the indices of siblings were not updated.