### PR TITLE
fix: taking into account comma on decimal validation

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Numeric.php
+++ b/models/DataObject/ClassDefinition/Data/Numeric.php
@@ -554,7 +554,7 @@ class Numeric extends Model\DataObject\ClassDefinition\Data
             return (string) $value;
         }
 
-        if (strpos((string) $value, '.') === false) {
+        if (strpos((string) $value, '.') === false && strpos((string) $value, ',') === false) {
             return (int) $value;
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #4861

## Additional info  
Also checks for a comma before returning an integer