### PR TITLE
Pimcore installation on MySQL with required SSL connection

### DIFF
--- a/bundles/InstallBundle/Command/InstallCommand.php
+++ b/bundles/InstallBundle/Command/InstallCommand.php
@@ -117,7 +117,7 @@ class InstallCommand extends Command
             ],
             'mysql-ssl-cert-path' => [
                 'description' => 'MySQL SSL certificate path (if empty non-ssl connection assumed)',
-                'mode' => InputOption::VALUE_REQUIRED,
+                'mode' => InputOption::VALUE_OPTIONAL,
                 'default' => '',
                 'group' => 'db_credentials'
             ],

--- a/bundles/InstallBundle/Command/InstallCommand.php
+++ b/bundles/InstallBundle/Command/InstallCommand.php
@@ -115,6 +115,12 @@ class InstallCommand extends Command
                 'default' => 3306,
                 'group' => 'db_credentials',
             ],
+            'mysql-ssl-cert-path' => [
+                'description' => 'MySQL SSL certificate path (if empty non-ssl connection assumed)',
+                'mode' => InputOption::VALUE_REQUIRED,
+                'default' => '',
+                'group' => 'db_credentials'
+            ],
             'skip-database-structure' => [
                 'description' => 'Skipping creation of database structure during install',
                 'mode' => InputOption::VALUE_OPTIONAL,
@@ -310,7 +316,7 @@ class InstallCommand extends Command
             $value = $input->getOption($name);
 
             // Empty MySQL password allowed
-            if ($value || $name === 'mysql-password') {
+            if ($value || $name === 'mysql-password' || $name === 'mysql-ssl-cert-path') {
                 $param = str_replace('-', '_', $name);
                 $params[$param] = $value;
             } else {

--- a/bundles/InstallBundle/Command/InstallCommand.php
+++ b/bundles/InstallBundle/Command/InstallCommand.php
@@ -315,7 +315,7 @@ class InstallCommand extends Command
 
             $value = $input->getOption($name);
 
-            // Empty MySQL password allowed
+            // Empty MySQL password allowed, empty ssl cert path means it is not used
             if ($value || $name === 'mysql-password' || $name === 'mysql-ssl-cert-path') {
                 $param = str_replace('-', '_', $name);
                 $params[$param] = $value;

--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -19,6 +19,7 @@ namespace Pimcore\Bundle\InstallBundle;
 
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\DriverManager;
+use PDO;
 use Pimcore\Bundle\InstallBundle\Event\InstallerStepEvent;
 use Pimcore\Bundle\InstallBundle\SystemConfig\ConfigWriter;
 use Pimcore\Config;
@@ -319,6 +320,13 @@ class Installer
             $dbConfig['port'] = $params['mysql_port'];
         }
 
+        $mysqlSslCertPath = $params['mysql_ssl_cert_path'];
+        if (!empty($mysqlSslCertPath)) {
+            $dbConfig['driverOptions'] = [
+                PDO::MYSQL_ATTR_SSL_CA => $mysqlSslCertPath
+            ];
+        }
+
         return $dbConfig;
     }
 
@@ -330,6 +338,11 @@ class Installer
 
         unset($dbConfig['driver']);
         unset($dbConfig['wrapperClass']);
+
+        if (isset($dbConfig['driverOptions'])) {
+            $dbConfig['options'] = $dbConfig['driverOptions'];
+            unset($dbConfig['driverOptions']);
+        }
 
         $this->createConfigFiles([
             'doctrine' => [


### PR DESCRIPTION
## Changes in this pull request  

This PR adds a possibility to install Pimcore with databases where [SSL connection](https://dev.mysql.com/doc/refman/5.7/en/encrypted-connections.html) is required. 

An example here can be [Azure Database for MySQL](https://azure.microsoft.com/en-us/services/mysql/) where SSL connection is recommended: https://docs.microsoft.com/en-us/azure/mysql/concepts-ssl-connection-security 

## Additional info  

This PR should make no changes to the actual installation process - it is just an addition:

- `mysql-ssl-cert-path` won't be asked interactively
- if `mysql-ssl-cert-path` parameter will be omitted in CLI (or env variables) then the installation is like it was until now
