### PR TITLE
[UI][User] "Copy to clipboard" feature for "Login as this user" dialog

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
@@ -426,8 +426,22 @@ pimcore.settings.user.user.settings = Class.create({
                     success: function (response) {
                         var res = Ext.decode(response.responseText);
                         if (res["link"]) {
-                            Ext.MessageBox.alert("", t("login_as_this_user_description")
-                                + ' <br /><br /><textarea style="width:100%;height:70px;">' + res["link"] + "</textarea>");
+                            Ext.MessageBox.show({
+                                title: t("login_as_this_user"),
+                                msg: t("login_as_this_user_description")
+                                    + '<br /><br /><textarea style="width:100%;height:90px;" readonly="readonly">' + res["link"] + "</textarea>",
+                                buttons: Ext.MessageBox.YESNO,
+                                buttonText: {
+                                    yes: t("copy") + ' & ' + t("close"),
+                                    no: t("close")
+                                },
+                                scope: this,
+                                fn: function (result) {
+                                    if (result === 'yes') {
+                                        pimcore.helpers.copyStringToClipboard(res["link"]);
+                                    }
+                                }
+                            });
                         }
                     },
                     failure: function (response) {


### PR DESCRIPTION
This PR brings a new button "Copy & Close" to the "Login as this user" dialog, so the user isn't required to select & copy the URL.

Also included are minor changes such as
* Meaningful alert title
* Increased textarea height so URL will usually fit
* Make textarea readonly, as changing the value doesn't make sense