### PR TITLE
Better performance for retrieving outdated versions

### DIFF
--- a/models/Version/Dao.php
+++ b/models/Version/Dao.php
@@ -147,11 +147,11 @@ class Dao extends Model\Dao\AbstractDao
                     $versionIds = array_merge($versionIds, $tmpVersionIds);
                 } else {
                     // by steps
-                    $elementIds = $this->db->fetchCol('SELECT cid,count(*) as amount FROM versions WHERE ctype = ? AND NOT public AND id NOT IN (' . $ignoreIdsList . ') GROUP BY cid HAVING amount > ?', [$elementType['elementType'], $elementType['steps']]);
-                    foreach ($elementIds as $elementId) {
+                    $versionData = $this->db->executeQuery('SELECT cid, GROUP_CONCAT(id ORDER BY id DESC) AS versions FROM versions WHERE ctype = ? AND NOT public AND id NOT IN (' . $ignoreIdsList . ') GROUP BY cid HAVING COUNT(*) > ? LIMIT 1000', [$elementType['elementType'], $elementType['steps']]);
+                    while( $versionInfo = $versionData->fetch()) {
                         $count++;
-                        Logger::info($elementId . '(object ' . $count . ') Vcount ' . count($versionIds));
-                        $elementVersions = $this->db->fetchCol('SELECT id FROM versions WHERE cid = ? and ctype = ? ORDER BY date DESC LIMIT ' . $elementType['steps'] . ',1000000', [$elementId, $elementType['elementType']]);
+                        Logger::info($versionInfo['cid'] . '(object ' . $count . ') Vcount ' . count($versionIds));
+                        $elementVersions = \array_slice(explode(',', $versionInfo['versions']), $elementType['steps']);
 
                         $versionIds = array_merge($versionIds, $elementVersions);
 
@@ -159,8 +159,6 @@ class Dao extends Model\Dao\AbstractDao
                         if (memory_get_usage() > 100000000 && ($count % 100 == 0)) {
                             \Pimcore::collectGarbage();
                             sleep(1);
-
-                            $versionIds = array_unique($versionIds);
                         }
 
                         if (count($versionIds) > 1000) {
@@ -168,8 +166,6 @@ class Dao extends Model\Dao\AbstractDao
                             break;
                         }
                     }
-
-                    $versionIds = array_unique($versionIds);
 
                     if ($stop) {
                         break;


### PR DESCRIPTION
I extended #4983's version by the following points:
* Only one SQL query to get all outdated versions (via ordered GROUP_CONCAT) instead of n+1 with n being the number of elements which have outdated versions
* Remove `array_unique` calls as in my opinion it is not possible for one version to belong to multiple elements

I kept the `LIMIT 1000` as in https://github.com/pimcore/pimcore/blob/22a337f716b99409db2746410abbe2ba53b87513/models/Version/Dao.php#L166-L169 the loop gets aborted if there are more than 1000 outdated versions. And as for 1000 outdated versions at most 1000 elements (with at least one outdated version) are needed, the limit is correct (if some elements have more than 1 outdated versions, some elements are fetched to no avail - but this is also the case with the current implementation without the `LIMIT 1000` - but even worse as more useless data gets fetched).

#4983 could be closed if this PR got merged.