### PR TITLE
Update system requirements docs

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/01_System_Requirements.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/01_System_Requirements.md
@@ -27,12 +27,12 @@ Both **mod_php** and **FCGI (FPM)** are supported.
 - [zip](http://php.net/zip)
 - [intl](http://www.php.net/intl)
 - [opcache](http://php.net/opcache)
+- [curl](http://php.net/curl)
 - CLI SAPI (for Cron Jobs)
 - [Composer](https://getcomposer.org/) (added to `$PATH` - see also [Additional Tools Installation](./03_System_Setup_and_Hosting/06_Additional_Tools_Installation.md))
 
 #### Recommended Modules & Extensions 
 - [imagick](http://php.net/imagick) (if not installed *gd* is used instead, but with less supported image types)
-- [curl](http://php.net/curl) (required if Google APIs are used)
 - [phpredis](https://github.com/phpredis/phpredis) (recommended cache backend adapter)
 - [graphviz](https://www.graphviz.org/) (for rendering workflow overview)
 


### PR DESCRIPTION
Curl should be be a required extension, since following the installation instructions without curl installed results in the following error:

![pimcore](https://user-images.githubusercontent.com/9052094/66852509-68d12c00-ef7d-11e9-9fd3-946f857767e0.png)
