### PR TITLE
[UI] Use monospace font for server file explorer

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/fileexplorer/file.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/fileexplorer/file.js
@@ -46,7 +46,9 @@ pimcore.settings.fileexplorer.file = Class.create({
 
             this.textarea = new Ext.form.TextArea({
                 value: response.content,
-                style: "font-family:courier"
+                fieldStyle: {
+                    "fontFamily": "courier"
+                }
             });
 
             var isNew = false;


### PR DESCRIPTION
## Changes in this pull request

The original styling has no visible effect. I suppose the intention was to display the file-explorer with a monospace font so I adjusted for that with fieldStyle:

https://docs.sencha.com/extjs/6.2.0/classic/Ext.form.field.TextArea.html#cfg-fieldStyle

![image](https://user-images.githubusercontent.com/23225429/63033058-4eb09a00-beb7-11e9-9604-e403435c398e.png)


