### PR TITLE
Expose all classes and interfaces of DataObjects for js

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -377,6 +377,9 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                     $objectData['general'][$key] = $value;
                 }
             }
+            
+            $objectData['general']['php']['classes'] = array_merge([get_class($object)], array_values(class_parents($object)));
+            $objectData['general']['php']['interfaces'] = array_values(class_implements($object));
 
             $objectData['general']['o_locked'] = $object->isLocked();
 


### PR DESCRIPTION
add interfaces and classes to the js data.

This allows very clean code for example in listeners: 
```   
postSaveObject: function (object, task) {
        if(object.data.general.php.interfaces.includes('AppBundle\\Model\\DataObject\\MyInterface')) {
            console.log('do something');
        }
    }
```