### PR TITLE
[Perspective] Translation for name in toolbar

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
@@ -32,7 +32,7 @@ pimcore.layout.toolbar = Class.create({
                     for (var i = 0; i < pimcore.settings.availablePerspectives.length; i++) {
                         var perspective = pimcore.settings.availablePerspectives[i];
                         var itemCfg = {
-                            text: perspective.name,
+                            text: t(perspective.name),
                             disabled: perspective.active,
                             handler: this.openPerspective.bind(this, perspective.name)
                         };


### PR DESCRIPTION
With this change it is possible to translate the menu items in the perspective toolbar tree.

/app/config/pimcore/perspectives.php
```
return [
    'default' => [
    ],
    'location' => [
    ],
];
```

![image](https://user-images.githubusercontent.com/998558/61220660-116db680-a717-11e9-8d16-7a07e3f4d480.png)
