### PR TITLE
Fix Symfony Deprecations

### DIFF
--- a/bundles/CoreBundle/Resources/config/services.yml
+++ b/bundles/CoreBundle/Resources/config/services.yml
@@ -167,10 +167,10 @@ services:
         class:  Pimcore\Translation\ExportService\ExportService
 
     Pimcore\Translation\ExportDataExtractorService\DataExtractor\DataObjectDataExtractor:
-        tags: [{name:pimcore.translation.data-extractor, type:object}]
+        tags: [{name: pimcore.translation.data-extractor, type: object}]
 
     Pimcore\Translation\ExportDataExtractorService\DataExtractor\DocumentDataExtractor:
-        tags: [{name:pimcore.translation.data-extractor, type:document}]
+        tags: [{name: pimcore.translation.data-extractor, type: document}]
 
     Pimcore\Translation\ExportService\Exporter\ExporterInterface:
         class: Pimcore\Translation\ExportService\Exporter\Xliff12Exporter
@@ -179,10 +179,10 @@ services:
         class: Pimcore\Translation\ImporterService\ImporterService
 
     Pimcore\Translation\ImporterService\Importer\DataObjectImporter:
-        tags: [{name:pimcore.translation.importer, type:object}]
+        tags: [{name: pimcore.translation.importer, type: object}]
 
     Pimcore\Translation\ImporterService\Importer\DocumentImporter:
-        tags: [{name:pimcore.translation.importer, type:document}]
+        tags: [{name: pimcore.translation.importer, type: document}]
 
     Pimcore\Translation\ImportDataExtractor\ImportDataExtractorInterface:
         class: Pimcore\Translation\ImportDataExtractor\Xliff12DataExtractor


### PR DESCRIPTION
Fix following Deprecations:
`Using a colon after an unquoted mapping key that is not followed by an indication character (i.e. " ", ",", "[", "]", "{", "}") is deprecated since Symfony 3.2 and will throw a ParseException in 4.0`