### PR TITLE
When sorting data objects in the tree, the new index isn't reflected in event listener

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1085,9 +1085,16 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 $object->setUserModification($this->getAdminUser()->getId());
 
                 try {
+                    $isIndexUpdate = isset($values['index']) && is_int($values['index']);
+                    
+                    if ($isIndexUpdate) {
+                        // Ensure the update sort index is already available in the postUpdate eventListener
+                        $object->setIndex($values['index']);
+                    }
+                    
                     $object->save();
 
-                    if (isset($values['index']) && is_int($values['index'])) {
+                    if ($isIndexUpdate) {
                         $this->updateIndexesOfObjectSiblings($object, $values['index']);
                     }
 


### PR DESCRIPTION
When sorting data objects in the tree, the new index isn't reflected in the object instance that is passed into the event listener.

While technically the object sort index hasn't been updated yet, it is still
confusing that the postUpdate listener doesn't get the updated index value.
I'm not sure if there is a reason for updating indexes of siblings after the save,
that is why I didn't put everything in one if statement.

## Changes in this pull request  
The index in the object that is passed into the postUpdate listener has the correct index.

