### PR TITLE
Refactor how robots.txt files get persisted

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/Controller/Admin/SettingsController.php
@@ -1506,25 +1506,17 @@ class SettingsController extends AdminController
     /**
      * @Route("/robots-txt", methods={"GET"})
      *
-     * @param Request $request
-     *
      * @return JsonResponse
      */
-    public function robotsTxtGetAction(Request $request)
+    public function robotsTxtGetAction()
     {
         $this->checkPermission('robots.txt');
 
-        $robotsPath = $this->getRobotsTxtPath($request);
-
-        $data = '';
-        if (is_file($robotsPath)) {
-            $data = file_get_contents($robotsPath);
-        }
+        $config = Config::getRobotsConfig();
 
         return $this->adminJson([
             'success' => true,
-            'data' => $data,
-            'onFileSystem' => file_exists(PIMCORE_WEB_ROOT . '/robots.txt')
+            'data' => $config
         ]);
     }
 
@@ -1539,30 +1531,19 @@ class SettingsController extends AdminController
     {
         $this->checkPermission('robots.txt');
 
-        $robotsPath = $this->getRobotsTxtPath($request);
-        File::put($robotsPath, $request->get('data'));
+        $values = $request->get('data');
+        if (!is_array($values)) {
+            $values = [];
+        }
+
+        File::putPhpFile(
+            Config::locateConfigFile('robots.php'),
+            to_php_data_file_format($values)
+        );
 
         return $this->adminJson([
             'success' => true
         ]);
-    }
-
-    /**
-     * @param Request $request
-     *
-     * @return string
-     */
-    protected function getRobotsTxtPath(Request $request)
-    {
-        if ($request->get('site')) {
-            $siteSuffix = '-' . $request->get('site');
-        } else {
-            $siteSuffix = '-default';
-        }
-
-        $robotsPath = PIMCORE_CONFIGURATION_DIRECTORY . '/robots' . $siteSuffix . '.txt';
-
-        return $robotsPath;
     }
 
     /**

--- a/bundles/CoreBundle/Resources/migrations/Version20190124105627.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20190124105627.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Config;
+use Pimcore\File;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+use Pimcore\Model\Site;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190124105627 extends AbstractPimcoreMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $siteList = new Site\Listing();
+        $siteList->load();
+
+        $robotFiles = [];
+
+        $defaultRobotsPath = PIMCORE_CONFIGURATION_DIRECTORY.'/robots-default.txt';
+
+        if (file_exists($defaultRobotsPath)) {
+            $robotFiles['default'] = file_get_contents($defaultRobotsPath);
+        }
+
+        foreach ($siteList->getSites() as $site) {
+            if (!$site instanceof Site) {
+                continue;
+            }
+
+            $robotsPath = PIMCORE_CONFIGURATION_DIRECTORY.'/robots-'.$site->getId().'.txt';
+
+            if (file_exists($robotsPath)) {
+                $robotFiles[$site->getId()] = file_get_contents($robotsPath);
+            }
+        }
+
+        File::putPhpFile(
+            Config::locateConfigFile('robots.php'),
+            to_php_data_file_format($robotFiles)
+        );
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $configPath = Config::locateConfigFile('robots.php');
+
+        if (!file_exists($configPath)) {
+            return;
+        }
+
+        $content = include($configPath);
+
+        if (!is_array($content)) {
+            $content = [];
+        }
+
+        $config = new Config\Config($content);
+        $config = $config->toArray();
+
+        foreach ($config as $siteId => $robotsContent) {
+            $robotsPath = PIMCORE_CONFIGURATION_DIRECTORY.'/robots-'.$siteId.'.txt';
+
+            file_put_contents($robotsPath, $robotsContent);
+        }
+    }
+}

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -325,6 +325,40 @@ class Config
      *
      * @return \Pimcore\Config\Config
      */
+    public static function getRobotsConfig()
+    {
+        if (\Pimcore\Cache\Runtime::isRegistered('pimcore_config_robots')) {
+            $config = \Pimcore\Cache\Runtime::get('pimcore_config_robots');
+        } else {
+            try {
+                $file = self::locateConfigFile('robots.php');
+                $config = static::getConfigInstance($file);
+            } catch (\Exception $e) {
+                $config = new \Pimcore\Config\Config([]);
+            }
+
+            self::setRobotsConfig($config);
+        }
+
+        return $config;
+    }
+
+
+    /**
+     * @static
+     *
+     * @param \Pimcore\Config\Config $config
+     */
+    public static function setRobotsConfig(\Pimcore\Config\Config $config)
+    {
+        \Pimcore\Cache\Runtime::set('pimcore_config_robots', $config);
+    }
+
+    /**
+     * @static
+     *
+     * @return \Pimcore\Config\Config
+     */
     public static function getWeb2PrintConfig()
     {
         if (\Pimcore\Cache\Runtime::isRegistered('pimcore_config_web2print')) {


### PR DESCRIPTION
the current solution is unsuitable for a lot of sites with a proper deployment process

It now gets stored in a `reports.php` file in `var/config`