### PR TITLE
New option in classs definition: Disallow deletion of objects if dependencies exist 

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -418,6 +418,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             $objectData['general']['allowVariants'] = $objectFromDatabase->getClass()->getAllowVariants();
             $objectData['general']['showVariants'] = $objectFromDatabase->getClass()->getShowVariants();
             $objectData['general']['showAppLoggerTab'] = $objectFromDatabase->getClass()->getShowAppLoggerTab();
+            $objectData['general']['disallowDeleteIfDependencies'] = $objectFromDatabase->getClass()->getDisallowDeleteIfDependencies();
             if ($objectFromDatabase instanceof DataObject\Concrete) {
                 $objectData['general']['linkGeneratorReference'] = $objectFromDatabase->getClass()->getLinkGeneratorReference();
             }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
@@ -88,12 +88,20 @@ pimcore.elementservice.deleteElementCheckDependencyComplete = function (window, 
 
         var deleteMethod = "delete" + ucfirst(options.elementType) + "FromServer";
 
+        if (res.disallowDeleteIfDependencies) {
+            message = t('deletion_not_allowed_if_dependencies_extist');
+        }
+
         Ext.MessageBox.show({
             title:t('delete'),
             msg: message,
-            buttons: Ext.Msg.OKCANCEL ,
+            buttons: !res.disallowDeleteIfDependencies ? Ext.Msg.OKCANCEL : Ext.Msg.OK,
             icon: Ext.MessageBox.INFO ,
-            fn: pimcore.elementservice.deleteElementFromServer.bind(window, res, options)
+            fn: function(r, options, button) {
+                    if (button === "ok" && (res.disallowDeleteIfDependencies === false)) {
+                        pimcore.elementservice.deleteElementFromServer.bind(window, r, options);
+                    }
+                }.bind(window, res, options)
         });
     }
     catch (e) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
@@ -794,6 +794,12 @@ pimcore.object.classes.klass = Class.create({
                 this.showVariants,
                 {
                     xtype: "checkbox",
+                    fieldLabel: t("disallow_delete_if_dependencies"),
+                    name: "disallowDeleteIfDependencies",
+                    checked: this.data.disallowDeleteIfDependencies
+                },
+                {
+                    xtype: "checkbox",
                     fieldLabel: t("show_applogger_tab"),
                     name: "showAppLoggerTab",
                     checked: this.data.showAppLoggerTab

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -910,4 +910,6 @@
   "split_view_object_dirty_msg": "There are unsaved modifications. You will lose all changes. Are you sure?",
   "all_translations": "All Translations",
   "set_to_null": "Empty (set to null)"
+  "disallow_delete_if_dependencies": "Disallow delete if dependencies exist",
+  "deletion_not_allowed_if_dependencies_extist": "Deletion of this object is not allowed, there are existing dependencies.", 
 }

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -116,6 +116,11 @@ class ClassDefinition extends Model\AbstractModel
      * @var bool
      */
     public $showVariants = false;
+    
+    /**
+     * @var bool
+     */
+    public $disallowDeleteIfDependencies = false;
 
     /**
      * @var array
@@ -1240,6 +1245,22 @@ class ClassDefinition extends Model\AbstractModel
     public function getShowVariants()
     {
         return $this->showVariants;
+    }
+    
+    /**
+     * @return bool
+     */
+    public function getDisallowDeleteIfDependencies()
+    {
+        return $this->disallowDeleteIfDependencies;
+    }
+
+    /**
+     * @param bool $disallowDeleteIfDependencies
+     */
+    public function setDisallowDeleteIfDependencies($disallowDeleteIfDependencies)
+    {
+        $this->disallowDeleteIfDependencies = (bool) $disallowDeleteIfDependencies;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -107,7 +107,7 @@ class Service
 
         foreach (['description', 'icon', 'group', 'allowInherit', 'allowVariants', 'showVariants', 'parentClass',
                     'listingParentClass', 'useTraits', 'listingUseTraits', 'previewUrl', 'propertyVisibility',
-                    'linkGeneratorReference'] as $importPropertyName) {
+                    'linkGeneratorReference', 'disallowDeleteIfDependencies'] as $importPropertyName) {
             if (isset($importData[$importPropertyName])) {
                 $class->{'set' . ucfirst($importPropertyName)}($importData[$importPropertyName]);
             }

--- a/models/Webservice/Data/ClassDefinition.php
+++ b/models/Webservice/Data/ClassDefinition.php
@@ -98,6 +98,11 @@ class ClassDefinition extends Model\Webservice\Data
      * @var bool
      */
     public $showVariants = false;
+    
+    /**
+     * @var bool
+     */
+    public $disallowDeleteIfDependencies = false;
 
     /**
      * @var array


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20427487/67188517-c8e82800-f3ec-11e9-857c-a39ff3c5f444.png)

Helps to keep data consistent. System critial data, like masterdata, can't be deleted as long dependencies exist. 
