### PR TITLE
[Semantical Error] Fix `@depricated` annotation

### DIFF
--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -503,7 +503,7 @@ class Config extends Model\AbstractModel
     /**
      * This is just for compatibility, this method will be removed with the next major release
      *
-     * @depricated
+     * @deprecated
      * @static
      *
      * @param $config


### PR DESCRIPTION
This fixes a spelling error in the annotation block of `getByLegacyConfig`.
