### PR TITLE
[EcommerceFramework][Datatrans-Lightbox] - add upp-start-target attribute

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Datatrans.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Datatrans.php
@@ -221,6 +221,7 @@ class Datatrans extends AbstractPayment
         $formAttributes['data-success-url'] = $config['successUrl'];
         $formAttributes['data-error-url'] = $config['errorUrl'];
         $formAttributes['data-cancel-url'] = $config['cancelUrl'];
+        $formAttributes['data-upp-start-target'] = $config['uppStartTarget'] ? $config['uppStartTarget'] : '_top';
         if ($config['useAlias']) {
             $formAttributes['data-use-alias'] = 'true';
         }


### PR DESCRIPTION
in case of the datatrans lightbox the additional attribute upp-start-target should be set to '_top'. this is necessary since chrome apparently blocks redirects from within the lightbox iframe.  Such a redirect may happen to the Access Control Server of the bank which can lead to the following error:

'Unsafe JavaScript attempt to initiate navigation .... The frame attempting navigation is targeting its top-level window, but is neither same-origin with its target nor has it received a user gesture'

@fashxp 