### PR TITLE
Asset doctype specification

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1400,7 +1400,7 @@ class Asset extends Element\AbstractElement
     }
 
     /**
-     * @param array $properties
+     * @param Property[] $properties
      *
      * @return $this
      */
@@ -1491,7 +1491,7 @@ class Asset extends Element\AbstractElement
     }
 
     /**
-     * @param array $versions
+     * @param Version[] $versions
      *
      * @return $this
      */

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1187,7 +1187,7 @@ class AbstractObject extends Model\Element\AbstractElement
     }
 
     /**
-     * @param array $o_properties
+     * @param Model\Property[] $o_properties
      *
      * @return $this
      */

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -335,7 +335,7 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
     }
 
     /**
-     * @param array $o_versions
+     * @param Model\Version[] $o_versions
      *
      * @return $this
      */

--- a/models/Document.php
+++ b/models/Document.php
@@ -1287,7 +1287,7 @@ class Document extends Element\AbstractElement
     /**
      * Set document properties.
      *
-     * @param array $properties
+     * @param Property[] $properties
      *
      * @return Document
      */

--- a/models/Element/ValidationException.php
+++ b/models/Element/ValidationException.php
@@ -38,8 +38,11 @@ class ValidationException extends \Exception
     /**
      * @param array $subItems
      */
-    public function setSubItems(array $subItems)
+    public function setSubItems($subItems)
     {
+        if(!\is_array($subItems)) {
+            @trigger_error('Calling '.__METHOD__.' with a '.\gettype($subItems).' as argument is deprecated', E_USER_DEPRECATED);
+        }
         $this->subItems = $subItems;
     }
 

--- a/models/Element/ValidationException.php
+++ b/models/Element/ValidationException.php
@@ -25,7 +25,7 @@ class ValidationException extends \Exception
     protected $contextStack = [];
 
     /** @var array */
-    protected $subItems;
+    protected $subItems = [];
 
     /**
      * @return array
@@ -38,7 +38,7 @@ class ValidationException extends \Exception
     /**
      * @param array $subItems
      */
-    public function setSubItems($subItems)
+    public function setSubItems(array $subItems)
     {
         $this->subItems = $subItems;
     }

--- a/models/Property/Predefined/Listing.php
+++ b/models/Property/Predefined/Listing.php
@@ -42,7 +42,7 @@ class Listing extends Model\Listing\JsonListing
     }
 
     /**
-     * @param array $properties
+     * @param \Pimcore\Model\Property\Predefined[] $properties
      *
      * @return $this
      */


### PR DESCRIPTION
Some doctypes in Asset class only declared parameters of type `array`. As this makes auto-complete implossible this PR specifies the type of the array.