### PR TITLE
fix multihref-metadata boolean

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multihrefMetadata.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multihrefMetadata.js
@@ -160,12 +160,12 @@ pimcore.object.tags.multihrefMetadata = Class.create(pimcore.object.tags.abstrac
                 };
 
                 if(readOnly) {
-                    columns.push(Ext.create('Ext.grid.column.Check'), {
+                    columns.push(Ext.create('Ext.grid.column.Check', {
                         text: ts(this.fieldConfig.columns[i].label),
                         dataIndex: this.fieldConfig.columns[i].key,
                         width: width,
                         renderer: renderer
-                    });
+                    }));
                     continue;
                 }
 


### PR DESCRIPTION
Current solution produces this:

![bildschirmfoto 2018-11-20 um 13 30 22](https://user-images.githubusercontent.com/5981845/48773748-97d91200-ecc8-11e8-9348-d0bfd6850786.png)

Cause the ending parenthesis is in the wrong place.

with this PR it looks like this:

![bildschirmfoto 2018-11-20 um 13 31 13](https://user-images.githubusercontent.com/5981845/48773770-aaebe200-ecc8-11e8-8a58-31c145dcbd33.png)


