### PR TITLE
Fix create translation modal display in document language overview

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/document_language_overview.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/document_language_overview.js
@@ -268,6 +268,7 @@ pimcore.document.document_language_overview = Class.create({
                     });
 
                     var win = new Ext.Window({
+                        modal: true,
                         width: 600,
                         bodyStyle: "padding:10px",
                         items: [pageForm],


### PR DESCRIPTION
## Changes in this pull request  
Fixes "Create Translation" modals to always display on top

## Additional info  

