### PR TITLE
Issue when System Language contains underscore

### DIFF
--- a/lib/Google/Cse.php
+++ b/lib/Google/Cse.php
@@ -59,6 +59,10 @@ class Cse implements \Iterator, AdapterInterface, AdapterAggregateInterface
 
             // determine language
             $language = \Pimcore::getContainer()->get('pimcore.locale')->findLocale();
+            
+            if ($position = strpos($language, "_")){
+                $language = substr($language, 0,$position);
+            }
 
             if (!array_key_exists('hl', $config) && !empty($language)) {
                 $config['hl'] = $language;


### PR DESCRIPTION
Google CSE search doesn't accept language parameters such as "pl_PL" "fr_FR" etc, it wants the language to be "pl", "fr" etc.
With the fix only the part before the underscore is used.

