### PR TITLE
Fix class name in PageSnippet::getUrl to work properly when used in a Site

### DIFF
--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -614,7 +614,7 @@ abstract class PageSnippet extends Model\Document
         $url = $scheme . $hostname . $this->getFullPath();
 
         $site = \Pimcore\Tool\Frontend::getSiteForDocument($this);
-        if ($site instanceof Site && $site->getMainDomain()) {
+        if ($site instanceof Model\Site && $site->getMainDomain()) {
             $url = $scheme . $site->getMainDomain() . preg_replace('@^' . $site->getRootPath() . '/?@', '/', $this->getRealFullPath());
         }
 


### PR DESCRIPTION
The link generated for the new "Open in new Window"-Button does not work for Documents in a Site because PageSnippet::getUrl never uses the code to handle the url for a Site. It generates invalid urls that result in a 404 error.
This happens because the class name "Site" is not properly resolved.
Either add a 
use Pimcore\Model\Site;
or change the if contition to use the class name "Model\Site" instead of "Site".
