### PR TITLE
[ADMIN] Token login links shouldn't contain the username

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/LoginController.php
+++ b/bundles/AdminBundle/Controller/Admin/LoginController.php
@@ -139,10 +139,9 @@ class LoginController extends AdminController implements BruteforceProtectedCont
             }
 
             if (!$error) {
-                $token = Authentication::generateToken($username, $user->getPassword());
+                $token = Authentication::generateToken($user->getName());
 
                 $loginUrl = $this->generateUrl('pimcore_admin_login_check', [
-                    'username' => $username,
                     'token' => $token,
                     'reset' => 'true'
                 ], UrlGeneratorInterface::ABSOLUTE_URL);

--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -936,11 +936,9 @@ class UserController extends AdminController implements EventedControllerInterfa
             ], Response::HTTP_FORBIDDEN);
         }
 
-        $token = Tool\Authentication::generateToken($user->getName(), $user->getPassword());
+        $token = Tool\Authentication::generateToken($user->getName());
         $link = $this->generateUrl('pimcore_admin_login_check', [
-            'username' => $user->getName(),
             'token' => $token,
-            'reset' => 'true'
         ], UrlGeneratorInterface::ABSOLUTE_URL);
 
         return $this->adminJson([
@@ -1143,10 +1141,8 @@ class UserController extends AdminController implements EventedControllerInterfa
                     $user->save();
                 }
 
-                $token = Tool\Authentication::generateToken($username, $user->getPassword());
-
+                $token = Tool\Authentication::generateToken($user->getName());
                 $loginUrl = $this->generateUrl('pimcore_admin_login_check', [
-                    'username' => $username,
                     'token' => $token,
                     'reset' => 'true'
                 ], UrlGeneratorInterface::ABSOLUTE_URL);

--- a/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
+++ b/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
@@ -149,11 +149,13 @@ class AdminAuthenticator extends AbstractGuardAuthenticator implements LoggerAwa
                     'password' => $password
                 ];
             } elseif ($token = $request->get('token')) {
+                $this->bruteforceProtectionHandler->checkProtection();
                 $credentials = [
                     'token' => $token,
                     'reset' => (bool) $request->get('reset', false)
                 ];
             } else {
+                $this->bruteforceProtectionHandler->checkProtection();
                 throw new AuthenticationException('Missing username or token');
             }
 

--- a/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
+++ b/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
@@ -142,11 +142,12 @@ class AdminAuthenticator extends AbstractGuardAuthenticator implements LoggerAwa
         $credentials = [];
 
         if ($request->attributes->get('_route') === 'pimcore_admin_login_check') {
-            if ($request->getMethod() === 'POST' && $password = $request->get('password') && $username = $request->get('username')) {
+            $username = $request->get('username');
+            if ($request->getMethod() === 'POST' && $request->get('password') && $username) {
                 $this->bruteforceProtectionHandler->checkProtection($username);
                 $credentials = [
                     'username' => $username,
-                    'password' => $password
+                    'password' => $request->get('password')
                 ];
             } elseif ($token = $request->get('token')) {
                 $this->bruteforceProtectionHandler->checkProtection();

--- a/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
+++ b/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
@@ -142,24 +142,19 @@ class AdminAuthenticator extends AbstractGuardAuthenticator implements LoggerAwa
         $credentials = [];
 
         if ($request->attributes->get('_route') === 'pimcore_admin_login_check') {
-            $username = $request->get('username');
-            if (null === $username) {
-                throw new AuthenticationException('Missing username');
-            }
-
-            $this->bruteforceProtectionHandler->checkProtection($username);
-
-            if ($request->getMethod() === 'POST' && $password = $request->get('password')) {
+            if ($request->getMethod() === 'POST' && $password = $request->get('password') && $username = $request->get('username')) {
+                $this->bruteforceProtectionHandler->checkProtection($username);
                 $credentials = [
                     'username' => $username,
                     'password' => $password
                 ];
             } elseif ($token = $request->get('token')) {
                 $credentials = [
-                    'username' => $username,
                     'token' => $token,
-                    'reset' => (bool)$request->get('reset', false)
+                    'reset' => (bool) $request->get('reset', false)
                 ];
+            } else {
+                throw new AuthenticationException('Missing username or token');
             }
 
             $event = new LoginCredentialsEvent($request, $credentials);
@@ -196,8 +191,8 @@ class AdminAuthenticator extends AbstractGuardAuthenticator implements LoggerAwa
                 $this->twoFactorRequired = true;
             }
         } else {
-            if (!isset($credentials['username'])) {
-                throw new AuthenticationException('Missing username');
+            if (!isset($credentials['username']) && !isset($credentials['token'])) {
+                throw new AuthenticationException('Missing username/token');
             }
 
             if (isset($credentials['password'])) {
@@ -217,7 +212,7 @@ class AdminAuthenticator extends AbstractGuardAuthenticator implements LoggerAwa
                     }
                 }
             } elseif (isset($credentials['token'])) {
-                $pimcoreUser = Authentication::authenticateToken($credentials['username'], $credentials['token']);
+                $pimcoreUser = Authentication::authenticateToken($credentials['token']);
 
                 if ($pimcoreUser) {
                     $user = new User($pimcoreUser);


### PR DESCRIPTION

Old link: `/admin/login/login?username=<username>&token=<token>`

New link: `/admin/login/login?token=<token>`