### PR TITLE
[ecommerceframework][elasticsearch] allow product index fields without mapping

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -190,6 +190,10 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
         $relationAttributesMapping = [];
 
         foreach ($this->tenantConfig->getAttributes() as $attribute) {
+            if(!$attribute->getType() && !$attribute->getOption('mapping') && !$attribute->getOption('mapper')) {
+                continue;
+            }
+
             // if option "mapping" is set (array), no other configuration is considered for mapping
             if (!empty($attribute->getOption('mapping'))) {
                 $customAttributesMapping[$attribute->getName()] = $attribute->getOption('mapping');

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -190,7 +190,11 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
         $relationAttributesMapping = [];
 
         foreach ($this->tenantConfig->getAttributes() as $attribute) {
-            if(!$attribute->getType() && !$attribute->getOption('mapping') && !$attribute->getOption('mapper')) {
+            if (empty($attribute->getType())
+                && empty($attribute->getOption('mapping'))
+                && empty($attribute->getOption('mapper'))
+                && empty($attribute->getOption('analyzer'))
+            ) {
                 continue;
             }
 

--- a/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/07_Elastic_Search.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/07_Elastic_Search.md
@@ -84,6 +84,8 @@ pimcore_ecommerce_framework:
 In addition to the `type` configuration, you also can provide custom mappings for a field. If provided, these mapping 
 configurations are used for creating the mapping of the elastic search index.
 
+You can also skip the `type` and `mapping`, then ES will try to create dynamic mapping. 
+
 ```yml
 
 pimcore_ecommerce_framework:


### PR DESCRIPTION
Elasticsearch allows to put all kind of json data structures into the index. Nevertheless the ecommerce framework currently forces to set a mapping in a product index columns. There are situations where it's better to do not use a mapping at all. Therefore this pull requests ignores columns without any kind of mapping set in the index service attribute configuration.