### PR TITLE
Catch error if a single quantity value fails

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers/quantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers/quantityValue.js
@@ -22,11 +22,7 @@ pimcore.helpers.quantityValue.initUnitStore = function(callback, filters) {
         var newListener = function () {
             pimcore.helpers.quantityValue.storeLoaded = true;
             pimcore.helpers.quantityValue.storeLoading = false;
-            try {
-                pimcore.helpers.quantityValue.getData(callback, filters);
-            } catch (e) {
-                console.log("An error occured while fetching quantity value data.");
-            }
+            pimcore.helpers.quantityValue.getData(callback, filters);
         }.bind(this);
 
         if (!pimcore.helpers.quantityValue.store) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers/quantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers/quantityValue.js
@@ -22,7 +22,11 @@ pimcore.helpers.quantityValue.initUnitStore = function(callback, filters) {
         var newListener = function () {
             pimcore.helpers.quantityValue.storeLoaded = true;
             pimcore.helpers.quantityValue.storeLoading = false;
-            pimcore.helpers.quantityValue.getData(callback, filters);
+            try {
+                pimcore.helpers.quantityValue.getData(callback, filters);
+            } catch (e) {
+                console.log("An error occured while fetching quantity value data.");
+            }
         }.bind(this);
 
         if (!pimcore.helpers.quantityValue.store) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
@@ -44,7 +44,7 @@ pimcore.object.tags.quantityValue = Class.create(pimcore.object.tags.abstract, {
         var storeData = data.data;
         storeData.unshift({'id': -1, 'abbreviation' : "(" + t("empty") + ")"});
 
-        if (Ext.getCmp(this.component.id) !== undefined) {
+        if (!!this.component && Ext.getCmp(this.component.id) !== undefined) {
             this.store.loadData(storeData);
             if (this.unitField) {
                 this.unitField.reset();

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
@@ -44,10 +44,11 @@ pimcore.object.tags.quantityValue = Class.create(pimcore.object.tags.abstract, {
         var storeData = data.data;
         storeData.unshift({'id': -1, 'abbreviation' : "(" + t("empty") + ")"});
 
-        this.store.loadData(storeData);
-
-        if (this.unitField) {
-            this.unitField.reset();
+        if (Ext.getCmp(this.component.id) !== undefined) {
+            this.store.loadData(storeData);
+            if (this.unitField) {
+                this.unitField.reset();
+            }
         }
     },
 


### PR DESCRIPTION
## Catch error if a single quantity value fails
Currently if one quantity value fails to load all fail.

### Use Case
When manipulating an object's layout within the `postOpenObject` hook (i.e. removing a tab which contains quantity values) since quantity value fields are fetched asynchronosly, if a single quantity value field can't be resolved any more (target fields for which the data would be fetched are gone) all quantity units fail.