### PR TITLE
admin/website translations backend - sort by language fix

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -379,16 +379,15 @@ class TranslationController extends AdminController
 
             $joins = [];
 
-            if ($sortingSettings['orderKey']) {
-                $sortingSettings['orderKey'] = preg_replace('/^_/', '', $sortingSettings['orderKey'], 1);
-                if (in_array($sortingSettings['orderKey'], $validLanguages)) {
-                    $sortingSettings['orderKey'] = str_replace('_', '', $sortingSettings['orderKey']); //replace all "_" from key
+            if ($orderKey = $sortingSettings['orderKey']) {
+                if (in_array(trim($orderKey, "_"), $validLanguages)) {
+                    $orderKey = trim($orderKey, "_");
                     $joins[] = [
-                        'language' => $sortingSettings['orderKey'],
+                        'language' => $orderKey,
                     ];
-                    $list->setOrderKey($sortingSettings['orderKey']);
+                    $list->setOrderKey($orderKey);
                 } else {
-                    $list->setOrderKey($tableName . '.' . $sortingSettings['orderKey'], false);
+                    $list->setOrderKey($tableName.'.'.$sortingSettings['orderKey'], false);
                 }
             }
             if ($sortingSettings['order']) {

--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -380,14 +380,14 @@ class TranslationController extends AdminController
             $joins = [];
 
             if ($orderKey = $sortingSettings['orderKey']) {
-                if (in_array(trim($orderKey, "_"), $validLanguages)) {
-                    $orderKey = trim($orderKey, "_");
+                if (in_array(trim($orderKey, '_'), $validLanguages)) {
+                    $orderKey = trim($orderKey, '_');
                     $joins[] = [
                         'language' => $orderKey,
                     ];
                     $list->setOrderKey($orderKey);
                 } else {
-                    $list->setOrderKey($tableName.'.'.$sortingSettings['orderKey'], false);
+                    $list->setOrderKey($tableName . '.' . $sortingSettings['orderKey'], false);
                 }
             }
             if ($sortingSettings['order']) {


### PR DESCRIPTION
Sorting by language value did not work in admin/website translations - with this fix it works.