### PR TITLE
Make the custom layout pop up properly after page refresh.

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -425,7 +425,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             $validLayouts = DataObject\Service::getValidLayouts($object);
 
             //master layout has id 0 so we check for is_null()
-            if (is_null($currentLayoutId) && !empty($validLayouts)) {
+            if ((is_null($currentLayoutId) || !strlen($currentLayoutId)) && !empty($validLayouts)) {
                 if (count($validLayouts) == 1) {
                     $firstLayout = reset($validLayouts);
                     $currentLayoutId = $firstLayout->getId();


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
## Issue this PR references  
#3934 
## Changes in this pull request  
 - treat the empty layoutId parameter in the getAction in DataObjectController as a null parameter

## Additional info  
Basically, when you apply a custom layout to an object and ascribe this custom layout to a user or group, when you first log in as this user or group and open an object the layout is applied correctly. However, when you refresh the page the custom layout is gone. This is because upon refreshing the Pimcore frontend puts an empty-valued `layoutId` parameter in the request. Why it does that is a different matter, but this empty parameter is treated as an actual parameter - thus the layout set for the user or group is lost. This way or another, an empty parameter shouldn't be processed at all.

If the issue is wrong then tell me - I'll create a different one for this problem specifically.
