### PR TITLE
Use readonly attribute for readonly input fields - not disabled

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/ext-modifications.css
+++ b/bundles/AdminBundle/Resources/public/css/ext-modifications.css
@@ -253,7 +253,7 @@ body > .x-mask {
     background-image: url(../js/lib/ext/classic/theme-triton/resources/images/tree/drop-between.gif);
 }
 
-.x-form-item-default.x-item-disabled {
+.x-form-item-default.x-item-disabled, .x-form-item-default.x-form-readonly {
     opacity: 0.7;
 }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
@@ -61,7 +61,7 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
     getLayoutShow: function () {
 
         this.getLayoutEdit();
-        this.component.disable();
+        this.component.setReadOnly(true);
 
         return this.component;
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/date.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/date.js
@@ -87,7 +87,7 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
     getLayoutShow:function () {
 
         this.component = this.getLayoutEdit();
-        this.component.disable();
+        this.component.setReadOnly(true);
 
         return this.component;
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/datetime.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/datetime.js
@@ -99,7 +99,7 @@ pimcore.object.tags.datetime = Class.create(pimcore.object.tags.abstract, {
     getLayoutShow:function () {
 
         this.component = this.getLayoutEdit();
-        this.component.disable();
+        this.component.setReadOnly(true);
 
         return this.component;
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/externalImage.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/externalImage.js
@@ -144,7 +144,7 @@ pimcore.object.tags.externalImage = Class.create(pimcore.object.tags.abstract, {
     getLayoutShow: function () {
 
         this.component = this.getLayoutEdit();
-        this.inputField.disable();
+        this.inputField.setReadOnly(true);
         this.deleteButton.disable();
 
         return this.component;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/input.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/input.js
@@ -89,7 +89,7 @@ pimcore.object.tags.input = Class.create(pimcore.object.tags.abstract, {
     getLayoutShow: function () {
 
         this.component = this.getLayoutEdit();
-        this.component.disable();
+        this.component.setReadOnly(true);
 
         return this.component;
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/inputQuantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/inputQuantityValue.js
@@ -144,8 +144,8 @@ pimcore.object.tags.inputQuantityValue = Class.create(pimcore.object.tags.abstra
     getLayoutShow: function () {
 
         this.getLayoutEdit();
-        this.unitField.disable();
-        this.inputField.disable();
+        this.unitField.setReadOnly(true);
+        this.inputField.setReadOnly(true);
 
         return this.component;
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/numeric.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/numeric.js
@@ -148,7 +148,7 @@ pimcore.object.tags.numeric = Class.create(pimcore.object.tags.abstract, {
         input.width += input.labelWidth;
 
         this.component = new Ext.form.TextField(input);
-        this.component.disable();
+        this.component.setReadOnly(true);
 
         return this.component;
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
@@ -156,10 +156,9 @@ pimcore.object.tags.quantityValue = Class.create(pimcore.object.tags.abstract, {
 
 
     getLayoutShow: function () {
-
         this.getLayoutEdit();
-        this.unitField.disable();
-        this.inputField.disable();
+        this.unitField.setReadOnly(true);
+        this.inputField.setReadOnly(true);
 
         return this.component;
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/select.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/select.js
@@ -304,7 +304,7 @@ pimcore.object.tags.select = Class.create(pimcore.object.tags.abstract, {
     getLayoutShow: function () {
 
         this.component = this.getLayoutEdit();
-        this.component.disable();
+        this.component.setReadOnly(true);
 
         return this.component;
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/textarea.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/textarea.js
@@ -82,7 +82,7 @@ pimcore.object.tags.textarea = Class.create(pimcore.object.tags.abstract, {
     getLayoutShow: function () {
 
         this.component = this.getLayoutEdit();
-        this.component.disable();
+        this.component.setReadOnly(true);
 
         return this.component;
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/time.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/time.js
@@ -45,7 +45,7 @@ pimcore.object.tags.time = Class.create(pimcore.object.tags.abstract, {
     getLayoutShow: function () {
 
         this.component = this.getLayoutEdit();
-        this.component.disable();
+        this.component.setReadOnly(true);
 
         return this.component;
     },


### PR DESCRIPTION
When you set an input field to be not editable, Pimcore uses ExtJS's disable() method in the input field. This leads to being not able to highlight or copy contents of such readonly fields in Firefox. Anyway readonly is the more approprate attribute for setting something to be not editable.
With this PR readonly attribute is used.