### PR TITLE
[Assets, Documents] Do not load listing data on Asset::getList() / Document::getList()

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -26,6 +26,7 @@ use Pimcore\Logger;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Tool\Mime;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Pimcore\Model\Asset\Listing;
 
 /**
  * @method \Pimcore\Model\Asset\Dao getDao()
@@ -381,15 +382,16 @@ class Asset extends Element\AbstractElement
      */
     public static function getList($config = [])
     {
-        if (is_array($config)) {
-            $listClass = 'Pimcore\\Model\\Asset\\Listing';
-
-            $list = self::getModelFactory()->build($listClass);
-            $list->setValues($config);
-            $list->load();
-
-            return $list;
+        if(!\is_array($config)) {
+            throw new \Exception('Unable to initiate list class - please provide valid configuration array');
         }
+
+        $listClass = Listing::class;
+
+        $list = self::getModelFactory()->build($listClass);
+        $list->setValues($config);
+
+        return $list;
     }
 
     /**
@@ -399,14 +401,10 @@ class Asset extends Element\AbstractElement
      */
     public static function getTotalCount($config = [])
     {
-        if (is_array($config)) {
-            $listClass = 'Pimcore\\Model\\Asset\\Listing';
-            $list = self::getModelFactory()->build($listClass);
-            $list->setValues($config);
-            $count = $list->getTotalCount();
+        $list = static::getList($config);
+        $count = $list->getTotalCount();
 
-            return $count;
-        }
+        return $count;
     }
 
     /**

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -384,28 +384,10 @@ class AbstractObject extends Model\Element\AbstractElement
      */
     public static function getTotalCount($config = [])
     {
-        $className = DataObject::class;
-        // get classname
-        if (!in_array(static::class, [__CLASS__, Concrete::class], true)) {
-            $tmpObject = new static();
-            $className = 'Pimcore\\Model\\DataObject\\' . ucfirst($tmpObject->getClassName());
-        }
+        $list = static::getList($config);
+        $count = $list->getTotalCount();
 
-        if (!empty($config['class'])) {
-            $className = ltrim($config['class'], '\\');
-        }
-
-        if (is_array($config)) {
-            if ($className) {
-                $listClass = ucfirst($className) . '\\Listing';
-                $list = self::getModelFactory()->build($listClass);
-            }
-
-            $list->setValues($config);
-            $count = $list->getTotalCount();
-
-            return $count;
-        }
+        return $count;
     }
 
     /**

--- a/models/Document.php
+++ b/models/Document.php
@@ -349,15 +349,14 @@ class Document extends Element\AbstractElement
     public static function getList($config = [])
     {
         if (is_array($config)) {
-            $listClass = 'Pimcore\\Model\\Document\\Listing';
+            $listClass = Listing::class;
             $list = self::getModelFactory()->build($listClass);
             $list->setValues($config);
-            $list->load();
 
             return $list;
         }
 
-        throw new \Exception('Unable to initiate list class - class not found or invalid configuration');
+        throw new \Exception('Unable to initiate list class - please provide valid configuration array');
     }
 
     /**
@@ -369,14 +368,10 @@ class Document extends Element\AbstractElement
      */
     public static function getTotalCount($config = [])
     {
-        if (is_array($config)) {
-            $listClass = 'Pimcore\\Model\\Document\\Listing';
-            $list = self::getModelFactory()->build($listClass);
-            $list->setValues($config);
-            $count = $list->getTotalCount();
+        $list = static::getList($config);
+        $count = $list->getTotalCount();
 
-            return $count;
-        }
+        return $count;
     }
 
     /**


### PR DESCRIPTION
Currently when you call Asset::getList() or Document::getList() the listing object is not only generated but also its items get loaded. This makes it impossible to have something like
```php
$listing = Asset::getList();
$listing->addConditionParam('type != "folder"');

// without this PR listing's items contain also assets with type="folder" 
// because Listing::load() is already executed in Asset::getList()
// thus any change to the listing parameters afterwards will be ignored
foreach($listing as $asset) {
 ...
}
```
For documents applies the same.

This is especially a bug as it is possible to modify a data object listing object after having it created via `AbstractObject::getList()`.