### PR TITLE
Add CSS selector for classification store tag

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/classificationstore.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/classificationstore.js
@@ -97,6 +97,7 @@ pimcore.object.tags.classificationstore = Class.create(pimcore.object.tags.abstr
         this.fieldConfig.fieldtype = "panel";
 
         var wrapperConfig = {
+            bodyCls: "pimcore_object_tag_classification_store",
             border: true,
             style: "margin-bottom: 10px",
             layout: "fit"


### PR DESCRIPTION
## Add CSS selector for classification store tag
Tags as `manyToManyObjectsRelation` and `manyToManyRelation` already have CSS selectors for their panel's bodies defined in the schema `pimcore_object_tag_xxxxx`. This PR adds a CSS selector in the same schema to the classification store tag.