### PR TITLE
add hardlink wrappers for web2print documents

### DIFF
--- a/models/Document/Hardlink/Wrapper/Printcontainer.php
+++ b/models/Document/Hardlink/Wrapper/Printcontainer.php
@@ -23,7 +23,7 @@ use Pimcore\Model\Element;
 /**
  * @method \Pimcore\Model\Document\Hardlink\Dao getDao()
  */
-class Printcontainer extends Model\Document\Page implements Model\Document\Hardlink\Wrapper\WrapperInterface
+class Printcontainer extends Model\Document\Printcontainer implements Model\Document\Hardlink\Wrapper\WrapperInterface
 {
     use Model\Document\Hardlink\Wrapper, Element\ChildsCompatibilityTrait;
 }

--- a/models/Document/Hardlink/Wrapper/Printcontainer.php
+++ b/models/Document/Hardlink/Wrapper/Printcontainer.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @category   Pimcore
+ * @package    Document
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Model\Document\Hardlink\Wrapper;
+
+use Pimcore\Model;
+use Pimcore\Model\Element;
+
+/**
+ * @method \Pimcore\Model\Document\Hardlink\Dao getDao()
+ */
+class Printcontainer extends Model\Document\Page implements Model\Document\Hardlink\Wrapper\WrapperInterface
+{
+    use Model\Document\Hardlink\Wrapper, Element\ChildsCompatibilityTrait;
+}

--- a/models/Document/Hardlink/Wrapper/Printpage.php
+++ b/models/Document/Hardlink/Wrapper/Printpage.php
@@ -23,7 +23,7 @@ use Pimcore\Model\Element;
 /**
  * @method \Pimcore\Model\Document\Hardlink\Dao getDao()
  */
-class Printpage extends Model\Document\Page implements Model\Document\Hardlink\Wrapper\WrapperInterface
+class Printpage extends Model\Document\Printpage implements Model\Document\Hardlink\Wrapper\WrapperInterface
 {
     use Model\Document\Hardlink\Wrapper, Element\ChildsCompatibilityTrait;
 }

--- a/models/Document/Hardlink/Wrapper/Printpage.php
+++ b/models/Document/Hardlink/Wrapper/Printpage.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @category   Pimcore
+ * @package    Document
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Model\Document\Hardlink\Wrapper;
+
+use Pimcore\Model;
+use Pimcore\Model\Element;
+
+/**
+ * @method \Pimcore\Model\Document\Hardlink\Dao getDao()
+ */
+class Printpage extends Model\Document\Page implements Model\Document\Hardlink\Wrapper\WrapperInterface
+{
+    use Model\Document\Hardlink\Wrapper, Element\ChildsCompatibilityTrait;
+}


### PR DESCRIPTION
Currently hardlink wrappers for web2print documents are missing. Therefore hardlinks in combination with web2print documents do not work correctly. In the old pimcore 4 web2print plugin these wrappers where delivered within the plugin...