### PR TITLE
Fix w3c validation warning in HeadStyle template helper

### DIFF
--- a/lib/Templating/Helper/HeadStyle.php
+++ b/lib/Templating/Helper/HeadStyle.php
@@ -379,7 +379,7 @@ class HeadStyle extends AbstractHelper
             $escapeEnd = null;
         }
 
-        $html = '<style type="text/css"' . $attrString . '>' . PHP_EOL
+        $html = '<style' . $attrString . '>' . PHP_EOL
             . $escapeStart . $indent . $item->content . PHP_EOL . $escapeEnd
             . '</style>';
 


### PR DESCRIPTION
The HTML Tags "style" now get rendered without "text/css".
