### PR TITLE
Bugfix: Send language param in grid tab 

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1987,7 +1987,7 @@ class DataObjectHelperController extends AdminController
                 // check for objects bricks and localized fields
                 if (DataObject\Service::isHelperGridColumnConfig($field)) {
                     if ($helperDefinitions[$field]) {
-                        return DataObject\Service::calculateCellValue($object, $helperDefinitions, $field);
+                        return DataObject\Service::calculateCellValue($object, $helperDefinitions, $field, ['language' => $requestedLanguage]);
                     }
                 } elseif (substr($field, 0, 1) == '~') {
                     $type = $fieldParts[1];

--- a/lib/DataObject/GridColumnConfig/Operator/Factory/TranslateValueFactory.php
+++ b/lib/DataObject/GridColumnConfig/Operator/Factory/TranslateValueFactory.php
@@ -19,7 +19,9 @@ namespace Pimcore\DataObject\GridColumnConfig\Operator\Factory;
 
 use Pimcore\DataObject\GridColumnConfig\Operator\OperatorInterface;
 use Pimcore\DataObject\GridColumnConfig\Operator\TranslateValue;
+use Pimcore\Tool;
 use Symfony\Component\Translation\TranslatorInterface;
+
 
 class TranslateValueFactory implements OperatorFactoryInterface
 {
@@ -35,6 +37,9 @@ class TranslateValueFactory implements OperatorFactoryInterface
 
     public function build(\stdClass $configElement, $context = null): OperatorInterface
     {
+	    if(null !== $context && isset($context['language']) && Tool::isValidLanguage($context['language'])) {
+		    $this->translator->setLocale($context['language']);
+	    }
         return new TranslateValue($this->translator, $configElement, $context);
     }
 }

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -465,6 +465,9 @@ class Service extends Model\Element\Service
     public static function getConfigForHelperDefinition($helperDefinitions, $key, $context = [])
     {
         $cacheKey = 'gridcolumn_config_' . $key;
+	    if(isset($context['language'])) {
+		    $cacheKey .= '_' . $context['language'];
+	    }
         if (Runtime::isRegistered($cacheKey)) {
             $config = Runtime::get($cacheKey);
         } else {

--- a/tests/_support/Util/TestHelper.php
+++ b/tests/_support/Util/TestHelper.php
@@ -168,7 +168,6 @@ class TestHelper
                 }
 
                 if ($document instanceof Document\Page) {
-                    $d['name'] = $document->getName();
                     $d['title'] = $document->getTitle();
                     $d['description'] = $document->getDescription();
                 }


### PR DESCRIPTION
When using the SQL editor in the grid view the selected language from grid config is not transfered.
After clicking the button to show SQL editor, the correct language is displayed but grid data is translated to default language.

This behavior is reproducable in demo system.