### PR TITLE
remove NotificationServiceFilterParser from DI

### DIFF
--- a/bundles/AdminBundle/Resources/config/services.yml
+++ b/bundles/AdminBundle/Resources/config/services.yml
@@ -33,7 +33,6 @@ services:
 
     Pimcore\Model\Notification\Service\NotificationService:
         public: true
-    Pimcore\Model\Notification\Service\NotificationServiceFilterParser: ~
     Pimcore\Model\Notification\Service\UserService: ~
 
     #


### PR DESCRIPTION
The file is not used and takes Request as parameter, which cannot be autowired anyway.
