### PR TITLE
Ecommerce: getCart() in CartItem class must use user-defined class definition 

### DIFF
--- a/bundles/EcommerceFrameworkBundle/CartManager/CartItem.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/CartItem.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\CartManager;
 
 use Pimcore\Cache\Runtime;
 use Pimcore\Logger;
+use Pimcore\Bundle\EcommerceFrameworkBundle\Factory;
 
 class CartItem extends AbstractCartItem implements CartItemInterface
 {
@@ -43,7 +44,8 @@ class CartItem extends AbstractCartItem implements CartItemInterface
     public function getCart()
     {
         if (empty($this->cart)) {
-            $this->cart = Cart::getById($this->cartId);
+            $cartClass = '\\'.Factory::getInstance()->getCartManager()->getCartClassName();
+            $this->cart = $cartClass::getById($this->class);
         }
 
         return $this->cart;

--- a/bundles/EcommerceFrameworkBundle/CartManager/CartItem.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/CartItem.php
@@ -45,7 +45,7 @@ class CartItem extends AbstractCartItem implements CartItemInterface
     {
         if (empty($this->cart)) {
             $cartClass = '\\'.Factory::getInstance()->getCartManager()->getCartClassName();
-            $this->cart = $cartClass::getById($this->class);
+            $this->cart = $cartClass::getById($this->cartId);
         }
 
         return $this->cart;


### PR DESCRIPTION
The getCart() method must appy the user-defined cart class, and not the default one.
If the default one is used, the application may throw random errors as soon as custom methods are applied to a cart, which do not exist within the default class implementation of Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart.