### PR TITLE
Minor config improvements in getWebsiteConfig()

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -190,11 +190,10 @@ class Config
 
                     $key = $item->getName();
 
-                    if (isset($settingsArray[$key]) && !$itemLanguage) {
+                    if (!$itemLanguage && isset($settingsArray[$key])) {
                         continue;
                     }
 
-                    $s = null;
 
                     switch ($item->getType()) {
                         case 'document':
@@ -208,7 +207,9 @@ class Config
                         case 'text':
                             $s = (string) $item->getData();
                             break;
-
+                        default:
+                            $s = null;
+                            break;
                     }
 
                     if ($s instanceof Model\Element\ElementInterface) {

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -176,26 +176,21 @@ class Config
 
                 /** @var $item WebsiteSetting */
                 foreach ($list as $item) {
-                    $key = $item->getName();
                     $itemSiteId = $item->getSiteId();
 
-                    if ($itemSiteId != 0 && $itemSiteId != $siteId) {
+                    if ($itemSiteId !== 0 && $itemSiteId !== $siteId) {
                         continue;
                     }
 
                     $itemLanguage = $item->getLanguage();
 
-                    if ($itemLanguage && $language != $itemLanguage) {
+                    if ($itemLanguage && $language !== $itemLanguage) {
                         continue;
                     }
 
-                    if (isset($settingsArray[$key])) {
-                        if (!$itemLanguage) {
-                            continue;
-                        }
-                    }
+                    $key = $item->getName();
 
-                    if ($settingsArray[$key] && !$itemLanguage) {
+                    if (isset($settingsArray[$key]) && !$itemLanguage) {
                         continue;
                     }
 


### PR DESCRIPTION
Removes duplicate if().
Does stricter comparison for site ids (which should always be integers).
Fetches $key later, after some continue's to avoid unnecessary execution.

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

