### PR TITLE
[Core] Fix typo in Bootstrap::bootstrap() method name

### DIFF
--- a/.travis/web/app_test.php
+++ b/.travis/web/app_test.php
@@ -22,7 +22,7 @@ define('PIMCORE_PROJECT_ROOT', __DIR__ . '/..');
 define('PIMCORE_ENVIRONMENT', 'test');
 
 \Pimcore\Bootstrap::setProjectRoot();
-\Pimcore\Bootstrap::boostrap();
+\Pimcore\Bootstrap::bootstrap();
 
 $request = Request::createFromGlobals();
 

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing.md
@@ -169,7 +169,7 @@ with the following content (customize as needed):
 include "../../vendor/autoload.php";
 
 \Pimcore\Bootstrap::setProjectRoot();
-\Pimcore\Bootstrap::boostrap();
+\Pimcore\Bootstrap::bootstrap();
 
 ```
 
@@ -337,7 +337,7 @@ putenv('PIMCORE_ENVIRONMENT=test');
 require_once PIMCORE_PROJECT_ROOT . '/vendor/autoload.php';
 
 \Pimcore\Bootstrap::setProjectRoot();
-\Pimcore\Bootstrap::boostrap();
+\Pimcore\Bootstrap::bootstrap();
 
 
 // add the core pimcore test library to the autoloader - this could also be done in composer.json's autoload-dev section

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -26,7 +26,7 @@ class Bootstrap
     public static function startup()
     {
         self::setProjectRoot();
-        self::boostrap();
+        self::bootstrap();
         $kernel = self::kernel();
 
         return $kernel;
@@ -45,7 +45,7 @@ class Bootstrap
         // determines if we're in Pimcore\Console mode
         $pimcoreConsole = (defined('PIMCORE_CONSOLE') && true === PIMCORE_CONSOLE);
 
-        self::boostrap();
+        self::bootstrap();
 
         $workingDirectory = getcwd();
         chdir(__DIR__);
@@ -114,7 +114,7 @@ class Bootstrap
         }
     }
 
-    public static function boostrap()
+    public static function bootstrap()
     {
         error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);
 
@@ -141,6 +141,15 @@ class Bootstrap
         if (file_exists($startupFile)) {
             include_once $startupFile;
         }
+    }
+
+    /**
+     * @deprecated 7.0.0 Typo in name; use Bootstrap::bootstrap() instead
+     * @see Bootstrap::bootstrap()
+     */
+    public static function boostrap()
+    {
+        self::bootstrap();
     }
 
     public static function defineConstants()

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -5,7 +5,7 @@ use Pimcore\Tests\Util\Autoloader;
 include __DIR__ . '/../vendor/autoload.php';
 
 \Pimcore\Bootstrap::setProjectRoot();
-\Pimcore\Bootstrap::boostrap();
+\Pimcore\Bootstrap::bootstrap();
 
 Autoloader::addNamespace('Pimcore\Model\DataObject', __DIR__ . '/_output/var/classes/DataObject');
 Autoloader::addNamespace('Pimcore\Tests\Cache', __DIR__ . '/cache');


### PR DESCRIPTION
BC (tests, existing web.php, ...) is assured by providing a deprecated
version with the old method name.

https://github.com/pimcore/skeleton, https://github.com/pimcore/demo-basic and https://github.com/pimcore/demo-basic-twig should be adjusted as well.