### PR TITLE
PHPDoc and empty conditions checks in Bracket.php 

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PricingManager/Condition/Bracket.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Condition/Bracket.php
@@ -52,7 +52,7 @@ class Bracket implements IBracket
     public function check(IEnvironment $environment)
     {
         // A bracket without conditions is not restricted and thus doesn't fail
-        if (sizeof($this->conditions) == 0) {
+        if (empty($this->conditions)) {
             return true;
         }
 

--- a/bundles/EcommerceFrameworkBundle/PricingManager/Condition/Bracket.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Condition/Bracket.php
@@ -125,8 +125,9 @@ class Bracket implements IBracket
 
     /**
      * @param string $string
+     * @throws \Pimcore\Bundle\EcommerceFrameworkBundle\Exception\InvalidConfigException
      *
-     * @return $this|ICondition
+     * @return $this
      */
     public function fromJSON($string)
     {


### PR DESCRIPTION
## Changes in this pull request  
Resolves no issue, just tiny things I noticed reading the code.

## Additional info  

`sizeof` is just an alias of `count` and computation time scales linearly with the size of the array, `empty` is a single operation. This might save many *μ-seconds* I tell you! ;)