### PR TITLE
Fix paths in yml files for more robust context and firewall

### DIFF
--- a/bundles/CoreBundle/Resources/config/pimcore/default.yml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yml
@@ -202,18 +202,18 @@ pimcore:
     context:
         profiler:
             routes:
-                - { path: ^/_(profiler|wdt) }
+                - { path: ^/_(profiler|wdt)(/.*)?$ }
         admin:
             routes:
-                - { path: ^/admin }
+                - { path: ^/admin(/.*)?$ }
                 - { route: ^pimcore_admin_ }
         webservice:
             routes:
-                - { path: ^/webservice }
+                - { path: ^/webservice(/.*)?$ }
                 - { route: ^pimcore_webservice }
         plugin:
             routes:
-                - { path: ^/plugin }
+                - { path: ^/plugin(/.*)?$ }
     admin:
         session:
             attribute_bags:

--- a/bundles/CoreBundle/Resources/config/pimcore/security.yml
+++ b/bundles/CoreBundle/Resources/config/pimcore/security.yml
@@ -20,7 +20,7 @@ security:
         # admin form login
         admin:
             anonymous: ~
-            pattern: ^/admin
+            pattern: ^/admin(/.*)?$
             # admin firewall is stateless as we open the admin
             # session on demand for non-blocking parallel requests
             stateless: true
@@ -44,7 +44,7 @@ security:
 
 
         webservice:
-            pattern: ^/webservice
+            pattern: ^/webservice(/.*)?$
             stateless: true
             provider: pimcore_admin
             guard:

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/40_Custom_Admin_Login_Entry_Point.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/40_Custom_Admin_Login_Entry_Point.md
@@ -11,7 +11,7 @@ pimcore_admin:
 ``` 
 > Please note:   
 > custom_admin_path_identifier should be at least 20 characters long
-> and must not start with `/admin` ! 
+> and must not start with `/admin` if Pimcore version <= 6.0.5 ! 
 
 Add custom entry for `PimcoreCoreBundle:PublicServices:customAdminEntryPoint` in your routing.yml:  
 ```yml


### PR DESCRIPTION
Hello,

This PR make context matching more robust so it does not include URLs like:
```
/admin-project
/webservice-project
/plugin-project
...
```

Actually they was resolved as admin/webservice/plugin context.
Firewall paths have been changed too, so firewall is not activated on these custom URLs.

Now, something like:
```
project_myfront_entry_point:
    path: /admin-front
    controller: AppBundle\Controller\DefaultController::testFrontAdminAction
```
will work ! : )

And custom admin pimcore entrypoint can now begin with /admin* too.
Doc for admin entrypoint is updated in this PR too.
https://github.com/pimcore/pimcore/issues/4790 is resolved with this PR.

Tested locally, all seems to works pretty fine.
Thanks.