### PR TITLE
Change mail log / redirect handling to retain the original message data - re-branched

### DIFF
--- a/lib/Mail/Plugins/RedirectingPlugin.php
+++ b/lib/Mail/Plugins/RedirectingPlugin.php
@@ -82,6 +82,7 @@ class RedirectingPlugin extends \Swift_Plugins_RedirectingPlugin
 
         $message = $evt->getMessage();
         if ($message instanceof Mail && $message->doRedirectMailsToDebugMailAddresses()) {
+            $this->setSenderAndReceiversParams($message);
             $this->removeDebugInformation($message);
         }
     }
@@ -127,7 +128,29 @@ class RedirectingPlugin extends \Swift_Plugins_RedirectingPlugin
             $originalData['subject'] = $subject;
             $message->setSubject('Debug email: ' . $subject);
 
+            // Set receiver & sender data.
+            $originalData['From'] = $message->getFrom();
+            $originalData['To'] = $message->getTo();
+            $originalData['Cc'] = $message->getCc();
+            $originalData['Bcc'] = $message->getBcc();
+            $originalData['ReplyTo'] = $message->getReplyTo();
+
             $message->setOriginalData($originalData);
+        }
+    }
+
+    /**
+     * Sets the sender and receiver information of the mail to keep the log searchable for the original data.
+     *
+     * @param Mail $message
+     */
+    protected function setSenderAndReceiversParams($message) {
+        $originalData = $message->getOriginalData();
+
+        $message->setParam('Debug-Redirected', 'true');
+        foreach (array('From', 'To', 'Cc', 'Bcc', 'ReplyTo') as $k) {
+            // Add parameters to show this was redirected
+            $message->setParam('Debug-Original-' . $k, $originalData[$k]);
         }
     }
 


### PR DESCRIPTION
Clone of #4142 as per request in comments.

Currently the mail redirecting in the mail debug mode leads to "information loss" in the email log.
The receivers are not retained and hence the log can't be searched for mails to a certain receiver. 

## Changes in this pull request  
`Pimcore\Mail\Plugins\RedirectingPlugin` now adds the original sender / receiver data as parameters to the mail log.