### PR TITLE
[ImageOptimizerQueue] write file path to 'data' column instead of 'id' column

### DIFF
--- a/lib/Maintenance/Tasks/ImageOptimizeTask.php
+++ b/lib/Maintenance/Tasks/ImageOptimizeTask.php
@@ -50,14 +50,19 @@ final class ImageOptimizeTask implements TaskInterface
 
         // id = path of image relative to PIMCORE_TEMPORARY_DIRECTORY
         foreach ($ids as $id) {
-            $file = PIMCORE_TEMPORARY_DIRECTORY.'/'.$id;
-            if (file_exists($file)) {
-                $originalFilesize = filesize($file);
-                $this->optimizer->optimizeImage($file);
+            $tmpStore = TmpStore::get($id);
 
-                $this->logger->debug('Optimized image: '.$file.' saved '.formatBytes($originalFilesize - filesize($file)));
-            } else {
-                $this->logger->debug('Skip optimizing of '.$file." because it doesn't exist anymore");
+            if ($tmpStore && $tmpStore->getData()) {
+                $file = PIMCORE_TEMPORARY_DIRECTORY.'/'.$tmpStore->getData();
+                if (file_exists($file)) {
+                    $originalFilesize = filesize($file);
+                    $this->optimizer->optimizeImage($file);
+
+                    $this->logger->debug('Optimized image: '.$file.' saved '.formatBytes($originalFilesize - filesize($file)));
+                } else {
+                    $this->logger->debug('Skip optimizing of '.$file." because it doesn't exist anymore");
+                }
+
             }
 
             TmpStore::delete($id);

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -354,8 +354,9 @@ class Processor
         $generated = true;
 
         if ($contentOptimizedFormat) {
-            $tmpStoreKey = str_replace(PIMCORE_TEMPORARY_DIRECTORY . '/', '', $fsPath);
-            TmpStore::add($tmpStoreKey, '-', 'image-optimize-queue');
+            $filePath = str_replace(PIMCORE_TEMPORARY_DIRECTORY . '/', '', $fsPath);
+            $tmpStoreKey = 'thumb_' . $asset->getId() . '__' . md5($filePath);
+            TmpStore::add($tmpStoreKey, $filePath, 'image-optimize-queue');
         }
 
         clearstatcache();


### PR DESCRIPTION
Currently, file paths of thumbnails to be optimised are written to the tmp_store.id column which has a stipulated length of 190.
In some cases, file paths will be longer than that and any characters over the limit will be cut off when inserted into the database.
The ImageOptimizeTask maintenance script then dies, as it cannot find any files with the faulty paths.

This PR creates an md5 hash of the file path as the id and writes the actual file path to the tmp_store.data column.