### PR TITLE
Element\Service::getValidKey - fix for names starting with both dots and spaces

### DIFF
--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -944,7 +944,7 @@ class Service extends Model\AbstractModel
             $key = preg_replace('/[#\?\*\:\\\\<\>\|"%]/', '-', $key);
         } else {
             $key = trim($key);
-            $key = ltrim($key, '.');
+            $key = ltrim($key, '. ');
         }
 
         $key = mb_substr($key, 0, 255);


### PR DESCRIPTION
When using keys that start with dot and space (e.g. `. test`) we get a key that still begins with aspace (eg. ` test`).