### PR TITLE
[BackendSearch] restart save transaction if it fails

### DIFF
--- a/models/Search/Backend/Data.php
+++ b/models/Search/Backend/Data.php
@@ -544,7 +544,29 @@ class Data extends \Pimcore\Model\AbstractModel
     {
         if ($this->id instanceof Data\Id) {
             \Pimcore::getEventDispatcher()->dispatch(SearchBackendEvents::PRE_SAVE, new SearchBackendEvent($this));
-            $this->getDao()->save();
+
+            $maxRetries = 5;
+            for ($retries = 0; $retries < $maxRetries; $retries++) {
+                try {
+                    $this->getDao()->save();
+                    // successfully completed, so we cancel the loop here -> no restart required
+                    break;
+                } catch (\Exception $e) {
+                    // we try to start saving $maxRetries times again (deadlocks, ...)
+                    if ($retries < ($maxRetries - 1)) {
+                        $run = $retries + 1;
+                        $waitTime = rand(1, 5) * 100000;
+                        Logger::warn('Unable to finish transaction (' . $run . ". run) because of the following reason '" . $e->getMessage() . "'. --> Retrying in " . $waitTime . ' microseconds ... (' . ($run + 1) . ' of ' . $maxRetries . ')');
+
+                        // wait specified time until we restart
+                        usleep($waitTime);
+                    } else {
+                        // if we fail after $maxRetries retries, we throw out the exception
+                        throw $e;
+                    }
+                }
+            }
+
             \Pimcore::getEventDispatcher()->dispatch(SearchBackendEvents::POST_SAVE, new SearchBackendEvent($this));
         } else {
             throw new \Exception('Search\\Backend\\Data cannot be saved - no id set!');


### PR DESCRIPTION
## Changes in this pull request  

Adding data to the backend search is called on every object/asset/document save. The element save transactions are protected against database failures (deadlocks etc.)
Due that backend search transaction is called afterwards (EventListener) it is not protected and will not restart on failure.

To fix it go inline with element save methods

## Additional info

We are importing a big amount of objects and assets multi threaded and we ran into this issue

