### PR TITLE
Relation data types: Default values and Type hints

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -29,11 +29,11 @@ namespace Pimcore\Model\DataObject\ClassDefinition\Data\Extension;
 trait Relation
 {
     /**
-     * @param bool|false $asArray
+     * @param bool $asArray
      *
      * @return string[]
      */
-    protected function getPhpDocClassString($asArray = false)
+    protected function getPhpDocClassString(bool $asArray = false): array
     {
         // init
         $class = [];
@@ -42,7 +42,7 @@ trait Relation
         // add documents
         if (method_exists($this, 'getDocumentsAllowed') && $this->getDocumentsAllowed()) {
             $documentTypes = $this->getDocumentTypes();
-            if (count($documentTypes) == 0) {
+            if (count($documentTypes) === 0) {
                 $class[] = '\Pimcore\Model\Document\Page' . $strArray;
                 $class[] = '\Pimcore\Model\Document\Snippet' . $strArray;
                 $class[] = '\Pimcore\Model\Document' . $strArray;
@@ -56,7 +56,7 @@ trait Relation
         // add asset
         if (method_exists($this, 'getAssetsAllowed') && $this->getAssetsAllowed()) {
             $assetTypes = $this->getAssetTypes();
-            if (count($assetTypes) == 0) {
+            if (count($assetTypes) === 0) {
                 $class[] = '\Pimcore\Model\Asset' . $strArray;
             } elseif (is_array($assetTypes)) {
                 foreach ($assetTypes as $item) {
@@ -67,8 +67,8 @@ trait Relation
 
         // add objects
         if ($this->getObjectsAllowed()) {
-            $classes = $this->getClasses() ? $this->getClasses() : [];
-            if (count($classes) == 0) {
+            $classes = $this->getClasses();
+            if (count($classes) === 0) {
                 $class[] = '\Pimcore\Model\DataObject\AbstractObject' . $strArray;
             } elseif (is_array($classes)) {
                 foreach ($this->getClasses() as $item) {

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -82,7 +82,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
     /**
      * @return bool
      */
-    public function getObjectsAllowed()
+    public function getObjectsAllowed(): bool
     {
         return true;
     }

--- a/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
@@ -80,38 +80,38 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
      *
      * @var bool
      */
-    public $objectsAllowed;
+    public $objectsAllowed = false;
 
     /**
      *
      * @var bool
      */
-    public $assetsAllowed;
+    public $assetsAllowed = false;
 
     /**
      * Allowed asset types
      *
      * @var array
      */
-    public $assetTypes;
+    public $assetTypes = [];
 
     /**
      *
      * @var bool
      */
-    public $documentsAllowed;
+    public $documentsAllowed = false;
 
     /**
      * Allowed document types
      *
      * @var array
      */
-    public $documentTypes;
+    public $documentTypes = [];
 
     /**
      * @return bool
      */
-    public function getObjectsAllowed()
+    public function getObjectsAllowed(): bool
     {
         return $this->objectsAllowed;
     }
@@ -121,7 +121,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
      *
      * @return $this
      */
-    public function setObjectsAllowed($objectsAllowed)
+    public function setObjectsAllowed(bool $objectsAllowed)
     {
         $this->objectsAllowed = $objectsAllowed;
 
@@ -131,7 +131,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
     /**
      * @return bool
      */
-    public function getDocumentsAllowed()
+    public function getDocumentsAllowed(): bool
     {
         return $this->documentsAllowed;
     }
@@ -141,7 +141,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
      *
      * @return $this
      */
-    public function setDocumentsAllowed($documentsAllowed)
+    public function setDocumentsAllowed(bool $documentsAllowed)
     {
         $this->documentsAllowed = $documentsAllowed;
 
@@ -151,7 +151,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
     /**
      * @return array
      */
-    public function getDocumentTypes()
+    public function getDocumentTypes(): array
     {
         return $this->documentTypes;
     }
@@ -161,7 +161,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
      *
      * @return $this
      */
-    public function setDocumentTypes($documentTypes)
+    public function setDocumentTypes(array $documentTypes)
     {
         $this->documentTypes = Element\Service::fixAllowedTypes($documentTypes, 'documentTypes');
 
@@ -172,7 +172,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
      *
      * @return bool
      */
-    public function getAssetsAllowed()
+    public function getAssetsAllowed(): bool
     {
         return $this->assetsAllowed;
     }
@@ -183,7 +183,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
      *
      * @return $this
      */
-    public function setAssetsAllowed($assetsAllowed)
+    public function setAssetsAllowed(bool $assetsAllowed)
     {
         $this->assetsAllowed = $assetsAllowed;
 
@@ -193,7 +193,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
     /**
      * @return array
      */
-    public function getAssetTypes()
+    public function getAssetTypes(): array
     {
         return $this->assetTypes;
     }
@@ -203,7 +203,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
      *
      * @return $this
      */
-    public function setAssetTypes($assetTypes)
+    public function setAssetTypes(array $assetTypes)
     {
         $this->assetTypes = Element\Service::fixAllowedTypes($assetTypes, 'assetTypes');
 

--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -72,38 +72,38 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      *
      * @var bool
      */
-    public $objectsAllowed;
+    public $objectsAllowed = false;
 
     /**
      *
      * @var bool
      */
-    public $assetsAllowed;
+    public $assetsAllowed = false;
 
     /**
      * Allowed asset types
      *
      * @var array
      */
-    public $assetTypes;
+    public $assetTypes = [];
 
     /**
      *
      * @var bool
      */
-    public $documentsAllowed;
+    public $documentsAllowed = false;
 
     /**
      * Allowed document types
      *
      * @var array
      */
-    public $documentTypes;
+    public $documentTypes = [];
 
     /**
      * @return bool
      */
-    public function getObjectsAllowed()
+    public function getObjectsAllowed(): bool
     {
         return $this->objectsAllowed;
     }
@@ -113,7 +113,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      *
      * @return $this
      */
-    public function setObjectsAllowed($objectsAllowed)
+    public function setObjectsAllowed(bool $objectsAllowed)
     {
         $this->objectsAllowed = $objectsAllowed;
 
@@ -123,7 +123,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
     /**
      * @return bool
      */
-    public function getDocumentsAllowed()
+    public function getDocumentsAllowed(): bool
     {
         return $this->documentsAllowed;
     }
@@ -133,7 +133,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      *
      * @return $this
      */
-    public function setDocumentsAllowed($documentsAllowed)
+    public function setDocumentsAllowed(bool $documentsAllowed)
     {
         $this->documentsAllowed = $documentsAllowed;
 
@@ -143,7 +143,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
     /**
      * @return array
      */
-    public function getDocumentTypes()
+    public function getDocumentTypes(): array
     {
         return $this->documentTypes;
     }
@@ -153,7 +153,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      *
      * @return $this
      */
-    public function setDocumentTypes($documentTypes)
+    public function setDocumentTypes(array $documentTypes)
     {
         $this->documentTypes = Element\Service::fixAllowedTypes($documentTypes, 'documentTypes');
 
@@ -164,7 +164,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      *
      * @return bool
      */
-    public function getAssetsAllowed()
+    public function getAssetsAllowed(): bool
     {
         return $this->assetsAllowed;
     }
@@ -175,7 +175,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      *
      * @return $this
      */
-    public function setAssetsAllowed($assetsAllowed)
+    public function setAssetsAllowed(bool $assetsAllowed)
     {
         $this->assetsAllowed = $assetsAllowed;
 
@@ -185,7 +185,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
     /**
      * @return array
      */
-    public function getAssetTypes()
+    public function getAssetTypes(): array
     {
         return $this->assetTypes;
     }
@@ -195,7 +195,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      *
      * @return $this
      */
-    public function setAssetTypes($assetTypes)
+    public function setAssetTypes(array $assetTypes)
     {
         $this->assetTypes = Element\Service::fixAllowedTypes($assetTypes, 'assetTypes');
 

--- a/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
@@ -43,7 +43,7 @@ abstract class AbstractRelations extends Data implements CustomResourcePersistin
      *
      * @var array
      */
-    public $classes;
+    public $classes = [];
 
     /** Optional path formatter class
      * @var null|string
@@ -53,7 +53,7 @@ abstract class AbstractRelations extends Data implements CustomResourcePersistin
     /**
      * @return array
      */
-    public function getClasses()
+    public function getClasses(): array
     {
         return $this->classes;
     }
@@ -63,7 +63,7 @@ abstract class AbstractRelations extends Data implements CustomResourcePersistin
      *
      * @return $this
      */
-    public function setClasses($classes)
+    public function setClasses(array $classes)
     {
         $this->classes = Element\Service::fixAllowedTypes($classes, 'classes');
 

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -1003,15 +1003,15 @@ class Service extends Model\AbstractModel
     }
 
     /**
-     * @param $data
-     * @param $type
+     * @param array $data
+     * @param string $type
      *
-     * @return array|string
+     * @return array
      */
-    public static function fixAllowedTypes($data, $type)
+    public static function fixAllowedTypes(array $data, string $type): array
     {
         // this is the new method with Ext.form.MultiSelect
-        if (is_array($data) && count($data)) {
+        if (count($data)) {
             $first = reset($data);
             if (!is_array($first)) {
                 $parts = $data;
@@ -1039,7 +1039,7 @@ class Service extends Model\AbstractModel
             }
         }
 
-        return $data ? $data : [];
+        return $data;
     }
 
     /**


### PR DESCRIPTION
If you create class definitions via PHP it is possible to get an PHP error in the count functions in Relation::getPhpDocClassString method.

I think we should set default values an type hints so this couldn't happen anymore.
