### PR TITLE
[Assets] Metadata name must be unique (or unique for certain language)

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1620,9 +1620,15 @@ class Asset extends Element\AbstractElement
      */
     public function setMetadata($metadata)
     {
-        $this->metadata = $metadata;
+        if(!empty($metadata)) {
+            foreach((array)$metadata as $metaItem) {
+                if(!isset($metaItem['language'])) {
+                    $metaItem['language'] = null;
+                }
 
-        $this->setHasMetaData(!empty($metadata));
+                $this->addMetadata($metaItem['name'], $metaItem['type'], $metaItem['data'], $metaItem['language']);
+            }
+        }
 
         return $this;
     }

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1620,6 +1620,7 @@ class Asset extends Element\AbstractElement
      */
     public function setMetadata($metadata)
     {
+        $this->metadata = [];
         if(!empty($metadata)) {
             foreach((array)$metadata as $metaItem) {
                 $this->addMetadata($metaItem['name'], $metaItem['type'], $metaItem['data'] ?? null, $metaItem['language'] ?? null);

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1621,6 +1621,7 @@ class Asset extends Element\AbstractElement
     public function setMetadata($metadata)
     {
         $this->metadata = [];
+        $this->setHasMetaData(false);
         if(!empty($metadata)) {
             foreach((array)$metadata as $metaItem) {
                 $this->addMetadata($metaItem['name'], $metaItem['type'], $metaItem['data'] ?? null, $metaItem['language'] ?? null);

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1622,11 +1622,7 @@ class Asset extends Element\AbstractElement
     {
         if(!empty($metadata)) {
             foreach((array)$metadata as $metaItem) {
-                if(!isset($metaItem['language'])) {
-                    $metaItem['language'] = null;
-                }
-
-                $this->addMetadata($metaItem['name'], $metaItem['type'], $metaItem['data'], $metaItem['language']);
+                $this->addMetadata($metaItem['name'], $metaItem['type'], $metaItem['data'] ?? null, $metaItem['language'] ?? null);
             }
         }
 


### PR DESCRIPTION
When you set an asset's metadata via `setMetadata` method it is possible to have two metadata items with the same name (and language).
To reproduce:
```php
<?php
$asset = \Pimcore\Model\Asset::getById(1234);
$asset->setMetadata([
    [
        'name' => 'test',
        'type' => 'input',
        'data' => 'test',
        'language' => null
    ], [
        'name' => 'test',
        'type' => 'input',
        'data' => 'another_test',
        'language' => null
    ]
]);
$asset->save();
```

The result is:
<img width="1300" alt="Bildschirmfoto 2019-10-10 um 08 50 03" src="https://user-images.githubusercontent.com/8749138/66546865-2f905a80-eb3e-11e9-842e-995ed496bed2.png">

This PR changes this behaviour to overwrite existing items with same key (or same key+language for localized metadata items).