### PR TITLE
Es Bugfix - Bool filter

### DIFF
--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/MultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/MultiSelect.php
@@ -64,12 +64,14 @@ class MultiSelect extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService
                 }
             }
 
-            if ($filterDefinition->getUseAndCondition()) {
-                foreach ($quotedValues as $value) {
-                    $productList->addCondition($value, $field);
+            if (!empty($quotedValues)) {
+                if ($filterDefinition->getUseAndCondition()) {
+                    foreach ($quotedValues as $value) {
+                        $productList->addCondition($value, $field);
+                    }
+                } else {
+                    $productList->addCondition(['terms' => ['attributes.' . $field => $quotedValues]], $field);
                 }
-            } else {
-                $productList->addCondition(['terms' => ['attributes.' . $field => $quotedValues]], $field);
             }
         }
 

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/MultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/MultiSelect.php
@@ -56,14 +56,20 @@ class MultiSelect extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService
                     $quotedValues[] = $v;
                 }
             }
-            if (!empty($quotedValues)) {
-                if ($filterDefinition->getUseAndCondition()) {
-                    foreach ($quotedValues as $value) {
-                        $productList->addCondition($value, $field);
-                    }
-                } else {
-                    $productList->addCondition(['terms' => ['attributes.' . $field => $quotedValues]], $field);
+
+            $attributeConfig = $productList->getTenantConfig()->getAttributeConfig()[$field];
+            if($attributeConfig['type'] == 'boolean'){
+                foreach($quotedValues as $k => $v){
+                    $quotedValues[$k] = (bool)$v;
                 }
+            }
+
+            if ($filterDefinition->getUseAndCondition()) {
+                foreach ($quotedValues as $value) {
+                    $productList->addCondition($value, $field);
+                }
+            } else {
+                $productList->addCondition(['terms' => ['attributes.' . $field => $quotedValues]], $field);
             }
         }
 

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/AbstractConfig.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/AbstractConfig.php
@@ -97,6 +97,15 @@ abstract class AbstractConfig implements IConfig
     }
 
     /**
+     * Attribute configuration
+     *
+     * @return array
+     */
+    public function getAttributeConfig(){
+        return $this->attributeConfig;
+    }
+
+    /**
      * Sets attribute factory as dependency. This was added as setter for BC reasons and will be added to the constructor
      * signature in Pimcore 6.
      *


### PR DESCRIPTION
If a property is defined as "bool" the value in the query has to be a bool or a string "true" or "false". 
Otherwise a parsing exception is thrown.

"0" or "1" is passed from a filterdefinition which  won't work. 
Changing the value in the backend from 0/1 to true/false didn't worked either...