### PR TITLE
Update 23_Localized_Fields.md

### DIFF
--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/23_Localized_Fields.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/23_Localized_Fields.md
@@ -54,12 +54,11 @@ You can disable the Fallbacklanguages
 
 Pimcore allows the back end (Pimcore administration user interface) to be translated. The back end and front end have different sets of languages and different translations.
 
-When saving an object in Pimcore, the registry contains a reference to the locale of the admin interface. If you try to use  translation for another language you will get an error that the language is not found. If you want to translate something to one of the available languages for the front end you can create a new instance of the website translator with a locale from one of the valid languages. See the example below:
+When saving an object in Pimcore, the registry contains a reference to the locale of the admin interface. If you try to use  translation for another language you will get an error that the language is not found. If you want to translate something to one of the available languages for the front end you can call the static function getByKeyLocalized from the website translator with a locale from one of the valid languages. See the example below:
 
 ```php
-//front end ($lang = string with language code)
-$websiteTranslator = new \Pimcore\Translate\Website($locale);
-$websiteTranslator->translate('name-of-translation-key');
+//front end ($locale = $this->getLocale() or string with language code)
+$translation = Pimcore\Model\Translation\Website::getByKeyLocalized('name-of-translation-key', $locale);
 ```
 
 ### Accessing the data


### PR DESCRIPTION
\Pimcore\Translate\Website was removed with Pimcore 5 so this change might also be relevant for 5.x documentation.
I'm not sure if this is the most elegant way, but Pimcore\Model\Translation\Website::getByKeyLocalized worked for me.

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

