### PR TITLE
Update Version marshal to ignore Doctrine

### DIFF
--- a/models/Version.php
+++ b/models/Version.php
@@ -281,6 +281,7 @@ class Version extends AbstractModel
             ),
             new MarshalMatcher($sourceType, $sourceId)
         );
+        $copier->addFilter(new \DeepCopy\Filter\Doctrine\DoctrineCollectionFilter(), new \DeepCopy\Matcher\PropertyTypeMatcher('Doctrine\Common\Collections\Collection'));
         $newData = $copier->copy($data);
 
         return $newData;


### PR DESCRIPTION
Otherwise, it would also copy entity-manager and that is not possible, this fixes CoreShop Builds: https://travis-ci.com/coreshop/CoreShop/jobs/224293440#L991

