### PR TITLE
Add possibility to enable debug mode when generating PDFs with PDFreactor

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/web2print.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/web2print.js
@@ -151,6 +151,11 @@ pimcore.settings.web2print = Class.create({
                         fieldLabel: t("web2print_licence"),
                         name: 'pdfreactorLicence',
                         value: this.getValue("pdfreactorLicence")
+                    }, {
+                        xtype: 'checkbox',
+                        fieldLabel: t("web2print_enableDebugMode"),
+                        name: 'pdfreactorEnableDebugMode',
+                        value: this.getValue("pdfreactorEnableDebugMode")
                     }
                 ]
             });

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -585,6 +585,7 @@
   "close_tab": "Close Tab",
   "web2print_only_published": "Only possible with published documents.",
   "web2print_documents_changed": "Documents changed since last pdf generation.",
+  "web2print_enableDebugMode": "Enable debug mode",
   "about_pimcore": "ABOUT PIMCORE PLATFORM",
   "phone": "Phone",
   "workflow_additional_info": "Additional Information",

--- a/lib/Web2Print/Processor/PdfReactor8.php
+++ b/lib/Web2Print/Processor/PdfReactor8.php
@@ -46,6 +46,7 @@ class PdfReactor8 extends Processor
             'encryption' => $config->encryption,
             'addTags' => $config->tags == 'true',
             'logLevel' => $config->loglevel,
+            'enableDebugMode'=> $web2PrintConfig->pdfreactorEnableDebugMode || $config->enableDebugMode == 'true',
             'addOverprint' => $config->addOverprint == 'true'
         ];
         if ($config->viewerPreference) {
@@ -214,6 +215,8 @@ class PdfReactor8 extends Processor
             'values' => [\LogLevel::FATAL, \LogLevel::WARN, \LogLevel::INFO, \LogLevel::DEBUG, \LogLevel::PERFORMANCE],
             'default' => \LogLevel::FATAL
         ];
+
+        $options[] = ['name' => 'enableDebugMode', 'type' => 'bool', 'default' => false];
 
         $event = new PrintConfigEvent($this, [
             'options' => $options


### PR DESCRIPTION
Add possibility to enable debug mode when generating PDFs with PDFreactor.

This is especially useful when using Javascript, because console.log output is appended to the generated PDF.

<img width="332" alt="PDFreactor Debug Mode Switch" src="https://user-images.githubusercontent.com/2217367/56851614-69afcc00-6911-11e9-8c7e-da6a5e421314.png">

This is a sample of the output (only the beginning, logs are really detailed) appended by PDFreactor at the end of the document
<img width="686" alt="PDFreactor Debug Logs" src="https://user-images.githubusercontent.com/2217367/56851620-759b8e00-6911-11e9-8f10-5d874dbc16a5.png">
