### PR TITLE
Sort objects numerically when sorting by index

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -147,10 +147,14 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             $childsList->setCondition($condition);
             $childsList->setLimit($limit);
             $childsList->setOffset($offset);
-            $childsList->setOrderKey(
-                sprintf('CAST(objects.o_%s AS CHAR CHARACTER SET utf8) COLLATE utf8_general_ci ASC', $object->getChildrenSortBy()),
-                false
-            );
+            if($object->getChildrenSortBy() === 'index') {
+                $childsList->setOrderKey('objects.o_index ASC', false);
+            } else {
+                $childsList->setOrderKey(
+                    sprintf('CAST(objects.o_%s AS CHAR CHARACTER SET utf8) COLLATE utf8_general_ci ASC', $object->getChildrenSortBy()),
+                    false
+                );
+            }
             $childsList->setObjectTypes($objectTypes);
 
             Element\Service::addTreeFilterJoins($cv, $childsList);


### PR DESCRIPTION
Currently sorting of child objects of a data object in the tree is done alphabetically. When sorting by index it has to be numerically, otherwise the order is 0, 1, 10, 11, 12, 2, 20.

How to reproduce:
* Create folder and set children sorting to "by index"
* Create 10 objects within the same folder
* Move the second item to the bottom (position 10)
* Refresh tree -> the item is now on position 3
