### PR TITLE
fix admin translation javascript issues

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/MiscController.php
+++ b/bundles/AdminBundle/Controller/Admin/MiscController.php
@@ -20,6 +20,7 @@ use Pimcore\Controller\Configuration\TemplatePhp;
 use Pimcore\Db;
 use Pimcore\File;
 use Pimcore\Tool;
+use Pimcore\Translation\Translator;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -169,7 +170,8 @@ class MiscController extends AdminController
             }
         }
 
-        $response = new Response('pimcore.system_i18n = ' . $this->encodeJson($translations) . ';');
+        $caseInsensitive = $translator instanceof Translator && $translator->getCaseInsensitive() ? "true" : "false";
+        $response = new Response('pimcore.system_i18n = ' . $this->encodeJson($translations) . ';pimcore.system_i18n_case_insensitive='. $caseInsensitive);
         $response->headers->set('Content-Type', 'text/javascript');
 
         return $response;

--- a/bundles/AdminBundle/Controller/Admin/MiscController.php
+++ b/bundles/AdminBundle/Controller/Admin/MiscController.php
@@ -170,8 +170,8 @@ class MiscController extends AdminController
             }
         }
 
-        $caseInsensitive = $translator instanceof Translator && $translator->getCaseInsensitive() ? "true" : "false";
-        $response = new Response('pimcore.system_i18n = ' . $this->encodeJson($translations) . ';pimcore.system_i18n_case_insensitive='. $caseInsensitive);
+        $caseInsensitive = $translator instanceof Translator && $translator->getCaseInsensitive();
+        $response = new Response('pimcore.system_i18n = ' . $this->encodeJson($translations) . ';pimcore.system_i18n_case_insensitive='. json_encode($caseInsensitive));
         $response->headers->set('Content-Type', 'text/javascript');
 
         return $response;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/functions.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/functions.js
@@ -29,13 +29,23 @@ function t(key, defaultValue) {
         return $1;
     });
 
-    if (pimcore && pimcore.system_i18n && pimcore.system_i18n[key]) {
-        pimcore.globalmanager.get("translations_admin_translated_values").push(pimcore.system_i18n[key]);
-        return pimcore.system_i18n[key];
-    } else {
+    var originalKey = key;
+    if(pimcore.system_i18n_case_insensitive && key){
+        key = key.toLocaleLowerCase();
+    }
+
+    if (pimcore && pimcore.system_i18n && (pimcore.system_i18n[key] || pimcore.system_i18n[originalKey])) {
+        var trans = pimcore.system_i18n[originalKey] ? pimcore.system_i18n[originalKey] : pimcore.system_i18n[key];
+        pimcore.globalmanager.get("translations_admin_translated_values").push(trans);
+        return trans;
+    }
+
+    var transKeys = Object.keys(pimcore.system_i18n);
+    if(pimcore && pimcore.system_i18n && transKeys.indexOf(key) === -1 && transKeys.indexOf(originalKey) === -1){
         if(!defaultValue && !in_array(key, alreadyTranslated)) {
             if(pimcore.globalmanager.exists("translations_admin_missing")) {
-                if (!in_array(key, pimcore.globalmanager.get("translations_admin_added"))) {
+                if (!in_array(key, pimcore.globalmanager.get("translations_admin_added")) &&
+                    !in_array(key, pimcore.globalmanager.get("translations_admin_missing"))) {
                     pimcore.globalmanager.get("translations_admin_missing").push(key);
                 }
             }
@@ -47,7 +57,7 @@ function t(key, defaultValue) {
     }  else if (defaultValue) {
         return defaultValue;
     } else {
-        return key;
+        return originalKey;
     }
 }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
@@ -950,18 +950,22 @@ pimcore["intervals"]["translations_admin_missing"] = window.setInterval(function
     var missingTranslations = pimcore.globalmanager.get("translations_admin_missing");
     var addedTranslations = pimcore.globalmanager.get("translations_admin_added");
     if (missingTranslations.length > 0) {
-        var params = Ext.encode(missingTranslations);
-        for (var i = 0; i < missingTranslations.length; i++) {
-            addedTranslations.push(missingTranslations[i]);
+        var thresholdIndex = 500;
+        var arraySurpassing = missingTranslations.length > thresholdIndex;
+        var sentTranslations = arraySurpassing ? missingTranslations.slice(0, thresholdIndex) : missingTranslations;
+        var params = Ext.encode(sentTranslations);
+        for (var i = 0; i < sentTranslations.length; i++) {
+            var translation = sentTranslations[i];
+            addedTranslations.push(translation);
         }
-        pimcore.globalmanager.add("translations_admin_missing", new Array());
+        var restMissingTranslations = missingTranslations.slice(thresholdIndex);
+        pimcore.globalmanager.add("translations_admin_missing", restMissingTranslations);
         Ext.Ajax.request({
             method: "POST",
             url: "/admin/translation/add-admin-translation-keys",
             params: {keys: params}
         });
     }
-
 }, 30000);
 
 // session renew

--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -459,6 +459,11 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
         return $text;
     }
 
+    public function getCaseInsensitive(): bool
+    {
+        return $this->caseInsensitive;
+    }
+
     /**
      * Passes through all unknown calls onto the translator object.
      */


### PR DESCRIPTION
This PR fixes several issues with the current admin translations Javascript implementation:

- For objects with massive amounts of translations (for example select boxes with thousands of entries) the current call of `/admin/translation/add-admin-translation-keys` does not work. If there are massive amounts of keys the request will fail and Pimcore will show a 503 maintenance error. Additionally this call can contain the same keys multiple times. Therefore this PR limits the amount of a single request to 500 (and stores the rest for the next request). As this method is called each 30 seconds for each admin users the translation keys will be added anyway. 

- Currently not translated keys are added to the `/admin/translation/add-admin-translation-keys` call again and again. In complex systems this could be a serious performance issue. Therefore this PR checks if a key exits and not only if the key is translated.

- If case_insensitive mode is enabled the admin translations did not work correctly. This is fixed in this PR too.