### PR TITLE
[Document|Object] Sort contextmenu by translated names

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
@@ -960,12 +960,12 @@ pimcore.document.tree = Class.create({
         };
 
         document_types.sort([{property: 'priority', direction: 'DESC'},
-            {property: 'name', direction: 'ASC'}]);
+            {property: 'translatedName', direction: 'ASC'}]);
 
         document_types.each(function (documentMenu, typeRecord) {
             if (typeRecord.get("type") == "page") {
                 docTypeMenu = {
-                    text: ts(typeRecord.get("name")),
+                    text: typeRecord.get("translatedName"),
                     iconCls: "pimcore_icon_page pimcore_icon_overlay_add",
                     handler: this.addDocument.bind(this, tree, record, "page", typeRecord.get("id"))
                 };
@@ -973,35 +973,35 @@ pimcore.document.tree = Class.create({
             }
             else if (typeRecord.get("type") == "snippet") {
                 docTypeMenu = {
-                    text: ts(typeRecord.get("name")),
+                    text: typeRecord.get("translatedName"),
                     iconCls: "pimcore_icon_snippet pimcore_icon_overlay_add",
                     handler: this.addDocument.bind(this, tree, record, "snippet", typeRecord.get("id"))
                 };
                 menuOption = "snippet";
             } else if (typeRecord.get("type") == "email") {
                 docTypeMenu = {
-                    text: ts(typeRecord.get("name")),
+                    text: typeRecord.get("translatedName"),
                     iconCls: "pimcore_icon_email pimcore_icon_overlay_add",
                     handler: this.addDocument.bind(this, tree, record, "email", typeRecord.get("id"))
                 };
                 menuOption = "email";
             } else if (typeRecord.get("type") == "newsletter") {
                 docTypeMenu = {
-                    text: ts(typeRecord.get("name")),
+                    text: typeRecord.get("translatedName"),
                     iconCls: "pimcore_icon_newsletter pimcore_icon_overlay_add",
                     handler: this.addDocument.bind(this, tree, record, "newsletter", typeRecord.get("id"))
                 };
                 menuOption = "newsletter";
             } else if (typeRecord.get("type") == "printpage") {
                 docTypeMenu = {
-                    text: ts(typeRecord.get("name")),
+                    text: typeRecord.get("translatedName"),
                     iconCls: "pimcore_icon_printpage pimcore_icon_overlay_add",
                     handler: this.addDocument.bind(this, tree, record, "printpage", typeRecord.get("id"))
                 };
                 menuOption = "printPage";
             } else if (typeRecord.get("type") == "printcontainer") {
                 docTypeMenu = {
-                    text: ts(typeRecord.get("name")),
+                    text: typeRecord.get("translatedName"),
                     iconCls: "pimcore_icon_printcontainer pimcore_icon_overlay_add",
                     handler: this.addDocument.bind(this, tree, record, "printcontainer", typeRecord.get("id"))
                 };

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
@@ -361,6 +361,8 @@ pimcore.object.tree = Class.create({
             var tmpMenuEntryImport;
             var $this = this;
 
+            object_types.sort([{property: 'translatedText', direction: 'ASC'}]);
+
             object_types.each(function (classRecord) {
 
                 if ($this.config.allowedClasses && !in_array(classRecord.get("id"), $this.config.allowedClasses)) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
@@ -276,8 +276,22 @@ Ext.onReady(function () {
     Ext.define('pimcore.model.doctypes', {
         extend: 'Ext.data.Model',
         fields: [
-            'id',  {name: 'name', allowBlank: false}, 'module', 'controller', 'action', 'template',
-            {name: 'type', allowBlank: false},'priority', 'creationDate', 'modificationDate'
+            'id',
+            {name: 'name', allowBlank: false},
+            {
+                name: "translatedName",
+                convert: function (v, rec) {
+                    return t(rec.data.name);
+                }
+            },
+            'module',
+            'controller',
+            'action',
+            'template',
+            {name: 'type', allowBlank: false},
+            'priority',
+            'creationDate',
+            'modificationDate'
         ],
         proxy: {
             type: 'ajax',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
@@ -281,7 +281,7 @@ Ext.onReady(function () {
             {
                 name: "translatedName",
                 convert: function (v, rec) {
-                    return t(rec.data.name);
+                    return t(rec.get("name"));
                 }
             },
             'module',


### PR DESCRIPTION
In the moment the contextmenu of document and object are not sorted by name if you have set translations.