### PR TITLE
#4709 Workaround for shutdown handling during cache warmup

### DIFF
--- a/lib/Pimcore.php
+++ b/lib/Pimcore.php
@@ -303,7 +303,9 @@ class Pimcore
         // set inShutdown to true so that the output-buffer knows that he is allowed to send the headers
         self::$inShutdown = true;
 
-        if (self::isInstalled()) {
+        // Check if this is a cache warming run and if this runs on an installed instance. If this is a cache warmup
+        // we can't use self::isInstalled() as it will refer to the wrong caching dir.
+        if (self::getKernel()->getCacheDir() === self::getContainer()->getParameter('kernel.cache_dir') && self::isInstalled()) {
             // write and clean up cache
             Cache::shutdown();
 


### PR DESCRIPTION
Fixes #4709 
tl;dr
Change https://github.com/pimcore/pimcore/commit/4f7725c70586767fc5ddd7e0fb8399adffd0be0f#diff-ff0c921492cef999788fd76dcb807a22R306 introduced code that isn't working properly with a cache warmup scenario.