### PR TITLE
Image thumbnail fallback alt option

### DIFF
--- a/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
+++ b/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
@@ -155,6 +155,13 @@ echo $thumbnail; // prints something like /var/tmp/....png
   
 // disable the automatically added width & height attributes
 <?= $asset->getThumbnail("exampleScaleWidth")->getHtml([], ["width","height"]) ?>
+
+// add alt text
+<?= $asset->getThumbnail("content")->getHtml(['alt' => 'top priority alt']) ?>
+// or
+<?= $asset->getThumbnail("content")->getHtml(['defaultalt' => 'default alt, if not set in image']) ?>
+
+
 ```
 
 

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -423,6 +423,8 @@ class Thumbnail
         if (empty($altText) && (!isset($options['disableAutoAlt']) || !$options['disableAutoAlt'])) {
             if ($image->getMetadata('alt')) {
                 $altText = $image->getMetadata('alt');
+            } else if (isset($options['defaultalt'])){
+                $altText = $options['defaultalt'];
             } else {
                 $altText = $titleText;
             }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #4737

## Additional info  
Introduced new option '**defaultalt**' to provide fallback alt, as **alt** is already being used to override meta information in Image

priorities:
1. **alt** option in getHtml()
2. **alt** from Image metadata
3. **defaultalt** option in getHtml()
4. **title** - from Image metadata

example 
```
$asset->getThumbnail("content")->getHtml(['defaultalt' => 'default alt']);
```