### PR TITLE
Fix checkbox editable not showing and saving the correct state

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tags/checkbox.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tags/checkbox.js
@@ -26,10 +26,6 @@ pimcore.document.tags.checkbox = Class.create(pimcore.document.tag, {
         }
 
         this.htmlId = id + "_editable";
-        var checked = "";
-        if(data) {
-            checked = ' checked="checked"';
-        }
 
         var elContainer = Ext.get(id);
 
@@ -38,7 +34,9 @@ pimcore.document.tags.checkbox = Class.create(pimcore.document.tag, {
         inputCheckbox.setAttribute('type', 'checkbox');
         inputCheckbox.setAttribute('value', 'true');
         inputCheckbox.setAttribute('id', this.htmlId);
-        inputCheckbox.setAttribute('checked', 'true');
+        if(data) {
+            inputCheckbox.setAttribute('checked', 'checked');
+        }
 
         elContainer.appendChild(inputCheckbox);
 
@@ -61,7 +59,7 @@ pimcore.document.tags.checkbox = Class.create(pimcore.document.tag, {
     },
 
     getValue: function () {
-        return this.elComponent.get(0).checked;
+        return this.elComponent.dom.checked;
     },
 
     getType: function () {


### PR DESCRIPTION
This patch fixes the jQuery removal of the checkbox editable which did not render according to its data and threw an exception on getValue() which made it no longer getting saved.

Resolves: #5290
