### PR TITLE
String-Replace-Operator: Commit configured label

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/StringReplace.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/StringReplace.js
@@ -140,6 +140,7 @@ pimcore.object.gridcolumn.operator.stringreplace = Class.create(pimcore.object.g
 
     commitData: function(params) {
         this.node.set('isOperator', true);
+        this.node.data.configAttributes.label = this.textField.getValue();
         this.node.data.configAttributes.search = this.searchField.getValue();
         this.node.data.configAttributes.replace = this.replaceField.getValue();
         this.node.data.configAttributes.insensitive = this.insensitiveField.getValue();


### PR DESCRIPTION
Currently set label does not get saved but reverted to default "Operator String Replace".