### PR TITLE
"Show in tree" did not work if last element in tree page is folder

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/treenodelocator.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/treenodelocator.js
@@ -337,7 +337,7 @@ pimcore.treenodelocator = function()
             var firstelementChild = childNodes[0];
             var lastelementChild = childNodes[childCount-1];
             
-            if (pagingState.elementType == "document") {
+            if (globalState.elementType == "document") {
                 direction = self.getDirectionForElementsSortedByIndex(
                     pagingState.elementKey,
                     firstelementChild,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/treenodelocator.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/treenodelocator.js
@@ -336,9 +336,6 @@ pimcore.treenodelocator = function()
             var direction = 0;
             var firstelementChild = childNodes[0];
             var lastelementChild = childNodes[childCount-1];
-            if (!firstelementChild) {
-                firstelementChild = childNode;
-            }
             
             if (pagingState.elementType == "document") {
                 direction = self.getDirectionForElementsSortedByIndex(

--- a/bundles/AdminBundle/Resources/public/js/pimcore/treenodelocator.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/treenodelocator.js
@@ -334,32 +334,10 @@ pimcore.treenodelocator = function()
 
             // Find out if we have to move forward or backward in paging:
             var direction = 0;
-            var firstFolderChild = null;
-            var lastFolderChild = null;
-            var firstelementChild = null;
-            var lastelementChild = null;
-
-            for (i = 0; i < childCount; i++) {
-                var childNode = childNodes[i];
-                if (globalState.elementType == "document" || (globalState.elementType == "object" && sortBy == "index")) {
-                    lastelementChild = childNode;
-                    if (!firstelementChild) {
-                        firstelementChild = childNode;
-                    }
-                } else {
-                    if (childNode.data.type == "folder") {
-                        lastFolderChild = childNode;
-                        if (!firstFolderChild) {
-                            firstFolderChild = childNode;
-                        }
-                    }
-                    if (childNode.data.type != "folder") {
-                        lastelementChild = childNode;
-                        if (!firstelementChild) {
-                            firstelementChild = childNode;
-                        }
-                    }
-                }
+            var firstelementChild = childNodes[0];
+            var lastelementChild = childNodes[childCount-1];
+            if (!firstelementChild) {
+                firstelementChild = childNode;
             }
             
             if (pagingState.elementType == "document") {
@@ -379,8 +357,6 @@ pimcore.treenodelocator = function()
                     direction = self.getDirectionForElementsSortedByKey(
                         pagingState.elementKey,
                         pagingState.elementType,
-                        firstFolderChild,
-                        lastFolderChild,
                         firstelementChild,
                         lastelementChild
                     );
@@ -488,25 +464,15 @@ pimcore.treenodelocator = function()
         /**
          * Returns the direction (-1/+1/0) for elements sorted by key.
          */
-        getDirectionForElementsSortedByKey: function (elementKey, elementType, firstFolderChild, lastFolderChild, firstElementChild, lastElementChild) {
+        getDirectionForElementsSortedByKey: function (elementKey, elementType, firstElementChild, lastElementChild) {
             var direction = 0;
-            if (elementType == "folder") {
-                if (firstFolderChild && elementKey.toUpperCase() < firstFolderChild.data.text.toUpperCase()) {
-                    direction = -1;
-                } else if (lastFolderChild && elementKey.toUpperCase() > lastFolderChild.data.text.toUpperCase()) {
-                    direction = 1;
-                } else if (firstElementChild) {
-                    direction = -1;
-                }
-            } else {
-                if (lastFolderChild) {
-                    direction = 1;
-                } else if (firstElementChild && elementKey.toUpperCase() < firstElementChild.data.text.toUpperCase()) {
-                    direction = -1;
-                } else if (lastElementChild && elementKey.toUpperCase() > lastElementChild.data.text.toUpperCase()) {
-                    direction = 1;
-                }
+
+            if (firstElementChild && elementKey.toUpperCase() < firstElementChild.data.text.toUpperCase()) {
+                direction = -1;
+            } else if (lastElementChild && elementKey.toUpperCase() > lastElementChild.data.text.toUpperCase()) {
+                direction = 1;
             }
+
             return direction;
         },
         

--- a/bundles/AdminBundle/Resources/public/js/pimcore/treenodelocator.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/treenodelocator.js
@@ -462,15 +462,23 @@ pimcore.treenodelocator = function()
          * Returns the direction (-1/+1/0) for elements sorted by key.
          */
         getDirectionForElementsSortedByKey: function (elementKey, elementType, firstElementChild, lastElementChild) {
-            var direction = 0;
-
-            if (firstElementChild && elementKey.toUpperCase() < firstElementChild.data.text.toUpperCase()) {
-                direction = -1;
-            } else if (lastElementChild && elementKey.toUpperCase() > lastElementChild.data.text.toUpperCase()) {
-                direction = 1;
+            if(elementType === 'asset' && lastElementChild && lastElementChild.data.type === 'folder') {
+                return 1;
             }
 
-            return direction;
+            if(elementType === 'folder' && firstElementChild && firstElementChild.data.type === 'asset') {
+                return -1;
+            }
+
+            if (firstElementChild && elementKey.toUpperCase() < firstElementChild.data.text.toUpperCase()) {
+                return -1;
+            }
+
+            if (lastElementChild && elementKey.toUpperCase() > lastElementChild.data.text.toUpperCase()) {
+                return 1;
+            }
+
+            return 0;
         },
         
         


### PR DESCRIPTION
When you click on "Show in tree" on a data object there is a bug in the current version when the last element of the data object tree page is a folder. In this case in https://github.com/pimcore/pimcore/blob/edd0f3e8457f0a230bf37819668716b01f9edcab/bundles/AdminBundle/Resources/public/js/pimcore/treenodelocator.js#L502-L508 it is only checked if last element is a folder - if it is, the tree gets paged forwards without checking if the folder name is alphabetically after the object being searched for.

This PR changes this behaviour and also simplifies the code. I have not understood why folders and objects are treated differently because - unlike as e.g. in Windows - Pimcore folders are not sorted after objects but alphabetically by name regardless of their type.