### PR TITLE
Add option to reload csv import column configuration

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1488,6 +1488,8 @@ class DataObjectHelperController extends AdminController
     public function importGetFileInfoAction(Request $request, ImportService $importService)
     {
         $importConfigId = $request->get('importConfigId');
+        $dialect = $request->get('dialect');
+        $dialect = json_decode($request->get('dialect'));
         $success = true;
         $supportedFieldTypes = ['checkbox', 'country', 'date', 'datetime', 'href', 'image', 'input', 'language', 'table', 'multiselect', 'numeric', 'password', 'select', 'slider', 'textarea', 'wysiwyg', 'objects', 'multihref', 'geopoint', 'geopolygon', 'geobounds', 'link', 'user', 'email', 'gender', 'firstname', 'lastname', 'newsletterActive', 'newsletterConfirmed', 'countrymultiselect', 'objectsMetadata'];
 
@@ -1496,7 +1498,10 @@ class DataObjectHelperController extends AdminController
 
         $originalFile = $file . '_original';
         // determine type
-        $dialect = Tool\Admin::determineCsvDialect($file . '_original');
+        if (empty($dialect)) {
+            $dialect = Tool\Admin::determineCsvDialect($file . '_original');
+        }
+
 
         $count = 0;
         if (($handle = fopen($originalFile, 'r')) !== false) {
@@ -1559,7 +1564,10 @@ class DataObjectHelperController extends AdminController
         } catch (\Exception $e) {
         }
 
-        $dialect->lineterminator = bin2hex($dialect->lineterminator);
+        //ignore if lineterminator is already hex otherwise generate hex for string
+        if (!empty($dialect->lineterminator) && empty(preg_match('/[a-f0-9]{2}/i', $dialect->lineterminator))) {
+            $dialect->lineterminator = bin2hex($dialect->lineterminator);
+        }
 
         $selectedGridColumns = [];
         if ($importConfig) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/import/configDialog.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/import/configDialog.js
@@ -31,7 +31,7 @@ pimcore.object.helpers.import.configDialog = Class.create({
         if (config.mode == "direct") {
             this.uniqueImportId = config.uniqueImportId;
             this.parentId = config.parentId;
-            this.getFileInfo(false, config.importConfigId);
+            this.getFileInfo(false, config.importConfigId, null);
         } else {
             this.showUpload();
         }
@@ -191,7 +191,7 @@ pimcore.object.helpers.import.configDialog = Class.create({
         return title;
     },
 
-    getFileInfo: function (isReload, importConfigId) {
+    getFileInfo: function (isReload, importConfigId, dialect) {
         Ext.Ajax.request({
             url: "/admin/object-helper/import-get-file-info",
             params: {
@@ -199,7 +199,8 @@ pimcore.object.helpers.import.configDialog = Class.create({
                 importId: this.uniqueImportId,
                 method: "post",
                 className: this.className,          //TODO really needed ?
-                classId: this.classId
+                classId: this.classId,
+                dialect: dialect
             },
             success: this.getFileInfoComplete.bind(this, isReload)
         });
@@ -503,7 +504,7 @@ pimcore.object.helpers.import.configDialog = Class.create({
                     iconCls: "pimcore_icon_apply",
                     handler: function (configsCombo) {
                         if (configsCombo.getValue()) {
-                            this.getFileInfo(true, configsCombo.getValue());
+                            this.getFileInfo(true, configsCombo.getValue(), null);
                             this.loadWindow.close();
                         }
                     }.bind(this, configsCombo)

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -864,5 +864,7 @@
   "recipient": "Recipient",
   "this_field_is_required": "This field is required",
   "paste_recursive_as_language_variant": "Paste as new language variant (recursive)",
-  "paste_no_new_language_error": "All system languages already linked to source element."
+  "paste_no_new_language_error": "All system languages already linked to source element.",
+  "reload_column_configuration": "Reload column configuration",
+  "reload_column_configuration_notice": "Note: Reloading column configuration will reset selected grid columns"
 }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #3864 

## Additional info  
Added button to reload column configuration(with csv settings changes) on Import configuration
![refresh_csvimport](https://user-images.githubusercontent.com/5137917/52627746-187c6880-2edc-11e9-880b-6b0e6baaecf4.png)

