### PR TITLE
[DataObject] Classificationstore cannot add collections

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -931,7 +931,7 @@ class ClassificationstoreController extends AdminController implements EventedCo
             $db = \Pimcore\Db::get();
             $mappedData = [];
             $groupsData = $db->fetchAll('select * from classificationstore_groups g, classificationstore_collectionrelations c where colId IN (:ids) and g.id = c.groupId', [
-                'ids' => $ids
+                'ids' => implode(',', array_filter($ids, 'intval')),
             ]);
 
             foreach ($groupsData as $groupData) {


### PR DESCRIPTION
Ran into this issue after updating to version 6.2.1.

How to reproduce
- Create a classification store with collections
- Add a classification store field to a data object
- Add classifications using collection(s)

No classifications are added since none are found. When debugging the controller I noticed the groups data query didn't return any results and when checking the file history I noticed this change, which causes the problem: https://github.com/pimcore/pimcore/commit/ccfc5c30869a18b05ba4cc415fdc32fedd8854e2