### PR TITLE
Exception when copying an object recursive with updating references without children

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -2055,19 +2055,19 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                         ]];
                     }
                 }
-            }
 
-            // add id-rewrite steps
-            if ($request->get('type') == 'recursive-update-references') {
-                for ($i = 0; $i < (count($childIds) + 1); $i++) {
-                    $pasteJobs[] = [[
-                        'url' => '/admin/object/copy-rewrite-ids',
-                        'method' => 'PUT',
-                        'params' => [
-                            'transactionId' => $transactionId,
-                            '_dc' => uniqid()
-                        ]
-                    ]];
+                // add id-rewrite steps
+                if ($request->get('type') == 'recursive-update-references') {
+                    for ($i = 0; $i < (count($childIds) + 1); $i++) {
+                        $pasteJobs[] = [[
+                            'url' => '/admin/object/copy-rewrite-ids',
+                            'method' => 'PUT',
+                            'params' => [
+                                'transactionId' => $transactionId,
+                                '_dc' => uniqid()
+                            ]
+                        ]];
+                    }
                 }
             }
         } elseif ($request->get('type') == 'child' || $request->get('type') == 'replace') {


### PR DESCRIPTION
## Changes in this pull request  
When copying an object without children via "recursive, updating references" an exception is raised. This is due to the variable $childIds not being countable (not existent without children). Thus the for loop iterating over the children should only be accessible if there are children present.
