### PR TITLE
[Data object > Relation fields] Sort items by drag & drop

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -354,10 +354,10 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
             },
             viewConfig: {
                 plugins: {
-                    ptype: 'gridviewdragdrop',
-                    draggroup: 'element'
+                    ptype: 'gridviewdragdrop'
                 },
                 markDirty: false,
+                enableTextSelection: true,
                 listeners: {
                     afterrender: function (gridview) {
                         this.requestNicePathData(this.store.data, true);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -354,7 +354,8 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
             },
             viewConfig: {
                 plugins: {
-                    ptype: 'gridviewdragdrop'
+                    ptype: 'gridviewdragdrop',
+                    draggroup: 'element'
                 },
                 markDirty: false,
                 enableTextSelection: true,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -351,10 +351,10 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
             },
             viewConfig: {
                 plugins: {
-                    ptype: 'gridviewdragdrop',
-                    draggroup: 'element'
+                    ptype: 'gridviewdragdrop'
                 },
                 markDirty: false,
+                enableTextSelection: true,
                 listeners: {
                     afterrender: function (gridview) {
                         this.requestNicePathData(this.store.data, true);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -351,7 +351,8 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
             },
             viewConfig: {
                 plugins: {
-                    ptype: 'gridviewdragdrop'
+                    ptype: 'gridviewdragdrop',
+                    draggroup: 'element'
                 },
                 markDirty: false,
                 enableTextSelection: true,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -410,9 +410,9 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
             style: "margin-bottom: 10px",
             viewConfig: {
                 markDirty: false,
+                enableTextSelection: true,
                 plugins: {
-                    ptype: 'gridviewdragdrop',
-                    dragroup: 'element'
+                    ptype: 'gridviewdragdrop'
                 },
                 listeners: {
                     drop: function (node, data, dropRec, dropPosition) {
@@ -610,6 +610,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
             style: "margin-bottom: 10px",
             title: this.fieldConfig.title,
             viewConfig: {
+            enableTextSelection: true,
                 listeners: {
                     refresh: function (gridview) {
                         this.requestNicePathData(this.store.data);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -412,7 +412,8 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                 markDirty: false,
                 enableTextSelection: true,
                 plugins: {
-                    ptype: 'gridviewdragdrop'
+                    ptype: 'gridviewdragdrop',
+                    draggroup: 'element'
                 },
                 listeners: {
                     drop: function (node, data, dropRec, dropPosition) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -185,8 +185,7 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
             viewConfig: {
                 markDirty: false,
                 plugins: {
-                    ptype: 'gridviewdragdrop',
-                    dragroup: 'element'
+                    ptype: 'gridviewdragdrop'
                 },
                 listeners: {
                     refresh: function (gridview) {
@@ -402,6 +401,7 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
             style: "margin-bottom: 10px",
             title: this.fieldConfig.title,
             viewConfig: {
+            enableTextSelection: true,
                 listeners: {
                     refresh: function (gridview) {
                         this.requestNicePathData(this.store.data);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -185,7 +185,8 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
             viewConfig: {
                 markDirty: false,
                 plugins: {
-                    ptype: 'gridviewdragdrop'
+                    ptype: 'gridviewdragdrop',
+                    draggroup: 'element'
                 },
                 listeners: {
                     refresh: function (gridview) {


### PR DESCRIPTION
Many to many (object) relations had a typo which prevented changing the order within a relation field.
Additionally this PR allows text selection in edit mode for all relational fields when they are configured as readonly / non-editable (as done in #5125 for the folder object grid).