### PR TITLE
do not throw exceptions when properties in data object versions do not exist any more

### DIFF
--- a/models/DataObject/Traits/ObjectVarTrait.php
+++ b/models/DataObject/Traits/ObjectVarTrait.php
@@ -55,12 +55,17 @@ trait ObjectVarTrait
     /**
      * @param $var mixed
      * @param $value mixed
+     * @param $silent bool
      *
      * @return $this
      */
-    public function setObjectVar($var, $value)
+    public function setObjectVar($var, $value, bool $silent = false)
     {
         if (!property_exists($this, $var)) {
+            if($silent) {
+                return $this;
+            }
+
             throw new \Exception('property ' . $var . ' does not exist');
         }
         $this->$var = $value;

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -657,13 +657,13 @@ class Service extends Model\AbstractModel
                 if ($data instanceof Model\AbstractModel) {
                     $properties = $data->getObjectVars();
                     foreach ($properties as $name => $value) {
-                        $data->setObjectVar($name, self::renewReferences($value, false, $name));
+                        $data->setObjectVar($name, self::renewReferences($value, false, $name), true);
                     }
                 } else {
                     $properties = method_exists($data, 'getObjectVars') ? $data->getObjectVars() : get_object_vars($data);
                     foreach ($properties as $name => $value) {
                         if (method_exists($data, 'setObjectVar')) {
-                            $data->setObjectVar($name, self::renewReferences($value, false, $name));
+                            $data->setObjectVar($name, self::renewReferences($value, false, $name), true);
                         } else {
                             $data->$name = self::renewReferences($value, false, $name);
                         }


### PR DESCRIPTION
Currently when for example someone deletes an object brick Pimcore will throw an Exception when someone tries to show a previous version. This fix silently ignores these fields in the version preview.