### PR TITLE
Omit mandatory check when an object is not to publish

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1716,6 +1716,9 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                     }
 
                     $object->setValues($objectData);
+                    if (!$data['published']) {
+                        $object->setOmitMandatoryCheck(true);
+                    }
 
                     $object->save();
 


### PR DESCRIPTION
 

## Changes in this pull request  
Resolves #

Pimcore doesn't allow to edit an object with empty required fields, directly from the grid even if the user doesn't want to publish changes, but only save.

![image](https://user-images.githubusercontent.com/17409731/68110071-72024880-feec-11e9-9d8d-34769a581115.png)

After below changes editing and saving from the grid is possible. 

