### PR TITLE
Add missing trims for email-array getters

### DIFF
--- a/lib/Helper/Mail.php
+++ b/lib/Helper/Mail.php
@@ -418,7 +418,7 @@ CSS;
         $emailArray = preg_split('/,|;/', $emailString);
         if ($emailArray) {
             foreach ($emailArray as $emailStringEntry) {
-                $entryAddress = $emailStringEntry;
+                $entryAddress = trim($emailStringEntry);
                 $entryName = null;
                 $matches = [];
                 if (preg_match('/(.*)<(.*)>/', $entryAddress, $matches)) {

--- a/models/Document/Email.php
+++ b/models/Document/Email.php
@@ -215,7 +215,7 @@ class Email extends Model\Document\PageSnippet
     {
         $emailAddresses = preg_split('/,|;/', $this->getFrom());
 
-        return $emailAddresses;
+        return array_map('trim', $emailAddresses);
     }
 
     /**
@@ -257,7 +257,7 @@ class Email extends Model\Document\PageSnippet
 
         $emailAddresses = preg_split('/,|;/', $this->getReplyTo());
 
-        return $emailAddresses;
+        return array_map('trim', $emailAddresses);
     }
 
     /**

--- a/models/Document/Newsletter.php
+++ b/models/Document/Newsletter.php
@@ -131,7 +131,7 @@ class Newsletter extends Model\Document\PageSnippet
     {
         $emailAddresses = preg_split('/,|;/', $this->getFrom());
 
-        return $emailAddresses;
+        return array_map('trim', $emailAddresses);
     }
 
     /**


### PR DESCRIPTION
## Steps to Reproduce

Set your default email settings (receiver and copy) to include spaces like `john.doe@example.com; jane.doe@example.com`.  
Send an email with these default settings. It should throw an error that the second email is not compliant to the RFC 2822, 3.6.2

## Changes in this pull request  

Adds trim command for all email split strings (found with `preg_split('/,|;/'`)
