### PR TITLE
Fixed typo for return type and wrong usage of method_exist function.

### DIFF
--- a/models/DataObject/ClassDefinition/Data/EncryptedField.php
+++ b/models/DataObject/ClassDefinition/Data/EncryptedField.php
@@ -306,7 +306,7 @@ class EncryptedField extends Model\DataObject\ClassDefinition\Data
     {
         $fd = $this->getDelegateDatatypeDefinition();
         if ($fd) {
-            $data = $data instanceof Model\DataObject\Data\EncryptedField ? $data->getPlain() : data;
+            $data = $data instanceof Model\DataObject\Data\EncryptedField ? $data->getPlain() : $data;
             $result = $fd->checkValidity($data, $omitMandatoryCheck);
 
             return $result;
@@ -647,7 +647,7 @@ class EncryptedField extends Model\DataObject\ClassDefinition\Data
     {
         $delegate = $this->getDelegate();
 
-        if (method_exists($delegate, enrichLayoutDefinition)) {
+        if (method_exists($delegate, 'enrichLayoutDefinition')) {
             $delegate->enrichLayoutDefinition($object, $context);
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #
This bugfix addresses the fix for the save/publish event of encrypted fields. Because of the typos it was unable to save and results in an ContextException.

## Additional info  
Fixed two small bugfixes.
