### PR TITLE
[Documentation} Wysiwyg field configuration -> enterMode

### DIFF
--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/01_Text_Types.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/01_Text_Types.md
@@ -61,7 +61,7 @@ on selected text in the WYSIWYG widget. The text is stored as HTML.
 
 ![WYSIWYG Field](../../../img/classes-datatypes-text6.jpg)
 
-#### Editor - Configuration
+### Editor - Configuration
 It's possible to pass a custom CKEditor config object to the wysiwyg editor. 
 
 ```
@@ -86,12 +86,8 @@ More examples and config options for the toolbar and toolbarGroups can be found 
 
 Please refer to the [CKeditor 4.0 Documentation](http://docs.ckeditor.com/).
 
-#### Input Quantity Value
-
-Quite similar to [Quantity Value](03_Number_Types.md) except that text values are allowed instead of the strict restriction to numeric values.
-
   
-##### Global Configuration
+### Global Configuration
 You can add a Global Configuration for all WYSIWYG Editors for all objects by setting ```pimcore.object.tags.wysiwyg.defaultEditorConfig```
 
 For this purpose, you can create a bundle and add the configuration in the new created file `/Resources/public/js/pimcore/startup.js` like this:
@@ -101,5 +97,9 @@ pimcore.object.tags.wysiwyg.defaultEditorConfig = {
     allowedContent: true
 };
 ```
+
+## Input Quantity Value
+
+Quite similar to [Quantity Value](03_Number_Types.md) except that text values are allowed instead of the strict restriction to numeric values.
 
 

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/01_Text_Types.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/01_Text_Types.md
@@ -66,9 +66,20 @@ It's possible to pass a custom CKEditor config object to the wysiwyg editor.
 
 ```
 {
-  toolbarGroups : [ { name: 'links' }]
+  toolbarGroups : [ { name: 'links' }],
+  enterMode: CKEDITOR.CKEDITOR.ENTER_P,
 }
 ```
+
+While most configuration parameters define which features shall be available when using the wysiwyg editor the `enterMode` defines the following behaviour:
+* `CKEDITOR.CKEDITOR.ENTER_BR` (default)
+  * Pressing `enter` key adds a `<br>` tag at the cursor position
+* `CKEDITOR.CKEDITOR.ENTER_P`
+  * Pressing `enter` key adds a paragraph `<p></p>` tag at the cursor position
+  * content gets always wrapped in `<p>` tags, even if you just enter one line
+  * When setting the field's content via its setter method, the `<p>` tags do not get automatically added. When you later open the object in the admin panel and save the object, the `<p>` tags get added. This can be misleading because the content of the field changed although the field has not been touched.
+* `CKEDITOR.CKEDITOR.ENTER_DIV`
+  * same as `CKEDITOR.CKEDITOR.ENTER_P` but paragraphs get wrapped in `<div>` tags
 
 More examples and config options for the toolbar and toolbarGroups can be found at 
 [http://docs.ckeditor.com/#!/guide/dev_toolbar](http://docs.ckeditor.com/#!/guide/dev_toolbar). 


### PR DESCRIPTION
As discussed in #4411 there was a BC break in 6.0 because the default `enterMode` got changed. This PR explains the details how to reset it and what the consequences are.