### PR TITLE
fix admin translation javascript issues - bug fix when translations are not loaded

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/functions.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/functions.js
@@ -40,7 +40,7 @@ function t(key, defaultValue) {
         return trans;
     }
 
-    var transKeys = Object.keys(pimcore.system_i18n);
+    var transKeys = pimcore && pimcore.system_i18n ? Object.keys(pimcore.system_i18n) : {};
     if(pimcore && pimcore.system_i18n && transKeys.indexOf(key) === -1 && transKeys.indexOf(originalKey) === -1){
         if(!defaultValue && !in_array(key, alreadyTranslated)) {
             if(pimcore.globalmanager.exists("translations_admin_missing")) {


### PR DESCRIPTION
This is a important follow up to #4170 
There are situations when pimcore.system_i18n is not loaded but the t() function get's called. We should merge this PR urgently as otherwise very strange bugs can occur.