### PR TITLE
[Class definition] Show unique checkbox for newly created fields

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
@@ -96,7 +96,7 @@ pimcore.object.classes.data.data = Class.create({
             disabled: !in_array("unique",this.availableSettingsFields),
             autoEl: {
                 tag: 'div',
-                'data-qtip': t('unique')
+                'data-qtip': t('unique_qtip')
             },
             hidden: true
         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
@@ -84,7 +84,8 @@ pimcore.object.classes.data.data = Class.create({
             name: "index",
             itemId: "index",
             checked: this.datax.index,
-            disabled: !in_array("index",this.availableSettingsFields)
+            disabled: !in_array("index",this.availableSettingsFields),
+            hidden: true
         });
 
         var uniqueCheckbox = new Ext.form.field.Checkbox({
@@ -96,7 +97,8 @@ pimcore.object.classes.data.data = Class.create({
             autoEl: {
                 tag: 'div',
                 'data-qtip': t('unique')
-            }
+            },
+            hidden: true
         });
 
         this.mandatoryCheckbox = new Ext.form.field.Checkbox({
@@ -197,6 +199,11 @@ pimcore.object.classes.data.data = Class.create({
                 checked: this.datax.visibleSearch,
                 disabled: !in_array("visibleSearch",this.availableSettingsFields)
             });
+
+            indexCheckbox.setHidden(false);
+            if (in_array("unique",this.availableSettingsFields)) {
+                uniqueCheckbox.setHidden(false);
+            }
         }
 
         var layoutSettings = [

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
@@ -84,8 +84,7 @@ pimcore.object.classes.data.data = Class.create({
             name: "index",
             itemId: "index",
             checked: this.datax.index,
-            disabled: !in_array("index",this.availableSettingsFields),
-            hidden: true
+            disabled: !in_array("index",this.availableSettingsFields)
         });
 
         var uniqueCheckbox = new Ext.form.field.Checkbox({
@@ -93,7 +92,11 @@ pimcore.object.classes.data.data = Class.create({
             name: "unique",
             itemId: "unique",
             checked: this.datax.unique,
-            hidden: true
+            disabled: !in_array("unique",this.availableSettingsFields),
+            autoEl: {
+                tag: 'div',
+                'data-qtip': t('unique')
+            }
         });
 
         this.mandatoryCheckbox = new Ext.form.field.Checkbox({
@@ -194,13 +197,6 @@ pimcore.object.classes.data.data = Class.create({
                 checked: this.datax.visibleSearch,
                 disabled: !in_array("visibleSearch",this.availableSettingsFields)
             });
-
-            indexCheckbox.setHidden(false);
-            if (this.datax.hasOwnProperty("unique")) {
-                uniqueCheckbox.setHidden(false);
-                Ext.QuickTips.init();
-                Ext.QuickTips.register({target:  uniqueCheckbox, text: t("unique")});
-            }
         }
 
         var layoutSettings = [


### PR DESCRIPTION
Currently there is the following bug:
1. Create class
1. Create field of type `input` (but the bug happens for all fields which support a unique index)
1. In the field's properties on the right panel there is no `unique` checkbox

This PR solves this.
I wonder what the tooltip is good for:
https://github.com/pimcore/pimcore/blob/b42962724ab4f1d8343e2afea5bab854c462350e/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js#L201-L202
While it currently does not even work (at least I have not seen any tooltip on hovering the checkbox), I wonder why `t("unique")` should be shown as tooltip while this is already the checkbox's label. Is there a translation missing which shall explain what `unique` means?