### PR TITLE
asset image: xmp data fix when file is not available in filesystem

### DIFF
--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -595,6 +595,11 @@ EOT;
     {
         $data = [];
 
+        if(!file_exists($this->getFileSystemPath())) {
+            return [];
+        }
+
+
         if (in_array(File::getFileExtension($this->getFilename()), ['jpg', 'jpeg', 'jp2', 'png', 'gif', 'webp', 'j2k', 'jpf', 'jpx', 'jpm'])) {
             $chunkSize = 1024;
             if (!is_int($chunkSize)) {


### PR DESCRIPTION
Sometimes for dev instances it's usefull to just copy the database but not the assets in the filesystem. Currently the result for images can be that it is not possible to open the asset in the pimcore backend. This fix just returns an empty array instead of a exception and therefore the asset can be opened without a problem.