### PR TITLE
Mark path and published fields as changed when data object comparing versions

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.php
@@ -44,7 +44,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
         <?php if (!$this->isImportPreview || !$this->isNew) { ?>
             <td><?= $this->object1->getRealFullPath(); ?></td>
         <?php } ?>
-        <td><?= $this->object2->getRealFullPath(); ?></td>
+        <td<?php if ($this->object1->getRealFullPath() !== $this->object2->getRealFullPath()) { ?> class="modified"<?php } ?>><?= $this->object2->getRealFullPath(); ?></td>
     </tr>
     <tr class="system">
         <td>Published</td>
@@ -52,7 +52,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
         <?php if (!$this->isImportPreview || !$this->isNew) { ?>
             <td><?= json_encode($this->object1->getPublished()); ?></td>
         <?php } ?>
-        <td><?= json_encode($this->object2->getPublished()); ?></td>
+        <td<?php if ($this->object1->getPublished() !== $this->object2->getPublished()) { ?> class="modified"<?php } ?>><?= json_encode($this->object2->getPublished()); ?></td>
     </tr>
     <tr class="system">
         <td>Id</td>


### PR DESCRIPTION
When compoaring versions of a data object, the system fields "path" and "published" have not been marked as "changed".

Steps to reproduce:
1. Create data object
1. Create folders A and B
1. Move object to folder A
1. Move object to folder B
1. Open object and compare versions
Result: Path was not marked as changed, with this PR it is.