### PR TITLE
[Bug][Ecommerce] More unique keys for order items and gifts

### DIFF
--- a/bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
@@ -707,7 +707,7 @@ class OrderManager implements IOrderManager
      *
      * @return string
      */
-    protected function buildOrderItemKey(ICartItem $item, bool $isGiftitem = false)
+    protected function buildOrderItemKey(ICartItem $item, bool $isGiftItem = false)
     {
         $key = File::getValidFilename(sprintf(
             '%s_%s%s',

--- a/bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
@@ -615,6 +615,12 @@ class OrderManager implements IOrderManager
     {
         $key = $this->buildOrderItemKey($item);
 
+        // Prevents key collisions where a regular order product item and a gift product item
+        // could otherwise get the same key
+        if ($isGiftItem) {
+            $key .= "_gift";
+        }
+
         $orderItemList = $this->buildOrderItemList();
         $orderItemList->setCondition('o_parentId = ? AND o_key = ?', [$parent->getId(), $key]);
 

--- a/bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
@@ -613,13 +613,7 @@ class OrderManager implements IOrderManager
      */
     protected function createOrderItem(ICartItem $item, $parent, $isGiftItem = false)
     {
-        $key = $this->buildOrderItemKey($item);
-
-        // Prevents key collisions where a regular order product item and a gift product item
-        // could otherwise get the same key
-        if ($isGiftItem) {
-            $key .= "_gift";
-        }
+        $key = $this->buildOrderItemKey($item, $isGiftItem);
 
         $orderItemList = $this->buildOrderItemList();
         $orderItemList->setCondition('o_parentId = ? AND o_key = ?', [$parent->getId(), $key]);
@@ -709,15 +703,17 @@ class OrderManager implements IOrderManager
      * Build order item key from cart item
      *
      * @param ICartItem $item
+     * @param bool $isGiftItem
      *
      * @return string
      */
-    protected function buildOrderItemKey(ICartItem $item)
+    protected function buildOrderItemKey(ICartItem $item, bool $isGiftitem = false)
     {
         $key = File::getValidFilename(sprintf(
-            '%s_%s',
+            '%s_%s%s',
             $item->getProduct()->getId(),
-            $item->getItemKey()
+            $item->getItemKey(),
+            $isGiftItem ? '_gift' : ''
         ));
 
         return $key;


### PR DESCRIPTION
Prevents key collisions where a regular order product item and a gift product item could otherwise get the same key

<!--
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
 
## Changes in this pull request  
Resolves a key collision where a regular order product item and a gift product item could otherwise get the same key

## Additional info  

To reproduce:

1. Create a Price Rule with a gift item product as an Action.
2. In the front end, add the same product as would be the gift to your cart.
3. Complete the Checkout steps. (Making sure the Price Rule applies and you also get the gift item).
4. Look at the order, result: The order now contains only one of the items.
5. If you now do `$order->getItems()`  and `$order->getGiftItems()` you will only get the same object and the same object for both methods. But you should get two different objects.