### PR TITLE
Fixes __clone method non-object by moving it to after instanceof

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -66,12 +66,11 @@ class AssetController extends ElementControllerBase implements EventedController
         Element\Editlock::lock($request->get('id'), 'asset');
 
         $asset = Asset::getById(intval($request->get('id')));
-        $asset = clone $asset;
-
         if (!$asset instanceof Asset) {
             return $this->adminJson(['success' => false, 'message' => "asset doesn't exist"]);
         }
 
+        $asset = clone $asset;
         //$asset->getVersions();
         $asset->getScheduledTasks();
         $asset->idPath = Element\Service::getIdPath($asset);


### PR DESCRIPTION
Error was: `CRITICAL: __clone method called on non-object ... _clone method called on non-object at vendor/pimcore/pimcore/bundles/AdminBundle/Controller/Admin/AssetController.php:69`

## Changes in this pull request  
Resolves no specific bug report, but this has sometimes happened after assets were not fully uploaded and some traces of seemed to be left in caches (maybe).

Just hardening the code against those odd situations.