### PR TITLE
Set correct parent value

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/Index/index.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/Index/index.html.php
@@ -707,6 +707,7 @@ $scripts = array(
 <?php // pimcore constants ?>
 <script>
     pimcore.settings = <?= json_encode($this->settings, JSON_PRETTY_PRINT) ?>;
+    try {parent.pimcore} catch (err) {parent=window}
 </script>
 
 <script src="/admin/misc/json-translations-system?language=<?= $language ?>&_dc=<?= \Pimcore\Version::getRevision() ?>"></script>


### PR DESCRIPTION
## Changes in this pull request  
I've noticed, that if PimCore Admin is in an iFrame, an error occurs: the parent.pimcore value will be set incorrectly and this will cause further issues. 
With a simple line this is fixable.

## Additional info  
This setting must be done before loading the library and internal scripts, because some of those rely on this variable too.
