### PR TITLE
fix workflow place issue

### DIFF
--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -243,7 +243,10 @@ class Manager
         $this->notesSubscriber->setAdditionalData([]);
 
         if ($saveSubject && $subject instanceof AbstractElement && method_exists($subject, 'save')) {
-            $subject->save();
+            if($subject->getPublished())
+                $subject->save();
+            else
+                $subject->saveVersion();
         }
 
         return $marking;


### PR DESCRIPTION
currently, if workflow place of an dataobject would be changed from the admin area, all the changes including published flag will be merged from the last version. in this case, if the product was already "live" it becames the status unpublished und goes away from the shop. this fix should avoid it. (not sure if it's enough)