### PR TITLE
Option to skip database structure on install is not working

### DIFF
--- a/bundles/InstallBundle/Command/InstallCommand.php
+++ b/bundles/InstallBundle/Command/InstallCommand.php
@@ -117,20 +117,17 @@ class InstallCommand extends Command
             ],
             'skip-database-structure' => [
                 'description' => 'Skipping creation of database structure during install',
-                'mode' => InputOption::VALUE_OPTIONAL,
-                'default' => false,
+                'mode' => InputOption::VALUE_NONE,
                 'group' => 'install_options',
             ],
             'skip-database-data' => [
                 'description' => 'Skipping importing of any data into database',
-                'mode' => InputOption::VALUE_OPTIONAL,
-                'default' => false,
+                'mode' => InputOption::VALUE_NONE,
                 'group' => 'install_options',
             ],
             'skip-database-data-dump' => [
                 'description' => 'Skipping importing of provided data dumps into database (if available). Only imports needed base data.',
-                'mode' => InputOption::VALUE_OPTIONAL,
-                'default' => false,
+                'mode' => InputOption::VALUE_NONE,
                 'group' => 'install_options',
             ],
         ];
@@ -283,7 +280,7 @@ class InstallCommand extends Command
             return false;
         }
 
-        if ('install_options' === ($config['group'] ?? null) && InputOption::VALUE_OPTIONAL === ($config['mode'] ?? null)) {
+        if ('install_options' === ($config['group'] ?? null) && InputOption::VALUE_REQUIRED === ($config['mode'] ?? null)) {
             return false;
         }
 
@@ -310,7 +307,8 @@ class InstallCommand extends Command
             $value = $input->getOption($name);
 
             // Empty MySQL password allowed
-            if ($value || $name === 'mysql-password') {
+            // Group install_options is optional
+            if ($value || $name === 'mysql-password' || 'install_options' === $config['group']) {
                 $param = str_replace('-', '_', $name);
                 $params[$param] = $value;
             } else {


### PR DESCRIPTION
Fix installer options:

* skip-database-structure
* skip-database-data
* skip-database-dump

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #3852

## Additional info  

Comment and request from @dpfaffenbauer (https://github.com/pimcore/pimcore/issues/3852#issuecomment-456087497) is not included.

