### PR TITLE
Replace % sign in asset keys

### DIFF
--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -904,7 +904,7 @@ class Service extends Model\AbstractModel
             $key = trim($key, '. ');
 
             // windows forbidden filenames + URL reserved characters (at least the once which are problematic)
-            $key = preg_replace('/[#\?\*\:\\\\<\>\|"]/', '-', $key);
+            $key = preg_replace('/[#\?\*\:\\\\<\>\|"%]/', '-', $key);
         } else {
             $key = trim($key);
             $key = ltrim($key, '.');


### PR DESCRIPTION
When uploading an asset or creating a folder with a % sign in its name, the asset is not accessible via its URL. After uploading an asset with name "100%cotton.png", for example, its neither accessible via "example.com/100%cotton.png" nor "example.com/100%25cotton.png" (with the encoded percent sign).
I suggest to replace the % sign in asset keys as in this PR. I suspect that this is somehow related to the rewrite rules for assets, so changing them might also be a solution. But I have no idea what side effect that may have.