### PR TITLE
[DataObject] Avoid fatal errors if class definition file is missing

### DIFF
--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -22,6 +22,7 @@ use Pimcore\Db;
 use Pimcore\Event\DataObjectClassDefinitionEvents;
 use Pimcore\Event\Model\DataObject\ClassDefinitionEvent;
 use Pimcore\File;
+use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
 
@@ -206,6 +207,7 @@ class ClassDefinition extends Model\AbstractModel
 
                 \Pimcore\Cache\Runtime::set($cacheKey, $class);
             } catch (\Exception $e) {
+                Logger::error($e);
                 return null;
             }
         }

--- a/models/DataObject/ClassDefinition/Listing/Dao.php
+++ b/models/DataObject/ClassDefinition/Listing/Dao.php
@@ -36,7 +36,9 @@ class Dao extends Model\Listing\Dao\AbstractDao
         $classesRaw = $this->db->fetchCol('SELECT id FROM classes' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
 
         foreach ($classesRaw as $classRaw) {
-            $classes[] = DataObject\ClassDefinition::getById($classRaw);
+            if ($class = DataObject\ClassDefinition::getById($classRaw)) {
+                $classes[] = $class;
+            }
         }
 
         $this->model->setClasses($classes);


### PR DESCRIPTION
If another developer forgets to check in a class definition, it would be good if the page were still usable.

The `DataObject\ClassDefinition::getById` method log the missing class now.