### PR TITLE
[ecommerceframework][v7 CheckoutManager] recreate order if trying to start a payment with an aborted, cancelled or commited order

### DIFF
--- a/bundles/EcommerceFrameworkBundle/CheckoutManager/V7/CheckoutManager.php
+++ b/bundles/EcommerceFrameworkBundle/CheckoutManager/V7/CheckoutManager.php
@@ -98,15 +98,9 @@ class CheckoutManager extends \Pimcore\Bundle\EcommerceFrameworkBundle\CheckoutM
         if ($order) {
             $notAllowedOrderStates = [AbstractOrder::ORDER_STATE_ABORTED, AbstractOrder::ORDER_STATE_CANCELLED, AbstractOrder::ORDER_STATE_COMMITTED];
             if (in_array($order->getOrderState(), $notAllowedOrderStates)) {
-                throw new PaymentNotAllowedException(
-                    "Payment not allowed since orderState set to '" . $order->getOrderState() . "'. Fix orderState or recreate order.",
-                    $order,
-                    $this->cart,
-                    $orderManager->orderNeedsUpdate($this->cart, $order)
-                );
-            }
-
-            if ($orderManager->cartHasPendingPayments($this->cart)) {
+                // recreate order if trying to start a payment with an aborted, cancelled or commited order
+                $orderManager->recreateOrder($this->cart);
+            } elseif ($orderManager->cartHasPendingPayments($this->cart)) {
                 $order = $this->getHandlePendingPaymentsStrategy()->handlePaymentNotAllowed(
                     $order,
                     $this->cart,

--- a/bundles/EcommerceFrameworkBundle/CheckoutManager/V7/CheckoutManager.php
+++ b/bundles/EcommerceFrameworkBundle/CheckoutManager/V7/CheckoutManager.php
@@ -98,7 +98,7 @@ class CheckoutManager extends \Pimcore\Bundle\EcommerceFrameworkBundle\CheckoutM
         if ($order) {
             $notAllowedOrderStates = [AbstractOrder::ORDER_STATE_ABORTED, AbstractOrder::ORDER_STATE_CANCELLED, AbstractOrder::ORDER_STATE_COMMITTED];
             if (in_array($order->getOrderState(), $notAllowedOrderStates)) {
-                // recreate order if trying to start a payment with an aborted, cancelled or commited order
+                // recreate order if trying to start a payment with an aborted, cancelled or committed order
                 $orderManager->recreateOrder($this->cart);
             } elseif ($orderManager->cartHasPendingPayments($this->cart)) {
                 $order = $this->getHandlePendingPaymentsStrategy()->handlePaymentNotAllowed(


### PR DESCRIPTION
As the only practical possible solution for handling this exception is to recreate the order it's better if the ecommerce framework directly handles this.