### PR TITLE
Key of assoc array is lost when using the webservice

### DIFF
--- a/models/Webservice/Data/Mapper.php
+++ b/models/Webservice/Data/Mapper.php
@@ -98,9 +98,9 @@ abstract class Mapper
             }
         } elseif (is_array($object)) {
             $tmpArray = [];
-            foreach ($object as $v) {
+            foreach ($object as $k => $v) {
                 $className = self::findWebserviceClass($v, $type);
-                $tmpArray[] = self::map($v, $className, $type);
+                $tmpArray[$k] = self::map($v, $className, $type);
             }
             $object = $tmpArray;
         }


### PR DESCRIPTION
# How to reproduce

- Go to any Pimcore site (with the webservice available) `<host>/webservice/rest/document/id/<existing-document-id>`.
- Add an area block to the document, if none is available.
- Find the area block by utilizing the browsers seach bar (search for _areablock_).
- Under value/indices you will see that there are a few entries (non-associative).

# What the commit does

- Adds the keys to the non-associative arrays, therefore the information is not lost.

# Why it is useful
When using the webservice to acquire information about a document (and its content), one could not programmatically access the type of the brick within the area block (for example), unless index `1` is considered to _always_ be the type (which might change in the future).