### PR TITLE
getBundle returns object so array_pop does not work

### DIFF
--- a/bundles/CoreBundle/Templating/LegacyTemplateGuesser.php
+++ b/bundles/CoreBundle/Templating/LegacyTemplateGuesser.php
@@ -96,8 +96,7 @@ class LegacyTemplateGuesser extends BaseTemplateGuesser
                     $bundleName = $bundle->getName();
                     break;
                 }
-                $bundles = $this->kernel->getBundle($parentBundleName, false);
-                $bundle = array_pop($bundles);
+                $bundle = $this->kernel->getBundle($parentBundleName);
             }
         } else {
             $bundleName = null;


### PR DESCRIPTION
And getBundle does only accept one parameter.

When getParent returns a Bundle and we want to get the bundle from the
kernel there is a warning

```
Warning: array_pop() expects parameter 1 to be array, object given
```

Because \Symfony\Component\HttpKernel\Kernel::getBundle will always
return an object or throw an exception.

``` php
/**
 * {@inheritdoc}
 */
public function getBundle($name)
{
    if (!isset($this->bundles[$name])) {
        $class = \get_class($this);
        $class = 'c' === $class[0] && 0 === strpos($class, "class@anonymous\0") ? get_parent_class($class).'@anonymous' : $class;

        throw new \InvalidArgumentException(sprintf('Bundle "%s" does not exist or it is not enabled. Maybe you forgot to add it in the registerBundles() method of your %s.php file?', $name, $class));
    }

    return $this->bundles[$name];
}
```

So the getBundle will return us the desired object immediatly.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

