### PR TITLE
[Data Objects] Relational Fields with Image Previews are not automatically adjusting the Grids height

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -109,6 +109,7 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
         var columns = [];
         columns.push({text: 'ID', dataIndex: 'id', width: 50});
 
+        var repaintNeeded = false;
         for (i = 0; i < visibleFields.length; i++) {
             if (!empty(this.fieldConfig.visibleFieldDefinitions) && !empty(visibleFields[i])) {
                 var layout = this.fieldConfig.visibleFieldDefinitions[visibleFields[i]];
@@ -132,6 +133,10 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
                     fc.renderer = this.fullPathRenderCheck.bind(this);
                 }
                 columns.push(fc);
+
+                if(layout.fieldtype === "image") {
+                    repaintNeeded = true;
+                }
             }
         }
 
@@ -403,9 +408,16 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
 
         this.component.reference = this;
 
+        if(repaintNeeded) {
+            this.component.on("afterrender", function () {
+                setTimeout(function() {
+                    this.component.getView().refresh()
+                }.bind(this), 500);
+            }.bind(this));
+        }
+
         if (!readOnly) {
             this.component.on("afterrender", function () {
-
                 var dropTargetEl = this.component.getEl();
                 var gridDropTarget = new Ext.dd.DropZone(dropTargetEl, {
                     ddGroup: 'element',


### PR DESCRIPTION
In fbda3b52181cbd5846390e6ff32d1eca9ef4f2c7 @weisswurstkanone has reset image thumbnail size of relations to 88x88. As described in https://github.com/pimcore/pimcore/commit/fbda3b52181cbd5846390e6ff32d1eca9ef4f2c7#commitcomment-33425737 there is a problem on initial loading: As the thumbnail is not yet loaded, the row height does not match the image height.

To reproduce:
1. Create class with an image field
1. Save class
1. Reload class definition and add advanced many-to-many object relation field. Allow the class itself and specify the image field as "visible field".
1. Create an object "A" and assign an image
1. Create another object "B" and assign "A" to the advanced many-to-many object relation. In this moment you see something like this:
<img width="1260" alt="Bildschirmfoto 2019-05-08 um 14 54 51" src="https://user-images.githubusercontent.com/8749138/57376826-430b5400-71a1-11e9-8b73-54b381e08764.png">
1. After switching to Properties tab (or another object or any other panel) and back to edit panel you get:
<img width="1259" alt="Bildschirmfoto 2019-05-08 um 14 55 54" src="https://user-images.githubusercontent.com/8749138/57376896-66ce9a00-71a1-11e9-8651-21f51a704a19.png">
Because of the layout refresh the row height gets adjusted.

This behaviour is not only the case for initially assigning an object but also if you reload the page in the browser and repoen the object - at first the image is cut.

I am a bit ashamed of my solution in this PR because it uses a timeout. Certainly there is a better way to recognize the image being loaded to trigger the view refresh. Perhaps you could give me a hint.
When we have a nice solution this has to be also implemented for normal many-to-many object relation.