### PR TITLE
Enable localized fields in object bricks

### DIFF
--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -258,7 +258,16 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
                  * @var $def DataObject\ClassDefinition\Data
                  */
                 $cd .= $def->getGetterCodeObjectbrick($this);
+                
+                if ($def instanceof DataObject\ClassDefinition\Data\Localizedfields) {
+                    $cd .= $def->getGetterCode($this);
+                }
+                
                 $cd .= $def->getSetterCodeObjectbrick($this);
+                
+                if ($def instanceof DataObject\ClassDefinition\Data\Localizedfields) {
+                    $cd .= $def->getSetterCode($this);
+                }
             }
         }
 


### PR DESCRIPTION
Now the getter functions in the localized fields are set in the objectbrick Definition.