### PR TITLE
[User Permissions] Fix wrong inheritance of wider permissions

### DIFF
--- a/models/Asset/Dao.php
+++ b/models/Asset/Dao.php
@@ -465,7 +465,7 @@ class Dao extends Model\Element\Dao
         $userIds[] = $user->getId();
 
         try {
-            $permissionsParent = $this->db->fetchOne('SELECT `' . $type . '` FROM users_workspaces_asset WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') AND `' . $type . '`=1 ORDER BY LENGTH(cpath) DESC, ABS(userId-' . $user->getId() . ') ASC LIMIT 1');
+            $permissionsParent = $this->db->fetchOne('SELECT `' . $type . '` FROM users_workspaces_asset WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, ABS(userId-' . $user->getId() . ') ASC LIMIT 1');
 
             if ($permissionsParent) {
                 return true;

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -450,7 +450,7 @@ class Dao extends Model\Element\Dao
         $userIds[] = $user->getId();
 
         try {
-            $permissionsParent = $this->db->fetchOne('SELECT `' . $type . '` FROM users_workspaces_object WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') AND `' . $type . '`=1 ORDER BY LENGTH(cpath) DESC, ABS(userId-' . $user->getId() . ') ASC LIMIT 1');
+            $permissionsParent = $this->db->fetchOne('SELECT `' . $type . '` FROM users_workspaces_object WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, ABS(userId-' . $user->getId() . ') ASC LIMIT 1');
 
             if ($permissionsParent) {
                 return true;

--- a/models/Document/Dao.php
+++ b/models/Document/Dao.php
@@ -488,7 +488,7 @@ class Dao extends Model\Element\Dao
         $userIds[] = $user->getId();
 
         try {
-            $permissionsParent = $this->db->fetchOne('SELECT `' . $type . '` FROM users_workspaces_document WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') AND `' . $type . '`=1 ORDER BY LENGTH(cpath) DESC, ABS(userId-' . $user->getId() . ') ASC LIMIT 1');
+            $permissionsParent = $this->db->fetchOne('SELECT `' . $type . '` FROM users_workspaces_document WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, ABS(userId-' . $user->getId() . ') ASC LIMIT 1');
 
             if ($permissionsParent) {
                 return true;


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [X] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [X] Features need to be proper documented in `doc/`
- [X] Bugfixes need a short guide how to reproduce them. 
- [X] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [X] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
The problem appears when setting restrictive permissions on a child of an element to which wider permissions have been defined.
Restrictive permissions on the child are ignored.
The behavior can be reproduced on Documents, Assets and Objects.

## Steps to reproduce  
The following steps were performed on the current basic demo.
1. Create a user with wider permissions to parent document and restrictive permissions on child
![users_workspaces_permissions](https://user-images.githubusercontent.com/16133208/59114091-b0e4a000-8946-11e9-9a84-8319775c14d3.png)

2. The user can rightly perform all operations on the parent document
![homepage](https://user-images.githubusercontent.com/16133208/59114228-0751de80-8947-11e9-9bbf-bdc34e57c4fc.png)

3. The user can wrongly perform all operations on the child document even if more restrictive permissions have been defined
![homepage_child](https://user-images.githubusercontent.com/16133208/59114373-5435b500-8947-11e9-9e79-cdbd9d176dd1.png)

  

