### PR TITLE
[Video Editable] Fix: No poster if no thumbnail option is set

### DIFF
--- a/models/Document/Tag/Video.php
+++ b/models/Document/Tag/Video.php
@@ -788,12 +788,12 @@ class Video extends Model\Document\Tag
                 //"interactionCount" => "1234",
             ];
 
+            if (!$thumbnail) {
+                $thumbnail = $video->getImageThumbnail([]);
+            }
+
             if (!preg_match('@https?://@', $thumbnail)) {
-                if ($thumbnail) {
-                    $jsonLd['thumbnailUrl'] = Tool::getHostUrl() . $thumbnail;
-                } else {
-                    $jsonLd['thumbnailUrl'] = Tool::getHostUrl() . $video->getImageThumbnail([]);
-                }
+                $jsonLd['thumbnailUrl'] = Tool::getHostUrl() . $thumbnail;
             }
 
             $code .= "\n\n<script type=\"application/ld+json\">\n" . json_encode($jsonLd) . "\n</script>\n\n";


### PR DESCRIPTION
If I create a video editable without set the thumbnail option I get no poster.
```
{{ pimcore_video('video', {
    'attributes': {
        'class': 'video-js vjs-fluid vjs-default-skin vjs-big-play-centered',
        'data-setup': '{}'
    }
}) }}
```
