### PR TITLE
[workflow] email notifications: set correct translator locale

### DIFF
--- a/lib/Workflow/NotificationEmail/NotificationEmailService.php
+++ b/lib/Workflow/NotificationEmail/NotificationEmailService.php
@@ -240,12 +240,19 @@ class NotificationEmailService
         $inheritanceBackup = AbstractObject::getGetInheritedValues();
         AbstractObject::setGetInheritedValues(true);
 
+        $translatorLocaleBackup = $this->translator->getLocale();
+        $this->translator->setLocale($language);
+
         $emailTemplate = $this->templatingEngine->render(
             $mailPath, $this->getNotificationEmailParameters($subjectType, $subject, $workflow, $action, $deeplink, $language)
         );
 
+
         //reset inheritance
         AbstractObject::setGetInheritedValues($inheritanceBackup);
+
+        //reset translation locale
+        $this->translator->setLocale($translatorLocaleBackup);
 
         return $emailTemplate;
     }


### PR DESCRIPTION
Currently the translator locale does not work correctly