### PR TITLE
Ecommerce index bootstrapping for specific tenants.

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Command/IndexService/BootstrapCommand.php
+++ b/bundles/EcommerceFrameworkBundle/Command/IndexService/BootstrapCommand.php
@@ -35,7 +35,8 @@ class BootstrapCommand extends AbstractIndexServiceCommand
             ->addOption('create-or-update-index-structure', null, InputOption::VALUE_NONE, 'Use to create or update the index structure')
             ->addOption('update-index', null, InputOption::VALUE_NONE, 'Use to rebuild the index data')
             ->addOption('object-list-class', null, InputOption::VALUE_REQUIRED, 'The object list class to use', '\\Pimcore\\Model\\DataObject\\Product\\Listing')
-            ->addOption('list-condition', null, InputOption::VALUE_OPTIONAL, 'An optional condition for object list', '');
+            ->addOption('tenant', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Tenant to perform action on (defaults to all)')
+        ;
     }
 
     /**
@@ -47,6 +48,16 @@ class BootstrapCommand extends AbstractIndexServiceCommand
         $createOrUpdateIndexStructure = $input->getOption('create-or-update-index-structure');
         $objectListClass = $input->getOption('object-list-class');
         $listCondition = $input->getOption('list-condition');
+        $tenants = count($input->getOption('tenant')) ? $input->getOption('tenant') : null;
+
+        //set active tenant workers.
+        if (!empty($tenants)) {
+            $tenantWorkerList = [];
+            foreach ($tenants as $tenantName) {
+                $tenantWorkerList[] = Factory::getInstance()->getIndexService()->getTenantWorker($tenantName);
+            }
+            Factory::getInstance()->getIndexService()->setTenantWorkers($tenantWorkerList);
+        }
 
         if ($createOrUpdateIndexStructure && $updateIndex) {
             // create/update structure and update index

--- a/bundles/EcommerceFrameworkBundle/Command/IndexService/BootstrapCommand.php
+++ b/bundles/EcommerceFrameworkBundle/Command/IndexService/BootstrapCommand.php
@@ -35,6 +35,7 @@ class BootstrapCommand extends AbstractIndexServiceCommand
             ->addOption('create-or-update-index-structure', null, InputOption::VALUE_NONE, 'Use to create or update the index structure')
             ->addOption('update-index', null, InputOption::VALUE_NONE, 'Use to rebuild the index data')
             ->addOption('object-list-class', null, InputOption::VALUE_REQUIRED, 'The object list class to use', '\\Pimcore\\Model\\DataObject\\Product\\Listing')
+            ->addOption('list-condition', null, InputOption::VALUE_OPTIONAL, 'An optional condition for object list', '')
             ->addOption('tenant', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Tenant to perform action on (defaults to all)')
         ;
     }

--- a/bundles/EcommerceFrameworkBundle/IndexService/IndexService.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/IndexService.php
@@ -330,4 +330,18 @@ class IndexService
 
         return $this->getDefaultWorker();
     }
+
+    /**
+     * @param WorkerInterface[] $tenantWorkers
+     * @return IndexService
+     */
+    public function setTenantWorkers(array $tenantWorkers): self
+    {
+        $tenantWorkerAssocList = [];
+        foreach ($tenantWorkers as $tenantWorker) {
+            $tenantWorkerAssocList[$tenantWorker->getTenantConfig()->getTenantName()] = $tenantWorker;
+        }
+        $this->tenantWorkers = $tenantWorkerAssocList;
+        return $this;
+    }
 }


### PR DESCRIPTION
Add an option to the ecommerce index bootstrapping command, which will build/update the index only for specific tenants.