### PR TITLE
Fix: Unable to open objects with ManyToManyObjectRelation fields and visible fields but no classes

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -100,7 +100,7 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
         columns.push({text: 'ID', dataIndex: 'id', width: 50});
 
         for (i = 0; i < visibleFields.length; i++) {
-            if (!empty(visibleFields[i])) {
+            if (!empty(this.fieldConfig.visibleFieldDefinitions) && !empty(visibleFields[i])) {
                 var layout = this.fieldConfig.visibleFieldDefinitions[visibleFields[i]];
 
                 var field = {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -299,7 +299,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
         ];
 
         for (i = 0; i < visibleFields.length; i++) {
-            if (!empty(visibleFields[i])) {
+            if (!empty(this.fieldConfig.visibleFieldDefinitions) && !empty(visibleFields[i])) {
                 var layout = this.fieldConfig.visibleFieldDefinitions[visibleFields[i]];
 
                 var field = {

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -676,16 +676,18 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
 
         $classIds = $this->getClasses();
 
-        if (!$classIds) {
-            $classIds;
+        if (empty($classIds)) {
+            return;
         }
 
         $classId = $classIds[0]['classes'];
 
         if (is_numeric($classId)) {
             $class = DataObject\ClassDefinition::getById($classId);
-        } else {
+        } elseif (is_string($classId)) {
             $class = DataObject\ClassDefinition::getByName($classId);
+        } else {
+            return;
         }
 
         $this->visibleFieldDefinitions = [];


### PR DESCRIPTION
# Steps to reproduce
1. Create class with Many-To-Many Object Relation
2. Select Many-To-Many Object Relation classes and visible fields
3. Save class
4. Create object
4. Remove Many-To-Many Object Relation classes
5. Save class
6. Open object

