### PR TITLE
Update image dimensions on the fly

### DIFF
--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -444,6 +444,16 @@ EOT;
             }
         }
 
+        if (($width = $dimensions["width"]) && ($height = $dimensions["height"])) {
+            $this->setCustomSetting('imageDimensionsCalculated', true);
+            $this->setCustomSetting("imageWidth", $width);
+            $this->setCustomSetting("imageHeight", $height);
+            $customSettingsData = \Pimcore\Tool\Serialize::serialize($this->getCustomSettings());
+            Db::get()->query("UPDATE assets SET customSettings = ? WHERE id = ?", [$customSettingsData, $this->getId()]);
+            $cacheKey = "asset_" . $this->getId();
+            \Pimcore\Cache::save(null, $cacheKey);
+        }
+        
         return $dimensions;
     }
 

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -445,7 +445,7 @@ EOT;
         }
 
         if (($width = $dimensions["width"]) && ($height = $dimensions["height"])) {
-            $this->setCustomSetting('imageDimensionsCalculated', true);
+            $this->setCustomSetting("imageDimensionsCalculated", true);
             $this->setCustomSetting("imageWidth", $width);
             $this->setCustomSetting("imageHeight", $height);
             $customSettingsData = \Pimcore\Tool\Serialize::serialize($this->getCustomSettings());


### PR DESCRIPTION
# Bugfix

## Szenario
1. You import your assets and the dimensions cannot be calculated
2. You don't check your logs or ignore the error ["Problem getting the dimensions of the image with ID  ..."](https://github.com/jremmurd/pimcore/blob/e33a2eca40835abf1858d6975fdcb4a4bca6d985/models/Asset/Image.php#L62)
3. You will still use your assets and maybe call the `->getThumbnail()` method (as Pimcore does as well in the Backend)
4. Pimcore now tries on every request (sometimes twice) to load the image from the filesystem and to calculate the dimensions. But even if the calculation was successfull, the data won't be updated in the database. 

Im not sure if the PR does fix the issue in full, but for our use case it's sufficient. Maybe it's better to just check for `$this->getCustomSetting('imageDimensionsCalculated')` in the [getDimensions()](https://github.com/jremmurd/pimcore/blob/e33a2eca40835abf1858d6975fdcb4a4bca6d985/models/Asset/Image.php#L385) Method , but certainly it should not result in requests which take 20 Seconds for 20 Images, as it was the case on our website.