### PR TITLE
A possibility to define environment specific constants

### DIFF
--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -224,7 +224,7 @@ class Bootstrap
         // load custom constants
         $customConstantsEnvFile = PIMCORE_PROJECT_ROOT . '/app/constants-env.php';
         if (file_exists($customConstantsEnvFile)) {
-            include_once $customConstantsFile;
+            include_once $customConstantsEnvFile;
         }
 
         $resolveConstant = function (string $name, $default, bool $define = true) {

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -220,6 +220,12 @@ class Bootstrap
         }
 
         self::prepareEnvVariables();
+        
+        // load custom constants
+        $customConstantsEnvFile = PIMCORE_PROJECT_ROOT . '/app/constants-env.php';
+        if (file_exists($customConstantsEnvFile)) {
+            include_once $customConstantsFile;
+        }
 
         $resolveConstant = function (string $name, $default, bool $define = true) {
             // return constant if defined


### PR DESCRIPTION
The number of files to be changed in a deployment should be as small as possible (best case only .env files and the specific config files). As the constants file is loaded before the environment i detected, we should have a possibility to define environment specific constants after PIMCORE_ENVIRONMENT has been loaded.

# Use case
Disabling Amazon S3 on local (defining S3 variables only for staging and prod environment).
