### PR TITLE
[Ecommerce][CartManager] Calculate GiftItems of Cart only if not already calculated

### DIFF
--- a/bundles/EcommerceFrameworkBundle/CartManager/AbstractCart.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/AbstractCart.php
@@ -481,7 +481,9 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
     public function getGiftItems()
     {
         //make sure that cart is calculated
-        $this->getPriceCalculator()->calculate();
+        if (!$this->getPriceCalculator()->isCalculated()) {
+            $this->getPriceCalculator()->calculate();
+        }
 
         return $this->giftItems;
     }
@@ -494,7 +496,9 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
     public function getGiftItem($itemKey)
     {
         //make sure that cart is calculated
-        $this->getPriceCalculator()->calculate();
+        if (!$this->getPriceCalculator()->isCalculated()) {
+            $this->getPriceCalculator()->calculate();
+        }
 
         return array_key_exists($itemKey, $this->giftItems) ? $this->giftItems[$itemKey] : null;
     }

--- a/bundles/EcommerceFrameworkBundle/CartManager/CartPriceCalculator.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/CartPriceCalculator.php
@@ -415,4 +415,12 @@ class CartPriceCalculator implements CartPriceCalculatorInterface
 
         return array_values($uniqueItemRules);
     }
+
+    /**
+     * @return bool
+     */
+    public function isCalculated(): bool
+    {
+        return $this->isCalculated;
+    }
 }

--- a/bundles/EcommerceFrameworkBundle/CartManager/CartPriceCalculatorInterface.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/CartPriceCalculatorInterface.php
@@ -107,6 +107,11 @@ interface CartPriceCalculatorInterface
      * @throws UnsupportedException
      */
     public function getAppliedPricingRules(): array;
+
+    /**
+     * @return bool
+     */
+    public function isCalculated(): bool;
 }
 
 class_alias(CartPriceCalculatorInterface::class, 'Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\ICartPriceCalculator');


### PR DESCRIPTION
This PR fixes calculating a already calculated cart.

Whenever getGiftItems or getGiftItem is called the calculate method is executed. This also triggers the applyCartRules function. However, this should not be the case if the cart was calculated before.

@fashxp 