### PR TITLE
[Webservices] Remove useless & dangerous urldecode from query filter

### DIFF
--- a/bundles/AdminBundle/Controller/Rest/AbstractRestController.php
+++ b/bundles/AdminBundle/Controller/Rest/AbstractRestController.php
@@ -302,7 +302,7 @@ abstract class AbstractRestController extends AdminController
      */
     protected function buildCondition(Request $request)
     {
-        $q = trim(urldecode($request->get('q')));
+        $q = trim($request->get('q'));
         if (!$q) {
             return;
         }

--- a/lib/Tool/RestClient/AbstractRestClient.php
+++ b/lib/Tool/RestClient/AbstractRestClient.php
@@ -459,7 +459,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     protected function buildRestParameters(array $parameters = [], $condition = null, $order = null, $orderKey = null, $offset = null, $limit = null, $groupBy = null, $objectClass = null)
     {
         if ($condition) {
-            $parameters['q'] = urlencode($condition);
+            $parameters['q'] = $condition;
         }
 
         if ($order) {


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [X] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [X] Features need to be proper documented in `doc/`
- [X] Bugfixes need a short guide how to reproduce them. 
- [X] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [X] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request
Removed useless & dangerous urldecode, which could cause an unwanted transformation, when take the query from the request to filter the results.

## Additional info  
As indicated in the [PHP documentation](https://www.php.net/manual/en/function.urldecode.php#refsect1-function.urldecode-notes), the `$ _GET` and `$ _REQUEST` variables are already decoded, so the urldecode could accidentally transform the query.

For example the query `{"field":{"$like":"%6232%"}}` is transformed to
`{"field":{"$like":"b32%"}}` because `%62` represents the char `b`.
Below a screenshot with the first value corresponds to the query taken from the request and the second the value `urldecoded` two times.

![Screenshot from 2019-05-31 14-32-00](https://user-images.githubusercontent.com/16133208/58792954-72bd4880-85f5-11e9-9271-d0349f02a053.png)

The behavior can be reproduced on the latest demo, in all calls where filters are made:

- Search Assets
- Search Documents
- Search Objects
- Get Asset Count
- Get Document Count
- Get Object Count
- Get Classification Store Definition
- Get QuantityValue unit Definition