### PR TITLE
Fix exception when loading empty not editable thumbnail in a Custom Layout

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -1163,6 +1163,13 @@ class AssetController extends ElementControllerBase implements EventedController
         $fileinfo = $request->get('fileinfo');
         $image = Asset\Image::getById(intval($request->get('id')));
 
+
+        //Fallback if no image with specified id exists
+        //Fixes bug for custom layout when image is shown but not editable
+        if(!$image){
+            return new Response();
+        }
+
         if (!$image->isAllowed('view')) {
             throw new \Exception('not allowed to view thumbnail');
         }


### PR DESCRIPTION
Get exception when loading empty not editable thumbnail in a Custom Layout.
This bug occurs when creating a Custom Layout for a class. Afterwards add a Image Advanced to the Custom Layout and set it not editable. Keep the image empty. After opening the Custom Layout and no image is set to the image field, pimcore throws an exception because of the missing check if the image is even existing.
