### PR TITLE
Bugfix: Relational items of field collections disappeared

### DIFF
--- a/models/DataObject/Fieldcollection.php
+++ b/models/DataObject/Fieldcollection.php
@@ -156,6 +156,8 @@ class Fieldcollection extends Model\AbstractModel implements \Iterator, DirtyInd
     public function add($item)
     {
         $this->items[] = $item;
+
+        $this->markFieldDirty('_self', true);
     }
 
     /**
@@ -165,6 +167,8 @@ class Fieldcollection extends Model\AbstractModel implements \Iterator, DirtyInd
     {
         if ($this->items[$index]) {
             array_splice($this->items, $index, 1);
+
+            $this->markFieldDirty('_self', true);
         }
     }
 

--- a/models/DataObject/Fieldcollection/Dao.php
+++ b/models/DataObject/Fieldcollection/Dao.php
@@ -96,7 +96,7 @@ class Dao extends Model\Dao\AbstractDao
                             $collection->setValue($key, $value);
 
                             if ($collection instanceof DataObject\DirtyIndicatorInterface) {
-                                $collection->markFieldDirty($key, false);
+                                $collection->markFieldDirty($key, true);
                             }
                         }
                     }
@@ -187,8 +187,9 @@ class Dao extends Model\Dao\AbstractDao
                 foreach ($childDefinitions as $fd) {
                     if (!DataObject\AbstractObject::isDirtyDetectionDisabled() && $this->model instanceof DataObject\DirtyIndicatorInterface) {
                         if ($fd instanceof DataObject\ClassDefinition\Data\Relations\AbstractRelations && !$this->model->isFieldDirty(
-                                '_self'
+                                $fd->getName()
                             )) {
+                            $this->model->markFieldDirty($fd->getName(), true);
                             continue;
                         }
                     }


### PR DESCRIPTION
Solves #3842 

Field collections have not been marked dirty if an item got added or removed.
Furthermore we had the problem that the relations of existing field collection items got empty after adding a new field collection item. This is caused because when saving a field collection all relational items get deleted, see https://github.com/pimcore/pimcore/blob/master/models/DataObject/Fieldcollection/Dao.php#L40 and https://github.com/pimcore/pimcore/blob/master/models/DataObject/Fieldcollection/Dao.php#L237. For this reason they have to be recreated again but as the original field collection items and also their relations have not been touched to mark them dirty, they won't be saved again. For this reason I mark all fields of a field collection item as dirty after loading. This works but nevertheless feels a bit unclean. 