### PR TITLE
Clarifies 6.x Upgrade notes wrt WYSIWYG

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_V5_to_V6.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_V5_to_V6.md
@@ -100,7 +100,7 @@ If your're using `pimcore_admin.dataObjects` in your config, please rename `data
 - Getter hook `preGetValue()` requires now the use of `Pimcore\Model\DataObject\PreGetValueHookInterface`, all your classes using `preGetValue()` need to implement this interface.
 - Namespace `Pimcore\Model\Object` is not supported anymore, use `Pimcore\Model\DataObject` instead
 - Custom object data-types must implement interfaces (`CustomResourcePersistingInterface`, `QueryResourcePersistenceAwareInterface` and `ResourcePersistenceAwareInterface`)
-- WYSIWYG uses now `<br>` instead of `<p>` when pressing ENTER
+- The bundled WYSIWYG CKeditor no longer uses the default and recommended paragraph breaks `<p>` (`CKEDITOR.ENTER_P`) instead of `<br>` (`CKEDITOR.ENTER_BR`) when pressing ENTER, see [documentation](../../05_Objects/01_Object_Classes/01_Data_Types/01_Text_Types.md) for more information.
 
 #### Removed Classes, Interfaces, Methods, Constants, Functions, Aliases
 ```


### PR DESCRIPTION
I understand that on the face of it may look like there is a degree of p.a. here, but it is not my intention. I really *do* want Pimcore to heed best practices and be clear about the places where steps have been taken to deviate from them:

> Changing the Enter Mode setting to BR or DIV is not recommended. The default CKEDITOR.ENTER_P mode is fully supported by all editor features and plugins and is also the most correct one in terms of best practices for creating web content. 