### PR TITLE
Elasticsearch - add service definitions for version 5+6

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Resources/config/index_service_configs_workers.yml
+++ b/bundles/EcommerceFrameworkBundle/Resources/config/index_service_configs_workers.yml
@@ -71,6 +71,12 @@ services:
     Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Worker\DefaultElasticSearch:
         parent: Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Worker\AbstractWorker
 
+    Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Worker\ElasticSearch\DefaultElasticSearch5:
+        parent: Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Worker\ElasticSearch\AbstractElasticSearch
+
+    Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Worker\ElasticSearch\DefaultElasticSearch6:
+        parent: Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Worker\ElasticSearch\AbstractElasticSearch
+
     Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Worker\DefaultFactFinder:
         parent: Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Worker\AbstractWorker
 


### PR DESCRIPTION
Add service definitions. Otherwise

pimcore_ecommerce_framework:
    index_service:
        tenants:
            test:
                enabled: true
                config_id: Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\ElasticSearch
                worker_id: Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Worker\ElasticSearch\DefaultElasticSearch6

would not work.