### PR TITLE
Fix max image size in image editor - No more limits

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/Asset/imageEditor.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/Asset/imageEditor.html.php
@@ -70,7 +70,7 @@
 <div id="popup"></div>
 
 
-<img style="visibility: hidden" id='image' src='/admin/asset/get-image-thumbnail?id=<?= $this->asset->getId() ?>&width=3000&height=3000&contain=true'/>
+<img style="visibility: hidden" id='image' src='/admin/asset/get-image-thumbnail?id=<?= $this->asset->getId() ?>&width=<?= $this->asset->getWidth() ?>&height=<?= $this->asset->getHeight() ?>&contain=true'/>
 <script>
     window.addEventListener('load', function (e) {
         var image = document.getElementById('image');


### PR DESCRIPTION
Hello,

This pull request resolve https://github.com/pimcore/pimcore/issues/3723

There is no more limits of 3000x3000.
Test on image resolution of less 3000x3000 and more than 3000, saving it on the image editor preserve original image size.
Resizing up the image work well too.

Thanks