### PR TITLE
[Documents] Newsletter: add option to maintain a manual edited plain-text version

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/NewsletterController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/NewsletterController.php
@@ -192,6 +192,12 @@ class NewsletterController extends DocumentControllerBase
         $this->addSettingsToDocument($request, $page);
         $this->addDataToDocument($request, $page);
         $this->addPropertiesToDocument($request, $page);
+        
+        // plaintext
+        if ($request->get('plaintext')) {
+            $plaintext = $this->decodeJson($request->get('plaintext'));
+            $page->setValues($plaintext);    
+        }
     }
 
     /**

--- a/bundles/AdminBundle/Resources/public/css/icons.css
+++ b/bundles/AdminBundle/Resources/public/css/icons.css
@@ -1821,6 +1821,10 @@
     background: url(/bundles/pimcoreadmin/img/material-icons/outline-settings-24px.svg) center center no-repeat;
 }
 
+.pimcore_material_icon_text {
+    background: url(/bundles/pimcoreadmin/img/flat-white-icons/text.svg) center center no-repeat;
+}
+
 .pimcore_material_icon_workflow {
     background: url(/bundles/pimcoreadmin/img/material-icons/outline-directions-24px.svg) center center no-repeat;
 }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/newsletter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/newsletter.js
@@ -56,6 +56,7 @@ pimcore.document.newsletter = Class.create(pimcore.document.page_snippet, {
 
         this.sendingPanel = new pimcore.document.newsletters.sendingPanel(this);
         // this.reports = new pimcore.report.panel("document_snippet", this);
+        this.plaintextPanel = new pimcore.document.newsletters.plaintextPanel(this);
 
         this.tagAssignment = new pimcore.element.tag.assignment(this, "document");
         this.workflows = new pimcore.element.workflows(this, "document");
@@ -67,6 +68,7 @@ pimcore.document.newsletter = Class.create(pimcore.document.page_snippet, {
         var items = [];
 
         items.push(this.edit.getLayout());
+        items.push(this.plaintextPanel.getLayout());
         items.push(this.preview.getLayout());
         if (this.isAllowed("settings")) {
             items.push(this.settings.getLayout());
@@ -161,6 +163,14 @@ pimcore.document.newsletter = Class.create(pimcore.document.page_snippet, {
                 //console.log(e3);
             }
 
+        }
+        
+        // plaintext
+        try {
+            parameters.plaintext = Ext.encode(this.plaintextPanel.getValues());
+        }
+        catch (e4) {
+            //console.log(e4);
         }
 
         // data

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/newsletters/plaintextPanel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/newsletters/plaintextPanel.js
@@ -1,0 +1,78 @@
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+pimcore.registerNS("pimcore.document.newsletters.plaintextPanel");
+pimcore.document.newsletters.plaintextPanel = Class.create({
+    
+    initialize: function(document) {
+        this.document = document;
+    },
+
+    getLayout: function () {
+
+        if (this.layout == null) {
+
+            this.layout = new Ext.FormPanel({
+                title: t('plaintext'),
+                border: false,
+                autoScroll: true,
+                bodyStyle:'padding:0 10px 0 10px;',
+                iconCls: "pimcore_material_icon_text pimcore_material_icon",
+                items: [
+                    {
+                    xtype:'fieldset',
+                        title: t('plain_text_email_part'),
+                        itemId: "plaintextPanel",
+                        collapsible: true,
+                        autoHeight:true,
+                        defaults: {
+                            labelWidth: 200
+                        },
+                        defaultType: 'textarea',
+                        items :[
+                            {
+                                fieldLabel: t('plain_text') + " (" + this.document.data.plaintext.length + ")",
+                                maxLength: 4000,
+                                height: 700,
+                                width: 1400,
+                                name: 'plaintext',
+                                itemId: 'plaintext',
+                                value: this.document.data.plaintext,
+                                enableKeyEvents: true,
+                                listeners: {
+                                    "keyup": function (el) {
+                                        el.labelEl.update(t("plain text") + " (" + el.getValue().length + "):");
+                                    }
+                                }
+                            }
+                        ]
+                    }    
+                ]
+            });
+        }
+
+        return this.layout;
+    },
+    
+    getValues: function () {
+
+        if (!this.layout.rendered) {
+            throw "plaintext not available";
+        }
+
+        // get values
+        var plaintext = this.getLayout().getForm().getFieldValues();
+        return plaintext;
+    }
+
+});

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/newsletters/plaintextPanel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/newsletters/plaintextPanel.js
@@ -23,7 +23,7 @@ pimcore.document.newsletters.plaintextPanel = Class.create({
         if (this.layout == null) {
 
             this.layout = new Ext.FormPanel({
-                title: t('plaintext'),
+                title: t('plain_text'),
                 border: false,
                 autoScroll: true,
                 bodyStyle:'padding:0 10px 0 10px;',
@@ -51,7 +51,7 @@ pimcore.document.newsletters.plaintextPanel = Class.create({
                                 enableKeyEvents: true,
                                 listeners: {
                                     "keyup": function (el) {
-                                        el.labelEl.update(t("plain text") + " (" + el.getValue().length + "):");
+                                        el.labelEl.update(t("plain_text") + " (" + el.getValue().length + "):");
                                     }
                                 }
                             }

--- a/bundles/AdminBundle/Resources/views/Admin/Index/index.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/Index/index.html.php
@@ -379,6 +379,7 @@ $scripts = array(
     "pimcore/document/emails/settings.js",
     "pimcore/document/newsletters/settings.js",
     "pimcore/document/newsletters/sendingPanel.js",
+    "pimcore/document/newsletters/plaintextPanel.js",
     "pimcore/document/newsletters/addressSourceAdapters/default.js",
     "pimcore/document/newsletters/addressSourceAdapters/csvList.js",
     "pimcore/document/newsletters/addressSourceAdapters/report.js",

--- a/bundles/CoreBundle/Resources/translations/de.json
+++ b/bundles/CoreBundle/Resources/translations/de.json
@@ -52,8 +52,6 @@
     "send_newsletter": "Newsletter JETZT versenden",
     "object_filter": "Objekt Filter",
     "add_newsletter": "Newsletter hinzufügen",
-    "plain_text": "Klartext",
-    "plain_text_email_part": "E-Mail-Klartextteil",
     "newsletter": "Newsletter",
     "crm": "CRM",
     "notes_events": "Notizen und Termine",

--- a/bundles/CoreBundle/Resources/translations/de.json
+++ b/bundles/CoreBundle/Resources/translations/de.json
@@ -52,6 +52,8 @@
     "send_newsletter": "Newsletter JETZT versenden",
     "object_filter": "Objekt Filter",
     "add_newsletter": "Newsletter hinzufügen",
+    "plain_text": "Klartext",
+    "plain_text_email_part": "E-Mail-Klartextteil",
     "newsletter": "Newsletter",
     "crm": "CRM",
     "notes_events": "Notizen und Termine",

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -74,6 +74,8 @@
   "send_newsletter": "Send Newsletter Now",
   "object_filter": "Object Filter",
   "add_newsletter": "Add Newsletter",
+  "plain_text": "Plain Text",
+  "plain_text_email_part": "Email Plain Text Part",
   "newsletter": "Newsletter",
   "crm": "CRM",
   "notes_events": "Notes &amp; Events",

--- a/lib/Tool/Newsletter.php
+++ b/lib/Tool/Newsletter.php
@@ -69,6 +69,10 @@ class Newsletter
         if ($sendingContainer && $sendingContainer->getParams()) {
             $mail->setParams($sendingContainer->getParams());
         }
+        
+        if(strlen(trim($newsletterDocument->getPlaintext())) > 0) {
+            $mail->setBodyText(trim($newsletterDocument->getPlaintext()));
+        }
 
         $contentHTML = $mail->getBodyHtmlRendered();
         $contentText = $mail->getBodyTextRendered();
@@ -115,6 +119,8 @@ class Newsletter
 
         $mail->setBodyHtml($contentHTML);
         $mail->setBodyText($contentText);
+        // Adds the plain text part to the message, that it becomes a multipart email
+        $mail->addPart($contentText, 'text/plain');
         $mail->setSubject($mail->getSubjectRendered());
 
         return $mail;
@@ -137,8 +143,6 @@ class Newsletter
 
         if (!empty($mailAddress)) {
             $mail->setTo($mailAddress);
-            // Getting bounces
-            $mail->setReturnPath(key($mail->getFrom()));
 
             $mailer = null;
             // check if newsletter specific mailer is needed

--- a/models/Document/Newsletter.php
+++ b/models/Document/Newsletter.php
@@ -37,7 +37,14 @@ class Newsletter extends Model\Document\PageSnippet
      * @var string
      */
     protected $subject = '';
-
+    
+    /**
+     * Contains the plain text part of the email
+     *
+     * @var string
+     */
+    protected $plaintext = '';
+    
     /**
      * Contains the from email address
      *
@@ -108,6 +115,30 @@ class Newsletter extends Model\Document\PageSnippet
         $this->from = $from;
 
         return $this;
+    }
+    
+    /**
+     * Contains the email plain text part
+     *
+     * @param string $plaintext
+     *
+     * @return $this
+     */
+    public function setPlaintext($plaintext)
+    {
+        $this->plaintext = $plaintext;
+
+        return $this;
+    }
+
+    /**
+     * Returns the email plain text part
+     *
+     * @return string
+     */
+    public function getPlaintext()
+    {
+        return $this->plaintext;
     }
 
     /**


### PR DESCRIPTION
Spam filters like SpamAssassin rate multipart emails higher than just html-email. Having the text part is worth one score point. The existing version just sends html-emails, also with the detour via html2text. (See comment in code).

Following database change has to be done first: (I don't know how to send the db-update in a PR)
ALTER TABLE `intranet`.`documents_newsletter` 
ADD COLUMN `plaintext` LONGTEXT NULL DEFAULT NULL AFTER `sendingMode`;

Best regards
Lexi
  