### PR TITLE
do not output useless language hint for field collections

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/previewVersion.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/previewVersion.html.php
@@ -190,7 +190,7 @@ $fields = $this->object->getClass()->getFieldDefinitions();
 
                         $value = $fieldItem->{"get" . ucfirst($fieldKey->name)}();  ?>
                         <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                            <td><?= ucfirst($fieldItem->getType()) . " - " . $fieldKey->title ?> (<?= $language; ?>)</td>
+                            <td><?= ucfirst($fieldItem->getType()) . " - " . $fieldKey->title ?></td>
                             <td><?= $fieldKey->name ?></td>
                             <td><?= $fieldKey->getVersionPreview($value) ?></td>
                         </tr>


### PR DESCRIPTION
The language output does not make any sense here.