### PR TITLE
[DataObject] Mandatory setting for Geopolygon and Geopolyline

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/tags/checkbox.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/tags/checkbox.js
@@ -91,10 +91,6 @@ pimcore.asset.tags.checkbox = Class.create(pimcore.asset.tags.abstract, {
         return this.fieldConfig.name;
     },
 
-    isInvalidMandatory:function () {
-        return false;
-    },
-
     isDirty:function () {
         return this.dataChanged;
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/geopolygon.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/geopolygon.js
@@ -22,7 +22,7 @@ pimcore.object.classes.data.geopolygon = Class.create(pimcore.object.classes.dat
         this.initData(initData);
 
         // overwrite default settings
-        this.availableSettingsFields = ['name','title','noteditable','invisible','style'];
+        this.availableSettingsFields = ['name','title','mandatory','noteditable','invisible','style'];
 
         this.treeNode = treeNode;
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/geopolyline.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/geopolyline.js
@@ -22,7 +22,7 @@ pimcore.object.classes.data.geopolyline = Class.create(pimcore.object.classes.da
         this.initData(initData);
 
         // overwrite default settings
-        this.availableSettingsFields = ['name','title','noteditable','invisible','style'];
+        this.availableSettingsFields = ['name','title','mandatory','noteditable','invisible','style'];
 
         this.treeNode = treeNode;
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/abstract.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/abstract.js
@@ -182,21 +182,6 @@ pimcore.object.tags.abstract = Class.create({
         }
     },
 
-    isInvalidMandatory:function () {
-
-        if (!this.isRendered() && this.getInitialData() && this.getInitialData().length > 0) {
-            return false;
-        } else if (!this.isRendered()) {
-            return true;
-        }
-
-        if (this.getValue().length < 1) {
-            return true;
-        }
-        return false;
-    },
-
-
     isMandatory:function () {
         return this.fieldConfig.mandatory;
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/block.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/block.js
@@ -396,35 +396,6 @@ pimcore.object.tags.block = Class.create(pimcore.object.tags.abstract, {
         }
 
         return false;
-    },
-
-    isInvalidMandatory: function () {
-        var element;
-        var isInvalid = false;
-        var invalidMandatoryFields = [];
-
-        for(var s=0; s<this.component.items.items.length; s++) {
-            if(this.currentElements[this.component.items.items[s].key]) {
-                element = this.currentElements[this.component.items.items[s].key];
-
-                for (var u=0; u<element.fields.length; u++) {
-                    if(element.fields[u].isMandatory()) {
-                        if(element.fields[u].isInvalidMandatory()) {
-                            invalidMandatoryFields.push(element.fields[u].getTitle() + " ("
-                                + element.fields[u].getName() + ")");
-                            isInvalid = true;
-                        }
-                    }
-                }
-            }
-        }
-
-        // return the error messages not bool, this is handled in object/edit.js
-        if(isInvalid) {
-            return invalidMandatoryFields;
-        }
-
-        return isInvalid;
     }
 });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
@@ -75,10 +75,6 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
         return this.fieldConfig.name;
     },
 
-    isInvalidMandatory: function () {
-        return true;
-    },
-
     getGridColumnFilter: function (field) {
         return {type: 'string', dataIndex: field.key};
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/checkbox.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/checkbox.js
@@ -178,10 +178,6 @@ pimcore.object.tags.checkbox = Class.create(pimcore.object.tags.abstract, {
         return this.fieldConfig.name;
     },
 
-    isInvalidMandatory:function () {
-        return false;
-    },
-
     isDirty:function () {
         return this.dataChanged;
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/classificationstore.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/classificationstore.js
@@ -370,40 +370,6 @@ pimcore.object.tags.classificationstore = Class.create(pimcore.object.tags.abstr
         return false;
     },
 
-    isInvalidMandatory: function () {
-        var isInvalid = false;
-        var invalidMandatoryFields = [];
-        var currentLanguage;
-
-        for (var i=0; i < this.frontendLanguages.length; i++) {
-
-            currentLanguage = this.frontendLanguages[i];
-
-            for (var s=0; s<this.languageElements[currentLanguage].length; s++) {
-                if(this.languageElements[currentLanguage][s].isMandatory()) {
-                    var languageElement = this.languageElements[currentLanguage][s];
-                    try {
-                        if (languageElement.isInvalidMandatory()) {
-                            invalidMandatoryFields.push(this.languageElements[currentLanguage][s].getTitle() + " - "
-                                + currentLanguage.toUpperCase() + " ("
-                                + this.languageElements[currentLanguage][s].getName() + ")");
-                            isInvalid = true;
-                        }
-                    } catch (e) {
-                        console.log(e);
-                    }
-                }
-            }
-        }
-
-        // return the error messages not bool, this is handled in object/edit.js
-        if(isInvalid) {
-            return invalidMandatoryFields;
-        }
-
-        return isInvalid;
-    },
-
     createGroupFieldset: function (language, group, groupedChildItems, isNew) {
         var groupId = group.id;
         var groupTitle = group.description ? group.name + " - " + group.description : group.name;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/consent.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/consent.js
@@ -129,10 +129,5 @@ pimcore.object.tags.consent = Class.create(pimcore.object.tags.abstract, {
 
     getName:function () {
         return this.fieldConfig.name;
-    },
-
-    isInvalidMandatory:function () {
-        return false;
     }
-
 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/date.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/date.js
@@ -107,15 +107,6 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
         return this.fieldConfig.name;
     },
 
-    isInvalidMandatory:function () {
-
-        // no render check is necessary because the date compontent returns the right values even it is not rendered
-        if (this.getValue() == false) {
-            return true;
-        }
-        return false;
-    },
-
     isDirty:function () {
         var dirty = false;
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/datetime.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/datetime.js
@@ -132,15 +132,6 @@ pimcore.object.tags.datetime = Class.create(pimcore.object.tags.abstract, {
         return this.fieldConfig.name;
     },
 
-    isInvalidMandatory:function () {
-
-        // no render check is necessary because the date compontent returns the right values even if it is not rendered
-        if (this.getValue() == false) {
-            return true;
-        }
-        return false;
-    },
-
     isDirty:function () {
         var dirty = false;
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/encryptedField.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/encryptedField.js
@@ -48,10 +48,6 @@ pimcore.object.tags.encryptedField = Class.create(pimcore.object.tags.abstract, 
         return this.delegate.getCellEditValue();
     },
 
-    isInvalidMandatory: function () {
-        return this.delegate.isInvalidMandatory();
-    },
-
     getGridColumnEditor: function (field) {
 
         return pimcore.object.tags[field.layout.delegateDatatype].prototype.getGridColumnEditor(this.getDelegateGridConfig(field));
@@ -67,7 +63,7 @@ pimcore.object.tags.encryptedField = Class.create(pimcore.object.tags.abstract, 
             return this.component;
         }
     },
-    
+
     getLayoutShow: function () {
         if (this.delegate) {
             this.component = this.delegate.getLayoutShow();

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/externalImage.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/externalImage.js
@@ -227,14 +227,6 @@ pimcore.object.tags.externalImage = Class.create(pimcore.object.tags.abstract, {
         return this.fieldConfig.name;
     },
 
-    isInvalidMandatory: function () {
-        if (this.getValue()) {
-            return false;
-        }
-        return true;
-    }
-    ,
-
     isDirty: function() {
         return this.inputField.isDirty();
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
@@ -539,38 +539,6 @@ pimcore.object.tags.fieldcollections = Class.create(pimcore.object.tags.abstract
         }
 
         return false;
-    },
-
-    isInvalidMandatory: function () {
-        var element;
-        var isInvalid = false;
-        var invalidMandatoryFields = [];
-
-        for(var s=0; s<this.component.items.items.length; s++) {
-            if(this.currentElements[this.component.items.items[s].key]) {
-                element = this.currentElements[this.component.items.items[s].key];
-
-                var elementFieldNames = Object.keys(element.fields);
-
-                for (var u=0; u < elementFieldNames.length; u++) {
-                    var elementFieldName = elementFieldNames[u];
-                    if(element.fields[elementFieldName].isMandatory()) {
-                        if(element.fields[elementFieldName].isInvalidMandatory()) {
-                            invalidMandatoryFields.push(element.fields[elementFieldName].getTitle() + " ("
-                                                                    + element.fields[elementFieldName].getName() + ")");
-                            isInvalid = true;
-                        }
-                    }
-                }
-            }
-        }
-
-        // return the error messages not bool, this is handled in object/edit.js
-        if(isInvalid) {
-            return invalidMandatoryFields;
-        }
-
-        return isInvalid;
     }
 });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geobounds.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geobounds.js
@@ -169,17 +169,6 @@ pimcore.object.tags.geobounds = Class.create(pimcore.object.tags.geo.abstract, {
         return this.fieldConfig.name;
     },
 
-    isInvalidMandatory: function () {
-        var value = this.getValue();
-
-        // @TODO
-        /*if (value.longitude && value.latitude) {
-         return false;
-         }*/
-
-        return true;
-    },
-
     isDirty: function () {
         if (!this.isRendered()) {
             return false;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geopoint.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geopoint.js
@@ -228,17 +228,6 @@ pimcore.object.tags.geopoint = Class.create(pimcore.object.tags.geo.abstract, {
         return this.fieldConfig.name;
     },
 
-    isInvalidMandatory: function () {
-
-        // no render check is necessary because the input component returns the right values even if it is not
-        // rendered
-        var value = this.getValue();
-        if (value.longitude && value.latitude) {
-            return false;
-        }
-        return true;
-    },
-
     isDirty: function () {
         if (!this.isRendered()) {
             return false;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geopolygon.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geopolygon.js
@@ -189,17 +189,6 @@ pimcore.object.tags.geopolygon = Class.create(pimcore.object.tags.geo.abstract, 
         return this.fieldConfig.name;
     },
 
-    isInvalidMandatory: function () {
-        var value = this.getValue();
-
-        // @TODO
-        /*if (value.longitude && value.latitude) {
-            return false;
-        }*/
-
-        return true;
-    },
-
     isDirty: function() {
         if(!this.isRendered()) {
             return false;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geopolyline.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geopolyline.js
@@ -174,12 +174,6 @@ pimcore.object.tags.geopolyline = Class.create(pimcore.object.tags.geo.abstract,
         return this.fieldConfig.name;
     },
 
-    isInvalidMandatory: function () {
-        var value = this.getValue();
-
-        return true;
-    },
-
     isDirty: function () {
         if (!this.isRendered()) {
             return false;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/image.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/image.js
@@ -388,13 +388,6 @@ pimcore.object.tags.image = Class.create(pimcore.object.tags.abstract, {
         return this.fieldConfig.name;
     },
 
-    isInvalidMandatory: function () {
-        if (this.getValue()) {
-            return false;
-        }
-        return true;
-    },
-
     isDirty: function () {
         if (!this.isRendered()) {
             return false;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/inputQuantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/inputQuantityValue.js
@@ -158,9 +158,5 @@ pimcore.object.tags.inputQuantityValue = Class.create(pimcore.object.tags.abstra
 
     getName: function () {
         return this.fieldConfig.name;
-    },
-
-    isInvalidMandatory: function () {
-        return !(this.unitField.getValue() && this.inputField.getValue());
     }
 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/localizedfields.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/localizedfields.js
@@ -589,41 +589,6 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
         return false;
     },
 
-    isInvalidMandatory: function () {
-        // also check the referenced localized fields
-        if (this.referencedFields.length > 0) {
-            for (var r = 0; r < this.referencedFields.length; r++) {
-                if (this.referencedFields[r].isInvalidMandatory()) {
-                    return true;
-                }
-            }
-        }
-
-        var currentLanguage;
-        var isInvalid = false;
-        var invalidMandatoryFields = [];
-
-        for (var i = 0; i < this.frontendLanguages.length; i++) {
-            currentLanguage = this.frontendLanguages[i];
-
-            for (var s = 0; s < this.languageElements[currentLanguage].length; s++) {
-                if (this.languageElements[currentLanguage][s].isMandatory()) {
-                    if (this.languageElements[currentLanguage][s].isInvalidMandatory()) {
-                        invalidMandatoryFields.push(this.languageElements[currentLanguage][s].getTitle() + " - "
-                            + currentLanguage.toUpperCase() + " ("
-                            + this.languageElements[currentLanguage][s].getName() + ")");
-                        isInvalid = true;
-                    }
-                }
-            }
-        }
-
-        // return the error messages not bool, this is handled in object/edit.js
-        if (isInvalid) {
-            return invalidMandatoryFields;
-        }
-    },
-
     removeInheritanceSourceButton: function () {
         //nothing to do
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -691,19 +691,6 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
     }
     ,
 
-    isInvalidMandatory: function () {
-
-        var data = this.store.queryBy(function (record, id) {
-            return true;
-        });
-        if (data.items.length < 1) {
-            return true;
-        }
-        return false;
-
-    }
-    ,
-
     addDataFromSelector: function (items) {
 
         if (items.length > 0) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -592,18 +592,6 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
         item.parentMenu.destroy();
     },
 
-
-    isInvalidMandatory: function () {
-
-        var data = this.store.queryBy(function (record, id) {
-            return true;
-        });
-        if (data.items.length < 1) {
-            return true;
-        }
-        return false;
-    },
-
     getValue: function () {
 
         var tmData = [];

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -461,13 +461,6 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
         return isAllowed;
     },
 
-    isInvalidMandatory: function () {
-        if (this.data.id) {
-            return false;
-        }
-        return true;
-    },
-
     requestNicePathData: function () {
         if (this.data.id) {
             var targets = new Ext.util.Collection();

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/numeric.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/numeric.js
@@ -170,20 +170,6 @@ pimcore.object.tags.numeric = Class.create(pimcore.object.tags.abstract, {
         return this.fieldConfig.name;
     },
 
-    isInvalidMandatory: function () {
-
-        if (!this.isRendered() && (!empty(this.getInitialData() || this.getInitialData() === 0))) {
-            return false;
-        } else if (!this.isRendered()) {
-            return true;
-        }
-
-        if (this.getValue()) {
-            return false;
-        }
-        return true;
-    },
-
     isDirty: function () {
         var dirty = false;
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
@@ -477,38 +477,6 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
 
             return false;
         }
-    ,
-
-        isInvalidMandatory: function () {
-            var element;
-            var isInvalid = false;
-            var invalidMandatoryFields = [];
-
-            var types = Object.keys(this.currentElements);
-            for (var t = 0; t < types.length; t++) {
-                if (this.currentElements[types[t]]) {
-                    element = this.currentElements[types[t]];
-                    if (element.action != "deleted") {
-                        for (var u = 0; u < element.fields.length; u++) {
-                            if (element.fields[u].isMandatory()) {
-                                if (element.fields[u].isInvalidMandatory()) {
-                                    invalidMandatoryFields.push(element.fields[u].getTitle()
-                                        + " (" + element.fields[u].getName() + "|" + types[t] + ")");
-                                    isInvalid = true;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // return the error messages not bool, this is handled in object/edit.js
-            if (isInvalid) {
-                return invalidMandatoryFields;
-            }
-
-            return isInvalid;
-        }
 
     });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
@@ -199,13 +199,5 @@ pimcore.object.tags.quantityValue = Class.create(pimcore.object.tags.abstract, {
 
     getName: function () {
         return this.fieldConfig.name;
-    },
-
-    isInvalidMandatory: function () {
-        if (this.unitField.getValue() && this.inputField.getValue()) {
-            return false;
-        }
-        return true;
     }
-
 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/rgbaColor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/rgbaColor.js
@@ -53,13 +53,6 @@ pimcore.object.tags.rgbaColor = Class.create(pimcore.object.tags.abstract, {
         return this.getValue();
     },
 
-    isInvalidMandatory: function () {
-        if (this.isMandatory() && !this.getValue()) {
-            return true;
-        }
-        return false;
-    },
-
     getGridColumnEditor: function (field) {
         var editorConfig = {};
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/slider.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/slider.js
@@ -124,10 +124,6 @@ pimcore.object.tags.slider = Class.create(pimcore.object.tags.abstract, {
         return this.fieldConfig.name;
     },
 
-    isInvalidMandatory: function () {
-        return false;
-    },
-
     isDirty: function () {
         if (!this.isRendered()) {
             return false;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/structuredTable.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/structuredTable.js
@@ -289,21 +289,6 @@ pimcore.object.tags.structuredTable = Class.create(pimcore.object.tags.abstract,
         this.dataChanged = true;
     },
 
-    isInvalidMandatory: function () {
-        var empty = true;
-
-        this.store.each(function(record) {
-            for(var j = 0; j < this.fieldConfig.cols.length; j++) {
-                if(record.data[this.fieldConfig.cols[j].key] != null
-                                                        && record.data[this.fieldConfig.cols[j].key] != "") {
-                    empty = false;
-                }
-            }
-        }.bind(this));
-
-        return empty;
-    },
-
     getValue: function () {
         var tmData = [];
 
@@ -327,7 +312,7 @@ pimcore.object.tags.structuredTable = Class.create(pimcore.object.tags.abstract,
         if(!this.isRendered()) {
             return false;
         }
-        
+
         return this.dataChanged;
     }
 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/time.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/time.js
@@ -59,13 +59,6 @@ pimcore.object.tags.time = Class.create(pimcore.object.tags.abstract, {
         return this.fieldConfig.name;
     },
 
-    isInvalidMandatory: function () {
-        if (this.getValue() == false) {
-            return true;
-        }
-        return false;
-    },
-
     getGridColumnConfig: function (field) {
         var renderer = function (key, value, metaData, record) {
             this.applyPermissionStyle(key, value, metaData, record);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/video.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/video.js
@@ -215,13 +215,6 @@ pimcore.object.tags.video = Class.create(pimcore.object.tags.abstract, {
         return this.fieldConfig.name;
     },
 
-    isInvalidMandatory: function () {
-        if (this.getValue()) {
-            return false;
-        }
-        return true;
-    },
-
     isDirty: function () {
         if (!this.isRendered()) {
             return false;

--- a/bundles/EcommerceFrameworkBundle/Resources/public/js/indexfieldselectionfield/tags/indexFieldSelection.js
+++ b/bundles/EcommerceFrameworkBundle/Resources/public/js/indexfieldselectionfield/tags/indexFieldSelection.js
@@ -24,7 +24,7 @@ pimcore.object.tags.indexFieldSelection = Class.create(pimcore.object.tags.selec
             this.data = {};
         }
         this.fieldConfig = fieldConfig;
-        
+
         this.store = new Ext.data.JsonStore({
             autoDestroy: true,
             autoLoad: true,
@@ -260,13 +260,5 @@ pimcore.object.tags.indexFieldSelection = Class.create(pimcore.object.tags.selec
 
     isDirty: function() {
         return this.fieldsCombobox.isDirty() || (this.preSelectCombobox && this.preSelectCombobox.isDirty());
-    },
-
-    isInvalidMandatory: function () {
-        if (this.fieldsCombobox.getValue()) {
-            return false;
-        }
-        return true;
     }
-
 });


### PR DESCRIPTION
This PR activates the mandatory settings in Geopolygon and Geopolyline fields.
The mandatory check works at the server.

At the client the validation is removed since #3085

I think we can remove all the isInvalidMandatory JS functions, right?
