### PR TITLE
Load .env variables before custom constants

### DIFF
--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -213,13 +213,14 @@ class Bootstrap
 
     public static function defineConstants()
     {
+        self::prepareEnvVariables();
+        
         // load custom constants
         $customConstantsFile = PIMCORE_PROJECT_ROOT . '/app/constants.php';
         if (file_exists($customConstantsFile)) {
             include_once $customConstantsFile;
         }
-
-        self::prepareEnvVariables();
+        
 
         $resolveConstant = function (string $name, $default, bool $define = true) {
             // return constant if defined


### PR DESCRIPTION
... because then we can use the values of .env variables in the custom constants. Or is there any good reason against changing the order?

Please check if there is any good reasons AGAINST this. If there is please reject.
