### PR TITLE
[Ecommerce] Consider json_decode errors on updating index

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -387,7 +387,14 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
     {
         if (empty($data)) {
             $data = $this->db->fetchOne('SELECT data FROM ' . $this->getStoreTableName() . ' WHERE o_id = ? AND tenant = ?', [$objectId, $this->name]);
-            $data = json_decode($data, true);
+            if ($data) {
+                $data = json_decode($data, true);
+
+                $jsonDecodeError = json_last_error();
+                if ($jsonDecodeError !== JSON_ERROR_NONE) {
+                    throw new \Exception("Could not decode store data for updating index - maybe there is invalid json data. Json decode error code was {$jsonDecodeError}, ObjectId was {$objectId}.");
+                }
+            }
         }
 
         if ($data) {


### PR DESCRIPTION
## Improvement

I had the case that there was invalid json data in my index store table. As the json_decode failed the data was not added to the index itself and there always was some inconsistency between store and index - without any errors shown. This PR now throws an error if the json_decode fails.
