### PR TITLE
[Data objects] Enable text selection for version data

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/versions.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/versions.js
@@ -126,7 +126,8 @@ pimcore.object.versions = Class.create({
                     mode: 'MULTI'
                 }),
                 viewConfig: {
-                    xtype: 'patchedgridview'
+                    xtype: 'patchedgridview',
+                    enableTextSelection: true
                 }
             });
 


### PR DESCRIPTION
In the versions tab sometimes it would be useful to be able to copy the timestamp of a certain version. This PR makes this possible.