### PR TITLE
Improvement: support workflow permissions for all element types

### DIFF
--- a/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
+++ b/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
@@ -152,18 +152,18 @@ class WorkflowManagementListener implements EventSubscriberInterface
                 'globalActions' => $globalActions
             ];
 
-            if ($element instanceof ConcreteObject) {
-                $marking = $workflow->getMarking($element);
+            $marking = $workflow->getMarking($element);
 
-                if (!sizeof($marking->getPlaces())) {
-                    continue;
-                }
+            if (!sizeof($marking->getPlaces())) {
+                continue;
+            }
 
-                $permissionsRespected = false;
-                foreach ($this->workflowManager->getOrderedPlaceConfigs($workflow, $marking) as $placeConfig) {
-                    if (!$permissionsRespected && !empty($placeConfig->getPermissions($workflow, $element))) {
-                        $data['userPermissions'] = array_merge((array)$data['userPermissions'], $placeConfig->getUserPermissions($workflow, $element));
+            $permissionsRespected = false;
+            foreach ($this->workflowManager->getOrderedPlaceConfigs($workflow, $marking) as $placeConfig) {
+                if (!$permissionsRespected && !empty($placeConfig->getPermissions($workflow, $element))) {
+                    $data['userPermissions'] = array_merge((array)$data['userPermissions'], $placeConfig->getUserPermissions($workflow, $element));
 
+                    if ($element instanceof ConcreteObject) {
                         $workflowLayoutId = $placeConfig->getObjectLayout($workflow, $element);
                         $hasSelectedCustomLayout = $this->requestStack->getMasterRequest() && $this->requestStack->getMasterRequest()->query->has('layoutId') && $this->requestStack->getMasterRequest()->query->get('layoutId') !== '';
 
@@ -185,8 +185,8 @@ class WorkflowManagementListener implements EventSubscriberInterface
                                 }
                             }
                         }
-                        $permissionsRespected = true;
                     }
+                    $permissionsRespected = true;
                 }
             }
         }


### PR DESCRIPTION
# Why merge?
The `WorkflowManagementListener` only allows to use permissions for elements of type `ConcreteObject`. However, in some situations it may be needed to restrict permissions for other element types (such as documents, and assets).

# What changed?
The code of the `WorkflowManagementListener` was updated to also allow other element types.

