### PR TITLE
[wip] Pimcore 5.5.3 - Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields#doGetDataForEditMode missing if-Statements

### DIFF
--- a/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/SettingsController.php
+++ b/pimcore/lib/Pimcore/Bundle/AdminBundle/Controller/Admin/SettingsController.php
@@ -1771,13 +1771,13 @@ class SettingsController extends AdminController
                     $date = $value;
                     $value = null;
 
-                    if(!empty($date) && !empty($data[$cleanKeyParts[0].".".$cleanKeyParts[1].".time"])) {
-                        $time = $data[$cleanKeyParts[0].".".$cleanKeyParts[1].".time"];
-                        $time = explode("T", $time);
-                        $date = explode("T", $date);
-                        $value = strtotime($date[0]."T".$time[1]);
+                    if (!empty($date) && !empty($data[$cleanKeyParts[0].'.'.$cleanKeyParts[1].'.time'])) {
+                        $time = $data[$cleanKeyParts[0].'.'.$cleanKeyParts[1].'.time'];
+                        $time = explode('T', $time);
+                        $date = explode('T', $date);
+                        $value = strtotime($date[0].'T'.$time[1]);
                     }
-                } else if ($cleanKeyParts[2] == 'time') {
+                } elseif ($cleanKeyParts[2] == 'time') {
                     continue;
                 }
 

--- a/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/TagManagerListener.php
+++ b/pimcore/lib/Pimcore/Bundle/CoreBundle/EventListener/Frontend/TagManagerListener.php
@@ -149,7 +149,6 @@ class TagManagerListener
 
                 if (is_array($tag->getItems()) && $paramsValid) {
                     foreach ($tag->getItems() as $itemKey => $item) {
-
                         if ($item['disabled']) {
                             continue;
                         }

--- a/pimcore/lib/Pimcore/Update.php
+++ b/pimcore/lib/Pimcore/Update.php
@@ -504,6 +504,10 @@ class Update
      */
     public static function invalidateComposerAutoloadClassmap()
     {
+        // we don't invalidate anymore here, this would break the final update to Pimcore 5.4.0
+        // this doesn't matter anymore since this class is gone anyway in 5.4.0
+        return;
+
 
         // unfortunately \Composer\Autoload\ClassLoader has no method setClassMap()
         // so we need to invalidate the existing classmap by replacing all mappings beginning with 'Pimcore'

--- a/pimcore/lib/Pimcore/Update.php
+++ b/pimcore/lib/Pimcore/Update.php
@@ -508,7 +508,6 @@ class Update
         // this doesn't matter anymore since this class is gone anyway in 5.4.0
         return;
 
-
         // unfortunately \Composer\Autoload\ClassLoader has no method setClassMap()
         // so we need to invalidate the existing classmap by replacing all mappings beginning with 'Pimcore'
 

--- a/pimcore/lib/Pimcore/Version.php
+++ b/pimcore/lib/Pimcore/Version.php
@@ -24,12 +24,12 @@ class Version
     /**
      * @var int
      */
-    public static $revision = 297;
+    public static $revision = 298;
 
     /**
      * @var string
      */
-    public static $buildDate = '2018-07-31T12:18:50+02:00';
+    public static $buildDate = '2018-07-31T12:40:07+02:00';
 
     /**
      * @return string

--- a/pimcore/lib/Pimcore/Version.php
+++ b/pimcore/lib/Pimcore/Version.php
@@ -24,12 +24,12 @@ class Version
     /**
      * @var int
      */
-    public static $revision = 296;
+    public static $revision = 297;
 
     /**
      * @var string
      */
-    public static $buildDate = '2018-07-26T11:03:57+02:00';
+    public static $buildDate = '2018-07-31T12:18:50+02:00';
 
     /**
      * @return string

--- a/pimcore/models/Tool/Tag/Config.php
+++ b/pimcore/models/Tool/Tag/Config.php
@@ -18,8 +18,8 @@
 namespace Pimcore\Model\Tool\Tag;
 
 use Pimcore\Cache;
-use Pimcore\Model;
 use Pimcore\Logger;
+use Pimcore\Model;
 
 /**
  * @method \Pimcore\Model\Tool\Tag\Config\Dao getDao()
@@ -351,8 +351,6 @@ class Config extends Model\AbstractModel
         $this->disabled = $disabled;
     }
 
-    /**
-     */
     public static function markExpiredTagsAsDisabled()
     {
         $currentTime = new \Carbon\Carbon();
@@ -369,7 +367,6 @@ class Config extends Model\AbstractModel
                 } catch (\Exception $e) {
                     Logger::debug('Unable to process tag' . $tag->name . ', reason: '.$e->getMessage());
                 }
-
             }
         }
     }


### PR DESCRIPTION
In `doGetDataForEditMode` there were some IF-statements missing that caused code-breaks when  localized-fields of object-parents or bricks were called due to inheritance.

## Changes in this pull request  

            `if ($foundEmptyValue) {
                    // Initializing was missing in 5.5.3 
                    $parentData = null;

                    // still some values are passing, ask the parent
                    if ($params['context'] && $params['context']['containerType'] == 'objectbrick') {
                        $brickContainerGetter = 'get' . ucfirst($params['fieldname']);
                        $brickContainer = $parent->$brickContainerGetter();
                        $brickGetter = 'get' . ucfirst($params['context']['containerKey']);
                        $brickData = $brickContainer->$brickGetter();
                        // IF-Statement was missing in 5.5.3 
                        if($brickData) {
                            $parentData = $brickData->getLocalizedFields();
                        }
                    } else {
                        if (method_exists($parent, 'getLocalizedFields')) {
                            $parentData = $parent->getLocalizedFields();
                        }
                    }
                    // IF-Statement was missing in 5.5.3 
                    if($parentData) {
                        $parentResult = $this->doGetDataForEditMode(
                            $parentData,
                            $parent,
                            $fieldData,
                            $metaData,
                            $level + 1,
                            $params
                        );
                    }
                }`


## Additional info  

