### PR TITLE
[Data Object] Custom Layouts: allow spaces in names

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
@@ -763,7 +763,7 @@ pimcore.object.helpers.customLayoutEditor = Class.create({
     save: function () {
         var id = this.layoutChangeCombo.getValue();
 
-        var regresult = this.data["name"].match(/[a-zA-Z][a-zA-Z0-9]+/);
+        var regresult = this.data["name"].match(/[a-zA-Z ][a-zA-Z0-9 ]+/);
 
         if (this.data["name"].length > 2 && this.data["name"].length < 64 && regresult == this.data["name"]) {
             this.saveCurrentNode();


### PR DESCRIPTION
## Changes in this pull request  
Fixed custom layout saving

1. Remove preg match and create custom layout with name like "My Test Custom Layout" like allowed before preg_match intoduction.
2. Add preg match again and try to save layout. You get "Invalid name" message.

