### PR TITLE
[UI] Fix: Edit Icon in Areabricks

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/icons.css
+++ b/bundles/AdminBundle/Resources/public/css/icons.css
@@ -38,8 +38,8 @@
 
 .pimcore_icon_overlay_edit:before {
     position: absolute;
-    width: 16px;
-    height: 16px;
+    width: 24px;
+    height: 24px;
     bottom: 0px;
     right: 0px;
     content: "";


### PR DESCRIPTION
See edit icon in embed brick (Basic Demo):
![image](https://user-images.githubusercontent.com/998558/59030308-e9aa4980-8860-11e9-85cc-9bd723ef8102.png)

