### PR TITLE
Don't strip optional datatrans config properties

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Datatrans.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Datatrans.php
@@ -184,9 +184,9 @@ class Datatrans extends AbstractPayment implements \Pimcore\Bundle\EcommerceFram
         // check params
         $required = $this->getRequiredRequestFields();
 
-        $required_config_intersect = array_intersect_key($config, $required);
+        $requiredConfigIntersect = array_intersect_key($config, $required);
 
-        if (count($required) != count($required_config_intersect)) {
+        if (count($required) != count($requiredConfigIntersect)) {
             throw new \Exception(sprintf('required fields are missing! required: %s', implode(', ', array_keys(array_diff_key($required, $config)))));
         }
 

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Datatrans.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Datatrans.php
@@ -184,9 +184,9 @@ class Datatrans extends AbstractPayment implements \Pimcore\Bundle\EcommerceFram
         // check params
         $required = $this->getRequiredRequestFields();
 
-        $config = array_intersect_key($config, $required);
+        $required_config_intersect = array_intersect_key($config, $required);
 
-        if (count($required) != count($config)) {
+        if (count($required) != count($required_config_intersect)) {
             throw new \Exception(sprintf('required fields are missing! required: %s', implode(', ', array_keys(array_diff_key($required, $config)))));
         }
 


### PR DESCRIPTION
It would be nice to be able to extend the Datatrans Payment Method without the need to defined new required configuration properties.
Currently the check if all required configuration options are set: `$config = array_intersect_key($config, $required);` overwrites possibly optional options.