### PR TITLE
override default dump_directory from public to web

### DIFF
--- a/bundles/CoreBundle/Resources/config/pimcore/default.yml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yml
@@ -469,6 +469,8 @@ swiftmailer:
     default_mailer: pimcore_mailer
 
 presta_sitemap:
+    # override default dump_directory from public to web
+    dump_directory: web
     # do not add properties by default
     defaults:
         lastmod: ~


### PR DESCRIPTION
Presta Sitemap now sets dump_directory to public by default for Symfony Flex.
Since Pimcore does not use Symfony Flex yet, this should be set by default.