### PR TITLE
Remove redundant isValidPassword helper function

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -2639,14 +2639,6 @@ pimcore.helpers.getNicePathHandlerStore = function (store, config, gridView, res
 
 };
 
-pimcore.helpers.isValidPassword = function (pass) {
-    var passRegExp = /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[^a-zA-Z0-9])(?!.*\s).{10,}$/;
-    if (!pass.match(passRegExp)) {
-        return false;
-    }
-    return true;
-};
-
 pimcore.helpers.csvExportWarning = function (callback) {
 
     var iconComponent = new Ext.Component({


### PR DESCRIPTION
This function is also defined in line 2765
https://github.com/pimcore/pimcore/blob/f778e30b42aae7e4a771788d6f3b1ced85b874c2/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js#L2642-L2648

https://github.com/pimcore/pimcore/blob/f778e30b42aae7e4a771788d6f3b1ced85b874c2/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js#L2765-L2771