### PR TITLE
Fix pimcore:migrations:migrate command

### DIFF
--- a/lib/Migrations/Command/Traits/PimcoreMigrationsConfiguration.php
+++ b/lib/Migrations/Command/Traits/PimcoreMigrationsConfiguration.php
@@ -109,7 +109,7 @@ trait PimcoreMigrationsConfiguration
         }
     }
 
-    protected function getConnection(InputInterface $input): Connection
+    protected function getConnection(InputInterface $input): ConnectionInterface
     {
         if ($this->connection) {
             return $this->connection;
@@ -117,7 +117,7 @@ trait PimcoreMigrationsConfiguration
 
         $loader = new ConnectionHelperLoader($this->getHelperSet(), 'connection');
 
-        /** @var Connection $connection */
+        /** @var ConnectionInterface $connection */
         $connection = $loader->chosen();
         if ($connection) {
             return $this->connection = $connection;


### PR DESCRIPTION
I get following error if I want execute the migrate command:
`php bin/console pimcore:migrations:migrate -s pimcore_core`

```
In PimcoreMigrationsConfiguration.php line 123:
Type error: Return value of Pimcore\Migrations\Command\MigrateCommand::getConnection() must be an instance of Pimcore\Migrations\Command\Traits\Connection, instance of Pimcore\Db\Connection returned
```

Regression from https://github.com/pimcore/pimcore/pull/4044