### PR TITLE
adding the key 'context' to the $params array

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
@@ -276,9 +276,12 @@ abstract class AbstractRelations extends Model\DataObject\ClassDefinition\Data
         if ($params['isUntouchable']) {
             return;
         }
-
+        
+        if (!isset($params['context'])) {
+            $params['context'] = null;
+        }
         $context = $params['context'];
-
+        
         if (!DataObject\AbstractObject::isDirtyDetectionDisabled() && $object instanceof DataObject\DirtyIndicatorInterface) {
             if ($object instanceof DataObject\Localizedfield) {
                 if ($context['containerType'] != 'fieldcollection' && $object->getObject() instanceof DataObject\DirtyIndicatorInterface) {


### PR DESCRIPTION
setting it to null, so it does not throw a warning.

This is an example of the stack trace of this warning.

```
Notice: Undefined index: context - #0 <project>/vendor/pimcore/pimcore/models/DataObject/Concrete/Dao.php(227): Pimcore\Model\DataObject\ClassDefinition\Data\Relations\AbstractRelations->save(Object(Pimcore\Model\DataObject\Colour), Array)
#1 <project>/vendor/pimcore/pimcore/models/DataObject/Concrete.php(222): Pimcore\Model\DataObject\Concrete\Dao->update(false)
#2 <project>/src/Interceptor/Main.php(50): Pimcore\Model\DataObject\Concrete->update(false)
```

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

