### PR TITLE
Added batch edit option for Advanced Many-To-Many Object Relation meta fields

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -708,7 +708,7 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
             bodyStyle: "padding: 10px;",
             buttons: [
                 {
-                    text: t("set"),
+                    text: t("edit"),
                     handler: function() {
                         if(formPanel.isValid()) {
                             this.batchProcess(columnDataIndex.dataIndex, editor, grid);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #3674 

Batch edit option for meta fields in Advanced Many-To-Many Object Relation
![batchupdate1](https://user-images.githubusercontent.com/5137917/50220646-eb6a7880-03b8-11e9-94f0-be2d478df7ef.png)
![batchupdate2](https://user-images.githubusercontent.com/5137917/50220652-ee656900-03b8-11e9-9be4-35057b1804e7.png)


## Additional info  

