### PR TITLE
[XLIFF] ignore not exportable tags in localized blocks

### DIFF
--- a/lib/Translation/ExportDataExtractorService/DataExtractor/DataObjectDataExtractor.php
+++ b/lib/Translation/ExportDataExtractorService/DataExtractor/DataObjectDataExtractor.php
@@ -184,6 +184,11 @@ class DataObjectDataExtractor extends AbstractElementDataExtractor
             foreach ($blockElements as $index => $blockElementFields) {
                 /** @var DataObject\Data\BlockElement $blockElement */
                 foreach ($blockElementFields as $blockElement) {
+                    // check allowed datatypes
+                    if (!in_array($blockElement->getType(), self::EXPORTABLE_TAGS)) {
+                        continue;
+                    }
+                    
                     $content = $blockElement->getData();
 
                     if (!empty($content)) {


### PR DESCRIPTION
Only text fields can be exported. Images, relations and other field types need to be ignored.