### PR TITLE
[ClassificationStore] Error validating mandatory fields

### DIFF
--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -183,13 +183,7 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
         }
 
         if ($validationExceptions) {
-            $message = 'Validation failed: ';
-            $errors = [];
-            foreach ($validationExceptions as $e) {
-                $errors[] = $e->getMessage();
-            }
-            $message .= implode(' / ', $errors);
-            $aggregatedExceptions = new Model\Element\ValidationException($message);
+            $aggregatedExceptions = new Model\Element\ValidationException();
             $aggregatedExceptions->setSubItems($validationExceptions);
             throw $aggregatedExceptions;
         }


### PR DESCRIPTION
Error message: Call to a member function getMessage() on array
Caused by classification store validation setting array data as sub items
instead of nested validation exceptions, resulting in the error when iterating
through the sub items in the admin exception listener (recursiveAddValidationExceptionSubItems).
Fixed by creating validation exceptions on group and key level and adding these
as sub items of the field validation exception.
Additionally fixed an issue in the admin exception listener where the message
based on the sub items was never passed to the response data.
Updated Concrete to only return the sub items to prevent double messages.

Pimcore 6.2.1
To reproduce:
- Add a classification store to a data object
- Set a key to mandatory
- Save the data object while the field is still empty

While I tried to test as much as possible, I may have overlooked something. Hopefully someone with more knowledge of the Pimcore internals can pick this up and check if validation works correctly within other components.