### PR TITLE
Bugfix: Controllers in bundles have not been listed in static routes / document types settings

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/docTypes.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/docTypes.js
@@ -172,7 +172,8 @@ pimcore.settings.document.doctypes = Class.create({
                             var currentRecord = this.grid.getSelection();
                             el.getStore().reload({
                                 params: {
-                                    controllerName: currentRecord[0].data.controller
+                                    controllerName: currentRecord[0].data.controller,
+                                    moduleName: currentRecord[0].data.module
                                 },
                                 callback: function () {
                                     el.expand();

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/staticroutes.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/staticroutes.js
@@ -185,7 +185,8 @@ pimcore.settings.staticroutes = Class.create({
                             var currentRecord = this.grid.getSelection();
                             el.getStore().reload({
                                 params:{
-                                    controllerName:currentRecord[0].data.controller
+                                    controllerName:currentRecord[0].data.controller,
+                                    moduleName: currentRecord[0].data.module
                                 },
                                 callback: function() {
                                     el.expand();


### PR DESCRIPTION
When you have a bundle other than AppBundle which does not have its controllers being registered as services then its action methods have not been listed in static routes and document types settings.

How to reproduce:
1. Create Bundle named TestBundle
1. Create controller DefaultController with action method testAction
1. Go to static routes settings
1. Select Module=TestBundle, Controller=DefaultController
1. Open action dropdown -> it shows methods of AppBundle\DefaultController not of TestBundle\DefaultController

The same applies for choosing the action in document type settings.