### PR TITLE
Improve 'Send Test Email'

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/EmailController.php
+++ b/bundles/AdminBundle/Controller/Admin/EmailController.php
@@ -356,7 +356,7 @@ class EmailController extends AdminController
 
         if ($request->get('emailType') == 'text') {
             $mail->setBodyText($request->get('content'));
-        } elseif($request->get('emailType') == 'text') {
+        } elseif($request->get('emailType') == 'html') {
             $mail->setBodyHtml($request->get('content'));
         } elseif($request->get('emailType') == 'document') {
             $doc = \Pimcore\Model\Document::getByPath($request->get('documentPath'));

--- a/bundles/AdminBundle/Controller/Admin/EmailController.php
+++ b/bundles/AdminBundle/Controller/Admin/EmailController.php
@@ -346,14 +346,37 @@ class EmailController extends AdminController
         }
 
         $mail = new Mail();
+
+        if($from = $request->get('from')) {
+            $mail->setFrom($from);
+        }
         $mail->addTo($request->get('to'));
         $mail->setSubject($request->get('subject'));
         $mail->setIgnoreDebugMode(true);
 
-        if ($request->get('type') == 'text') {
+        if ($request->get('emailType') == 'text') {
             $mail->setBodyText($request->get('content'));
-        } else {
+        } elseif($request->get('emailType') == 'text') {
             $mail->setBodyHtml($request->get('content'));
+        } elseif($request->get('emailType') == 'document') {
+            $doc = \Pimcore\Model\Document::getByPath($request->get('documentPath'));
+
+            if($doc instanceof \Pimcore\Model\Document\Email || $doc instanceof \Pimcore\Model\Document\Newsletter) {
+                $mail->setDocument($doc);
+
+                if($request->get('mailParamaters')) {
+                    if($mailParamsArray = json_decode($request->get('mailParamaters'), true)) {
+                        foreach($mailParamsArray as $mailParam) {
+                            if($mailParam['key']) {
+                                $mail->setParam($mailParam['key'], $mailParam['value']);
+                            }
+                        }
+                    }
+                }
+
+            } else {
+                throw new \Exception("Email document not found!");
+            }
         }
 
         $mail->send();

--- a/bundles/AdminBundle/Controller/Admin/IndexController.php
+++ b/bundles/AdminBundle/Controller/Admin/IndexController.php
@@ -418,6 +418,7 @@ class IndexController extends AdminController
         }
 
         $settings->mail = !$mailIncomplete;
+        $settings->mailDefaultAddress = $config->email->sender->email ?: null;
 
         return $this;
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/email.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/email.js
@@ -166,6 +166,23 @@ pimcore.document.email = Class.create(pimcore.document.page_snippet, {
         }
 
         return parameters;
+    },
+
+    getLayoutToolbar : function ($super) {
+        $super();
+
+        this.toolbar.add(
+            new Ext.Button({
+                text: t('send_test_email'),
+                iconCls: "pimcore_icon_email",
+                scale: "medium",
+                handler: function() {
+                    pimcore.helpers.sendTestEmail(this.settings.document.data['from']? this.settings.document.data['from'] : pimcore.settings.mailDefaultAddress, this.settings.document.data['to'], this.settings.document.data['subject'], 'document', this.settings.document.data['path'] + this.settings.document.data['key'], null);
+                }.bind(this)
+            })
+        );
+
+        return this.toolbar;
     }
 
 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/newsletter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/newsletter.js
@@ -172,6 +172,23 @@ pimcore.document.newsletter = Class.create(pimcore.document.page_snippet, {
         }
 
         return parameters;
+    },
+
+    getLayoutToolbar : function ($super) {
+        $super();
+
+        this.toolbar.add(
+            new Ext.Button({
+                text: t('send_test_email'),
+                iconCls: "pimcore_icon_email",
+                scale: "medium",
+                handler: function() {
+                    pimcore.helpers.sendTestEmail(this.settings.document.data['from']? this.settings.document.data['from'] : pimcore.settings.mailDefaultAddress, this.settings.document.data['to'], this.settings.document.data['subject'], 'document', this.settings.document.data['path'] + this.settings.document.data['key'], null);
+                }.bind(this)
+            })
+        );
+
+        return this.toolbar;
     }
 
 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1646,7 +1646,7 @@ pimcore.helpers.sendTestEmail = function (from = null, to = null, subject = null
     var searchDocumentButton = new Ext.Button({
         name: 'searchDocument',
         fieldLabel: t('document'),
-        iconCls: 'pimcore_icon_open',
+        iconCls: 'pimcore_icon_search',
         handler: function() {
             pimcore.helpers.itemselector(false, function(e) {
                 documentTextField.setValue(e.fullpath);
@@ -1720,8 +1720,8 @@ pimcore.helpers.sendTestEmail = function (from = null, to = null, subject = null
 
     var paramsStore = new Ext.data.ArrayStore({
         fields: [
-            {name: 'key', type: 'string'},
-            {name: 'value', type: 'string'}
+            {name: 'key', type: 'string', persist: false},
+            {name: 'value', type: 'string', persist: false}
         ]
     });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1628,60 +1628,198 @@ pimcore.helpers.searchAndMove = function (parentId, callback, type) {
 };
 
 
-pimcore.helpers.sendTestEmail = function () {
+pimcore.helpers.sendTestEmail = function (from = null, to = null, subject = null, emailType = null, documentPath = null, content = null) {
+
+
+    var emailContentTextField = new Ext.form.TextArea({
+        name: "content",
+        fieldLabel: t("content"),
+        width: 780,
+        height: 300,
+    });
+    emailContentTextField.hide();
+
+    var documentTextField = new Ext.form.TextField({
+        name: 'documentPath',
+        width: 300,
+        editable: false
+    });
+    var searchDocumentButton = new Ext.Button({
+        name: 'searchDocument',
+        fieldLabel: t('document'),
+        iconCls: 'pimcore_icon_open',
+        handler: function() {
+            pimcore.helpers.itemselector(false, function(e) {
+                documentTextField.setValue(e.fullpath);
+            }, {
+                type: ["document"],
+                subtype: {
+                    document: ["email"]
+                }
+            });
+        }
+    });
+
+    var documentComponent = Ext.create('Ext.form.FieldContainer', {
+        fieldLabel: t('document'),
+        layout: 'hbox',
+        items: [
+            documentTextField,
+            searchDocumentButton
+        ],
+        componentCls: "object_field",
+        border: false,
+        style: {
+            padding: 0
+        }
+    });
+    documentComponent.hide();
+
+
+    var emailTypeDropdown = new Ext.form.ComboBox({
+        name: 'emailType',
+        store: [
+            ['document', t('document')],
+            ['html', t('html')],
+            ['text', t('text')]
+        ],
+        fieldLabel: t('type'),
+        listeners: {
+            select: function(t) {
+                if(t.value == 'text' || t.value == 'html') {
+                    emailContentTextField.show();
+                } else {
+                    emailContentTextField.hide();
+                }
+
+                if(t.value == 'document') {
+                    documentComponent.show();
+                    paramGrid.show();
+                } else {
+                    documentComponent.hide();
+                    paramGrid.hide();
+                }
+            }
+        }
+    });
+
+    var fromTextField = new Ext.form.TextField({
+        name: "from",
+        fieldLabel: t("from"),
+        width: 780
+    });
+
+    var toTextField = new Ext.form.TextField({
+        name: "to",
+        fieldLabel: t("to"),
+        width: 780
+    });
+
+    var subjectTextField = new Ext.form.TextField({
+        name: "subject",
+        fieldLabel: t("subject"),
+        width: 780
+    });
+
+    var paramsStore = new Ext.data.ArrayStore({
+        fields: [
+            {name: 'key', type: 'string'},
+            {name: 'value', type: 'string'}
+        ]
+    });
+
+    var paramGrid = Ext.create('Ext.grid.Panel', {
+        store: paramsStore,
+        columns: [
+            {
+                text: 'key',
+                dataIndex: 'key',
+                editor: new Ext.form.TextField({
+                    allowBlank: true
+                }),
+                width: 200
+            },
+            {
+                text: 'value',
+                dataIndex: 'value',
+                editor: new Ext.form.TextField({
+                    allowBlank: true
+                }),
+                flex: 1
+            }
+        ],
+        stripeRows: true,
+        columnLines: true,
+        bodyCls: "pimcore_editable_grid",
+        autoHeight: true,
+        selModel: Ext.create('Ext.selection.CellModel'),
+        hideHeaders: false,
+        plugins: [
+            Ext.create('Ext.grid.plugin.CellEditing', {})
+        ],
+        tbar: [
+            {
+                iconCls: "pimcore_icon_table_row pimcore_icon_overlay_add",
+                handler: function() {
+                    paramsStore.add({'key' : '', 'value': ''});
+                }
+            },
+            {
+                xtype: 'label',
+                html: t('parameters')
+            }
+        ]
+    });
+    paramGrid.hide();
 
     var win = new Ext.Window({
         width: 800,
         height: 600,
         modal: true,
         title: t("send_test_email"),
-        iconCls: "pimcore_icon_email",
         layout: "fit",
         closeAction: "close",
         items: [{
             xtype: "form",
             bodyStyle: "padding:10px;",
             itemId: "form",
-            items: [{
-                xtype: "textfield",
-                name: "to",
-                fieldLabel: t("to"),
-                width: 780
-            }, {
-                xtype: "textfield",
-                name: "subject",
-                fieldLabel: t("subject"),
-                width: 780
-            }, {
-                xtype: "textarea",
-                name: "content",
-                fieldLabel: t("content"),
-                width: 780,
-                height: 400
-            }]
+            items: [
+                fromTextField,
+                toTextField,
+                subjectTextField,
+                emailTypeDropdown,
+                emailContentTextField,
+                documentComponent,
+                paramGrid
+            ]
         }],
         buttons: [{
-            text: t("send_as_plain_text"),
-            iconCls: "pimcore_icon_text",
+            text: t("send"),
+            iconCls: "pimcore_icon_email",
             handler: function () {
-                send("text");
-            }
-        }, {
-            text: t("send_as_html_mime"),
-            iconCls: "pimcore_icon_html",
-            handler: function () {
-                send("html");
+                send();
             }
         }]
     });
 
-    var send = function (type) {
+    var send = function () {
+
 
         var params = win.getComponent("form").getForm().getFieldValues();
-        params["type"] = type;
+        if(emailTypeDropdown.getValue() === 'document') {
+            var allRecords = paramsStore
+                .queryBy(function() { return true; }) // returns a collection
+                .getRange();
+            var emailParamsArray = [];
+            for (var i = 0; i < allRecords.length; i++) {
+                emailParamsArray.push({"key": allRecords[i].data['key'], "value": allRecords[i].data['value']});
+
+            }
+            params['mailParamaters'] =  JSON.stringify(emailParamsArray);
+        }
+
 
         win.disable();
-
         Ext.Ajax.request({
             url: "/admin/email/send-test-email",
             params: params,
@@ -1704,9 +1842,40 @@ pimcore.helpers.sendTestEmail = function () {
                 win.close();
             }
         });
+
     };
 
+
+
+    if(emailType) {
+        emailTypeDropdown.setValue(emailType);
+        if(emailType == 'document') {
+            documentComponent.show();
+            paramGrid.show();
+        }
+        if(emailType == 'html' || emailType == 'text') {
+            emailContentTextField.show();
+        }
+    }
+    if(documentPath) {
+        documentTextField.setValue(documentPath);
+    }
+    if(content) {
+        emailContentTextField.setValue(content);
+    }
+    if(from) {
+        fromTextField.setValue(from);
+    }
+    if(to) {
+        toTextField.setValue(to);
+    }
+    if(subject) {
+        subjectTextField.setValue(subject);
+    }
+
+
     win.show();
+
 
 };
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1634,14 +1634,13 @@ pimcore.helpers.sendTestEmail = function (from = null, to = null, subject = null
     var emailContentTextField = new Ext.form.TextArea({
         name: "content",
         fieldLabel: t("content"),
-        width: 780,
         height: 300,
     });
     emailContentTextField.hide();
 
     var documentTextField = new Ext.form.TextField({
         name: 'documentPath',
-        width: 300,
+        flex: 1,
         editable: false
     });
     var searchDocumentButton = new Ext.Button({
@@ -1678,6 +1677,7 @@ pimcore.helpers.sendTestEmail = function (from = null, to = null, subject = null
 
     var emailTypeDropdown = new Ext.form.ComboBox({
         name: 'emailType',
+        width: 300,
         store: [
             ['document', t('document')],
             ['html', t('html')],
@@ -1706,19 +1706,16 @@ pimcore.helpers.sendTestEmail = function (from = null, to = null, subject = null
     var fromTextField = new Ext.form.TextField({
         name: "from",
         fieldLabel: t("from"),
-        width: 780
     });
 
     var toTextField = new Ext.form.TextField({
         name: "to",
         fieldLabel: t("to"),
-        width: 780
     });
 
     var subjectTextField = new Ext.form.TextField({
         name: "subject",
         fieldLabel: t("subject"),
-        width: 780
     });
 
     var paramsStore = new Ext.data.ArrayStore({
@@ -1773,6 +1770,7 @@ pimcore.helpers.sendTestEmail = function (from = null, to = null, subject = null
     paramGrid.hide();
 
     var win = new Ext.Window({
+
         width: 800,
         height: 600,
         modal: true,
@@ -1791,7 +1789,10 @@ pimcore.helpers.sendTestEmail = function (from = null, to = null, subject = null
                 emailContentTextField,
                 documentComponent,
                 paramGrid
-            ]
+            ],
+            defaults: {
+                width: 780
+            }
         }],
         buttons: [{
             text: t("send"),

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1731,17 +1731,13 @@ pimcore.helpers.sendTestEmail = function (from = null, to = null, subject = null
             {
                 text: 'key',
                 dataIndex: 'key',
-                editor: new Ext.form.TextField({
-                    allowBlank: true
-                }),
+                editor: new Ext.form.TextField(),
                 width: 200
             },
             {
                 text: 'value',
                 dataIndex: 'value',
-                editor: new Ext.form.TextField({
-                    allowBlank: true
-                }),
+                editor: new Ext.form.TextField(),
                 flex: 1
             }
         ],

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1729,13 +1729,13 @@ pimcore.helpers.sendTestEmail = function (from = null, to = null, subject = null
         store: paramsStore,
         columns: [
             {
-                text: 'key',
+                text: t('key'),
                 dataIndex: 'key',
                 editor: new Ext.form.TextField(),
                 width: 200
             },
             {
-                text: 'value',
+                text: t('value'),
                 dataIndex: 'value',
                 editor: new Ext.form.TextField(),
                 flex: 1

--- a/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
@@ -1310,7 +1310,7 @@ pimcore.layout.toolbar = Class.create({
     },
 
     sendTestEmail: function () {
-        pimcore.helpers.sendTestEmail();
+        pimcore.helpers.sendTestEmail(pimcore.settings.mailDefaultAddress);
     },
 
     showReports: function (reportClass, reportConfig) {


### PR DESCRIPTION
add option to choose a document
add option to add parameters

add from field (prefilled with system settings)

add send test mail button to email and newsletter documents (will prefill the email window with data)