### PR TITLE
Reset cached counts in SessionCart

### DIFF
--- a/bundles/EcommerceFrameworkBundle/CartManager/SessionCart.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/SessionCart.php
@@ -102,6 +102,20 @@ class SessionCart extends AbstractCart implements ICart
 
         return $this;
     }
+    
+    /**
+     * @inheritDoc
+     */
+    public function modified()
+    {
+        // Reset cached values
+        $this->itemCount = null;
+        $this->subItemCount = null;
+        $this->itemAmount = null;
+        $this->subItemAmount = null;
+        
+        return parent::modified();
+    }
 
     /**
      * @param int $id


### PR DESCRIPTION
Method `Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\AbstractCart::getItemCount()`and `getSubItemCount()` cache their result, which in case of the SessionCart gets serialized and thus never updated.

This resets these values in case the cart gets modified and triggers a re-count.