### PR TITLE
[Custom layouts] Prevent SQL error for non-numarical ID

### DIFF
--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -910,7 +910,7 @@ class Service extends Model\Element\Service
         $condition = 'classId = ' . $list->quote($classId);
         if (is_array($layoutPermissions) && count($layoutPermissions)) {
             $layoutIds = array_values($layoutPermissions);
-            $condition .= ' AND id IN (' . implode(',', $layoutIds) . ')';
+            $condition .= ' AND id IN (' . implode(',', array_map([$list, 'quote'], $layoutIds)) . ')';
         }
         $list->setCondition($condition);
         $list = $list->load();


### PR DESCRIPTION
Nowadays custom layouts can have non-numerical IDs. In https://github.com/pimcore/pimcore/blob/eebc75491fffdc848d9435668f874d387b3cefa2/models/DataObject/Service.php#L913 they are used in an SQL query's IN-criteria but without quoting them. This results in an SQL error.

To reproduce:
1. Create custom layout with non-numerical ID
2. Assign custom layout to a user's workspace settings
3. Login with this user
4. Try to open an object where workspace settings from 2. apply