### PR TITLE
Process queue improvements

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Command/IndexService/ProcessQueueCommand.php
+++ b/bundles/EcommerceFrameworkBundle/Command/IndexService/ProcessQueueCommand.php
@@ -92,7 +92,7 @@ class ProcessQueueCommand extends AbstractIndexServiceCommand
     {
         return $this->getName() . "_" . md5(implode("", [
                 implode("", $input->getOption("tenant")),
-                $input->getArgument("queue")
+                implode("", $input->getArgument("queue"))
             ]));
     }
 

--- a/bundles/EcommerceFrameworkBundle/Command/IndexService/ProcessQueueCommand.php
+++ b/bundles/EcommerceFrameworkBundle/Command/IndexService/ProcessQueueCommand.php
@@ -38,7 +38,7 @@ class ProcessQueueCommand extends AbstractIndexServiceCommand
             ->addOption('max-rounds', null, InputOption::VALUE_REQUIRED, 'Maximum rounds to process', null)
             ->addOption('items-per-round', null, InputOption::VALUE_REQUIRED, 'Items per round to process', 200)
             ->addOption('unlock', null, InputOption::VALUE_NONE, 'Unlock a command that is currently locked.')
-            ->addOption('ignore-lock', null, InputOption::VALUE_REQUIRED, 'Run a command and ignore lock.', true)
+            ->addOption('ignore-lock', null, InputOption::VALUE_REQUIRED, 'Run a command and ignore lock.', "true")
             ->addOption('lock-timeout', null, InputOption::VALUE_OPTIONAL, 'Timeout of command lock in minutes.', null)
             ->addOption('timeout', null, InputOption::VALUE_OPTIONAL, 'Max time for the command to run in minutes.');
         ;

--- a/bundles/EcommerceFrameworkBundle/Command/IndexService/ProcessQueueCommand.php
+++ b/bundles/EcommerceFrameworkBundle/Command/IndexService/ProcessQueueCommand.php
@@ -15,6 +15,7 @@
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\Command\IndexService;
 
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Tool\IndexUpdater;
+use Pimcore\Model\Tool\Lock;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -35,7 +36,12 @@ class ProcessQueueCommand extends AbstractIndexServiceCommand
             ->addArgument('queue', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'Queues to process (preparation|update-index)')
             ->addOption('tenant', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Tenant to perform action on (defaults to all)')
             ->addOption('max-rounds', null, InputOption::VALUE_REQUIRED, 'Maximum rounds to process', null)
-            ->addOption('items-per-round', null, InputOption::VALUE_REQUIRED, 'Items per round to process', 200);
+            ->addOption('items-per-round', null, InputOption::VALUE_REQUIRED, 'Items per round to process', 200)
+            ->addOption('unlock', null, InputOption::VALUE_NONE, 'Unlock a command that is currently locked.')
+            ->addOption('ignore-lock', null, InputOption::VALUE_REQUIRED, 'Run a command and ignore lock.', true)
+            ->addOption('lock-timeout', null, InputOption::VALUE_OPTIONAL, 'Timeout of command lock in minutes.', null)
+            ->addOption('timeout', null, InputOption::VALUE_OPTIONAL, 'Max time for the command to run in minutes.');
+        ;
     }
 
     /**
@@ -49,16 +55,45 @@ class ProcessQueueCommand extends AbstractIndexServiceCommand
         $processPreparationQueue = in_array('preparation', $queues);
         $processUpdateIndexQueue = in_array('update-index', $queues);
 
+        if ($timeoutInMinutes = $input->getOption('timeout')) {
+            $timeoutInSeconds = (int)$timeoutInMinutes * 60;
+        }
+
+        $lockName = $this->getLockName($input);
+        $ignoreLock = filter_var($input->getOption('ignore-lock'), FILTER_VALIDATE_BOOLEAN);
+        $unlock = filter_var($input->getOption('unlock'), FILTER_VALIDATE_BOOLEAN);
+
+        if ($lockTimeoutInMinutes = $input->getOption('lock-timeout')) {
+            $lockTimeoutInSeconds = (int)$lockTimeoutInMinutes * 60;
+        }
+
+        if ($unlock) {
+            Lock::release($lockName);
+            $output->writeln(sprintf('<info>UNLOCKED "%s". Please start over again.</info>', $lockName));
+            return;
+        }
+
+        if (!$ignoreLock) {
+            if (Lock::isLocked($lockName, $lockTimeoutInSeconds)) {
+                throw new \Exception(sprintf('Could not lock command "%s" as another process is running.', $lockName));
+            }
+            Lock::lock($lockName);
+        }
+
         if (!$processPreparationQueue && !$processUpdateIndexQueue) {
             throw new \Exception('No queue to process');
         }
 
         if ($processPreparationQueue) {
-            IndexUpdater::processPreparationQueue($tenants, $input->getOption('max-rounds'), self::LOGGER_NAME, $input->getOption('items-per-round'));
+            IndexUpdater::processPreparationQueue($tenants, $input->getOption('max-rounds'), self::LOGGER_NAME, $input->getOption('items-per-round'), $timeoutInSeconds);
         }
 
         if ($processUpdateIndexQueue) {
-            IndexUpdater::processUpdateIndexQueue($tenants, $input->getOption('max-rounds'), self::LOGGER_NAME, $input->getOption('items-per-round'));
+            IndexUpdater::processUpdateIndexQueue($tenants, $input->getOption('max-rounds'), self::LOGGER_NAME, $input->getOption('items-per-round'), $timeoutInSeconds);
+        }
+
+        if (!$ignoreLock) {
+            Lock::release($lockName);
         }
     }
 }

--- a/bundles/EcommerceFrameworkBundle/Command/IndexService/ProcessQueueCommand.php
+++ b/bundles/EcommerceFrameworkBundle/Command/IndexService/ProcessQueueCommand.php
@@ -55,19 +55,18 @@ class ProcessQueueCommand extends AbstractIndexServiceCommand
         $processPreparationQueue = in_array('preparation', $queues);
         $processUpdateIndexQueue = in_array('update-index', $queues);
 
-        if ($timeoutInMinutes = $input->getOption('timeout')) {
-            $timeoutInSeconds = (int)$timeoutInMinutes * 60;
+        if ($timeoutInMinutes = (int)$input->getOption('timeout')) {
+            $timeoutInSeconds = $timeoutInMinutes * 60;
         }
 
         $lockName = $this->getLockName($input);
         $ignoreLock = filter_var($input->getOption('ignore-lock'), FILTER_VALIDATE_BOOLEAN);
-        $unlock = filter_var($input->getOption('unlock'), FILTER_VALIDATE_BOOLEAN);
 
-        if ($lockTimeoutInMinutes = $input->getOption('lock-timeout')) {
-            $lockTimeoutInSeconds = (int)$lockTimeoutInMinutes * 60;
+        if ($lockTimeoutInMinutes = (int)$input->getOption('lock-timeout')) {
+            $lockTimeoutInSeconds = $lockTimeoutInMinutes * 60;
         }
 
-        if ($unlock) {
+        if ($input->getOption('unlock')) {
             Lock::release($lockName);
             $output->writeln(sprintf('<info>UNLOCKED "%s". Please start over again.</info>', $lockName));
             return;

--- a/bundles/EcommerceFrameworkBundle/IndexService/Tool/IndexUpdater.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Tool/IndexUpdater.php
@@ -95,11 +95,15 @@ class IndexUpdater
      * @param int $maxRounds - max rounds after process returns. null for infinite run until no work is left
      * @param string $loggername
      * @param int $preparationItemsPerRound - number of items to prepare per round
+     * @param int $timeout - timeout in seconds
      *
      * @throws InvalidConfigException
+     * @throws \Exception
      */
-    public static function processPreparationQueue($tenants = null, $maxRounds = null, $loggername = 'indexupdater', $preparationItemsPerRound = 200)
+    public static function processPreparationQueue($tenants = null, $maxRounds = null, $loggername = 'indexupdater', $preparationItemsPerRound = 200, $timeout = -1)
     {
+        $startTime = microtime(true);
+
         if ($tenants == null) {
             $tenants = Factory::getInstance()->getAllTenants();
         }
@@ -123,6 +127,8 @@ class IndexUpdater
                 $round = 0;
                 $result = true;
                 while ($result) {
+                    self::checkTimeout($timeout, $startTime);
+
                     $round++;
                     self::log($loggername, 'Starting round: ' . $round);
 
@@ -148,11 +154,15 @@ class IndexUpdater
      * @param int $maxRounds - max rounds after process returns. null for infinite run until no work is left
      * @param string $loggername
      * @param int $indexItemsPerRound - number of items to index per round
+     * @param int $timeout - timeout in seconds
      *
      * @throws InvalidConfigException
+     * @throws \Exception
      */
-    public static function processUpdateIndexQueue($tenants = null, $maxRounds = null, $loggername = 'indexupdater', $indexItemsPerRound = 200)
+    public static function processUpdateIndexQueue($tenants = null, $maxRounds = null, $loggername = 'indexupdater', $indexItemsPerRound = 200, $timeout = -1)
     {
+        $startTime = microtime(true);
+
         if ($tenants == null) {
             $tenants = Factory::getInstance()->getAllTenants();
         }
@@ -176,6 +186,8 @@ class IndexUpdater
                 $result = true;
                 $round = 0;
                 while ($result) {
+                    self::checkTimeout($timeout, $startTime);
+
                     $round++;
                     self::log($loggername, 'Starting round: ' . $round);
 
@@ -198,5 +210,22 @@ class IndexUpdater
     {
         Simple::log($loggername, $message);
         echo $message . "\n";
+    }
+
+    /**
+     * @param $timeout
+     * @param $startTime
+     * @throws \Exception
+     */
+    private static function checkTimeout($timeout, $startTime): void
+    {
+        if ($timeout > 0) {
+            $timeSinceStart = microtime(true) - $startTime;
+            if ($timeout <= $timeSinceStart) {
+                throw new \Exception(sprintf('Timeout "%d minutes" has been reached. Aborted.',
+                    $timeout / 60
+                ));
+            }
+        }
     }
 }


### PR DESCRIPTION
# Process queue improvements

If you have got a lot of products (several hundred thousand) with a complex data structure the preparation may sometimes take quite some time if i.e. a product category with a lot of dependencies gets updated. So if I configured the preparation (`ecommerce:indexservice:process-queue preparation`) to run every 5 minutes but it takes about an hour to finish the job the server load continues to increase as more and more processes are running.
 
This PR now adds several new options to the `ecommerce:indexservice:process-queue` command:
- `ignore-lock` (default true for bc)
- `unlock`
- `lock-timeout`
- `timeout`

The lock-name is a checksum of the `queue` argument and the `tenant ` option.