### PR TITLE
Show unreferenced assets

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -2268,6 +2268,10 @@ class AssetController extends ElementControllerBase implements EventedController
                 $conditionFilters[] = 'path LIKE ' . ($folder->getRealFullPath() == '/' ? "'/%'" : $list->quote($folder->getRealFullPath() . '/%'));
             }
 
+            if ($allParams['only_unreferenced'] == 'true') {
+                $conditionFilters[] = 'id NOT IN (SELECT targetid FROM dependencies WHERE targettype=\'asset\')';
+            }
+
             $conditionFilters[] = "type != 'folder'";
             $filterJson = $allParams['filter'];
             if ($filterJson) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/listfolder.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/listfolder.js
@@ -106,7 +106,6 @@ pimcore.asset.listfolder = Class.create({
                     this.onlyDirectChildren = checked;
 
                     this.store.getProxy().setExtraParam("only_direct_children", this.onlyDirectChildren);
-                    this.store.getProxy().setExtraParam("only_unreferenced", this.onlyUnreferenced);
 
                     this.pagingtoolbar.moveFirst();
                 }.bind(this)
@@ -123,7 +122,6 @@ pimcore.asset.listfolder = Class.create({
                     this.grid.filters.clearFilters();
                     this.onlyUnreferenced = checked;
 
-                    this.store.getProxy().setExtraParam("only_direct_children", this.onlyDirectChildren);
                     this.store.getProxy().setExtraParam("only_unreferenced", this.onlyUnreferenced);
 
                     this.pagingtoolbar.moveFirst();

--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/listfolder.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/listfolder.js
@@ -15,6 +15,7 @@ pimcore.registerNS("pimcore.asset.listfolder");
 pimcore.asset.listfolder = Class.create({
 
     onlyDirectChildren: false,
+    onlyUnreferenced: false,
 
     initialize: function (element) {
         this.element = element;
@@ -102,10 +103,29 @@ pimcore.asset.listfolder = Class.create({
             listeners: {
                 "change" : function (field, checked) {
                     this.grid.filters.clearFilters();
-
-                    this.store.getProxy().setExtraParam("only_direct_children", checked);
-
                     this.onlyDirectChildren = checked;
+
+                    this.store.getProxy().setExtraParam("only_direct_children", this.onlyDirectChildren);
+                    this.store.getProxy().setExtraParam("only_unreferenced", this.onlyUnreferenced);
+
+                    this.pagingtoolbar.moveFirst();
+                }.bind(this)
+            }
+        });
+
+        this.checkboxOnlyUnreferenced = new Ext.form.Checkbox({
+            name: "onlyUnreferenced",
+            style: "margin-bottom: 5px; margin-left: 5px",
+            checked: this.onlyUnreferenced,
+            boxLabel: t("only_unreferenced"),
+            listeners: {
+                "change" : function (field, checked) {
+                    this.grid.filters.clearFilters();
+                    this.onlyUnreferenced = checked;
+
+                    this.store.getProxy().setExtraParam("only_direct_children", this.onlyDirectChildren);
+                    this.store.getProxy().setExtraParam("only_unreferenced", this.onlyUnreferenced);
+
                     this.pagingtoolbar.moveFirst();
                 }.bind(this)
             }
@@ -130,6 +150,7 @@ pimcore.asset.listfolder = Class.create({
             listeners: {
                 activate: function() {
                     this.store.getProxy().setExtraParam("only_direct_children", this.onlyDirectChildren);
+                    this.store.getProxy().setExtraParam("only_unreferenced", this.onlyUnreferenced);
                     this.store.load();
                 }.bind(this),
                 rowdblclick: function(grid, record, tr, rowIndex, e, eOpts ) {
@@ -141,6 +162,8 @@ pimcore.asset.listfolder = Class.create({
             tbar: [
                 "->"
                 ,this.checkboxOnlyDirectChildren
+                , "-"
+                ,this.checkboxOnlyUnreferenced
                 , "-"
                 ,{
                     text: t("download_selected_as_zip"),

--- a/bundles/CoreBundle/Resources/translations/de.json
+++ b/bundles/CoreBundle/Resources/translations/de.json
@@ -435,6 +435,7 @@
     "columns": "Spalten",
     "children_grid": "Kinder Tabelle",
     "only_children": "Nur direkte Kindelemente",
+    "only_unreferenced": "Nur nicht referenzierte",
     "cut": "Ausschneiden",
     "paste_cut_element": "Ausgeschnittenes Element einfügen",
     "memorize_tabs": "Geöffnete Tabs merken",

--- a/bundles/CoreBundle/Resources/translations/de.json
+++ b/bundles/CoreBundle/Resources/translations/de.json
@@ -435,7 +435,6 @@
     "columns": "Spalten",
     "children_grid": "Kinder Tabelle",
     "only_children": "Nur direkte Kindelemente",
-    "only_unreferenced": "Nur nicht referenzierte",
     "cut": "Ausschneiden",
     "paste_cut_element": "Ausgeschnittenes Element einfügen",
     "memorize_tabs": "Geöffnete Tabs merken",

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -486,6 +486,7 @@
   "columns": "Columns",
   "children_grid": "Children Grid",
   "only_children": "just direct children",
+  "only_unreferenced": "only not referenced",
   "cut": "Cut",
   "paste_cut_element": "Paste cut-out element",
   "memorize_tabs": "Memorize open tabs",

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -486,7 +486,7 @@
   "columns": "Columns",
   "children_grid": "Children Grid",
   "only_children": "just direct children",
-  "only_unreferenced": "only not referenced",
+  "only_unreferenced": "only unreferenced",
   "cut": "Cut",
   "paste_cut_element": "Paste cut-out element",
   "memorize_tabs": "Memorize open tabs",


### PR DESCRIPTION
Sometimes you want to clean up your assets. To be able to show assets which are not referenced in any object or document this PR introduces a new checkbox in the asset list view.