### PR TITLE
[ClassificationStore] - don't output data of non active groups

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -207,6 +207,9 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
         $items = $data->getItems();
 
         foreach ($items  as $groupId => $keys) {
+            if (!isset($data->getActiveGroups()[$groupId])) {
+                continue;
+            }
             foreach ($keys as $keyId => $languages) {
                 $keyConfig = DataObject\Classificationstore\DefinitionCache::get($keyId);
                 if ($keyConfig->getEnabled()) {
@@ -417,6 +420,9 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
         $items = $classificationStore->getItems();
         if ($items) {
             foreach ($items as $groupId => $keys) {
+                if (!isset($data->getActiveGroups()[$groupId])) {
+                    continue;
+                }
                 foreach ($keys as $keyId => $values) {
                     $keyConfig = $this->getKeyConfiguration($keyId);
                     $fieldDefinition = DataObject\Classificationstore\Service::getFieldDefinitionFromKeyConfig($keyConfig);
@@ -486,6 +492,9 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
             $items = $data->getItems();
 
             foreach ($items as $groupId => $groupData) {
+                if (!isset($activeGroups[$groupId])) {
+                    continue;
+                }
                 $groupResult = [];
 
                 foreach ($groupData as $keyId => $keyData) {

--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -418,9 +418,10 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
         $getter = 'get' . ucfirst($this->getName());
         $classificationStore = $object->$getter();
         $items = $classificationStore->getItems();
+        $activeGroups = $classificationStore->getActiveGroups();
         if ($items) {
             foreach ($items as $groupId => $keys) {
-                if (!isset($data->getActiveGroups()[$groupId])) {
+                if (!isset($activeGroups[$groupId])) {
                     continue;
                 }
                 foreach ($keys as $keyId => $values) {


### PR DESCRIPTION
there may be data for a specific classification store key in the object_classificationstore_data_X table although the refered group in this table is not among the active groups.

in this case data should not be put out for editmode/webserviceexport/searchindex

this pr checks if a group is among said active groups and only then outputs the referring value

@weisswurstkanone 