### PR TITLE
Better performance for loading field collections / blocks

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/block.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/block.js
@@ -76,6 +76,7 @@ pimcore.object.tags.block = Class.create(pimcore.object.tags.abstract, {
         if(this.data.length < 1) {
             this.component.add(this.getControls());
         } else {
+            Ext.suspendLayouts();
             for (var i=0; i<this.data.length; i++) {
                 this.addBlockElement(
                     i,
@@ -85,6 +86,7 @@ pimcore.object.tags.block = Class.create(pimcore.object.tags.abstract, {
                     this.data[i].data,
                     true);
             }
+            Ext.resumeLayouts();
         }
 
         this.component.updateLayout();

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
@@ -116,7 +116,6 @@ pimcore.object.tags.fieldcollections = Class.create(pimcore.object.tags.abstract
     },
 
     initData: function (response) {
-
         var collectionData = Ext.decode(response.responseText);
         this.fieldcollections = collectionData.fieldcollections;
         this.layoutDefinitions = collectionData.layoutDefinitions;
@@ -124,6 +123,7 @@ pimcore.object.tags.fieldcollections = Class.create(pimcore.object.tags.abstract
         if(this.data.length < 1) {
             this.component.add(this.getControls());
         } else {
+            Ext.suspendLayouts();
             for (var i=0; i<this.data.length; i++) {
                 this.addBlockElement(
                     i,
@@ -135,6 +135,7 @@ pimcore.object.tags.fieldcollections = Class.create(pimcore.object.tags.abstract
                     this.data[i].data,
                     true);
             }
+            Ext.resumeLayouts();
         }
 
         this.component.updateLayout();


### PR DESCRIPTION
Loading field collections in Pimcore's backend with e.g. > 20 items can be quite slow. According to https://www.sencha.com/blog/performance-optimization-for-layout-runs/ it is a best practice to not redraw ExtJS component for every child item but to suspend layout calls until all child items have been added. 
Especially field collections and blocks would profit by suspending layout updates. If you can imagine this to be useful also for other data types please comment.

Performance comparison (for a field collection with 47 items) for reloading object:
Without suspending layout: 116 seconds
With suspending layout: 24 seconds