### PR TITLE
Transfer elementType on cloning / copying calculated value field

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/calculatedValue.js
@@ -96,7 +96,8 @@ pimcore.object.classes.data.calculatedValue = Class.create(pimcore.object.classe
             }
             Ext.apply(this.datax,
                 {
-                    calculatorClass: source.datax.calculatorClass
+                    calculatorClass: source.datax.calculatorClass,
+                    elementType: source.datax.elementType
                 });
         }
     }


### PR DESCRIPTION
Currently when you copy or clone a calculated value field its element type (input or textarea) does not get copied. This PR fixes that.