### PR TITLE
Ensure mail text is logged for plain text mails too

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/email/log.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/email/log.js
@@ -191,7 +191,6 @@ pimcore.settings.email.log = Class.create({
                 dataIndex: 'emailLogExistsText',
                 menuText: t('text'),
                 text: t('text'),
-                hidden: true,
                 items : [{
                     icon: '/bundles/pimcoreadmin/img/flat-color-icons/text.svg',
                     handler: function(grid, rowIndex){

--- a/lib/Helper/Mail.php
+++ b/lib/Helper/Mail.php
@@ -184,6 +184,12 @@ CSS;
         if ($text) {
             $emailLog->setBodyText($text->getBody());
         }
+        else {
+            // Mail was probably sent as plain text only.
+            if ($text = $mail->getBodyText()) {
+                $emailLog->setBodyText($text);
+            }
+        }
 
         foreach (['To', 'Cc', 'Bcc', 'ReplyTo'] as $key) {
             $addresses = isset($recipients[$key]) ? $recipients[$key] : null;


### PR DESCRIPTION
It looks like currently `Pimcore\Helper\Mail::logEmail()` only checks for plain text of an email by checking the text mime part. Which, I assume, is only set if you send a multi mime part e-mail but not for a plain text only e-mail. At least the current logging behavior suggests that this assumption is correct.

Hence an email sent like this:
```php
$mail = Tool::getMail([$user->getEmail()], 'Pimcore lost password service');
$mail->setIgnoreDebugMode(true);
$mail->setBodyText("Login to pimcore and change your password using the following link. This temporary login link will expire in 30 minutes: \r\n\r\n" . $loginUrl);
$mail->send();
```
Wont log any payload.

Additionally the text column in the email logging overview is permanently hidden - which makes access to the text unnecessarily difficult. (Probably was hidden because nothing was logged ;) )  

## Changes in this pull request  
1. `Pimcore\Helper\Mail::logEmail()` adjusted to fall back to plain text check if no multipart plain text was found when logging a message
2. Enable the Text column in the email log overview.

