### PR TITLE
Optimize version cleanup process

### DIFF
--- a/models/Version/Dao.php
+++ b/models/Version/Dao.php
@@ -147,7 +147,7 @@ class Dao extends Model\Dao\AbstractDao
                     $versionIds = array_merge($versionIds, $tmpVersionIds);
                 } else {
                     // by steps
-                    $elementIds = $this->db->fetchCol('SELECT cid,count(*) as amount FROM versions WHERE ctype = ? AND NOT public AND id NOT IN (' . $ignoreIdsList . ') GROUP BY cid HAVING amount > ?', [$elementType['elementType'], $elementType['steps']]);
+                    $elementIds = $this->db->fetchCol('SELECT cid,count(*) as amount FROM versions WHERE ctype = ? AND NOT public AND id NOT IN (' . $ignoreIdsList . ') GROUP BY cid HAVING amount > ? LIMIT 1000', [$elementType['elementType'], $elementType['steps']]);
                     foreach ($elementIds as $elementId) {
                         $count++;
                         Logger::info($elementId . '(object ' . $count . ') Vcount ' . count($versionIds));


### PR DESCRIPTION
This optimizes the version cleanup process speed without affecting the functionality in any way. In a system with a huge number of versions (multiple millions) this reduces the query time from multiple minutes to few seconds.