### PR TITLE
Static property "doGetInheritedValues" for all classes?

### DIFF
--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -241,7 +241,7 @@ class AbstractObject extends Model\Element\AbstractElement
      */
     public static function doGetInheritedValues(Concrete $object = null)
     {
-        if (self::$getInheritedValues && $object !== null) {
+        if ($object !== null) {
             $class = $object->getClass();
 
             return $class->getAllowInherit();

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -671,7 +671,7 @@ abstract class Data
 
         // insert this line if inheritance from parent objects is allowed
         if ($class instanceof DataObject\ClassDefinition && $class->getAllowInherit() && $this->supportsInheritance()) {
-            $code .= "\t" . 'if(\Pimcore\Model\DataObject::doGetInheritedValues() && $this->getClass()->getFieldDefinition("' . $key . '")->isEmpty($data)) {' . "\n";
+            $code .= "\t" . 'if(\Pimcore\Model\DataObject::doGetInheritedValues($this) && $this->getClass()->getFieldDefinition("' . $key . '")->isEmpty($data)) {' . "\n";
             $code .= "\t\t" . 'try {' . "\n";
             $code .= "\t\t\t" . 'return $this->getValueFromParent("' . $key . '");' . "\n";
             $code .= "\t\t" . '} catch (InheritanceParentNotFoundException $e) {' . "\n";


### PR DESCRIPTION
The code for data object class getters is defined in https://github.com/pimcore/pimcore/blob/1ebe1ad4215de36075b6994b1aae86741717fb27/models/DataObject/ClassDefinition/Data.php#L674 
The function to check if inhertance is enabled is: https://github.com/pimcore/pimcore/blob/1ebe1ad4215de36075b6994b1aae86741717fb27/models/DataObject/AbstractObject.php#L242-L251

Certainly I am missing something but how can the **private** **static** property `self::$getInheritedValues` be used here? A private, static property can only have one value for all class instances of AbstractObject.

This PR changes the behaviour as it always checks the setting of the class definition.

If I am right (which would really wonder me as this would have been noticed earlier), I will add a migration to resave data model classes. I stumbled open this behaviour when analysing the reasons of #4956 