### PR TITLE
Update Video.php - getImageThumbnail() to getThumbnail()

### DIFF
--- a/models/Document/Tag/Video.php
+++ b/models/Document/Tag/Video.php
@@ -383,7 +383,7 @@ class Video extends Model\Document\Tag
                     $image = $poster->getThumbnail($imageThumbnailConf);
                 } else {
                     if ($asset->getCustomSetting('image_thumbnail_asset') && ($customPreviewAsset = Asset::getById($asset->getCustomSetting('image_thumbnail_asset')))) {
-                        $image = (string) $customPreviewAsset->getImageThumbnail($imageThumbnailConf);
+                        $image = (string) $customPreviewAsset->getThumbnail($imageThumbnailConf);
                     } else {
                         $image = (string) $asset->getImageThumbnail($imageThumbnailConf);
                     }


### PR DESCRIPTION
Wenn direkt im Video-Asset ein Posterimage zugewiesen wird, funktioniert die Funktion "getImageThumbnail" nicht -> habe es auf "getThumbnail" geändert.

Zusätzlich noch mit "Current player position as image" getestet und in der pimcore_video Funktion ein Posterimage zugewiesen.