### PR TITLE
Update GitHub pull request template to new Pimcore version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,8 @@
 - [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
 - [ ] Features need to be proper documented in `doc/`
 - [ ] Bugfixes need a short guide how to reproduce them. 
-- [ ] We're not accepting any feature PR's only for **version 4** anymore, you have to provide a feature PR for both versions. 
-- [ ] Submit bugfixes for version 4 to the target branch `pimcore4`, version 5 is `master` branch.
+- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
+- [ ] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.
 
 **Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
 -->  


### PR DESCRIPTION
Updates the GitHub PR template to the new version 6 of Pimcore.

Is Pimcore 4 still maintained and should be kept in the template or is it EOL and can be removed?

