### PR TITLE
Error handling and logging

### DIFF
--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -123,7 +123,7 @@ class Bootstrap
         $loader = include __DIR__ . '/../../../../vendor/autoload.php';
         self::defineConstants();
 
-        if (defined(PIMCORE_PHP_ERROR_REPORTING)) {
+        if (defined('PIMCORE_PHP_ERROR_REPORTING')) {
             error_reporting(PIMCORE_PHP_ERROR_REPORTING);
         }
 

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -123,14 +123,14 @@ class Bootstrap
         $loader = include __DIR__ . '/../../../../vendor/autoload.php';
         self::defineConstants();
 
-        if (is_integer(PIMCORE_PHP_ERROR_REPORTING)) {
+        if (defined(PIMCORE_PHP_ERROR_REPORTING)) {
             error_reporting(PIMCORE_PHP_ERROR_REPORTING);
         }
 
         \Pimcore::setAutoloader($loader);
         self::autoload();
 
-        if ('syslog' === PIMCORE_PHP_ERROR_LOG || is_writable(dirname(PIMCORE_PHP_ERROR_LOG))) {
+        if (defined('PIMCORE_PHP_ERROR_LOG')) {
             ini_set('error_log', PIMCORE_PHP_ERROR_LOG);
             ini_set('log_errors', '1');
         }


### PR DESCRIPTION
This is a proposal/food for thought or a drive-by PR if you will... For context, we've been trying to run Pimcore in a set of Docker containers.

# is_integer vs defined

Especially when you use environment variables to configure this setting, it's never ever going to be an integer as the code to "resolve constants" has no context/domain knowledge of the setting, doesn't cast the constant and therefor it's of type `string` and the `is_integer` is always false. You could probably use `is_numeric()` or so. But I haven't tested it.

# error_log

I changed this as well as it doesn't work when you e.g. set the `error_log` to `/proc/self/fd/2` to catch logs on `stdout` or `stderr`.

I would assume that when people set this environment variable (or the constant) they know what's going on and checking for writable is not necessary. The `is_writable` is also a hefty performance penalty each time this code is executed too. Removing this definitely fixes "my" problem, but I am also sure there are other use cases and maybe someone else has a better idea.


## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.
  