### PR TITLE
Fix: Translation of predefined properties doesn't work

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/properties.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/properties.js
@@ -34,7 +34,7 @@ pimcore.element.properties = Class.create({
                     {
                         name:"translatedName",
                         convert: function(v, rec){
-                            return ts(rec.name);
+                            return ts(rec.data.name);
                         }
                     }
                 ],
@@ -51,7 +51,7 @@ pimcore.element.properties = Class.create({
 
             var predefinedcombo = new Ext.form.ComboBox({
                 name: "type",
-                displayField:'name',
+                displayField:'translatedName',
                 valueField: "id",
                 store: predefinedPropertiesStore,
                 editable: false,


### PR DESCRIPTION
### Steps to reproduce

1. Create a predefined property
2. Open predefined property select in a document
3. Go to Admin translations (The property name doesn't exist)
4. Create Admin translation
5. Open predefined property select in a document (Predefined Properties are not translated)