### PR TITLE
Sort backend search results by relevance

### DIFF
--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -217,9 +217,16 @@ class SearchController extends AdminController
         $searcherList->setOffset($offset);
         $searcherList->setLimit($limit);
 
-        // do not sort per default, it is VERY SLOW
-        //$searcherList->setOrder("desc");
-        //$searcherList->setOrderKey("modificationdate");
+        $orderQuery = $query;
+        if ($orderQuery === '*') {
+            $orderQuery = '';
+        }
+        $orderQuery = \str_replace(['+','-'.'(',')','"',"'"], '', $orderQuery);
+
+        $orderKey = 'MATCH (`data`,`properties`) AGAINST ('.$db->quote($orderQuery).')';
+        $searcherList->validOrderKeys[] = $orderKey;
+        $searcherList->setOrderKey($orderKey, false);
+        $searcherList->setOrder('DESC');
 
         $sortingSettings = \Pimcore\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($allParams);
         if ($sortingSettings['orderKey']) {


### PR DESCRIPTION
Currently backend search results are not sorted for search via menu nor on grid if no columns are set to be used for sorting.
Moreover in https://github.com/pimcore/pimcore/blob/8ef2d6610e438198e11fd381b0172883856213d7/bundles/AdminBundle/Controller/Searchadmin/SearchController.php#L227 general sorting is commented out for performance reasons.

This PR adds sorting by relevance via MySQL's full text search. As the table `search_backend_data`already has a fulltext index on columns data and properties for filtering the same index could be used for sorting without much performance problems. I have tried this sorting on customers with 12.000 and 33.000 objects and search is as fast as before.