### PR TITLE
add version preview for metadata fields of advanced multi relation types

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/object_versions.css
+++ b/bundles/AdminBundle/Resources/public/css/object_versions.css
@@ -45,6 +45,10 @@ body {
 	background: #ffe5e5;
 }
 
+.preview .preview-metadata {
+	color: #a0a0a0;
+}
+
 .system {
     font-family: "courier new";
 }

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -279,13 +279,30 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
      */
     public function getVersionPreview($data, $object = null, $params = [])
     {
+        $items = [];
         if (is_array($data) && count($data) > 0) {
             foreach ($data as $metaObject) {
                 $o = $metaObject->getObject();
-                $pathes[] = $o->getRealFullPath();
+                $item = $o->getRealFullPath();
+
+                if(sizeof($metaObject->getData())) {
+                    $subItems = [];
+                    foreach($metaObject->getData() as $key => $value) {
+                        if(!$value) {
+                            continue;
+                        }
+                        $subItems[] = $key . ': ' . $value;
+                    }
+
+                    if(sizeof($subItems)) {
+                        $item .= ' <br/><span class="preview-metadata">[' . implode(' | ' , $subItems) . ']</span>';
+                    }
+                }
+
+                $items[] = $item;
             }
 
-            return implode('<br />', $pathes);
+            return implode('<br />', $items);
         }
     }
 

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -397,13 +397,31 @@ class AdvancedManyToManyRelation extends ManyToManyObjectRelation
      */
     public function getVersionPreview($data, $object = null, $params = [])
     {
+        $items = [];
         if (is_array($data) && count($data) > 0) {
             foreach ($data as $metaObject) {
                 $o = $metaObject->getElement();
-                $pathes[] = Element\Service::getElementType($o) . ' ' . $o->getRealFullPath();
+                $item = Element\Service::getElementType($o) . ' ' . $o->getRealFullPath();
+
+                if(sizeof($metaObject->getData())) {
+                    $subItems = [];
+                    foreach($metaObject->getData() as $key => $value) {
+                        if(!$value) {
+                            continue;
+                        }
+                        $subItems[] = $key . ': ' . $value;
+                    }
+
+                    if(sizeof($subItems)) {
+                        $item .= ' <br/><span class="preview-metadata">[' . implode(' | ' , $subItems) . ']</span>';
+                    }
+
+                }
+
+                $items[] = $item;
             }
 
-            return implode('<br />', $pathes);
+            return implode('<br />', $items);
         }
     }
 


### PR DESCRIPTION
This pull request adds metadata columns of advanced multi relation data types to the data object version preview.

Styling is not that easy but should be acceptable:
![image](https://user-images.githubusercontent.com/4639428/49939438-22ceb600-fedd-11e8-8405-9e3b63924a25.png)
