### PR TITLE
[Data objects] Truncate unique fields on copying

### DIFF
--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -115,7 +115,7 @@ class Service extends Model\Element\Service
      * @param AbstractObject $target
      * @param AbstractObject $source
      *
-     * @return mixed
+     * @return AbstractObject
      */
     public function copyRecursive($target, $source)
     {
@@ -131,9 +131,7 @@ class Service extends Model\Element\Service
         //load all in case of lazy loading fields
         self::loadAllObjectFields($source);
 
-        /**
-         * @var AbstractObject $new
-         */
+        /** @var Concrete $new */
         $new = Element\Service::cloneMe($source);
         $new->setId(null);
         $new->setChildren(null);
@@ -144,6 +142,14 @@ class Service extends Model\Element\Service
         $new->setDao(null);
         $new->setLocked(false);
         $new->setCreationDate(time());
+
+        foreach($new->getClass()->getFieldDefinitions() as $fieldDefinition) {
+            if($fieldDefinition->getUnique()) {
+                $new->set($fieldDefinition->getName(), null);
+                $new->setPublished(false);
+            }
+        }
+
         $new->save();
 
         // add to store
@@ -202,6 +208,7 @@ class Service extends Model\Element\Service
         foreach($new->getClass()->getFieldDefinitions() as $fieldDefinition) {
             if($fieldDefinition->getUnique()) {
                 $new->set($fieldDefinition->getName(), null);
+                $new->setPublished(false);
             }
         }
 

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -115,7 +115,7 @@ class Service extends Model\Element\Service
      * @param AbstractObject $target
      * @param AbstractObject $source
      *
-     * @return AbstractObject
+     * @return AbstractObject|void
      */
     public function copyRecursive($target, $source)
     {

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -177,8 +177,8 @@ class Service extends Model\Element\Service
      */
     public function copyAsChild($target, $source)
     {
-        $isDirtyDetectionDisabled = Model\DataObject\AbstractObject::isDirtyDetectionDisabled();
-        Model\DataObject\AbstractObject::setDisableDirtyDetection(true);
+        $isDirtyDetectionDisabled = AbstractObject::isDirtyDetectionDisabled();
+        AbstractObject::setDisableDirtyDetection(true);
 
         //load properties
         $source->getProperties();
@@ -186,6 +186,7 @@ class Service extends Model\Element\Service
         //load all in case of lazy loading fields
         self::loadAllObjectFields($source);
 
+        /** @var Concrete $new */
         $new = Element\Service::cloneMe($source);
         $new->setId(null);
 
@@ -197,9 +198,16 @@ class Service extends Model\Element\Service
         $new->setDao(null);
         $new->setLocked(false);
         $new->setCreationDate(time());
+
+        foreach($new->getClass()->getFieldDefinitions() as $fieldDefinition) {
+            if($fieldDefinition->getUnique()) {
+                $new->set($fieldDefinition->getName(), null);
+            }
+        }
+
         $new->save();
 
-        Model\DataObject\AbstractObject::setDisableDirtyDetection($isDirtyDetectionDisabled);
+        AbstractObject::setDisableDirtyDetection($isDirtyDetectionDisabled);
 
         $this->updateChildren($target, $new);
 

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -31,6 +31,7 @@ use Pimcore\Model\Dependency;
 use Pimcore\Model\Document;
 use Pimcore\Tool;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Doctrine\Common\Collections\Collection;
 
 /**
  * @method \Pimcore\Model\Element\Dao getDao()
@@ -1128,7 +1129,9 @@ class Service extends Model\AbstractModel
         $deepCopy->addFilter(new SetNullFilter(), new PropertyNameMatcher('dao'));
         $deepCopy->addFilter(new SetNullFilter(), new PropertyNameMatcher('resource'));
         $deepCopy->addFilter(new SetNullFilter(), new PropertyNameMatcher('writeResource'));
-        $deepCopy->addFilter(new \DeepCopy\Filter\Doctrine\DoctrineCollectionFilter(), new \DeepCopy\Matcher\PropertyTypeMatcher('Doctrine\Common\Collections\Collection'));
+        $deepCopy->addFilter(new \DeepCopy\Filter\Doctrine\DoctrineCollectionFilter(), new \DeepCopy\Matcher\PropertyTypeMatcher(
+            Collection::class
+        ));
 
         if ($element instanceof DataObject\Concrete) {
             DataObject\Service::loadAllObjectFields($element);


### PR DESCRIPTION
Resolves #4333 

This PR truncates unique fields on pasting an object because such objects could otherwise not be saved.
It also unpublishes the object if it has unique fields because otherwise it could not be saved if the unique field was also mandatory - and also to show the user that it was not a 1:1 copy but something was modified.