### PR TITLE
fixed #4905 - [Elements] Save button must not unpublish element

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/page_snippet.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/page_snippet.js
@@ -115,7 +115,7 @@ pimcore.document.page_snippet = Class.create(pimcore.document.document, {
                 menu: [{
                     text: t('save_close'),
                     iconCls: "pimcore_icon_save",
-                    handler: this.unpublishClose.bind(this)
+                    handler: this.save.bind(this)
                 }]
             });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
@@ -361,7 +361,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                 iconCls: "pimcore_icon_save_white",
                 cls: "pimcore_save_button",
                 scale: "medium",
-                handler: this.save.bind(this, "unpublish"),
+                handler: this.save.bind(this, "version"),
                 menu: [{
                     text: t('save_close'),
                     iconCls: "pimcore_icon_save",

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -2,6 +2,9 @@
 
 ## 6.2.0 
 - Support for links and folders as a fallback document, details see [#4860](https://github.com/pimcore/pimcore/pull/4860)
+- Documents & DataObjects: save button (visible when user has no publish permission) does not unpublish element anymore (if user has unpublish permission). 
+  Details see [#4905](https://github.com/pimcore/pimcore/issues/4905)
+
 
 ### Workflow Refactorings
 - Notifications for workflows now support Pimcore notifications. Due to that, some namespaces


### PR DESCRIPTION
when user has no publish permission, he sees only save button in documents and data objects controller.
hitting this button must not unpublish element (if already published). it only should save new version.

![image](https://user-images.githubusercontent.com/8792145/63930624-fd2a1280-ca53-11e9-981a-7052bcf71c63.png)
