### PR TITLE
Fix: Language for TranslateValue operator

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1987,7 +1987,7 @@ class DataObjectHelperController extends AdminController
                 // check for objects bricks and localized fields
                 if (DataObject\Service::isHelperGridColumnConfig($field)) {
                     if ($helperDefinitions[$field]) {
-                        return DataObject\Service::calculateCellValue($object, $helperDefinitions, $field);
+                        return DataObject\Service::calculateCellValue($object, $helperDefinitions, $field, ['language' => $requestedLanguage]);
                     }
                 } elseif (substr($field, 0, 1) == '~') {
                     $type = $fieldParts[1];

--- a/lib/DataObject/GridColumnConfig/Operator/Factory/TranslateValueFactory.php
+++ b/lib/DataObject/GridColumnConfig/Operator/Factory/TranslateValueFactory.php
@@ -19,7 +19,6 @@ namespace Pimcore\DataObject\GridColumnConfig\Operator\Factory;
 
 use Pimcore\DataObject\GridColumnConfig\Operator\OperatorInterface;
 use Pimcore\DataObject\GridColumnConfig\Operator\TranslateValue;
-use Pimcore\Tool;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class TranslateValueFactory implements OperatorFactoryInterface
@@ -36,9 +35,6 @@ class TranslateValueFactory implements OperatorFactoryInterface
 
     public function build(\stdClass $configElement, $context = null): OperatorInterface
     {
-	    if(null !== $context && isset($context['language']) && Tool::isValidLanguage($context['language'])) {
-		    $this->translator->setLocale($context['language']);
-	    }
-        return new TranslateValue($this->translator, $configElement, $context);
+	    return new TranslateValue($this->translator, $configElement, $context);
     }
 }

--- a/lib/DataObject/GridColumnConfig/Operator/Factory/TranslateValueFactory.php
+++ b/lib/DataObject/GridColumnConfig/Operator/Factory/TranslateValueFactory.php
@@ -19,6 +19,7 @@ namespace Pimcore\DataObject\GridColumnConfig\Operator\Factory;
 
 use Pimcore\DataObject\GridColumnConfig\Operator\OperatorInterface;
 use Pimcore\DataObject\GridColumnConfig\Operator\TranslateValue;
+use Pimcore\Tool;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class TranslateValueFactory implements OperatorFactoryInterface
@@ -35,6 +36,9 @@ class TranslateValueFactory implements OperatorFactoryInterface
 
     public function build(\stdClass $configElement, $context = null): OperatorInterface
     {
+	    if(null !== $context && isset($context['language']) && Tool::isValidLanguage($context['language'])) {
+		    $this->translator->setLocale($context['language']);
+	    }
         return new TranslateValue($this->translator, $configElement, $context);
     }
 }

--- a/lib/DataObject/GridColumnConfig/Operator/TranslateValue.php
+++ b/lib/DataObject/GridColumnConfig/Operator/TranslateValue.php
@@ -28,12 +28,17 @@ class TranslateValue extends AbstractOperator
 
     private $prefix;
 
+	private $locale;
+
     public function __construct(TranslatorInterface $translator, \stdClass $config, $context = null)
     {
         parent::__construct($config, $context);
 
         $this->translator = $translator;
         $this->prefix = $config->prefix;
+	    if(null != $context && isset($context['language'])) {
+		    $this->locale = $context['language'];
+	    }
     }
 
     public function getLabeledValue($element)
@@ -42,7 +47,15 @@ class TranslateValue extends AbstractOperator
         if ($childs[0]) {
             $value = $childs[0]->getLabeledValue($element);
             if (strval($value->value) != '') {
-                $value->value = $this->translator->trans($this->prefix . strval($value->value), []);
+	            $currentLocale = $this->translator->getLocale();
+	            if(null != $this->locale)
+	            {
+		            $this->translator->setLocale($this->locale);
+	            }
+
+	            $value->value = $this->translator->trans($this->prefix . strval($value->value), []);
+
+	            $this->translator->setLocale($currentLocale);
             }
 
             return $value;

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -465,6 +465,9 @@ class Service extends Model\Element\Service
     public static function getConfigForHelperDefinition($helperDefinitions, $key, $context = [])
     {
         $cacheKey = 'gridcolumn_config_' . $key;
+	    if(isset($context['language'])) {
+		    $cacheKey .= '_' . $context['language'];
+	    }
         if (Runtime::isRegistered($cacheKey)) {
             $config = Runtime::get($cacheKey);
         } else {

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -262,7 +262,8 @@ class Service extends Model\Element\Service
 
         if ($object instanceof Concrete) {
             $context = ['object' => $object,
-                'purpose' => 'gridview'];
+                'purpose' => 'gridview',
+                'language' => $requestedLanguage];
             $data['classname'] = $object->getClassName();
             $data['idPath'] = Element\Service::getIdPath($object);
             $data['inheritedFields'] = [];


### PR DESCRIPTION
The TranslateValue operator does not take into account the language setting of the grid configuration (for view and CSV export).
## Steps to reproduce

1. Configure gridview with "Transformers > Operator Translate Value" + Input attribute
2. Select other language than default language
3. Value in grid column and CSV export column will not be translated
