### PR TITLE
Bug in ElementListener - DataObject Preview in Pimcore

### DIFF
--- a/bundles/CoreBundle/EventListener/Frontend/ElementListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/ElementListener.php
@@ -104,7 +104,7 @@ class ElementListener implements EventSubscriberInterface, LoggerAwareInterface
         }
 
         $document = $this->documentResolver->getDocument($request);
-        if (!$document instanceof Document\PageSnippet) {
+        if (!$document instanceof Document\PageSnippet && !Staticroute::getCurrentRoute()) {
             return;
         }
 


### PR DESCRIPTION
Fix bug in ElementListener that happens when you use Object Previews in Pimcore where the base-url of the Static Route points to a none Document\PageSnippet Item (like a Link). Pimcore then doesn't resolve the Tmp Object from the Session.
