### PR TITLE
Fix: Symfony deprecation event dispatcher

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -393,7 +393,7 @@ class AssetController extends ElementControllerBase implements EventedController
             $context = json_decode($context, true);
             $context = $context ? $context : [];
             $event = new \Pimcore\Event\Model\Asset\ResolveUploadTargetEvent($parentId, $filename, $context);
-            \Pimcore::getEventDispatcher()->dispatch(AssetEvents::RESOLVE_UPLOAD_TARGET, $event);
+            \Pimcore::getEventDispatcher()->dispatch($event, AssetEvents::RESOLVE_UPLOAD_TARGET);
             $filename = Element\Service::getValidKey($event->getFilename(), 'asset');
             $parentId = $event->getParentId();
         }

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
@@ -885,7 +885,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             'list' => $definitions,
             'objectId' => $request->get('object_id')
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(AdminEvents::CLASS_FIELDCOLLECTION_LIST_PRE_SEND_DATA, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::CLASS_FIELDCOLLECTION_LIST_PRE_SEND_DATA);
         $definitions = $event->getArgument('list');
 
         if ($forObjectEditor) {
@@ -943,7 +943,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             'list' => $list,
             'objectId' => $request->get('object_id')
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(AdminEvents::CLASS_FIELDCOLLECTION_LIST_PRE_SEND_DATA, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::CLASS_FIELDCOLLECTION_LIST_PRE_SEND_DATA);
         $list = $event->getArgument('list');
 
         return $this->adminJson(['fieldcollections' => $list]);
@@ -1266,7 +1266,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             'list' => $definitions,
             'objectId' => $request->get('object_id')
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(AdminEvents::CLASS_OBJECTBRICK_LIST_PRE_SEND_DATA, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::CLASS_OBJECTBRICK_LIST_PRE_SEND_DATA);
         $definitions = $event->getArgument('list');
 
         if ($forObjectEditor) {
@@ -1336,7 +1336,7 @@ class ClassController extends AdminController implements EventedControllerInterf
             'list' => $list,
             'objectId' => $request->get('object_id')
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(AdminEvents::CLASS_OBJECTBRICK_LIST_PRE_SEND_DATA, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::CLASS_OBJECTBRICK_LIST_PRE_SEND_DATA);
         $list = $event->getArgument('list');
 
         return $this->adminJson(['objectbricks' => $list]);

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1644,7 +1644,7 @@ class DataObjectHelperController extends AdminController
         $eventData->setContext($context);
 
         if ($job == 1) {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectImportEvents::BEFORE_START, $eventData);
+            \Pimcore::getEventDispatcher()->dispatch($eventData, DataObjectImportEvents::BEFORE_START);
 
             if (!copy($originalFile, $file)) {
                 throw new \Exception('failed to copy file');

--- a/bundles/AdminBundle/Controller/Admin/Document/EmailController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/EmailController.php
@@ -79,7 +79,7 @@ class EmailController extends DocumentControllerBase
             'data' => $data,
             'document' => $email
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(AdminEvents::DOCUMENT_GET_PRE_SEND_DATA, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::DOCUMENT_GET_PRE_SEND_DATA);
         $data = $event->getArgument('data');
 
         if ($email->isAllowed('view')) {

--- a/bundles/AdminBundle/Controller/Admin/Document/FolderController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/FolderController.php
@@ -72,7 +72,7 @@ class FolderController extends DocumentControllerBase
             'data' => $data,
             'document' => $folder
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(AdminEvents::DOCUMENT_GET_PRE_SEND_DATA, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::DOCUMENT_GET_PRE_SEND_DATA);
         $data = $event->getArgument('data');
 
         if ($folder->isAllowed('view')) {

--- a/bundles/AdminBundle/Controller/Admin/Document/HardlinkController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/HardlinkController.php
@@ -77,7 +77,7 @@ class HardlinkController extends DocumentControllerBase
             'data' => $data,
             'document' => $link
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(AdminEvents::DOCUMENT_GET_PRE_SEND_DATA, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::DOCUMENT_GET_PRE_SEND_DATA);
         $data = $event->getArgument('data');
         $data['versionDate'] = $link->getModificationDate();
 

--- a/bundles/AdminBundle/Controller/Admin/Document/LinkController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/LinkController.php
@@ -81,7 +81,7 @@ class LinkController extends DocumentControllerBase
             'data' => $data,
             'document' => $link
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(AdminEvents::DOCUMENT_GET_PRE_SEND_DATA, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::DOCUMENT_GET_PRE_SEND_DATA);
         $data = $event->getArgument('data');
 
         if ($link->isAllowed('view')) {

--- a/bundles/AdminBundle/Controller/Admin/Document/NewsletterController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/NewsletterController.php
@@ -93,7 +93,7 @@ class NewsletterController extends DocumentControllerBase
             'data' => $data,
             'document' => $email
         ]);
-        Pimcore::getEventDispatcher()->dispatch(AdminEvents::DOCUMENT_GET_PRE_SEND_DATA, $event);
+        Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::DOCUMENT_GET_PRE_SEND_DATA);
         $data = $event->getArgument('data');
 
         if ($email->isAllowed('view')) {

--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -93,7 +93,7 @@ class PageController extends DocumentControllerBase
             'data' => $data,
             'document' => $page
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(AdminEvents::DOCUMENT_GET_PRE_SEND_DATA, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::DOCUMENT_GET_PRE_SEND_DATA);
         $data = $event->getArgument('data');
 
         if ($page->isAllowed('view')) {

--- a/bundles/AdminBundle/Controller/Admin/Document/PrintpageControllerBase.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PrintpageControllerBase.php
@@ -86,7 +86,7 @@ class PrintpageControllerBase extends DocumentControllerBase
             'data' => $data,
             'document' => $page
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(AdminEvents::DOCUMENT_GET_PRE_SEND_DATA, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::DOCUMENT_GET_PRE_SEND_DATA);
 
         if ($page->isAllowed('view')) {
             $data = $event->getArgument('data');

--- a/bundles/AdminBundle/Controller/Admin/Document/SnippetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/SnippetController.php
@@ -85,7 +85,7 @@ class SnippetController extends DocumentControllerBase
             'data' => $data,
             'document' => $snippet
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(AdminEvents::DOCUMENT_GET_PRE_SEND_DATA, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::DOCUMENT_GET_PRE_SEND_DATA);
         $data = $event->getArgument('data');
 
         if ($snippet->isAllowed('view')) {

--- a/bundles/AdminBundle/Controller/Admin/ElementController.php
+++ b/bundles/AdminBundle/Controller/Admin/ElementController.php
@@ -76,7 +76,7 @@ class ElementController extends AdminController
         $type = $request->get('type');
 
         $event = new ResolveElementEvent($type, $idOrPath);
-        \Pimcore::getEventDispatcher()->dispatch(AdminEvents::RESOLVE_ELEMENT, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::RESOLVE_ELEMENT);
         $idOrPath = $event->getId();
         $type = $event->getType();
 

--- a/bundles/AdminBundle/Controller/Admin/TargetingController.php
+++ b/bundles/AdminBundle/Controller/Admin/TargetingController.php
@@ -233,7 +233,7 @@ class TargetingController extends AdminController implements EventedControllerIn
         $targetGroup->save();
 
         $event = new TargetGroupEvent($targetGroup);
-        \Pimcore::getEventDispatcher()->dispatch(TargetGroupEvents::POST_ADD, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, TargetGroupEvents::POST_ADD);
 
         $cache->clearTag('target_groups');
 
@@ -259,7 +259,7 @@ class TargetingController extends AdminController implements EventedControllerIn
             $targetGroup->delete();
             $success = true;
 
-            \Pimcore::getEventDispatcher()->dispatch(TargetGroupEvents::POST_DELETE, $event);
+            \Pimcore::getEventDispatcher()->dispatch($event, TargetGroupEvents::POST_DELETE);
         }
 
         $cache->clearTag('target_groups');
@@ -300,7 +300,7 @@ class TargetingController extends AdminController implements EventedControllerIn
         $targetGroup->save();
 
         $event = new TargetGroupEvent($targetGroup);
-        \Pimcore::getEventDispatcher()->dispatch(TargetGroupEvents::POST_UPDATE, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, TargetGroupEvents::POST_UPDATE);
 
         $cache->clearTag('target_groups');
 

--- a/bundles/AdminBundle/Controller/Rest/AbstractRestController.php
+++ b/bundles/AdminBundle/Controller/Rest/AbstractRestController.php
@@ -324,7 +324,7 @@ abstract class AbstractRestController extends AdminController
     public function dispatchBeforeLoadEvent(Request $request, FilterEvent $eventData)
     {
         if ($request->get('condition')) {
-            \Pimcore::getEventDispatcher()->dispatch(WebserviceEvents::BEFORE_LIST_LOAD, $eventData);
+            \Pimcore::getEventDispatcher()->dispatch($eventData, WebserviceEvents::BEFORE_LIST_LOAD);
             if (!$eventData->isConditionDirty()) {
                 throw new \Exception('the condition parameter is not supported anymore');
             }

--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -55,7 +55,7 @@ class Cache
         if (\Pimcore::hasKernel()) {
             \Pimcore::getContainer()
                 ->get('event_dispatcher')
-                ->dispatch(CoreCacheEvents::INIT, new Event());
+                ->dispatch(new Event(), CoreCacheEvents::INIT);
 
             if (isset($_REQUEST['pimcore_nocache']) && \Pimcore::inDebugMode()) {
                 self::getHandler()->disable();

--- a/lib/Cache/Core/EventDispatchingCoreHandler.php
+++ b/lib/Cache/Core/EventDispatchingCoreHandler.php
@@ -63,10 +63,10 @@ class EventDispatchingCoreHandler extends CoreHandler
     protected function setEnabled($enabled)
     {
         $this->dispatcher->dispatch(
+            new Event(),
             $this->isEnabled()
                 ? CoreCacheEvents::ENABLE
-                : CoreCacheEvents::DISABLE,
-            new Event()
+                : CoreCacheEvents::DISABLE
         );
     }
 

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -44,6 +44,7 @@ use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
+use Symfony\Component\EventDispatcher\Event;
 
 abstract class Kernel extends SymfonyKernel
 {
@@ -199,7 +200,7 @@ abstract class Kernel extends SymfonyKernel
             // check if container still exists at this point as it could already
             // be cleared (e.g. when running tests which boot multiple containers)
             if (null !== $container = $this->getContainer()) {
-                $container->get('event_dispatcher')->dispatch(SystemEvents::SHUTDOWN);
+                $container->get('event_dispatcher')->dispatch(new Event(), SystemEvents::SHUTDOWN);
             }
 
             \Pimcore::shutdown();

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -618,7 +618,7 @@ class Mail extends \Swift_Message
             'mailer' => $mailer
         ]);
 
-        \Pimcore::getEventDispatcher()->dispatch(MailEvents::PRE_SEND, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, MailEvents::PRE_SEND);
 
         if ($event->hasArgument('mailer')) {
             $mailer = $event->getArgument('mailer');

--- a/lib/Templating/Helper/HeadLink.php
+++ b/lib/Templating/Helper/HeadLink.php
@@ -376,9 +376,10 @@ class HeadLink extends CacheBusterAware
                 }
             }
 
-            \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::VIEW_HELPER_HEAD_LINK, new GenericEvent($this, [
+            \Pimcore::getEventDispatcher()->dispatch(new GenericEvent($this, [
                 'item' => $item
-            ]));
+            ]),
+            FrontendEvents::VIEW_HELPER_HEAD_LINK);
 
             $source = (string)($item->href ?? '');
             $itemAttributes = isset($item->extras) ? $item->extras : [];

--- a/lib/Templating/Helper/HeadScript.php
+++ b/lib/Templating/Helper/HeadScript.php
@@ -559,9 +559,10 @@ class HeadScript extends CacheBusterAware
                 }
             }
 
-            \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::VIEW_HELPER_HEAD_SCRIPT, new GenericEvent($this, [
+            \Pimcore::getEventDispatcher()->dispatch(new GenericEvent($this, [
                 'item' => $item
-            ]));
+            ]),
+            FrontendEvents::VIEW_HELPER_HEAD_SCRIPT);
 
             if (isset($item->attributes) && is_array($item->attributes)) {
                 $source = (string)($item->attributes['src'] ?? '');

--- a/lib/Tool/Admin.php
+++ b/lib/Tool/Admin.php
@@ -19,6 +19,7 @@ use Pimcore\Event\SystemEvents;
 use Pimcore\File;
 use Pimcore\Model\User;
 use Pimcore\Tool\Text\Csv;
+use Symfony\Component\EventDispatcher\Event;
 
 class Admin
 {
@@ -166,7 +167,7 @@ class Admin
 
         @chmod(self::getMaintenanceModeFile(), 0777); // so it can be removed also via FTP, ...
 
-        \Pimcore::getEventDispatcher()->dispatch(SystemEvents::MAINTENANCE_MODE_ACTIVATE);
+        \Pimcore::getEventDispatcher()->dispatch(new Event(), SystemEvents::MAINTENANCE_MODE_ACTIVATE);
     }
 
     /**
@@ -176,7 +177,7 @@ class Admin
     {
         @unlink(self::getMaintenanceModeFile());
 
-        \Pimcore::getEventDispatcher()->dispatch(SystemEvents::MAINTENANCE_MODE_DEACTIVATE);
+        \Pimcore::getEventDispatcher()->dispatch(new Event(), SystemEvents::MAINTENANCE_MODE_DEACTIVATE);
     }
 
     /**
@@ -224,14 +225,14 @@ class Admin
 
         @chmod(self::getMaintenanceModeScheduleLoginFile(), 0777); // so it can be removed also via FTP, ...
 
-        \Pimcore::getEventDispatcher()->dispatch(SystemEvents::MAINTENANCE_MODE_SCHEDULE_LOGIN);
+        \Pimcore::getEventDispatcher()->dispatch(new Event(), SystemEvents::MAINTENANCE_MODE_SCHEDULE_LOGIN);
     }
 
     public static function unscheduleMaintenanceModeOnLogin()
     {
         @unlink(self::getMaintenanceModeScheduleLoginFile());
 
-        \Pimcore::getEventDispatcher()->dispatch(SystemEvents::MAINTENANCE_MODE_UNSCHEDULE_LOGIN);
+        \Pimcore::getEventDispatcher()->dispatch(new Event(), SystemEvents::MAINTENANCE_MODE_UNSCHEDULE_LOGIN);
     }
 
     /**

--- a/lib/Tool/Newsletter.php
+++ b/lib/Tool/Newsletter.php
@@ -157,9 +157,9 @@ class Newsletter
                 'mailer' => $mailer
             ]);
 
-            Pimcore::getEventDispatcher()->dispatch(DocumentEvents::NEWSLETTER_PRE_SEND, $event);
+            Pimcore::getEventDispatcher()->dispatch($event, DocumentEvents::NEWSLETTER_PRE_SEND);
             $mail->sendWithoutRendering($mailer);
-            Pimcore::getEventDispatcher()->dispatch(DocumentEvents::NEWSLETTER_POST_SEND, $event);
+            Pimcore::getEventDispatcher()->dispatch($event, DocumentEvents::NEWSLETTER_POST_SEND);
 
             Logger::info(
                 sprintf(

--- a/lib/Web2Print/Processor.php
+++ b/lib/Web2Print/Processor.php
@@ -102,18 +102,20 @@ abstract class Processor
         $pdf = null;
 
         try {
-            \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::PRINT_PRE_PDF_GENERATION, new DocumentEvent($document, [
+            \Pimcore::getEventDispatcher()->dispatch(new DocumentEvent($document, [
                 'processor' => $this,
                 'jobConfig' => $jobConfigFile->config
-            ]));
+            ]),
+            DocumentEvents::PRINT_PRE_PDF_GENERATION);
 
             $pdf = $this->buildPdf($document, $jobConfigFile->config);
             file_put_contents($document->getPdfFileName(), $pdf);
 
-            \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::PRINT_POST_PDF_GENERATION, new DocumentEvent($document, [
+            \Pimcore::getEventDispatcher()->dispatch(new DocumentEvent($document, [
                 'filename' => $document->getPdfFileName(),
                 'pdf' => $pdf
-            ]));
+            ]),
+            DocumentEvents::PRINT_POST_PDF_GENERATION);
 
             $document->setLastGenerated((time() + 1));
             $document->save();

--- a/lib/Web2Print/Processor/PdfReactor8.php
+++ b/lib/Web2Print/Processor/PdfReactor8.php
@@ -137,7 +137,7 @@ class PdfReactor8 extends Processor
         $reactorConfig['document'] = $html;
 
         $event = new PrintConfigEvent($this, ['config' => $config, 'reactorConfig' => $reactorConfig, 'document' => $document]);
-        \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::PRINT_MODIFY_PROCESSING_CONFIG, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, DocumentEvents::PRINT_MODIFY_PROCESSING_CONFIG);
 
         $reactorConfig = $event->getArguments()['reactorConfig'];
 
@@ -223,7 +223,7 @@ class PdfReactor8 extends Processor
             'options' => $options
         ]);
 
-        \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::PRINT_MODIFY_PROCESSING_OPTIONS, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, DocumentEvents::PRINT_MODIFY_PROCESSING_OPTIONS);
 
         return (array)$event->getArguments()['options'];
     }

--- a/lib/Web2Print/Processor/WkHtmlToPdf.php
+++ b/lib/Web2Print/Processor/WkHtmlToPdf.php
@@ -121,7 +121,7 @@ class WkHtmlToPdf extends Processor
             'options' => []
         ]);
 
-        \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::PRINT_MODIFY_PROCESSING_OPTIONS, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, DocumentEvents::PRINT_MODIFY_PROCESSING_OPTIONS);
 
         return (array)$event->getArgument('options');
     }
@@ -224,7 +224,7 @@ class WkHtmlToPdf extends Processor
             'dstFile' => $dstFile,
             'config' => $this->config
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::PRINT_MODIFY_PROCESSING_CONFIG, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, DocumentEvents::PRINT_MODIFY_PROCESSING_CONFIG);
 
         $params = $event->getArguments();
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -484,9 +484,9 @@ class Asset extends Element\AbstractElement
 
             if ($this->getId()) {
                 $isUpdate = true;
-                \Pimcore::getEventDispatcher()->dispatch(AssetEvents::PRE_UPDATE, $preEvent);
+                \Pimcore::getEventDispatcher()->dispatch($preEvent, AssetEvents::PRE_UPDATE);
             } else {
-                \Pimcore::getEventDispatcher()->dispatch(AssetEvents::PRE_ADD, $preEvent);
+                \Pimcore::getEventDispatcher()->dispatch($preEvent, AssetEvents::PRE_ADD);
             }
 
             $params = $preEvent->getArguments();
@@ -578,9 +578,9 @@ class Asset extends Element\AbstractElement
                 if ($differentOldPath) {
                     $updateEvent->setArgument('oldPath', $differentOldPath);
                 }
-                \Pimcore::getEventDispatcher()->dispatch(AssetEvents::POST_UPDATE, $updateEvent);
+                \Pimcore::getEventDispatcher()->dispatch($updateEvent, AssetEvents::POST_UPDATE);
             } else {
-                \Pimcore::getEventDispatcher()->dispatch(AssetEvents::POST_ADD, new AssetEvent($this));
+                \Pimcore::getEventDispatcher()->dispatch(new AssetEvent($this), AssetEvents::POST_ADD);
             }
 
             return $this;
@@ -588,9 +588,9 @@ class Asset extends Element\AbstractElement
             $failureEvent = new AssetEvent($this);
             $failureEvent->setArgument('exception', $e);
             if ($isUpdate) {
-                \Pimcore::getEventDispatcher()->dispatch(AssetEvents::POST_UPDATE_FAILURE, $failureEvent);
+                \Pimcore::getEventDispatcher()->dispatch($failureEvent, AssetEvents::POST_UPDATE_FAILURE);
             } else {
-                \Pimcore::getEventDispatcher()->dispatch(AssetEvents::POST_ADD_FAILURE, $failureEvent);
+                \Pimcore::getEventDispatcher()->dispatch($failureEvent, AssetEvents::POST_ADD_FAILURE);
             }
 
             throw $e;
@@ -818,9 +818,10 @@ class Asset extends Element\AbstractElement
         try {
             // hook should be also called if "save only new version" is selected
             if ($saveOnlyVersion) {
-                \Pimcore::getEventDispatcher()->dispatch(AssetEvents::PRE_UPDATE, new AssetEvent($this, [
+                \Pimcore::getEventDispatcher()->dispatch(new AssetEvent($this, [
                     'saveVersionOnly' => true
-                ]));
+                ]),
+                AssetEvents::PRE_UPDATE);
             }
 
             // set date
@@ -844,17 +845,19 @@ class Asset extends Element\AbstractElement
 
             // hook should be also called if "save only new version" is selected
             if ($saveOnlyVersion) {
-                \Pimcore::getEventDispatcher()->dispatch(AssetEvents::POST_UPDATE, new AssetEvent($this, [
+                \Pimcore::getEventDispatcher()->dispatch(new AssetEvent($this, [
                     'saveVersionOnly' => true
-                ]));
+                ]),
+                AssetEvents::POST_UPDATE);
             }
 
             return $version;
         } catch (\Exception $e) {
-            \Pimcore::getEventDispatcher()->dispatch(AssetEvents::POST_UPDATE_FAILURE, new AssetEvent($this, [
+            \Pimcore::getEventDispatcher()->dispatch(new AssetEvent($this, [
                 'saveVersionOnly' => true,
                 'exception' => $e
-            ]));
+            ]),
+            AssetEvents::POST_UPDATE_FAILURE);
 
             throw $e;
         }
@@ -875,7 +878,7 @@ class Asset extends Element\AbstractElement
             $event = new GenericEvent($this, [
                 'frontendPath' => $path
             ]);
-            \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::ASSET_PATH, $event);
+            \Pimcore::getEventDispatcher()->dispatch($event, FrontendEvents::ASSET_PATH);
             $path = $event->getArgument('frontendPath');
         }
 
@@ -997,7 +1000,7 @@ class Asset extends Element\AbstractElement
             throw new \Exception('root-node cannot be deleted');
         }
 
-        \Pimcore::getEventDispatcher()->dispatch(AssetEvents::PRE_DELETE, new AssetEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new AssetEvent($this), AssetEvents::PRE_DELETE);
 
         $this->beginTransaction();
 
@@ -1049,7 +1052,7 @@ class Asset extends Element\AbstractElement
             $this->rollBack();
             $failureEvent = new AssetEvent($this);
             $failureEvent->setArgument('exception', $e);
-            \Pimcore::getEventDispatcher()->dispatch(AssetEvents::POST_DELETE_FAILURE, $failureEvent);
+            \Pimcore::getEventDispatcher()->dispatch($failureEvent, AssetEvents::POST_DELETE_FAILURE);
             Logger::crit($e);
             throw $e;
         }
@@ -1060,7 +1063,7 @@ class Asset extends Element\AbstractElement
         // clear asset from registry
         \Pimcore\Cache\Runtime::set('asset_' . $this->getId(), null);
 
-        \Pimcore::getEventDispatcher()->dispatch(AssetEvents::POST_DELETE, new AssetEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new AssetEvent($this), AssetEvents::POST_DELETE);
     }
 
     /**

--- a/models/Asset/Document/ImageThumbnail.php
+++ b/models/Asset/Document/ImageThumbnail.php
@@ -62,7 +62,7 @@ class ImageThumbnail
             'filesystemPath' => $fsPath,
             'frontendPath' => $path
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::ASSET_DOCUMENT_IMAGE_THUMBNAIL, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, FrontendEvents::ASSET_DOCUMENT_IMAGE_THUMBNAIL);
         $path = $event->getArgument('frontendPath');
 
         return $path;
@@ -118,10 +118,11 @@ class ImageThumbnail
                 $this->filesystemPath = $errorImage;
             }
 
-            \Pimcore::getEventDispatcher()->dispatch(AssetEvents::DOCUMENT_IMAGE_THUMBNAIL, new GenericEvent($this, [
+            \Pimcore::getEventDispatcher()->dispatch(new GenericEvent($this, [
                 'deferred' => $deferred,
                 'generated' => $generated
-            ]));
+            ]),
+            AssetEvents::DOCUMENT_IMAGE_THUMBNAIL);
         }
     }
 

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -253,7 +253,7 @@ EOT;
             'filesystemPath' => $fsPath,
             'frontendPath' => $path
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::ASSET_IMAGE_THUMBNAIL, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, FrontendEvents::ASSET_IMAGE_THUMBNAIL);
         $path = $event->getArgument('frontendPath');
 
         return $path;

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -65,7 +65,7 @@ class Thumbnail
             'filesystemPath' => $fsPath,
             'frontendPath' => $path
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::ASSET_IMAGE_THUMBNAIL, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, FrontendEvents::ASSET_IMAGE_THUMBNAIL);
         $path = $event->getArgument('frontendPath');
 
         return $path;
@@ -114,10 +114,11 @@ class Thumbnail
             }
         }
 
-        \Pimcore::getEventDispatcher()->dispatch(AssetEvents::IMAGE_THUMBNAIL, new GenericEvent($this, [
+        \Pimcore::getEventDispatcher()->dispatch(new GenericEvent($this, [
             'deferred' => $deferred,
             'generated' => $generated
-        ]));
+        ]),
+        AssetEvents::IMAGE_THUMBNAIL);
     }
 
     /**

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -97,9 +97,10 @@ class Service extends Model\Element\Service
         }
 
         // triggers actions after the complete asset cloning
-        \Pimcore::getEventDispatcher()->dispatch(AssetEvents::POST_COPY, new AssetEvent($new, [
+        \Pimcore::getEventDispatcher()->dispatch(new AssetEvent($new, [
             'base_element' => $source // the element used to make a copy
-        ]));
+        ]),
+        AssetEvents::POST_COPY);
 
         return $new;
     }
@@ -135,9 +136,10 @@ class Service extends Model\Element\Service
         }
 
         // triggers actions after the complete asset cloning
-        \Pimcore::getEventDispatcher()->dispatch(AssetEvents::POST_COPY, new AssetEvent($new, [
+        \Pimcore::getEventDispatcher()->dispatch(new AssetEvent($new, [
             'base_element' => $source // the element used to make a copy
-        ]));
+        ]),
+        AssetEvents::POST_COPY);
 
         return $new;
     }

--- a/models/Asset/Video.php
+++ b/models/Asset/Video.php
@@ -136,7 +136,7 @@ class Video extends Model\Asset
                             'filesystemPath' => $fullPath,
                             'frontendPath' => $path
                         ]);
-                        \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::ASSET_VIDEO_THUMBNAIL, $event);
+                        \Pimcore::getEventDispatcher()->dispatch($event, FrontendEvents::ASSET_VIDEO_THUMBNAIL);
                         $path = $event->getArgument('frontendPath');
                     }
 

--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -70,7 +70,7 @@ class ImageThumbnail
             'filesystemPath' => $fsPath,
             'frontendPath' => $path
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::ASSET_VIDEO_IMAGE_THUMBNAIL, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, FrontendEvents::ASSET_VIDEO_IMAGE_THUMBNAIL);
         $path = $event->getArgument('frontendPath');
 
         return $path;
@@ -167,10 +167,11 @@ class ImageThumbnail
                 $this->filesystemPath = $path;
             }
 
-            \Pimcore::getEventDispatcher()->dispatch(AssetEvents::VIDEO_IMAGE_THUMBNAIL, new GenericEvent($this, [
+            \Pimcore::getEventDispatcher()->dispatch(new GenericEvent($this, [
                 'deferred' => $deferred,
                 'generated' => $generated
-            ]));
+            ]),
+            AssetEvents::VIDEO_IMAGE_THUMBNAIL);
         }
     }
 

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -518,7 +518,7 @@ class AbstractObject extends Model\Element\AbstractElement
      */
     public function delete(bool $isNested = false)
     {
-        \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::PRE_DELETE, new DataObjectEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new DataObjectEvent($this), DataObjectEvents::PRE_DELETE);
 
         $this->beginTransaction();
 
@@ -551,7 +551,7 @@ class AbstractObject extends Model\Element\AbstractElement
             $this->rollBack();
             $failureEvent = new DataObjectEvent($this);
             $failureEvent->setArgument('exception', $e);
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_DELETE_FAILURE, $failureEvent);
+            \Pimcore::getEventDispatcher()->dispatch($failureEvent, DataObjectEvents::POST_DELETE_FAILURE);
 
             Logger::crit($e);
             throw $e;
@@ -563,7 +563,7 @@ class AbstractObject extends Model\Element\AbstractElement
         //clear object from registry
         Runtime::set('object_' . $this->getId(), null);
 
-        \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_DELETE, new DataObjectEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new DataObjectEvent($this), DataObjectEvents::POST_DELETE);
     }
 
     /**
@@ -587,10 +587,10 @@ class AbstractObject extends Model\Element\AbstractElement
             $preEvent = new DataObjectEvent($this, $params);
             if ($this->getId()) {
                 $isUpdate = true;
-                \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::PRE_UPDATE, $preEvent);
+                \Pimcore::getEventDispatcher()->dispatch($preEvent, DataObjectEvents::PRE_UPDATE);
             } else {
                 self::disableDirtyDetection();
-                \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::PRE_ADD, $preEvent);
+                \Pimcore::getEventDispatcher()->dispatch($preEvent, DataObjectEvents::PRE_ADD);
             }
 
             $params = $preEvent->getArguments();
@@ -691,10 +691,10 @@ class AbstractObject extends Model\Element\AbstractElement
                 if ($differentOldPath) {
                     $updateEvent->setArgument('oldPath', $differentOldPath);
                 }
-                \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_UPDATE, $updateEvent);
+                \Pimcore::getEventDispatcher()->dispatch($updateEvent, DataObjectEvents::POST_UPDATE);
             } else {
                 self::setDisableDirtyDetection($isDirtyDetectionDisabled);
-                \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_ADD, new DataObjectEvent($this));
+                \Pimcore::getEventDispatcher()->dispatch(new DataObjectEvent($this), DataObjectEvents::POST_ADD);
             }
 
             return $this;
@@ -702,9 +702,9 @@ class AbstractObject extends Model\Element\AbstractElement
             $failureEvent = new DataObjectEvent($this);
             $failureEvent->setArgument('exception', $e);
             if ($isUpdate) {
-                \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_UPDATE_FAILURE, $failureEvent);
+                \Pimcore::getEventDispatcher()->dispatch($failureEvent, DataObjectEvents::POST_UPDATE_FAILURE);
             } else {
-                \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_ADD_FAILURE, $failureEvent);
+                \Pimcore::getEventDispatcher()->dispatch($failureEvent, DataObjectEvents::POST_ADD_FAILURE);
             }
 
             throw $e;

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -321,13 +321,13 @@ class ClassDefinition extends Model\AbstractModel
 
         if (!$isUpdate) {
             \Pimcore::getEventDispatcher()->dispatch(
-                DataObjectClassDefinitionEvents::PRE_ADD,
-                new ClassDefinitionEvent($this)
+                new ClassDefinitionEvent($this),
+                DataObjectClassDefinitionEvents::PRE_ADD
             );
         } else {
             \Pimcore::getEventDispatcher()->dispatch(
-                DataObjectClassDefinitionEvents::PRE_UPDATE,
-                new ClassDefinitionEvent($this)
+                new ClassDefinitionEvent($this),
+                DataObjectClassDefinitionEvents::PRE_UPDATE
             );
         }
 
@@ -523,13 +523,13 @@ class ClassDefinition extends Model\AbstractModel
 
         if ($isUpdate) {
             \Pimcore::getEventDispatcher()->dispatch(
-                DataObjectClassDefinitionEvents::POST_UPDATE,
-                new ClassDefinitionEvent($this)
+                new ClassDefinitionEvent($this),
+                DataObjectClassDefinitionEvents::POST_UPDATE
             );
         } else {
             \Pimcore::getEventDispatcher()->dispatch(
-                DataObjectClassDefinitionEvents::POST_ADD,
-                new ClassDefinitionEvent($this)
+                new ClassDefinitionEvent($this),
+                DataObjectClassDefinitionEvents::POST_ADD
             );
         }
     }

--- a/models/DataObject/ClassDefinition/CustomLayout.php
+++ b/models/DataObject/ClassDefinition/CustomLayout.php
@@ -197,9 +197,9 @@ class CustomLayout extends Model\AbstractModel
         $isUpdate = $this->exists();
 
         if ($isUpdate) {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectCustomLayoutEvents::PRE_UPDATE, new CustomLayoutEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new CustomLayoutEvent($this), DataObjectCustomLayoutEvents::PRE_UPDATE);
         } else {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectCustomLayoutEvents::PRE_ADD, new CustomLayoutEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new CustomLayoutEvent($this), DataObjectCustomLayoutEvents::PRE_ADD);
         }
 
         $this->setModificationDate(time());

--- a/models/DataObject/Classificationstore/CollectionConfig.php
+++ b/models/DataObject/Classificationstore/CollectionConfig.php
@@ -171,9 +171,9 @@ class CollectionConfig extends Model\AbstractModel
      */
     public function delete()
     {
-        \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::COLLECTION_CONFIG_PRE_DELETE, new CollectionConfigEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new CollectionConfigEvent($this), DataObjectClassificationStoreEvents::COLLECTION_CONFIG_PRE_DELETE);
         $this->getDao()->delete();
-        \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::COLLECTION_CONFIG_POST_DELETE, new CollectionConfigEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new CollectionConfigEvent($this), DataObjectClassificationStoreEvents::COLLECTION_CONFIG_POST_DELETE);
     }
 
     /**
@@ -185,17 +185,17 @@ class CollectionConfig extends Model\AbstractModel
 
         if ($this->getId()) {
             $isUpdate = true;
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::COLLECTION_CONFIG_PRE_UPDATE, new CollectionConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new CollectionConfigEvent($this), DataObjectClassificationStoreEvents::COLLECTION_CONFIG_PRE_UPDATE);
         } else {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::COLLECTION_CONFIG_PRE_ADD, new CollectionConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new CollectionConfigEvent($this), DataObjectClassificationStoreEvents::COLLECTION_CONFIG_PRE_ADD);
         }
 
         $model = $this->getDao()->save();
 
         if ($isUpdate) {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::COLLECTION_CONFIG_POST_UPDATE, new CollectionConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new CollectionConfigEvent($this), DataObjectClassificationStoreEvents::COLLECTION_CONFIG_POST_UPDATE);
         } else {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::COLLECTION_CONFIG_POST_ADD, new CollectionConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new CollectionConfigEvent($this), DataObjectClassificationStoreEvents::COLLECTION_CONFIG_POST_ADD);
         }
 
         return $model;

--- a/models/DataObject/Classificationstore/GroupConfig.php
+++ b/models/DataObject/Classificationstore/GroupConfig.php
@@ -214,13 +214,13 @@ class GroupConfig extends Model\AbstractModel
      */
     public function delete()
     {
-        \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::GROUP_CONFIG_PRE_DELETE, new GroupConfigEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new GroupConfigEvent($this), DataObjectClassificationStoreEvents::GROUP_CONFIG_PRE_DELETE);
         $cacheKey = 'cs_groupconfig_' . $this->getId();
         Cache\Runtime::set($cacheKey, null);
         Cache::remove($cacheKey);
 
         $this->getDao()->delete();
-        \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::GROUP_CONFIG_POST_DELETE, new GroupConfigEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new GroupConfigEvent($this), DataObjectClassificationStoreEvents::GROUP_CONFIG_POST_DELETE);
     }
 
     /**
@@ -236,17 +236,17 @@ class GroupConfig extends Model\AbstractModel
             Cache::remove($cacheKey);
 
             $isUpdate = true;
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::GROUP_CONFIG_PRE_UPDATE, new GroupConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new GroupConfigEvent($this), DataObjectClassificationStoreEvents::GROUP_CONFIG_PRE_UPDATE);
         } else {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::GROUP_CONFIG_PRE_ADD, new GroupConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new GroupConfigEvent($this), DataObjectClassificationStoreEvents::GROUP_CONFIG_PRE_ADD);
         }
 
         $model = $this->getDao()->save();
 
         if ($isUpdate) {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::GROUP_CONFIG_POST_UPDATE, new GroupConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new GroupConfigEvent($this), DataObjectClassificationStoreEvents::GROUP_CONFIG_POST_UPDATE);
         } else {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::GROUP_CONFIG_POST_ADD, new GroupConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new GroupConfigEvent($this), DataObjectClassificationStoreEvents::GROUP_CONFIG_POST_ADD);
         }
 
         return $model;

--- a/models/DataObject/Classificationstore/KeyConfig.php
+++ b/models/DataObject/Classificationstore/KeyConfig.php
@@ -259,14 +259,14 @@ class KeyConfig extends Model\AbstractModel
     {
         DefinitionCache::clear($this);
 
-        \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::KEY_CONFIG_PRE_DELETE, new KeyConfigEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new KeyConfigEvent($this), DataObjectClassificationStoreEvents::KEY_CONFIG_PRE_DELETE);
         if ($this->getId()) {
             unset(self::$cache[$this->getId()]);
             $cacheKey = 'cs_keyconfig_' . $this->getId();
             Cache::remove($cacheKey);
         }
         $this->getDao()->delete();
-        \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::KEY_CONFIG_POST_DELETE, new KeyConfigEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new KeyConfigEvent($this), DataObjectClassificationStoreEvents::KEY_CONFIG_POST_DELETE);
     }
 
     /**
@@ -291,17 +291,17 @@ class KeyConfig extends Model\AbstractModel
             Cache::remove($cacheKey);
 
             $isUpdate = true;
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::KEY_CONFIG_PRE_UPDATE, new KeyConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new KeyConfigEvent($this), DataObjectClassificationStoreEvents::KEY_CONFIG_PRE_UPDATE);
         } else {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::KEY_CONFIG_PRE_ADD, new KeyConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new KeyConfigEvent($this), DataObjectClassificationStoreEvents::KEY_CONFIG_PRE_ADD);
         }
 
         $model = $this->getDao()->save();
 
         if ($isUpdate) {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::KEY_CONFIG_POST_UPDATE, new KeyConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new KeyConfigEvent($this), DataObjectClassificationStoreEvents::KEY_CONFIG_POST_UPDATE);
         } else {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::KEY_CONFIG_POST_ADD, new KeyConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new KeyConfigEvent($this), DataObjectClassificationStoreEvents::KEY_CONFIG_POST_ADD);
         }
 
         return $model;

--- a/models/DataObject/Classificationstore/StoreConfig.php
+++ b/models/DataObject/Classificationstore/StoreConfig.php
@@ -135,9 +135,9 @@ class StoreConfig extends Model\AbstractModel
      */
     public function delete()
     {
-        \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::STORE_CONFIG_PRE_DELETE, new StoreConfigEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new StoreConfigEvent($this), DataObjectClassificationStoreEvents::STORE_CONFIG_PRE_DELETE);
         $this->getDao()->delete();
-        \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::STORE_CONFIG_POST_DELETE, new StoreConfigEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new StoreConfigEvent($this), DataObjectClassificationStoreEvents::STORE_CONFIG_POST_DELETE);
     }
 
     /**
@@ -149,17 +149,17 @@ class StoreConfig extends Model\AbstractModel
 
         if ($this->getId()) {
             $isUpdate = true;
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::STORE_CONFIG_PRE_UPDATE, new StoreConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new StoreConfigEvent($this), DataObjectClassificationStoreEvents::STORE_CONFIG_PRE_UPDATE);
         } else {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::STORE_CONFIG_PRE_ADD, new StoreConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new StoreConfigEvent($this), DataObjectClassificationStoreEvents::STORE_CONFIG_PRE_ADD);
         }
 
         $model = $this->getDao()->save();
 
         if ($isUpdate) {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::STORE_CONFIG_POST_UPDATE, new StoreConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new StoreConfigEvent($this), DataObjectClassificationStoreEvents::STORE_CONFIG_POST_UPDATE);
         } else {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectClassificationStoreEvents::STORE_CONFIG_POST_ADD, new StoreConfigEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new StoreConfigEvent($this), DataObjectClassificationStoreEvents::STORE_CONFIG_POST_ADD);
         }
 
         return $model;

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -277,7 +277,7 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
             $this->commit();
         } catch (\Exception $e) {
             $this->rollBack();
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_DELETE_FAILURE, new DataObjectEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new DataObjectEvent($this), DataObjectEvents::POST_DELETE_FAILURE);
             Logger::crit($e);
             throw $e;
         }
@@ -302,9 +302,10 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
 
             // hook should be also called if "save only new version" is selected
             if ($saveOnlyVersion) {
-                \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::PRE_UPDATE, new DataObjectEvent($this, [
+                \Pimcore::getEventDispatcher()->dispatch(new DataObjectEvent($this, [
                     'saveVersionOnly' => true
-                ]));
+                ]),
+                DataObjectEvents::PRE_UPDATE);
             }
 
             // scheduled tasks are saved always, they are not versioned!
@@ -322,17 +323,19 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
 
             // hook should be also called if "save only new version" is selected
             if ($saveOnlyVersion) {
-                \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_UPDATE, new DataObjectEvent($this, [
+                \Pimcore::getEventDispatcher()->dispatch(new DataObjectEvent($this, [
                     'saveVersionOnly' => true
-                ]));
+                ]),
+                DataObjectEvents::POST_UPDATE);
             }
 
             return $version;
         } catch (\Exception $e) {
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_UPDATE_FAILURE, new DataObjectEvent($this, [
+            \Pimcore::getEventDispatcher()->dispatch(new DataObjectEvent($this, [
                 'saveVersionOnly' => true,
                 'exception' => $e
-            ]));
+            ]),
+            DataObjectEvents::POST_UPDATE_FAILURE);
 
             throw $e;
         }

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -170,9 +170,10 @@ class Service extends Model\Element\Service
         $this->updateChildren($target, $new);
 
         // triggers actions after the complete document cloning
-        \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_COPY, new DataObjectEvent($new, [
+        \Pimcore::getEventDispatcher()->dispatch(new DataObjectEvent($new, [
             'base_element' => $source // the element used to make a copy
-        ]));
+        ]),
+        DataObjectEvents::POST_COPY);
 
         return $new;
     }
@@ -223,9 +224,10 @@ class Service extends Model\Element\Service
         $this->updateChildren($target, $new);
 
         // triggers actions after the complete object cloning
-        \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_COPY, new DataObjectEvent($new, [
+        \Pimcore::getEventDispatcher()->dispatch(new DataObjectEvent($new, [
             'base_element' => $source // the element used to make a copy
-        ]));
+        ]),
+        DataObjectEvents::POST_COPY);
 
         return $new;
     }

--- a/models/Document.php
+++ b/models/Document.php
@@ -392,9 +392,9 @@ class Document extends Element\AbstractElement
             $preEvent = new DocumentEvent($this, $params);
             if ($this->getId()) {
                 $isUpdate = true;
-                \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::PRE_UPDATE, $preEvent);
+                \Pimcore::getEventDispatcher()->dispatch($preEvent, DocumentEvents::PRE_UPDATE);
             } else {
-                \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::PRE_ADD, $preEvent);
+                \Pimcore::getEventDispatcher()->dispatch($preEvent, DocumentEvents::PRE_ADD);
             }
 
             $params = $preEvent->getArguments();
@@ -473,9 +473,9 @@ class Document extends Element\AbstractElement
                 if ($differentOldPath) {
                     $updateEvent->setArgument('oldPath', $differentOldPath);
                 }
-                \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_UPDATE, $updateEvent);
+                \Pimcore::getEventDispatcher()->dispatch($updateEvent, DocumentEvents::POST_UPDATE);
             } else {
-                \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_ADD, new DocumentEvent($this));
+                \Pimcore::getEventDispatcher()->dispatch(new DocumentEvent($this), DocumentEvents::POST_ADD);
             }
 
             return $this;
@@ -483,9 +483,9 @@ class Document extends Element\AbstractElement
             $failureEvent = new DocumentEvent($this);
             $failureEvent->setArgument('exception', $e);
             if ($isUpdate) {
-                \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_UPDATE_FAILURE, $failureEvent);
+                \Pimcore::getEventDispatcher()->dispatch($failureEvent, DocumentEvents::POST_UPDATE_FAILURE);
             } else {
-                \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_ADD_FAILURE, $failureEvent);
+                \Pimcore::getEventDispatcher()->dispatch($failureEvent, DocumentEvents::POST_ADD_FAILURE);
             }
 
             throw $e;
@@ -778,7 +778,7 @@ class Document extends Element\AbstractElement
      */
     public function delete(bool $isNested = false)
     {
-        \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::PRE_DELETE, new DocumentEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new DocumentEvent($this), DocumentEvents::PRE_DELETE);
 
         $this->beginTransaction();
 
@@ -815,7 +815,7 @@ class Document extends Element\AbstractElement
             $this->rollBack();
             $failureEvent = new DocumentEvent($this);
             $failureEvent->setArgument('exception', $e);
-            \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_DELETE_FAILURE, $failureEvent);
+            \Pimcore::getEventDispatcher()->dispatch($failureEvent, DocumentEvents::POST_DELETE_FAILURE);
             Logger::error($e);
             throw $e;
         }
@@ -826,7 +826,7 @@ class Document extends Element\AbstractElement
         //clear document from registry
         \Pimcore\Cache\Runtime::set('document_' . $this->getId(), null);
 
-        \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_DELETE, new DocumentEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new DocumentEvent($this), DocumentEvents::POST_DELETE);
     }
 
     /**
@@ -932,7 +932,7 @@ class Document extends Element\AbstractElement
             $event = new GenericEvent($this, [
                 'frontendPath' => $path
             ]);
-            \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::DOCUMENT_PATH, $event);
+            \Pimcore::getEventDispatcher()->dispatch($event, FrontendEvents::DOCUMENT_PATH);
             $path = $event->getArgument('frontendPath');
         }
 

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -124,9 +124,10 @@ abstract class PageSnippet extends Model\Document
         try {
             // hook should be also called if "save only new version" is selected
             if ($saveOnlyVersion) {
-                \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::PRE_UPDATE, new DocumentEvent($this, [
+                \Pimcore::getEventDispatcher()->dispatch(new DocumentEvent($this, [
                     'saveVersionOnly' => true
-                ]));
+                ]),
+                DocumentEvents::PRE_UPDATE);
             }
 
             // set date
@@ -150,17 +151,19 @@ abstract class PageSnippet extends Model\Document
 
             // hook should be also called if "save only new version" is selected
             if ($saveOnlyVersion) {
-                \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_UPDATE, new DocumentEvent($this, [
+                \Pimcore::getEventDispatcher()->dispatch(new DocumentEvent($this, [
                     'saveVersionOnly' => true
-                ]));
+                ]),
+                DocumentEvents::POST_UPDATE);
             }
 
             return $version;
         } catch (\Exception $e) {
-            \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_UPDATE_FAILURE, new DocumentEvent($this, [
+            \Pimcore::getEventDispatcher()->dispatch(new DocumentEvent($this, [
                 'saveVersionOnly' => true,
                 'exception' => $e
-            ]));
+            ]),
+            DocumentEvents::POST_UPDATE_FAILURE);
 
             throw $e;
         }
@@ -187,7 +190,7 @@ abstract class PageSnippet extends Model\Document
             $this->commit();
         } catch (\Exception $e) {
             $this->rollBack();
-            \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_DELETE_FAILURE, new DocumentEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new DocumentEvent($this), DocumentEvents::POST_DELETE_FAILURE);
             Logger::error($e);
             throw $e;
         }

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -181,9 +181,10 @@ class Service extends Model\Element\Service
         $this->updateChildren($target, $new);
 
         // triggers actions after the complete document cloning
-        \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_COPY, new DocumentEvent($new, [
+        \Pimcore::getEventDispatcher()->dispatch(new DocumentEvent($new, [
             'base_element' => $source // the element used to make a copy
-        ]));
+        ]),
+        DocumentEvents::POST_COPY);
 
         return $new;
     }
@@ -248,9 +249,10 @@ class Service extends Model\Element\Service
         }
 
         // triggers actions after the complete document cloning
-        \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_COPY, new DocumentEvent($new, [
+        \Pimcore::getEventDispatcher()->dispatch(new DocumentEvent($new, [
             'base_element' => $source // the element used to make a copy
-        ]));
+        ]),
+        DocumentEvents::POST_COPY);
 
         return $new;
     }

--- a/models/Document/Tag.php
+++ b/models/Document/Tag.php
@@ -727,7 +727,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
         $tagName = $namingStrategy->buildTagName($name, $type, $blockState, $targetGroupElementName);
 
         $event = new TagNameEvent($type, $name, $blockState, $tagName, $document);
-        \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::TAG_NAME, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, DocumentEvents::TAG_NAME);
 
         $tagName = $event->getTagName();
 

--- a/models/Element/Note.php
+++ b/models/Element/Note.php
@@ -133,7 +133,7 @@ class Note extends Model\AbstractModel
         $this->getDao()->save();
 
         if (!$isUpdate) {
-            \Pimcore::getEventDispatcher()->dispatch(ElementEvents::POST_ADD, new ElementEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new ElementEvent($this), ElementEvents::POST_ADD);
         }
     }
 

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -929,7 +929,7 @@ class Service extends Model\AbstractModel
             'key' => $key,
             'type' => $type
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(SystemEvents::SERVICE_PRE_GET_VALID_KEY, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, SystemEvents::SERVICE_PRE_GET_VALID_KEY);
         $key = $event->getArgument('key');
 
         // replace all 4 byte unicode characters

--- a/models/Redirect.php
+++ b/models/Redirect.php
@@ -529,17 +529,17 @@ class Redirect extends AbstractModel
 
     public function save()
     {
-        \Pimcore::getEventDispatcher()->dispatch(RedirectEvents::PRE_SAVE, new RedirectEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new RedirectEvent($this), RedirectEvents::PRE_SAVE);
         $this->getDao()->save();
-        \Pimcore::getEventDispatcher()->dispatch(RedirectEvents::POST_SAVE, new RedirectEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new RedirectEvent($this), RedirectEvents::PRE_SAVE);
         $this->clearDependentCache();
     }
 
     public function delete()
     {
-        \Pimcore::getEventDispatcher()->dispatch(RedirectEvents::PRE_DELETE, new RedirectEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new RedirectEvent($this), RedirectEvents::PRE_DELETE);
         $this->getDao()->delete();
-        \Pimcore::getEventDispatcher()->dispatch(RedirectEvents::POST_DELETE, new RedirectEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new RedirectEvent($this), RedirectEvents::POST_DELETE);
         $this->clearDependentCache();
     }
 }

--- a/models/Search/Backend/Data.php
+++ b/models/Search/Backend/Data.php
@@ -543,7 +543,7 @@ class Data extends \Pimcore\Model\AbstractModel
     public function save()
     {
         if ($this->id instanceof Data\Id) {
-            \Pimcore::getEventDispatcher()->dispatch(SearchBackendEvents::PRE_SAVE, new SearchBackendEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new SearchBackendEvent($this), SearchBackendEvents::PRE_SAVE);
 
             $maxRetries = 5;
             for ($retries = 0; $retries < $maxRetries; $retries++) {
@@ -567,7 +567,7 @@ class Data extends \Pimcore\Model\AbstractModel
                 }
             }
 
-            \Pimcore::getEventDispatcher()->dispatch(SearchBackendEvents::POST_SAVE, new SearchBackendEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new SearchBackendEvent($this), SearchBackendEvents::POST_SAVE);
         } else {
             throw new \Exception('Search\\Backend\\Data cannot be saved - no id set!');
         }

--- a/models/Staticroute.php
+++ b/models/Staticroute.php
@@ -594,7 +594,7 @@ class Staticroute extends AbstractModel
             'reset' => $reset,
             'encode' => $encode
         ]);
-        \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::STATICROUTE_PATH, $event);
+        \Pimcore::getEventDispatcher()->dispatch($event, FrontendEvents::STATICROUTE_PATH);
         $url = $event->getArgument('frontendPath');
 
         return $url;

--- a/models/Translation/AbstractTranslation.php
+++ b/models/Translation/AbstractTranslation.php
@@ -261,7 +261,7 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
 
     public function save()
     {
-        \Pimcore::getEventDispatcher()->dispatch(TranslationEvents::PRE_SAVE, new TranslationEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new TranslationEvent($this), TranslationEvents::PRE_SAVE);
 
         if (!$this->getCreationDate()) {
             $this->setCreationDate(time());
@@ -273,19 +273,19 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
 
         $this->getDao()->save();
 
-        \Pimcore::getEventDispatcher()->dispatch(TranslationEvents::POST_SAVE, new TranslationEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new TranslationEvent($this), TranslationEvents::POST_SAVE);
 
         self::clearDependentCache();
     }
 
     public function delete()
     {
-        \Pimcore::getEventDispatcher()->dispatch(TranslationEvents::PRE_DELETE, new TranslationEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new TranslationEvent($this), TranslationEvents::PRE_DELETE);
 
         $this->getDao()->delete();
         self::clearDependentCache();
 
-        \Pimcore::getEventDispatcher()->dispatch(TranslationEvents::POST_DELETE, new TranslationEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new TranslationEvent($this), TranslationEvents::POST_DELETE);
     }
 
     /**

--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -184,9 +184,9 @@ class AbstractUser extends Model\AbstractModel
         $isUpdate = false;
         if ($this->getId()) {
             $isUpdate = true;
-            \Pimcore::getEventDispatcher()->dispatch(UserRoleEvents::PRE_UPDATE, new UserRoleEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new UserRoleEvent($this), UserRoleEvents::PRE_UPDATE);
         } else {
-            \Pimcore::getEventDispatcher()->dispatch(UserRoleEvents::PRE_ADD, new UserRoleEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new UserRoleEvent($this), UserRoleEvents::PRE_ADD);
         }
 
         if (!preg_match('/^[a-zA-Z0-9\-\.~_@]+$/', $this->getName())) {
@@ -208,9 +208,9 @@ class AbstractUser extends Model\AbstractModel
         }
 
         if ($isUpdate) {
-            \Pimcore::getEventDispatcher()->dispatch(UserRoleEvents::POST_UPDATE, new UserRoleEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new UserRoleEvent($this), UserRoleEvents::POST_UPDATE);
         } else {
-            \Pimcore::getEventDispatcher()->dispatch(UserRoleEvents::POST_ADD, new UserRoleEvent($this));
+            \Pimcore::getEventDispatcher()->dispatch(new UserRoleEvent($this), UserRoleEvents::POST_ADD);
         }
 
         return $this;
@@ -222,7 +222,7 @@ class AbstractUser extends Model\AbstractModel
             throw new \Exception('Deleting the system user is not allowed!');
         }
 
-        \Pimcore::getEventDispatcher()->dispatch(UserRoleEvents::PRE_DELETE, new UserRoleEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new UserRoleEvent($this), UserRoleEvents::PRE_DELETE);
 
         // delete all childs
         $list = new Listing();
@@ -239,7 +239,7 @@ class AbstractUser extends Model\AbstractModel
         $this->getDao()->delete();
         \Pimcore\Cache::clearAll();
 
-        \Pimcore::getEventDispatcher()->dispatch(UserRoleEvents::POST_DELETE, new UserRoleEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new UserRoleEvent($this), UserRoleEvents::POST_DELETE);
     }
 
     /**

--- a/models/Version.php
+++ b/models/Version.php
@@ -166,7 +166,7 @@ class Version extends AbstractModel
      */
     public function save()
     {
-        \Pimcore::getEventDispatcher()->dispatch(VersionEvents::PRE_SAVE, new VersionEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new VersionEvent($this), VersionEvents::PRE_SAVE);
 
         // check if versioning is disabled for this process
         if (self::$disabled) {
@@ -253,7 +253,7 @@ class Version extends AbstractModel
                 }
             }
         }
-        \Pimcore::getEventDispatcher()->dispatch(VersionEvents::POST_SAVE, new VersionEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new VersionEvent($this), VersionEvents::POST_SAVE);
     }
 
     /**
@@ -357,7 +357,7 @@ class Version extends AbstractModel
      */
     public function delete()
     {
-        \Pimcore::getEventDispatcher()->dispatch(VersionEvents::PRE_DELETE, new VersionEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new VersionEvent($this), VersionEvents::PRE_DELETE);
 
         foreach ([$this->getFilePath(), $this->getLegacyFilePath()] as $path) {
             if (is_file($path)) {
@@ -375,7 +375,7 @@ class Version extends AbstractModel
         }
 
         $this->getDao()->delete();
-        \Pimcore::getEventDispatcher()->dispatch(VersionEvents::POST_DELETE, new VersionEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(new VersionEvent($this), VersionEvents::POST_DELETE);
     }
 
     /**

--- a/tests/_support/Helper/Pimcore.php
+++ b/tests/_support/Helper/Pimcore.php
@@ -16,6 +16,7 @@ use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\ClassDefinitionManager;
 use Pimcore\Model\Document;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\EventDispatcher\Event;
 
 class Pimcore extends Module\Symfony
 {
@@ -111,7 +112,7 @@ class Pimcore extends Module\Symfony
         }
 
         // dispatch kernel booted event - will be used from services which need to reset state between tests
-        $this->kernel->getContainer()->get('event_dispatcher')->dispatch(TestEvents::KERNEL_BOOTED);
+        $this->kernel->getContainer()->get('event_dispatcher')->dispatch(new Event(), TestEvents::KERNEL_BOOTED);
     }
 
     protected function setupPimcoreDirectories()


### PR DESCRIPTION
## Changes in this pull request  

Change order of event and eventname calls for all dispatcher calls.

Resolves #

Symfony 4.3 deprecation log

## Additional info  

With Symfony 4.3 the order of the parameters of the dispatch function was changed. Using the old order cause a deprecation error log.

This change should not have any functional impact since the parameter order is switched anyway in dispatch after the error log:

vendor\symfony\symfony\src\Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher.php
	@trigger_error(sprintf('Calling the "%s::dispatch()" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead.', EventDispatcherInterface::class), E_USER_DEPRECATED);
	$swap = $event;
	$event = $eventName ?? new Event();
	$eventName = $swap;


vendor\symfony\symfony\src\Symfony\Component\EventDispatcher\EventDispatcher.php
	@trigger_error(sprintf('Calling the "%s::dispatch()" method with the event name as the first argument is deprecated since Symfony 4.3, pass it as the second argument and provide the event object as the first argument instead.', EventDispatcherInterface::class), E_USER_DEPRECATED);
	$swap = $event;
	$event = $eventName ?? new Event();
	$eventName = $swap;
