### PR TITLE
[Notifications] Role permission are not inherited

### DIFF
--- a/models/Notification.php
+++ b/models/Notification.php
@@ -32,12 +32,12 @@ class Notification extends AbstractModel
     protected $id;
 
     /**
-     * @var int
+     * @var string
      */
     protected $creationDate;
 
     /**
-     * @var int
+     * @var string
      */
     protected $modificationDate;
 

--- a/models/Notification.php
+++ b/models/Notification.php
@@ -32,12 +32,12 @@ class Notification extends AbstractModel
     protected $id;
 
     /**
-     * @var string
+     * @var int
      */
     protected $creationDate;
 
     /**
-     * @var string
+     * @var int
      */
     protected $modificationDate;
 


### PR DESCRIPTION
## Bugfix
Users without `notifications` permissions  with a role that has permission are not listed on recipient list.
Same problem is when we want to send notification to group, users without permission dont get the message.

## Steps to reproduce
1. Add Role with `notifications` permissions
2. Add user without `notifications` permissions and add him to created role
3. Try to send notification:
3.1. Try to send notification to him - he isnt listed on recipient list
3.2. Send notification to created group - used dont get the message
