### PR TITLE
[quicksearch]: do not allow to consume mouse events behind quicksearch overlay

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -2893,6 +2893,14 @@ pimcore.helpers.showQuickSearch = function () {
 
     Ext.get('pimcore_body').addCls('blurry');
     Ext.get('pimcore_sidebar').addCls('blurry');
+    var elem = document.createElement('div');
+    elem.id = 'pimcore_quickSearch_overlay';
+    elem.style.cssText = 'position:absolute;width:100vw;height:100vh;z-index:100;top:0;left:0;opacity:0';
+    elem.addEventListener('click', function(e) {
+        document.body.removeChild(elem);
+        pimcore.helpers.hideQuickSearch();
+    });
+    document.body.appendChild(elem);
 };
 
 pimcore.helpers.hideQuickSearch = function () {
@@ -2900,6 +2908,9 @@ pimcore.helpers.hideQuickSearch = function () {
     quicksearchContainer.hide();
     Ext.get('pimcore_body').removeCls('blurry');
     Ext.get('pimcore_sidebar').removeCls('blurry');
+    if (Ext.get('pimcore_quickSearch_overlay')) {
+        Ext.get('pimcore_quickSearch_overlay').remove();
+    }
 };
 
 


### PR DESCRIPTION
## How to reproduce

- Be sure to have asset tree preview enabled
- open quicksearch
- hover over the asset tree
- preview will be opened

another case

- implement an iFrame with whatever application or target
- open quicksearch
- try to close quicksearch with click in the area of the iframe
- quicksearch does not close


## Additional information

current implementation allows the application to consume mouse events behind the quicksearch overlay

This is a bad UX on several places....e.g. if asset tree preview is enabled or if an iframe is implemented
which will consume the mouse events and prevent the quicksearch overlay to be closed.

Simply add an additional div to control this behaviour