### PR TITLE
[Fieldcollection] Allow class definition import with missing fieldcollections

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -862,9 +862,9 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
     public function classSaved($class, $params = [])
     {
         if (is_array($this->allowedTypes)) {
-            foreach ($this->allowedTypes as $allowedType) {
-                $definition = DataObject\Fieldcollection\Definition::getByKey($allowedType);
-                if ($definition) {
+            foreach ($this->allowedTypes as $i => $allowedType) {
+                try {
+                    $definition = DataObject\Fieldcollection\Definition::getByKey($allowedType);
                     $definition->getDao()->createUpdateTable($class);
                     $fieldDefinition = $definition->getFieldDefinitions();
 
@@ -878,6 +878,9 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
                     }
 
                     $definition->getDao()->classSaved($class);
+                } catch (\Exception $exception) {
+                    Logger::warn("Removed unknown allowed type [ $allowedType ] from allowed types of field collection");
+                    unset($this->allowedTypes[$i]);
                 }
             }
         }

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -241,6 +241,8 @@ class Definition extends Model\AbstractModel
      * @param $key
      *
      * @throws \Exception
+     *
+     * @return Definition
      */
     public static function getByKey($key)
     {


### PR DESCRIPTION
## Additional info  

`Definition::getByKey` should always return Fieldcollection/Definition objects. Otherwise it throws an exception. With try/catch it is possible to import the class and remove the missing fieldcollections.

The same is in the setAllowedTypes function:
https://github.com/pimcore/pimcore/blob/cc117f07839630a73063109f424d0b9ecf6aa5bb/models/DataObject/ClassDefinition/Data/Fieldcollections.php#L372-L377