### PR TITLE
Use instanceof instead of get_class in Version Data Check

### DIFF
--- a/models/Version.php
+++ b/models/Version.php
@@ -299,8 +299,8 @@ class Version extends AbstractModel
 
         if ($this->getSerialized()) {
             $data = Serialize::unserialize($data);
-            if (get_class($data) == '__PHP_Incomplete_Class') {
-                Logger::err('Version: cannot read version data from file system becaus of incompatible class.');
+            if ($data instanceof \__PHP_Incomplete_Class) {
+                Logger::err('Version: cannot read version data from file system because of incompatible class.');
 
                 return;
             }


### PR DESCRIPTION
This is a follow-up for #4165. `$data` could be `false` which triggers an exception in `get_class`method.

PS: Yes, I'm currently struggling with a some messed up versions. 😄