### PR TITLE
Don't load by tag parent by empty id

### DIFF
--- a/models/Element/Tag.php
+++ b/models/Element/Tag.php
@@ -232,8 +232,8 @@ class Tag extends Model\AbstractModel
      */
     public function getParent()
     {
-        if ($this->parent == null) {
-            $this->parent = Tag::getById($this->getParentId());
+        if ($this->parent == null && $parentId = $this->getParentId()) {
+            $this->parent = Tag::getById($parentId);
         }
 
         return $this->parent;


### PR DESCRIPTION
I'd say we can skip to attempt loading a 0 / empty parent tag id as it will lead to null anyways.
Checking that in the function itself is less overhead (no db query, no exception handling)

