### PR TITLE
Fix: exception  'undefined index google' on running tests

### DIFF
--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Pimcore
+ * Pimcore.
  *
  * This source file is available under two different licenses:
  * - GNU General Public License version 3 (GPLv3)
@@ -34,7 +34,7 @@ class Cache
     }
 
     /**
-     * Get the cache handler implementation
+     * Get the cache handler implementation.
      *
      * @return CoreHandlerInterface
      */
@@ -55,7 +55,8 @@ class Cache
         if (\Pimcore::hasKernel()) {
             \Pimcore::getContainer()
                 ->get('event_dispatcher')
-                ->dispatch(CoreCacheEvents::INIT, new Event());
+                ->dispatch(new Event(), CoreCacheEvents::INIT)
+    ;
 
             if (isset($_REQUEST['pimcore_nocache']) && \Pimcore::inDebugMode()) {
                 self::getHandler()->disable();
@@ -64,7 +65,7 @@ class Cache
     }
 
     /**
-     * Returns the content of the requested cache entry
+     * Returns the content of the requested cache entry.
      *
      * @param string $key
      *
@@ -76,14 +77,14 @@ class Cache
     }
 
     /**
-     * Save an item to the cache (deferred to shutdown if force is false and forceImmediateWrite is not set)
+     * Save an item to the cache (deferred to shutdown if force is false and forceImmediateWrite is not set).
      *
-     * @param mixed $data
-     * @param string $key
-     * @param array $tags
-     * @param int|\DateInterval|null $lifetime
-     * @param int $priority
-     * @param bool $force
+     * @param mixed                  $data
+     * @param string                 $key
+     * @param array                  $tags
+     * @param null|\DateInterval|int $lifetime
+     * @param int                    $priority
+     * @param bool                   $force
      *
      * @return bool
      */
@@ -93,7 +94,7 @@ class Cache
     }
 
     /**
-     * Remove an item from the cache
+     * Remove an item from the cache.
      *
      * @param $key
      *
@@ -105,7 +106,7 @@ class Cache
     }
 
     /**
-     * Empty the cache
+     * Empty the cache.
      *
      * @return bool
      */
@@ -115,7 +116,7 @@ class Cache
     }
 
     /**
-     * Removes entries from the cache matching the given tag
+     * Removes entries from the cache matching the given tag.
      *
      * @param string $tag
      *
@@ -127,7 +128,7 @@ class Cache
     }
 
     /**
-     * Removes entries from the cache matching the given tags
+     * Removes entries from the cache matching the given tags.
      *
      * @param array $tags
      *
@@ -143,7 +144,7 @@ class Cache
     }
 
     /**
-     * Adds a tag to the shutdown queue
+     * Adds a tag to the shutdown queue.
      *
      * @param string $tag
      */
@@ -163,7 +164,7 @@ class Cache
     }
 
     /**
-     * Remove tag from the list ignored on save
+     * Remove tag from the list ignored on save.
      *
      * @param string $tag
      */
@@ -173,7 +174,7 @@ class Cache
     }
 
     /**
-     * Add tag to the list ignored on clear. Tags in this list won't be cleared via clearTags()
+     * Add tag to the list ignored on clear. Tags in this list won't be cleared via clearTags().
      *
      * @param string $tag
      */
@@ -183,7 +184,7 @@ class Cache
     }
 
     /**
-     * Remove tag from the list ignored on clear
+     * Remove tag from the list ignored on clear.
      *
      * @param string $tag
      */
@@ -193,7 +194,7 @@ class Cache
     }
 
     /**
-     * Write and clean up cache
+     * Write and clean up cache.
      *
      * @param bool $forceWrite
      */
@@ -203,7 +204,7 @@ class Cache
     }
 
     /**
-     * Disables the complete pimcore cache
+     * Disables the complete pimcore cache.
      */
     public static function disable()
     {
@@ -211,7 +212,7 @@ class Cache
     }
 
     /**
-     * Enables the pimcore cache
+     * Enables the pimcore cache.
      */
     public static function enable()
     {

--- a/lib/Cache/Core/EventDispatchingCoreHandler.php
+++ b/lib/Cache/Core/EventDispatchingCoreHandler.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Pimcore
+ * Pimcore.
  *
  * This source file is available under two different licenses:
  * - GNU General Public License version 3 (GPLv3)
@@ -28,7 +28,7 @@ class EventDispatchingCoreHandler extends CoreHandler
     protected $dispatcher;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function __construct(PimcoreCacheItemPoolInterface $adapter, WriteLockInterface $writeLock, EventDispatcherInterface $dispatcher)
     {
@@ -38,7 +38,7 @@ class EventDispatchingCoreHandler extends CoreHandler
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function enable()
     {
@@ -48,7 +48,7 @@ class EventDispatchingCoreHandler extends CoreHandler
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function disable()
     {
@@ -58,20 +58,7 @@ class EventDispatchingCoreHandler extends CoreHandler
     }
 
     /**
-     * @param bool $enabled
-     */
-    protected function setEnabled($enabled)
-    {
-        $this->dispatcher->dispatch(
-            $this->isEnabled()
-                ? CoreCacheEvents::ENABLE
-                : CoreCacheEvents::DISABLE,
-            new Event()
-        );
-    }
-
-    /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function purge()
     {
@@ -81,5 +68,18 @@ class EventDispatchingCoreHandler extends CoreHandler
         $this->dispatcher->dispatch(CoreCacheEvents::PURGE, $purgeEvent);
 
         return $purgeEvent->getResult();
+    }
+
+    /**
+     * @param bool $enabled
+     */
+    protected function setEnabled($enabled)
+    {
+        $this->dispatcher->dispatch(
+            new Event(),
+            $this->isEnabled()
+                ? CoreCacheEvents::ENABLE
+                : CoreCacheEvents::DISABLE
+        );
     }
 }

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -263,6 +263,22 @@ class Config
         return $config;
     }
 
+    private static function getArrayValueSave($keys, $array)
+    {
+        $len = count($keys);
+        $pointer = $array;
+        for ($i = 0; $i < $len; $i++) {
+            $key = $keys[$i];
+            if (array_key_exists($key, $pointer)) {
+                $pointer = $pointer[$key];
+            } else {
+                return null;
+            }
+        }
+
+        return $pointer;
+    }
+
     /**
      * @param $config
      *
@@ -276,132 +292,132 @@ class Config
             //legacy system configuration mapping
             $systemConfig = new \Pimcore\Config\Config([
                 'general' => [
-                    'timezone' => $config['general']['timezone'],
-                    'path_variable' => $config['general']['path_variable'],
-                    'domain' => $config['general']['domain'],
-                    'redirect_to_maindomain' => $config['general']['redirect_to_maindomain'],
-                    'language' => $config['general']['language'],
-                    'validLanguages' => $config['general']['valid_languages'],
-                    'fallbackLanguages' => $config['general']['fallback_languages'],
-                    'defaultLanguage' => $config['general']['default_language'],
-                    'loginscreencustomimage' => $config['branding']['login_screen_custom_image'],
-                    'disableusagestatistics' => $config['general']['disable_usage_statistics'],
-                    'debug_admin_translations' => $config['general']['debug_admin_translations'],
-                    'instanceIdentifier' => $config['general']['instance_identifier'],
-                    'show_cookie_notice' => $config['general']['show_cookie_notice']
+                    'timezone' => self::getArrayValueSave(['general', 'timezone'], $config),
+                    'path_variable' => self::getArrayValueSave(['general', 'path_variable'], $config),
+                    'domain' => self::getArrayValueSave(['general', 'domain'], $config),
+                    'redirect_to_maindomain' => self::getArrayValueSave(['general', 'redirect_to_maindomain'], $config),
+                    'language' => self::getArrayValueSave(['general', 'language'], $config),
+                    'validLanguages' => self::getArrayValueSave(['general', 'valid_languages'], $config),
+                    'fallbackLanguages' => self::getArrayValueSave(['general', 'fallback_languages'], $config),
+                    'defaultLanguage' => self::getArrayValueSave(['general', 'default_language'], $config),
+                    'loginscreencustomimage' => self::getArrayValueSave(['branding', 'login_screen_custom_image'], $config),
+                    'disableusagestatistics' => self::getArrayValueSave(['general', 'disable_usage_statistics'], $config),
+                    'debug_admin_translations' => self::getArrayValueSave(['general', 'debug_admin_translations'], $config),
+                    'instanceIdentifier' => self::getArrayValueSave(['general', 'instance_identifier'], $config),
+                    'show_cookie_notice' => self::getArrayValueSave(['general', 'show_cookie_notice'], $config)
                 ],
                 'documents' => [
                     'versions' => [
-                        'days' => $config['documents']['versions']['days'],
-                        'steps' => $config['documents']['versions']['steps']
+                        'days' => self::getArrayValueSave(['documents', 'versions', 'days'], $config),
+                        'steps' => self::getArrayValueSave(['documents', 'versions', 'steps'], $config)
                     ],
-                    'error_pages' => $config['documents']['error_pages'],
-                    'createredirectwhenmoved' => $config['documents']['create_redirect_when_moved'],
-                    'allowtrailingslash' => $config['documents']['allow_trailing_slash'],
-                    'generatepreview' => $config['documents']['generate_preview']
+                    'error_pages' => self::getArrayValueSave(['documents', 'error_pages'], $config),
+                    'createredirectwhenmoved' => self::getArrayValueSave(['documents', 'create_redirect_when_moved'], $config),
+                    'allowtrailingslash' => self::getArrayValueSave(['documents', 'allow_trailing_slash'], $config),
+                    'generatepreview' => self::getArrayValueSave(['documents', 'generate_preview'], $config)
                 ],
                 'objects' => [
                     'versions' => [
-                        'days' => $config['objects']['versions']['days'],
-                        'steps' => $config['objects']['versions']['steps']
+                        'days' => self::getArrayValueSave(['objects', 'versions', 'days'], $config),
+                        'steps' => self::getArrayValueSave(['objects', 'versions', 'steps'], $config)
                     ]
                 ],
                 'assets' => [
                     'versions' => [
-                        'days' => $config['assets']['versions']['days'],
-                        'steps' => $config['assets']['versions']['steps']
+                        'days' => self::getArrayValueSave(['assets', 'versions', 'days'], $config),
+                        'steps' => self::getArrayValueSave(['assets', 'versions', 'steps'], $config)
                     ],
-                    'icc_rgb_profile' => $config['assets']['icc_rgb_profile'],
-                    'icc_cmyk_profile' => $config['assets']['icc_cmyk_profile'],
-                    'hide_edit_image' => $config['assets']['hide_edit_image'],
-                    'disable_tree_preview' => $config['assets']['disable_tree_preview']
+                    'icc_rgb_profile' => self::getArrayValueSave(['assets', 'icc_rgb_profile'], $config),
+                    'icc_cmyk_profile' => self::getArrayValueSave(['assets', 'icc_cmyk_profile'], $config),
+                    'hide_edit_image' => self::getArrayValueSave(['assets', 'hide_edit_image'], $config),
+                    'disable_tree_preview' => self::getArrayValueSave(['assets', 'disable_tree_preview'], $config)
                 ],
                 'services' => [
                     'google' => [
-                        'client_id' => $config['services']['google']['client_id'],
-                        'email' => $config['services']['google']['email'],
-                        'simpleapikey' => $config['services']['google']['simple_api_key'],
-                        'browserapikey' => $config['services']['google']['browser_api_key']
+                        'client_id' => self::getArrayValueSave(['services', 'google', 'client_id'], $config),
+                        'email' => self::getArrayValueSave(['services', 'google', 'email'], $config),
+                        'simpleapikey' => self::getArrayValueSave(['services', 'google', 'simple_api_key'], $config),
+                        'browserapikey' => self::getArrayValueSave(['services', 'google', 'browser_api_key'], $config)
                     ]
                 ],
                 'cache' => [
-                    'enabled' => $config['cache']['enabled'],
-                    'lifetime' => $config['cache']['lifetime'],
-                    'excludePatterns' => $config['cache']['exclude_patterns'],
-                    'excludeCookie' => $config['cache']['exclude_cookie']
+                    'enabled' => self::getArrayValueSave(['cache', 'enabled'], $config),
+                    'lifetime' => self::getArrayValueSave(['cache', 'lifetime'], $config),
+                    'excludePatterns' => self::getArrayValueSave(['cache', 'exclude_patterns'], $config),
+                    'excludeCookie' => self::getArrayValueSave(['cache', 'exclude_cookie'], $config)
                 ],
                 'webservice' => [
-                    'enabled' => $config['webservice']['enabled']
+                    'enabled' => self::getArrayValueSave(['webservice', 'enabled'], $config)
                 ],
                 'httpclient' => [
-                    'adapter' => $config['httpclient']['adapter'],
-                    'proxy_host' => $config['httpclient']['proxy_host'],
-                    'proxy_port' => $config['httpclient']['proxy_port'],
-                    'proxy_user' => $config['httpclient']['proxy_user'],
-                    'proxy_pass' => $config['httpclient']['proxy_pass']
+                    'adapter' => self::getArrayValueSave(['httpclient', 'adapter'], $config),
+                    'proxy_host' => self::getArrayValueSave(['httpclient', 'proxy_host'], $config),
+                    'proxy_port' => self::getArrayValueSave(['httpclient', 'proxy_port'], $config),
+                    'proxy_user' => self::getArrayValueSave(['httpclient', 'proxy_user'], $config),
+                    'proxy_pass' => self::getArrayValueSave(['httpclient', 'proxy_pass'], $config)
                 ],
                 'email' => [
                     'sender' => [
-                        'name' => $config['email']['sender']['name'],
-                        'email' => $config['email']['sender']['email']
+                        'name' => self::getArrayValueSave(['email', 'sender', 'name'], $config),
+                        'email' => self::getArrayValueSave(['email', 'sender', 'email'], $config)
                     ],
                     'return' => [
-                        'name' => $config['email']['return']['name'],
-                        'email' => $config['email']['return']['email']
+                        'name' => self::getArrayValueSave(['email', 'return', 'name'], $config),
+                        'email' => self::getArrayValueSave(['email', 'return', 'email'], $config)
                     ],
-                    'method' => $config['email']['method'],
+                    'method' => self::getArrayValueSave(['email', 'method'], $config),
                     'smtp' => [
-                        'host' => $config['email']['smtp']['host'],
-                        'port' => $config['email']['smtp']['port'],
-                        'ssl' => $config['email']['smtp']['encryption'],
+                        'host' => self::getArrayValueSave(['email', 'smtp', 'host'], $config),
+                        'port' => self::getArrayValueSave(['email', 'smtp', 'port'], $config),
+                        'ssl' => self::getArrayValueSave(['email', 'smtp', 'encryption'], $config),
                         'name' => 'smtp',
                         'auth' => [
-                            'method' => $config['email']['smtp']['auth_mode'],
-                            'username' => $config['email']['smtp']['username'],
-                            'password' => $config['email']['smtp']['password']
+                            'method' => self::getArrayValueSave(['email', 'smtp', 'auth_mode'], $config),
+                            'username' => self::getArrayValueSave(['email', 'smtp', 'username'], $config),
+                            'password' => self::getArrayValueSave(['email', 'smtp', 'password'], $config)
                         ],
                     ],
                     'debug' => [
-                        'emailaddresses' => $config['email']['debug']['email_addresses']
+                        'emailaddresses' => self::getArrayValueSave(['email', 'debug', 'email_addresses'], $config)
                     ]
                 ],
                 'newsletter' => [
                     'sender' => [
-                        'name' => $config['newsletter']['sender']['name'],
-                        'email' => $config['newsletter']['sender']['email']
+                        'name' => self::getArrayValueSave(['newsletter', 'sender', 'name'], $config),
+                        'email' => self::getArrayValueSave(['newsletter', 'sender', 'email'], $config)
                     ],
                     'return' => [
-                        'name' => $config['newsletter']['return']['name'],
-                        'email' => $config['newsletter']['return']['name']
+                        'name' => self::getArrayValueSave(['newsletter', 'return', 'name'], $config),
+                        'email' => self::getArrayValueSave(['newsletter', 'return', 'name'], $config)
                     ],
-                    'method' => $config['newsletter']['method'],
+                    'method' => self::getArrayValueSave(['newsletter', 'method'], $config),
                     'smtp' => [
-                        'host' => $config['newsletter']['smtp']['host'],
-                        'port' => $config['newsletter']['smtp']['port'],
-                        'ssl' => $config['newsletter']['smtp']['encryption'],
+                        'host' => self::getArrayValueSave(['newsletter', 'smtp', 'host'], $config),
+                        'port' => self::getArrayValueSave(['newsletter', 'smtp', 'port'], $config),
+                        'ssl' => self::getArrayValueSave(['newsletter', 'smtp', 'encryption'], $config),
                         'name' => 'smtp',
                         'auth' => [
-                            'method' => $config['newsletter']['smtp']['auth_mode'],
-                            'username' => $config['newsletter']['smtp']['username'],
-                            'password' => $config['newsletter']['smtp']['password']
+                            'method' => self::getArrayValueSave(['newsletter', 'smtp', 'auth_mode'], $config),
+                            'username' => self::getArrayValueSave(['newsletter', 'smtp', 'username'], $config),
+                            'password' => self::getArrayValueSave(['newsletter', 'smtp', 'password'], $config)
                         ],
                     ],
-                    'debug' => $config['newsletter']['debug']['email_addresses'],
-                    'usespecific' => $config['newsletter']['use_specific']
+                    'debug' => self::getArrayValueSave(['newsletter', 'debug', 'email_addresses'], $config),
+                    'usespecific' => self::getArrayValueSave(['newsletter', 'use_specific'], $config)
                 ],
                 'branding' => [
-                    'login_screen_invert_colors' => $config['branding']['login_screen_invert_colors'],
-                    'color_login_screen' => $config['branding']['color_login_screen'],
-                    'color_admin_interface' => $config['branding']['color_admin_interface']
+                    'login_screen_invert_colors' => self::getArrayValueSave(['branding', 'login_screen_invert_colors'], $config),
+                    'color_login_screen' => self::getArrayValueSave(['branding', 'color_login_screen'], $config),
+                    'color_admin_interface' => self::getArrayValueSave(['branding', 'color_admin_interface'], $config)
                 ],
                 'applicationlog' => [
                     'mail_notification' => [
-                        'send_log_summary' => $config['applicationlog']['mail_notification']['send_log_summary'],
-                        'filter_priority' => $config['applicationlog']['mail_notification']['filter_priority'],
-                        'mail_receiver' => $config['applicationlog']['mail_notification']['mail_receiver']
+                        'send_log_summary' => self::getArrayValueSave(['applicationlog', 'mail_notification', 'send_log_summary'], $config),
+                        'filter_priority' => self::getArrayValueSave(['applicationlog', 'mail_notification', 'filter_priority'], $config),
+                        'mail_receiver' => self::getArrayValueSave(['applicationlog', 'mail_notification', 'mail_receiver'], $config)
                     ],
-                    'archive_treshold' => $config['applicationlog']['archive_treshold'],
-                    'archive_alternative_database' => $config['applicationlog']['archive_alternative_database']
+                    'archive_treshold' => self::getArrayValueSave(['applicationlog', 'archive_treshold'], $config),
+                    'archive_alternative_database' => self::getArrayValueSave(['applicationlog', 'archive_alternative_database'], $config)
                 ]
             ]);
         }

--- a/lib/Event/Model/UserRoleEvent.php
+++ b/lib/Event/Model/UserRoleEvent.php
@@ -15,7 +15,7 @@
 namespace Pimcore\Event\Model;
 
 use Pimcore\Model\User\AbstractUser;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class UserRoleEvent extends Event
 {

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -143,10 +143,12 @@ class Service extends Model\Element\Service
         $new->setLocked(false);
         $new->setCreationDate(time());
 
-        foreach ($new->getClass()->getFieldDefinitions() as $fieldDefinition) {
-            if ($fieldDefinition->getUnique()) {
-                $new->set($fieldDefinition->getName(), null);
-                $new->setPublished(false);
+        if($new instanceof Concrete) {
+            foreach ($new->getClass()->getFieldDefinitions() as $fieldDefinition) {
+                if ($fieldDefinition->getUnique()) {
+                    $new->set($fieldDefinition->getName(), null);
+                    $new->setPublished(false);
+                }
             }
         }
 
@@ -205,10 +207,12 @@ class Service extends Model\Element\Service
         $new->setLocked(false);
         $new->setCreationDate(time());
 
-        foreach ($new->getClass()->getFieldDefinitions() as $fieldDefinition) {
-            if ($fieldDefinition->getUnique()) {
-                $new->set($fieldDefinition->getName(), null);
-                $new->setPublished(false);
+        if($new instanceof Concrete) {
+            foreach ($new->getClass()->getFieldDefinitions() as $fieldDefinition) {
+                if ($fieldDefinition->getUnique()) {
+                    $new->set($fieldDefinition->getName(), null);
+                    $new->setPublished(false);
+                }
             }
         }
 

--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Pimcore
+ * Pimcore.
  *
  * This source file is available under two different licenses:
  * - GNU General Public License version 3 (GPLv3)
@@ -9,7 +9,6 @@
  * LICENSE.md which is distributed with this source code.
  *
  * @category   Pimcore
- * @package    User
  *
  * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
@@ -49,11 +48,12 @@ class AbstractUser extends Model\AbstractModel
     /**
      * @param int $id
      *
-     * @return AbstractUser|null
+     * @return null|AbstractUser
      */
     public static function getById($id)
     {
-        $cacheKey = 'user_' . $id;
+        $cacheKey = 'user_'.$id;
+
         try {
             if (\Pimcore\Cache\Runtime::isRegistered($cacheKey)) {
                 $user = \Pimcore\Cache\Runtime::get($cacheKey);
@@ -61,7 +61,7 @@ class AbstractUser extends Model\AbstractModel
                 $user = new static();
                 $user->getDao()->getById($id);
 
-                if (get_class($user) == 'Pimcore\\Model\\User\\AbstractUser') {
+                if ('Pimcore\\Model\\User\\AbstractUser' == get_class($user)) {
                     $className = Service::getClassNameForType($user->getType());
                     $user = $className::getById($user->getId());
                 }
@@ -92,7 +92,7 @@ class AbstractUser extends Model\AbstractModel
     /**
      * @param string $name
      *
-     * @return self|null
+     * @return null|self
      */
     public static function getByName($name)
     {
@@ -175,25 +175,26 @@ class AbstractUser extends Model\AbstractModel
     }
 
     /**
-     * @return $this
-     *
      * @throws \Exception
+     *
+     * @return $this
      */
     public function save()
     {
         $isUpdate = false;
         if ($this->getId()) {
             $isUpdate = true;
-            \Pimcore::getEventDispatcher()->dispatch(UserRoleEvents::PRE_UPDATE, new UserRoleEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new UserRoleEvent($this), UserRoleEvents::PRE_UPDATE);
         } else {
-            \Pimcore::getEventDispatcher()->dispatch(UserRoleEvents::PRE_ADD, new UserRoleEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new UserRoleEvent($this), UserRoleEvents::PRE_ADD);
         }
 
         if (!preg_match('/^[a-zA-Z0-9\-\.~_@]+$/', $this->getName())) {
-            throw new \Exception('Invalid name for user/role `' . $this->getName() . '` (allowed characters: a-z A-Z 0-9 -.~_@)');
+            throw new \Exception('Invalid name for user/role `'.$this->getName().'` (allowed characters: a-z A-Z 0-9 -.~_@)');
         }
 
         $this->beginTransaction();
+
         try {
             if (!$this->getId()) {
                 $this->getDao()->create();
@@ -204,13 +205,14 @@ class AbstractUser extends Model\AbstractModel
             $this->commit();
         } catch (\Exception $e) {
             $this->rollBack();
+
             throw $e;
         }
 
         if ($isUpdate) {
-            \Pimcore::getEventDispatcher()->dispatch(UserRoleEvents::POST_UPDATE, new UserRoleEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new UserRoleEvent($this), UserRoleEvents::POST_UPDATE);
         } else {
-            \Pimcore::getEventDispatcher()->dispatch(UserRoleEvents::POST_ADD, new UserRoleEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new UserRoleEvent($this), UserRoleEvents::POST_ADD);
         }
 
         return $this;


### PR DESCRIPTION
# Changes in this pull request  

Save access of $config values array in Config::mapLegacyConfiguration to avoid exceptions if values are missing.

Resolves #

Broken Codeception tests packages ecommerce, model, rest an service with inital Skeleton config and DB.

## Additional info  

On loading page and on running Codeception tests with initial skeleton DB and config exceptions occur because of missing config values, e.g. service.google.*. This breaks the tests and cause errors when loading the web app.
