### PR TITLE
Unless grid is filtered or sorted - ignore localized fields when getting ids

### DIFF
--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -400,7 +400,7 @@ class GridHelperService
 
         $start = 0;
         $limit = 20;
-        $orderKey = 'oo_id';
+        $orderKey = 'o_id';
         $order = 'ASC';
 
         $fields = [];
@@ -428,10 +428,10 @@ class GridHelperService
             if (!(substr($orderKey, 0, 1) == '~')) {
                 if (array_key_exists($orderKey, $colMappings)) {
                     $orderKey = $colMappings[$orderKey];
-                } elseif ($class->getFieldDefinition($orderKey) instanceof  ClassDefinition\Data\QuantityValue) {
+                } elseif ($class->getFieldDefinition($orderKey) instanceof ClassDefinition\Data\QuantityValue) {
                     $orderKey = 'concat(' . $orderKey . '__unit, ' . $orderKey . '__value)';
                     $doNotQuote = true;
-                } elseif ($class->getFieldDefinition($orderKey) instanceof  ClassDefinition\Data\RgbaColor) {
+                } elseif ($class->getFieldDefinition($orderKey) instanceof ClassDefinition\Data\RgbaColor) {
                     $orderKey = 'concat(' . $orderKey . '__rgb, ' . $orderKey . '__a)';
                     $doNotQuote = true;
                 } elseif (strpos($orderKey, '~') !== false) {
@@ -545,6 +545,12 @@ class GridHelperService
 
         $this->addGridFeatureJoins($list, $featureJoins, $class, $featureFilters);
         $list->setLocale($requestedLanguage);
+
+        if (!$requestParams['filter']
+            && !$requestParams['condition']
+            && (!$sortingSettings['order'] || !$sortingSettings['orderKey'])) {
+            $list->setIgnoreLocalizedFields(true);
+        }
 
         return $list;
     }

--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -546,9 +546,7 @@ class GridHelperService
         $this->addGridFeatureJoins($list, $featureJoins, $class, $featureFilters);
         $list->setLocale($requestedLanguage);
 
-        if (!$requestParams['filter']
-            && !$requestParams['condition']
-            && (!$sortingSettings['order'] || !$sortingSettings['orderKey'])) {
+        if (!$requestParams['filter'] && !$requestParams['condition'] && !$requestParams['sort']) {
             $list->setIgnoreLocalizedFields(true);
         }
 


### PR DESCRIPTION
With large datasets (especially gigabytes in size), grid performance can be really low. This is caused by large views used in listings and MySQL not using indexes in them.
Probably views themself could be optimized?
Nevertheless:
## Changes in this pull request  
Unless grid is sorted or filtered, gridProxyAction will use listing with ignoreLocalizedFields flag ON. This speeds up queries, by ignoring unnecessary layer of views and using smaller temporary tables.
Default order key has been changed from oo_id to o_id as it appears to be faster.

## Additional info  
Tests has been done on Ecommerce Demo on a grid with ~65k randomly generated products.
Query cache has been disabled in MySQL.

**GridProxyAction before changes:**

`1760-2160ms`
Slowest queries:
```SELECT COUNT(*) AS `totalCount` FROM `object_localized_12_en_GB` WHERE ((o_path = '/BigFolder' OR o_path LIKE '/BigFolder/%') AND  object_localized_12_en_GB.o_type IN ('object','folder'))``` - **670.36 ms** (31.49%)

```SELECT object_localized_12_en_GB.o_id as o_id, `object_localized_12_en_GB`.`o_type` FROM `object_localized_12_en_GB` WHERE ((o_path = '/BigFolder' OR o_path LIKE '/BigFolder/%') AND  object_localized_12_en_GB.o_type IN ('object','folder')) ORDER BY `oo_id` ASC LIMIT 25 OFFSET 65275``` - **572.05 ms** (26.88%)

**GridProxyAction after changes:**

`1200-1300ms`
Slowest queries:
```SELECT COUNT(*) AS `totalCount` FROM `object_12` WHERE ((o_path = '/BigFolder' OR o_path LIKE '/BigFolder/%') AND  object_12.o_type IN ('object','folder'))``` - **288.17 ms** (22.55%)
```SELECT object_12.o_id as o_id, `object_12`.`o_type` FROM `object_12` WHERE ((o_path = '/BigFolder' OR o_path LIKE '/BigFolder/%') AND  object_12.o_type IN ('object','folder')) ORDER BY `o_id` ASC LIMIT 25 OFFSET 65325``` - **282.07 ms** (22.08%)