### PR TITLE
Bugfix: AbstractBatchProcessingWorker getDefaultDataForIndex() should respect tenantConfig

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
@@ -89,7 +89,7 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements I
      */
     protected function getDefaultDataForIndex(IIndexable $object, $subObjectId)
     {
-        $categories = $object->getCategories();
+        $categories = $this->tenantConfig->getCategories($object);
         $categoryIds = [];
         $parentCategoryIds = [];
         $categoryIdPaths = [];


### PR DESCRIPTION
In the AbstractBatchProcessingWorker when you call getDefaultDataForIndex the getCategories method is hardcoded to the object. 
It would be better to use the tenantconfig here. (like on all the other workers) 
So you can use a different function/field to retrieve "categories" for your object even if you already have categories defined in your object. 
