### PR TITLE
Remove "prod" env from clear cache list

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/Controller/Admin/SettingsController.php
@@ -594,7 +594,7 @@ class SettingsController extends AdminController
         $this->forward(self::class . '::clearCacheAction', [
             'only_symfony_cache' => false,
             'only_pimcore_cache' => false,
-            'env' => array_unique(['dev', 'prod', \Pimcore::getKernel()->getEnvironment()])
+            'env' => array_unique(['dev', \Pimcore::getKernel()->getEnvironment()])
         ]);
 
         return $this->adminJson(['success' => true]);


### PR DESCRIPTION
Do not add (by guessing) "prod" to `env` list to clear cache after saving system settings: 
- Most of the time, it's not required (long build time)
- Others may use `production`, `staging` instead of `prod`, `stag` as env names.
 