### PR TITLE
Video conversion not working when storing assets in S3

### DIFF
--- a/lib/helper-functions.php
+++ b/lib/helper-functions.php
@@ -455,14 +455,14 @@ function recursiveCopy($source, $destination)
             if ($item->isDir()) {
                 \Pimcore\File::mkdir($destination . DIRECTORY_SEPARATOR . $iterator->getSubPathName());
             } else {
-                copy($item, $destination . DIRECTORY_SEPARATOR . $iterator->getSubPathName());
+                copy($item, $destination . DIRECTORY_SEPARATOR . $iterator->getSubPathName(), \Pimcore\File::getContext());
             }
         }
     } elseif (is_file($source)) {
         if (is_dir(dirname($destination))) {
             \Pimcore\File::mkdir(dirname($destination));
         }
-        copy($source, $destination);
+        copy($source, $destination, \Pimcore\File::getContext());
     }
 
     return true;

--- a/models/Asset/Video.php
+++ b/models/Asset/Video.php
@@ -193,7 +193,9 @@ class Video extends Model\Asset
             $converter = \Pimcore\Video::getInstance();
             $converter->load($filePath);
 
-            return $converter->getDuration();
+            $duration = $converter->getDuration();
+            $converter->destroy();
+            return $duration;
         }
 
         return null;
@@ -210,7 +212,9 @@ class Video extends Model\Asset
             $converter = \Pimcore\Video::getInstance();
             $converter->load($this->getFileSystemPath());
 
-            return $converter->getDimensions();
+            $dimensions = $converter->getDimensions();
+            $converter->destroy();
+            return $dimensions;
         }
 
         return null;

--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -176,10 +176,23 @@ class ImageThumbnail
                     Model\Tool\Lock::release($lockKey);
                 }
 
+                $converter->destroy();
+
                 if ($this->getConfig()) {
                     $this->getConfig()->setFilenameSuffix('time-' . $timeOffset);
 
                     try {
+                        // The path can be remote. In that case, the processor will create a local copy of the asset, which is the video itself.
+                        // That is not what is intended, as we are tying to generate a thumbnail based on the already existing video still that
+                        // the converter created earlier. To prevent the processor from doing that, we will create a local copy here if needed
+                        $tmpFile = null;
+                        if (!stream_is_local($path)) {
+                            $tmpFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/video-thumbnail-' . uniqid() . '.png';
+
+                            recursiveCopy($path, $tmpFile);
+                            $path = $tmpFile;
+                        }
+
                         $path = Image\Thumbnail\Processor::process(
                             $this->asset,
                             $this->getConfig(),
@@ -188,6 +201,10 @@ class ImageThumbnail
                             true,
                             $generated
                         );
+
+                        if ($tmpFile) {
+                            @unlink($tmpFile);
+                        }
                     } catch (\Exception $e) {
                         Logger::error("Couldn't create image-thumbnail of video " . $this->asset->getRealFullPath());
                         Logger::error($e);


### PR DESCRIPTION
### Expected behavior
Converting videos (and creating video thumbnails) works regardless of the asset storage location.

### Actual behavior
When I use S3 as asset store (set up as described [in the docs](https://pimcore.com/docs/5.x/Development_Documentation/Installation_and_Upgrade/System_Setup_and_Hosting/Amazon_AWS_Setup/Amazon_AWS_S3_Setup.html)), it is not possible to use the ffmpeg adapter to convert videos or generate video thumbnails. The problem lies with the creation of the ffmpeg cli command. In [Video/Adapter/Ffmpeg.php](https://github.com/pimcore/pimcore/blob/a4b5160f2e26d00bf2614b40d7bcf11b583898a5/lib/Video/Adapter/Ffmpeg.php#L120), the path to the file to convert is created as `realpath($this->file)`, where `$this->file` is in the format of `s3://my-bucket/assets/video.mp4`. The `realpath` call will then return false, and the resulting command has no input file argument.
