### PR TITLE
[Backend search] Find related objects

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
@@ -343,17 +343,6 @@ abstract class AbstractRelations extends Data implements CustomResourcePersistin
     }
 
     /**
-     * @param $object
-     * @param mixed $params
-     *
-     * @return string
-     */
-    public function getDataForSearchIndex($object, $params = [])
-    {
-        return '';
-    }
-
-    /**
      * @inheritdoc
      */
     public function appendData($existingData, $additionalData)


### PR DESCRIPTION
Normally all data fields of data objects are used to fill the backend search index. Somehow this does not apply for relations. In 15c4f4fc88fc6070dfb6e37765aaad7d98034b09 there is a change which prevents relation's data from being written to search index with commit message "index optimization". 
Is this really on purpose or why should an object not be found if a user searches for a related object of it?
This PR only adds the full path of related objects to search index to not jumble search results up too much (otherwise if we wrote all data of related objects to search index it could happen that the related objects are listed before the object which actually contains the data).