### PR TITLE
Fixed layout bug which granted access to admin layout without permissions

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -472,7 +472,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             }
             if(!$ok){
                 if (count($validLayouts) > 0) {
-                    $currentLayoutId = $validLayouts[array_key_first($validLayouts)]->getId();
+                    $currentLayoutId = reset($validLayouts)->getId();
                 }
             }
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -462,6 +462,20 @@ class DataObjectController extends ElementControllerBase implements EventedContr
 
             $validLayouts = DataObject\Service::getValidLayouts($object);
 
+            //Fallback if $currentLayoutId is not set or empty string
+            //Uses first valid layout instead of admin layout when empty
+            $ok = false;
+            foreach ($validLayouts as $key => $layout){
+                if($currentLayoutId == $layout->getId()){
+                    $ok = true;
+                }
+            }
+            if(!$ok){
+                if (count($validLayouts) > 0) {
+                    $currentLayoutId = $validLayouts[array_key_first($validLayouts)]->getId();
+                }
+            }
+
             //master layout has id 0 so we check for is_null()
             if ((is_null($currentLayoutId) || !strlen($currentLayoutId)) && !empty($validLayouts)) {
                 if (count($validLayouts) == 1) {


### PR DESCRIPTION
Getting Admin Layout without permissions:
To reproduce this bug, simply open a object but set the "layoutId" param to an empty string beforehand. Now pimcore will show the admin layout to the user even without the necessary permission.
