### PR TITLE
Add MySQL config option to set index table engine

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultMysql.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultMysql.php
@@ -36,6 +36,14 @@ class DefaultMysql extends AbstractConfig implements IMysqlConfig
     /**
      * @return string
      */
+    public function getTableEngine()
+    {
+        return 'MyISAM';
+    }
+
+    /**
+     * @return string
+     */
     public function getRelationTablename()
     {
         return 'ecommerceframework_productindex_relations';

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultMysql.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultMysql.php
@@ -23,7 +23,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\IIndexable;
  *
  * @method DefaultMysqlWorker getTenantWorker()
  */
-class DefaultMysql extends AbstractConfig implements IMysqlConfig
+class DefaultMysql extends AbstractConfig implements IMysqlEngineConfig
 {
     /**
      * @return string

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/IMysqlConfig.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/IMysqlConfig.php
@@ -27,6 +27,13 @@ interface IMysqlConfig extends IConfig
     public function getTablename();
 
     /**
+     * returns table engine of product index
+     *
+     * @return string
+     */
+    public function getTableEngine();
+
+    /**
      * returns table name of product index reations
      *
      * @return string

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/IMysqlEngineConfig.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/IMysqlEngineConfig.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config;
+
+/**
+ * Interface for IndexService Tenant Configurations using mysql as index
+ */
+interface IMysqlEngineConfig extends IMysqlConfig
+{
+    /**
+     * returns table engine of product index
+     *
+     * @return string
+     */
+    public function getTableEngine();
+
+}

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/Helper/MySql.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/Helper/MySql.php
@@ -15,6 +15,7 @@
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Worker\Helper;
 
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\IMysqlConfig;
+use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\IMysqlEngineConfig;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Interpreter\IRelationInterpreter;
 use Pimcore\Cache;
 use Pimcore\Db\Connection;
@@ -142,13 +143,8 @@ class MySql
             }
 
             $indexTableEngine = 'MyISAM';
-            try {
-                $reflectionConfig = new \ReflectionClass(get_class($this->tenantConfig));
-                if ($reflectionConfig->implementsInterface('Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\IMysqlEngineConfig')) {
-                    $indexTableEngine = $this->tenantConfig->getTableEngine();
-                }
-            } catch (\ReflectionException $exception) {
-                Logger::info($exception);
+            if ($this->tenantConfig instanceof IMysqlEngineConfig) {
+                $indexTableEngine = $this->tenantConfig->getTableEngine();
             }
 
             $this->dbexec('ALTER TABLE `' . $this->tenantConfig->getTablename() . '` ENGINE = ' . $indexTableEngine . ';');

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/Helper/MySql.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/Helper/MySql.php
@@ -141,7 +141,7 @@ class MySql
                 Logger::info($e);
             }
 
-            $this->dbexec('ALTER TABLE `' . $this->tenantConfig->getTablename() . '` ENGINE = MyISAM;');
+            $this->dbexec('ALTER TABLE `' . $this->tenantConfig->getTablename() . '` ENGINE = ' . $this->tenantConfig->getTableEngine() . ';');
             $columnNames = [];
             foreach ($searchIndexColums as $c) {
                 $columnNames[] = $this->db->quoteIdentifier($c);

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/Helper/MySql.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/Helper/MySql.php
@@ -141,7 +141,17 @@ class MySql
                 Logger::info($e);
             }
 
-            $this->dbexec('ALTER TABLE `' . $this->tenantConfig->getTablename() . '` ENGINE = ' . $this->tenantConfig->getTableEngine() . ';');
+            $indexTableEngine = 'MyISAM';
+            try {
+                $reflectionConfig = new \ReflectionClass(get_class($this->tenantConfig));
+                if ($reflectionConfig->implementsInterface('Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\IMysqlEngineConfig')) {
+                    $indexTableEngine = $this->tenantConfig->getTableEngine();
+                }
+            } catch (\ReflectionException $exception) {
+                Logger::info($exception);
+            }
+
+            $this->dbexec('ALTER TABLE `' . $this->tenantConfig->getTablename() . '` ENGINE = ' . $indexTableEngine . ';');
             $columnNames = [];
             foreach ($searchIndexColums as $c) {
                 $columnNames[] = $this->db->quoteIdentifier($c);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #3850 

## Additional info  
Added a getter in the MySQL config for the ecommerce index service. This returns MyISAM by default but can be changed to what ever engine is needed.