### PR TITLE
[WebsiteSettings] getData should lazy load like Property class

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5/README.md
@@ -1,11 +1,11 @@
 # Upgrade Notes for Upgrades within Pimcore 5
 
 ## Version 5.7.0
-- `WebsiteSetting` properties are now `protected` instead of `public`
+- `\Pimcore\Model\WebsiteSetting` and `\Pimcore\Model\Property` properties are now `protected` instead of `public`
 
 ## Version 5.6.4
 
-- `Pimcore\Model\DataObject\Localizedfield` properties are now `protected` instead of `public` 
+- `\Pimcore\Model\DataObject\Localizedfield` properties are now `protected` instead of `public` 
 
 ## Version 5.6.0
 - Removed method `\Pimcore\Model\DataObject\ClassDefinition\Data::setFieldtype($fieldtype)`

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5/README.md
@@ -1,5 +1,8 @@
 # Upgrade Notes for Upgrades within Pimcore 5
 
+## Version 5.7.0
+- `WebsiteSetting` properties are now `protected` instead of `public`
+
 ## Version 5.6.4
 
 - `Pimcore\Model\DataObject\Localizedfield` properties are now `protected` instead of `public` 

--- a/models/Property.php
+++ b/models/Property.php
@@ -28,42 +28,42 @@ class Property extends AbstractModel
     /**
      * @var string
      */
-    public $name;
+    protected $name;
 
     /**
      * @var mixed
      */
-    public $data;
+    protected $data;
 
     /**
      * @var string
      */
-    public $type;
+    protected $type;
 
     /**
      * @var string
      */
-    public $ctype;
+    protected $ctype;
 
     /**
      * @var string
      */
-    public $cpath;
+    protected $cpath;
 
     /**
      * @var int
      */
-    public $cid;
+    protected $cid;
 
     /**
      * @var bool
      */
-    public $inheritable;
+    protected $inheritable;
 
     /**
      * @var bool
      */
-    public $inherited = false;
+    protected $inherited = false;
 
     /**
      * Takes data from editmode and convert it to internal objects

--- a/models/Webservice/Data.php
+++ b/models/Webservice/Data.php
@@ -85,9 +85,9 @@ abstract class Data
     }
 
     /**
-     * @param $value
+     * @param array $value
      *
-     * @return array
+     * @return \Pimcore\Model\Property[]
      */
     private function mapProperties($value)
     {
@@ -99,7 +99,8 @@ abstract class Data
                     $newProperty = new Model\Property();
                     $vars = get_object_vars($property);
                     foreach ($vars as $varName => $varValue) {
-                        $newProperty->$varName = $property->$varName;
+                        $method = 'set' . ucfirst($varName);
+                        $newProperty->$method($property->$varName);
                     }
                     $result[] = $newProperty;
                 } else {
@@ -123,7 +124,7 @@ abstract class Data
     {
         $keys = get_object_vars($this);
         foreach ($keys as $key => $value) {
-            $method = 'set' . $key;
+            $method = 'set' . ucfirst($key);
             if (method_exists($object, $method)) {
                 if ($object instanceof Element\ElementInterface && $key == 'properties') {
                     $value = $this->mapProperties($value);

--- a/models/WebsiteSetting.php
+++ b/models/WebsiteSetting.php
@@ -14,6 +14,9 @@
 
 namespace Pimcore\Model;
 
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\Element\Service;
+
 /**
  * @method \Pimcore\Model\WebsiteSetting\Dao getDao()
  * @method void save()
@@ -202,6 +205,11 @@ class WebsiteSetting extends AbstractModel
      */
     public function setData($data)
     {
+        if ($data instanceof ElementInterface) {
+            $this->setType(Service::getElementType($data));
+            $data = $data->getId();
+        }
+
         $this->data = $data;
 
         return $this;
@@ -212,6 +220,11 @@ class WebsiteSetting extends AbstractModel
      */
     public function getData()
     {
+        // lazy-load data of type asset, document, object
+        if (in_array($this->getType(), ['document', 'asset', 'object']) && !$this->data instanceof ElementInterface && is_numeric($this->data)) {
+            return Element\Service::getElementById($this->getType(), $this->data);
+        }
+
         return $this->data;
     }
 

--- a/models/WebsiteSetting.php
+++ b/models/WebsiteSetting.php
@@ -27,42 +27,42 @@ class WebsiteSetting extends AbstractModel
     /**
      * @var int
      */
-    public $id;
+    protected $id;
 
     /**
      * @var string
      */
-    public $name;
+    protected $name;
 
     /**
      * @var string
      */
-    public $language;
+    protected $language;
 
     /**
      * @var
      */
-    public $type;
+    protected $type;
 
     /**
      * @var
      */
-    public $data;
+    protected $data;
 
     /**
      * @var
      */
-    public $siteId;
+    protected $siteId;
 
     /**
      * @var
      */
-    public $creationDate;
+    protected $creationDate;
 
     /**
      * @var
      */
-    public $modificationDate;
+    protected $modificationDate;
 
     /**
      * this is a small per request cache to know which website setting is which is, this info is used in self::getByName()

--- a/models/WebsiteSetting.php
+++ b/models/WebsiteSetting.php
@@ -40,27 +40,27 @@ class WebsiteSetting extends AbstractModel
     protected $language;
 
     /**
-     * @var
+     * @var string
      */
     protected $type;
 
     /**
-     * @var
+     * @var mixed
      */
     protected $data;
 
     /**
-     * @var
+     * @var int
      */
     protected $siteId;
 
     /**
-     * @var
+     * @var int
      */
     protected $creationDate;
 
     /**
-     * @var
+     * @var int
      */
     protected $modificationDate;
 
@@ -97,9 +97,9 @@ class WebsiteSetting extends AbstractModel
 
     /**
      * @param string $name name of the config
-     * @param null $siteId site ID
-     * @param null $language language, if property cannot be found the value of property without language is returned
-     * @param null $fallbackLanguage fallback language
+     * @param int|null $siteId site ID
+     * @param string|null $language language, if property cannot be found the value of property without language is returned
+     * @param string|null $fallbackLanguage fallback language
      *
      * @return null|WebsiteSetting
      */
@@ -179,7 +179,7 @@ class WebsiteSetting extends AbstractModel
     }
 
     /**
-     * @param $creationDate
+     * @param int $creationDate
      *
      * @return $this
      */
@@ -191,7 +191,7 @@ class WebsiteSetting extends AbstractModel
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getCreationDate()
     {
@@ -199,7 +199,7 @@ class WebsiteSetting extends AbstractModel
     }
 
     /**
-     * @param $data
+     * @param mixed $data
      *
      * @return $this
      */
@@ -229,7 +229,7 @@ class WebsiteSetting extends AbstractModel
     }
 
     /**
-     * @param $modificationDate
+     * @param int $modificationDate
      *
      * @return $this
      */
@@ -241,7 +241,7 @@ class WebsiteSetting extends AbstractModel
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getModificationDate()
     {
@@ -249,7 +249,7 @@ class WebsiteSetting extends AbstractModel
     }
 
     /**
-     * @param $siteId
+     * @param int $siteId
      *
      * @return $this
      */
@@ -261,7 +261,7 @@ class WebsiteSetting extends AbstractModel
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getSiteId()
     {
@@ -269,7 +269,7 @@ class WebsiteSetting extends AbstractModel
     }
 
     /**
-     * @param $type
+     * @param string $type
      *
      * @return $this
      */
@@ -281,7 +281,7 @@ class WebsiteSetting extends AbstractModel
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getType()
     {

--- a/tests/_support/Util/TestHelper.php
+++ b/tests/_support/Util/TestHelper.php
@@ -39,7 +39,7 @@ class TestHelper
     }
 
     /**
-     * @param  array $properties
+     * @param \Pimcore\Model\Property[] $properties
      *
      * @return array
      *
@@ -53,22 +53,22 @@ class TestHelper
 
         if (is_array($properties)) {
             foreach ($properties as $key => $value) {
-                if ($value->type == 'asset' || $value->type == 'object' || $value->type == 'document') {
-                    if ($value->data instanceof ElementInterface) {
-                        $propertiesStringArray['property_' . $key . '_' . $value->type] = 'property_' . $key . '_' . $value->type . ':' . $value->data->getId();
+                if (in_array($value->getType(), ['document', 'asset', 'object'])) {
+                    if ($value->getData() instanceof ElementInterface) {
+                        $propertiesStringArray['property_' . $key . '_' . $value->getType()] = 'property_' . $key . '_' . $value->getType() . ':' . $value->getData()->getId();
                     } else {
-                        $propertiesStringArray['property_' . $key . '_' . $value->type] = 'property_' . $key . '_' . $value->type . ': null';
+                        $propertiesStringArray['property_' . $key . '_' . $value->getType()] = 'property_' . $key . '_' . $value->getType() . ': null';
                     }
-                } elseif ($value->type == 'date') {
-                    if ($value->data instanceof \DateTimeInterface) {
-                        $propertiesStringArray['property_' . $key . '_' . $value->type] = 'property_' . $key . '_' . $value->type . ':' . $value->data->getTimestamp();
+                } elseif ($value->getType() === 'date') {
+                    if ($value->getData() instanceof \DateTimeInterface) {
+                        $propertiesStringArray['property_' . $key . '_' . $value->getType()] = 'property_' . $key . '_' . $value->getType() . ':' . $value->getData()->getTimestamp();
                     }
-                } elseif ($value->type == 'bool') {
-                    $propertiesStringArray['property_' . $key . '_' . $value->type] = 'property_' . $key . '_' . $value->type . ':' . (bool)$value->data;
-                } elseif ($value->type == 'text' || $value->type == 'select') {
-                    $propertiesStringArray['property_' . $key . '_' . $value->type] = 'property_' . $key . '_' . $value->type . ':' . $value->data;
+                } elseif ($value->getType() === 'bool') {
+                    $propertiesStringArray['property_' . $key . '_' . $value->getType()] = 'property_' . $key . '_' . $value->getType() . ':' . (bool)$value->getData();
+                } elseif (in_array($value->getType(), ['text', 'select'])) {
+                    $propertiesStringArray['property_' . $key . '_' . $value->getType()] = 'property_' . $key . '_' . $value->getType() . ':' . $value->getData();
                 } else {
-                    throw new \Exception('Unknown property of type [ ' . $value->type . ' ]');
+                    throw new \Exception('Unknown property of type [ ' . $value->getType() . ' ]');
                 }
             }
         }


### PR DESCRIPTION
The Property class loads the elements but the WebsiteSetting class doesn't:
https://github.com/pimcore/pimcore/blob/652a614a0c50d1b33212471e548e3cc96a517aad/models/Property.php#L140-L152

I know its a kind of bc break. Perhaps it is possible in 5.7.0 with a bc notice?
