### PR TITLE
Thumbnail - preserve color space

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -456,7 +456,10 @@ class Imagick extends Adapter
             }
 
             $this->resource->readImage($this->imagePath);
-            $this->setColorspaceToRGB();
+
+            if (!$this->isPreserveColor()) {
+                $this->setColorspaceToRGB();
+            }
         }
 
         $width = (int)$width;


### PR DESCRIPTION
Do not change the colorspace if "PreserveColor" is set. Otherwise cmyk images would be converted to rgb...
