### PR TITLE
[Ecommerce] index getter that retrieves data from a classification store attribute

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Getter/DefaultClassificationAttributeGetter.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Getter/DefaultClassificationAttributeGetter.php
@@ -6,7 +6,6 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Getter;
 
 use Pimcore\Bundle\EcommerceFrameworkBundle\Traits\OptionsResolverTrait;
 use Pimcore\Model\DataObject\Classificationstore;
-use Pimcore\Model\DataObject\Data\QuantityValue;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DefaultClassificationAttributeGetter implements GetterInterface

--- a/bundles/EcommerceFrameworkBundle/IndexService/Getter/DefaultClassificationAttributeGetter.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Getter/DefaultClassificationAttributeGetter.php
@@ -9,7 +9,7 @@ use Pimcore\Model\DataObject\Classificationstore;
 use Pimcore\Model\DataObject\Data\QuantityValue;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class DefaultCustomAttributeGetter implements GetterInterface
+class DefaultClassificationAttributeGetter implements GetterInterface
 {
     use OptionsResolverTrait;
 

--- a/bundles/EcommerceFrameworkBundle/IndexService/Getter/DefaultCustomAttributeGetter.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Getter/DefaultCustomAttributeGetter.php
@@ -1,0 +1,65 @@
+<?php
+
+
+namespace Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Getter;
+
+
+use Pimcore\Bundle\EcommerceFrameworkBundle\Traits\OptionsResolverTrait;
+use Pimcore\Model\DataObject\Classificationstore;
+use Pimcore\Model\DataObject\Data\QuantityValue;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class DefaultCustomAttributeGetter implements GetterInterface
+{
+    use OptionsResolverTrait;
+
+    /**
+     * gets a classification store attribute of an object using provided getter_options (key_id, group_id, fieldname)
+     * ** key_id    - id of the classification store attribute
+     * ** group_id  - id of the group related to the id | key can occur multiple times in classification store field through multiple groups
+     * ** fieldname - name of the field upon which the classification store is saved on the specific object [defaults to attributes]
+     * note that this getter does not support localization at the moment
+     * @param $object
+     * @param null $config
+     * @return mixed
+     */
+    public function get($object, $config = null)
+    {
+        $config = $this->resolveOptions($config ?? []);
+        $sourceList = $config['source'];
+
+        foreach ($sourceList as $source) {
+            $attributeGetter = 'get' . ucfirst($source['fieldname']);
+            if (!method_exists($object, $attributeGetter) || !($classificationStore = $object->$attributeGetter()) instanceof Classificationstore) {
+                continue;
+            }
+            /** @var $classificationStore Classificationstore */
+            $val = $classificationStore->getLocalizedKeyValue($source['group_id'], $source['key_id']);
+
+            if ($val !== null) {
+                return $val;
+            }
+        }
+
+        return null;
+    }
+
+    protected function configureOptionsResolver(string $resolverName, OptionsResolver $resolver)
+    {
+        if ('default' === $resolverName) {
+            $resolver->setRequired('source');
+            $resolver->setAllowedTypes('source', 'array');
+        } elseif ('source' === $resolverName) {
+            foreach (['key_id', 'group_id'] as $field) {
+                $resolver->setRequired($field);
+                $resolver->setAllowedTypes($field, 'int');
+            }
+
+            $resolver->setRequired('fieldname');
+            $resolver->setDefault('fieldname', 'attributes');
+            $resolver->setAllowedTypes('fieldname', 'string');
+        } else {
+            throw new \InvalidArgumentException(sprintf('Resolver with name "%s" is not defined', $resolverName));
+        }
+    }
+}


### PR DESCRIPTION
This PR provides an index getter that retrieves data from a classification store attribute of an object.

It can be defined through through the index_service config in which the getter can be defined through a getter_id as usual. It is required to additionally provide getter_options:

- key_id    - id of the classification store attribute
- group_id  - id of the group related to the id | key can occur multiple times in classification store field through multiple groups
- fieldname - name of the field upon which the classification store is saved on the specific object [defaults to attributes]

the getter_options can contain multiple items. if the current item sepcified by fieldname, key_id and group_id is not present or null the next item will be evaluated as fallback. 

Note that Localization is not supported and that there may be specified an interpreter (e.g. for QuantityValues where we want to index the value, the __toString value or convert it to an other unit before indexing)

@fashxp 