### PR TITLE
allow custom field-definitions to marshal and unmarshal version data differently

### DIFF
--- a/models/DataObject/ClassDefinition/Data/CustomVersionMarshalInterface.php
+++ b/models/DataObject/ClassDefinition/Data/CustomVersionMarshalInterface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @category   Pimcore
+ * @package    Element
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Model\DataObject\ClassDefinition\Data;
+
+interface CustomVersionMarshalInterface
+{
+    /**
+     * @param $object
+     * @param $data
+     */
+    public function marshalVersion($object, $data);
+
+    /**
+     * @param $object
+     * @param $data
+     */
+    public function unmarshalVersion($object, $data);
+}

--- a/models/Version.php
+++ b/models/Version.php
@@ -22,11 +22,14 @@ use Pimcore\Event\Model\VersionEvent;
 use Pimcore\Event\VersionEvents;
 use Pimcore\File;
 use Pimcore\Logger;
+use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
 use Pimcore\Model\Version\ElementDescriptor;
 use Pimcore\Model\Version\MarshalMatcher;
+use Pimcore\Model\Version\PimcoreClassDefinitionMatcher;
+use Pimcore\Model\Version\PimcoreClassDefinitionReplaceFilter;
 use Pimcore\Model\Version\UnmarshalMatcher;
 use Pimcore\Tool\Serialize;
 
@@ -281,12 +284,27 @@ class Version extends AbstractModel
             ),
             new MarshalMatcher($sourceType, $sourceId)
         );
+
+        if ($data instanceof Concrete) {
+            $copier->addFilter(
+                new PimcoreClassDefinitionReplaceFilter(
+                    function (Concrete $object, Data $fieldDefinition, $property, $currentValue) {
+                        if ($fieldDefinition instanceof Data\CustomVersionMarshalInterface) {
+                            return $fieldDefinition->marshalVersion($object, $currentValue);
+                        }
+
+                        return $currentValue;
+                    }
+                ),
+                new PimcoreClassDefinitionMatcher()
+            );
+        }
+
         $copier->addFilter(new \DeepCopy\Filter\Doctrine\DoctrineCollectionFilter(), new \DeepCopy\Matcher\PropertyTypeMatcher('Doctrine\Common\Collections\Collection'));
         $copier->addFilter(new \DeepCopy\Filter\SetNullFilter(), new \DeepCopy\Matcher\PropertyTypeMatcher('Pimcore\Templating\Model\ViewModelInterface'));
         $copier->addFilter(new \DeepCopy\Filter\SetNullFilter(), new \DeepCopy\Matcher\PropertyTypeMatcher('Psr\Container\ContainerInterface'));
-        $newData = $copier->copy($data);
 
-        return $newData;
+        return $copier->copy($data);
     }
 
     /**
@@ -311,9 +329,23 @@ class Version extends AbstractModel
             ),
             new UnmarshalMatcher()
         );
-        $newData = $copier->copy($data);
 
-        return $newData;
+        if ($data instanceof Concrete) {
+            $copier->addFilter(
+                new PimcoreClassDefinitionReplaceFilter(
+                    function (Concrete $object, Data $fieldDefinition, $property, $currentValue) {
+                        if ($fieldDefinition instanceof Data\CustomVersionMarshalInterface) {
+                            return $fieldDefinition->unmarshalVersion($object, $currentValue);
+                        }
+
+                        return $currentValue;
+                    }
+                ),
+                new PimcoreClassDefinitionMatcher()
+            );
+        }
+
+        return $copier->copy($data);
     }
 
     /**

--- a/models/Version/PimcoreClassDefinitionMatcher.php
+++ b/models/Version/PimcoreClassDefinitionMatcher.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @category   Pimcore
+ * @package    Element
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Model\Version;
+
+use DeepCopy\Matcher\Matcher;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\Concrete;
+
+class PimcoreClassDefinitionMatcher implements Matcher
+{
+    public function matches($object, $property)
+    {
+        return $object instanceof Concrete &&
+            $object->getClass()->getFieldDefinition($property) instanceof ClassDefinition\Data;
+    }
+
+}

--- a/models/Version/PimcoreClassDefinitionMatcher.php
+++ b/models/Version/PimcoreClassDefinitionMatcher.php
@@ -26,7 +26,7 @@ class PimcoreClassDefinitionMatcher implements Matcher
     public function matches($object, $property)
     {
         return $object instanceof Concrete &&
-            $object->getClass()->getFieldDefinition($property) instanceof ClassDefinition\Data;
+            $object->getClass()->getFieldDefinition($property) instanceof ClassDefinition\Data\CustomVersionMarshalInterface;
     }
 
 }

--- a/models/Version/PimcoreClassDefinitionReplaceFilter.php
+++ b/models/Version/PimcoreClassDefinitionReplaceFilter.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @category   Pimcore
+ * @package    Element
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Model\Version;
+
+use DeepCopy\Filter\Filter;
+use DeepCopy\Reflection\ReflectionHelper;
+use Pimcore\Model\DataObject\Concrete;
+
+class PimcoreClassDefinitionReplaceFilter implements Filter
+{
+    /**
+     * @var callable
+     */
+    protected $callback;
+
+    /**
+     * @param callable $callable Will be called to get the new value for each property to replace
+     */
+    public function __construct(callable $callable)
+    {
+        $this->callback = $callable;
+    }
+
+    public function apply($object, $property, $objectCopier)
+    {
+        if (!$object instanceof Concrete) {
+            return;
+        }
+
+        $fieldDefinition = $object->getClass()->getFieldDefinition($property);
+
+        if (!$fieldDefinition) {
+            return;
+        }
+
+        $reflectionProperty = ReflectionHelper::getProperty($object, $property);
+        $reflectionProperty->setAccessible(true);
+
+        $value = call_user_func($this->callback, $object, $fieldDefinition, $property, $reflectionProperty->getValue($object));
+
+        $reflectionProperty->setValue($object, $value);
+    }
+}


### PR DESCRIPTION
This makes a lot of Problems with complex custom data-types where we in CoreShop link DataObjects with Doctrine Entities. This PR basically adds support for Custom Data Types to marshal and unmarshal Data for Versions as they need id.