### PR TITLE
Enable Editable Icons for Region Panels in DataObjects

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/region.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/region.js
@@ -30,6 +30,25 @@ pimcore.object.classes.layout.region = Class.create(pimcore.object.classes.layou
 
     getIconClass: function () {
         return "pimcore_icon_region";
-    }
+    },
 
+    getLayout: function ($super) {
+        $super();
+
+        this.layout.add({
+            xtype: "form",
+            bodyStyle: "padding: 10px;",
+            style: "margin: 10px 0 10px 0",
+            items: [
+                {
+                    xtype: "textfield",
+                    name: "icon",
+                    fieldLabel: t("icon"),
+                    value: this.datax.icon
+                }
+            ]
+        });
+
+        return this.layout;
+    }
 });

--- a/models/DataObject/ClassDefinition/Layout/Region.php
+++ b/models/DataObject/ClassDefinition/Layout/Region.php
@@ -26,4 +26,25 @@ class Region extends Model\DataObject\ClassDefinition\Layout
      * @var string
      */
     public $fieldtype = 'region';
+    
+    /**
+     * @var string|null
+     */
+    public $icon;
+
+    /**
+     * @return string
+     */
+    public function getIcon(): ?string
+    {
+        return $this->icon;
+    }
+
+    /**
+     * @param string $icon
+     */
+    public function setIcon(?string $icon): void
+    {
+        $this->icon = $icon;
+    }
 }


### PR DESCRIPTION
## Changes in this pull request  
Icons were already editable for basic panel in data object's edit mode. This PR just enables the same feature for region panels as well.

