### PR TITLE
[Tests] Fix Compile Error in Symfony 4

### DIFF
--- a/tests/cache/Pool/SymfonyProxy/ArrayAdapterProxyTest.php
+++ b/tests/cache/Pool/SymfonyProxy/ArrayAdapterProxyTest.php
@@ -98,4 +98,13 @@ class ArrayAdapterProxyTest extends ArrayAdapterTest
         }, INF));
         $this->assertFalse($isHit);
     }
+
+    /**
+     * No runInSeparateProcess
+     * See: https://github.com/symfony/symfony/commit/85c50119f146e1c2e25738d6ac9f02b6cb05a471
+     */
+    public function testSavingObject()
+    {
+        parent::testSavingObject();
+    }
 }

--- a/tests/cache/Pool/SymfonyProxy/FilesystemAdapterProxyTest.php
+++ b/tests/cache/Pool/SymfonyProxy/FilesystemAdapterProxyTest.php
@@ -72,4 +72,13 @@ class FilesystemAdapterProxyTest extends FilesystemAdapterTest
         }, INF));
         $this->assertFalse($isHit);
     }
+
+    /**
+     * No runInSeparateProcess
+     * See: https://github.com/symfony/symfony/commit/85c50119f146e1c2e25738d6ac9f02b6cb05a471
+     */
+    public function testSavingObject()
+    {
+        parent::testSavingObject();
+    }
 }

--- a/tests/cache/Pool/Traits/CacheItemPoolTestTrait.php
+++ b/tests/cache/Pool/Traits/CacheItemPoolTestTrait.php
@@ -26,7 +26,7 @@ trait CacheItemPoolTestTrait
         static::setupLogger((new \ReflectionClass(__CLASS__))->getShortName());
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
         static::handleLogOutput();


### PR DESCRIPTION
Fix error in Travis tests:
```
Fatal error: Declaration of Pimcore\Tests\Cache\Pool\Traits\CacheItemPoolTestTrait::tearDownAfterClass() must be compatible with Symfony\Component\Cache\Tests\Adapter\FilesystemAdapterTest::tearDownAfterClass(): void in /home/travis/build/pimcore/pimcore/tests/cache/Pool/SymfonyProxy/FilesystemAdapterProxyTest.php on line 15
```