### PR TITLE
introduce new delete-info event

### DIFF
--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -474,6 +474,8 @@
   "delete_message_dependencies": "There are dependencies, delete anyway?",
   "delete_message": "Do you really want to delete this item?",
   "delete_message_batch": "Do you really want to delete these elements?",
+  "delete_error_batch": "Following items cannot be deleted, do you wanna proceed with deleting the remaining?",
+  "delete_error": "The item cannot be deleted. Reason:",
   "no_further_objectbricks_allowed": "No further objectbricks allowed",
   "grid_current_language": "Current language",
   "selected_grid_columns": "Selected grid columns",

--- a/lib/Event/AssetEvents.php
+++ b/lib/Event/AssetEvents.php
@@ -68,6 +68,13 @@ final class AssetEvents
     const POST_UPDATE_FAILURE = 'pimcore.asset.postUpdateFailure';
 
     /**
+     * @Event("Pimcore\Event\Model\AssetDeleteInfoEvent")
+     *
+     * @var string
+     */
+    const DELETE_INFO = 'pimcore.asset.deleteInfo';
+
+    /**
      * @Event("Pimcore\Event\Model\AssetEvent")
      *
      * @var string

--- a/lib/Event/DataObjectEvents.php
+++ b/lib/Event/DataObjectEvents.php
@@ -67,6 +67,13 @@ final class DataObjectEvents
      */
     const POST_UPDATE_FAILURE = 'pimcore.dataobject.postUpdateFailure';
 
+     /**
+     * @Event("Pimcore\Event\Model\DataObjectDeleteInfoEvent")
+     *
+     * @var string
+     */
+    const DELETE_INFO = 'pimcore.dataobject.deleteInfo';
+
     /**
      * @Event("Pimcore\Event\Model\DataObjectEvent")
      *

--- a/lib/Event/DocumentEvents.php
+++ b/lib/Event/DocumentEvents.php
@@ -68,6 +68,13 @@ final class DocumentEvents
     const POST_UPDATE_FAILURE = 'pimcore.document.postUpdateFailure';
 
     /**
+     * @Event("Pimcore\Event\Model\DocumentDeleteInfoEvent")
+     *
+     * @var string
+     */
+    const DELETE_INFO = 'pimcore.document.deleteInfo';
+
+    /**
      * @Event("Pimcore\Event\Model\DocumentEvent")
      *
      * @var string

--- a/lib/Event/Model/AssetDeleteInfoEvent.php
+++ b/lib/Event/Model/AssetDeleteInfoEvent.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Event\Model;
+
+use Pimcore\Event\Traits\ElementDeleteInfoEventTrait;
+
+/**
+ * Class AssetDeleteInfoEvent
+ *
+ * @package Pimcore\Event\Model
+ */
+class AssetDeleteInfoEvent extends AssetEvent implements ElementDeleteInfoEventInterface
+{
+    use ElementDeleteInfoEventTrait;
+}

--- a/lib/Event/Model/DataObjectDeleteInfoEvent.php
+++ b/lib/Event/Model/DataObjectDeleteInfoEvent.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Event\Model;
+
+use Pimcore\Event\Traits\ElementDeleteInfoEventTrait;
+
+/**
+ * Class DataObjectDeleteInfoEvent
+ *
+ * @package Pimcore\Event\Model
+ */
+class DataObjectDeleteInfoEvent extends DataObjectEvent implements ElementDeleteInfoEventInterface
+{
+    use ElementDeleteInfoEventTrait;
+}

--- a/lib/Event/Model/DocumentDeleteInfoEvent.php
+++ b/lib/Event/Model/DocumentDeleteInfoEvent.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Event\Model;
+
+use Pimcore\Event\Traits\ElementDeleteInfoEventTrait;
+
+/**
+ * Class DocumentDeleteInfoEvent
+ *
+ * @package Pimcore\Event\Model
+ */
+class DocumentDeleteInfoEvent extends DocumentEvent implements ElementDeleteInfoEventInterface
+{
+    use ElementDeleteInfoEventTrait;
+}

--- a/lib/Event/Model/ElementDeleteInfoEventInterface.php
+++ b/lib/Event/Model/ElementDeleteInfoEventInterface.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Event\Model;
+
+interface ElementDeleteInfoEventInterface extends ElementEventInterface
+{
+     /**
+     * @return bool
+     */
+    public function getDeletionAllowed(): bool;
+
+    /**
+     * @param bool $deletionAllowed
+     */
+    public function setDeletionAllowed(bool $deletionAllowed): void;
+
+    /**
+     * @return string
+     */
+    public function getReason(): string;
+
+    /**
+     * @param string $reason
+     */
+    public function setReason(string $reason): void;
+}

--- a/lib/Event/Traits/ElementDeleteInfoEventTrait.php
+++ b/lib/Event/Traits/ElementDeleteInfoEventTrait.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Event\Traits;
+
+/**
+ * Trait ElementDeleteInfoEventTrait
+ *
+ * @package Pimcore\Event\Traits
+ */
+trait ElementDeleteInfoEventTrait
+{
+    /**
+     * @var bool
+     */
+    protected $deletionAllowed = true;
+
+    /**
+     * @var string
+     */
+    protected $reason;
+
+    /**
+     * @return mixed
+     */
+    public function getDeletionAllowed(): bool
+    {
+        return $this->deletionAllowed;
+    }
+
+    /**
+     * @param bool $deletionAllowed
+     */
+    public function setDeletionAllowed(bool $deletionAllowed): void
+    {
+        $this->deletionAllowed = $deletionAllowed;
+    }
+
+    /**
+     * @return string
+     */
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+
+    /**
+     * @param string $reason
+     */
+    public function setReason(string $reason): void
+    {
+        $this->reason = $reason;
+    }
+}


### PR DESCRIPTION
which allows to determine what elements can be deleted from backend and which don't.

*Cause*
There is a Problem with pre-delete events. They would work in cases where the element doesn't have any childs. When the element has childs, Pimcore deletes those first and then the "selected" element. 

This event looks like that:

*Objects*
http://g.recordit.co/gADtiNMZY7.gif
http://g.recordit.co/6IgWGJ1out.gif

*Documents*
http://g.recordit.co/sYbBgnYYO9.gif

*Assets*
http://g.recordit.co/RgoK2PNjbh.gif

