### PR TITLE
add null smtp transport for dev environments where no sendmail nor smtp is available

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/system.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/system.js
@@ -499,7 +499,8 @@ pimcore.settings.system = Class.create({
                                     value: this.getValue("email.method"),
                                     store: [
                                         ["mail", "mail"],
-                                        ["smtp", "smtp"]
+                                        ["smtp", "smtp"],
+                                        ["null", "null"]
                                     ],
                                     listeners: {
                                         select: this.emailMethodSelected.bind(this, "email")


### PR DESCRIPTION
Since the update to SwiftMailer 6, the MailTransport is gone, thus resulting in a lot of issues for developers. Cause sendmail is not an option on most systems (cause its either deactivated or doesn't support TLS). So an SMTP Server has to be used. (Thus means creating a SMTP account for every project, but so it is).

This makes it easier for developers to just don't use any transport at all in dev/staging systems (or possibly also production which doesn't make any sense TBH). The developer can see the email in the backend log then.