### PR TITLE
PDFreactor: Add httpsMode option to work around ssl connection problems

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/web2print.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/web2print.js
@@ -153,6 +153,17 @@ pimcore.settings.web2print = Class.create({
                         value: this.getValue("pdfreactorLicence")
                     }, {
                         xtype: 'checkbox',
+                        fieldLabel: t("web2print_enableLenientHttpsMode"),
+                        name: 'pdfreactorEnableLenientHttpsMode',
+                        value: this.getValue("pdfreactorEnableLenientHttpsMode")
+                    }, {
+                        xtype: "displayfield",
+                        hideLabel: true,
+                        width: 600,
+                        value: t('web2print_enableLenientHttpsMode_txt'),
+                        cls: "pimcore_extra_label_bottom"
+                    }, {
+                        xtype: 'checkbox',
                         fieldLabel: t("web2print_enableDebugMode"),
                         name: 'pdfreactorEnableDebugMode',
                         value: this.getValue("pdfreactorEnableDebugMode")

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -598,6 +598,8 @@
   "web2print_only_published": "Only possible with published documents.",
   "web2print_documents_changed": "Documents changed since last pdf generation.",
   "web2print_enableDebugMode": "Enable debug mode",
+  "web2print_enableLenientHttpsMode": "Enable lenient HTTPS mode",
+  "web2print_enableLenientHttpsMode_txt": "Enable this option if PDFreactor fails to connect successfully via HTTPS",
   "about_pimcore": "ABOUT PIMCORE PLATFORM",
   "phone": "Phone",
   "workflow_additional_info": "Additional Information",

--- a/lib/Web2Print/Processor/PdfReactor8.php
+++ b/lib/Web2Print/Processor/PdfReactor8.php
@@ -47,7 +47,8 @@ class PdfReactor8 extends Processor
             'addTags' => $config->tags == 'true',
             'logLevel' => $config->loglevel,
             'enableDebugMode' => $web2PrintConfig->pdfreactorEnableDebugMode || $config->enableDebugMode == 'true',
-            'addOverprint' => $config->addOverprint == 'true'
+            'addOverprint' => $config->addOverprint == 'true',
+            'httpsMode' => $web2PrintConfig->pdfreactorEnableLenientHttpsMode ? \HttpsMode::LENIENT : \HttpsMode::STRICT
         ];
         if ($config->viewerPreference) {
             $reactorConfig['viewerPreferences'] = [$config->viewerPreference];


### PR DESCRIPTION
## Changes in this pull request  
We had to change our SSL certificates some days ago. PDFreactor is now unable to access images and css file hosted on the Pimcore server. 

`SSLHandshake: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target 11:53:05.905 `

The newly installed SSL certificate is perfectly valid and accepted by every major browser, no intermediate or other certificates need to be installed manually (our certificate is issued by Swiss Sign, it isn't a self-signed certificate).

PDFreactor supports to suggests to set the following option: https://support.realobjects.com/support/solutions/articles/7000016828-how-can-pdfreactor-connect-to-a-server-using-https-

This PR adds an option to enable this option on the web2print settings view.

## Additional info  

