### PR TITLE
Transmit values of system columns to grid operators

### DIFF
--- a/lib/DataObject/GridColumnConfig/Value/DefaultValue.php
+++ b/lib/DataObject/GridColumnConfig/Value/DefaultValue.php
@@ -18,6 +18,7 @@
 namespace Pimcore\DataObject\GridColumnConfig\Value;
 
 use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Objectbrick;
 use Pimcore\Model\DataObject\Service;
@@ -67,6 +68,10 @@ class DefaultValue extends AbstractValue
             $brickClass = Objectbrick\Definition::getByKey($brickType);
             $context = ['object' => $object, 'outerFieldname' => $key];
             $fieldDefinition = $brickClass->getFieldDefinition($brickKey, $context);
+        }
+
+        if(!$fieldDefinition instanceof Data) {
+            return $this->getDefaultValue($value);
         }
 
         if ($fieldDefinition->isEmpty($value)) {


### PR DESCRIPTION
Currently there is an error if you add a date formatter operator to a grid config and assign this date formatter operator the modificationDate or creationDate system columns. 
<img width="855" alt="Bildschirmfoto 2019-08-06 um 13 00 35" src="https://user-images.githubusercontent.com/8749138/62535179-140d8880-b84b-11e9-8561-77a3e3945e7c.png">
(This screenshot is done including this PR's changes)

This results in the error
´´´
Call to a member function isEmpty() on null
Trace: 
#0 /path/to/pimcore/vendor/pimcore/pimcore/lib/DataObject/GridColumnConfig/Value/DefaultValue.php
...
´´´

This PR fixes this problem.
