### PR TITLE
Use index for version maintenance query

### DIFF
--- a/bundles/CoreBundle/Resources/migrations/Version20190508074339.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20190508074339.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+
+class Version20190508074339 extends AbstractPimcoreMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE `versions`
+            DROP INDEX `ctype`,
+            ADD INDEX `ctype_cid` (`ctype`, `cid`);');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE `versions`
+            DROP INDEX `ctype_cid`,
+            ADD INDEX `ctype` (`ctype`);');
+    }
+}

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -773,7 +773,7 @@ CREATE TABLE `versions` (
   `binaryFileId` BIGINT(20) UNSIGNED NULL DEFAULT NULL,
   PRIMARY KEY  (`id`),
   KEY `cid` (`cid`),
-  KEY `ctype` (`ctype`),
+  KEY `ctype_cid` (`ctype`, `cid`),
   KEY `date` (`date`),
   KEY `binaryFileHash` (`binaryFileHash`),
   KEY `binaryFileId` (`binaryFileId`)


### PR DESCRIPTION
In the maintenance job at the step of removing excess versions the following SQL query gets executed (when using max. steps of object versions and not versioning by days):
https://github.com/pimcore/pimcore/blob/606c231f9dddd5fbc6458077014aafe4af315493/models/Version/Dao.php#L200
The actual query for example is then:
`SELECT cid,count(*) as amount FROM versions WHERE ctype = 'object' AND NOT public AND id NOT IN (0) GROUP BY cid HAVING amount > 10`

Currently this query is using a temporary table and filesort:
```
id | select_type | table | partitions | type | possible_keys | key | key_len | ref | rows | filtered | Extra
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | SIMPLE | versions | NULL | ref | PRIMARY,cid,ctype | ctype | 2 | const | 83065 | 5.00 | Using index condition; Using where; Using temporary; Using filesort
```

In this PR I added an index with 2 columns `ctype`, `cid`. With this index the query plan is quite better:
```
id | select_type | table | partitions | type | possible_keys | key | key_len | ref | rows | filtered | Extra
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | SIMPLE | versions | NULL | ref | PRIMARY,cid,ctype_cid | ctype_cid | 2 | const | 83064 | 5.00 | Using index condition; Using where
```

As MySQL always uses matching prefixes of indexes all queries which used the single-column index `ctype` until now, can now use the new 2-column index.