### PR TITLE
Changes private attributes to protected ones in TagHandler

### DIFF
--- a/lib/Document/Tag/TagHandler.php
+++ b/lib/Document/Tag/TagHandler.php
@@ -76,7 +76,7 @@ class TagHandler implements TagHandlerInterface, LoggerAwareInterface
     /**
      * @var ResponseStack
      */
-    private $responseStack;
+    protected $responseStack;
 
     /**
      * @var array
@@ -284,7 +284,7 @@ class TagHandler implements TagHandlerInterface, LoggerAwareInterface
         $this->handleBrickActionResult($brick->postRenderAction($info));
     }
 
-    private function handleBrickActionResult($result)
+    protected function handleBrickActionResult($result)
     {
         // TODO Pimcore 6 rely on responseStack being set as constructor dependency
         if (null === $this->responseStack) {


### PR DESCRIPTION
When decorating the TagHandler class the method handleBrickActionResult and the attribute $responseStack needs to be reimplemented in the decorating class because these are private in the original TagHandler. 

Changing them to protected would prevent reimplementation.
