### PR TITLE
Use proper binary KiB, MiB, ... for base 2 numbering in formatBytes()

### DIFF
--- a/lib/helper-functions.php
+++ b/lib/helper-functions.php
@@ -285,7 +285,7 @@ function return_bytes($val)
  */
 function formatBytes($bytes, $precision = 2)
 {
-    $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    $units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
 
     $bytes = max($bytes, 0);
     $pow = floor(($bytes ? log($bytes) : 0) / log(1024));


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Kibibyte