### PR TITLE
Add option to reset target groups for a visitor

### DIFF
--- a/lib/Targeting/ActionHandler/AssignTargetGroup.php
+++ b/lib/Targeting/ActionHandler/AssignTargetGroup.php
@@ -75,6 +75,11 @@ class AssignTargetGroup implements ActionHandlerInterface
         $this->assignToVisitor($visitorInfo, $targetGroup, $count);
     }
 
+    public function reset(VisitorInfo $visitorInfo)
+    {
+        $success = $this->deleteAssignments($visitorInfo);
+    }
+
     /**
      * Loads stored assignments from storage and applies it to visitor info
      *
@@ -119,6 +124,26 @@ class AssignTargetGroup implements ActionHandlerInterface
         );
 
         return $count;
+    }
+
+    protected function deleteAssignments(VisitorInfo $visitorInfo): bool
+    {
+        $data = array();
+
+        try{
+            $this->storage->set(
+                $visitorInfo,
+                TargetingStorageInterface::SCOPE_VISITOR,
+                self::STORAGE_KEY,
+                $data
+            );
+        }
+        catch (\Exception $e){
+            echo $e;
+            return false;
+        }
+
+        return true;
     }
 
     protected function assignToVisitor(VisitorInfo $visitorInfo, TargetGroup $targetGroup, int $count)


### PR DESCRIPTION
There is no possibility to remove target groups from a visitor. This does add a function to reset (remove) the target groups.
