### PR TITLE
Make the cache templating helper more modular

### DIFF
--- a/lib/Templating/Helper/Cache.php
+++ b/lib/Templating/Helper/Cache.php
@@ -94,7 +94,8 @@ class Cache extends Helper
         }
 
         if ($content = CacheManager::load($this->key)) {
-            echo $content;
+
+            $this->outputContent($content, $this->key, true);
 
             return true;
         }
@@ -119,8 +120,8 @@ class Cache extends Helper
             }
 
             $content = ob_get_clean();
-            CacheManager::save($content, $this->key, $tags, $this->lifetime, 996, true);
-            echo $content;
+            $this->saveContentToCache($content, $this->key, $tags);
+            $this->outputContent($content, $this->key, false);
         }
     }
 
@@ -130,5 +131,28 @@ class Cache extends Helper
     public function stop()
     {
         $this->end();
+    }
+
+
+
+    /**
+     * Output the content.
+     * @param $content the content, either rendered or retrieved directly from the cache.
+     * @param string $key the cache key
+     * @param bool $isLoadedFromCache true if the content origins from the cache and hasn't been created "live".
+     */
+    protected function outputContent($content, string $key, bool $isLoadedFromCache) {
+        echo $content;
+    }
+
+
+    /**
+     * Save the (rendered) content to to cache. May be overriden to add custom markup / code, or specific tags, etc.
+     * @param $content
+     * @param string $key
+     * @param $tags
+     */
+    protected function saveContentToCache($content, string $key, array $tags) {
+        CacheManager::save($content, $key, $tags, $this->lifetime, 996, true);
     }
 }


### PR DESCRIPTION
Make the cache templating helper more modular, so that 

1. content can be added to the cached data before writting it to the cache, 
2. the cached data can be modified after retrievela and before output.