### PR TITLE
set getContainer to internal

### DIFF
--- a/lib/Pimcore.php
+++ b/lib/Pimcore.php
@@ -256,7 +256,8 @@ class Pimcore
     /**
      * Accessing the container this way is discouraged as dependencies should be wired through the container instead of
      * needing to access the container directly. This exists mainly for compatibility with legacy code.
-     *
+     *  
+     * @internal Don't use unless there is no other way of accessing Services. Think twice, in most cases there is another way to access the Service.
      * @return ContainerInterface
      */
     public static function getContainer()


### PR DESCRIPTION
Explicitly set `getContainer` to internal to get a IDE Warning when using it. It should really only be used when there is no other way of accessing the Service. There are some valid cases in Pimcore for that, but that are mostly legacy reasons.