### PR TITLE
[DataObject] Unsorted Quantity value units

### DIFF
--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -600,6 +600,8 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
                 if (!is_array($table)) {
                     $table = [];
                     $list = new Model\DataObject\QuantityValue\Unit\Listing();
+                    $list->setOrderKey('abbreviation');
+                    $list->setOrder('asc');
                     $list = $list->load();
                     /** @var $item Model\DataObject\QuantityValue\Unit */
                     foreach ($list as $item) {


### PR DESCRIPTION
If a quantity value has no valid units defined, all units are available. Rhese units are not sorted.