### PR TITLE
[Static Routes] Delegate `encode` Param to the Generator

### DIFF
--- a/lib/Routing/Staticroute/Router.php
+++ b/lib/Routing/Staticroute/Router.php
@@ -124,7 +124,7 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
     /**
      * @inheritDoc
      */
-    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH)
+    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH, $encode = true)
     {
         // when using $name = false we don't use the default route (happens when $name = null / ZF default behavior)
         // but just the query string generation using the given parameters
@@ -178,11 +178,7 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
 
         if ($name && $route = Staticroute::getByName($name, $siteId)) {
             $reset = isset($parameters['reset']) ? (bool)$parameters['reset'] : false;
-            $encode = isset($parameters['encode']) ? (bool)$parameters['encode'] : true;
             
-            // unset param encode
-            unset($parameters['encode']);
-
             // assemble the route / url in Staticroute::assemble()
             $url = $route->assemble($parameters, $reset, $encode);
 

--- a/lib/Routing/Staticroute/Router.php
+++ b/lib/Routing/Staticroute/Router.php
@@ -179,7 +179,7 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
         if ($name && $route = Staticroute::getByName($name, $siteId)) {
             $reset = isset($parameters['reset']) ? (bool)$parameters['reset'] : false;
             $encode = isset($parameters['encode']) ? (bool)$parameters['encode'] : false;
-            unlink( $parameters['encode'] );
+            unset( $parameters['encode'] );
             // assemble the route / url in Staticroute::assemble()
             $url = $route->assemble($parameters, $reset, $encode);
 

--- a/lib/Routing/Staticroute/Router.php
+++ b/lib/Routing/Staticroute/Router.php
@@ -178,7 +178,7 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
 
         if ($name && $route = Staticroute::getByName($name, $siteId)) {
             $reset = isset($parameters['reset']) ? (bool)$parameters['reset'] : false;
-            $encode = isset($parameters['encode']) ? (bool)$parameters['encode'] : false;
+            $encode = isset($parameters['encode']) ? (bool)$parameters['encode'] : true;
             unset( $parameters['encode'] );
             // assemble the route / url in Staticroute::assemble()
             $url = $route->assemble($parameters, $reset, $encode);

--- a/lib/Routing/Staticroute/Router.php
+++ b/lib/Routing/Staticroute/Router.php
@@ -124,7 +124,7 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
     /**
      * @inheritDoc
      */
-    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH, $encode = true)
+    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH)
     {
         // when using $name = false we don't use the default route (happens when $name = null / ZF default behavior)
         // but just the query string generation using the given parameters
@@ -178,7 +178,8 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
 
         if ($name && $route = Staticroute::getByName($name, $siteId)) {
             $reset = isset($parameters['reset']) ? (bool)$parameters['reset'] : false;
-            
+            $encode = isset($parameters['encode']) ? (bool)$parameters['encode'] : false;
+            unlink( $parameters['encode'] );
             // assemble the route / url in Staticroute::assemble()
             $url = $route->assemble($parameters, $reset, $encode);
 

--- a/lib/Routing/Staticroute/Router.php
+++ b/lib/Routing/Staticroute/Router.php
@@ -179,6 +179,9 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
         if ($name && $route = Staticroute::getByName($name, $siteId)) {
             $reset = isset($parameters['reset']) ? (bool)$parameters['reset'] : false;
             $encode = isset($parameters['encode']) ? (bool)$parameters['encode'] : true;
+            
+            // unset param encode
+            unset($parameters['encode']);
 
             // assemble the route / url in Staticroute::assemble()
             $url = $route->assemble($parameters, $reset, $encode);

--- a/lib/Templating/Helper/PimcoreUrl.php
+++ b/lib/Templating/Helper/PimcoreUrl.php
@@ -71,8 +71,6 @@ class PimcoreUrl extends Helper
      */
     protected function generateUrl($name = null, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH, $encode = true)
     {
-        // set default encode parameter
-        $parameters['encode'] = $encode;
         
         // if name is an array, treat it as parameters
         if (is_array($name)) {
@@ -109,7 +107,7 @@ class PimcoreUrl extends Helper
         }
 
         if ($name !== null) {
-            return $this->generator->generate($name, $parameters, $referenceType);
+            return $this->generator->generate($name, $parameters, $referenceType, $encode);
         }
 
         return '';

--- a/lib/Templating/Helper/PimcoreUrl.php
+++ b/lib/Templating/Helper/PimcoreUrl.php
@@ -71,6 +71,7 @@ class PimcoreUrl extends Helper
      */
     protected function generateUrl($name = null, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH, $encode = true)
     {
+        $parameters['encode'] = $encode;
         
         // if name is an array, treat it as parameters
         if (is_array($name)) {
@@ -107,7 +108,7 @@ class PimcoreUrl extends Helper
         }
 
         if ($name !== null) {
-            return $this->generator->generate($name, $parameters, $referenceType, $encode);
+            return $this->generator->generate($name, $parameters, $referenceType);
         }
 
         return '';

--- a/lib/Templating/Helper/PimcoreUrl.php
+++ b/lib/Templating/Helper/PimcoreUrl.php
@@ -57,7 +57,7 @@ class PimcoreUrl extends Helper
             $urlOptions = array_replace($this->requestHelper->getMasterRequest()->query->all(), $urlOptions);
         }
 
-        return $this->generateUrl($name, $urlOptions, $relative ? UrlGeneratorInterface::RELATIVE_PATH : UrlGeneratorInterface::ABSOLUTE_PATH);
+        return $this->generateUrl($name, $urlOptions, $relative ? UrlGeneratorInterface::RELATIVE_PATH : UrlGeneratorInterface::ABSOLUTE_PATH, $encode);
     }
 
     /**
@@ -69,8 +69,11 @@ class PimcoreUrl extends Helper
      *
      * @return string
      */
-    protected function generateUrl($name = null, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
+    protected function generateUrl($name = null, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH, $encode = true)
     {
+        // set default encode parameter
+        $parameters['encode'] = $encode;
+        
         // if name is an array, treat it as parameters
         if (is_array($name)) {
             if (is_array($parameters)) {


### PR DESCRIPTION
If you add the param encode in pimcoreUrl() (4. param) now you get the url with all utf8 stuff