### PR TITLE
don't allow folders in ManyToManyObject Relations Search Dialog

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -667,7 +667,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
         pimcore.helpers.itemselector(true, this.addDataFromSelector.bind(this), {
                 type: ["object"],
                 subtype: {
-                    object: ["object", "folder", "variant"]
+                    object: ["object", "variant"]
                 },
                 specific: {
                     classes: allowedClasses


### PR DESCRIPTION
Without this fix, it always shows every folder in the Search Dialog within a ManyToMany Object Relation