### PR TITLE
Enrich object layout before preSendData event

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -471,11 +471,12 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 'data' => $objectData,
                 'object' => $object,
             ]);
+            
+            DataObject\Service::enrichLayoutDefinition($objectData['layout'], $object);
             $eventDispatcher->dispatch(AdminEvents::OBJECT_GET_PRE_SEND_DATA, $event);
             $data = $event->getArgument('data');
 
             $data = $this->filterLocalizedFields($object, $data);
-            DataObject\Service::enrichLayoutDefinition($data['layout'], $object);
 
             DataObject\Service::removeObjectFromSession($object->getId());
 


### PR DESCRIPTION
### Description
The field definitions of the keys for classification stores get enriched after the `pimcore.admin.dataobject.get.preSendData` is sent. So manipulating the field definitions of the classification store's keys is not possible yet.

### Use Case
I want to set a specific field of a single key in a classification store group to `notEditable`.