### PR TITLE
[Ecommerce] Consider json_encode errors on updating index

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
@@ -233,6 +233,11 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
                     'subtenants' => ($subTenantData ? $subTenantData : [])
                 ]);
 
+                $jsonLastError = \json_last_error();
+                if ($jsonLastError !== JSON_ERROR_NONE) {
+                    throw new \Exception("Could not encode product data for updating index. Json encode error code was {$jsonLastError}, ObjectId was {$subObjectId}.");
+                }
+                
                 $crc = crc32($jsonData);
                 $insertData = [
                     'o_id' => $subObjectId,


### PR DESCRIPTION
# Improvement

I had the case that there were encoding errors (Error code 5) for some product related data. As the json_encode failed the data was added to the mysql store table but not sent to the elastic search index, so there always was some inconsistency between store and the elastic index - without any errors shown. 

This PR now throws an error if the json_encode fails. This PR is related to https://github.com/pimcore/pimcore/pull/4827.
