### PR TITLE
[Data objects] Symfony service as calculated field calculator

### DIFF
--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/33_Calculated_Value_Type.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/33_Calculated_Value_Type.md
@@ -14,28 +14,24 @@ called `sum` placed inside a localizedfields container.
 ![Calculated Value Configuration](../../../img/classes-datatypes-calculated.png)
 
 
-The first step is to provide a PHP calculator class implementing at least one method which computes the result 
-for the `sum` field. An example is shown below.
+The first step is to provide a PHP calculator class implementing the `CalculatorClassInterface` interface. At least the `compute` method needs to be implemented which computes the result for the `sum` field. An example is shown below.
 
 The arguments passed into this method is the Pimcore object and the contextual information telling you which 
-calculated-value field is affected and where it is located it.
+calculated-value field is affected and where it is located at.
 
-The extent of information differs on which datatype is the owner of the calculated-value field 
+The extent of information depends on the datatype of the owner of the calculated-value field 
 (localizedfield, object brick etc.). The details are documented below.
 
 ```php
 namespace Website;
  
 use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\ClassDefinition\CalculatorClassInterface;
+use Pimcore\Model\DataObject\Data\CalculatedValue;
  
-class CalculatorDemo
+class CalculatorDemo implements CalculatorClassInterface
 {
-    /**
-     * @param $object Concrete
-     * @param $context \Pimcore\Model\DataObject\Data\CalculatedValue
-     * @return string
-     */
-    public static function compute($object, $context) {
+    public function compute(Concrete $object, CalculatedValue $context):string {
         if ($context->getFieldname() == "sum") {
             $language = $context->getPosition();
             return $object->getXValue($language) +  $object->getYValue($language);
@@ -50,14 +46,9 @@ As we see here, the calculator class sums up the x and y values from the corresp
 
 It is also possible to provide a different representation for edit mode by providing a second (optional) implementation just for this purpose. An example would be:
 ```php
-/**
- * @param $object
- * @param $context \Pimcore\Model\DataObject\Data\CalculatedValue
- * @return string
- */
-public static function getCalculatedValueForEditMode($object, $context) {
+public function getCalculatedValueForEditMode(Concrete $object, CalculatedValue $context): string {
     $language = $context->getPosition();
-    $result = $object->getXValue($language) . " + " . $object->getYValue($language) . " = " . self::compute($object, $context);
+    $result = $object->getXValue($language) . " + " . $object->getYValue($language) . " = " . $this->compute($object, $context);
     return $result;
 }
 ```
@@ -66,8 +57,7 @@ The visual outcome would be as follows:
 
 ![Calculated Value Field](../../../img/classes-datatypes-calculated-field.png)
 
-You can also provide a Symfony service as calculator class via `@` prefix (e.g. `@service_name`). The `compute` and `getCalculatedValueForEditMode` methods do not need to be static to be able to use dependency injection.
-
+You can also provide a Symfony service as calculator class via `@` prefix (e.g. `@service_name`).
 
 
 ## Working with PHP API

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/33_Calculated_Value_Type.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/33_Calculated_Value_Type.md
@@ -14,7 +14,7 @@ called `sum` placed inside a localizedfields container.
 ![Calculated Value Configuration](../../../img/classes-datatypes-calculated.png)
 
 
-The first step is to provide a PHP calculator class implementing at least one static method which computes the result 
+The first step is to provide a PHP calculator class implementing at least one method which computes the result 
 for the `sum` field. An example is shown below.
 
 The arguments passed into this method is the Pimcore object and the contextual information telling you which 
@@ -65,6 +65,8 @@ public static function getCalculatedValueForEditMode($object, $context) {
 The visual outcome would be as follows: 
 
 ![Calculated Value Field](../../../img/classes-datatypes-calculated-field.png)
+
+You can also provide a Symfony service as calculator class via `@` prefix (e.g. `@service_name`). The `compute` and `getCalculatedValueForEditMode` methods do not need to be static to be able to use dependency injection.
 
 
 

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/33_Calculated_Value_Type.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/33_Calculated_Value_Type.md
@@ -14,7 +14,7 @@ called `sum` placed inside a localizedfields container.
 ![Calculated Value Configuration](../../../img/classes-datatypes-calculated.png)
 
 
-The first step is to provide a PHP calculator class implementing the `CalculatorClassInterface` interface. At least the `compute` method needs to be implemented which computes the result for the `sum` field. An example is shown below.
+The first step is to provide a PHP calculator class implementing the `CalculatorClassInterface` interface. The `compute` method needs to be implemented which computes the result for the `sum` field. An example is shown below.
 
 The arguments passed into this method is the Pimcore object and the contextual information telling you which 
 calculated-value field is affected and where it is located at.
@@ -44,7 +44,7 @@ class CalculatorDemo implements CalculatorClassInterface
 
 As we see here, the calculator class sums up the x and y values from the corresponding language tab.
 
-It is also possible to provide a different representation for edit mode by providing a second (optional) implementation just for this purpose. An example would be:
+In addition to the `compute` method you need to implement the `getCalculatedValueForEditMode` method. This method is used to display the value in object edit mode:
 ```php
 public function getCalculatedValueForEditMode(Concrete $object, CalculatedValue $context): string {
     $language = $context->getPosition();

--- a/models/DataObject/ClassDefinition/CalculatorClassInterface.php
+++ b/models/DataObject/ClassDefinition/CalculatorClassInterface.php
@@ -10,4 +10,5 @@ use Pimcore\Model\DataObject\Data\CalculatedValue;
 interface CalculatorClassInterface
 {
     public function compute(Concrete $object, CalculatedValue $context): string;
+    public function getCalculatedValueForEditMode(Concrete $object, CalculatedValue $context): string;
 }

--- a/models/DataObject/ClassDefinition/CalculatorClassInterface.php
+++ b/models/DataObject/ClassDefinition/CalculatorClassInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace Pimcore\Model\DataObject\ClassDefinition;
+
+
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Data\CalculatedValue;
+
+interface CalculatorClassInterface
+{
+    public function compute(Concrete $object, CalculatedValue $context): string;
+}

--- a/models/DataObject/ClassDefinition/Helper/CalculatorClassResolver.php
+++ b/models/DataObject/ClassDefinition/Helper/CalculatorClassResolver.php
@@ -17,19 +17,18 @@
 namespace Pimcore\Model\DataObject\ClassDefinition\Helper;
 
 use Pimcore\Logger;
-use Pimcore\Model\DataObject\ClassDefinition\LinkGeneratorInterface;
+use Pimcore\Model\DataObject\ClassDefinition\DynamicOptionsProvider\MultiSelectOptionsProviderInterface;
+use Pimcore\Model\DataObject\ClassDefinition\DynamicOptionsProvider\SelectOptionsProviderInterface;
 
-class LinkGeneratorResolver extends ClassResolver
+class CalculatorClassResolver extends ClassResolver
 {
     /**
-     * @param $generatorClass
+     * @param $calculatorClass
      *
-     * @return LinkGeneratorInterface
+     * @return |null
      */
-    public static function resolveGenerator($generatorClass)
+    public static function resolveCalculatorClass($calculatorClass)
     {
-        return self::resolve($generatorClass, static function($generator) {
-            return $generator instanceof LinkGeneratorInterface;
-        });
+        return self::resolve($calculatorClass);
     }
 }

--- a/models/DataObject/ClassDefinition/Helper/CalculatorClassResolver.php
+++ b/models/DataObject/ClassDefinition/Helper/CalculatorClassResolver.php
@@ -22,11 +22,6 @@ use Pimcore\Model\DataObject\ClassDefinition\DynamicOptionsProvider\SelectOption
 
 class CalculatorClassResolver extends ClassResolver
 {
-    /**
-     * @param $calculatorClass
-     *
-     * @return |null
-     */
     public static function resolveCalculatorClass($calculatorClass)
     {
         return self::resolve($calculatorClass);

--- a/models/DataObject/ClassDefinition/Helper/ClassResolver.php
+++ b/models/DataObject/ClassDefinition/Helper/ClassResolver.php
@@ -18,13 +18,15 @@ class ClassResolver
                 $serviceName = substr($class, 1);
                 try {
                     $service = \Pimcore::getKernel()->getContainer()->get($serviceName);
-                    return self::returnValidServiceOrNull($service, $validationCallback);
+                    self::$cache[$class] = self::returnValidServiceOrNull($service, $validationCallback);
+                    return self::$cache[$class];
                 } catch (\Exception $e) {
                     Logger::error($e);
                 }
             } else {
                 $service = new $class;
-                return self::returnValidServiceOrNull($service, $validationCallback);
+                self::$cache[$class] = self::returnValidServiceOrNull($service, $validationCallback);
+                return self::$cache[$class];
             }
         }
 

--- a/models/DataObject/ClassDefinition/Helper/ClassResolver.php
+++ b/models/DataObject/ClassDefinition/Helper/ClassResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Pimcore\Model\DataObject\ClassDefinition\Helper;
+
+use Pimcore\Logger;
+
+class ClassResolver
+{
+    private static $cache;
+
+    protected static function resolve($class, callable $validationCallback = null)
+    {
+        if ($class) {
+            if (isset(self::$cache[$class])) {
+                return self::$cache[$class];
+            }
+            if (strpos($class, '@') === 0) {
+                $serviceName = substr($class, 1);
+                try {
+                    $service = \Pimcore::getKernel()->getContainer()->get($serviceName);
+                    return self::returnValidServiceOrNull($service, $validationCallback);
+                } catch (\Exception $e) {
+                    Logger::error($e);
+                }
+            } else {
+                $service = new $class;
+                return self::returnValidServiceOrNull($service, $validationCallback);
+            }
+        }
+
+        return null;
+    }
+
+    private static function returnValidServiceOrNull($service, callable $validationCallback = null) {
+        if($validationCallback && !$validationCallback($service)) {
+            return null;
+        }
+
+        return $service;
+    }
+}

--- a/models/DataObject/ClassDefinition/Helper/OptionsProviderResolver.php
+++ b/models/DataObject/ClassDefinition/Helper/OptionsProviderResolver.php
@@ -20,7 +20,7 @@ use Pimcore\Logger;
 use Pimcore\Model\DataObject\ClassDefinition\DynamicOptionsProvider\MultiSelectOptionsProviderInterface;
 use Pimcore\Model\DataObject\ClassDefinition\DynamicOptionsProvider\SelectOptionsProviderInterface;
 
-class OptionsProviderResolver
+class OptionsProviderResolver extends ClassResolver
 {
     const MODE_SELECT = 1;
 
@@ -30,29 +30,9 @@ class OptionsProviderResolver
 
     public static function resolveProvider($providerClass, $mode)
     {
-        if ($providerClass) {
-            if (isset(self::$providerCache[$providerClass])) {
-                return self::$providerCache[$providerClass];
-            }
-            if (substr($providerClass, 0, 1) == '@') {
-                $serviceName = substr($providerClass, 1);
-                try {
-                    $provider = \Pimcore::getKernel()->getContainer()->get($serviceName);
-                } catch (\Exception $e) {
-                    Logger::error($e);
-                }
-            } else {
-                $provider = new $providerClass;
-            }
-
-            if (($mode == self::MODE_SELECT && ($provider instanceof  SelectOptionsProviderInterface))
-                    || ($mode == self::MODE_MULTISELECT && ($provider instanceof MultiSelectOptionsProviderInterface))) {
-                self::$providerCache[$providerClass] = $provider;
-
-                return $provider;
-            }
-        }
-
-        return null;
+        return self::resolve($providerClass, function($provider) use ($mode) {
+            return ($mode == self::MODE_SELECT && ($provider instanceof SelectOptionsProviderInterface))
+                || ($mode == self::MODE_MULTISELECT && ($provider instanceof MultiSelectOptionsProviderInterface));
+        });
     }
 }

--- a/models/DataObject/ClassDefinition/Helper/PathFormatterResolver.php
+++ b/models/DataObject/ClassDefinition/Helper/PathFormatterResolver.php
@@ -19,7 +19,7 @@ namespace Pimcore\Model\DataObject\ClassDefinition\Helper;
 use Pimcore\Logger;
 use Pimcore\Model\DataObject\ClassDefinition\PathFormatterInterface;
 
-class PathFormatterResolver
+class PathFormatterResolver extends ClassResolver
 {
     public static $formatterCache = [];
 
@@ -30,28 +30,8 @@ class PathFormatterResolver
      */
     public static function resolvePathFormatter($formatterClass): ?PathFormatterInterface
     {
-        if ($formatterClass) {
-            $formatter = null;
-
-            if (isset(self::$formatterCache[$formatterClass])) {
-                return self::$formatterCache[$formatterClass];
-            }
-            if (substr($formatterClass, 0, 1) == '@') {
-                $serviceName = substr($formatterClass, 1);
-                try {
-                    $formatter = \Pimcore::getKernel()->getContainer()->get($serviceName);
-                } catch (\Exception $e) {
-                    Logger::error($e);
-                }
-            } else {
-                $formatter = new $formatterClass;
-            }
-
-            if ($formatter instanceof PathFormatterInterface) {
-                return $formatter;
-            }
-        }
-
-        return null;
+        return self::resolve($formatterClass, static function($formatter) {
+            return $formatter instanceof PathFormatterInterface;
+        });
     }
 }

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1440,7 +1440,8 @@ class Service extends Model\Element\Service
             return $data;
         }
         $className = $fd->getCalculatorClass();
-        if (!$className || !\Pimcore\Tool::classExists($className)) {
+        $calculator = Model\DataObject\ClassDefinition\Helper\CalculatorClassResolver::resolveCalculatorClass($className);
+        if (!$className || $calculator === null) {
             Logger::error('Class does not exist: ' . $className);
 
             return null;
@@ -1449,8 +1450,8 @@ class Service extends Model\Element\Service
         $inheritanceEnabled = Model\DataObject\Concrete::getGetInheritedValues();
         Model\DataObject\Concrete::setGetInheritedValues(true);
 
-        if (method_exists($className, 'getCalculatedValueForEditMode')) {
-            $result = call_user_func($className . '::getCalculatedValueForEditMode', $object, $data);
+        if (method_exists($calculator, 'getCalculatedValueForEditMode')) {
+            $result = call_user_func([$calculator, 'getCalculatedValueForEditMode'], $object, $data);
         } else {
             $result = self::getCalculatedFieldValue($object, $data);
         }
@@ -1487,13 +1488,14 @@ class Service extends Model\Element\Service
             return null;
         }
         $className = $fd->getCalculatorClass();
-        if (!$className || !\Pimcore\Tool::classExists($className)) {
+        $calculator = Model\DataObject\ClassDefinition\Helper\CalculatorClassResolver::resolveCalculatorClass($className);
+        if (!$className || $calculator === null) {
             Logger::error('Calculator class "' . $className.'" does not exist -> '.$fieldname.'=null');
 
             return null;
         }
 
-        if (method_exists($className, 'compute')) {
+        if (method_exists($calculator, 'compute')) {
             $inheritanceEnabled = Model\DataObject\Concrete::getGetInheritedValues();
             Model\DataObject\Concrete::setGetInheritedValues(true);
 
@@ -1501,7 +1503,7 @@ class Service extends Model\Element\Service
                     || $object instanceof Model\DataObject\Objectbrick\Data\AbstractData) {
                 $object = $object->getObject();
             }
-            $result = call_user_func($className . '::compute', $object, $data);
+            $result = call_user_func([$calculator, 'compute'], $object, $data);
             Model\DataObject\Concrete::setGetInheritedValues($inheritanceEnabled);
 
             return $result;

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1447,6 +1447,10 @@ class Service extends Model\Element\Service
             return null;
         }
 
+        if(!$calculator instanceof Model\DataObject\ClassDefinition\CalculatorClassInterface) {
+            @trigger_error('Using a calculator class which does not implement '.Model\DataObject\ClassDefinition\CalculatorClassInterface::class.' is deprecated', \E_USER_DEPRECATED);
+        }
+
         $inheritanceEnabled = Model\DataObject\Concrete::getGetInheritedValues();
         Model\DataObject\Concrete::setGetInheritedValues(true);
 


### PR DESCRIPTION
As (multi-)select fields, fields with path resolver and link formatter support providing a symfony service, this would be also quite nice for calculated value calculators. This PR implements this.
This enables developers to also use dependency injection for calculator classes.
At the moment this PR is implemented in a way that the `compute` and `getCalculatedValueForEditMode`methods do not need to be static, but can be. On the one hand this is quite handy, on the other hand this prevents us from providing a clean interface which would be really nice for calculator classes.
Imho calculator methods should not be static at all but changing that would result in a backward incompatible change - which is no option at the moment, I think.