### PR TITLE
[Assets] Set remote stream

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1310,15 +1310,12 @@ class Asset extends Element\AbstractElement
             $this->stream = $stream;
 
             $isRewindable = @rewind($this->stream);
-            $tmpFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/asset-create-tmp-file-' . uniqid() . '.' . File::getFileExtension($this->getFilename());
-            $dest = fopen($tmpFile, 'w+', false, File::getContext());
-            stream_copy_to_stream($this->stream, $dest);
 
             if (!$isRewindable) {
+                $tmpFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/asset-create-tmp-file-' . uniqid() . '.' . File::getFileExtension($this->getFilename());
+                $dest = fopen($tmpFile, 'w+', false, File::getContext());
+                stream_copy_to_stream($this->stream, $dest);
                 $this->stream = $dest;
-            } else {
-                fclose($dest);
-                unlink($tmpFile);
             }
         } elseif (is_null($stream)) {
             $this->stream = null;

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1308,7 +1308,18 @@ class Asset extends Element\AbstractElement
         if (is_resource($stream)) {
             $this->setDataChanged(true);
             $this->stream = $stream;
-            rewind($this->stream);
+
+            $isRewindable = @rewind($this->stream);
+            $tmpFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/asset-create-tmp-file-' . uniqid() . '.' . File::getFileExtension($this->getFilename());
+            $dest = fopen($tmpFile, 'w+', false, File::getContext());
+            stream_copy_to_stream($this->stream, $dest);
+
+            if (!$isRewindable) {
+                $this->stream = $dest;
+            } else {
+                fclose($dest);
+                unlink($tmpFile);
+            }
         } elseif (is_null($stream)) {
             $this->stream = null;
         }

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1316,6 +1316,8 @@ class Asset extends Element\AbstractElement
                 $dest = fopen($tmpFile, 'w+', false, File::getContext());
                 stream_copy_to_stream($this->stream, $dest);
                 $this->stream = $dest;
+
+                $this->_temporaryFiles[] = $tmpFile;
             }
         } elseif (is_null($stream)) {
             $this->stream = null;


### PR DESCRIPTION
Currently it is not possible to set a remote stream as the new data source for an asset.
Reproducable with this script:
```php
$asset = \Pimcore\Model\Asset::getById(<ID of an existing Asset>);
$asset->setStream(fopen('https://picsum.photos/200/300', 'rb'));
$asset->save();
```

Results in lots of exceptions because PHP cannot rewind a remote stream (as discussed in #4416 -  the code in this PR is just copied from there).