### PR TITLE
Move Symfony toolbar trigger to left navigation bar

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/admin.css
+++ b/bundles/AdminBundle/Resources/public/css/admin.css
@@ -2282,3 +2282,15 @@ ul.leaflet-draw-actions.leaflet-draw-actions-top.leaflet-draw-actions-bottom li:
 }
 
 /** END notifications **/
+
+.x-body .sf-minitoolbar {
+    left:0;
+    right:auto;
+    bottom: 200px;
+    background: #0C0F12;
+    text-align: center;
+}
+
+.x-body .sf-minitoolbar a {
+    width: 48px;
+}

--- a/bundles/AdminBundle/Resources/views/Admin/Login/login.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/Login/login.html.php
@@ -82,6 +82,12 @@ if ($browser->getBrowser() == \Pimcore\Browser::BROWSER_OPERA && $browserVersion
     // clear opened tabs store
     localStorage.removeItem("pimcore_opentabs");
     <?php } ?>
+
+    // hide symfony toolbar by default
+    var symfonyToolbarKey = 'symfony/profiler/toolbar/displayState';
+    if(!window.localStorage.getItem(symfonyToolbarKey)) {
+        window.localStorage.setItem(symfonyToolbarKey, 'none');
+    }
 </script>
 
 <?php $view->slots()->stop() ?>


### PR DESCRIPTION
... and should be closed by default


![image](https://user-images.githubusercontent.com/142037/68774452-6bcb4500-062d-11ea-9dda-ecc2e794a7d5.png)
