### PR TITLE
[Targeting] allow to set custom VisitorInfo via event

### DIFF
--- a/lib/Event/Targeting/TargetingResolveVisitorInfoEvent.php
+++ b/lib/Event/Targeting/TargetingResolveVisitorInfoEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Event\Targeting;
+
+use Pimcore\Targeting\Model\VisitorInfo;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+
+class TargetingResolveVisitorInfoEvent extends TargetingEvent
+{
+    /**
+     * @param VisitorInfo $visitorInfo
+     */
+    public function setVisitorInfo(VisitorInfo $visitorInfo)
+    {
+        $this->visitorInfo = $visitorInfo;
+    }
+}

--- a/lib/Targeting/VisitorInfoResolver.php
+++ b/lib/Targeting/VisitorInfoResolver.php
@@ -21,6 +21,7 @@ use Doctrine\DBAL\Connection;
 use Pimcore\Debug\Traits\StopwatchTrait;
 use Pimcore\Event\Targeting\TargetingEvent;
 use Pimcore\Event\Targeting\TargetingRuleEvent;
+use Pimcore\Event\Targeting\TargetingResolveVisitorInfoEvent;
 use Pimcore\Event\TargetingEvents;
 use Pimcore\Model\Tool\Targeting\Rule;
 use Pimcore\Targeting\ActionHandler\ActionHandlerInterface;
@@ -103,10 +104,14 @@ class VisitorInfoResolver
             return $visitorInfo;
         }
 
+        $event = new TargetingResolveVisitorInfoEvent($visitorInfo);
+
         $this->eventDispatcher->dispatch(
             TargetingEvents::PRE_RESOLVE,
-            new TargetingEvent($visitorInfo)
+            $event
         );
+
+        $visitorInfo = $event->getVisitorInfo();
 
         $this->matchTargetingRuleConditions($visitorInfo);
 


### PR DESCRIPTION
This allows to define a custom VisitorInfo. I have currently the use-case where I track page-views and sessions manually, but still wanna use the Targeting Engine. With this little change, it is possible for me to write my own VisitorInfo "Resolver" by defining the Visitor based on an event.