### PR TITLE
[Assets] Make metadata setters chainable

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1625,6 +1625,8 @@ class Asset extends Element\AbstractElement
         if (!empty($metadata)) {
             $this->setHasMetaData(true);
         }
+
+        return $this;
     }
 
     /**
@@ -1641,6 +1643,8 @@ class Asset extends Element\AbstractElement
     public function setHasMetaData($hasMetaData)
     {
         $this->hasMetaData = (bool) $hasMetaData;
+
+        return $this;
     }
 
     /**
@@ -1672,6 +1676,8 @@ class Asset extends Element\AbstractElement
 
             $this->setHasMetaData(true);
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request 
Return `$this` from the three metadata setters `setMetadata`, `setHasMetaData` and `addMetadata` to make them chainable.

Resolves #4858
