### PR TITLE
[Data Object] fixes behavior of DataObject\Concrete::getValueFromParent() ...

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Model/AbstractFilterDefinition.php
+++ b/bundles/EcommerceFrameworkBundle/Model/AbstractFilterDefinition.php
@@ -82,7 +82,12 @@ abstract class AbstractFilterDefinition extends \Pimcore\Model\DataObject\Concre
                 'get' . $checkInheritanceKey
                 }() == 'true'
             ) {
-                $parentValue = $this->getValueFromParent($key);
+                try {
+                    $parentValue = $this->getValueFromParent($key);
+                } catch (\Exception $e) {
+                    $parentValue = null;
+                }
+
                 $data = $this->$key;
                 if (!$data) {
                     $data = $this->getClass()->getFieldDefinition($key)->preGetData($this);

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_V5_to_V6.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_V5_to_V6.md
@@ -59,6 +59,7 @@ with the following configuration:
 #### Data Object Changes
 - **Checkbox data-type** is tri-state from now on (`null`, `true`, `false`). A default value can be set for the editmode (not on database-level). Null means that inheritance is enabled, otherwise it isn't. Until now, inheritance was enabled also for false value.
 - Removed the `Persona` and `Persona Multiselect` data object data-types, please use `TargetGroup` and `TargetGroupMultiselect` instead
+- `Pimcore\Model\DataObject\Concrete::getValueFromParent()` and `Pimcore\Model\DataObject\Objectbrick\Data\AbstractData::getValueFromParent` throws an exception if it can't get a value from a parent
 
 #### Removed Classes, Interfaces, Methods, Constants, Functions
 ```
@@ -165,5 +166,5 @@ Pimcore\Model\Document\Tag\Area::getBrickConfigs()
 
 #### Method Singnature Changes
 ```
-\Pimcore\Templating\Renderer\IncludeRenderer::render() - removed last optional argument $legacyView
+Pimcore\Templating\Renderer\IncludeRenderer::render() - removed last optional argument $legacyView
 ```

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -659,7 +659,11 @@ abstract class Data
         // insert this line if inheritance from parent objects is allowed
         if ($class instanceof DataObject\ClassDefinition && $class->getAllowInherit() && $this->supportsInheritance()) {
             $code .= "\t" . 'if(\Pimcore\Model\DataObject::doGetInheritedValues() && $this->getClass()->getFieldDefinition("' . $key . '")->isEmpty($data)) {' . "\n";
-            $code .= "\t\t" . 'return $this->getValueFromParent("' . $key . '");' . "\n";
+            $code .= "\t\t" . 'try {' . "\n";
+            $code .= "\t\t\t" . 'return $this->getValueFromParent("' . $key . '");' . "\n";
+            $code .= "\t\t" . '} catch (\Exception $e) {' . "\n";
+            $code .= "\t\t\t" . '// no data from parent available, continue ... ' . "\n";
+            $code .= "\t\t" . '}' . "\n";
             $code .= "\t" . '}' . "\n";
         }
 
@@ -751,7 +755,11 @@ abstract class Data
 
         if ($this->supportsInheritance()) {
             $code .= "\t" . 'if(\Pimcore\Model\DataObject::doGetInheritedValues($this->getObject()) && $this->getDefinition()->getFieldDefinition("' . $key . '")->isEmpty($data)) {' . "\n";
-            $code .= "\t\t" . 'return $this->getValueFromParent("' . $key . '");' . "\n";
+            $code .= "\t\t" . 'try {' . "\n";
+            $code .= "\t\t\t" . 'return $this->getValueFromParent("' . $key . '");' . "\n";
+            $code .= "\t\t" . '} catch (\Exception $e) {' . "\n";
+            $code .= "\t\t\t" . '// no data from parent available, continue ... ' . "\n";
+            $code .= "\t\t" . '}' . "\n";
             $code .= "\t" . '}' . "\n";
         }
 

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -523,11 +523,9 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
 
     /**
      * @param $key
-     * @param $params
-     *
+     * @param null $params
      * @return mixed
-     *
-     * @todo: return explicit null or false
+     * @throws \Exception
      */
     public function getValueFromParent($key, $params = null)
     {
@@ -536,10 +534,12 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
             $method = 'get' . $key;
             if (method_exists($parent, $method)) {
                 return call_user_func([$parent, $method], $params);
+            } else {
+                throw new \Exception(sprintf('Parent object does not have a method called `%s()`, unable to retrieve value for key `%s`', $method, $key));
             }
         }
 
-        return;
+        throw new \Exception('No parent object available to get a value from');
     }
 
     /**

--- a/models/DataObject/Objectbrick.php
+++ b/models/DataObject/Objectbrick.php
@@ -183,9 +183,13 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
                     $inheritanceModeBackup = AbstractObject::getGetInheritedValues();
                     AbstractObject::setGetInheritedValues(true);
                     if (AbstractObject::doGetInheritedValues($object)) {
-                        $container = $object->getValueFromParent($this->fieldname);
-                        if (!empty($container)) {
-                            $parentBrick = $container->$getter();
+                        try {
+                            $container = $object->getValueFromParent($this->fieldname);
+                            if (!empty($container)) {
+                                $parentBrick = $container->$getter();
+                            }
+                        } catch (\Exception $e) {
+                            // no data from parent available, continue ...
                         }
                     }
                     AbstractObject::setGetInheritedValues($inheritanceModeBackup);
@@ -207,9 +211,13 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
                     $inheritanceModeBackup = AbstractObject::getGetInheritedValues();
                     AbstractObject::setGetInheritedValues(true);
                     if (AbstractObject::doGetInheritedValues($object)) {
-                        $container = $object->getValueFromParent($this->fieldname);
-                        if (!empty($container)) {
-                            $parentBrick = $container->$getter();
+                        try {
+                            $container = $object->getValueFromParent($this->fieldname);
+                            if (!empty($container)) {
+                                $parentBrick = $container->$getter();
+                            }
+                        } catch (\Exception $e) {
+                            // no data from parent available, continue ...
                         }
                     }
                     AbstractObject::setGetInheritedValues($inheritanceModeBackup);

--- a/models/DataObject/Objectbrick/Data/AbstractData.php
+++ b/models/DataObject/Objectbrick/Data/AbstractData.php
@@ -146,8 +146,8 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
 
     /**
      * @param $key
-     *
      * @return mixed
+     * @throws \Exception
      */
     public function getValueFromParent($key)
     {
@@ -163,7 +163,7 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
             }
         }
 
-        return null;
+        throw new \Exception('No parent object available to get a value from');
     }
 
     /**

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -499,10 +499,14 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
 
                     if ($class->getAllowInherit()) {
                         $cd .= "\t" . 'if(!$this->' . $brickKey . ' && \\Pimcore\\Model\\DataObject\\AbstractObject::doGetInheritedValues($this->getObject())) { ' . "\n";
-                        $cd .= "\t\t" . '$brick = $this->getObject()->getValueFromParent("' . $fieldname . '");' . "\n";
-                        $cd .= "\t\t" . 'if(!empty($brick)) {' . "\n";
-                        $cd .= "\t\t\t" . 'return $this->getObject()->getValueFromParent("' . $fieldname . '")->get' . ucfirst($brickKey) . "(); \n";
-                        $cd .= "\t\t" . "}\n";
+                        $cd .= "\t\t" . 'try {' . "\n";
+                        $cd .= "\t\t\t" . '$brick = $this->getObject()->getValueFromParent("' . $fieldname . '");' . "\n";
+                        $cd .= "\t\t\t" . 'if(!empty($brick)) {' . "\n";
+                        $cd .= "\t\t\t\t" . 'return $this->getObject()->getValueFromParent("' . $fieldname . '")->get' . ucfirst($brickKey) . "(); \n";
+                        $cd .= "\t\t\t" . "}\n";
+                        $cd .= "\t\t" . '} catch (\Exception $e) {' . "\n";
+                        $cd .= "\t\t\t" . '// no data from parent available, continue ... ' . "\n";
+                        $cd .= "\t\t" . '}' . "\n";
                         $cd .= "\t" . "}\n";
                     }
                     $cd .= '   return $this->' . $brickKey . "; \n";


### PR DESCRIPTION
..., to work as expected without the workaround using 'null' - related to discussion here #4268
