### PR TITLE
Detecting UTF-16 encoding fails in CSV import

### DIFF
--- a/lib/Tool/Text.php
+++ b/lib/Tool/Text.php
@@ -368,14 +368,31 @@ class Text
      */
     public static function detectEncoding($text)
     {
+        // Detect UTF-8, UTF-16 and UTF-32 by BOM
+        $utf32_big_endian_bom =     chr(0x00) . chr(0x00) . chr(0xFE) . chr(0xFF);
+        $utf32_little_endian_bom =  chr(0xFF) . chr(0xFE) . chr(0x00) . chr(0x00);
+        $utf16_big_endian_bom =     chr(0xFE) . chr(0xFF);
+        $utf16_little_endian_bom =  chr(0xFF) . chr(0xFE);
+        $utf8_bom =                 chr(0xEF) . chr(0xBB) . chr(0xBF);
+
+        $first2bytes = substr($text, 0, 2);
+        $first3bytes = substr($text, 0, 3);
+        $first4bytes = substr($text, 0, 3);
+
+        if ($first3bytes === $utf8_bom) {
+            return 'UTF-8';
+        } else if ($first4bytes === $utf32_big_endian_bom) {
+            return 'UTF-32BE';
+        } else if ($first4bytes === $utf32_little_endian_bom) {
+            return 'UTF-32LE';
+        } else if ($first2bytes === $utf16_big_endian_bom) {
+            return 'UTF-16BE';
+        } else if ($first2bytes === $utf16_little_endian_bom) {
+            return 'UTF-16LE';
+        }
+
         if (function_exists('mb_detect_encoding')) {
             $encoding = mb_detect_encoding($text, [
-                'UTF-32',
-                'UTF-32BE',
-                'UTF-32LE',
-                'UTF-16',
-                'UTF-16BE',
-                'UTF-16LE',
                 'UTF-8',
                 'UTF-7',
                 'UTF7-IMAP',


### PR DESCRIPTION
Importing a UTF-16 encoded file was not possible for me, since the encoding detection failed and the following conversion to UTF-8 messed up the file. According to the docs at http://php.net/manual/de/function.mb-detect-order.php, detection of UTF-8 and UTF-16 is not supported and will always fail. That why I've taken the BOM detection approach from http://php.net/manual/en/function.mb-detect-encoding.php#91051 and added it to the `detectEncoding` method.