### PR TITLE
Set group when importing from JSON definition.

### DIFF
--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -106,6 +106,7 @@ class Service
         $class->setModificationDate(time());
         $class->setUserModification($userId);
         $class->setIcon($importData['icon']);
+        $class->setGroup($importData['group']);
         $class->setAllowInherit($importData['allowInherit']);
         $class->setAllowVariants($importData['allowVariants']);
         $class->setShowVariants($importData['showVariants']);


### PR DESCRIPTION
Issue: When importing class definition from exported JSON file the group is ignored.

Fix: Set the group when importing from JSON definition. 