### PR TITLE
Sort permissions for users & roles by categories

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/role/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/role/settings.js
@@ -35,16 +35,16 @@ pimcore.settings.user.role.settings = Class.create({
         });
 
         this.perspectivesField = Ext.create('Ext.ux.form.MultiSelect', {
-            name:"perspectives",
-            triggerAction:"all",
-            editable:false,
-            fieldLabel:t("perspectives"),
-            width:400,
+            name: "perspectives",
+            triggerAction: "all",
+            editable: false,
+            fieldLabel: t("perspectives"),
+            width: 400,
             minHeight: 100,
             store: perspectivesStore,
             displayField: "name",
             valueField: "name",
-            value:this.data.role.perspectives ? this.data.role.perspectives.join(",") : null
+            value: this.data.role.perspectives ? this.data.role.perspectives.join(",") : null
         });
 
         generalItems.push(this.perspectivesField);
@@ -52,14 +52,21 @@ pimcore.settings.user.role.settings = Class.create({
 
         this.generalSet = new Ext.form.FieldSet({
             collapsible: true,
-            title:t("general"),
-            items:generalItems
+            title: t("general"),
+            items: generalItems
         });
 
-        var availPermsItems = [];
-        // add available permissions
+        var itemsPerSection = [];
+        var sectionArray = [];
         for (var i = 0; i < this.data.availablePermissions.length; i++) {
-            availPermsItems.push({
+            let section = this.data.availablePermissions[i].category;
+            if(!section){
+                section = "default";
+            }
+            if (!itemsPerSection[section]) {
+                itemsPerSection[section] = [];
+            }
+            itemsPerSection[section].push({
                 xtype: "checkbox",
                 fieldLabel: t(this.data.availablePermissions[i].key),
                 name: "permission_" + this.data.availablePermissions[i].key,
@@ -67,22 +74,29 @@ pimcore.settings.user.role.settings = Class.create({
                 labelWidth: 200
             });
         }
+        for (var key in itemsPerSection) {
+            let title = t("permissions");
+            if (key && key != "default") {
+                title += " " + t(key);
+            }
 
-        this.permissionsSet = new Ext.form.FieldSet({
-            collapsible: true,
-            title: t("permissions"),
-            items: availPermsItems
-        });
+            sectionArray.push(new Ext.form.FieldSet({
+                collapsible: true,
+                title: title,
+                items: itemsPerSection[key],
+                collapsed: true,
+            }));
+        }
 
         this.typesSet = new Ext.form.FieldSet({
             collapsible: true,
-            title:t("allowed_types_to_create") + " (" + t("defaults_to_all") + ")",
-            items:[{
+            title: t("allowed_types_to_create") + " (" + t("defaults_to_all") + ")",
+            items: [{
                 xtype: "multiselect",
                 name: "docTypes",
-                triggerAction:"all",
-                editable:false,
-                fieldLabel:t("document_types"),
+                triggerAction: "all",
+                editable: false,
+                fieldLabel: t("document_types"),
                 width: 400,
                 displayField: "name",
                 valueField: "id",
@@ -91,9 +105,9 @@ pimcore.settings.user.role.settings = Class.create({
             }, {
                 xtype: "multiselect",
                 name: "classes",
-                triggerAction:"all",
-                editable:false,
-                fieldLabel:t("classes"),
+                triggerAction: "all",
+                editable: false,
+                fieldLabel: t("classes"),
                 width: 400,
                 displayField: "text",
                 valueField: "id",
@@ -106,7 +120,7 @@ pimcore.settings.user.role.settings = Class.create({
 
         this.panel = new Ext.form.FormPanel({
             title: t("settings"),
-            items: [this.generalSet, this.permissionsSet, this.typesSet, this.websiteTranslationSettings.getPanel()],
+            items: array_merge([this.generalSet], sectionArray, [this.typesSet, this.websiteTranslationSettings.getPanel()]),
             bodyStyle: "padding:10px;",
             autoScroll: true
         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
@@ -405,26 +405,37 @@ pimcore.settings.user.user.settings = Class.create({
             items: adminItems
         });
 
-
-        var availPermsItems = [];
-        // add available permissions
+        var itemsPerSection = [];
+        var sectionArray = [];
         for (var i = 0; i < this.data.availablePermissions.length; i++) {
-            availPermsItems.push({
+            let section = this.data.availablePermissions[i].category;
+            if(!section){
+                section = "default";
+            }
+            if (!itemsPerSection[section]) {
+                itemsPerSection[section] = [];
+            }
+            itemsPerSection[section].push({
                 xtype: "checkbox",
-                boxLabel: t(this.data.availablePermissions[i].key),
+                fieldLabel: t(this.data.availablePermissions[i].key),
                 name: "permission_" + this.data.availablePermissions[i].key,
                 checked: this.data.permissions[this.data.availablePermissions[i].key],
-                labelStyle: "width: 200px;"
+                labelWidth: 200
             });
         }
+        for (var key in itemsPerSection) {
+            let title = t("permissions");
+            if (key && key != "default") {
+                title += " " + t(key);
+            }
 
-        this.permissionsSet = new Ext.form.FieldSet({
-            collapsible: true,
-            title: t("permissions"),
-            items: availPermsItems,
-            hidden: this.currentUser.admin
-        });
-
+            sectionArray.push(new Ext.form.FieldSet({
+                collapsible: true,
+                title: title,
+                items: itemsPerSection[key],
+                collapsed: true,
+            }));
+        }
 
         this.typesSet = new Ext.form.FieldSet({
             collapsible: true,
@@ -465,7 +476,7 @@ pimcore.settings.user.user.settings = Class.create({
 
         this.panel = new Ext.form.FormPanel({
             title: t("settings"),
-            items: [this.generalSet, this.adminSet, this.permissionsSet, this.typesSet, this.editorSettings.getPanel(), websiteSettingsPanel],
+            items: array_merge([this.generalSet, this.adminSet], sectionArray, [this.typesSet, this.editorSettings.getPanel(), websiteSettingsPanel]),
             bodyStyle: "padding:10px;",
             autoScroll: true
         });

--- a/bundles/CoreBundle/Resources/migrations/Version20190729085052.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20190729085052.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190729085052 extends AbstractPimcoreMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE users_permission_definitions ADD category varchar(50) NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // no downgrade because of loss of category data
+    }
+}

--- a/models/User/Permission/Definition.php
+++ b/models/User/Permission/Definition.php
@@ -31,6 +31,11 @@ class Definition extends Model\AbstractModel
     public $key;
 
     /**
+     * @var string
+     */
+    public $category;
+
+    /**
      * @param array
      */
     public function __construct($data = [])
@@ -57,6 +62,24 @@ class Definition extends Model\AbstractModel
     {
         $this->key = $key;
 
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCategory(): string
+    {
+        return $this->category;
+    }
+
+    /**
+     * @param string $category
+     * @return Definition
+     */
+    public function setCategory(string $category): Definition
+    {
+        $this->category = $category;
         return $this;
     }
 


### PR DESCRIPTION
added a category column to the database
sort permissions for user & roles by category
if no category is available the permissions will be sort in a default group