### PR TITLE
Fix PhpDoc parameter type of ICart::removeVoucherToken()

### DIFF
--- a/bundles/EcommerceFrameworkBundle/CartManager/ICart.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/ICart.php
@@ -16,7 +16,6 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\CartManager;
 
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractSetProductEntry;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\ICheckoutable;
-use Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\Token;
 
 /**
  * Interface for cart implementations of online shop framework
@@ -310,7 +309,7 @@ interface ICart
     public function addVoucherToken($token);
 
     /**
-     * @param Token $token
+     * @param string $token
      *
      * @return bool
      */


### PR DESCRIPTION
The implementation of the interface has already the correct type hint in its PhpDoc:
https://github.com/pimcore/pimcore/blob/8b3f023feb8ee06731d2aa0b65dd95d5e30085b2/bundles/EcommerceFrameworkBundle/CartManager/AbstractCart.php#L853