### PR TITLE
Added objects-with-metadata-relation to supported non-owner-field-types.

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/reverseManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/reverseManyToManyObjectRelation.js
@@ -112,7 +112,7 @@ pimcore.object.classes.data.reverseManyToManyObjectRelation = Class.create(pimco
                     rootProperty: "availableFields"
                 },
                 extraParams: {
-                    types: 'manyToManyObjectRelation',
+                    types: 'manyToManyObjectRelation,advancedManyToManyObjectRelation',
                     name: this.datax.ownerClassName
                 }
             },


### PR DESCRIPTION
## Changes in this pull request  
Resolves/adds feature-request #3135 by adding objects-with-metadata type to list of allowed field-types when loading available fields for non-owner-object-relation in admin.

