### PR TITLE
Fix: Can't execute tests locally

### DIFF
--- a/tests/cache/Factory.php
+++ b/tests/cache/Factory.php
@@ -75,7 +75,7 @@ class Factory
      */
     public function createFilesystemAdapterProxyItemPool($defaultLifetime = 0)
     {
-        $filesystemAdapter = new FilesystemAdapter('', $defaultLifetime, \Pimcore::getKernel()->getCacheDir());
+        $filesystemAdapter = new FilesystemAdapter('', $defaultLifetime, \Pimcore::getKernel()->getCacheDir() . '/pimcore');
 
         return $this->createSymfonyProxyItemPool($filesystemAdapter);
     }


### PR DESCRIPTION
Without this fix I get an error, because the FilesystemCoreHandlerTest removes the complete cache dir with the container files. One of the next tests would like initiate a service and can't load the file:

```
[Symfony\Component\Debug\Exception\FatalErrorException]                                                                                                                                            
Compile Error: ContainerKyj7wso\appTestDebugProjectContainer::load(): Failed opening required '/var/www/pimcore-test/var/cache/test/ContainerKyj7wso/getInstallerService.php'
```

I have attached a subdirectory, as well as in normal use:
https://github.com/pimcore/pimcore/blob/82199d8cf1bee19844690b76f048ec01814ae5a0/bundles/CoreBundle/Resources/config/cache.yml#L63-L72

I don't know why it works on travis.