### PR TITLE
[ClassificationStore] - add given group to active groups

### DIFF
--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -189,6 +189,9 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
 
         $keyConfig = Model\DataObject\Classificationstore\DefinitionCache::get($keyId);
         $dataDefinition = Model\DataObject\Classificationstore\Service::getFieldDefinitionFromKeyConfig($keyConfig);
+        
+        // set the given group to active groups
+        $this->setActiveGroups($this->activeGroups + [$groupId => true]);
 
         if (!$this->isFieldDirty('_self')) {
             if ($this->object) {


### PR DESCRIPTION
adds the given group to active groups in case setLocalizedKeyValue is called. this is useful whenever you  are inserting values via php api

not sure if we should add a check if the given group really exists there too. what do you think @weisswurstkanone 
