### PR TITLE
[Ecommerce][IndexService][Elastic] Add database index to ecommerce index

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
@@ -65,7 +65,8 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
           `preparation_worker_id` varchar(20) DEFAULT NULL,
           `update_status` SMALLINT(5) UNSIGNED NULL DEFAULT NULL,
           `update_error` CHAR(255) NULL DEFAULT NULL,
-          PRIMARY KEY (`o_id`,`tenant`)
+          PRIMARY KEY (`o_id`,`tenant`),
+          KEY `update_worker_index` (`tenant`,`crc_current`,`crc_index`,`worker_timestamp`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8;");
     }
 


### PR DESCRIPTION
## Summary 

Mass updates on the ecommerce product index store can cause the system to slow down, because no index is used when updating the worker. By adding a new index, the performance increases massively.

## Problem
On index updates, the ecommerce queue is processed. SQL update queries, such as follows, occur frequently.
```sql
UPDATE ecommerceframework_productindex_store_elastic SET worker_id = '5d97121450e87', 
worker_timestamp = '1570181652' WHERE (crc_current != crc_index OR ISNULL(crc_index)) AND 
tenant = 'AT_hr_elastic' AND (ISNULL(worker_timestamp) 
OR worker_timestamp < '1570181352') 
LIMIT 200
```

This caused our system to slow down, so we analyzed the update statement by rewritting it into a sql statement, and then using SQL ``explain``. We found out that no index is used on the update statement!

## Solution
We added an index and executed the statement again.

In our case the query time was reduced from **1.906** seconds to **0.016** seconds per query!
![image](https://user-images.githubusercontent.com/16687355/66200480-7515d900-e6a1-11e9-88b1-4eb7e6b9a5ae.png)






