### PR TITLE
Use numeric field options also for cleaning up data in setter

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Numeric.php
+++ b/models/DataObject/ClassDefinition/Data/Numeric.php
@@ -577,16 +577,8 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
      */
     public function preSetData($object, $data, $params = [])
     {
-        if($this->getInteger()) {
-            $data = (int)$data;
-        }
-
         if($this->getDecimalPrecision()) {
             $data = round($data, $this->getDecimalPrecision());
-        }
-
-        if($this->getUnsigned()) {
-            $data = max(0, $data);
         }
 
         return $data;

--- a/models/DataObject/ClassDefinition/Data/Numeric.php
+++ b/models/DataObject/ClassDefinition/Data/Numeric.php
@@ -567,4 +567,28 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
 
         return (float) $value;
     }
+
+    /**
+     * @param $object
+     * @param $data
+     * @param array $params
+     *
+     * @return array|null
+     */
+    public function preSetData($object, $data, $params = [])
+    {
+        if($this->getInteger()) {
+            $data = (int)$data;
+        }
+
+        if($this->getDecimalPrecision()) {
+            $data = round($data, $this->getDecimalPrecision());
+        }
+
+        if($this->getUnsigned()) {
+            $data = max(0, $data);
+        }
+
+        return $data;
+    }
 }


### PR DESCRIPTION
Currently when calling the setter of a numeric field the data gets written to the object without any validation or cleanup. With this PR the field's settings "integer", "decimal precision" and "unsigned" are used to clean-up set data.