### PR TITLE
fix: don't set brick if brick is empty

### DIFF
--- a/lib/DataObject/Import/ColumnConfig/Operator/ObjectBrickSetter.php
+++ b/lib/DataObject/Import/ColumnConfig/Operator/ObjectBrickSetter.php
@@ -76,7 +76,7 @@ class ObjectBrickSetter extends AbstractOperator
 
         $childs = $this->getChilds();
 
-        if (!$childs) {
+        if (!$childs || !$brick) {
             return;
         } else {
             /** @var $child AbstractConfigElement */


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #3667 

## Additional info  
Check if brick is not empty before call "process" function on childs. Because brick is not necessary defined, calling "process" with a target on NULL displaying error on CSV import.
