### PR TITLE
Fixes the nullable container issue in Pimcore::shutdown() mentod

### DIFF
--- a/lib/Pimcore.php
+++ b/lib/Pimcore.php
@@ -270,6 +270,10 @@ class Pimcore
         // set inShutdown to true so that the output-buffer knows that he is allowed to send the headers
         self::$inShutdown = true;
 
+        if (self::getContainer() === null) {
+            return;
+        }
+
         // Check if this is a cache warming run and if this runs on an installed instance. If this is a cache warmup
         // we can't use self::isInstalled() as it will refer to the wrong caching dir.
         if (self::getKernel()->getCacheDir() === self::getContainer()->getParameter('kernel.cache_dir') && self::isInstalled()) {


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [ +] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ +] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ +] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #5300 

## Problem 
```
Error: Call to a member function getParameter() on null in /var/www/vendor/pimcore/pimcore/lib/Pimcore.php on line 275
```

## Reproduce guide
My case.
There is a conflict between `\Symfony\Bundle\FrameworkBundle\Test\KernelTestCase` and `\Pimcore\Kernel`. When you create a test that extends the `KernelTestCase` it will cause an error after execution:
```
Error: Call to a member function getParameter() on null in /var/www/vendor/pimcore/pimcore/lib/Pimcore.php on line 275
```
This error caused by trying to call the `getParameter()` method on the nullable container because it was deleted by `KernelTestCase` already. [See this link](https://github.com/symfony/symfony/blob/996d8a708fd5fe5043c5098c3da4921f75b95e52/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php#L134) (doesn't matter whether it's 4.4 or 4.3. I'm using the 4.3 version)