### PR TITLE
AssetController cannot generate thumbnails

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -1200,7 +1200,8 @@ class AssetController extends ElementControllerBase implements EventedController
             $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig((bool) $request->get('hdpi'));
         }
 
-        if ($request->get('cropPercent')) {
+        $cropPercent = $request->get('cropPercent');
+        if ($cropPercent && filter_var($cropPercent, FILTER_VALIDATE_BOOLEAN)) {
             $thumbnail->addItemAt(0, 'cropPercent', [
                 'width' => $request->get('cropWidth'),
                 'height' => $request->get('cropHeight'),


### PR DESCRIPTION
### How to reproduce
Simply, call the following url: **\<your-domain\>/admin/asset/get-image-thumbnail?id=\<your-asset-id\>&thumbnail=\<your-thumbnail-name\>&cropPercent=false**.

_Obviously, you'll have to use proper values for the URL._

### Changes made
The parameter is additionally checked for its value, ultimately, resolving the issue with this PR.