### PR TITLE
Fix: Objectbrick csv import

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Base64.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Base64.js
@@ -126,7 +126,7 @@ pimcore.object.gridcolumn.operator.base64 = Class.create(pimcore.object.gridcolu
             width: 400,
             height: 300,
             modal: true,
-            title: t('settings'),
+            title: this.getDefaultText(),
             layout: "fit",
             items: [this.configPanel]
         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/classTree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/classTree.js
@@ -262,6 +262,7 @@ pimcore.object.helpers.classTree = Class.create({
             var newNode = {
                 text: text,
                 key: key,
+                name: initData.name,
                 type: "data",
                 layout: initData,
                 leaf: isLeaf,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/import/columnConfigurationTab.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/import/columnConfigurationTab.js
@@ -214,7 +214,7 @@ pimcore.object.helpers.import.columnConfigurationTab = Class.create({
                                         }
                                     }
                                 }
-                               
+
                                 var attr = record.data;
                                 if (record.data.configAttributes) {
                                     attr = record.data.configAttributes;
@@ -223,33 +223,25 @@ pimcore.object.helpers.import.columnConfigurationTab = Class.create({
 
                                 var copy = element.getCopyNode(record);
 
-                                if (attr.key && attr.key.indexOf("~") !== -1) {
+                                if (record.data.brickDescriptor && record.data.brickDescriptor.insideBrick) {
                                     var brickOperator = new pimcore.object.importcolumn.operator.objectbricksetter();
                                     var brickNode = brickOperator.getConfigTreeNode();
                                     brickNode.expanded = true;
-                                    brickNode.configAttributes.attr = record.data.brickField;
-                                    keyParts = attr.key.split("~");
-                                    brickNode.configAttributes.brickType = keyParts[0];
+                                    brickNode.configAttributes.attr = record.data.brickDescriptor.brickField;
+                                    brickNode.configAttributes.brickType = record.data.brickDescriptor.brickType;
                                     brickNode = realOverModel.createNode(brickNode);
                                     brickNode.appendChild(copy);
                                     copy = brickNode;
-
                                 }
-
-
 
                                 if (isOverwrite) {
                                     var parentNode = realOverModel.parentNode;
                                     parentNode.replaceChild(copy, realOverModel);
                                     dropHandlers.cancelDrop();
                                     this.updatePreviewArea();
-
                                 } else {
                                     data.records = [copy]; // assign the copy as the new dropNode
                                 }
-                                this.showConfigWindow(element, copy);
-
-                               
                             } else {
                                 // node has been moved inside right selection panel
                                 var record = data.records[0];

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/Ignore.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/Ignore.js
@@ -110,7 +110,7 @@ pimcore.object.importcolumn.operator.ignore = Class.create(pimcore.object.gridco
             width: 400,
             height: 300,
             modal: true,
-            title: t('settings'),
+            title: this.getDefaultText(),
             layout: "fit",
             items: [this.configPanel]
         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/Iterator.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/Iterator.js
@@ -104,7 +104,7 @@ pimcore.object.importcolumn.operator.iterator = Class.create(pimcore.object.grid
             width: 400,
             height: 200,
             modal: true,
-            title: t('settings'),
+            title: this.getDefaultText(),
             layout: "fit",
             items: [this.configPanel]
         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/ObjectBrickSetter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/ObjectBrickSetter.js
@@ -139,7 +139,7 @@ pimcore.object.importcolumn.operator.objectbricksetter = Class.create(pimcore.ob
             width: 400,
             height: 450,
             modal: true,
-            title: t('operator_objectbricksetter_settings'),
+            title: t('settings'),
             layout: "fit",
             items: [this.configPanel]
         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/ObjectBrickSetter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/ObjectBrickSetter.js
@@ -139,7 +139,7 @@ pimcore.object.importcolumn.operator.objectbricksetter = Class.create(pimcore.ob
             width: 400,
             height: 450,
             modal: true,
-            title: t('settings'),
+            title: this.getDefaultText(),
             layout: "fit",
             items: [this.configPanel]
         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/PHPCode.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/PHPCode.js
@@ -116,7 +116,7 @@ pimcore.object.importcolumn.operator.phpcode = Class.create(pimcore.object.gridc
             width: 600,
             height: 300,
             modal: true,
-            title: t('operator_phpcode_settings'),
+            title: this.getDefaultText(),
             layout: "fit",
             items: [this.configPanel]
         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/Published.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/Published.js
@@ -109,7 +109,7 @@ pimcore.object.importcolumn.operator.published = Class.create(pimcore.object.gri
             width: 400,
             height: 300,
             modal: true,
-            title: t('settings'),
+            title: this.getDefaultText(),
             layout: "fit",
             items: [this.configPanel]
         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/Splitter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/Splitter.js
@@ -112,7 +112,7 @@ pimcore.object.importcolumn.operator.splitter = Class.create(pimcore.object.grid
             width: 400,
             height: 200,
             modal: true,
-            title: t('settings'),
+            title: this.getDefaultText(),
             layout: "fit",
             items: [this.configPanel]
         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/Unserialize.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/Unserialize.js
@@ -106,7 +106,7 @@ pimcore.object.importcolumn.operator.unserialize = Class.create(pimcore.object.g
             width: 400,
             height: 300,
             modal: true,
-            title: t('settings'),
+            title: this.getDefaultText(),
             layout: "fit",
             items: [this.configPanel]
         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/value/DefaultValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/value/DefaultValue.js
@@ -51,7 +51,7 @@ pimcore.object.importcolumn.value.defaultvalue = Class.create(pimcore.object.imp
                 label: source.data.text,
                 type: this.type,
                 class: this.class,
-                attribute: source.data.key,
+                attribute: source.data.name,
                 dataType: source.data.dataType
             }
         });

--- a/lib/DataObject/Import/ColumnConfig/Value/DefaultValue.php
+++ b/lib/DataObject/Import/ColumnConfig/Value/DefaultValue.php
@@ -61,8 +61,14 @@ class DefaultValue extends AbstractConfigElement implements ValueInterface
             $realAttribute = $this->attribute;
             $container = $target->getClass();
         } elseif ($target instanceof AbstractData) {
-            $realAttribute = $this->attribute;
-            $container = $target->getDefinition();
+            if (strpos($this->attribute, '~') !== false) {
+                $keyParts = explode('~', $this->attribute);
+                [$brickType, $realAttribute] = $keyParts;
+                $container = Definition::getByKey($brickType);
+            } else {
+                $realAttribute = $this->attribute;
+                $container = $target->getDefinition();
+            }
         }
 
         if (null === $container) {

--- a/lib/DataObject/Import/ColumnConfig/Value/DefaultValue.php
+++ b/lib/DataObject/Import/ColumnConfig/Value/DefaultValue.php
@@ -61,10 +61,8 @@ class DefaultValue extends AbstractConfigElement implements ValueInterface
             $realAttribute = $this->attribute;
             $container = $target->getClass();
         } elseif ($target instanceof AbstractData) {
-            $keyParts = explode('~', $this->attribute);
-            $brickType = $keyParts[0];
-            $realAttribute = $keyParts[1];
-            $container = Definition::getByKey($brickType);
+            $realAttribute = $this->attribute;
+            $container = $target->getDefinition();
         }
 
         if (null === $container) {


### PR DESCRIPTION
If I drag and drop a object brick field in the column tab of the csv import, the attribute fields are empty/incorrect and readonly.