### PR TITLE
Performance enhancement when moving object to folder with lots of children

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1128,15 +1128,16 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         $updatedObject->saveIndex($newIndex);
 
         Db::get()->executeUpdate('UPDATE '.$list->getDao()->getTableName().' o, 
-        (
-            SELECT newIndex, o_id FROM (SELECT @n := IF(@n = ? - 1,@n + 2,@n + 1) AS newIndex, o_id 
-            FROM '.$list->getDao()->getTableName().', 
-            (SELECT @n := -1) variable 
-            WHERE o_id != ? AND o_parentId = ? AND o_type IN (\'' . implode("','", [DataObject\AbstractObject::OBJECT_TYPE_OBJECT, DataObject\AbstractObject::OBJECT_TYPE_VARIANT, DataObject\AbstractObject::OBJECT_TYPE_FOLDER]) . '\') 
-            ORDER BY o_index, o_id=?
-        ) tmp) order_table
-        SET o.o_index = order_table.newIndex
-        WHERE o.o_id=order_table.o_id',
+            (
+                SELECT newIndex, o_id FROM (SELECT @n := IF(@n = ? - 1,@n + 2,@n + 1) AS newIndex, o_id 
+                FROM '.$list->getDao()->getTableName().', 
+                (SELECT @n := -1) variable 
+                WHERE o_id != ? AND o_parentId = ? AND o_type IN (\'' . implode("','", [DataObject\AbstractObject::OBJECT_TYPE_OBJECT, DataObject\AbstractObject::OBJECT_TYPE_VARIANT, DataObject\AbstractObject::OBJECT_TYPE_FOLDER]) . '\') 
+                    ORDER BY o_index, o_id=?
+                ) tmp
+            ) order_table
+            SET o.o_index = order_table.newIndex
+            WHERE o.o_id=order_table.o_id',
             [
                 $newIndex, $updatedObject->getId(), $updatedObject->getParentId(), $updatedObject->getId()
             ]

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1128,17 +1128,17 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         $updatedObject->saveIndex($newIndex);
 
         Db::get()->executeUpdate('UPDATE '.$list->getDao()->getTableName().' o, 
-            (
-                SELECT newIndex, o_id FROM (SELECT @n := IF(o_id=?,o_index,@n + 1) AS newIndex, o_id 
-                FROM '.$list->getDao()->getTableName().', 
-                (SELECT @n := -1) variable 
-                WHERE o_parentId = ? AND o_type IN (\'' . implode("','", [DataObject\AbstractObject::OBJECT_TYPE_OBJECT, DataObject\AbstractObject::OBJECT_TYPE_VARIANT, DataObject\AbstractObject::OBJECT_TYPE_FOLDER]) . '\') 
-                ORDER BY o_index, o_id=?
-            ) tmp) order_table
-            SET o.o_index = order_table.newIndex
-            WHERE o.o_id=order_table.o_id',
+        (
+            SELECT newIndex, o_id FROM (SELECT @n := IF(@n = ? - 1,@n + 2,@n + 1) AS newIndex, o_id 
+            FROM '.$list->getDao()->getTableName().', 
+            (SELECT @n := -1) variable 
+            WHERE o_id != ? AND o_parentId = ? AND o_type IN (\'' . implode("','", [DataObject\AbstractObject::OBJECT_TYPE_OBJECT, DataObject\AbstractObject::OBJECT_TYPE_VARIANT, DataObject\AbstractObject::OBJECT_TYPE_FOLDER]) . '\') 
+            ORDER BY o_index, o_id=?
+        ) tmp) order_table
+        SET o.o_index = order_table.newIndex
+        WHERE o.o_id=order_table.o_id',
             [
-                $updatedObject->getId(), $updatedObject->getParentId(), $updatedObject->getId()
+                $newIndex, $updatedObject->getId(), $updatedObject->getParentId(), $updatedObject->getId()
             ]
         );
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1124,9 +1124,24 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             }
         };
 
+        $list = new DataObject\Listing();
         $updatedObject->saveIndex($newIndex);
 
-        $list = new DataObject\Listing();
+        Db::get()->executeUpdate('UPDATE '.$list->getDao()->getTableName().' o, 
+            (
+                SELECT newIndex, o_id FROM (SELECT @n := IF(o_id=?,o_index,@n + 1) AS newIndex, o_id 
+                FROM '.$list->getDao()->getTableName().', 
+                (SELECT @n := -1) variable 
+                WHERE o_parentId = ? AND o_type IN (\'' . implode("','", [DataObject\AbstractObject::OBJECT_TYPE_OBJECT, DataObject\AbstractObject::OBJECT_TYPE_VARIANT, DataObject\AbstractObject::OBJECT_TYPE_FOLDER]) . '\') 
+                ORDER BY o_index, o_id=?
+            ) tmp) order_table
+            SET o.o_index = order_table.newIndex
+            WHERE o.o_id=order_table.o_id',
+            [
+                $updatedObject->getId(), $updatedObject->getParentId(), $updatedObject->getId()
+            ]
+        );
+
         $list->setCondition(
             'o_parentId = ? AND o_id != ?',
             [$updatedObject->getParentId(), $updatedObject->getId()]
@@ -1143,9 +1158,10 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 $index++;
             }
 
-            $sibling->saveIndex($index);
             $updateLatestVersionIndex($sibling, $index);
             $index++;
+
+            $sibling->clearDependentCache();
         }
     }
 


### PR DESCRIPTION
As described in #4332 there is a major performance issue when moving a data object to a folder with lots of objects because all siblings get updated separately:
https://github.com/pimcore/pimcore/blob/606c231f9dddd5fbc6458077014aafe4af315493/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php#L1107-L1140

This PR updates all sibling's o_index values at once.

Performance comparison for a folder with 14.000 objects:
without this PR: 267 seconds
with this PR: 130 seconds

Resolves #4332 