### PR TITLE
Workaround for database services which doesn't support MyISAM

### DIFF
--- a/bundles/InstallBundle/Command/InstallCommand.php
+++ b/bundles/InstallBundle/Command/InstallCommand.php
@@ -117,7 +117,7 @@ class InstallCommand extends Command
             ],
             'is-myisam-supported' => [
                 'description' => 'If set to "no" then MyISAM engine is changed to InnoDB in all tables (useful e.g. in Azure database for MySQL)',
-                'mode' => InputOption::VALUE_REQUIRED,
+                'mode' => InputOption::VALUE_OPTIONAL,
                 'default' => 'yes',
                 'group' => 'db_credentials'
             ],

--- a/bundles/InstallBundle/Command/InstallCommand.php
+++ b/bundles/InstallBundle/Command/InstallCommand.php
@@ -115,6 +115,12 @@ class InstallCommand extends Command
                 'default' => 3306,
                 'group' => 'db_credentials',
             ],
+            'is-myisam-supported' => [
+                'description' => 'If set to "no" then MyISAM engine is changed to InnoDB in all tables (useful e.g. in Azure database for MySQL)',
+                'mode' => InputOption::VALUE_REQUIRED,
+                'default' => 'yes',
+                'group' => 'db_credentials'
+            ],
             'skip-database-structure' => [
                 'description' => 'Skipping creation of database structure during install',
                 'mode' => InputOption::VALUE_OPTIONAL,


### PR DESCRIPTION
## Changes in this pull request  
This PR adds a workaround for MySQL services which don't support MyISAM engine. It was created mainly for Azure Database for [MySQL service]((https://azure.microsoft.com/en-us/services/mysql/) - https://docs.microsoft.com/en-us/azure/mysql/concepts-limits#unsupported

## Additional info  

This PR should make no changes to the actual installation process - it is just an addition:

* `is-myisam-supported` -cert-path won't be asked interactively
* if `is-myisam-supported` parameter will be omitted in CLI (or env variables) then the installation is like it was until now

Theoretically, it could be done better but then `installerNeedsOption` usage should be rewritten (e.g. currently parameters like `skip-database-data-dump` doesn't work because of this method), so I decided that in one PR should be done only one change.
