### PR TITLE
[Quantity Value] Error when auto-converting unset unit

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/QuantityValueController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/QuantityValueController.php
@@ -209,7 +209,7 @@ class QuantityValueController extends AdminController
         $fromUnit = Unit::getById($fromUnitId);
         $toUnit = Unit::getById($toUnitId);
         if (!$fromUnit instanceof Unit || !$toUnit instanceof Unit) {
-            return null;
+            return $this->adminJson(['success' => false]);
         }
 
         /** @var UnitConversionService $converter */

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
@@ -100,7 +100,7 @@ pimcore.object.tags.quantityValue = Class.create(pimcore.object.tags.abstract, {
             queryMode: 'local',
             listeners: {
                 change: function( combo, newValue, oldValue) {
-                    if(this.fieldConfig.autoConvert) {
+                    if(this.fieldConfig.autoConvert && oldValue && newValue) {
                         Ext.Ajax.request({
                             url: "/admin/quantity-value/convert",
                             params: {


### PR DESCRIPTION
Steps to reproduce:
1. Create 2 quantity value units "g" and "kg"
1. Set "kg" as base unit of "g", set conversion factor to 0.001
1. Create data object class with quantity value field, set allowed units to "kg" and "g", enable auto-conversion
1. Open / Create new object
1. Change quantity value field's unit
This results in an error because previously there was no unit being set and the controller returns `null`.