### PR TITLE
Do not replace a replaced link in Glossary

### DIFF
--- a/lib/Tool/Glossary/Processor.php
+++ b/lib/Tool/Glossary/Processor.php
@@ -254,9 +254,9 @@ class Processor
 
             // add PCRE delimiter and modifiers
             if ($d['exactmatch']) {
-                $d['text'] = '/<a.*?(?<!\w)' . preg_quote($d['text'], '/') . '(?!\w).*?\/a>(*SKIP)(*FAIL)|(?<!\w)' . preg_quote($d['text'], '/') . '(?!\w)/';
+                $d['text'] = '/<a.*\/a>(*SKIP)(*FAIL)|(?<!\w)' . preg_quote($d['text'], '/') . '(?!\w)/';
             } else {
-                $d['text'] = '/<a.*?' . preg_quote($d['text'], '/') . '.*?\/a>(*SKIP)(*FAIL)|' . preg_quote($d['text'], '/') . '/';
+                $d['text'] = '/<a.*\/a>(*SKIP)(*FAIL)|' . preg_quote($d['text'], '/') . '/';
             }
 
             if (!$d['casesensitive']) {

--- a/lib/Tool/Glossary/Processor.php
+++ b/lib/Tool/Glossary/Processor.php
@@ -254,9 +254,9 @@ class Processor
 
             // add PCRE delimiter and modifiers
             if ($d['exactmatch']) {
-                $d['text'] = "/(?<!\w)" . preg_quote($d['text'], '/') . "(?!\w)/";
+                $d['text'] = '/<a.*?(?<!\w)' . preg_quote($d['text'], '/') . '(?!\w).*?\/a>(*SKIP)(*FAIL)|(?<!\w)' . preg_quote($d['text'], '/') . '(?!\w)/';
             } else {
-                $d['text'] = '/' . preg_quote($d['text'], '/') . '/';
+                $d['text'] = '/<a.*?' . preg_quote($d['text'], '/') . '.*?\/a>(*SKIP)(*FAIL)|' . preg_quote($d['text'], '/') . '/';
             }
 
             if (!$d['casesensitive']) {


### PR DESCRIPTION
When you have two Glossary entrys like:

Test 1 -> Link: /de/Test 1
Test 2 -> Link: /de/Test 1

in the old way the link looks like:
<a href="/de/<a href="Test 1">Test 1">">Test 1</a>

Now it looks if the Link is in a <a> Tag and ignore this one.

