### PR TITLE
[WebsiteSettings] getByName shouldn't log a warning

### DIFF
--- a/models/WebsiteSetting.php
+++ b/models/WebsiteSetting.php
@@ -117,8 +117,6 @@ class WebsiteSetting extends AbstractModel
         try {
             $setting->getDao()->getByName($name, $siteId, $language);
         } catch (\Exception $e) {
-            Logger::warning($e->getMessage());
-
             if ($language != $fallbackLanguage) {
                 $result = self::getByName($name, $siteId, $fallbackLanguage, $fallbackLanguage);
 


### PR DESCRIPTION
I think the WebsiteSetting::getByName function shouln't log an warning, if the setting doesn't exists.

It is impossible to check if a website settings does exists. So I can't avoid this warning.

Other get functions also doesn't log warnings. Return null should be enough.

