### PR TITLE
Extend asset tree store timout

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/tree.js
@@ -90,7 +90,8 @@ pimcore.asset.tree = Class.create({
                 extraParams: {
                     limit: itemsPerPage,
                     view: this.config.customViewId
-                }
+                },
+                timeout: 60000
             },
             pageSize: itemsPerPage,
             root: rootNodeConfig


### PR DESCRIPTION
# Bugfix
Due to Ext.js default timeout of 30 sec for ajax requests, when having a slow server or limited bandwidth one may soon run into a lot of error messages "communication failure" because Ext.js canceled the requests an Pimcore can't handle the responses. This actually is a thing which should be checked for all ajax requests in Pimcore, we especially experienced this as problematic for the asset tree store.

I gues a better solution would be to not show a popup modal for such communication failures, but just a toast in the bottom right corner (like the success notifications), it should also be considered that the message should only be shown once at a time. In addition the JS handler for the failing requests should be considered. (i.e. in the element trees the folder icons should not stay in the "loading" status so that the user can try again without having to reload Pimcore or refresh the folder)

![image](https://user-images.githubusercontent.com/9052094/59032610-06498000-8867-11e9-9c14-9b714ba431ce.png)
