### PR TITLE
[Document] Fix: Tags getElement method returns only saved data

### DIFF
--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -344,7 +344,7 @@ abstract class PageSnippet extends Model\Document
                 $this->elements[$name] = $element;
                 $this->elements[$name]->setDataFromEditmode($data);
                 $this->elements[$name]->setName($name);
-                $this->elements[$name]->setDocumentId($this->getId());
+                $this->elements[$name]->setDocument($this);
             }
         } catch (\Exception $e) {
             Logger::warning("can't set element " . $name . ' with the type ' . $type . ' to the document: ' . $this->getRealFullPath());

--- a/models/Document/PageSnippet/Dao.php
+++ b/models/Document/PageSnippet/Dao.php
@@ -50,7 +50,7 @@ abstract class Dao extends Model\Document\Dao
             /** @var Document\Tag $element */
             $element = $loader->build($elementRaw['type']);
             $element->setName($elementRaw['name']);
-            $element->setDocumentId($this->model->getId());
+            $element->setDocument($this->model);
             $element->setDataFromResource($elementRaw['data']);
 
             $elements[$elementRaw['name']] = $element;

--- a/models/Document/Tag.php
+++ b/models/Document/Tag.php
@@ -70,6 +70,13 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
     protected $documentId;
 
     /**
+     * Element belongs to the document
+     *
+     * @var Document\PageSnippet
+     */
+    protected $document;
+
+    /**
      * @deprecated Unused - will be removed in 7.0
      *
      * @var null
@@ -343,6 +350,31 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
     public function getDocumentId()
     {
         return $this->documentId;
+    }
+
+    /**
+     * @param Document\PageSnippet $document
+     *
+     * @return $this
+     */
+    public function setDocument(Document\PageSnippet $document)
+    {
+        $this->document = $document;
+        $this->documentId = (int) $document->getId();
+
+        return $this;
+    }
+
+    /**
+     * @return Document\PageSnippet
+     */
+    public function getDocument()
+    {
+        if (!$this->document) {
+            $this->document = Document\PageSnippet::getById($this->documentId);
+        }
+
+        return $this->document;
     }
 
     /**

--- a/models/Document/Tag.php
+++ b/models/Document/Tag.php
@@ -341,6 +341,10 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
     {
         $this->documentId = (int) $id;
 
+        if ($this->document instanceof PageSnippet && $this->document->getId() !== $this->documentId) {
+            $this->document = null;
+        }
+
         return $this;
     }
 

--- a/models/Document/Tag.php
+++ b/models/Document/Tag.php
@@ -631,6 +631,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
 
         unset($el['dao']);
         unset($el['documentId']);
+        unset($el['document']);
         unset($el['controller']);
         unset($el['view']);
         unset($el['editmode']);

--- a/models/Document/Tag.php
+++ b/models/Document/Tag.php
@@ -479,11 +479,11 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
      */
     public function __sleep()
     {
+        $finalVars = [];
+        $parentVars = parent::__sleep();
+        $blockedVars = ['controller', 'view', 'editmode', 'options', 'parentBlockNames', 'document'];
 
-        // here the "normal" task of __sleep ;-)
-        $blockedVars = ['dao', 'controller', 'view', 'editmode', 'options', 'parentBlockNames'];
-        $vars = get_object_vars($this);
-        foreach ($vars as $key => $value) {
+        foreach ($parentVars as $key) {
             if (!in_array($key, $blockedVars)) {
                 $finalVars[] = $key;
             }

--- a/models/Document/Tag/Area.php
+++ b/models/Document/Tag/Area.php
@@ -156,7 +156,7 @@ class Area extends Model\Document\Tag
      */
     public function getElement(string $name)
     {
-        $document = Model\Document\Page::getById($this->getDocumentId());
+        $document = $this->getDocument();
         $namingStrategy = \Pimcore::getContainer()->get('pimcore.document.tag.naming.strategy');
 
         $parentBlockNames = $this->getParentBlockNames();

--- a/models/Document/Tag/Area/Info.php
+++ b/models/Document/Tag/Area/Info.php
@@ -219,7 +219,7 @@ class Info
         if ($this->view && isset($this->view->document)) {
             $document = $this->view->document;
         } else {
-            $document = Document::getById($this->tag->getDocumentId());
+            $document = $this->tag->getDocument();
         }
 
         return $document;

--- a/models/Document/Tag/Areablock.php
+++ b/models/Document/Tag/Areablock.php
@@ -604,7 +604,7 @@ class Areablock extends Model\Document\Tag implements BlockInterface
      */
     public function getElement(string $name)
     {
-        $document = Model\Document::getById($this->getDocumentId());
+        $document = $this->getDocument();
 
         $parentBlockNames = $this->getParentBlockNames();
         $parentBlockNames[] = $this->getName();

--- a/models/Document/Tag/Block.php
+++ b/models/Document/Tag/Block.php
@@ -374,7 +374,7 @@ class Block extends Model\Document\Tag implements BlockInterface
      */
     public function getElements()
     {
-        $document = Model\Document::getById($this->getDocumentId());
+        $document = $this->getDocument();
 
         $parentBlockNames = $this->getParentBlockNames();
         $parentBlockNames[] = $this->getName();

--- a/models/Document/Tag/Link.php
+++ b/models/Document/Tag/Link.php
@@ -288,7 +288,7 @@ class Link extends Model\Document\Tag
                                 $this->data['path'] = $linkGenerator->generate(
                                     $object,
                                     [
-                                        'document' => Document::getById($this->getDocumentId()),
+                                        'document' => $this->getDocument(),
                                         'context' => $this,
                                     ]
                                 );
@@ -588,13 +588,13 @@ class Link extends Model\Document\Tag
                     $referencedDocument = Document::getById($this->data['internalId']);
                     if (!$referencedDocument instanceof Document) {
                         //detected broken link
-                        $document = Document::getById($this->getDocumentId());
+                        $document = $this->getDocument();
                     }
                 } elseif ($this->data['internalType'] == 'asset') {
                     $referencedAsset = Asset::getById($this->data['internalId']);
                     if (!$referencedAsset instanceof Asset) {
                         //detected broken link
-                        $document = Document::getById($this->getDocumentId());
+                        $document = $this->getDocument();
                     }
                 }
             }

--- a/models/Document/Tag/Scheduledblock.php
+++ b/models/Document/Tag/Scheduledblock.php
@@ -244,7 +244,7 @@ class Scheduledblock extends Block implements BlockInterface
      */
     public function getElements()
     {
-        $document = Model\Document\Page::getById($this->getDocumentId());
+        $document = $this->getDocument();
 
         $parentBlockNames = $this->getParentBlockNames();
         $parentBlockNames[] = $this->getName();

--- a/models/Document/Tag/Wysiwyg.php
+++ b/models/Document/Tag/Wysiwyg.php
@@ -59,7 +59,7 @@ class Wysiwyg extends Model\Document\Tag
      */
     public function getDataEditmode()
     {
-        $document = Model\Document::getById($this->getDocumentId());
+        $document = $this->getDocument();
 
         return Text::wysiwygText($this->text, [
             'document' => $document,
@@ -74,7 +74,7 @@ class Wysiwyg extends Model\Document\Tag
      */
     public function frontend()
     {
-        $document = Model\Document::getById($this->getDocumentId());
+        $document = $this->getDocument();
 
         return Text::wysiwygText($this->text, [
                 'document' => $document,


### PR DESCRIPTION
I have an areablock with items. These items have editables like an input.
In the moment it is impossible to get the current data from this input in the controller.
Because the getElement method loads the saved version of the document.

I add a setDocument and getDocument method. So we can use the modified document.
