### PR TITLE
Remove unused variables in document editmode dnd

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/edit/dnd.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/edit/dnd.js
@@ -22,7 +22,6 @@ pimcore.document.edit.dnd = Class.create({
 
         parentExt.dd.DragDropMgr.notifyOccluded = true;
         this.dndManager = parentExt.dd.DragDropMgr;
-        var iFrameElement = parent.Ext.get('document_iframe_' + window.editWindow.document.id);
 
         body.addListener('mousemove', this.ddMouseMove.bind(this));
         body.addListener('mouseup', this.ddMouseUp.bind(this));
@@ -95,8 +94,6 @@ pimcore.document.edit.dnd = Class.create({
         var doc = (window.contentDocument || window.document);
         scrollTop = doc.documentElement.scrollTop || doc.body.scrollTop;
         scrollLeft = doc.documentElement.scrollLeft || doc.body.scrollLeft;
-
-        var xy = e.getXY();
 
         if (this.dndManager.dragCurrent) {
             e.xy = [e.pageX + this.iframeOffset[0] - scrollLeft, e.pageY + this.iframeOffset[1] - scrollTop];


### PR DESCRIPTION
## Changes in this pull request  

Removed unused variables `iFrameElement` and `xy`

* `iframeElement` (spelled differently) is passed through initialize parameters
* `xy` is never used in the function scope