### PR TITLE
Fix readme: Placeholders

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/23_Placeholders/README.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/23_Placeholders/README.md
@@ -20,7 +20,7 @@ config is used)
 Lets assume you have a text `"Thank you for the order of "PRODUCTNAME""` and you want replace 
 `"PRODUCTNAME"` with the real Product name.
 
-The following code-snippet replaces the Placeholder `"%DataObject(...);"` with the Product name.
+The following code-snippet replaces the Placeholder `%DataObject(...);` with the Product name.
 
 ```php
 $text = 'Thank you for the order of "%DataObject(object_id,{"method" : "getName"});"';


### PR DESCRIPTION
Actually the placeholder does not contain the quotes. Or the other way around: the quotes do not belong to the placeholder and thus do not get replaced.