### PR TITLE
Fix: Don't call jQuery.noConflict

### DIFF
--- a/bundles/CoreBundle/EventListener/Frontend/EditmodeListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/EditmodeListener.php
@@ -241,7 +241,6 @@ class EditmodeListener implements EventSubscriberInterface
         }
 
         $headHtml .= "\n\n";
-        $headHtml .= '<script>var jQueryPreviouslyLoaded = (typeof jQuery == "undefined") ? false : true;</script>' . "\n";
 
         // include script libraries
         foreach ($libraries as $script) {
@@ -271,10 +270,6 @@ class EditmodeListener implements EventSubscriberInterface
         $headHtml .= '<script>
             var editableConfigurations = new Array();
             var pimcore_document_id = ' . $document->getId() . ';
-
-            if(jQueryPreviouslyLoaded) {
-                jQuery.noConflict( true );
-            }
         </script>';
 
         $headHtml .= "\n\n<!-- /pimcore editmode -->\n\n\n";


### PR DESCRIPTION
We use jQuery in the frontend.

Now we get in the editmode following exceptions and all JS is broken:
`Uncaught TypeError: $ is not a function`

I think its a regression from https://github.com/pimcore/pimcore/pull/5222