### PR TITLE
[Customview] Icon not in center and doesn't invert on active

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
@@ -751,7 +751,7 @@ Ext.onReady(function () {
                                 rootId: treeConfig.rootId,
                                 rootVisible: treeConfig.showroot,
                                 treeId: "pimcore_panel_tree_" + treetype + "_" + treeConfig.id,
-                                treeIconCls: "pimcore_" + treetype + "_customview_icon_" + treeConfig.id,
+                                treeIconCls: "pimcore_" + treetype + "_customview_icon_" + treeConfig.id + " pimcore_icon_material",
                                 treeTitle: ts(treeConfig.name),
                                 parentPanel: treepanel,
                                 loaderBaseParams: {}

--- a/bundles/AdminBundle/Resources/views/Admin/Misc/admin-css.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/Misc/admin-css.html.php
@@ -23,7 +23,7 @@
             $treetype = $cv["treetype"] ? $cv["treetype"] : "object";
             ?>
     .pimcore_<?= $treetype ?>_customview_icon_<?= $cv["id"]; ?> {
-        background: url(<?= $cv["icon"]; ?>) left center no-repeat !important;
+        background: url(<?= $cv["icon"]; ?>) center center no-repeat !important;
     }
     <?php } ?>
 


### PR DESCRIPTION
## Fixes
- Icon is black on active now
- Icon is in center

## Before
![image](https://user-images.githubusercontent.com/998558/61308524-b9a37e00-a7f0-11e9-8c27-1c7c443d0293.png)


## After
![image](https://user-images.githubusercontent.com/998558/61308461-9ed10980-a7f0-11e9-84fb-96236438c466.png)

## Additional
The size of the icons are 24x24 but in this case they should 30x30. I tried to resize with background-size but it doesn't work (Chrome). Maybe it works if we remove the fixed size in the SVGs? Does someone have an idea?