### PR TITLE
Fix classificationstore key tooltips

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -1222,7 +1222,8 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
                     continue;
                 }
                 $definition = \Pimcore\Model\DataObject\Classificationstore\Service::getFieldDefinitionFromKeyConfig($keyGroupRelation);
-                $definition->setTooltip($definition->getName() . ' - ' . $keyGroupRelation->getDescription());
+                $fallbackTooltip = $definition->getName() . ' - ' . $keyGroupRelation->getDescription();
+                $definition->setTooltip($definition->getTooltip() ?: $fallbackTooltip);
 
                 if (method_exists($definition, '__wakeup')) {
                     $definition->__wakeup();


### PR DESCRIPTION
Configured tooltips of classificationstore keys get overriden and so are not displayed in the objects. This PR fixes the issue and uses the previous value as fallback.

Resolves #4139