### PR TITLE
[Data objects] Enable inheritance for select data option providers

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -541,7 +541,10 @@ class Multiselect extends Data implements ResourcePersistenceAwareInterface, Que
             }
             $context['fieldname'] = $this->getName();
 
+            $inheritanceEnabled = DataObject::getGetInheritedValues();
+            DataObject::setGetInheritedValues(true);
             $options = $optionsProvider->{'getOptions'}($context, $this);
+            DataObject::setGetInheritedValues($inheritanceEnabled);
             $this->setOptions($options);
 
             $hasStaticOptions = $optionsProvider->{'hasStaticOptions'}($context, $this);

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -442,7 +442,10 @@ class Select extends Data implements ResourcePersistenceAwareInterface, QueryRes
                 $context['purpose'] = 'layout';
             }
 
+            $inheritanceEnabled = DataObject::getGetInheritedValues();
+            DataObject::setGetInheritedValues(true);
             $options = $optionsProvider->{'getOptions'}($context, $this);
+            DataObject::setGetInheritedValues($inheritanceEnabled);
             $this->setOptions($options);
 
             $defaultValue = $optionsProvider->{'getDefaultValue'}($context, $this);


### PR DESCRIPTION
Currently inheritance is disabled for all Pimcore admin routes. This makes it kind of weird to develop data object providers which depend on object state as one would have to always call `AbstractObject::setGetInheritedValues(true)` before being able to use inheritance.

While inheritance has been activated for calculated fields
https://github.com/pimcore/pimcore/blob/1ebe1ad4215de36075b6994b1aae86741717fb27/models/DataObject/Service.php#L1449-L1457
this is not the case for select and multiselect fields with data option providers. This PR changes this.

Resolves #4956