### PR TITLE
WebTestCase: ensure on Kernel::shutdown a container was instantiated

### DIFF
--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -171,8 +171,10 @@ abstract class Kernel extends SymfonyKernel
      */
     public function shutdown()
     {
-        // cleanup runtime cache, doctrine, monolog ... to free some memory and avoid locking issues
-        $this->container->get(\Pimcore\Helper\LongRunningHelper::class)->cleanUp();
+        if (true === $this->booted) {
+            // cleanup runtime cache, doctrine, monolog ... to free some memory and avoid locking issues
+            $this->container->get(\Pimcore\Helper\LongRunningHelper::class)->cleanUp();
+        }
 
         return parent::shutdown();
     }


### PR DESCRIPTION
If a WebTestCase with two or more test methods is used there will be a php error `Call to a member function get() on null`. After every test method the kernel will be shutdown and on every `bootKernel` will be ensured the kernel has been shutdown. Therefore it must be checked if there is a container instantiated.