### PR TITLE
[Bug] ObjectBrick import does not import title & group

### DIFF
--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -223,6 +223,8 @@ class Service
 
         $objectBrick->setClassDefinitions($toAssignClassDefinitions);
         $objectBrick->setParentClass($importData['parentClass']);
+        $objectBrick->setTitle($importData['title']);
+        $objectBrick->setGroup($importData['group']);
         $objectBrick->save();
 
         return true;

--- a/tests/_support/Resources/objects/brick-import.json
+++ b/tests/_support/Resources/objects/brick-import.json
@@ -5,6 +5,8 @@
 			"fieldname":"mybricks"
 		}
 	],
+  "title":"",
+  "group":"",
 	"parentClass":"",
 	"layoutDefinitions":{
 		"fieldtype":"panel",


### PR DESCRIPTION
## Changes in this pull request  
ObjectBrick import currently only sets parent class in general settings, but ignores title and group

## Additional Info
To reproduce:
- Create an object brick
- Set parent class, title and group in general settings
- Export object brick
- Delete object brick
- Create new and empty object brick
- Import from json
- Title & group fields are empty