### PR TITLE
fixed the isFieldDirty to avoid uninitialised keys

### DIFF
--- a/models/DataObject/Traits/DirtyIndicatorTrait.php
+++ b/models/DataObject/Traits/DirtyIndicatorTrait.php
@@ -39,7 +39,7 @@ trait DirtyIndicatorTrait
      */
     public function isFieldDirty($key)
     {
-        if (is_array($this->o_dirtyFields) && $this->o_dirtyFields[$key]) {
+        if (is_array($this->o_dirtyFields) && array_key_exists($key, $this->o_dirtyFields)) {
             return true;
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #
it will avoid getting the warning bellow:
```
Notice: Undefined index: o_parentId
#0 <project>/vendor/pimcore/pimcore/models/DataObject/Concrete/Dao.php(226): Pimcore\Model\DataObject\Colour->isFieldDirty('o_parentId')
#1 <project>/vendor/pimcore/pimcore/models/DataObject/Concrete.php(222): Pimcore\Model\DataObject\Concrete\Dao->update(true, Array)
#3 <project>/vendor/pimcore/pimcore/models/DataObject/AbstractObject.php(644): Interceptor\Main->update(true, Array)
#4 <project>/vendor/pimcore/pimcore/models/DataObject/Concrete.php(705): Pimcore\Model\DataObject\AbstractObject->save()
```
## Additional info  

