### PR TITLE
Update AWS setup readme

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/13_Amazon_AWS_Setup/03_Amazon_AWS_S3_Setup.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/13_Amazon_AWS_Setup/03_Amazon_AWS_S3_Setup.md
@@ -151,7 +151,7 @@ class S3Listener
 
 ## Customize the Storage Locations of Pimcore
 
-Create a new file named `/constants.php` in your document root and put the following code in it.
+Create a new file named `/constants.php` in `/app/constants.php` and put the following code in it.
 
 Again, please have a look at the comments in the code.
  


### PR DESCRIPTION
constants.php should be in /app directory not root directory

<!--
## Please make sure your PR complies with all of the following points: 
- [ * ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ * ] Features need to be proper documented in `doc/`
- [ * ] Bugfixes need a short guide how to reproduce them. 
- [  * ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ * ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
AWS Documentation file had a problem on constants.php location

## Additional info  

