### PR TITLE
[Data objects] Do not hide tooltips automatically after 5s

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/edit.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/edit.js
@@ -393,7 +393,8 @@ pimcore.object.helpers.edit = {
                                         target: el,
                                         html: nl2br(ts(field.tooltip)),
                                         trackMouse:true,
-                                        showDelay: 200
+                                        showDelay: 200,
+                                        dismissDelay: 0
                                     });
                                 } catch (e6) {
                                     console.log(e6);


### PR DESCRIPTION
ExtJs closes Ext.Tooltip instances automatically after 5s (see https://docs.sencha.com/extjs/6.2.0/modern/Ext.tip.ToolTip.html#cfg-dismissDelay).
When you have long or complex helper texts in the tooltip of a data object field this can be annoying. This PR disables automatic closing of tooltips while the mouse is still on the field - of course it gets still hidden when the mouse leaves the field label.