### PR TITLE
[Calculated value fields] readOnly instead of disabled

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
@@ -29,7 +29,7 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
             fieldLabel: '<img src="/bundles/pimcoreadmin/img/flat-color-icons/calculator.svg" style="height: 1.8em; display: inline-block; vertical-align: middle;"/>' + this.fieldConfig.title,
             componentCls: "object_field",
             labelWidth: 100,
-            disabled: true
+            readOnly: true
         };
 
         if (this.data) {


### PR DESCRIPTION
Render calculated fields with `readOnly` attribute instead of `disabled` to be able to select and copy the content. Somehow we forgot this in #3693.