### PR TITLE
Output document thumbnail with correct content-type header

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -1326,10 +1326,7 @@ class AssetController extends ElementControllerBase implements EventedController
         $thumb = $document->getImageThumbnail($thumbnail, $page);
         $thumbnailFile = $thumb->getFileSystemPath();
 
-        $format = 'png';
-
         $response = new BinaryFileResponse($thumbnailFile);
-        $response->headers->set('Content-type', 'image/' . $format);
         $this->addThumbnailCacheHeaders($response);
 
         return $response;

--- a/models/Asset/Document.php
+++ b/models/Asset/Document.php
@@ -119,7 +119,7 @@ class Document extends Model\Asset
      * @param int $page
      * @param bool $deferred $deferred deferred means that the image will be generated on-the-fly (details see below)
      *
-     * @return mixed|string
+     * @return Document\ImageThumbnail
      */
     public function getImageThumbnail($thumbnailName, $page = 1, $deferred = false)
     {

--- a/models/Asset/Video.php
+++ b/models/Asset/Video.php
@@ -156,7 +156,7 @@ class Video extends Model\Asset
      * @param null $timeOffset
      * @param null $imageAsset
      *
-     * @return mixed|string
+     * @return Video\ImageThumbnail
      *
      * @throws \Exception
      */


### PR DESCRIPTION
When there is an error during document thumbnail generation Pimcore tries to load the SVG `PIMCORE_WEB_ROOT . '/bundles/pimcoreadmin/img/filetype-not-supported.svg'` (see https://github.com/pimcore/pimcore/blob/43e14cca6b5f9171ffc4abc21b1921b23feec33b/models/Asset/Document/ImageThumbnail.php#L123)

But in https://github.com/pimcore/pimcore/blob/43e14cca6b5f9171ffc4abc21b1921b23feec33b/bundles/AdminBundle/Controller/Admin/AssetController.php#L1329-L1332 there is always Content-Type image/png being set - also for the above SVG.