### PR TITLE
Allow _ in custom object layout names

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
@@ -764,7 +764,7 @@ pimcore.object.helpers.customLayoutEditor = Class.create({
         var id = this.layoutChangeCombo.getValue();
 
         this.saveCurrentNode();
-        var regresult = this.data["name"].match(/[a-zA-Z ][a-zA-Z0-9 ]+/);
+        var regresult = this.data["name"].match(/[a-zA-Z _][a-zA-Z0-9 _]+/);
 
         if (this.data["name"].length > 2 && this.data["name"].length < 64 && regresult == this.data["name"]) {
             delete this.data.layoutDefinitions;


### PR DESCRIPTION
In previous versions there was no regex name check therfore some legacy names do not work anymore. I suggest to allow _ here as it is not a dangerous character.