### PR TITLE
[Workflows] Allow non-integer object layout IDs

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -1450,7 +1450,7 @@ class Configuration implements ConfigurationInterface
                                                         ->booleanNode('versions')->info('versions permission as it can be configured in Pimcore workplaces')->end()
                                                         ->booleanNode('properties')->info('properties permission as it can be configured in Pimcore workplaces')->end()
                                                         ->booleanNode('modify')->info('a short hand for save, publish, unpublish, delete + rename')->end()
-                                                        ->integerNode('objectLayout')->info('if set, the user will see the configured custom data object layout')->end()
+                                                        ->scalarNode('objectLayout')->info('if set, the user will see the configured custom data object layout')->end()
                                                     ->end()
                                                 ->end()
                                             ->end()

--- a/lib/Workflow/Place/PlaceConfig.php
+++ b/lib/Workflow/Place/PlaceConfig.php
@@ -86,7 +86,7 @@ class PlaceConfig
         return $this->placeConfigArray['visibleInHeader'];
     }
 
-    public function getObjectLayout(Workflow $workflow, $subject): ?int
+    public function getObjectLayout(Workflow $workflow, $subject): ?string
     {
         return $this->getPermissions($workflow, $subject)['objectLayout'] ?? null;
     }


### PR DESCRIPTION
Object/custom layouts can have a string as ID. However, when configuring those for a workflow the system will throw an exception because of the configuration validation.