### PR TITLE
Bugfix: Create asset from remote stream

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -332,12 +332,17 @@ class Asset extends Element\AbstractElement
                         $mimeType = Mime::detect($streamMeta['uri']);
                     } else {
                         // write a tmp file because the stream isn't a pointer to the local filesystem
-                        rewind($data['stream']);
+                        $isRewindable = @rewind($data['stream']);
                         $dest = fopen($tmpFile, 'w+', false, File::getContext());
                         stream_copy_to_stream($data['stream'], $dest);
-                        fclose($dest);
                         $mimeType = Mime::detect($tmpFile);
-                        unlink($tmpFile);
+
+                        if(!$isRewindable) {
+                            $data['stream'] = $dest;
+                        } else {
+                            fclose($dest);
+                            unlink($tmpFile);
+                        }
                     }
                 }
             } else {
@@ -1273,7 +1278,7 @@ class Asset extends Element\AbstractElement
         if ($this->stream) {
             $streamMeta = stream_get_meta_data($this->stream);
             if (!@rewind($this->stream) && $streamMeta['stream_type'] === 'STDIO') {
-                $this->stream = null;
+                    $this->stream = null;
             }
         }
 


### PR DESCRIPTION
Currently there is a bug when you want to create an asset from a remote stream, reproducable with the following script:
```php
<?php
$fileStream = fopen('https://picsum.photos/200', 'rb');
\Pimcore\Model\Asset::create(1, [
    'filename' => 'test'.uniqid(),
    'stream' => $fileStream,
    'userOwner' => 0,
    'userModification' => 0,
]);
```

Problem is that PHP does not support rewinding remote streams. For this reason I keep the temporary file which originally was used to determine the MIME type and use this also for the data import.