### PR TITLE
Fix syntax error in migration

### DIFF
--- a/bundles/CoreBundle/Resources/migrations/Version20190828142756.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20190828142756.php
@@ -12,7 +12,7 @@ class Version20190828142756 extends AbstractPimcoreMigration
         $table = $schema->getTable('http_error_log');
 
         if (!$table->hasColumn('id')) {
-            $this->addSql('ALTER TABLE `http_error_log` ADD `id` int(11) NULL AUTO_INCREMENT PRIMARY KEY FIRST;');
+            $this->addSql('ALTER TABLE `http_error_log` ADD `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST;');
         }
     }
 


### PR DESCRIPTION
I get following error in this migration with MySQL 5.7:
```
Migration 20190828142756 failed during Execution. Error An exception occurred while executing 'ALTER TABLE `http_error_log` ADD `id` int(11) NULL AUTO_INCREMENT PRIMARY KEY FIRST;':

SQLSTATE[42000]: Syntax error or access violation: 1171 All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead
```

See #4900