### PR TITLE
Install custom layouts

### DIFF
--- a/bundles/CoreBundle/Command/ClassesRebuildCommand.php
+++ b/bundles/CoreBundle/Command/ClassesRebuildCommand.php
@@ -45,7 +45,7 @@ class ClassesRebuildCommand extends AbstractCommand
                 'delete-classes',
                 'd',
                 InputOption::VALUE_NONE,
-                'Delete missing Classes (Classes that dont exists in var/classes anymore but in the database)'
+                'Delete missing Classes (Classes that don\'t exists in var/classes anymore but in the database)'
             );
     }
 

--- a/bundles/CoreBundle/Command/CustomLayoutRebuildCommand.php
+++ b/bundles/CoreBundle/Command/CustomLayoutRebuildCommand.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Command;
+
+use Pimcore\Console\AbstractCommand;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\ClassLayoutDefinitionManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CustomLayoutRebuildCommand extends AbstractCommand
+{
+    /**
+     * @var ClassLayoutDefinitionManager
+     */
+    protected $classLayoutDefinitionManager;
+
+    protected function configure()
+    {
+        $this
+            ->setName('pimcore:deployment:custom-layouts-rebuild')
+            ->setAliases(['deployment:custom-layouts-rebuild'])
+            ->setDescription('rebuilds db structure for custom layouts based on updated var/classes/customlayouts/definition_*.php files')
+            ->addOption(
+                'create-custom-layouts',
+                'c',
+                InputOption::VALUE_NONE,
+                'Create missing custom layouts (custom layouts that exists in var/classes/customlayouts but not in the database)'
+            )
+            ->addOption(
+                'delete-custom-layouts',
+                'd',
+                InputOption::VALUE_NONE,
+                'Delete missing custom layouts (custom layouts that don\'t exists in var/classes/customlayouts anymore but in the database)'
+            );
+    }
+
+    /**
+     * @param ClassLayoutDefinitionManager $classLayoutDefinitionManager
+     * @required
+     */
+    public function setClassLayoutDefinitionManager(ClassLayoutDefinitionManager $classLayoutDefinitionManager)
+    {
+        $this->classLayoutDefinitionManager = $classLayoutDefinitionManager;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($input->getOption('delete-custom-layouts')) {
+            $questionResult = true;
+
+            if ($input->isInteractive()) {
+                $questionResult = $this->io->confirm(
+                    '<error>You are going to delete custom layouts that don\'t have custom-layout-definitions anymore. This could lead to data loss! Do you want to continue?</error>',
+                    false
+                );
+            }
+
+            if ($questionResult) {
+                if ($output->isVerbose()) {
+                    $output->writeln('---------------------');
+                    $output->writeln('Delete custom layouts that don\'t have custom-layout-definitions anymore.');
+                }
+
+                foreach ($this->classLayoutDefinitionManager->cleanUpDeletedLayoutDefinitions() as $deleted) {
+                    if ($output->isVerbose()) {
+                        [$layout, $id, $action] = $deleted;
+                        $output->writeln(sprintf('%s [%s] %s', $layout, $id, $action));
+                    }
+                }
+            }
+        }
+
+        $list = new ClassDefinition\CustomLayout\Listing();
+
+        if ($output->isVerbose()) {
+            $output->writeln('---------------------');
+            $output->writeln('Saving all custom layouts');
+        }
+
+        if ($input->getOption('create-custom-layouts')) {
+            foreach ($this->classLayoutDefinitionManager->createOrUpdateLayoutDefinitions() as $changes) {
+                if ($output->isVerbose()) {
+                    [$layout, $id, $action] = $changes;
+                    $output->writeln(sprintf('%s [%s] %s', $layout, $id, $action));
+                }
+            }
+        } else {
+            foreach ($list->getLayoutDefinitions() as $layout) {
+                if ($layout instanceof ClassDefinition\CustomLayout) {
+                    if ($output->isVerbose()) {
+                        $output->writeln(sprintf('%s [%s] created', $layout->getName(), $layout->getId()));
+                    }
+
+                    $layout->save(false);
+                }
+            }
+        }
+    }
+}

--- a/bundles/CoreBundle/Resources/config/commands.yml
+++ b/bundles/CoreBundle/Resources/config/commands.yml
@@ -85,3 +85,9 @@ services:
             - [setClassDefinitionManager, ['@Pimcore\Model\DataObject\ClassDefinition\ClassDefinitionManager']]
         tags:
             - { name: console.command, command: 'pimcore:deployment:classes-rebuild' }
+
+    Pimcore\Bundle\CoreBundle\Command\CustomLayoutRebuildCommand:
+        calls:
+            - [setClassLayoutDefinitionManager, ['@Pimcore\Model\DataObject\ClassDefinition\ClassLayoutDefinitionManager']]
+        tags:
+            - { name: console.command, command: 'pimcore:deployment:custom-layouts-rebuild' }

--- a/bundles/CoreBundle/Resources/config/services.yml
+++ b/bundles/CoreBundle/Resources/config/services.yml
@@ -185,6 +185,9 @@ services:
     Pimcore\Model\DataObject\ClassDefinition\ClassDefinitionManager:
         public: true
 
+    Pimcore\Model\DataObject\ClassDefinition\ClassLayoutDefinitionManager:
+        public: true
+
     # Override Swiftmailer redirecting plugin
     swiftmailer.plugin.redirecting.abstract:
         abstract: true

--- a/lib/Model/DataObject/ClassDefinition/ClassLayoutDefinitionManager.php
+++ b/lib/Model/DataObject/ClassDefinition/ClassLayoutDefinitionManager.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Model\DataObject\ClassDefinition;
+
+use Pimcore\Db;
+use Pimcore\Model\DataObject\ClassDefinition\CustomLayout;
+
+class ClassLayoutDefinitionManager
+{
+    public const SAVED = 'saved';
+    public const CREATED = 'created';
+    public const DELETED = 'deleted';
+
+    /**
+     * Delete all custom layouts from db
+     */
+    public function cleanUpDeletedLayoutDefinitions(): array
+    {
+        $db = \Pimcore\Db::get();
+        $layouts = $db->fetchAll('SELECT * FROM custom_layouts');
+        $deleted = [];
+
+        foreach ($layouts as $layout) {
+            $id = $layout['id'];
+            $name = $layout['name'];
+
+            $cls = new CustomLayout();
+            $cls->setId($id);
+            $definitionFile = $cls->getDefinitionFile($name);
+
+            if (!file_exists($definitionFile)) {
+                $deleted[] = [$name, $id];
+
+                //CustomLayout doesn't exist anymore, therefore we delete it
+                $cls->delete();
+            }
+        }
+
+        return $deleted;
+    }
+
+    /**
+     * Updates all custom layouts from PIMCORE_CUSTOMLAYOUT_DIRECTORY
+     */
+    public function createOrUpdateLayoutDefinitions(): array
+    {
+        $customLayoutFolder = PIMCORE_CUSTOMLAYOUT_DIRECTORY;
+        $files = glob($customLayoutFolder.'/*.php');
+
+        $changes = [];
+
+        foreach ($files as $file) {
+            $layout = include $file;
+
+            if ($layout instanceof CustomLayout) {
+                $existingLayout = CustomLayout::getByNameAndClassId($layout->getName(), $layout->getClassId());
+
+                if ($existingLayout instanceof CustomLayout) {
+                    $changes[] = [$layout->getName(), $layout->getId(), self::SAVED];
+                    $existingLayout->save(false);
+                } else {
+                    $changes[] = [$layout->getName(), $layout->getId(), self::CREATED];
+                    $layout->save(false);
+                }
+            }
+        }
+
+        return $changes;
+    }
+}

--- a/models/DataObject/ClassDefinition/CustomLayout.php
+++ b/models/DataObject/ClassDefinition/CustomLayout.php
@@ -126,6 +126,23 @@ class CustomLayout extends Model\AbstractModel
     }
 
     /**
+     * @param string $name
+     * @param int    $classId
+     *
+     * @return null|CustomLayout
+     */
+    public static function getByNameAndClassId(string $name, $classId)
+    {
+        $customLayout = new self();
+        $id = $customLayout->getDao()->getIdByNameAndClassId($name, $classId);
+        if ($id) {
+            return self::getById($id);
+        }
+
+        return null;
+    }
+
+    /**
      * @param string $field
      *
      * @return \Pimcore\Model\DataObject\ClassDefinition\Data | null
@@ -172,8 +189,10 @@ class CustomLayout extends Model\AbstractModel
 
     /**
      * @todo: $isUpdate is not needed
+     *
+     * @param bool $saveDefinitionFile
      */
-    public function save()
+    public function save($saveDefinitionFile = true)
     {
         $isUpdate = $this->exists();
 
@@ -192,7 +211,7 @@ class CustomLayout extends Model\AbstractModel
 
         $this->getDao()->save($isUpdate);
 
-        $this->saveCustomLayoutFile();
+        $this->saveCustomLayoutFile($saveDefinitionFile);
 
         // empty custom layout cache
         try {
@@ -201,6 +220,11 @@ class CustomLayout extends Model\AbstractModel
         }
     }
 
+    /**
+     * @param bool $saveDefinitionFile
+     *
+     * @throws \Exception
+     */
     private function saveCustomLayoutFile($saveDefinitionFile = true)
     {
         // save definition as a php file
@@ -227,7 +251,6 @@ class CustomLayout extends Model\AbstractModel
     }
 
     /**
-     *
      * @return string
      */
     public function getDefinitionFile()
@@ -328,6 +351,9 @@ class CustomLayout extends Model\AbstractModel
      */
     public function exists()
     {
+        if (is_null($this->getId())) {
+            return false;
+        }
         $name = $this->getDao()->getNameById($this->getId());
 
         return is_string($name);

--- a/models/DataObject/ClassDefinition/CustomLayout/Dao.php
+++ b/models/DataObject/ClassDefinition/CustomLayout/Dao.php
@@ -88,6 +88,25 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
+     * @param string $name
+     * @param int    $classId
+     *
+     * @return int|null
+     */
+    public function getIdByNameAndClassId($name, $classId)
+    {
+        $id = null;
+        try {
+            if (!empty($name) && !empty($classId)) {
+                $id = $this->db->fetchOne('SELECT id FROM custom_layouts WHERE name = ? AND classId = ?', [$name, $classId]);
+            }
+        } catch (\Exception $e) {
+        }
+
+        return $id;
+    }
+
+    /**
      * @return int|mixed
      */
     public function getNewId()
@@ -132,6 +151,8 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
+     * Save layout to database
+     *
      * @param bool $isUpdate
      *
      * @throws \Exception
@@ -145,13 +166,12 @@ class Dao extends Model\Dao\AbstractDao
 
         if (!$isUpdate) {
             $this->create();
+        } else {
+            $this->update();
         }
-
-        $this->update();
     }
 
     /**
-     * @throws \Exception
      * @throws \Exception
      */
     public function update()
@@ -182,6 +202,8 @@ class Dao extends Model\Dao\AbstractDao
 
         $this->model->setCreationDate(time());
         $this->model->setModificationDate(time());
+
+        $this->update();
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
With the command "pimcore:deployment:classes-rebuild" it's possible to update/install classes/bricks/collections in Pimcore from existing files. The custom layouts were not considered yet.
This PR adds a new command "pimcore:deployment:custom-layouts-rebuild" and works like classes rebuild. 
The new command has been integrated to the Pimcore installer.

## Additional info  
I decided to split and integrate the custom layout into a separate command to not break anything. It could be integrated into the classes-rebuild process as well.