### PR TITLE
globalParams

### DIFF
--- a/models/Document/Tag/Areablock.php
+++ b/models/Document/Tag/Areablock.php
@@ -308,7 +308,7 @@ class Areablock extends Model\Document\Tag implements BlockInterface
      */
     protected function outputEditmodeOptions(array $options, $return = false)
     {
-        // clean up invalid brick editmode options and merge global config to local config
+        // clean up invalid brick editmode options
         if (array_key_exists('options', $options)) {
             $validOptions = ['forceEditInView', 'editWidth', 'editHeight'];
 

--- a/models/Document/Tag/Areablock.php
+++ b/models/Document/Tag/Areablock.php
@@ -323,16 +323,9 @@ class Areablock extends Model\Document\Tag implements BlockInterface
             }
             if (array_key_exists('globalParams', $options['options'])) {
                 if (array_key_exists('allowed', $options['options'])) {
-                    foreach ($options['options']['allowed'] as $brickName) {
-                        foreach ($options['options']['globalParams'] as $key => $val) {
-                            if (!in_array($key, $validOptions)) {
-                                if (!is_array($options['options']['params'])) {
-                                    $options['options']['params'] = [];
-                                }
-                                if (!array_key_exists($brickName, $options['options']['params']) || !array_key_exists($key, $options['options']['params'][$brickName])) {
-                                    $options['options']['params'][$brickName][$key] = $val;
-                                }
-                            }
+                    foreach ($options['options']['globalParams'] as $key => $val) {
+                        if (!in_array($key, $validOptions)) {
+                            unset($options['options']['globalParams'][$key]);
                         }
                     }
                 }

--- a/models/Document/Tag/Areablock.php
+++ b/models/Document/Tag/Areablock.php
@@ -308,15 +308,30 @@ class Areablock extends Model\Document\Tag implements BlockInterface
      */
     protected function outputEditmodeOptions(array $options, $return = false)
     {
-        // clean up invalid brick editmode options
+        // clean up invalid brick editmode options and merge global config to local config
         if (array_key_exists('options', $options)) {
-            foreach (['params', 'globalParams'] as $paramKey) {
-                if (array_key_exists($paramKey, $options['options'])) {
-                    $validOptions = ['forceEditInView', 'editWidth', 'editHeight'];
-                    foreach ($options['options'][$paramKey] as $brickName => $params) {
-                        foreach ($params as $key => $val) {
+            $validOptions = ['forceEditInView', 'editWidth', 'editHeight'];
+
+            if (array_key_exists('params', $options['options'])) {
+                foreach ($options['options']['params'] as $brickName => $params) {
+                    foreach ($params as $key => $val) {
+                        if (!in_array($key, $validOptions)) {
+                            unset($options['options']['params'][$brickName][$key]);
+                        }
+                    }
+                }
+            }
+            if (array_key_exists('globalParams', $options['options'])) {
+                if (array_key_exists('allowed', $options['options'])) {
+                    foreach ($options['options']['allowed'] as $brickName) {
+                        foreach ($options['options']['globalParams'] as $key => $val) {
                             if (!in_array($key, $validOptions)) {
-                                unset($options['options'][$paramKey][$brickName][$key]);
+                                if (!is_array($options['options']['params'])) {
+                                    $options['options']['params'] = [];
+                                }
+                                if (!array_key_exists($brickName, $options['options']['params']) || !array_key_exists($key, $options['options']['params'][$brickName])) {
+                                    $options['options']['params'][$brickName][$key] = $val;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Merge globalParams to all allowed brick configs.

At the moment it is not possible to set a globalParams like it is described here
https://pimcore.com/docs/5.x/Development_Documentation/Documents/Editables/Areablock/index.html

Without this fix you need to set all globalParams in a array like:
'globalParams' => [[
        'containerClass' => 'mt-5',
]],

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

