### PR TITLE
[Object grid] Enable text selection

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/folder/search.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/folder/search.js
@@ -371,7 +371,8 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
             plugins: plugins,
             viewConfig: {
                 forceFit: false,
-                xtype: 'patchedgridview'
+                xtype: 'patchedgridview',
+                enableTextSelection: true
             },
             listeners: {
                 celldblclick: function(grid, td, cellIndex, record, tr, rowIndex, e, eOpts) {


### PR DESCRIPTION
Sometimes it is good to be able to copy field contents from the object grid. By default text selection is disabled for ExtJS grid panels.
While currently text selection is possible for editable fields via its editor (but at the cost of one extra click) it is impossible for system and non-editable fields. This PR enables text selection und so also copying values from the grid. It does not affect the behaviour of inline-editing.