### PR TITLE
[Newsletter] Improved error handling while sending newsletter

### DIFF
--- a/bundles/CoreBundle/Command/InternalNewsletterDocumentSendCommand.php
+++ b/bundles/CoreBundle/Command/InternalNewsletterDocumentSendCommand.php
@@ -145,13 +145,12 @@ class InternalNewsletterDocumentSendCommand extends AbstractCommand
         $limit = $fifth > 10 ? 10 : ($fifth < 3 ? 3 : intval($fifth));
         $offset = 0;
         $hasElements = true;
+        $index = 1;
 
         while ($hasElements) {
             $tmpStore = Model\Tool\TmpStore::get($sendingId);
 
             $data = $tmpStore->getData();
-
-            Logger::info('Sending newsletter ' . $hasElements . ' / ' . $totalCount. ' [' . $document->getId(). ']');
 
             $data['progress'] = round($offset / $totalCount * 100, 2);
             $tmpStore->setData($data);
@@ -159,6 +158,8 @@ class InternalNewsletterDocumentSendCommand extends AbstractCommand
 
             $sendingParamContainers = $addressAdapter->getParamsForSingleSending($limit, $offset);
             foreach ($sendingParamContainers as $sendingParamContainer) {
+                Logger::warn('Sending newsletter ' . $index . ' / ' . $totalCount. ' [' . $document->getId(). ']');
+                
                 try {
                     $mail = \Pimcore\Tool\Newsletter::prepareMail($document, $sendingParamContainer, $hostUrl);
                     \Pimcore\Tool\Newsletter::sendNewsletterDocumentBasedMail($mail, $sendingParamContainer);
@@ -170,6 +171,7 @@ class InternalNewsletterDocumentSendCommand extends AbstractCommand
                     Logger::warn("Sending configuration for sending ID $sendingId was deleted. Cancelling sending process.");
                     exit;
                 }
+                ++$index;
             }
 
             $offset += $limit;

--- a/bundles/CoreBundle/Command/InternalNewsletterDocumentSendCommand.php
+++ b/bundles/CoreBundle/Command/InternalNewsletterDocumentSendCommand.php
@@ -158,6 +158,7 @@ class InternalNewsletterDocumentSendCommand extends AbstractCommand
 
             $sendingParamContainers = $addressAdapter->getParamsForSingleSending($limit, $offset);
             foreach ($sendingParamContainers as $sendingParamContainer) {
+                //Please leave log-level warning, otherwise current status of sending process won't be logged in newsletter-sending-output.log
                 Logger::warn('Sending newsletter ' . $index . ' / ' . $totalCount. ' [' . $document->getId(). ']');
                 
                 try {

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -627,7 +627,6 @@ class Mail extends \Swift_Message
                 $mailer->send($this, $emailaddress);            
             } catch (\Exception $e){
                 $mailer->getTransport()->stop();
-                sleep(10);
                 throw new \Exception($emailaddress[0].' - '.$e->getMessage());
             }
         }

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -623,7 +623,13 @@ class Mail extends \Swift_Message
 
         if ($event->hasArgument('mailer')) {
             $mailer = $event->getArgument('mailer');
-            $mailer->send($this);
+            try {
+                $mailer->send($this, $emailaddress);            
+            } catch (\Exception $e){
+                $mailer->getTransport()->stop();
+                sleep(10);
+                throw new \Exception($emailaddress[0].' - '.$e->getMessage());
+            }
         }
 
         if ($this->loggingIsEnabled()) {

--- a/lib/Tool/Newsletter.php
+++ b/lib/Tool/Newsletter.php
@@ -114,8 +114,16 @@ class Newsletter
     public static function sendNewsletterDocumentBasedMail(Mail $mail, SendingParamContainer $sendingContainer)
     {
         $mailAddress = $sendingContainer->getEmail();
+        
+        if(!self::to_domain_exists($mailAddress)) {
+            Logger::err('E-Mail address invalid: ' . self::obfuscateEmail($mailAddress));
+            $mailAddress = null;
+        }
+        
         if (!empty($mailAddress)) {
             $mail->setTo($mailAddress);
+            //Getting bounces
+            $mail->setReturnPath(key($mail->getFrom()));
 
             $mailer = null;
             //check if newsletter specific mailer is needed
@@ -522,5 +530,18 @@ class Newsletter
     public function getClass()
     {
         return $this->class;
+    }
+    
+    /**
+     * Checks if domain of email has a MX record
+     *
+     * @email string $email
+     *
+     * @return bool
+     */
+    public function to_domain_exists($email)
+    {
+	    list($user, $domain) = explode('@', $email);
+	    return checkdnsrr($domain, 'MX');
     }
 }


### PR DESCRIPTION
If the domain of a recipient is misspelled or not existing, the existing process causes:

Expected response code 354 but got code "554", with message "554 5.5.0 No valid recipients have been specified

Improvement:
First Step: Avoiding any email domains with no MX entries.
Second Step: If any error occurs cancel the jamming smtp-process via $mailer->getTransport()->stop();

* Changed Logger:info to Logge r:warn otherwise no output in the “newsletter-sending-output.log”
* Added counter to see the exact progress of the sending process in the .log file, helps later in finding any further errors
* Added ReturnPath for hard bounces
