### PR TITLE
Fixed a bug where meta data isn't saved when uploading a file.

### DIFF
--- a/models/Asset/MetaData/EmbeddedMetaDataTrait.php
+++ b/models/Asset/MetaData/EmbeddedMetaDataTrait.php
@@ -70,6 +70,9 @@ trait EmbeddedMetaDataTrait
 
         if (stream_is_local($this->getStream()) && $exiftool && $useExifTool) {
             $path = escapeshellarg($filePath);
+            if(!file_exists($path)){
+                $path =  escapeshellarg($this->getTemporaryFile());
+            }
             $output = Tool\Console::exec($exiftool . ' -j ' . $path);
             $embeddedMetaData = $this->flattenArray((array) json_decode($output)[0]);
 


### PR DESCRIPTION
Look for temporary file, if the asset wasn't found within the file system path. 