### PR TITLE
Use flex instead of fixed width for columns in an advanced many-to-many relation

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -113,7 +113,7 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
 
                 var fc = pimcore.object.tags[layout.fieldtype].prototype.getGridColumnConfig(field);
 
-                fc.width = 100;
+                fc.flex = 1;
                 fc.hidden = false;
                 fc.layout = field;
                 fc.editor = null;


### PR DESCRIPTION
Visible columns in advanced Many-to-Many object relations are 100px wide by default, often hiding parts of the content. The regular many-to-many-relation already makes use of the flex param, improving visibility.

Current view:
![Bildschirmfoto 2019-03-28 um 15 07 26](https://user-images.githubusercontent.com/8749138/55169003-3fcd8300-5174-11e9-9414-984be9602d94.png)


When using flex:
![Bildschirmfoto 2019-03-28 um 15 07 45](https://user-images.githubusercontent.com/8749138/55169019-478d2780-5174-11e9-83f2-b9b747dd128e.png)
