### PR TITLE
Fix: Can't save object with CalculatedValue

### DIFF
--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -243,7 +243,7 @@ class Dao extends Model\DataObject\AbstractObject\Dao
                 }
                 $fd->save($this->model, $saveParams);
             }
-            if ($fd instanceof ResourcePersistenceAwareInterface || (!method_exists($fd, 'save') && $fd->getColumnType())) {
+            if ($fd instanceof ResourcePersistenceAwareInterface || method_exists($fd, 'getDataForResource')) {
                 if (!$fd instanceof ResourcePersistenceAwareInterface) {
                     Tool::triggerMissingInterfaceDeprecation(get_class($fd), 'getDataForResource', ResourcePersistenceAwareInterface::class);
                 }

--- a/models/DataObject/Fieldcollection/Dao.php
+++ b/models/DataObject/Fieldcollection/Dao.php
@@ -100,7 +100,7 @@ class Dao extends Model\Dao\AbstractDao
                             }
                         }
                     }
-                    if ($fd instanceof ResourcePersistenceAwareInterface || !method_exists($fd, 'load')) {
+                    if ($fd instanceof ResourcePersistenceAwareInterface || method_exists($fd, 'getDataFromResource')) {
                         if (!$fd instanceof ResourcePersistenceAwareInterface) {
                             Tool::triggerMissingInterfaceDeprecation(get_class($fd), 'getDataFromResource', ResourcePersistenceAwareInterface::class);
                         }

--- a/models/DataObject/Fieldcollection/Data/Dao.php
+++ b/models/DataObject/Fieldcollection/Data/Dao.php
@@ -72,7 +72,7 @@ class Dao extends Model\Dao\AbstractDao
 
                     );
                 }
-                if ($fd instanceof ResourcePersistenceAwareInterface || (!method_exists($fd, 'save') && $fd->getColumnType())) {
+                if ($fd instanceof ResourcePersistenceAwareInterface || method_exists($fd, 'getDataForResource')) {
                     if (!$fd instanceof ResourcePersistenceAwareInterface) {
                         Tool::triggerMissingInterfaceDeprecation(get_class($fd), 'getDataForResource', ResourcePersistenceAwareInterface::class);
                     }

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -151,7 +151,7 @@ class Dao extends Model\Dao\AbstractDao
 
                     $fd->save($this->model, $childParams);
                 }
-                if ($fd instanceof ResourcePersistenceAwareInterface || !method_exists($fd, 'save')) {
+                if ($fd instanceof ResourcePersistenceAwareInterface || method_exists($fd, 'getDataForResource')) {
                     if (!$fd instanceof ResourcePersistenceAwareInterface) {
                         Tool::triggerMissingInterfaceDeprecation(get_class($fd), 'getDataForResource', ResourcePersistenceAwareInterface::class);
                     }

--- a/models/DataObject/Objectbrick/Dao.php
+++ b/models/DataObject/Objectbrick/Dao.php
@@ -81,7 +81,7 @@ class Dao extends Model\DataObject\Fieldcollection\Dao
                             $brick->setValue($key, $value);
                         }
                     }
-                    if ($fd instanceof ResourcePersistenceAwareInterface || !method_exists($fd, 'load')) {
+                    if ($fd instanceof ResourcePersistenceAwareInterface || method_exists($fd, 'getDataFromResource')) {
                         if (!$fd instanceof ResourcePersistenceAwareInterface) {
                             Tool::triggerMissingInterfaceDeprecation(get_class($fd), 'getDataFromResource', ResourcePersistenceAwareInterface::class);
                         }

--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -119,7 +119,7 @@ class Dao extends Model\Dao\AbstractDao
                         ]
                     ]));
             }
-            if ($fd instanceof ResourcePersistenceAwareInterface || (!method_exists($fd, 'save') && $fd->getColumnType())) {
+            if ($fd instanceof ResourcePersistenceAwareInterface || method_exists($fd, 'getDataForResource')) {
                 if (!$fd instanceof ResourcePersistenceAwareInterface) {
                     Tool::triggerMissingInterfaceDeprecation(get_class($fd), 'getDataForResource', ResourcePersistenceAwareInterface::class);
                 }


### PR DESCRIPTION
## Steps to reproduce

1. Open Advanced Demo
2. Open Product
3. Try to save
![image](https://user-images.githubusercontent.com/998558/50055687-5c5c2700-0152-11e9-879b-0e615fa6805c.png)

## Additional infos
After https://github.com/pimcore/pimcore/commit/81cbbd66e14bd8ec9e48108ec25eacca28efc936 it should be used `method_exists($fd, 'getDataForResource')` and `method_exists($fd, 'getDataFromResource')` consistently

