### PR TITLE
Elastic search subtenants

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultElasticSearchSubTenantConfig.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultElasticSearchSubTenantConfig.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config;
+
+use Pimcore\Bundle\EcommerceFrameworkBundle\EnvironmentInterface;
+use Pimcore\Bundle\EcommerceFrameworkBundle\Model\IndexableInterface;
+use Pimcore\Db\ConnectionInterface;
+
+/**
+ * Sample implementation for sub-tenants based on elastic search.
+ */
+class DefaultElasticSearchSubTenantConfig extends ElasticSearch
+{
+
+    /**
+     * checks, if product should be in index for current tenant (not subtenant)
+     *
+     * @param IndexableInterface $object
+     *
+     * @return bool
+     */
+    public function inIndex(IndexableInterface $object)
+    {
+        $tenants = $object->getTenants();
+
+        return !empty($tenants);
+    }
+
+    /**
+     * in case of subtenants returns an array containing all sub tenants
+     *
+     * In this case tenants are also Pimcore objects and are assigned to product objects.
+     * This method extracts assigned tenants and returns an array of subtenant-IDs
+     *
+     * @param IndexableInterface $object
+     * @param null $subObjectId
+     *
+     * @return array $subTenantData
+     */
+    public function prepareSubTenantEntries(IndexableInterface $object, $subObjectId = null)
+    {
+        $subTenantData = [];
+        if ($this->inIndex($object)) {
+            //implementation specific tenant get logic
+            foreach ($object->getTenants() as $tenant) {
+                $subTenantData[] = $tenant->getId();
+            }
+        }
+
+        return $subTenantData;
+    }
+}

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
@@ -186,7 +186,7 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
 
     /**
      * in case of subtenants returns a data structure containing all sub tenants,
-     * by default should return an array of IDs of sub tenant assortments
+     * should return an array of IDs of sub tenant assortments
      *
      * @param IndexableInterface $object
      * @param null $subObjectId

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
@@ -14,6 +14,8 @@
 
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config;
 
+use Pimcore\Bundle\EcommerceFrameworkBundle\EnvironmentInterface;
+use Pimcore\Bundle\EcommerceFrameworkBundle\Factory;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\Definition\Attribute;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Interpreter\RelationInterpreterInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Worker\ElasticSearch\AbstractElasticSearch as DefaultElasticSearchWorker;
@@ -66,6 +68,11 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
         'active' => 'system.active',
         'inProductList' => 'system.inProductList',
     ];
+
+    /**
+     * @var EnvironmentInterface
+     */
+    protected $environment;
 
     protected function addAttribute(Attribute $attribute)
     {
@@ -178,16 +185,17 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
     }
 
     /**
-     * in case of subtenants returns a data structure containing all sub tenants
+     * in case of subtenants returns a data structure containing all sub tenants,
+     * by default should return an array of IDs of sub tenant assortments
      *
      * @param IndexableInterface $object
      * @param null $subObjectId
      *
-     * @return mixed $subTenantData
+     * @return array $subTenantData
      */
     public function prepareSubTenantEntries(IndexableInterface $object, $subObjectId = null)
     {
-        return null;
+        return [];
     }
 
     /**
@@ -212,7 +220,11 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
      */
     public function getSubTenantCondition()
     {
-        return;
+        if ($currentSubTenant = $this->environment->getCurrentAssortmentSubTenant()) {
+            return ['term' => ['subtenants' => $currentSubTenant]];
+        }
+
+        return [];
     }
 
     /**
@@ -256,4 +268,15 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
     {
         return $this->getTenantWorker()->getMockupFromCache($objectId);
     }
+
+    /**
+     * @required
+     *
+     * @param EnvironmentInterface $environment
+     */
+    public function setEnvironment(EnvironmentInterface $environment)
+    {
+        $this->environment = $environment;
+    }
+
 }

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
@@ -15,7 +15,6 @@
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config;
 
 use Pimcore\Bundle\EcommerceFrameworkBundle\EnvironmentInterface;
-use Pimcore\Bundle\EcommerceFrameworkBundle\Factory;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\Definition\Attribute;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Interpreter\RelationInterpreterInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Worker\ElasticSearch\AbstractElasticSearch as DefaultElasticSearchWorker;

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -245,7 +245,7 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
 
         $mappingAttributes['attributes'] = ['type' => 'object', 'dynamic' => true, 'properties' => $customAttributesMapping];
         $mappingAttributes['relations'] = ['type' => 'object', 'dynamic' => false, 'properties' => $relationAttributesMapping];
-        $mappingAttributes['subtenants'] = ['type' => 'long'];
+        $mappingAttributes['subtenants'] = ['type' => 'object', 'dynamic' => true];
         //has to be at top -> join field [system.relation] cannot be added inside an object or in a multi-field
         $mappingAttributes[static::RELATION_FIELD] = ['type' => 'join', 'relations' => ['object' => 'variant']];
 

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -245,7 +245,7 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
 
         $mappingAttributes['attributes'] = ['type' => 'object', 'dynamic' => true, 'properties' => $customAttributesMapping];
         $mappingAttributes['relations'] = ['type' => 'object', 'dynamic' => false, 'properties' => $relationAttributesMapping];
-        $mappingAttributes['subtenants'] = ['type' => 'object', 'dynamic' => true];
+        $mappingAttributes['subtenants'] = ['type' => 'long'];
         //has to be at top -> join field [system.relation] cannot be added inside an object or in a multi-field
         $mappingAttributes[static::RELATION_FIELD] = ['type' => 'join', 'relations' => ['object' => 'variant']];
 

--- a/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/03_Assortment_Tenant_Configuration.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/03_Assortment_Tenant_Configuration.md
@@ -152,6 +152,8 @@ In order to populate the additional mapping data, also following methods have to
     public function updateSubTenantEntries($objectId, $subTenantData, $subObjectId = null);
 ```
 
-For an complete example have a look at the [sample implementation](https://github.com/pimcore/pimcore/blob/master/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultMysqlSubTenantConfig.php).
+For an complete example have a look at the sample implementation for 
+- [MySQL](https://github.com/pimcore/pimcore/blob/master/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultMysqlSubTenantConfig.php)
+- [Elastic Serach](https://github.com/pimcore/pimcore/blob/master/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultElasticSearchSubTenantConfig.php)
 
-> Note: This is currently only implemented for mysql based Product Index Implementations. 
+> Note: This is currently only implemented for MySQL and Elastic Search based product index implementations. 

--- a/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/03_Assortment_Tenant_Configuration.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/03_Assortment_Tenant_Configuration.md
@@ -178,4 +178,4 @@ For an complete example have a look at the [sample implementation](https://githu
 
 ---
 
-> Note: Assortment subtenant are currently only implemented for MySQL and Elastic Search based product index implementations. 
+> Note: This is currently only implemented for MySQL and Elastic Search based product index implementations. 

--- a/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/03_Assortment_Tenant_Configuration.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/03_Assortment_Tenant_Configuration.md
@@ -96,7 +96,7 @@ The Index Service provides the corresponding Product List implementation based o
   //doing stuff with product list
 ```
 
-## Subtenant Assortments
+## Assortment Subtenants
 Subtenants are light-weight tenants, which share the same Product Index with the same attributes as their parent 
 assortment tenant.
 

--- a/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/03_Assortment_Tenant_Configuration.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/03_Assortment_Tenant_Configuration.md
@@ -16,7 +16,7 @@ of saving products, since all *Product Indices* need to be updated on every save
 By default the system always uses one heavy-weight tenant (= `DefaultMysql`), but the default tenant can be disabled. 
 
 
-### Configuration of Assortment Tenants
+## Assortment Tenants
 For setting up an Assortment Tenant, following steps are necessary: 
 
 - **Implementation of a Tenant Config:**
@@ -96,10 +96,11 @@ The Index Service provides the corresponding Product List implementation based o
   //doing stuff with product list
 ```
 
-
-### Implementing an Assortment Subtenant
+## Subtenant Assortments
 Subtenants are light-weight tenants, which share the same Product Index with the same attributes as their parent 
 assortment tenant.
+
+### Implementing an Assortment Subtenant for MySQL
 The mapping which product is assigned to with subtenant is done with an additional mapping table. The necessary 
 joins and conditions are implemented within additional methods within 
 [`Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\MysqlConfigInterface`](https://github.com/pimcore/pimcore/blob/master/bundles/EcommerceFrameworkBundle/IndexService/Config/MysqlConfigInterface.php): 
@@ -152,8 +153,29 @@ In order to populate the additional mapping data, also following methods have to
     public function updateSubTenantEntries($objectId, $subTenantData, $subObjectId = null);
 ```
 
-For an complete example have a look at the sample implementation for 
-- [MySQL](https://github.com/pimcore/pimcore/blob/master/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultMysqlSubTenantConfig.php)
-- [Elastic Serach](https://github.com/pimcore/pimcore/blob/master/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultElasticSearchSubTenantConfig.php)
+For an complete example have a look at the [sample implementation](https://github.com/pimcore/pimcore/blob/master/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultMysqlSubTenantConfig.php).
 
-> Note: This is currently only implemented for MySQL and Elastic Search based product index implementations. 
+
+### Implementing an Assortment Subtenant for Elastic Search
+
+In order to populate the additional mapping data, the following method has to be implemented: 
+
+```php
+    /**
+     * in case of subtenants returns a data structure containing all sub tenants,
+     * should return an array of IDs of sub tenant assortments
+     *
+     * @param IndexableInterface $object
+     * @param null $subObjectId
+     *
+     * @return array $subTenantData
+     */
+    public function prepareSubTenantEntries(IIndexable $object, $subObjectId = null);
+
+```
+
+For an complete example have a look at the [sample implementation](https://github.com/pimcore/pimcore/blob/master/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultElasticSearchSubTenantConfig.php).
+
+---
+
+> Note: Assortment subtenant are currently only implemented for MySQL and Elastic Search based product index implementations. 


### PR DESCRIPTION
# Elastic subtenants

Changes in this PR

1. Update mapping in elastic search worker to store subtenant assortments as a simple list of IDs
2. Default condition in eastic search config for subtenants
3. Default ElasticSearchConfig implementation
3. Update docs