### PR TITLE
[Assets] exclude asset folder from tree preview

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -630,6 +630,7 @@ class AssetController extends ElementControllerBase implements EventedController
             $folderThumbs = [];
             $children = new Asset\Listing();
             $children->setCondition('path LIKE ?', [$asset->getRealFullPath() . '/%']);
+            $children->addConditionParam('type IN (\'image\', \'video\', \'document\')', 'AND');
             $children->setLimit(35);
 
             foreach ($children as $child) {


### PR DESCRIPTION
Listing returned folders as well which results in empty tree preview on
instances with nested folder structures.

## Changes in this pull request  

Fix it with limiting the
listing to asset types which actually have a thumbnail.

## Additional info  

To reproduce....let's assume a nested structure like this:

![image](https://user-images.githubusercontent.com/38670469/55010754-0ca8b980-4fe5-11e9-9cf0-eee17bc749e4.png)

As you see there are a lot of folders which finally have images in it. Hovering over the Artikel folder is showing just 5 tree preview images, although there are a lot more present.

Due that we fetch as well folders in our query and filter out assets afterwards, which are not a folder, we get this poor result.

Hence query just for assets which really have a thumbnail and show the first 35 we get
