### PR TITLE
ApplicationLoggerDb service exception fix

### DIFF
--- a/bundles/CoreBundle/Resources/config/logging.yml
+++ b/bundles/CoreBundle/Resources/config/logging.yml
@@ -34,6 +34,7 @@ services:
 
     # the DB write handler
     Pimcore\Log\Handler\ApplicationLoggerDb:
+        public: true
         calls:
             - [pushProcessor, ['@monolog.processor.psr_log_message']]
             - [pushProcessor, ['@Pimcore\Log\Processor\ApplicationLoggerProcessor']]


### PR DESCRIPTION
## Bugfix
This PR is fixing a problem with using the `ApplicationLogger` with a [custom app logger](https://pimcore.com/docs/5.x/Development_Documentation/Tools_and_Features/Application_Logger.html#page_Setting-an-individual-logger-level) in Pimcore 6.0.0.

## Steps to reproduce
1. create a custom logger instance with the `initDbHandler` option:
`$logger = ApplicationLogger::getInstance('MyCustomLogger', true)`
2. try to use it...
=> You will get the following exception: 
```
The "Pimcore\Log\Handler\ApplicationLoggerDb" service or alias has been removed or inlined when the container was compiled. 
You should either make it public, or stop using the container directly and use dependency injection instead.
```

## Changes in this pull request  
Solving this issue is just a one-liner by making the `Pimcore\Log\Handler\ApplicationLoggerDb` service public.

---
_Please not: This is my first Pimcore PR - I hope that I did everything right_ 😉
