### PR TITLE
Empty role prevents login fix

### DIFF
--- a/bundles/AdminBundle/Security/User/User.php
+++ b/bundles/AdminBundle/Security/User/User.php
@@ -77,9 +77,9 @@ class User implements UserInterface, EquatableInterface, GoogleTwoFactorInterfac
 
         foreach ($this->user->getRoles() as $roleId) {
             /** @var PimcoreUser\Role $role */
-            $role = PimcoreUser\Role::getById($roleId);
-
-            $roles[] = 'ROLE_' . strtoupper($role->getName());
+            if($role = PimcoreUser\Role::getById($roleId)) {
+                $roles[] = 'ROLE_' . strtoupper($role->getName());
+            }
         }
 
         return $roles;


### PR DESCRIPTION
Not sure how this occurs but somethimes the roleId of a User can be empty - that results in a boolean value trying to call ->getName() and prevents the User from logging in.