### PR TITLE
[Assets] hasMetaData should be false if setMetaData(null) gets called

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1622,9 +1622,7 @@ class Asset extends Element\AbstractElement
     {
         $this->metadata = $metadata;
 
-        if (!empty($metadata)) {
-            $this->setHasMetaData(true);
-        }
+        $this->setHasMetaData(!empty($metadata));
 
         return $this;
     }


### PR DESCRIPTION
Currently if an asset had metadata and `$asset->setMetadata(null)` or `$asset->setMetadata([])`gets called, the property `hasMetaData` stays true.