### PR TITLE
[REST] hotspot images are neither properly exported nor imported

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Hotspotimage.php
+++ b/models/DataObject/ClassDefinition/Data/Hotspotimage.php
@@ -329,10 +329,10 @@ class Hotspotimage extends Model\DataObject\ClassDefinition\Data\Image
     }
 
     /**
-
      * @param DataObject\Data\Hotspotimage $data
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params
+     * @return DataObject\Data\Hotspotimage
      */
     public function getDataFromGridEditor($data, $object = null, $params = [])
     {
@@ -366,6 +366,7 @@ class Hotspotimage extends Model\DataObject\ClassDefinition\Data\Image
      * @param array $params
      *
      * @return string
+     * @throws \Exception
      */
     public function getForCsvExport($object, $params = [])
     {
@@ -503,6 +504,7 @@ class Hotspotimage extends Model\DataObject\ClassDefinition\Data\Image
      * @param mixed $params
      *
      * @return mixed
+     * @throws \Exception
      */
     public function getForWebserviceExport($object, $params = [])
     {
@@ -511,8 +513,9 @@ class Hotspotimage extends Model\DataObject\ClassDefinition\Data\Image
         $dataForResource = $this->getDataForResource($data, $object, $params);
 
         if ($dataForResource) {
-            if ($dataForResource['image__hotspots']) {
-                $dataForResource['image__hotspots'] = Serialize::unserialize($dataForResource['image__hotspots']);
+            $hotspotsKey = "{$this->getName()}__hotspots";
+            if ($dataForResource[$hotspotsKey]) {
+                $dataForResource[$hotspotsKey] = Serialize::unserialize($dataForResource[$hotspotsKey]);
             }
 
             return $dataForResource;
@@ -536,13 +539,16 @@ class Hotspotimage extends Model\DataObject\ClassDefinition\Data\Image
         if (!is_null($value)) {
             $value = json_decode(json_encode($value), true);
 
-            if ($value['image__image']) {
-                $value['image__image'] = $idMapper ? $idMapper->getMappedId('asset', $value['image__image']) : $value['image__image'] ;
+            $imageKey = "{$this->getName()}__image";
+
+            if ($value[$imageKey]) {
+                $value[$imageKey] = $idMapper ? $idMapper->getMappedId('asset', $value[$imageKey]) : $value[$imageKey] ;
             }
         }
 
-        if (is_array($value) && isset($value['image__hotspots']) && $value['image__hotspots']) {
-            $value['image__hotspots'] = serialize($value['image__hotspots']);
+        $hotspotsKey = "{$this->getName()}__hotspots";
+        if (is_array($value) && isset($value[$hotspotsKey]) && $value[$hotspotsKey]) {
+            $value[$hotspotsKey] = serialize($value[$hotspotsKey]);
         }
         $hotspotImage = $this->getDataFromResource($value);
 
@@ -603,6 +609,7 @@ class Hotspotimage extends Model\DataObject\ClassDefinition\Data\Image
      * @param array $params
      *
      * @return Element\ElementInterface
+     * @throws \Exception
      */
     public function rewriteIds($object, $idMapping, $params = [])
     {


### PR DESCRIPTION
# Bug Report
When exporting data using the `RestImporter`, `HotspotImage`s fail (i.e., they are not imported).

## Expected behaviour
Importing `HotspotImage`s simple works without any trouble - so that they are set in the new Pimcore instance.

## Actual behaviour
`HotspotImage`s are not set.

## Changes in this pull request  
The file `models/DataObject/ClassDefinition/Data/Hotspotimage.php` was changed in order to properly access they keys.

## Additional info 
The following `JSON` shows an example of the "before and after" behaviour.

### Actually exported data
```json
{
    type: "hotspotimage",
    value: {
        headerImage__image: 243,
        headerImage__hotspots: "a:3:{s:8:"hotspots";a:0:{}s:6:"marker";a:0:{}s:4:"crop";N;}"
    },
    name: "image",
    language: null
}
```

### Correct exported data (after merging this PR)
```json
{
    type: "hotspotimage",
    value: {
        headerImage__image: 243,
        headerImage__hotspots: {
            hotspots: [ ],
            marker: [ ],
            crop: null
        }
    },
    name: "image",
    language: null
}
```
