### PR TITLE
Respect the default language setting when creating new users

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -118,7 +118,8 @@ class UserController extends AdminController implements EventedControllerInterfa
                 'parentId' => intval($request->get('parentId')),
                 'name' => trim($request->get('name')),
                 'password' => '',
-                'active' => $request->get('active')
+                'active' => $request->get('active'),
+                'language' => \Pimcore\Config::getSystemConfig()->get('general')->get('language')
             ]);
 
             if ($request->get('rid')) {


### PR DESCRIPTION
Pimcore doesn't respect the default language setting in the system settings when creating new users. With this PR the language is set to the system settings value for every user on user creation.

## Bug Report:

## Expected behavior:
When setting the 'Default-Language in Admin-Interface' in System Settings > General to e.g. 'German', a new users 'Language' setting should by default be set to 'German'

## Actual Behavior:
The default language is always 'English'

## Steps to reproduce:
- Go to https://demo-basic.pimcore.org/admin/
- Open Settings > System Settings > General
- Change the default admin language to something other than English
- Save and agree to reload Pimcore
- Go to Settings > User and Roles > Users
- Create a new user
=> The language of the new user is 'English'

