### PR TITLE
fix publish or unpublish the dataobject by changing the workflow place

### DIFF
--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -243,7 +243,10 @@ class Manager
         $this->notesSubscriber->setAdditionalData([]);
 
         if ($saveSubject && $subject instanceof AbstractElement && method_exists($subject, 'save')) {
-            $subject->save();
+            if($subject->getPublished())
+                $subject->save();
+            else
+                $subject->saveVersion();
         }
 
         return $marking;


### PR DESCRIPTION
if workflow place would be changed from admin area, all changes from the last version including publish status will be merge into dataobject. In this case the live product will be away from the shop. this fix avoid it.