### PR TITLE
Skip Incomplete Classes in renewing References Process

### DIFF
--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -624,6 +624,11 @@ class Service extends Model\AbstractModel
      */
     public static function renewReferences($data, $initial = true, $key = null)
     {
+        if ($data instanceof \__PHP_Incomplete_Class) {
+            Logger::err(sprintf('Renew References: Cannot read data (%s) of incomplete class.', is_null($key) ? 'not available' : $key));
+            return null;
+        }
+
         if (is_array($data)) {
             foreach ($data as $dataKey => &$value) {
                 $value = self::renewReferences($value, false, $dataKey);


### PR DESCRIPTION
If a version stores incomplete (sub-) class, the [renewReferences](https://github.com/pimcore/pimcore/blob/a03da421d921a39249b76f72a1275f98e03994ab/models/Element/Service.php#L625) method fails in line:

https://github.com/pimcore/pimcore/blob/a03da421d921a39249b76f72a1275f98e03994ab/models/Element/Service.php#L663-L668

because the `method_exists` check may fails with `Error: method_exists(): The script tried to execute a method or access a property of an incomplete object.`.

This PR checks the incoming `$data` against valid classes and returns `null` otherwise.