### PR TITLE
Correct return type for inherited data

### DIFF
--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -676,7 +676,6 @@ abstract class Data
 
         // insert this line if inheritance from parent objects is allowed
         if ($class instanceof DataObject\ClassDefinition && $class->getAllowInherit() && $this->supportsInheritance()) {
-
             $code .= "\t" . 'if(\Pimcore\Model\DataObject::doGetInheritedValues() && $this->getClass()->getFieldDefinition("' . $key . '")->isEmpty($data)) {' . "\n";
             $code .= "\t\t" . 'return '.$typeCast.'$this->getValueFromParent("' . $key . '");' . "\n";
             $code .= "\t" . '}' . "\n";

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -652,6 +652,10 @@ abstract class Data
         $allowedReturnTypes = [];
         foreach(explode('|', $docTypes) as $docType) {
             $docType = trim($docType);
+            if(strpos($docType, '?') === 0) {
+                $allowedReturnTypes[] = 'null';
+                $docType = substr($docType, 1);
+            }
             if(substr($docType, -2) === '[]') {
                 $allowedReturnTypes[] = 'array';
             } else {

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -694,7 +694,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
      * @param $object
      * @param array $params
      *
-     * @return array|mixed|null
+     * @return array
      */
     public function preGetData($object, $params = [])
     {

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -774,7 +774,7 @@ class AdvancedManyToManyRelation extends ManyToManyRelation
      * @param $object
      * @param array $params
      *
-     * @return array|mixed|null
+     * @return array
      */
     public function preGetData($object, $params = [])
     {

--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -328,10 +328,6 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
             $container = new DataObject\Fieldcollection(null, $this->getName());
             $container->load($object);
 
-            if ($container->isEmpty()) {
-                return null;
-            }
-
             return $container;
         }
 

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -528,7 +528,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
      * @param $object
      * @param array $params
      *
-     * @return array|mixed|null
+     * @return array
      */
     public function preGetData($object, $params = [])
     {

--- a/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
@@ -701,7 +701,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
      * @param $object
      * @param array $params
      *
-     * @return array|mixed|null
+     * @return array
      */
     public function preGetData($object, $params = [])
     {


### PR DESCRIPTION
Without this PR it is possible to get data from getters whose type does not match with the doc tags. This often confuses programmers and IDEs. This is especially annoying for relation getters which shall return arrays but do return `null` if neither the object itself has the relation field being filled nor its parents (because https://github.com/pimcore/pimcore/blob/master/models/DataObject/Concrete.php#L532-L543 is independent of the field type). 
But this also applies for non-inherited data. With this PR the returned data gets casted to the correct return type.