### PR TITLE
Fix: deleting element containing pimcore_areablock

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tags/areablock.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tags/areablock.js
@@ -282,7 +282,7 @@ pimcore.document.tags.areablock = Class.create(pimcore.document.tag, {
         // click outside, hide all block buttons
         if(this.options['controlsTrigger'] === 'hover') {
             Ext.getBody().on('click', function (event) {
-                if (!Ext.get(id).isAncestor(event.target)) {
+                if (Ext.get(id) && !Ext.get(id).isAncestor(event.target)) {
                     Ext.get(id).query('.pimcore_area_buttons', false).forEach(function (el) {
                         el.hide();
                     });


### PR DESCRIPTION
Reproduce:
 * Create a brick containing a pimcore_areablock('ident')
 * Insert any brick in the newly generated brick
 * delete the parent brick containing the pimcore_areablock

=> Cannot read isAncestor of 'null'

Fix: inserted check if 
```
Ext.get(id) 
```
gets an element at all

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

