### PR TITLE
Don't use complete url

### DIFF
--- a/doc/Development_Documentation/03_Documents/02_Document_Types/15_Print_Documents.md
+++ b/doc/Development_Documentation/03_Documents/02_Document_Types/15_Print_Documents.md
@@ -85,8 +85,8 @@ The command that you enter in the binary field can then be something like this:
 ```
 xvfb-run -a -s "-screen 0 640x480x16" /usr/bin/wkhtmltopdf
 ```
-In the host field, enter the full URL, like you would in a web browser, not just the hostname. 
-For example: "http://example.mydevdomain.local"
+In the host field, enter the full URL, like you would in a web browser, but without the leading http:// or https://. 
+For example: "example.mydevdomain.local"
 
 To test and debug the PDF rendering, open a Print document, go to the tab "Generate & Preview PDF", click the "Generate PDF" 
 button and observe the message field for any errors.

--- a/doc/Development_Documentation/03_Documents/02_Document_Types/15_Print_Documents.md
+++ b/doc/Development_Documentation/03_Documents/02_Document_Types/15_Print_Documents.md
@@ -85,8 +85,8 @@ The command that you enter in the binary field can then be something like this:
 ```
 xvfb-run -a -s "-screen 0 640x480x16" /usr/bin/wkhtmltopdf
 ```
-In the host field, enter the full URL, like you would in a web browser, but without the leading http:// or https://. 
-For example: "example.mydevdomain.local"
+In the host field, enter the full URL, like you would in a web browser, but without the leading `http://` or `https://`. 
+For example: `example.mydevdomain.local`
 
 To test and debug the PDF rendering, open a Print document, go to the tab "Generate & Preview PDF", click the "Generate PDF" 
 button and observe the message field for any errors.


### PR DESCRIPTION
If the complete url is used, css and images will not be shown with wkhtmltopdf and web2print-output.log will have errors like this:

> Warning: Failed to load http://http//example.com/static/css/custom.css (ignore)
Warning: Failed to load http://http//example.com/images/example.png (ignore)
