### PR TITLE
 Support locking classifcations via fielddefinition

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/classificationstore.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/classificationstore.js
@@ -118,7 +118,7 @@ pimcore.object.tags.classificationstore = Class.create(pimcore.object.tags.abstr
 
         var tbarItems = [];
 
-        if (!this.fieldConfig.noteditable) {
+        if (!this.fieldConfig.noteditable && !this.fieldConfig.locked) {
             tbarItems.push(
                 {
                     xtype: 'button',
@@ -461,7 +461,7 @@ pimcore.object.tags.classificationstore = Class.create(pimcore.object.tags.abstr
         };
 
         var tools = [];
-        if (!this.fieldConfig.noteditable) {
+        if (!this.fieldConfig.noteditable && !this.fieldConfig.locked) {
             tools.push(
                 {
                     type: 'close',


### PR DESCRIPTION
# Feature Request 

Resolves #3834

## Additional info  
The PR only enables frontend layout changes i.e. via the `pimcore.admin.asset.get.preSendData` event and does NOT provide new configuration options via the class definition (maybe nice to have too) and also it does NOT include any backend permission checks.