### PR TITLE
Checkbox to exclude wysiwygs and textareas from the backend search index

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/textarea.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/textarea.js
@@ -88,6 +88,11 @@ pimcore.object.classes.data.textarea = Class.create(pimcore.object.classes.data.
                 fieldLabel: t("show_charcount"),
                 name: "showCharCount",
                 value: datax.showCharCount
+            }, {
+                xtype: "checkbox",
+                fieldLabel: t("exclude_from_search_index"),
+                name: "excludeFromSearchIndex",
+                checked: datax.excludeFromSearchIndex
             }
         ];
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/wysiwyg.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/wysiwyg.js
@@ -83,7 +83,13 @@ pimcore.object.classes.data.wysiwyg = Class.create(pimcore.object.classes.data.d
                 value: datax.toolbarConfig,
                 width:400,
                 height:150
+            }, {
+                xtype: "checkbox",
+                fieldLabel: t("exclude_from_search_index"),
+                name: "excludeFromSearchIndex",
+                checked: datax.excludeFromSearchIndex
             }
+
         ];
     },
 

--- a/bundles/CoreBundle/Resources/translations/de.extended.json
+++ b/bundles/CoreBundle/Resources/translations/de.extended.json
@@ -700,6 +700,5 @@
     "custom_login_background_image": "Custom Login Background Image",
     "show_charcount": "Show Character Count",
     "max_length": "Max Length",
-    "exclude_from_search_index": "Aus Suchindex ausschließen",
     "reverse_many_to_many_object_relation": "Reverse Many-To-Many Object Relation"
 }

--- a/bundles/CoreBundle/Resources/translations/de.extended.json
+++ b/bundles/CoreBundle/Resources/translations/de.extended.json
@@ -700,5 +700,6 @@
     "custom_login_background_image": "Custom Login Background Image",
     "show_charcount": "Show Character Count",
     "max_length": "Max Length",
+    "exclude_from_search_index": "Aus Suchindex ausschließen",
     "reverse_many_to_many_object_relation": "Reverse Many-To-Many Object Relation"
 }

--- a/bundles/CoreBundle/Resources/translations/en.extended.json
+++ b/bundles/CoreBundle/Resources/translations/en.extended.json
@@ -701,5 +701,5 @@
   "refresh_preview": "Refresh Preview",
   "show_charcount": "Show Character Count",
   "max_length": "Max Length",
-  "exclude_from_search_index": "Exclude from Search Index"
+  "exclude_from_search_index": "Exclude from Backend Full-Text Search"
 }

--- a/bundles/CoreBundle/Resources/translations/en.extended.json
+++ b/bundles/CoreBundle/Resources/translations/en.extended.json
@@ -700,5 +700,6 @@
   "operator_renderer_settings": "Renderer Settings",
   "refresh_preview": "Refresh Preview",
   "show_charcount": "Show Character Count",
-  "max_length": "Max Length"
+  "max_length": "Max Length",
+  "exclude_from_search_index": "Exclude from Search Index"
 }

--- a/models/DataObject/ClassDefinition/Data/Textarea.php
+++ b/models/DataObject/ClassDefinition/Data/Textarea.php
@@ -54,6 +54,11 @@ class Textarea extends Data implements ResourcePersistenceAwareInterface, QueryR
     public $showCharCount;
 
     /**
+     * @var bool
+     */
+    public $excludeFromSearchIndex = false;
+
+    /**
      * Type for the column to query
      *
      * @var string
@@ -144,6 +149,23 @@ class Textarea extends Data implements ResourcePersistenceAwareInterface, QueryR
     public function setShowCharCount($showCharCount)
     {
         $this->showCharCount = $showCharCount;
+    }
+    
+    /**
+     * @return bool
+     */
+    public function isExcludeFromSearchIndex(): bool
+    {
+        return $this->excludeFromSearchIndex;
+    }
+
+    /**
+     * @param bool $excludeFromSearchIndex
+     */
+    public function setExcludeFromSearchIndex(bool $excludeFromSearchIndex)
+    {
+        $this->excludeFromSearchIndex = $excludeFromSearchIndex;
+        return $this;
     }
 
     /**
@@ -240,6 +262,23 @@ class Textarea extends Data implements ResourcePersistenceAwareInterface, QueryR
             return $value;
         } else {
             return '';
+        }
+    }
+
+    /**
+     * @see Model\DataObject\ClassDefinition\Data::getDataForSearchIndex
+     *
+     * @param null|Model\DataObject\AbstractObject $object
+     * @param mixed $params
+     *
+     * @return string
+     */
+    public function getDataForSearchIndex($object, $params = [])
+    {
+        if ($this->isExcludeFromSearchIndex()) {
+            return "";
+        } else {
+            return parent::getDataForSearchIndex($object, $params);
         }
     }
 

--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -73,6 +73,12 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
     public $toolbarConfig = '';
 
     /**
+     * @var bool
+     */
+    public $excludeFromSearchIndex = false;
+
+
+    /**
      * @return int
      */
     public function getWidth()
@@ -133,6 +139,23 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
     }
 
     /**
+     * @return bool
+     */
+    public function isExcludeFromSearchIndex(): bool
+    {
+        return $this->excludeFromSearchIndex;
+    }
+
+    /**
+     * @param bool $excludeFromSearchIndex
+     */
+    public function setExcludeFromSearchIndex(bool $excludeFromSearchIndex)
+    {
+        $this->excludeFromSearchIndex = $excludeFromSearchIndex;
+        return $this;
+    }
+
+    /**
      * @see ResourcePersistenceAwareInterface::getDataForResource
      *
      * @param string $data
@@ -181,6 +204,23 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
         $data = preg_replace('#[ ]+#', ' ', $data);
 
         return $data;
+    }
+
+    /**
+     * @see Model\DataObject\ClassDefinition\Data::getDataForSearchIndex
+     *
+     * @param null|Model\DataObject\AbstractObject $object
+     * @param mixed $params
+     *
+     * @return string
+     */
+    public function getDataForSearchIndex($object, $params = [])
+    {
+        if ($this->isExcludeFromSearchIndex()) {
+            return "";
+        } else {
+            return parent::getDataForSearchIndex($object, $params);
+        }
     }
 
     /**


### PR DESCRIPTION
Feature: exclude wysiwyg and textarea contents from the Pimcore backend search.
Use cases:
- exclude sensitive information in search result
- exclude irrelevant data and reduce the fulltext search index size.