### PR TITLE
[Data Objects] Show editlock dialog only if user has permissions to edit object

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -59,16 +59,18 @@ class AssetController extends ElementControllerBase implements EventedController
      */
     public function getDataByIdAction(Request $request, EventDispatcherInterface $eventDispatcher)
     {
-
-        // check for lock
-        if (Element\Editlock::isLocked($request->get('id'), 'asset')) {
-            return $this->getEditLockResponse($request->get('id'), 'asset');
-        }
-        Element\Editlock::lock($request->get('id'), 'asset');
-
-        $asset = Asset::getById(intval($request->get('id')));
+        $asset = Asset::getById((int)$request->get('id'));
         if (!$asset instanceof Asset) {
             return $this->adminJson(['success' => false, 'message' => "asset doesn't exist"]);
+        }
+
+        // check for lock
+        if ($asset->isAllowed('publish') || $asset->isAllowed('delete')) {
+            if(Element\Editlock::isLocked($request->get('id'), 'asset')) {
+                return $this->getEditLockResponse($request->get('id'), 'asset');
+            }
+
+            Element\Editlock::lock($request->get('id'), 'asset');
         }
 
         $asset = clone $asset;

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -376,7 +376,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
 
         // check for lock
         $allowedToModify = $object->isAllowed('save') || $object->isAllowed('publish') || $object->isAllowed('unpublish') || $object->isAllowed('delete');
-        if (Element\Editlock::isLocked($request->get('id'), 'object') && $allowedToModify) {
+        if ($allowedToModify && Element\Editlock::isLocked($request->get('id'), 'object')) {
             return $this->getEditLockResponse($request->get('id'), 'object');
         }
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -375,10 +375,14 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         $object = $this->getLatestVersion($objectFromDatabase);
 
         // check for lock
-        if (Element\Editlock::isLocked($request->get('id'), 'object') && ($object->isAllowed('save') || $object->isAllowed('publish') || $object->isAllowed('unpublish') || $object->isAllowed('delete'))) {
+        $allowedToModify = $object->isAllowed('save') || $object->isAllowed('publish') || $object->isAllowed('unpublish') || $object->isAllowed('delete');
+        if (Element\Editlock::isLocked($request->get('id'), 'object') && $allowedToModify) {
             return $this->getEditLockResponse($request->get('id'), 'object');
         }
-        Element\Editlock::lock($request->get('id'), 'object');
+
+        if($allowedToModify) {
+            Element\Editlock::lock($request->get('id'), 'object');
+        }
 
         // we need to know if the latest version is published or not (a version), because of lazy loaded fields in $this->getDataForObject()
         $objectFromVersion = $object !== $objectFromDatabase;

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -372,8 +372,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         $objectFromDatabase = clone $objectFromDatabase;
 
         // set the latest available version for editmode
-        $latestObject = $this->getLatestVersion($objectFromDatabase);
-        $object = $latestObject;
+        $object = $this->getLatestVersion($objectFromDatabase);
 
         // check for lock
         if (Element\Editlock::isLocked($request->get('id'), 'object') && ($object->isAllowed('save') || $object->isAllowed('publish') || $object->isAllowed('unpublish') || $object->isAllowed('delete'))) {
@@ -382,8 +381,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         Element\Editlock::lock($request->get('id'), 'object');
 
         // we need to know if the latest version is published or not (a version), because of lazy loaded fields in $this->getDataForObject()
-        $objectFromVersion = $latestObject !== $objectFromDatabase;
-        $object = $latestObject;
+        $objectFromVersion = $object !== $objectFromDatabase;
 
         if ($object->isAllowed('view')) {
             $objectData = [];

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -375,12 +375,11 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         $object = $this->getLatestVersion($objectFromDatabase);
 
         // check for lock
-        $allowedToModify = $object->isAllowed('save') || $object->isAllowed('publish') || $object->isAllowed('unpublish') || $object->isAllowed('delete');
-        if ($allowedToModify && Element\Editlock::isLocked($request->get('id'), 'object')) {
-            return $this->getEditLockResponse($request->get('id'), 'object');
-        }
+        if($object->isAllowed('save') || $object->isAllowed('publish') || $object->isAllowed('unpublish') || $object->isAllowed('delete')) {
+            if (Element\Editlock::isLocked($request->get('id'), 'object')) {
+                return $this->getEditLockResponse($request->get('id'), 'object');
+            }
 
-        if($allowedToModify) {
             Element\Editlock::lock($request->get('id'), 'object');
         }
 

--- a/bundles/AdminBundle/Controller/Admin/Document/FolderController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/FolderController.php
@@ -39,13 +39,16 @@ class FolderController extends DocumentControllerBase
      */
     public function getDataByIdAction(Request $request)
     {
-        // check for lock
-        if (Element\Editlock::isLocked($request->get('id'), 'document')) {
-            return $this->getEditLockResponse($request->get('id'), 'document');
-        }
-        Element\Editlock::lock($request->get('id'), 'document');
-
         $folder = Document\Folder::getById($request->get('id'));
+
+        // check for lock
+        if($folder->isAllowed('save') || $folder->isAllowed('publish') || $folder->isAllowed('unpublish') || $folder->isAllowed('delete')) {
+            if (Element\Editlock::isLocked($request->get('id'), 'document')) {
+                return $this->getEditLockResponse($request->get('id'), 'document');
+            }
+            Element\Editlock::lock($request->get('id'), 'document');
+        }
+
         $folder = clone $folder;
 
         $folder->idPath = Element\Service::getIdPath($folder);

--- a/bundles/AdminBundle/Controller/Admin/Document/HardlinkController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/HardlinkController.php
@@ -39,13 +39,16 @@ class HardlinkController extends DocumentControllerBase
      */
     public function getDataByIdAction(Request $request)
     {
-        // check for lock
-        if (Element\Editlock::isLocked($request->get('id'), 'document')) {
-            return $this->getEditLockResponse($request->get('id'), 'document');
-        }
-        Element\Editlock::lock($request->get('id'), 'document');
-
         $link = Document\Hardlink::getById($request->get('id'));
+
+        // check for lock
+        if($link->isAllowed('save') || $link->isAllowed('publish') || $link->isAllowed('unpublish') || $link->isAllowed('delete')) {
+            if (Element\Editlock::isLocked($request->get('id'), 'document')) {
+                return $this->getEditLockResponse($request->get('id'), 'document');
+            }
+            Element\Editlock::lock($request->get('id'), 'document');
+        }
+
         $link = clone $link;
 
         $link->idPath = Element\Service::getIdPath($link);

--- a/bundles/AdminBundle/Controller/Admin/Document/LinkController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/LinkController.php
@@ -41,13 +41,16 @@ class LinkController extends DocumentControllerBase
      */
     public function getDataByIdAction(Request $request)
     {
-        // check for lock
-        if (Element\Editlock::isLocked($request->get('id'), 'document')) {
-            return $this->getEditLockResponse($request->get('id'), 'document');
-        }
-        Element\Editlock::lock($request->get('id'), 'document');
-
         $link = Document\Link::getById($request->get('id'));
+
+        // check for lock
+        if($link->isAllowed('save') || $link->isAllowed('publish') || $link->isAllowed('unpublish') || $link->isAllowed('delete')) {
+            if (Element\Editlock::isLocked($request->get('id'), 'document')) {
+                return $this->getEditLockResponse($request->get('id'), 'document');
+            }
+            Element\Editlock::lock($request->get('id'), 'document');
+        }
+
         $link = clone $link;
 
         $link->setObject(null);

--- a/bundles/AdminBundle/Controller/Admin/Document/NewsletterController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/NewsletterController.php
@@ -50,14 +50,17 @@ class NewsletterController extends DocumentControllerBase
      */
     public function getDataByIdAction(Request $request): JsonResponse
     {
-        // check for lock
-        if (Element\Editlock::isLocked($request->get('id'), 'document')) {
-            return $this->getEditLockResponse($request->get('id'), 'document');
-        }
-        Element\Editlock::lock($request->get('id'), 'document');
-
         /** @var Document\Newsletter $email */
         $email = Document\Newsletter::getById($request->get('id'));
+
+        // check for lock
+        if($email->isAllowed('save') || $email->isAllowed('publish') || $email->isAllowed('unpublish') || $email->isAllowed('delete')) {
+            if (Element\Editlock::isLocked($request->get('id'), 'document')) {
+                return $this->getEditLockResponse($request->get('id'), 'document');
+            }
+            Element\Editlock::lock($request->get('id'), 'document');
+        }
+
         $email = clone $email;
         $email = $this->getLatestVersion($email);
 

--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -42,16 +42,20 @@ class PageController extends DocumentControllerBase
      */
     public function getDataByIdAction(Request $request)
     {
+        $page = Document\Page::getById($request->get('id'));
+
         // check for lock
-        if (Element\Editlock::isLocked($request->get('id'), 'document')) {
-            return $this->getEditLockResponse($request->get('id'), 'document');
+        if($page->isAllowed('save') || $page->isAllowed('publish') || $page->isAllowed('unpublish') || $page->isAllowed('delete')) {
+            if (Element\Editlock::isLocked($request->get('id'), 'document')) {
+                return $this->getEditLockResponse($request->get('id'), 'document');
+            }
+            Element\Editlock::lock($request->get('id'), 'document');
         }
-        Element\Editlock::lock($request->get('id'), 'document');
 
         /**
          * @var $page Document\Page
          */
-        $page = Document\Page::getById($request->get('id'));
+
         $page = clone $page;
         $page = $this->getLatestVersion($page);
 

--- a/bundles/AdminBundle/Controller/Admin/Document/PrintpageControllerBase.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PrintpageControllerBase.php
@@ -41,13 +41,16 @@ class PrintpageControllerBase extends DocumentControllerBase
      */
     public function getDataByIdAction(Request $request)
     {
-        // check for lock
-        if (\Pimcore\Model\Element\Editlock::isLocked($request->get('id'), 'document')) {
-            return $this->getEditLockResponse($request->get('id'), 'document');
-        }
-        \Pimcore\Model\Element\Editlock::lock($request->get('id'), 'document');
-
         $page = Document\PrintAbstract::getById($request->get('id'));
+
+        // check for lock
+        if($page->isAllowed('save') || $page->isAllowed('publish') || $page->isAllowed('unpublish') || $page->isAllowed('delete')) {
+            if (\Pimcore\Model\Element\Editlock::isLocked($request->get('id'), 'document')) {
+                return $this->getEditLockResponse($request->get('id'), 'document');
+            }
+            \Pimcore\Model\Element\Editlock::lock($request->get('id'), 'document');
+        }
+
         $page = $this->getLatestVersion($page);
 
         $page->getVersions();

--- a/bundles/AdminBundle/Controller/Admin/Document/SnippetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/SnippetController.php
@@ -39,13 +39,16 @@ class SnippetController extends DocumentControllerBase
      */
     public function getDataByIdAction(Request $request)
     {
-        // check for lock
-        if (Element\Editlock::isLocked($request->get('id'), 'document')) {
-            return $this->getEditLockResponse($request->get('id'), 'document');
-        }
-        Element\Editlock::lock($request->get('id'), 'document');
-
         $snippet = Document\Snippet::getById($request->get('id'));
+
+        // check for lock
+        if($snippet->isAllowed('save') || $snippet->isAllowed('publish') || $snippet->isAllowed('unpublish') || $snippet->isAllowed('delete')) {
+            if (Element\Editlock::isLocked($request->get('id'), 'document')) {
+                return $this->getEditLockResponse($request->get('id'), 'document');
+            }
+            Element\Editlock::lock($request->get('id'), 'document');
+        }
+
         $snippet = clone $snippet;
         $snippet = $this->getLatestVersion($snippet);
 

--- a/bundles/AdminBundle/Resources/public/css/icons.css
+++ b/bundles/AdminBundle/Resources/public/css/icons.css
@@ -609,7 +609,7 @@
 .pimmore_icon_pnm, .pimcore_icon_ppm, .pimcore_icon_ras, .pimcore_icon_raw, .pimcore_icon_rgb, .pimcore_icon_rle,
 .pimcore_icon_tga, .pimcore_icon_webp, .pimcore_icon_xbm, .pimcore_icon_xcf, .pimcore_icon_xpm,.pimcore_icon_cr2,
 .pimcore_icon_pcx, .pimcore_icon_iff, .pimcore_icon_pct, .pimcore_icon_wmf, .pimcore_icon_svg, .pimcore_icon_dng,
-.pimcore_icon_heic,.pimcore_icon_heif, pimcore_icon_ico {
+.pimcore_icon_heic,.pimcore_icon_heif, pimcore_icon_ico, pimcore_icon_tiff {
     background: url(/bundles/pimcoreadmin/img/flat-color-icons/asset.svg) center center no-repeat !important;
 }
 


### PR DESCRIPTION
When two users open the same data object in Pimcore backend there is the message "The desired element is currently opened by another person" with the option to open it anyway. This dialogue's goal is to prevent the object from being edited by multiple users in parallel because this would overwrite the changes of each other. As it is currently too complex to implement a mechanism to allow parallel editing (#4810) this PR shows the edit-lock dialogue only to those users who have the right to edit the opened object. If a user does not have the right to open the object the dialogue does not make much sense because he cannot alter the object anyway.

Use case: Multiple support employees wiht only read permissions use Pimcore for researching data. When they open the same object the edit-lock dialogue appears - this confuses the user (and is not needed imho).