### PR TITLE
Adds missing content type to robots.txt

### DIFF
--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -159,7 +159,9 @@ class PublicServicesController extends Controller
             $content = "User-agent: *\nDisallow:";
         }
 
-        return new Response($content, 200);
+        return new Response($content, Response::HTTP_OK, [
+            'Content-Type' => 'text/plain'
+        ]);
     }
 
     /**


### PR DESCRIPTION
## Expected Behavior

robots.txt should be served with a Content-Type: text/plain header.

## Actual Behavior

robots.txt is served with a Content-Type: text/html header.

## Changes in this pull request  

* Adds the Content-Type header to the robots.txt Response.
* Adds the Response code 200 by Response class constant.