### PR TITLE
changed marking flag for complete object instead of 'last' field

### DIFF
--- a/models/DataObject/Objectbrick/Dao.php
+++ b/models/DataObject/Objectbrick/Dao.php
@@ -108,7 +108,7 @@ class Dao extends Model\DataObject\Fieldcollection\Dao
                 $setter = 'set' . ucfirst($type);
 
                 if ($brick instanceof DataObject\DirtyIndicatorInterface) {
-                    $brick->markFieldDirty($key, false);
+                    $brick->markFieldDirty('_self', false);
                 }
 
                 $this->model->$setter($brick);


### PR DESCRIPTION
This fixes issue #4999 .
The problem can not be easily reproduced in the demo shop because we had it during our product update scenario from outside of Pimcore.
Changing one product in Primcore leaded to a deletion of objectbricks of an another product which was in relation to the one being updated. Why?
Simply because the dirty flag map of the object bricks were handled incorrectly.