### PR TITLE
Fix: Missing field name translation in grid cell editor

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/gridCellEditor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/gridCellEditor.js
@@ -51,12 +51,15 @@ Ext.define('pimcore.object.helpers.gridCellEditor', {
             return;
         }
 
-        var title = fieldInfo.label ? fieldInfo.label : fieldInfo.key;
-
         this.context = this.editingPlugin.context;
         // this.callParent(arguments);
 
         var tagType = fieldInfo.layout.fieldtype;
+
+        // translate title
+        if(typeof fieldInfo.layout.title != "undefined") {
+            fieldInfo.layout.title = t(fieldInfo.layout.title);
+        }
 
         var tag = new pimcore.object.tags[tagType](value, fieldInfo.layout);
         var object = Ext.clone(this.context.record);
@@ -70,7 +73,7 @@ Ext.define('pimcore.object.helpers.gridCellEditor', {
         });
         this.editWin = new Ext.Window({
             modal: false,
-            title: t("edit") + " " + title,
+            title: t("edit") + " " + fieldInfo.layout.title,
             items: [formPanel],
             bodyStyle: "background: #fff;",
             width: 700,


### PR DESCRIPTION
This PR translates the field name like in edit helper:
https://github.com/pimcore/pimcore/blob/8b21bdd0e5cbb42b4261e2e596849f57292d8529/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/edit.js#L134-L137