### PR TITLE
Fixed a bug with isValidCartItem()

### DIFF
--- a/bundles/EcommerceFrameworkBundle/CartManager/AbstractCartItem.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/AbstractCartItem.php
@@ -35,7 +35,7 @@ abstract class AbstractCartItem extends \Pimcore\Model\AbstractModel implements 
      * @var ICheckoutable
      */
     protected $product;
-    protected $productId;
+    protected $productId = null;
     protected $itemKey;
     protected $count;
     protected $comment;
@@ -133,7 +133,7 @@ abstract class AbstractCartItem extends \Pimcore\Model\AbstractModel implements 
      */
     public function getProductId()
     {
-        if ($this->productId) {
+        if (!is_null($this->productId)) {
             return $this->productId;
         }
 


### PR DESCRIPTION
`\Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\AbstractCart::isValidCartItem()` fails with an error "Call to a member function getId() on null" when trying to log a warning.
productId "0" was being handled as "unknown" in `AbstractCartItem::getProductId()`, trying to obtain the Item's object to get it's Id, which fails since the Id is not valid.
This patch fixes this.