### PR TITLE
Improvement: show file name separately from path in asset grid view

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -2386,6 +2386,7 @@ class AssetController extends ElementControllerBase implements EventedController
                         'id' => $asset->getid(),
                         'type' => $asset->getType(),
                         'fullpath' => $asset->getRealFullPath(),
+                        'filename' => $asset->getKey(),
                         'creationDate' => $asset->getCreationDate(),
                         'modificationDate' => $asset->getModificationDate(),
                         'size' => formatBytes($size),

--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/listfolder.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/listfolder.js
@@ -56,13 +56,14 @@ pimcore.asset.listfolder = Class.create({
             }
         });
 
-        var readerFields = ['id', 'fullpath','type', 'creationDate', 'modificationDate', 'size', 'idPath'];
+        var readerFields = ['id', 'fullpath', 'filename', 'type', 'creationDate', 'modificationDate', 'size', 'idPath'];
 
         this.selectionColumn = new Ext.selection.CheckboxModel();
 
         var typesColumns = [
             {text: t("id"), sortable: true, dataIndex: 'id', editable: false, flex: 40, filter: 'numeric'},
-            {text: t("filename"), sortable: true, dataIndex: 'fullpath', editable: false, flex: 100, filter: 'string', renderer: Ext.util.Format.htmlEncode},
+            {text: t("filename"), sortable: true, dataIndex: 'filename', editable: false, flex: 100, filter: 'string', renderer: Ext.util.Format.htmlEncode},
+            {text: t("fullpath"), sortable: true, dataIndex: 'fullpath', editable: false, flex: 100, filter: 'string', renderer: Ext.util.Format.htmlEncode},
             {text: t("type"), sortable: true, dataIndex: 'type', editable: false, flex: 50, filter: 'string'}
         ];
 


### PR DESCRIPTION
Some users it may find it confusing to see the path in the `filename` column, thus, the `filename` column should only show the `key` of an asset.

This also increases the usability of the grid view (for assets).

This PR adds the `filename` column (event though it just looks like the `fullpath` column was added).
