### PR TITLE
Re-enables delete action for admin translations

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/translations.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/translations.js
@@ -130,7 +130,7 @@ pimcore.settings.translations = Class.create({
         })
         ;
 
-        if (pimcore.settings.websiteLanguages.length == this.editableLanguages.length) {
+        if (pimcore.settings.websiteLanguages.length == this.editableLanguages.length || this.translationType === 'admin') {
             typesColumns.push({
                 xtype: 'actioncolumn',
                 menuText: t('delete'),


### PR DESCRIPTION
## Changes in this pull request  
Updates condition for showing the delete action column in the translations backend view.
Adds check for `this.translationType === 'admin'` to allow deleting admin translations.

## Resolves
Because of an added condition (in issues #2437 - commit 1af633f734035e0736ecb42c033e23644c010ac7) around the delete action column it was not longer possible to delete admin translation.
