### PR TITLE
Allow custom admin login entry point

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/LoginController.php
+++ b/bundles/AdminBundle/Controller/Admin/LoginController.php
@@ -67,6 +67,11 @@ class LoginController extends AdminController implements BruteforceProtectedCont
      */
     public function loginAction(Request $request)
     {
+        $customAdminEntry = $this->checkCustomEntryPoint();
+        if (isset($customAdminEntry) && $customAdminEntry !== $request->cookies->get('pimcore_custom_admin')) {
+            return new Response("You don't have permission to access the page 🦄", 403);
+        }
+
         if ($request->get('_route') === 'pimcore_admin_login_fallback') {
             return $this->redirectToRoute('pimcore_admin_login', $request->query->all(), Response::HTTP_MOVED_PERMANENTLY);
         }
@@ -253,5 +258,16 @@ class LoginController extends AdminController implements BruteforceProtectedCont
      */
     public function twoFactorAuthenticationVerifyAction(Request $request)
     {
+    }
+
+    /**
+     * check custom admin entry point enabled in config
+     * @return bool
+     */
+    public function checkCustomEntryPoint()
+    {
+        $customAdminPathIdentifier = \Pimcore::getContainer()->getParameter('pimcore.config')['custom_admin_path_identifier'];
+
+        return $customAdminPathIdentifier;
     }
 }

--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -22,6 +22,8 @@ use Pimcore\Model\Tool;
 use Pimcore\Model\Tool\TmpStore;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller as FrameworkController;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -200,5 +202,25 @@ class PublicServicesController extends FrameworkController
         } else {
             Logger::error("called an QR code but '" . $request->get('key') . ' is not a code in the system.');
         }
+    }
+
+
+    /**
+     * @param Request $request
+     *
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     */
+    public function customAdminEntryPointAction(Request $request)
+    {
+        $url = $this->generateUrl('pimcore_admin_login');
+        $redirect = new RedirectResponse($url);
+
+        $customAdminPathIdentifier = \Pimcore::getContainer()->getParameter('pimcore.config')['custom_admin_path_identifier'];
+
+        if (isset($customAdminPathIdentifier) && $request->cookies->get('pimcore_custom_admin') != $customAdminPathIdentifier) {
+            $redirect->headers->setCookie(new Cookie('pimcore_custom_admin', $customAdminPathIdentifier, strtotime("+1 year"), '/', null, false, true));
+        }
+
+        return $redirect;
     }
 }

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -121,6 +121,15 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->scalarNode('custom_admin_path_identifier')
+                    ->cannotBeEmpty()
+                    ->validate()
+                        ->ifTrue(function ($v) {
+                            return strlen($v) < 20;
+                        })
+                        ->thenInvalid('custom_admin_path_identifier should be at least 20 characters long.')
+                    ->end()
+                ->end()
             ->end();
 
         $this->addObjectsNode($rootNode);

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/40_Custom_Admin_Login_Entry_Point.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/40_Custom_Admin_Login_Entry_Point.md
@@ -1,0 +1,21 @@
+# Custom Admin Login Entry Point
+
+Pimcore `/admin` login entry point can be restricted/changed by using pimcore configuration.
+
+Add custom admin identifier in your `app/config/config.yml`:
+```yml
+
+pimcore: 
+  custom_admin_path_identifier: min20CharCustomToken
+  
+``` 
+> Please note: custom_admin_path_identifier should be atleast 20 characters long
+
+Add custom entry for `PimcoreCoreBundle:PublicServices:customAdminEntryPoint` in your routing.yml:  
+```yml
+my_custom_admin_entry_point:
+    path: /my-custom-login-page
+        defaults: { _controller: PimcoreCoreBundle:PublicServices:customAdminEntryPoint }
+``` 
+
+> As soon as custom admin route (in this e.g. `/my-custom-login-page`) is called, admin cookie will be set in your browser which is validated for all /admin calls. 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #2544

## Additional info  
via config option:

In `routing.yml`: 
```yml
my_custom_admin_entry_point:
    path: /my-custom-login-page
        defaults: { _controller: PimcoreCoreBundle:PublicServices:customAdminEntryPoint }
```

in `config.yml`:  
```yml
pimcore: 
  custom_admin_path_identifier: min20CharCustomToken
```

+ validation for `custom_admin_path_identifier`, should be at least 20 characters
