### PR TITLE
Fix correct spelling of "Referer"

### DIFF
--- a/lib/Targeting/Condition/ReferringSite.php
+++ b/lib/Targeting/Condition/ReferringSite.php
@@ -56,7 +56,7 @@ class ReferringSite extends AbstractVariableCondition implements ConditionInterf
     public function match(VisitorInfo $visitorInfo): bool
     {
         $request = $visitorInfo->getRequest();
-        $referrer = $request->headers->get('Referrer', 'direct');
+        $referrer = $request->headers->get('Referer', 'direct');
 
         $result = preg_match($this->pattern, $referrer);
         if ($result) {


### PR DESCRIPTION
According to [RFC 2616][1], the header name is "Referer" instead of "Referrer".

[1]: https://tools.ietf.org/html/rfc2616#page-140

<!--
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #3678