### PR TITLE
Ecommerce Subtenant ambigious column o_id

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultMysql.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultMysql.php
@@ -570,7 +570,7 @@ class DefaultMysql implements ProductListInterface
             case ProductListInterface::VARIANT_MODE_INCLUDE_PARENT_OBJECT:
 
                 //make sure, that only variant objects are considered
-                $condition .= ' AND o_id != o_virtualProductId ';
+                $condition .= ' AND a.o_id != o_virtualProductId ';
                 break;
 
             case ProductListInterface::VARIANT_MODE_HIDE:


### PR DESCRIPTION
When using a subtenant with the basic implementation, the o_id column is ambigious since it is used in the product index table and the subtenant assortment table as well.

This will lead to an error when using the variant mode "VARIANT_MODE_INCLUDE_PARENT_OBJECT". Using the default alias "a" in the condition solves the issue.

