### PR TITLE
[Bug-Fix] Areablock not processing data from rest import properly

### DIFF
--- a/models/Document/Tag/Areablock.php
+++ b/models/Document/Tag/Areablock.php
@@ -580,18 +580,14 @@ class Areablock extends Model\Document\Tag implements BlockInterface
      * @param null $idMapper
      *
      * @throws \Exception
-     *
-     * @todo replace and with &&
      */
     public function getFromWebserviceImport($wsElement, $document = null, $params = [], $idMapper = null)
     {
         $data = $wsElement->value;
-        if (($data->indices === null or is_array($data->indices)) and ($data->current == null or is_numeric($data->current))
-            and ($data->currentIndex == null or is_numeric($data->currentIndex))) {
+        if (($data->indices === null || is_array($data->indices)) && ($data->current == null || is_numeric($data->current))
+            && ($data->currentIndex == null || is_numeric($data->currentIndex))) {
             $indices = $data->indices;
-            if ($indices instanceof \stdclass) {
-                $indices = (array) $indices;
-            }
+            $indices = json_decode(json_encode($indices),true);
 
             $this->indices = $indices;
             $this->current = $data->current;


### PR DESCRIPTION
## Description
When importing data from another Pimcore instance using REST, the `getFromWebserviceImport` method in the `AreaBlock.php` file incorrectly parses the `$indices`. This causes an error when trying to open the corresponding `document`, as the database now contains `stdClass` in the serialized data.

## What was changed?
The `$indices` are now properly parsed as seen in the commit. This resolves the issue, ultimately, making the content available as exptected.