### PR TITLE
Grid Tab batch edit error only show the IDs

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/gridTabAbstract.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/gridTabAbstract.js
@@ -321,9 +321,9 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
             if (this.batchErrors.length > 0) {
                 var jobErrors = [];
                 for (var i = 0; i < this.batchErrors.length; i++) {
-                    jobErrors.push(this.batchErrors[i].job);
+                    jobErrors.push(this.batchErrors[i].job + ' - ' + this.batchErrors[i].error);
                 }
-                Ext.Msg.alert(t("error"), t("error_jobs") + ": " + jobErrors.join(","));
+                Ext.Msg.alert(t("error"), t("error_jobs") + ":<br>" + jobErrors.join("<br>"));
             }
 
             return;
@@ -353,7 +353,9 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
                     }
                 } catch (e) {
                     this.batchErrors.push({
-                        job: currentJob
+                        job: currentJob,
+                        error: (typeof(rdata.message) !== "undefined" && rdata.message) ?
+                            rdata.message : 'Not Successful'
                     });
                 }
 


### PR DESCRIPTION
When batch editing in Grid Tab (ie: Advanced Object Search) errors are not returned and only show ids.
Suggestion:
Show the a list of failed IDs and error message (once that we already have the request with this message)
![Screenshot from 2019-05-20 14-42-41](https://user-images.githubusercontent.com/19567461/58023024-18a98700-7b0f-11e9-868d-bc3f517596ae.png)

This allow our users to see the error and take some action after this.

## Changes:
- Push the error message to allow with the job ID,
- Display the error message in the error message alert.

Resolves #4404 