### PR TITLE
Fix down logic in Migration 20190403120728

### DIFF
--- a/bundles/CoreBundle/Resources/migrations/Version20190403120728.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20190403120728.php
@@ -79,7 +79,7 @@ class Version20190403120728 extends AbstractPimcoreMigration
             foreach ($metaTables as $table) {
                 $metaTable = current($table);
                 $this->addSql('ALTER TABLE `' . $metaTable . '` DROP COLUMN `index`');
-                $this->addSql('ALTER TABLE `' . $relationTable . '` DROP PRIMARY KEY');
+                $this->addSql('ALTER TABLE `' . $metaTable . '` DROP PRIMARY KEY');
                 $this->addSql('ALTER TABLE `' . $metaTable . '` ADD PRIMARY KEY (`o_id`, `dest_id`, `type`, `fieldname`, `column`, `ownertype`, `ownername`, `position`)');
             }
         } catch (\Exception $e) {


### PR DESCRIPTION
Fix the used table when restoring the old primary keys.

Currently, this leaves the last modifed relation table without a primary key, and causes errors for the meta tables as you cannot add multiple primary keys to a table.