### PR TITLE
fixes a Bug where Custom Reports are loaded with a wrong reportClass

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/toolbarenricher.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/toolbarenricher.js
@@ -77,14 +77,14 @@ pimcore.report.custom.toolbarenricher = Class.create(pimcore.plugin.admin, {
                                         parentMenuEntry.add({
                                             text: report["niceName"],
                                             iconCls: report["iconClass"],
-                                            handler: function (report) {
+                                            handler: function (report, reportClass) {
                                                 toolbar.showReports(reportClass, {
                                                     name: report["name"],
                                                     text: report["niceName"],
                                                     niceName: report["niceName"],
                                                     iconCls: report["iconClass"]
                                                 });
-                                            }.bind(this, report)
+                                            }.bind(this, report, reportClass)
                                         });
                                     }
                                 } catch (e) {


### PR DESCRIPTION
## Changes in this pull request
fixes a Bug where Custom Reports are loaded with a wrong reportClass

### Steps to reproduce

* Create at least two custom reports
* Set different reportClasses on both reports
* Check "Create Shortcut in Menu" on both reports
* Reload Backend
* Click on the first custom report in the menu

### Expected
Every report loads with its **own** configured reportClass

### Actual Behaviour
Every report loads with the configured reportClass **of the last report**

## Additional info  
The `reportClass` inside `toolbarenricher.js` is read synchronously inside a for loop. The Menu-Item click handler is triggered asynchronously and uses the last set `reportClass`
