### PR TITLE
[Bug-Fix] Link not processing data from rest import properly

### DIFF
--- a/models/Document/Tag/Areablock.php
+++ b/models/Document/Tag/Areablock.php
@@ -580,18 +580,14 @@ class Areablock extends Model\Document\Tag implements BlockInterface
      * @param null $idMapper
      *
      * @throws \Exception
-     *
-     * @todo replace and with &&
      */
     public function getFromWebserviceImport($wsElement, $document = null, $params = [], $idMapper = null)
     {
         $data = $wsElement->value;
-        if (($data->indices === null or is_array($data->indices)) and ($data->current == null or is_numeric($data->current))
-            and ($data->currentIndex == null or is_numeric($data->currentIndex))) {
+        if (($data->indices === null || is_array($data->indices)) && ($data->current == null || is_numeric($data->current))
+            && ($data->currentIndex == null || is_numeric($data->currentIndex))) {
             $indices = $data->indices;
-            if ($indices instanceof \stdclass) {
-                $indices = (array) $indices;
-            }
+            $indices = json_decode(json_encode($indices),true);
 
             $this->indices = $indices;
             $this->current = $data->current;

--- a/models/Document/Tag/Link.php
+++ b/models/Document/Tag/Link.php
@@ -546,6 +546,10 @@ class Link extends Model\Document\Tag
                             }
                         }
                     }
+
+                    if($id) {
+                        $this->data['internalId'] = $id;
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
## Description
Pretty much the same thing as https://github.com/pimcore/pimcore/pull/4712 only for `Link.php`.

For internal links, the `internalId` is not updated with the local document ID, resulting in a `null` value when saving the document.

Ultimately, this means that links are not imported as the data is lost.

## What was changed?
If the link is `internal` the ID is updated with the local ID.