### PR TITLE
[Assets] Get checksum of remote assets before they got saved

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1342,6 +1342,8 @@ class Asset extends Element\AbstractElement
             } else {
                 throw new \Exception("hashing algorithm '" . $type . "' isn't supported");
             }
+        } elseif(\is_resource($this->getStream())) {
+            return hash($type, $this->getData());
         }
 
         return null;


### PR DESCRIPTION
Currently it is not possible to get the checksum of an asset before it got saved.
Code to reproduce:
```php
$fileStream = fopen('https://picsum.photos/200/300', 'rb');
$asset = \Pimcore\Model\Asset::create(1, array(
    'filename' => 'test.jpg',
    'stream' => $fileStream
), false);

var_dump($asset->getChecksum());
```
This outputs 
* without this PR: null
* with this PR: actual hash of the file

PS:
The same happens for 
```php
$fileStream = fopen('https://picsum.photos/200/300', 'rb');
$asset = new \Pimcore\Model\Asset();
$asset->setStream($fileStream);
var_dump($asset->getChecksum());
```