### PR TITLE
Lazy load notes list

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/notes.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/notes.js
@@ -51,7 +51,7 @@ pimcore.element.notes = Class.create({
                 '/admin/element/note-list?',
                 ['id', 'type', 'title', 'description',"user","date","data","cpath","cid","ctype"],
                 itemsPerPage,
-                {autoLoad: false}
+                {autoLoad: false, remoteFilter: false}
             );
 
             // only when used in element context
@@ -192,6 +192,9 @@ pimcore.element.notes = Class.create({
                 listeners: {
                     rowdblclick : function(grid, record, tr, rowIndex, e, eOpts ) {
                         this.showDetailedData(grid, rowIndex, event);
+                    }.bind(this),
+                    beforerender: function () {
+                        this.store.setRemoteFilter(true);
                     }.bind(this)
 
                 }


### PR DESCRIPTION
## Changes in this pull request  
Load notes only when `Notes & Events` tab is activated.

