### PR TITLE
Fix bulk importing new custom layout

### DIFF
--- a/models/DataObject/ClassDefinition/CustomLayout/Dao.php
+++ b/models/DataObject/ClassDefinition/CustomLayout/Dao.php
@@ -52,25 +52,37 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param null $name
+     * @param string $name
      *
-     * @return int|null
+     * @return mixed|null
      */
-    public function getIdByName($name = null)
+    public function getIdByName($name)
     {
-        $name = $this->db->fetchOne('SELECT id FROM custom_layouts WHERE name = ?', $name);
+        $id = null;
+        try {
+            if (!empty($name)) {
+                $id = $this->db->fetchOne('SELECT id FROM custom_layouts WHERE name = ?', $name);
+            }
+        } catch(\Exception $e) {
+        }
 
-        return $name;
+        return $id;
     }
 
     /**
-     * @param null $id
+     * @param mixed $id
      *
-     * @return string
+     * @return string|null
      */
-    public function getNameById($id = null)
+    public function getNameById($id)
     {
-        $name = $this->db->fetchOne('SELECT name FROM custom_layouts WHERE id = ?', (int) $id);
+        $name = null;
+        try{
+            if (!empty($id)) {
+                $name = $this->db->fetchOne('SELECT name FROM custom_layouts WHERE id = ?', $id);
+            }
+        } catch(\Exception $e) {
+        }
 
         return $name;
     }

--- a/models/DataObject/ClassDefinition/CustomLayout/Dao.php
+++ b/models/DataObject/ClassDefinition/CustomLayout/Dao.php
@@ -70,7 +70,7 @@ class Dao extends Model\Dao\AbstractDao
      */
     public function getNameById($id = null)
     {
-        $name = $this->db->fetchOne('SELECT name FROM custom_layouts WHERE id = ?', $id);
+        $name = $this->db->fetchOne('SELECT name FROM custom_layouts WHERE id = ?', (int) $id);
 
         return $name;
     }

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -38,25 +38,37 @@ class Dao extends Model\Dao\AbstractDao
     protected $tableDefinitions = null;
 
     /**
-     * @param null $id
+     * @param mixed $id
      *
-     * @return string
+     * @return string|null
      */
-    public function getNameById($id = null)
+    public function getNameById($id)
     {
-        $name = $this->db->fetchOne('SELECT name FROM classes WHERE id = ?', $id);
+        $name = null;
+        try{
+            if (!empty($id)) {
+                $name = $this->db->fetchOne('SELECT name FROM classes WHERE id = ?', $id);
+            }
+        } catch(\Exception $e) {
+        }
 
         return $name;
     }
 
     /**
-     * @param null $name
+     * @param string $name
      *
-     * @return string
+     * @return mixed|null
      */
-    public function getIdByName($name = null)
+    public function getIdByName($name)
     {
-        $id = $this->db->fetchOne('SELECT id FROM classes WHERE name = ?', $name);
+        $id = null;
+        try {
+            if (!empty($name)) {
+                $id = $this->db->fetchOne('SELECT id FROM classes WHERE name = ?', $name);
+            }
+        } catch(\Exception $e) {
+        }
 
         return $id;
     }


### PR DESCRIPTION
## Changes in this pull request  
Resolves (bulk) importing Custom Layouts that do not exists yet

## Exception
```
Timestamp: Tue Jul 09 2019 10:35:22 GMT+0200 (Central European Summer Time)
Status: 500 | Internal Server Error
URL: /admin/class/bulk-commit
Method: post
Message: Argument 2 passed to Doctrine\DBAL\Connection::fetchColumn() must be of the type array, null given, called in /var/www/html/vendor/pimcore/pimcore/lib/Db/PimcoreExtensionsTrait.php on line 303
Trace: 
#0 /var/www/html/vendor/pimcore/pimcore/lib/Db/PimcoreExtensionsTrait.php(303): Doctrine\DBAL\Connection->fetchColumn('SELECT name FRO...', NULL, 0, Array)
#1 /var/www/html/vendor/pimcore/pimcore/models/DataObject/ClassDefinition/CustomLayout/Dao.php(73): Pimcore\Db\Connection->fetchOne('SELECT name FRO...', NULL)
#2 /var/www/html/vendor/pimcore/pimcore/models/DataObject/ClassDefinition/CustomLayout.php(331): Pimcore\Model\DataObject\ClassDefinition\CustomLayout\Dao->getNameById(NULL)
#3 /var/www/html/vendor/pimcore/pimcore/models/DataObject/ClassDefinition/CustomLayout.php(178): Pimcore\Model\DataObject\ClassDefinition\CustomLayout->exists()
#4 /var/www/html/vendor/pimcore/pimcore/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php(1502): Pimcore\Model\DataObject\ClassDefinition\CustomLayout->save()
#5 /var/www/html/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(151): Pimcore\Bundle\AdminBundle\Controller\Admin\DataObject\ClassController->bulkCommitAction(Object(Symfony\Component\HttpFoundation\Request))
#6 /var/www/html/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(68): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#7 /var/www/html/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php(198): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#8 /var/www/html/web/app.php(36): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#9 {main}
```

## Reproduce
Bulk export custom layouts, delete them and bulk import them again.
Import will throw an Exception, because $id is null (see \Pimcore\Model\DataObject\ClassDefinition\CustomLayout\Dao::getNameById()) and is_scalar() will fail with null values (see \Pimcore\Db\PimcoreExtensionsTrait::prepareParams() and https://www.php.net/manual/de/function.is-scalar.php) thus not returning an array required by $params (see \Doctrine\DBAL\Connection::fetchColumn())

## Additional info  
You might consider adding additional is_null() check  in \Pimcore\Db\PimcoreExtensionsTrait::prepareParams(), but this will still fail with most queries as they do query with e.g. "id = ?" and "id = null" is not valid SQL.
```if (is_scalar($params) || is_null($params)) {```