### PR TITLE
Support style field for objects tag in pricing coditions

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/objects.js
+++ b/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/objects.js
@@ -226,6 +226,7 @@ pimcore.bundle.EcommerceFramework.pricing.config.objects = Class.create(pimcore.
             cls: cls,
             width: this.fieldConfig.width,
             height: this.fieldConfig.height,
+            style: this.fieldConfig.style,
             tbar: {
                 items: [
                     {


### PR DESCRIPTION
This pull request adds support for setting the `style` property for the objects tag in pricing coditions.

```JS    
new pimcore.bundle.EcommerceFramework.pricing.config.objects(data, {
                    name: "...",
                    title: "...",
                    visibleFields: "path",
                    height: 200,
                    width: 500,
                    style: 'float: left; margin-right: 10px'  // was not supported yet
                    ...
}
```