### PR TITLE
[Assets] Fix preview of video located into root folder

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -1445,7 +1445,7 @@ class AssetController extends ElementControllerBase implements EventedController
 
         $config = Asset\Video\Thumbnail\Config::getPreviewConfig();
         $thumbnail = $asset->getThumbnail($config, ['mp4']);
-        $fsFile = $asset->getVideoThumbnailSavePath() . '/' . preg_replace('@' . preg_quote($asset->getPath(), '@') . '@', '', urldecode($thumbnail['formats']['mp4']));
+        $fsFile = $asset->getVideoThumbnailSavePath() . '/' . ltrim(urldecode($thumbnail['formats']['mp4']), $asset->getPath());
 
         if (file_exists($fsFile)) {
             $response = new BinaryFileResponse($fsFile);


### PR DESCRIPTION
All occurrences of Asset path are wrongly removed causing bug for
preview of video stored into root folder.

<!--
## Please make sure your PR complies with all of the following points: 
- [X] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [X] Features need to be proper documented in `doc/`
- [X] Bugfixes need a short guide how to reproduce them. 
- [X] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [X] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #5084 