### PR TITLE
Fixed endless recursion on d&d objects in manyToManyObjectRelation

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -412,7 +412,13 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                 listeners: {
                     drop: function (node, data, dropRec, dropPosition) {
                         var dropOn = dropRec ? ' ' + dropPosition + ' ' + dropRec.get('name') : ' on empty view';
-                    },
+
+                        // this is necessary to avoid endless recursion when long lists are sorted via d&d
+                        // TODO: investigate if there this is already fixed 6.2
+                        if (this.object.toolbar && this.object.toolbar.items && this.object.toolbar.items.items) {
+                            this.object.toolbar.items.items[0].focus();
+                        }
+                    }.bind(this),
                     refresh: function (gridview) {
                         this.requestNicePathData(this.store.data);
                     }.bind(this)


### PR DESCRIPTION
## Changes in this pull request  
The many to many object relation tag freezes the browser, when sorting items via d&d. This happens with 3+ items in the tag. The issue was already resolved in the advanced many to many object relation tag.

Resolves #3559 
