### PR TITLE
Missing permissions check for Classificationstore

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -21,11 +21,12 @@ use Pimcore\Model\DataObject\Classificationstore;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Pimcore\Controller\EventedControllerInterface;
 
 /**
  * @Route("/classificationstore")
  */
-class ClassificationstoreController extends AdminController
+class ClassificationstoreController extends AdminController implements EventedControllerInterface
 {
     /**
      * Delete collection with the group-relations
@@ -1481,4 +1482,27 @@ class ClassificationstoreController extends AdminController
 
         return $this->adminJson(['success' => true, 'page' => $page]);
     }
+    
+    /**
+     * @inheritDoc
+     */
+    public function onKernelController(FilterControllerEvent $event)
+    {
+        $isMasterRequest = $event->isMasterRequest();
+        if (!$isMasterRequest) {
+            return;
+        }
+
+        $unrestrictedActions = [];
+        $this->checkActionPermission($event, 'classes', $unrestrictedActions);
+    }
+    
+
+    /**
+     * @param FilterResponseEvent $event
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+    }
+
 }

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -22,6 +22,8 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Pimcore\Controller\EventedControllerInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
 /**
  * @Route("/classificationstore")


### PR DESCRIPTION
# Bug Fix 
Adds permission check for ClassificationstoreController. Please re-check the list of `unrestrictedAction` in the `onKernelController()` method.

Resolves #3848
