### PR TITLE
add primary key to http_error_log

### DIFF
--- a/bundles/CoreBundle/Resources/migrations/Version20190828142756.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20190828142756.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+
+class Version20190828142756 extends AbstractPimcoreMigration
+{
+    public function up(Schema $schema)
+    {
+        $table = $schema->getTable('http_error_log');
+
+        if (!$table->hasColumn('id')) {
+            $this->addSql('ALTER TABLE `http_error_log` ADD `id` int(11) NULL AUTO_INCREMENT PRIMARY KEY FIRST;');
+        }
+    }
+
+    public function down(Schema $schema)
+    {
+        $table = $schema->getTable('http_error_log');
+
+        if ($table->hasColumn('id')) {
+            $this->addSql('ALTER TABLE `http_error_log` DROP `id`;');
+        }
+    }
+}

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -312,6 +312,7 @@ CREATE TABLE `glossary` (
 
 DROP TABLE IF EXISTS `http_error_log`;
 CREATE TABLE `http_error_log` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `uri` varchar(3000) CHARACTER SET ascii COLLATE ascii_general_ci DEFAULT NULL,
   `code` int(3) DEFAULT NULL,
   `parametersGet` longtext,
@@ -320,6 +321,7 @@ CREATE TABLE `http_error_log` (
   `serverVars` longtext,
   `date` int(11) unsigned DEFAULT NULL,
   `count` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
   KEY (`uri` (765)),
   KEY `code` (`code`),
   KEY `date` (`date`),


### PR DESCRIPTION
This fixes the Percona Error:

`WSREP: Percona-XtraDB-Cluster doesn't recommend use of DML command on a table (fotobuchDB.http_error_log) without an explicit primary key with pxc_strict_mode = PERMISSIVE`