### PR TITLE
Move ss option of ffmpeg to the beginning

### DIFF
--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -180,7 +180,7 @@ class Ffmpeg extends Adapter
             $file = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/ffmpeg-tmp-' . uniqid() . '.' . File::getFileExtension($file);
         }
 
-        $cmd = self::getFfmpegCli() . ' -i ' . escapeshellarg(realpath($this->file)) . ' -vcodec png -vframes 1 -vf scale=iw*sar:ih -ss ' . $timeOffset . ' ' . escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, $file));
+        $cmd = self::getFfmpegCli() . ' -ss ' . $timeOffset . ' -i ' . escapeshellarg(realpath($this->file)) . ' -vcodec png -vframes 1 -vf scale=iw*sar:ih ' . escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, $file));
         Console::exec($cmd, null, 60);
 
         if ($realTargetPath) {


### PR DESCRIPTION
Helps to avoid longer encoding times, see [https://www.nrg-media.de/2010/11/creating-screenshots-with-ffmpeg-is-slow/](https://www.nrg-media.de/2010/11/creating-screenshots-with-ffmpeg-is-slow/)

This one appears on large local video files, in my case it was an full-HD *.wmv. When picking a frame to generate a preview it would take more time, the higher the time offset is.

**how to reproduce:**
Click "Use current position as preview" on a long bing video file with a big offset (e.g. > 300)
