### PR TITLE
[Ecommerce] fixed Getting sub items of cart item ignores defined cart item class

### DIFF
--- a/bundles/EcommerceFrameworkBundle/CartManager/CartItem.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/CartItem.php
@@ -104,6 +104,7 @@ class CartItem extends AbstractCartItem implements ICartItem
                 }
             }
             $itemList = new $itemClass();
+            $itemList->setCartItemClassName(get_class($this));
 
             $db = \Pimcore\Db::get();
             $itemList->setCondition('cartId = ' . $db->quote($this->getCartId()) . ' AND parentItemKey = ' . $db->quote($this->getItemKey()));


### PR DESCRIPTION
This is a possible solution for issue: #4100 

Please check for side effects.