### PR TITLE
Fixes faulty column name escaping on Date field

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Date.php
+++ b/models/DataObject/ClassDefinition/Data/Date.php
@@ -430,7 +430,7 @@ class Date extends Data implements ResourcePersistenceAwareInterface, QueryResou
             $db = Db::get();
 
             if ($this->getColumnType() == 'date') {
-                $condition = '`' . $params['name'] . ' = '. $db->quote($value);
+                $condition = '`' . $params['name'] . '` = '. $db->quote($value);
 
                 return $condition;
             } else {


### PR DESCRIPTION
A missing ` would case this to not work when searching for objects with a specific date.

<!--
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request 

Resolves an error message when searching for data objects with a specific ("On") date.
