### PR TITLE
[Documents] Navigation - Added option to provide class for sub menus

### DIFF
--- a/doc/Development_Documentation/03_Documents/03_Navigation.md
+++ b/doc/Development_Documentation/03_Documents/03_Navigation.md
@@ -94,6 +94,59 @@ Having set up the navigation container as shown above, you can easily use it to 
 
 </div>
 
+### Meta Navigation - Multilevel
+
+<div class="code-section">
+
+```php
+<div class="my-menu">
+    <?php
+    // you can use array to apply different ulClass on depth levels 
+    echo $this->navigation()->menu()->renderMenu($mainNavigation, [
+        'maxDepth' => 2,
+        'ulClass'  => [
+            0 => 'nav navbar-nav', //ulClass for first level
+            1 => 'nav navbar-nav-second',
+            2 => 'nav navbar-nav-third'
+        ]
+    ]);
+    ?>
+    
+    <?php
+    // alternatively, you can use 'default' key to apply class on all depth levels
+    $this->navigation()->render($mainNavigation, 'menu', 'renderMenu', [
+        'maxDepth' => 2,
+        'ulClass'  => [
+            'default' => 'nav navbar-nav', //ulClass for all levels
+        ]
+    ]); ?>
+
+</div>
+```
+
+```twig
+<div class="my-menu">
+    {# you can use array for ulClass to provide depth level classes #}
+    {{ pimcore_render_nav(mainNavigation, 'menu', 'renderMenu', {
+        maxDepth: 2,
+        ulClass: {
+            0: 'nav navbar-nav',
+            1: 'nav navbar-nav-second',
+            2: 'nav navbar-nav-third'
+        }
+    }) }}
+    
+    {# alternatively, you can use 'default' key to apply class on all depth levels #}
+    {{ pimcore_render_nav(mainNavigation, 'menu', 'renderMenu', {
+            maxDepth: 2,
+            ulClass: {
+                'default': 'nav navbar-nav'
+            }
+        }) }}
+</div>
+```
+</div>
+
 ### Breadcrumbs
 
 ```php

--- a/lib/Navigation/Renderer/Menu.php
+++ b/lib/Navigation/Renderer/Menu.php
@@ -761,7 +761,7 @@ class Menu extends AbstractRenderer
 
             //set ulCLass depth wise
             if(is_array($ulClasses)) {
-                $ulClass = ($ulClasses[$depth] ? $ulClasses[$depth] : $ulClasses['default']);
+                $ulClass = $ulClasses[$depth] ?? $ulClasses['default'];
             }
 
             if ($depth < $minDepth || !$this->accept($page)) {

--- a/lib/Navigation/Renderer/Menu.php
+++ b/lib/Navigation/Renderer/Menu.php
@@ -516,7 +516,7 @@ class Menu extends AbstractRenderer
 
         // UL class
         if (isset($options['ulClass']) && $options['ulClass'] !== null) {
-            $options['ulClass'] = (string) $options['ulClass'];
+            $options['ulClass'] = $options['ulClass'];
         } else {
             $options['ulClass'] = $this->getUlClass();
         }
@@ -697,7 +697,7 @@ class Menu extends AbstractRenderer
      * Renders a normal menu (called from {@link renderMenu()})
      *
      * @param  Container $container     container to render
-     * @param  string                    $ulClass       CSS class for first UL
+     * @param  string                    $ulClasses       CSS class for UL levels
      * @param  string                    $indent        initial indentation
      * @param  string                    $innerIndent   inner indentation
      * @param  int|null                  $minDepth      minimum depth
@@ -719,7 +719,7 @@ class Menu extends AbstractRenderer
      */
     protected function _renderMenu(
         Container $container,
-        $ulClass,
+        $ulClasses,
         $indent,
         $innerIndent,
         $minDepth,
@@ -733,6 +733,7 @@ class Menu extends AbstractRenderer
         $renderParentClass
     ) {
         $html = '';
+        $ulClass = $ulClasses;
 
         // find deepest active
         if ($found = $this->findActive($container, $minDepth, $maxDepth)) {
@@ -756,6 +757,13 @@ class Menu extends AbstractRenderer
         foreach ($iterator as $page) {
             $depth = $iterator->getDepth();
             $isActive = $page->isActive(true);
+
+
+            //set ulCLass depth wise
+            if(is_array($ulClasses)) {
+                $ulClass = ($ulClasses[$depth] ? $ulClasses[$depth] : $ulClasses['default']);
+            }
+
             if ($depth < $minDepth || !$this->accept($page)) {
                 // page is below minDepth or not accepted by visibilty
                 continue;
@@ -805,7 +813,7 @@ class Menu extends AbstractRenderer
                 $attribs = [];
 
                 // start new ul tag
-                if (0 == $depth) {
+                if ((is_string($ulClasses) && 0 == $depth) || is_array($ulClasses)) {
                     $attribs = [
                         'class' => $ulClass,
                         'id' => $ulId,


### PR DESCRIPTION
Changes in this pull request  
Resolves #4741

## Additional info  
```php
    <?php
    echo $this->navigation()->menu()->renderMenu($mainNavigation, [
        'maxDepth' => 2,
        // apply different ulClass on depth levels 
        'ulClass'  => [
            0 => 'nav navbar-nav', //ulClass for first level
            1 => 'nav navbar-nav-second',
            2 => 'nav navbar-nav-third'
        ],
        //or apply same ulClass on depth levels
       'ulClass'  => [
          'default' => 'nav navbar-nav'
       ]
    ]);
    ?>
```