### PR TITLE
[DocType] Fix: Predefined Document Type Select in Settings Tab

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -618,7 +618,15 @@ class DocumentController extends ElementControllerBase implements EventedControl
 
         $docTypes = [];
         foreach ($list->getDocTypes() as $type) {
-            $docTypes[] = $type;
+            $docTypes[] = [
+                'id' => $type->getId(),
+                'module' => $type->getModule(),
+                'controller' => $type->getController(),
+                'action' => $type->getAction(),
+                'template' => $type->getTemplate(),
+                'group' => $type->getGroup(),
+                'name' => $type->getName(),
+            ];
         }
 
         return $this->adminJson(['docTypes' => $docTypes]);

--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -618,15 +618,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
 
         $docTypes = [];
         foreach ($list->getDocTypes() as $type) {
-            $docTypes[] = [
-                'id' => $type->getId(),
-                'module' => $type->getModule(),
-                'controller' => $type->getController(),
-                'action' => $type->getAction(),
-                'template' => $type->getTemplate(),
-                'group' => $type->getGroup(),
-                'name' => $type->getName(),
-            ];
+            $docTypes[] = $type->getObjectVars();
         }
 
         return $this->adminJson(['docTypes' => $docTypes]);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/settings_abstract.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/settings_abstract.js
@@ -208,7 +208,9 @@ pimcore.document.settings_abstract = Class.create({
             },
             fields: ["id","module","controller","action","template",{
                name: 'name',
-               convert: function(v, rec) { return rec['data']['group'] +' > '+ t(rec['data']['name']) }
+               convert: function(v, rec) {
+                   return (rec['data']['group'] ? ' > ' + rec['data']['group'] : '') + rec['data']['name'];
+               }
             }]
 
         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/settings_abstract.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/settings_abstract.js
@@ -208,7 +208,7 @@ pimcore.document.settings_abstract = Class.create({
             },
             fields: ["id","module","controller","action","template",{
                name: 'name',
-               convert: function(v, rec) { return rec['data']['group'] +' > '+ rec['data']['name'] }
+               convert: function(v, rec) { return rec['data']['group'] +' > '+ t(rec['data']['name']) }
             }]
 
         });

--- a/models/Document/DocType/Listing.php
+++ b/models/Document/DocType/Listing.php
@@ -32,7 +32,7 @@ class Listing extends Model\Listing\JsonListing
     public $docTypes = [];
 
     /**
-     * @return array
+     * @return \Pimcore\Model\Document\DocType[]
      */
     public function getDocTypes()
     {


### PR DESCRIPTION
## Changes in this pull request  
In the moment the select shows only undefined > undefined and doesn't work.

## Additional info  

