### PR TITLE
[Versions] Handle incompatible/ missing class more gracefully

### DIFF
--- a/models/Version.php
+++ b/models/Version.php
@@ -299,6 +299,11 @@ class Version extends AbstractModel
 
         if ($this->getSerialized()) {
             $data = Serialize::unserialize($data);
+            if(get_class($data) == '__PHP_Incomplete_Class'){
+                Logger::err('Version: cannot read version data from file system becaus of incompatible class.');
+                $this->delete();
+                return;
+            }
         }
 
         if ($data instanceof Concrete) {

--- a/models/Version.php
+++ b/models/Version.php
@@ -301,7 +301,6 @@ class Version extends AbstractModel
             $data = Serialize::unserialize($data);
             if(get_class($data) == '__PHP_Incomplete_Class'){
                 Logger::err('Version: cannot read version data from file system becaus of incompatible class.');
-                $this->delete();
                 return;
             }
         }


### PR DESCRIPTION
If a version file contains a class which doesn't exist anymore we get a " __PHP_Incomplete_Class" response. 
Therefore the we can't open the object anymore in the pimcore admin.

In this case -> delete the version as it is done if we can't get the data. 