### PR TITLE
Add option to display calculated value field as textarea

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/calculatedValue.js
@@ -45,6 +45,17 @@ pimcore.object.classes.data.calculatedValue = Class.create(pimcore.object.classe
         this.specificPanel.removeAll();
         this.specificPanel.add([
             {
+                xtype: "combo",
+                fieldLabel: t("type"),
+                name: "elementType",
+                value: this.datax.elementType,
+                labelWidth: 140,
+                store: [
+                    ['input', t('input')],
+                    ['textarea', t('textarea')]
+                ]
+            },
+            {
                 xtype: "numberfield",
                 fieldLabel: t("width"),
                 name: "width",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
@@ -51,8 +51,11 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
             input.value = this.data;
         }
 
-
-        this.component = new Ext.form.field.Text(input);
+        if(this.fieldConfig.elementType === 'textarea') {
+            this.component = new Ext.form.field.TextArea(input);
+        } else {
+            this.component = new Ext.form.field.Text(input);
+        }
 
         return this.component;
     },

--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -31,6 +31,9 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
      */
     public $fieldtype = 'calculatedValue';
 
+    /** @var string */
+    public $elementType = 'input';
+
     /**
      * @var float
      */
@@ -61,6 +64,22 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
      * @var string
      */
     public $phpdocType = '\\Pimcore\\Model\\DataObject\\Data\\CalculatedValue';
+
+    /**
+     * @return string
+     */
+    public function getElementType(): string
+    {
+        return $this->elementType;
+    }
+
+    /**
+     * @param string $elementType
+     */
+    public function setElementType($elementType)
+    {
+        $this->elementType = (string)$elementType;
+    }
 
     /**
      * @return int

--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -75,10 +75,16 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
 
     /**
      * @param string $elementType
+     *
+     * @return $this
      */
     public function setElementType($elementType)
     {
-        $this->elementType = (string)$elementType;
+        if ($elementType) {
+            $this->elementType = $elementType;
+        }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Currently calculated value fields are always displayed as input fields. With longer texts this has the disadvantage that not all content is visible (or only via horizontal scrolling). For example we have cases where whole product descriptions get generated by lots of object fields.
This PR adds an option to display calculated value fields as textareas. You can choose in class definition whether you want an input field or a textarea - input being the default.