### PR TITLE
Application::getInstance throws error

### DIFF
--- a/bundles/CoreBundle/Resources/config/logging.yml
+++ b/bundles/CoreBundle/Resources/config/logging.yml
@@ -7,8 +7,12 @@ services:
     # APPLICATION LOGGER
     #
 
-    pimcore.app_logger: '@pimcore.app_logger.default'
-    pimcore.app_logger.default: '@Pimcore\Log\ApplicationLogger'
+    pimcore.app_logger:
+        alias: '@pimcore.app_logger.default'
+
+    pimcore.app_logger.default:
+        alias: Pimcore\Log\ApplicationLogger
+        public: true
 
     # Monolog processors for the application logger. Autoconfigure is set to false as we don't
     # want Symfony to auto-register them for all handlers (this isn't the case at the moment as

--- a/bundles/CoreBundle/Resources/config/logging.yml
+++ b/bundles/CoreBundle/Resources/config/logging.yml
@@ -44,8 +44,8 @@ services:
 
     pimcore.app_logger:
         public: true
-        alias: '@pimcore.app_logger.default'
+        alias: pimcore.app_logger.default
 
     pimcore.app_logger.default:
         public: true
-        alias: '@Pimcore\Log\ApplicationLogger'
+        alias: Pimcore\Log\ApplicationLogger

--- a/bundles/CoreBundle/Resources/config/logging.yml
+++ b/bundles/CoreBundle/Resources/config/logging.yml
@@ -7,13 +7,6 @@ services:
     # APPLICATION LOGGER
     #
 
-    pimcore.app_logger:
-        alias: '@pimcore.app_logger.default'
-
-    pimcore.app_logger.default:
-        alias: Pimcore\Log\ApplicationLogger
-        public: true
-
     # Monolog processors for the application logger. Autoconfigure is set to false as we don't
     # want Symfony to auto-register them for all handlers (this isn't the case at the moment as
     # there is no interface for a processor, but in case support for autoconfiguration is added
@@ -45,5 +38,14 @@ services:
             - [pushProcessor, ['@pimcore.app_logger.introspection_processor']]
 
     Pimcore\Log\ApplicationLogger:
+        public: true
         calls:
             - [addWriter, ['@Pimcore\Log\Handler\ApplicationLoggerDb']]
+
+    pimcore.app_logger:
+        public: true
+        alias: '@pimcore.app_logger.default'
+
+    pimcore.app_logger.default:
+        public: true
+        alias: '@Pimcore\Log\ApplicationLogger'


### PR DESCRIPTION
# Description
When using Pimcore 6, it is no longer possible to call `ApplicationLogger::getInstance()` due to the `pimcore.app_logger.default` being private.

## Changes in this pull request  
This PR sets `pimcore.app_logger.default` public, which allows us to call `ApplicationLogger::getInstance()` again.

