### PR TITLE
Add cache to getByName Classification Store Key

### DIFF
--- a/models/DataObject/Classificationstore/KeyConfig.php
+++ b/models/DataObject/Classificationstore/KeyConfig.php
@@ -150,9 +150,9 @@ class KeyConfig extends Model\AbstractModel
     public static function getByName($name, $storeId = 1)
     {
          try {
-            $cacheKey = "cs_keyconfig_" . md5($name);
+            $cacheKey = "cs_keyconfig_" . $storeId . "_" . md5($name);
 
-            if (self::$cacheEnabled && \Pimcore\Cache\Runtime::isRegistered($cacheKey)) {
+            if (self::$cacheEnabled && Cache\Runtime::isRegistered($cacheKey)) {
                 $config = Cache\Runtime::get($cacheKey);
                 if ($config) {
                     return $config;
@@ -177,7 +177,7 @@ class KeyConfig extends Model\AbstractModel
 
             return $config;
         } catch (\Exception $e) {
-             return null;
+            return null;
         }
     }
 

--- a/models/DataObject/Classificationstore/KeyConfig.php
+++ b/models/DataObject/Classificationstore/KeyConfig.php
@@ -149,15 +149,35 @@ class KeyConfig extends Model\AbstractModel
      */
     public static function getByName($name, $storeId = 1)
     {
-        try {
+         try {
+            $cacheKey = "cs_keyconfig_" . md5($name);
+
+            if (self::$cacheEnabled && \Pimcore\Cache\Runtime::isRegistered($cacheKey)) {
+                $config = Cache\Runtime::get($cacheKey);
+                if ($config) {
+                    return $config;
+                }
+            }
+
+            $config = Cache::load($cacheKey);
+            if ($config) {
+                return $config;
+            }
+
             $config = new self();
             $config->setName($name);
             $config->setStoreId($storeId ? $storeId : 1);
             $config->getDao()->getByName();
 
+            if (self::$cacheEnabled) {
+                Cache\Runtime::set($cacheKey, $config);
+            }
+
+            Cache::save($config, $cacheKey, [], null, 0, true);
+
             return $config;
         } catch (\Exception $e) {
-            return null;
+             return null;
         }
     }
 


### PR DESCRIPTION
# Enhancement
This PR adds caching to `getByName()` classification store keys similar to `getById()`. 
