### PR TITLE
Correct field name: o_modificationDate instead of o_modification

### DIFF
--- a/bundles/EcommerceFrameworkBundle/CheckoutManager/CommitOrderProcessor.php
+++ b/bundles/EcommerceFrameworkBundle/CheckoutManager/CommitOrderProcessor.php
@@ -278,7 +278,7 @@ class CommitOrderProcessor implements ICommitOrderProcessor
         //Abort orders with payment pending
         $list = $orderManager->buildOrderList();
         $list->addFieldCollection('PaymentInfo');
-        $list->setCondition('orderState = ? AND o_modification < ?', [AbstractOrder::ORDER_STATE_PAYMENT_PENDING, $timestamp]);
+        $list->setCondition('orderState = ? AND o_modificationDate < ?', [AbstractOrder::ORDER_STATE_PAYMENT_PENDING, $timestamp]);
 
         /** @var AbstractOrder $order */
         foreach ($list as $order) {


### PR DESCRIPTION
The actual name of the SQL field is "o_modificationDate", not "o_modification".
The bugfix is important so that aborted orders are cleaned up properly.