### PR TITLE
No exception if opened object got deleted in the meantime

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -371,6 +371,9 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         Element\Editlock::lock($request->get('id'), 'object');
 
         $objectFromDatabase = DataObject::getById(intval($request->get('id')));
+        if($objectFromDatabase === null) {
+            return $this->adminJson(['success' => false, 'message' => 'element_not_found'], JsonResponse::HTTP_NOT_FOUND);
+        }
         $objectFromDatabase = clone $objectFromDatabase;
 
         // set the latest available version for editmode


### PR DESCRIPTION
Currently there is an exception thrown if you open an object which got deleted in the meantime.
Steps to reproduce:
1. Open Pimcore backend in 2 browser tabs
1. Browse the tree till you see a certain object in both browser tabs
1. Delete the object in browser tab 1
1. Try to open the object in tab 2