### PR TITLE
Make EcommerceFrameworkBundle::hasCurrentUserId() more reliable

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Environment.php
+++ b/bundles/EcommerceFrameworkBundle/Environment.php
@@ -174,7 +174,7 @@ class Environment implements IEnvironment
         $this->load();
 
         $this->customItems = null;
-        $this->userId = null;
+        $this->userId = self::USER_ID_NOT_SET;
         $this->currentAssortmentTenant = null;
         $this->currentAssortmentSubTenant = null;
         $this->currentCheckoutTenant = null;

--- a/bundles/EcommerceFrameworkBundle/SessionEnvironment.php
+++ b/bundles/EcommerceFrameworkBundle/SessionEnvironment.php
@@ -63,7 +63,7 @@ class SessionEnvironment extends Environment implements IEnvironment
 
         $this->customItems = $sessionBag->get(self::SESSION_KEY_CUSTOM_ITEMS, []);
 
-        $this->userId = $sessionBag->get(self::SESSION_KEY_USERID);
+        $this->userId = $sessionBag->get(self::SESSION_KEY_USERID, self::USER_ID_NOT_SET);
 
         $this->currentAssortmentTenant = $sessionBag->get(self::SESSION_KEY_ASSORTMENT_TENANT);
         $this->currentAssortmentSubTenant = $sessionBag->get(self::SESSION_KEY_ASSORTMENT_SUB_TENANT);


### PR DESCRIPTION
## Problem

Currently `Pimcore\Bundle\EcommerceFrameworkBundle::hasCurrentUserId()` isn't very reliable because it checks `userId` for the value defined in `Pimcore\Bundle\EcommerceFrameworkBundle\Environment::USER_ID_NOT_SET` (-1).
However, there are multiple locations in which `userId` is set to `null` as default/re-set value.

A loose `empty()` check in `hasCurrentUserId()` could be fair to handle that in a very generic way but I'd say it's preferable to fix the consistency first.

## Changes in this pull request  
Change two locations to use `Pimcore\Bundle\EcommerceFrameworkBundle\Environment::USER_ID_NOT_SET` when "re-"setting the `userId` property.