### PR TITLE
No timeout during installtion -> classes-rebuild

### DIFF
--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -398,7 +398,7 @@ class Installer
             $parts = $partsBuilder->getParts();
 
             $process = new Process($parts);
-            $process->setTimeout(120);
+            $process->setTimeout(0);
             $process->setWorkingDirectory(PIMCORE_PROJECT_ROOT);
             $process->run();
 


### PR DESCRIPTION
We have a project with ~ 30 classes, 5 field collections and ~ 50 object bricks.
I get a timeout error like khusseini in https://github.com/pimcore/pimcore/issues/3681

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

