### PR TITLE
Always use PIMCORE_PHP_ERROR_REPORTING and fix PHP notices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,7 +138,7 @@ env:
     - PIMCORE_TEST_CACHE_REDIS_DATABASE=1
     - SYMFONY_VERSION=^4.0
     - PIMCORE_PROJECT_ROOT=$TRAVIS_BUILD_DIR
-
+    - PIMCORE_PHP_ERROR_REPORTING=32767 # E_ALL
 
 # see https://docs.travis-ci.com/user/job-lifecycle/
 before_install:

--- a/bin/pimcore-install
+++ b/bin/pimcore-install
@@ -21,7 +21,6 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
 
-error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);
 @ini_set('display_errors', 'On');
 
 $maxExecutionTime = 0;

--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetHelperController.php
@@ -283,10 +283,10 @@ class AssetHelperController extends AdminController
         $sharedConfigs = $classId ? $this->getSharedGridColumnConfigs($this->getAdminUser(), $classId, $searchType) : [];
         $settings = $this->getShareSettings((int)$gridConfigId);
         $settings['gridConfigId'] = (int)$gridConfigId;
-        $settings['gridConfigName'] = $gridConfigName;
-        $settings['gridConfigDescription'] = $gridConfigDescription;
-        $settings['shareGlobally'] = $sharedGlobally;
-        $settings['isShared'] = (!$gridConfigId || $shared) ? true : false;
+        $settings['gridConfigName'] = $gridConfigName ?? null;
+        $settings['gridConfigDescription'] = $gridConfigDescription ?? null;
+        $settings['shareGlobally'] = $sharedGlobally ?? null;
+        $settings['isShared'] = !$gridConfigId || ($shared ?? null);
 
         return [
             'sortinfo' => isset($gridConfig['sortinfo']) ? $gridConfig['sortinfo'] : false,

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -93,6 +93,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         }
 
         $filteredTotalCount = 0;
+        $limit = 0;
 
         if ($object->hasChildren($objectTypes)) {
             $limit = (int)$request->get('limit');
@@ -193,7 +194,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         $eventDispatcher->dispatch(AdminEvents::OBJECT_TREE_GET_CHILDREN_BY_ID_PRE_SEND_DATA, $event);
         $objects = $event->getArgument('objects');
 
-        if ($request->get('limit')) {
+        if ($limit) {
             return $this->adminJson([
                 'offset' => $offset,
                 'limit' => $limit,
@@ -204,9 +205,9 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 'filter' => $request->get('filter') ? $request->get('filter') : '',
                 'inSearch' => intval($request->get('inSearch'))
             ]);
-        } else {
-            return $this->adminJson($objects);
         }
+
+        return $this->adminJson($objects);
     }
 
     /**
@@ -599,8 +600,10 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 $data = [];
 
                 if ($fielddefinition instanceof DataObject\ClassDefinition\Data\ManyToOneRelation) {
-                    $data = $relations[0];
-                    $data['published'] = (bool)$data['published'];
+                    if (isset($relations[0])) {
+                        $data = $relations[0];
+                        $data['published'] = (bool)$data['published'];
+                    }
                 } elseif (
                     ($fielddefinition instanceof DataObject\ClassDefinition\Data\OptimizedAdminLoadingInterface && $fielddefinition->isOptimizedAdminLoading())
                     || ($fielddefinition instanceof ManyToManyObjectRelation && !$fielddefinition->getVisibleFields() && !$fielddefinition instanceof DataObject\ClassDefinition\Data\AdvancedManyToManyObjectRelation)

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -634,10 +634,10 @@ class DataObjectHelperController extends AdminController
         $sharedConfigs = $class ? $this->getSharedGridColumnConfigs($this->getAdminUser(), $class->getId(), $searchType) : [];
         $settings = $this->getShareSettings((int)$gridConfigId);
         $settings['gridConfigId'] = (int)$gridConfigId;
-        $settings['gridConfigName'] = $gridConfigName;
-        $settings['gridConfigDescription'] = $gridConfigDescription;
-        $settings['shareGlobally'] = $sharedGlobally;
-        $settings['isShared'] = (!$gridConfigId || $shared) ? true : false;
+        $settings['gridConfigName'] = $gridConfigName ?? null;
+        $settings['gridConfigDescription'] = $gridConfigDescription ?? null;
+        $settings['shareGlobally'] = $sharedGlobally ?? null;
+        $settings['isShared'] = !$gridConfigId || ($shared ?? null);
 
         return [
             'sortinfo' => isset($gridConfig['sortinfo']) ? $gridConfig['sortinfo'] : false,
@@ -672,11 +672,11 @@ class DataObjectHelperController extends AdminController
             $vis = $class->getPropertyVisibility();
             foreach (self::SYSTEM_COLUMNS as $sc) {
                 $key = $sc;
-                if ($key == 'fullpath') {
+                if ($key === 'fullpath') {
                     $key = 'path';
                 }
 
-                if (empty($types) && ($vis[$gridType][$key] || $gridType == 'all')) {
+                if (empty($types) && (!empty($vis[$gridType][$key]) || $gridType === 'all')) {
                     $availableFields[] = [
                         'key' => $sc,
                         'type' => 'system',

--- a/bundles/AdminBundle/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/Controller/Admin/SettingsController.php
@@ -384,9 +384,9 @@ class SettingsController extends AdminController
         if (file_exists($debugModeFile)) {
             $debugMode = include $debugModeFile;
         }
-        $valueArray['general']['debug'] = $debugMode['active'];
-        $valueArray['general']['debug_ip'] = $debugMode['ip'];
-        $valueArray['general']['devmode'] = $debugMode['devmode'];
+        $valueArray['general']['debug'] = $debugMode['active'] ?? false;
+        $valueArray['general']['debug_ip'] = $debugMode['ip'] ?? '';
+        $valueArray['general']['devmode'] = $debugMode['devmode'] ?? false;
 
         $response = [
             'values' => $valueArray,
@@ -466,8 +466,8 @@ class SettingsController extends AdminController
             ],
             'documents' => [
                 'versions' => [
-                    'days' => $values['documents.versions.days'],
-                    'steps' => $values['documents.versions.steps']
+                    'days' => $values['documents.versions.days'] ?? null,
+                    'steps' => $values['documents.versions.steps'] ?? null,
                 ],
                 'error_pages' => [
                     'default' => $values['documents.error_pages.default']
@@ -478,14 +478,14 @@ class SettingsController extends AdminController
             ],
             'objects' => [
                 'versions' => [
-                    'days' => $values['objects.versions.days'],
-                    'steps' => $values['objects.versions.steps']
+                    'days' => $values['objects.versions.days'] ?? null,
+                    'steps' => $values['objects.versions.steps'] ?? null,
                 ]
             ],
             'assets' => [
                 'versions' => [
-                    'days' => $values['assets.versions.days'],
-                    'steps' => $values['assets.versions.steps']
+                    'days' => $values['assets.versions.days'] ?? null,
+                    'steps' => $values['assets.versions.steps'] ?? null,
                 ],
                 'icc_rgb_profile' => $values['assets.icc_rgb_profile'],
                 'icc_cmyk_profile' => $values['assets.icc_cmyk_profile'],
@@ -587,7 +587,7 @@ class SettingsController extends AdminController
         File::putPhpFile($debugModeFile, to_php_data_file_format([
             'active' => $values['general.debug'],
             'ip' => $values['general.debug_ip'],
-            'devmode' => $values['general.devmode']
+            'devmode' => $values['general.devmode'],
         ]));
 
         // clear all caches

--- a/bundles/AdminBundle/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/Controller/Admin/SettingsController.php
@@ -1178,7 +1178,7 @@ class SettingsController extends AdminController
         /** @var $item Asset\Image\Thumbnail\Config */
         foreach ($items as $item) {
             if ($item->getGroup()) {
-                if (!$groups[$item->getGroup()]) {
+                if (empty($groups[$item->getGroup()])) {
                     $groups[$item->getGroup()] = [
                         'id' => 'group_' . $item->getName(),
                         'text' => $item->getGroup(),
@@ -1799,17 +1799,19 @@ class SettingsController extends AdminController
                 });
             }
 
-            $list->setOrder(function ($a, $b) use ($sortingSettings) {
+            $list->setOrder(static function ($a, $b) use ($sortingSettings) {
                 if (!$sortingSettings) {
                     return 0;
                 }
                 $orderKey = $sortingSettings['orderKey'];
-                if ($a[$orderKey] == $b[$orderKey]) {
+                $aValue = $a[$orderKey] ?? null;
+                $bValue = $b[$orderKey] ?? null;
+                if ($aValue == $bValue) {
                     return 0;
                 }
 
-                $result = $a[$orderKey] < $b[$orderKey] ? -1 : 1;
-                if ($sortingSettings['order'] == 'DESC') {
+                $result = $aValue < $bValue ? -1 : 1;
+                if ($sortingSettings['order'] === 'DESC') {
                     $result = -1 * $result;
                 }
 

--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -893,7 +893,6 @@ class TranslationController extends AdminController
      */
     public function wordExportAction(Request $request)
     {
-        error_reporting(0);
         ini_set('display_errors', 'off');
 
         $id = $this->sanitzeExportId((string)$request->get('id'));

--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -430,9 +430,9 @@ class UserController extends AdminController implements EventedControllerInterfa
         // object <=> user dependencies
         $userObjects = DataObject\Service::getObjectsReferencingUser($user->getId());
         $userObjectData = [];
+        $hasHidden = false;
 
         foreach ($userObjects as $o) {
-            $hasHidden = false;
             if ($o->isAllowed('list')) {
                 $userObjectData[] = [
                     'path' => $o->getRealFullPath(),

--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -65,9 +65,9 @@ class SearchController extends AdminController
 
         $query = $this->filterQueryParam($allParams['query']);
 
-        $types = explode(',', $allParams['type']);
-        $subtypes = explode(',', $allParams['subtype']);
-        $classnames = explode(',', $allParams['class']);
+        $types = explode(',', $allParams['type'] ?? '');
+        $subtypes = explode(',', $allParams['subtype'] ?? '');
+        $classnames = explode(',', $allParams['class'] ?? '');
 
         $offset = intval($allParams['start']);
         $limit = intval($allParams['limit']);
@@ -101,7 +101,7 @@ class SearchController extends AdminController
         //For objects - handling of bricks
         $fields = [];
         $bricks = [];
-        if ($allParams['fields']) {
+        if (!empty($allParams['fields'])) {
             $fields = $allParams['fields'];
 
             foreach ($fields as $f) {
@@ -118,7 +118,7 @@ class SearchController extends AdminController
         }
 
         // filtering for objects
-        if ($allParams['filter'] && $allParams['class']) {
+        if (!empty($allParams['filter']) && !empty($allParams['class'])) {
             $class = DataObject\ClassDefinition::getByName($allParams['class']);
 
             // add Localized Fields filtering
@@ -197,8 +197,8 @@ class SearchController extends AdminController
         }
 
         //filtering for tags
-        $tagIds = $allParams['tagIds'];
-        if ($tagIds) {
+        if (!empty($allParams['tagIds'])) {
+            $tagIds = $allParams['tagIds'];
             foreach ($tagIds as $tagId) {
                 foreach ($types as $type) {
                     if ($allParams['considerChildTags'] == 'true') {

--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -49,7 +49,7 @@ class SearchController extends AdminController
     {
         $allParams = array_merge($request->request->all(), $request->query->all());
 
-        $requestedLanguage = $allParams['language'];
+        $requestedLanguage = $allParams['language'] ?? null;
         if ($requestedLanguage) {
             if ($requestedLanguage != 'default') {
                 $request->setLocale($requestedLanguage);

--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -475,7 +475,7 @@ class GridHelperService
         $featureFilters = [];
 
         // create filter condition
-        if ($requestParams['filter']) {
+        if (!empty($requestParams['filter'])) {
             $conditionFilters[] = $this->getFilterCondition($requestParams['filter'], $class);
             $featureFilters = $this->getFeatureFilters($requestParams['filter'], $class, $requestedLanguage);
             if ($featureFilters) {
@@ -483,11 +483,11 @@ class GridHelperService
             }
         }
 
-        if ($requestParams['condition'] && $adminUser->isAdmin()) {
+        if (!empty($requestParams['condition']) && $adminUser->isAdmin()) {
             $conditionFilters[] = '(' . $requestParams['condition'] . ')';
         }
 
-        if ($requestParams['query']) {
+        if (!empty($requestParams['query'])) {
             $query = $this->filterQueryParam($requestParams['query']);
             if (!empty($query)) {
                 $conditionFilters[] = 'oo_id IN (SELECT id FROM search_backend_data WHERE MATCH (`data`,`properties`) AGAINST (' . $list->quote($query) . ' IN BOOLEAN MODE))';
@@ -505,7 +505,7 @@ class GridHelperService
         }
 
         $list->setCondition(implode(' AND ', $conditionFilters));
-        if (!$requestParams['batch'] && empty($requestParams['ids'])) {
+        if (empty($requestParams['batch']) && empty($requestParams['ids'])) {
             $list->setLimit($limit);
             $list->setOffset($start);
         }
@@ -528,7 +528,7 @@ class GridHelperService
         $list->setOrder($order);
 
         //parameters specified in the objects grid
-        if ($requestParams['ids']) {
+        if (!empty($requestParams['ids'])) {
             $quotedIds = [];
             foreach ($requestParams['ids'] as $id) {
                 $quotedIds[] = $list->quote($id);
@@ -546,7 +546,7 @@ class GridHelperService
         $this->addGridFeatureJoins($list, $featureJoins, $class, $featureFilters);
         $list->setLocale($requestedLanguage);
 
-        if (!$requestParams['filter'] && !$requestParams['condition'] && !$requestParams['sort']) {
+        if (empty($requestParams['filter']) && empty($requestParams['condition']) && empty($requestParams['sort'])) {
             $list->setIgnoreLocalizedFields(true);
         }
 

--- a/bundles/EcommerceFrameworkBundle/CartManager/CartPriceModificator/Discount.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/CartPriceModificator/Discount.php
@@ -67,24 +67,22 @@ class Discount implements DiscountInterface
      */
     public function modify(PriceInterface $currentSubTotal, CartInterface $cart)
     {
-        if ($this->getAmount() != 0) {
-            $amount = $this->getAmount();
-            if ($currentSubTotal->getAmount()->lessThan($amount->mul(-1))) {
-                $amount = $currentSubTotal->getAmount()->mul(-1);
-            }
-
-            $modificatedPrice = new ModificatedPrice($amount, $currentSubTotal->getCurrency(), false, $this->rule->getLabel());
-
-            $taxClass = Factory::getInstance()->getPriceSystem('default')->getTaxClassForPriceModification($this);
-            if ($taxClass) {
-                $modificatedPrice->setTaxEntryCombinationMode($taxClass->getTaxEntryCombinationType());
-                $modificatedPrice->setTaxEntries(TaxEntry::convertTaxEntries($taxClass));
-
-                $modificatedPrice->setGrossAmount($amount, true);
-            }
-
-            return $modificatedPrice;
+        $amount = $this->getAmount();
+        if ($currentSubTotal->getAmount()->lessThan($amount->mul(-1))) {
+            $amount = $currentSubTotal->getAmount()->mul(-1);
         }
+
+        $modificatedPrice = new ModificatedPrice($amount, $currentSubTotal->getCurrency(), false, $this->rule->getLabel());
+
+        $taxClass = Factory::getInstance()->getPriceSystem('default')->getTaxClassForPriceModification($this);
+        if ($taxClass) {
+            $modificatedPrice->setTaxEntryCombinationMode($taxClass->getTaxEntryCombinationType());
+            $modificatedPrice->setTaxEntries(TaxEntry::convertTaxEntries($taxClass));
+
+            $modificatedPrice->setGrossAmount($amount, true);
+        }
+
+        return $modificatedPrice;
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
+++ b/bundles/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
@@ -425,7 +425,7 @@ class Configuration implements ConfigurationInterface
             ->validate()
                 ->always(function ($v) {
                     $enabled = null;
-                    if (is_bool($v['enabled'])) {
+                    if (isset($v['enabled']) && is_bool($v['enabled'])) {
                         $enabled = $v['enabled'];
                         unset($v['enabled']);
                     }

--- a/bundles/EcommerceFrameworkBundle/PricingManager/Rule.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Rule.php
@@ -64,12 +64,12 @@ class Rule extends AbstractModel implements RuleInterface
     /**
      * @var string[]
      */
-    protected $label;
+    protected $label = [];
 
     /**
      * @var string[]
      */
-    protected $description;
+    protected $description = [];
 
     /**
      * @var BracketInterface
@@ -171,11 +171,11 @@ class Rule extends AbstractModel implements RuleInterface
     /**
      * @param string $locale
      *
-     * @return string
+     * @return string|null
      */
     public function getLabel($locale = null)
     {
-        return $this->label[$this->getLanguage($locale)];
+        return $this->label[$this->getLanguage($locale)] ?? null;
     }
 
     /**
@@ -215,11 +215,11 @@ class Rule extends AbstractModel implements RuleInterface
     /**
      * @param string $locale
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription($locale = null)
     {
-        return $this->description[$this->getLanguage($locale)];
+        return $this->description[$this->getLanguage($locale)] ?? null;
     }
 
     /**

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -332,7 +332,7 @@ class Bootstrap
         }
 
         if ($debug) {
-            Debug::enable();
+            Debug::enable(PIMCORE_PHP_ERROR_REPORTING);
             @ini_set('display_errors', 'On');
         }
 

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -90,7 +90,6 @@ class Bootstrap
         // Error reporting is enabled in CLI
         @ini_set('display_errors', 'On');
         @ini_set('display_startup_errors', 'On');
-        error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);
 
         // Pimcore\Console handles maintenance mode through the AbstractCommand
         if (!$pimcoreConsole) {
@@ -119,8 +118,6 @@ class Bootstrap
 
     public static function bootstrap()
     {
-        error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);
-
         /** @var $loader \Composer\Autoload\ClassLoader */
         if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
             $loader = include __DIR__ . '/../vendor/autoload.php';

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -766,7 +766,7 @@ class Config
                     continue;
                 }
 
-                if ($tmpData['hidden']) {
+                if (!empty($tmpData['hidden'])) {
                     continue;
                 }
 
@@ -786,7 +786,7 @@ class Config
         }
 
         foreach ($tmpResult as $resultItem) {
-            if ($resultItem['hidden']) {
+            if (!empty($resultItem['hidden'])) {
                 continue;
             }
 

--- a/lib/Helper/Dashboard.php
+++ b/lib/Helper/Dashboard.php
@@ -82,8 +82,8 @@ class Dashboard
 
             if (empty($this->dashboards)) {
                 $perspectiveCfg = Config::getRuntimePerspective();
-                $dasboardCfg = $perspectiveCfg['dashboards'] ? $perspectiveCfg['dashboards'] : [];
-                $this->dashboards = $dasboardCfg['predefined'] ? $dasboardCfg['predefined'] : [];
+                $dasboardCfg = $perspectiveCfg['dashboards'] ?? [];
+                $this->dashboards = $dasboardCfg['predefined'] ?? [];
             }
         }
 
@@ -160,8 +160,8 @@ class Dashboard
     public function getDisabledPortlets()
     {
         $perspectiveCfg = Config::getRuntimePerspective($this->user);
-        $dasboardCfg = $perspectiveCfg['dashboards'] ? $perspectiveCfg['dashboards'] : [];
+        $dasboardCfg = $perspectiveCfg['dashboards'] ?? [];
 
-        return isset($dasboardCfg['disabledPortlets']) ? $dasboardCfg['disabledPortlets'] : [];
+        return $dasboardCfg['disabledPortlets'] ?? [];
     }
 }

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -156,9 +156,6 @@ abstract class Kernel extends SymfonyKernel
         // handle system requirements
         $this->setSystemRequirements();
 
-        // force load config
-        \Pimcore::initConfiguration();
-
         // initialize extension manager config
         $this->extensionConfig = new Extension\Config();
 
@@ -357,8 +354,6 @@ abstract class Kernel extends SymfonyKernel
         if (php_sapi_name() === 'cli') {
             $maxExecutionTime = 0;
         }
-
-        error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED);
 
         //@ini_set("memory_limit", "1024M");
         @ini_set('max_execution_time', $maxExecutionTime);

--- a/lib/Model/Listing/Dao/AbstractDao.php
+++ b/lib/Model/Listing/Dao/AbstractDao.php
@@ -110,12 +110,12 @@ abstract class AbstractDao extends Model\Dao\AbstractDao
 
         if (!empty($order) || !empty($orderKey)) {
             $c = 0;
-            $lastOrder = $order[0];
+            $lastOrder = $order[0] ?? null;
             $parts = [];
 
             if (is_array($orderKey)) {
                 foreach ($orderKey as $key) {
-                    if ($order[$c]) {
+                    if (!empty($order[$c])) {
                         $lastOrder = $order[$c];
                     }
 

--- a/lib/Pimcore.php
+++ b/lib/Pimcore.php
@@ -27,12 +27,12 @@ class Pimcore
     /**
      * @var bool|null
      */
-    protected static $debugMode = null;
+    protected static $debugMode;
 
     /**
      * @var bool|null
      */
-    protected static $devMode = null;
+    protected static $devMode;
 
     /**
      * @var bool
@@ -48,14 +48,6 @@ class Pimcore
      * @var \Composer\Autoload\ClassLoader
      */
     private static $autoloader;
-
-    public static function initConfiguration()
-    {
-        // custom error logging when debug flag is set
-        if (self::inDebugMode()) {
-            error_reporting(E_ALL & ~E_NOTICE);
-        }
-    }
 
     /**
      * @return bool

--- a/lib/Tool.php
+++ b/lib/Tool.php
@@ -536,9 +536,9 @@ class Tool
 
             foreach ($confArray['views'] as $tmp) {
                 if (isset($tmp['name'])) {
-                    $tmp['showroot'] = (bool) $tmp['showroot'];
+                    $tmp['showroot'] = !empty($tmp['showroot']);
 
-                    if ((bool) $tmp['hidden']) {
+                    if (!empty($tmp['hidden'])) {
                         continue;
                     }
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -471,6 +471,9 @@ class Asset extends Element\AbstractElement
      */
     public function save()
     {
+        $isUpdate = false;
+        $differentOldPath = null;
+
         try {
             // additional parameters (e.g. "versionNote" for the version note)
             $params = [];
@@ -478,7 +481,6 @@ class Asset extends Element\AbstractElement
                 $params = func_get_arg(0);
             }
 
-            $isUpdate = false;
 
             $preEvent = new AssetEvent($this, $params);
 

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -1169,18 +1169,18 @@ abstract class Data
             return $params['injectedData'];
         }
 
-        $context = is_array($params) && isset($params['context']) ? $params['context'] : null;
+        $context = $params['context'] ?? null;
 
-        if ($context) {
-            if ($context['containerType'] == 'fieldcollection' || $context['containerType'] == 'block') {
+        if (isset($context['containerType'])) {
+            if ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'block') {
                 if ($this instanceof DataObject\ClassDefinition\Data\Localizedfields || $object instanceof DataObject\Localizedfield) {
                     $fieldname = $context['fieldname'];
-                    $index = $context['index'];
+                    $index = $context['index'] ?? null;
 
                     if ($object instanceof DataObject\Concrete) {
                         $containerGetter = 'get' . ucfirst($fieldname);
                         $container = $object->$containerGetter();
-                        if (!$container && $context['containerType'] == 'block') {
+                        if (!$container && $context['containerType'] === 'block') {
                             // no data, so check if inheritance is enabled + there is parent value
                             if ($object->getClass()->getAllowInherit()) {
                                 try {
@@ -1192,11 +1192,11 @@ abstract class Data
                         }
 
                         if ($container) {
-                            $originalIndex = $context['oIndex'];
+                            $originalIndex = $context['oIndex'] ?? null;
 
                             // field collection or block items
-                            if (!is_null($originalIndex)) {
-                                if ($context['containerType'] == 'block') {
+                            if ($originalIndex !== null) {
+                                if ($context['containerType'] === 'block') {
                                     $items = $container;
                                 } else {
                                     $items = $container->getItems();
@@ -1205,7 +1205,7 @@ abstract class Data
                                 if ($items && count($items) > $originalIndex) {
                                     $item = $items[$originalIndex];
 
-                                    if ($context['containerType'] == 'block') {
+                                    if ($context['containerType'] === 'block') {
                                         $data = $item[$this->getName()];
                                         if ($data instanceof DataObject\Data\BlockElement) {
                                             $data = $data->getData();
@@ -1237,8 +1237,7 @@ abstract class Data
                         return $data;
                     }
                 }
-            }
-            if ($context['containerType'] == 'objectbrick' && ($this instanceof DataObject\ClassDefinition\Data\Localizedfields || $object instanceof DataObject\Localizedfield)) {
+            } elseif ($context['containerType'] === 'objectbrick' && ($this instanceof DataObject\ClassDefinition\Data\Localizedfields || $object instanceof DataObject\Localizedfield)) {
                 $fieldname = $context['fieldname'];
 
                 if ($object instanceof DataObject\Concrete) {
@@ -1264,7 +1263,7 @@ abstract class Data
 
                     return $data;
                 }
-            } elseif ($context['containerType'] == 'classificationstore') {
+            } elseif ($context['containerType'] === 'classificationstore') {
                 $fieldname = $context['fieldname'];
                 $getter = 'get' . ucfirst($fieldname);
                 if (method_exists($object, $getter)) {

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -648,16 +648,16 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
         $this->enrichRelation($object, $params, $classId, $relation);
 
         $position = (isset($relation['position']) && $relation['position']) ? $relation['position'] : '0';
+        $context = $params['context'] ?? null;
 
-        if ($params && $params['context'] && ($params['context']['containerType'] == 'fieldcollection' || $params['context']['containerType'] == 'objectbrick') && $params['context']['subContainerType'] == 'localizedfield') {
-            $context = $params['context'];
-            $index = $context['index'];
-            $containerName = $context['fieldname'];
+        if (isset($context['containerType'], $context['subContainerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick') && $context['subContainerType'] === 'localizedfield') {
+            $index = $context['index'] ?? null;
+            $containerName = $context['fieldname'] ?? null;
 
-            if ($params['context']['containerType'] == 'fieldcollection') {
-                $ownerName = '/' . $params['context']['containerType'] . '~' . $containerName . '/' . $index . '/%';
+            if ($context['containerType'] === 'fieldcollection') {
+                $ownerName = '/' . $context['containerType'] . '~' . $containerName . '/' . $index . '/%';
             } else {
-                $ownerName = '/' . $params['context']['containerType'] . '~' . $containerName . '/%';
+                $ownerName = '/' . $context['containerType'] . '~' . $containerName . '/%';
             }
 
             $sql = $db->quoteInto('o_id = ?', $objectId) . " AND ownertype = 'localizedfield' AND "
@@ -668,14 +668,14 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
             $sql = $db->quoteInto('o_id = ?', $objectId) . ' AND ' . $db->quoteInto('fieldname = ?', $this->getName())
                 . ' AND ' . $db->quoteInto('position = ?', $position);
 
-            if ($params && $params['context']) {
-                if ($params['context']['fieldname']) {
-                    $sql .= ' AND '.$db->quoteInto('ownername = ?', $params['context']['fieldname']);
+            if ($context) {
+                if (!empty($context['fieldname'])) {
+                    $sql .= ' AND '.$db->quoteInto('ownername = ?', $context['fieldname']);
                 }
 
                 if (!DataObject\AbstractObject::isDirtyDetectionDisabled() && $object instanceof DataObject\DirtyIndicatorInterface) {
-                    if ($params['context']['containerType']) {
-                        $sql .= ' AND '.$db->quoteInto('ownertype = ?', $params['context']['containerType']);
+                    if ($context['containerType']) {
+                        $sql .= ' AND '.$db->quoteInto('ownertype = ?', $context['containerType']);
                     }
                 }
             }
@@ -744,35 +744,35 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
     public function delete($object, $params = [])
     {
         $db = Db::get();
+        $context = $params['context'] ?? null;
 
-        if ($params && $params['context'] && ($params['context']['containerType'] == 'fieldcollection' || $params['context']['containerType'] == 'objectbrick') && $params['context']['subContainerType'] == 'localizedfield') {
-            if ($params['context']['containerType'] == 'objectbrick') {
+        if (isset($context['containerType'], $context['subContainerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick') && $context['subContainerType'] === 'localizedfield') {
+            if ($context['containerType'] === 'objectbrick') {
                 throw new \Exception('deletemeta not implemented');
             }
-            $context = $params['context'];
-            $containerName = $context['fieldname'];
+            $containerName = $context['fieldname'] ?? null;
 
-            if ($params['context']['containerType'] == 'fieldcollection') {
+            if ($context['containerType'] == 'fieldcollection') {
                 $index = $context['index'];
                 $db->deleteWhere(
                     'object_metadata_' . $object->getClassId(),
                     $db->quoteInto('o_id = ?', $object->getId()) . " AND ownertype = 'localizedfield' AND "
-                    . $db->quoteInto('ownername LIKE ?', '/' . $params['context']['containerType'] . '~' . $containerName . '/' . "$index . /%")
+                    . $db->quoteInto('ownername LIKE ?', '/' . $context['containerType'] . '~' . $containerName . '/' . "$index . /%")
                     . ' AND ' . $db->quoteInto('fieldname = ?', $this->getName())
                 );
-            } elseif ($params['context']['containerType'] == 'objectbrick') {
+            } elseif ($context['containerType'] === 'objectbrick') {
                 $index = $context['index'];
                 $db->deleteWhere(
                     'object_metadata_' . $object->getClassId(),
                     $db->quoteInto('o_id = ?', $object->getId()) . " AND ownertype = 'localizedfield' AND "
-                    . $db->quoteInto('ownername LIKE ?', '/' . $params['context']['containerType'] . '~' . $containerName . '/%')
+                    . $db->quoteInto('ownername LIKE ?', '/' . $context['containerType'] . '~' . $containerName . '/%')
                     . ' AND ' . $db->quoteInto('fieldname = ?', $this->getName())
                 );
             } else {
                 $db->deleteWhere(
                     'object_metadata_' . $object->getClassId(),
                     $db->quoteInto('o_id = ?', $object->getId()) . " AND ownertype = 'localizedfield' AND "
-                    . $db->quoteInto('ownername LIKE ?', '/' . $params['context']['containerType'] . '~' . $containerName . '/%')
+                    . $db->quoteInto('ownername LIKE ?', '/' . $context['containerType'] . '~' . $containerName . '/%')
                     . ' AND ' . $db->quoteInto('fieldname = ?', $this->getName())
                 );
             }
@@ -781,14 +781,14 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
                 'o_id' => $object->getId(),
                 'fieldname' => $this->getName()
             ];
-            if ($params && $params['context']) {
-                if ($params['context']['fieldname']) {
-                    $deleteConditions['ownername'] = $params['context']['fieldname'];
+            if ($context) {
+                if (!empty($context['fieldname'])) {
+                    $deleteConditions['ownername'] = $context['fieldname'];
                 }
 
                 if (!DataObject\AbstractObject::isDirtyDetectionDisabled() && $object instanceof DataObject\DirtyIndicatorInterface) {
-                    if ($params['context']['containerType']) {
-                        $deleteConditions['ownertype'] = $params['context']['containerType'];
+                    if ($context['containerType']) {
+                        $deleteConditions['ownertype'] = $context['containerType'];
                     }
                 }
             }

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -731,16 +731,16 @@ class AdvancedManyToManyRelation extends ManyToManyRelation
         $this->enrichRelation($object, $params, $classId, $relation);
 
         $position = (isset($relation['position']) && $relation['position']) ? $relation['position'] : '0';
+        $context = $params['context'] ?? null;
 
-        if ($params && $params['context'] && ($params['context']['containerType'] == 'fieldcollection' || $params['context']['containerType'] == 'objectbrick') && $params['context']['subContainerType'] == 'localizedfield') {
-            $context = $params['context'];
-            $index = $context['index'];
+        if (isset($context['containerType'], $context['subContainerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick') && $context['subContainerType'] === 'localizedfield') {
+            $index = $context['index'] ?? null;
             $containerName = $context['fieldname'];
 
-            if ($params['context']['containerType'] == 'fieldcollection') {
-                $ownerName = '/' . $params['context']['containerType'] . '~' . $containerName . '/' . $index . '/%';
+            if ($context['containerType'] === 'fieldcollection') {
+                $ownerName = '/' . $context['containerType'] . '~' . $containerName . '/' . $index . '/%';
             } else {
-                $ownerName = '/' . $params['context']['containerType'] . '~' . $containerName . '/%';
+                $ownerName = '/' . $context['containerType'] . '~' . $containerName . '/%';
             }
 
             $sql = $db->quoteInto('o_id = ?', $objectId) . " AND ownertype = 'localizedfield' AND "
@@ -751,14 +751,14 @@ class AdvancedManyToManyRelation extends ManyToManyRelation
             $sql = $db->quoteInto('o_id = ?', $objectId) . ' AND ' . $db->quoteInto('fieldname = ?', $this->getName())
                 . ' AND ' . $db->quoteInto('position = ?', $position);
 
-            if ($params && $params['context']) {
-                if ($params['context']['fieldname']) {
-                    $sql .= ' AND ' . $db->quoteInto('ownername = ?', $params['context']['fieldname']);
+            if ($context) {
+                if (!empty($context['fieldname'])) {
+                    $sql .= ' AND ' . $db->quoteInto('ownername = ?', $context['fieldname']);
                 }
 
                 if (!DataObject\AbstractObject::isDirtyDetectionDisabled() && $object instanceof DataObject\DirtyIndicatorInterface) {
-                    if ($params['context']['containerType']) {
-                        $sql .= ' AND ' . $db->quoteInto('ownertype = ?', $params['context']['containerType']);
+                    if ($context['containerType']) {
+                        $sql .= ' AND ' . $db->quoteInto('ownertype = ?', $context['containerType']);
                     }
                 }
             }
@@ -827,16 +827,16 @@ class AdvancedManyToManyRelation extends ManyToManyRelation
     public function delete($object, $params = [])
     {
         $db = Db::get();
+        $context = $params['context'] ?? null;
 
-        if ($params && $params['context'] && ($params['context']['containerType'] == 'fieldcollection' || $params['context']['containerType'] == 'objectbrick') && $params['context']['subContainerType'] == 'localizedfield') {
-            $context = $params['context'];
-            $containerName = $context['fieldname'];
+        if (isset($context['containerType'], $context['subContainerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick') && $context['subContainerType'] === 'localizedfield') {
+            $containerName = $context['fieldname'] ?? null;
 
-            if ($params['context']['containerType'] == 'objectbrick') {
+            if ($context['containerType'] === 'objectbrick') {
                 $db->deleteWhere(
                     'object_metadata_' . $object->getClassId(),
                     $db->quoteInto('o_id = ?', $object->getId()) . " AND ownertype = 'localizedfield' AND "
-                    . $db->quoteInto('ownername LIKE ?', '/' . $params['context']['containerType'] . '~' . $containerName . '/%')
+                    . $db->quoteInto('ownername LIKE ?', '/' . $context['containerType'] . '~' . $containerName . '/%')
                     . ' AND ' . $db->quoteInto('fieldname = ?', $this->getName())
                 );
             } else {
@@ -845,7 +845,7 @@ class AdvancedManyToManyRelation extends ManyToManyRelation
                 $db->deleteWhere(
                     'object_metadata_' . $object->getClassId(),
                     $db->quoteInto('o_id = ?', $object->getId()) . " AND ownertype = 'localizedfield' AND "
-                    . $db->quoteInto('ownername LIKE ?', '/' . $params['context']['containerType'] . '~' . $containerName . '/' . $index . '/%')
+                    . $db->quoteInto('ownername LIKE ?', '/' . $context['containerType'] . '~' . $containerName . '/' . $index . '/%')
                     . ' AND ' . $db->quoteInto('fieldname = ?', $this->getName())
                 );
             }
@@ -855,14 +855,14 @@ class AdvancedManyToManyRelation extends ManyToManyRelation
                 'fieldname' => $this->getName(),
             ];
 
-            if ($params && $params['context']) {
-                if ($params['context']['fieldname']) {
-                    $deleteCondition['ownername'] = $params['context']['fieldname'];
+            if ($context) {
+                if (!empty($context['fieldname'])) {
+                    $deleteCondition['ownername'] = $context['fieldname'];
                 }
 
                 if (!DataObject\AbstractObject::isDirtyDetectionDisabled() && $object instanceof DataObject\DirtyIndicatorInterface) {
-                    if ($params['context']['containerType']) {
-                        $deleteCondition['ownertype'] = $params['context']['containerType'];
+                    if (!empty($context['containerType'])) {
+                        $deleteCondition['ownertype'] = $context['containerType'];
                     }
                 }
             }

--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -229,7 +229,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params
      *
-     * @return string
+     * @return array
      */
     public function getDataForEditmode($data, $object = null, $params = [])
     {
@@ -350,10 +350,10 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
     {
         $data = null;
 
-        $context = is_array($params) && isset($params['context']) ? $params['context'] : null;
+        $context = $params['context'] ?? null;
 
-        if ($context) {
-            if ($context['containerType'] == 'fieldcollection') {
+        if (isset($context['containerType'])) {
+            if ($context['containerType'] === 'fieldcollection') {
                 $fieldname = $context['fieldname'];
 
                 if ($object instanceof DataObject\Concrete) {
@@ -381,7 +381,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
                         return null;
                     }
                 }
-            } elseif ($context['containerType'] == 'objectbrick') {
+            } elseif ($context['containerType'] === 'objectbrick') {
                 $fieldname = $context['fieldname'];
 
                 if ($object instanceof DataObject\Concrete) {
@@ -995,11 +995,10 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
     {
         $field = $this->getName();
         $db = Db::get();
+        $data = null;
 
         if ($container instanceof DataObject\Concrete) {
             if (!method_exists($this, 'getLazyLoading') or !$this->getLazyLoading() or (array_key_exists('force', $params) && $params['force'])) {
-                $data = null;
-
                 $query = 'select ' . $db->quoteIdentifier($field) . ' from object_store_' . $container->getClassId() . ' where oo_id  = ' . $container->getId();
                 $data = $db->fetchOne($query);
                 $data = $this->getDataFromResource($data, $container, $params);
@@ -1008,7 +1007,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
             $context = $params['context'];
             $object = $context['object'];
 
-            if ($context && $context['containerType'] == 'fieldcollection') {
+            if (isset($context['containerType']) && $context['containerType'] === 'fieldcollection') {
                 $query = 'select ' . $db->quoteIdentifier($field) . ' from object_collection_' . $context['containerKey'] . '_localized_' . $object->getClassId() . ' where language = ' . $db->quote($params['language']) . ' and  ooo_id  = ' . $object->getId() . ' and fieldname = ' . $db->quote($context['fieldname']) . ' and `index` =  ' . $context['index'];
             } else {
                 $query = 'select ' . $db->quoteIdentifier($field) . ' from object_localized_data_' . $object->getClassId() . ' where language = ' . $db->quote($params['language']) . ' and  ooo_id  = ' . $object->getId();
@@ -1163,7 +1162,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
 
                     foreach ($blockDefinitions as $fd) {
                         try {
-                            $blockElement = $item[$fd->getName()];
+                            $blockElement = $item[$fd->getName()] ?? null;
                             if (!$blockElement) {
                                 if ($fd->getMandatory()) {
                                     throw new Element\ValidationException('Block element empty [ ' . $fd->getName() . ' ]');

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -201,7 +201,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
                     $fieldData[$language][$key] = $fdata;
                     if (!$fd->isEmpty($fdata)) {
                         $inherited = $level > 1;
-                        if ($params['context'] && $params['context']['containerType'] == 'block') {
+                        if (isset($params['context']['containerType']) && $params['context']['containerType'] === 'block') {
                             $inherited = false;
                         }
 
@@ -211,7 +211,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
             }
         }
 
-        if ($params['context'] && $params['context']['containerType'] == 'block') {
+        if (isset($params['context']['containerType']) && $params['context']['containerType'] === 'block') {
             $inheritanceAllowed = false;
         }
 
@@ -238,7 +238,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
                 if ($foundEmptyValue) {
                     $parentData = null;
                     // still some values are passing, ask the parent
-                    if ($params['context'] && $params['context']['containerType'] == 'objectbrick') {
+                    if (isset($params['context']['containerType']) && $params['context']['containerType'] === 'objectbrick') {
                         $brickContainerGetter = 'get' . ucfirst($params['fieldname']);
                         $brickContainer = $parent->$brickContainerGetter();
                         $brickGetter = 'get' . ucfirst($params['context']['containerKey']);
@@ -326,8 +326,8 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
         $result = new \stdClass();
         foreach ($this->getFieldDefinitions() as $fd) {
             $key = $fd->getName();
-            $context = $params['context'];
-            if ($context && $context['containerType'] == 'objectbrick') {
+            $context = $params['context'] ?? null;
+            if (isset($context['containerType']) && $context['containerType'] === 'objectbrick') {
                 $result->$key = 'NOT SUPPORTED';
             } else {
                 $result->$key = $object->{'get' . ucfirst($fd->getName())}();
@@ -973,7 +973,9 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
 
         foreach ($data->getInternalData(true) as $language => $values) {
             foreach ($this->getFieldDefinitions() as $fd) {
-                $dependencies = array_merge($dependencies, $fd->resolveDependencies($values[$fd->getName()]));
+                if (isset($values[$fd->getName()])) {
+                    $dependencies = array_merge($dependencies, $fd->resolveDependencies($values[$fd->getName()]));
+                }
             }
         }
 

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -951,7 +951,9 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
 
         foreach ($data->getInternalData(true) as $language => $values) {
             foreach ($this->getFieldDefinitions() as $fd) {
-                $tags = $fd->getCacheTags($values[$fd->getName()], $tags);
+                if (isset($values[$fd->getName()])) {
+                    $tags = $fd->getCacheTags($values[$fd->getName()], $tags);
+                }
             }
         }
 

--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -219,9 +219,9 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
                 'type' => $type,
                 'fieldname' => $this->getName()
             ]];
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     /**
@@ -238,7 +238,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
             'data' => null
         ];
 
-        if ($data['dest_id'] && $data['type']) {
+        if (!empty($data['dest_id']) && !empty($data['type'])) {
             $element = Element\Service::getElementById($data['type'], $data['dest_id']);
             if ($element instanceof Element\ElementInterface) {
                 $result['data'] = $element;
@@ -262,10 +262,12 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
     public function getDataForQueryResource($data, $object = null, $params = [])
     {
         $rData = $this->prepareDataForPersistence($data, $object, $params);
-
         $return = [];
-        $return[$this->getName() . '__id'] = $rData[0]['dest_id'];
-        $return[$this->getName() . '__type'] = $rData[0]['type'];
+
+        if (!empty($rData[0]['dest_id']) && !empty($rData[0]['type'])) {
+            $return[$this->getName() . '__id'] = $rData[0]['dest_id'];
+            $return[$this->getName() . '__type'] = $rData[0]['type'];
+        }
 
         return $return;
     }
@@ -307,7 +309,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      */
     public function getDataFromEditmode($data, $object = null, $params = [])
     {
-        if ($data['id'] && $data['type']) {
+        if (!empty($data['id']) && !empty($data['type'])) {
             return Element\Service::getElementById($data['type'], $data['id']);
         }
 

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -586,6 +586,8 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
     {
         if (!$this->validUnits) {
             try {
+                $table = null;
+
                 if (Runtime::isRegistered(Model\DataObject\QuantityValue\Unit::CACHE_KEY)) {
                     $table = Runtime::get(Model\DataObject\QuantityValue\Unit::CACHE_KEY);
                 }

--- a/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
@@ -126,9 +126,9 @@ abstract class AbstractRelations extends Data implements CustomResourcePersistin
             $relation['ownertype'] = 'localizedfield';
             $relation['ownername'] = 'localizedfield';
             $context = $object->getContext();
-            if ($context && ($context['containerType'] == 'fieldcollection' || $context['containerType'] == 'objectbrick')) {
+            if (isset($context['containerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick')) {
                 $fieldname = $context['fieldname'];
-                $index = $context['index'];
+                $index = $context['index'] ?? null;
                 $relation['ownername'] = '/' . $context['containerType'] . '~' . $fieldname . '/' . $index . '/localizedfield~' . $relation['ownername'];
             }
 
@@ -163,17 +163,13 @@ abstract class AbstractRelations extends Data implements CustomResourcePersistin
         $context = $params['context'];
 
         if (!DataObject\AbstractObject::isDirtyDetectionDisabled() && $object instanceof DataObject\DirtyIndicatorInterface) {
-            if ($object instanceof DataObject\Localizedfield) {
-                if ($context['containerType'] != 'fieldcollection' && $object->getObject() instanceof DataObject\DirtyIndicatorInterface) {
-                    if (!$object->hasDirtyFields()) {
+            if (!isset($context['containerType']) || $context['containerType'] !== 'fieldcollection') {
+                if ($object instanceof DataObject\Localizedfield) {
+                    if ($object->getObject() instanceof DataObject\DirtyIndicatorInterface && !$object->hasDirtyFields()) {
                         return;
                     }
-                }
-            } else {
-                if ($context['containerType'] !== 'fieldcollection' && $this->supportsDirtyDetection()) {
-                    if (!$object->isFieldDirty($this->getName())) {
-                        return;
-                    }
+                } elseif ($this->supportsDirtyDetection() && !$object->isFieldDirty($this->getName())) {
+                    return;
                 }
             }
         }
@@ -224,14 +220,14 @@ abstract class AbstractRelations extends Data implements CustomResourcePersistin
         } elseif ($object instanceof DataObject\Fieldcollection\Data\AbstractData) {
             $relations = $db->fetchAll('SELECT * FROM object_relations_' . $object->getObject()->getClassId() . " WHERE src_id = ? AND fieldname = ? AND ownertype = 'fieldcollection' AND ownername = ? AND position = ?", [$object->getObject()->getId(), $this->getName(), $object->getFieldname(), $object->getIndex()]);
         } elseif ($object instanceof DataObject\Localizedfield) {
-            if (isset($params['context']) && isset($params['context']['containerType']) && (($params['context']['containerType'] == 'fieldcollection' || $params['context']['containerType'] == 'objectbrick'))) {
-                $context = $params['context'];
-                $fieldname = $context['fieldname'];
-                if ($params['context']['containerType'] == 'fieldcollection') {
-                    $index = $context['index'];
-                    $filter = '/' . $params['context']['containerType'] . '~' . $fieldname . '/' . $index . '/%';
+            $context = $params['context'] ?? null;
+            if (isset($context['containerType']) && (($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick'))) {
+                $fieldname = $context['fieldname'] ?? null;
+                if ($context['containerType'] === 'fieldcollection') {
+                    $index = $context['index'] ?? null;
+                    $filter = '/' . $context['containerType'] . '~' . $fieldname . '/' . $index . '/%';
                 } else {
-                    $filter = '/' . $params['context']['containerType'] .'~' . $fieldname . '/%';
+                    $filter = '/' . $context['containerType'] .'~' . $fieldname . '/%';
                 }
                 $relations = $db->fetchAll(
                     'SELECT * FROM object_relations_' . $object->getObject()->getClassId() . " WHERE src_id = ? AND fieldname = ? AND ownertype = 'localizedfield'  AND position = ? AND ownername LIKE ?",

--- a/models/DataObject/Classificationstore/Dao.php
+++ b/models/DataObject/Classificationstore/Dao.php
@@ -75,7 +75,7 @@ class Dao extends Model\Dao\AbstractDao
                 $fd = Service::getFieldDefinitionFromKeyConfig($keyConfig);
 
                 foreach ($keyData as $language => $value) {
-                    $collectionId = $collectionMapping[$groupId];
+                    $collectionId = $collectionMapping[$groupId] ?? null;
                     $data = [
                         'o_id' => $objectId,
                         'collectionId' => $collectionId,

--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -314,9 +314,11 @@ class Dao extends Model\DataObject\AbstractObject\Dao
                             if (is_array($insertData)) {
                                 $doInsert = false;
                                 foreach ($insertData as $insertDataKey => $insertDataValue) {
-                                    if ($isEmpty && $oldData[$insertDataKey] == $parentData[$insertDataKey]) {
+                                    $oldDataValue = $oldData[$insertDataKey] ?? null;
+                                    $parentDataValue = $parentData[$insertDataKey] ?? null;
+                                    if ($isEmpty && $oldDataValue == $parentDataValue) {
                                         // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                    } elseif ($oldData[$insertDataKey] != $insertDataValue) {
+                                    } elseif ($oldDataValue != $insertDataValue) {
                                         $doInsert = true;
                                         break;
                                     }
@@ -326,25 +328,31 @@ class Dao extends Model\DataObject\AbstractObject\Dao
                                     $this->inheritanceHelper->addRelationToCheck($key, $fd, array_keys($insertData));
                                 }
                             } else {
-                                if ($isEmpty && $oldData[$key] == $parentData[$key]) {
+                                $oldDataValue = $oldData[$key] ?? null;
+                                $parentDataValue = $parentData[$key] ?? null;
+                                if ($isEmpty && $oldDataValue == $parentDataValue) {
                                     // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                } elseif ($oldData[$key] != $insertData) {
+                                } elseif ($oldDataValue != $insertData) {
                                     $this->inheritanceHelper->addRelationToCheck($key, $fd);
                                 }
                             }
                         } else {
                             if (is_array($insertData)) {
                                 foreach ($insertData as $insertDataKey => $insertDataValue) {
-                                    if ($isEmpty && $oldData[$insertDataKey] == $parentData[$insertDataKey]) {
+                                    $oldDataValue = $oldData[$insertDataKey] ?? null;
+                                    $parentDataValue = $parentData[$insertDataKey] ?? null;
+                                    if ($isEmpty && $oldDataValue == $parentDataValue) {
                                         // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                    } elseif ($oldData[$insertDataKey] != $insertDataValue) {
+                                    } elseif ($oldDataValue != $insertDataValue) {
                                         $this->inheritanceHelper->addFieldToCheck($insertDataKey, $fd);
                                     }
                                 }
                             } else {
-                                if ($isEmpty && $oldData[$key] == $parentData[$key]) {
+                                $oldDataValue = $oldData[$key] ?? null;
+                                $parentDataValue = $parentData[$key] ?? null;
+                                if ($isEmpty && $oldDataValue == $parentDataValue) {
                                     // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                } elseif ($oldData[$key] != $insertData) {
+                                } elseif ($oldDataValue != $insertData) {
                                     // data changed, do check and update
                                     $this->inheritanceHelper->addFieldToCheck($key, $fd);
                                 }

--- a/models/DataObject/Concrete/Dao/InheritanceHelper.php
+++ b/models/DataObject/Concrete/Dao/InheritanceHelper.php
@@ -292,7 +292,9 @@ class InheritanceHelper
                 foreach ($o->childs as $c) {
                     $this->getIdsToCheckForDeletionForValuefields($c, $fieldname);
                 }
-                $this->updateQueryTableOnDelete($objectId, $this->deletionFieldIds[$fieldname], $fieldname);
+                if (isset($this->deletionFieldIds[$fieldname])) {
+                    $this->updateQueryTableOnDelete($objectId, $this->deletionFieldIds[$fieldname], $fieldname);
+                }
             }
         }
 
@@ -301,7 +303,9 @@ class InheritanceHelper
                 foreach ($o->childs as $c) {
                     $this->getIdsToCheckForDeletionForRelationfields($c, $fieldname);
                 }
-                $this->updateQueryTableOnDelete($objectId, $this->deletionFieldIds[$fieldname], $fieldname);
+                if (isset($this->deletionFieldIds[$fieldname])) {
+                    $this->updateQueryTableOnDelete($objectId, $this->deletionFieldIds[$fieldname], $fieldname);
+                }
             }
         }
 
@@ -368,7 +372,7 @@ class InheritanceHelper
 
             if (self::$useRuntimeCache) {
                 $queryCacheKey = 'tree_'.md5($query);
-                $parentIdGroups = self::$runtimeCache[$queryCacheKey];
+                $parentIdGroups = self::$runtimeCache[$queryCacheKey] ?? null;
             }
 
             if (!$parentIdGroups) {

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -396,6 +396,7 @@ class Link implements OwnerAwareFieldInterface
     public function setPath($path)
     {
         if (!empty($path)) {
+            $matchedElement = null;
             if ($this->getLinktype() == 'internal' && $this->getInternalType()) {
                 $matchedElement = Service::getElementByPath($this->getInternalType(), $path);
                 if ($matchedElement) {

--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -399,7 +399,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
         $doGetInheritedValues = AbstractObject::doGetInheritedValues();
 
         $allowInheritance = $fieldDefinition->supportsInheritance();
-        if (isset($context['containerType']) && ($context['containerType'] == 'block' || $context['containerType'] == 'fieldcollection')) {
+        if (isset($context['containerType']) && ($context['containerType'] === 'block' || $context['containerType'] === 'fieldcollection')) {
             $allowInheritance = false;
         }
 
@@ -421,7 +421,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
 
                             $parentContainer = $parent;
 
-                            if (isset($context['containerType']) && $context['containerType'] == 'objectbrick') {
+                            if (isset($context['containerType']) && $context['containerType'] === 'objectbrick') {
                                 $brickContainerGetter = 'get' . ucfirst($context['fieldname']);
                                 $brickContainer = $parent->$brickContainerGetter();
                                 $brickGetter = 'get' . $context['containerKey'];
@@ -499,7 +499,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
         $this->markLanguageAsDirty($language);
 
         $contextInfo = $this->getContext();
-        if ($contextInfo && $contextInfo['containerType'] == 'block') {
+        if (isset($contextInfo['containerType']) && $contextInfo['containerType'] === 'block') {
             $classId = $contextInfo['classId'];
             $containerDefinition = ClassDefinition::getById($classId);
             $blockDefinition = $containerDefinition->getFieldDefinition($contextInfo['fieldname']);
@@ -507,10 +507,10 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
             /** @var $fieldDefinition Model\DataObject\ClassDefinition\Data */
             $fieldDefinition = $blockDefinition->getFieldDefinition('localizedfields');
         } else {
-            if ($contextInfo && $contextInfo['containerType'] == 'fieldcollection') {
+            if (isset($contextInfo['containerType']) && $contextInfo['containerType'] === 'fieldcollection') {
                 $containerKey = $contextInfo['containerKey'];
                 $containerDefinition = Fieldcollection\Definition::getByKey($containerKey);
-            } elseif ($contextInfo && $contextInfo['containerType'] == 'objectbrick') {
+            } elseif (isset($contextInfo['containerType']) && $contextInfo['containerType'] === 'objectbrick') {
                 $containerKey = $contextInfo['containerKey'];
                 $containerDefinition = Model\DataObject\Objectbrick\Definition::getByKey($containerKey);
             } else {
@@ -532,7 +532,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
             );
         }
 
-        if ($markFieldAsDirty && !$fieldDefinition->isEqual($this->items[$language][$name], $value)) {
+        if ($markFieldAsDirty && !$fieldDefinition->isEqual($this->items[$language][$name] ?? null, $value)) {
             $this->markLanguageAsDirty($language);
         }
         $this->items[$language][$name] = $value;
@@ -681,7 +681,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
     {
         $lazyLoadedFieldNames = [];
 
-        if ($this->context && $this->context['containerType'] == 'block') {
+        if (isset($this->context['containerType']) && $this->context['containerType'] === 'block') {
             // if localized field is embedded in a block element there is no lazy loading. Maybe we can
             // prevent this already in the class definition editor
             return $lazyLoadedFieldNames;

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -50,12 +50,12 @@ class Dao extends Model\Dao\AbstractDao
     {
         $context = $this->model->getContext();
         if ($context) {
-            $containerType = $context['containerType'];
-            if ($containerType == 'fieldcollection') {
+            $containerType = $context['containerType'] ?? null;
+            if ($containerType === 'fieldcollection') {
                 $containerKey = $context['containerKey'];
 
                 return 'object_collection_'.$containerKey.'_localized_'.$this->model->getClass()->getId();
-            } elseif ($containerType == 'objectbrick') {
+            } elseif ($containerType === 'objectbrick') {
                 $containerKey = $context['containerKey'];
 
                 return 'object_brick_localized_'.$containerKey.'_'.$this->model->getClass()->getId();
@@ -98,10 +98,10 @@ class Dao extends Model\Dao\AbstractDao
         $object = $this->model->getObject();
         $validLanguages = Tool::getValidLanguages();
 
-        if ($context && $context['containerType'] == 'fieldcollection') {
+        if (isset($context['containerType']) && $context['containerType'] === 'fieldcollection') {
             $containerKey = $context['containerKey'];
             $container = DataObject\Fieldcollection\Definition::getByKey($containerKey);
-        } elseif ($context && $context['containerType'] == 'objectbrick') {
+        } elseif (isset($context['containerType']) && $context['containerType'] === 'objectbrick') {
             $containerKey = $context['containerKey'];
             $container = DataObject\Objectbrick\Definition::getByKey($containerKey);
         } else {
@@ -142,7 +142,7 @@ class Dao extends Model\Dao\AbstractDao
                 if ($fd instanceof CustomResourcePersistingInterface) {
                     // for fieldtypes which have their own save algorithm eg. relational data types, ...
                     $context = $this->model->getContext() ? $this->model->getContext() : [];
-                    if ($context['containerType'] == 'fieldcollection' || $context['containerType'] == 'objectbrick') {
+                    if (isset($context['containerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick')) {
                         $context['subContainerType'] = 'localizedfield';
                     }
 
@@ -303,9 +303,11 @@ class Dao extends Model\Dao\AbstractDao
                                     if (is_array($insertData)) {
                                         $doInsert = false;
                                         foreach ($insertData as $insertDataKey => $insertDataValue) {
-                                            if ($isEmpty && $oldData[$insertDataKey] == $parentData[$insertDataKey]) {
+                                            $oldDataValue = $oldData[$insertDataKey] ?? null;
+                                            $parentDataValue = $parentData[$insertDataKey] ?? null;
+                                            if ($isEmpty && $oldDataValue == $parentDataValue) {
                                                 // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                            } elseif ($oldData[$insertDataKey] != $insertDataValue) {
+                                            } elseif ($oldDataValue != $insertDataValue) {
                                                 $doInsert = true;
                                                 break;
                                             }
@@ -319,25 +321,31 @@ class Dao extends Model\Dao\AbstractDao
                                             );
                                         }
                                     } else {
-                                        if ($isEmpty && $oldData[$key] == $parentData[$key]) {
+                                        $oldDataValue = $oldData[$key] ?? null;
+                                        $parentDataValue = $parentData[$key] ?? null;
+                                        if ($isEmpty && $oldDataValue == $parentDataValue) {
                                             // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                        } elseif ($oldData[$key] != $insertData) {
+                                        } elseif ($oldDataValue != $insertData) {
                                             $this->inheritanceHelper->addRelationToCheck($key, $fd);
                                         }
                                     }
                                 } else {
                                     if (is_array($insertData)) {
                                         foreach ($insertData as $insertDataKey => $insertDataValue) {
-                                            if ($isEmpty && $oldData[$insertDataKey] == $parentData[$insertDataKey]) {
+                                            $oldDataValue = $oldData[$insertDataKey] ?? null;
+                                            $parentDataValue = $parentData[$insertDataKey] ?? null;
+                                            if ($isEmpty && $oldDataValue == $parentDataValue) {
                                                 // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                            } elseif ($oldData[$insertDataKey] != $insertDataValue) {
+                                            } elseif ($oldDataValue != $insertDataValue) {
                                                 $this->inheritanceHelper->addFieldToCheck($insertDataKey, $fd);
                                             }
                                         }
                                     } else {
-                                        if ($isEmpty && $oldData[$key] == $parentData[$key]) {
+                                        $oldDataValue = $oldData[$key] ?? null;
+                                        $parentDataValue = $parentData[$key] ?? null;
+                                        if ($isEmpty && $oldDataValue == $parentDataValue) {
                                             // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                        } elseif ($oldData[$key] != $insertData) {
+                                        } elseif ($oldDataValue != $insertData) {
                                             // data changed, do check and update
                                             $this->inheritanceHelper->addFieldToCheck($key, $fd);
                                         }
@@ -379,9 +387,9 @@ class Dao extends Model\Dao\AbstractDao
 
         try {
             $context = $this->model->getContext();
-            if ($context && ($context['containerType'] == 'fieldcollection' || $context['containerType'] == 'objectbrick')) {
+            if (isset($context['containerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick')) {
                 $containerKey = $context['containerKey'];
-                if ($context['containerType'] == 'fieldcollection') {
+                if ($context['containerType'] === 'fieldcollection') {
                     $container = DataObject\Fieldcollection\Definition::getByKey($containerKey);
                 } else {
                     $container = DataObject\Objectbrick\Definition::getByKey($containerKey);
@@ -392,7 +400,7 @@ class Dao extends Model\Dao\AbstractDao
             if ($deleteQuery) {
                 $id = $object->getId();
                 $tablename = $this->getTableName();
-                if ($context && $context['containerType'] == 'objectbrick') {
+                if (isset($context['containerType']) && $context['containerType'] === 'objectbrick') {
                     $this->db->delete($tablename, ['ooo_id' => $id, 'fieldname' => $context['fieldname']]);
                 } else {
                     $this->db->delete($tablename, ['ooo_id' => $id]);
@@ -415,7 +423,7 @@ class Dao extends Model\Dao\AbstractDao
                     if ($fd instanceof CustomResourcePersistingInterface) {
                         $params = [];
                         $params['context'] = $this->model->getContext() ? $this->model->getContext() : [];
-                        if (isset($params['context']['containerType']) && ($params['context']['containerType'] == 'fieldcollection' || $params['context']['containerType'] == 'objectbrick')) {
+                        if (isset($params['context']['containerType']) && ($params['context']['containerType'] === 'fieldcollection' || $params['context']['containerType'] === 'objectbrick')) {
                             $params['context']['subContainerType'] = 'localizedfield';
                         }
 
@@ -457,7 +465,7 @@ class Dao extends Model\Dao\AbstractDao
 
         if ($container instanceof DataObject\Objectbrick\Definition || $container instanceof DataObject\Fieldcollection\Definition) {
             $objectId = $object->getId();
-            $index = $context['index'];
+            $index = $context['index'] ?? null;
             $containerName = $context['fieldname'];
             if (!$context['containerType']) {
                 throw new \Exception('no container type set');
@@ -489,7 +497,7 @@ class Dao extends Model\Dao\AbstractDao
         }
 
         $context = $this->model->getContext();
-        if ($context && $context['containerType'] == 'fieldcollection') {
+        if (isset($context['containerType']) && $context['containerType'] === 'fieldcollection') {
             $containerKey = $context['containerKey'];
             $index = $context['index'];
             $fieldname = $context['fieldname'];
@@ -508,7 +516,7 @@ class Dao extends Model\Dao\AbstractDao
                     $index,
                 ]
             );
-        } elseif ($context && $context['containerType'] == 'objectbrick') {
+        } elseif (isset($context['containerType']) && $context['containerType'] === 'objectbrick') {
             $containerKey = $context['containerKey'];
             $container = DataObject\Objectbrick\Definition::getByKey($containerKey);
             $fieldname = $context['fieldname'];
@@ -685,7 +693,7 @@ QUERY;
         $table = $this->getTableName();
 
         $context = $this->model->getContext();
-        if ($context && isset($context['containerType']) && ($context['containerType'] == 'fieldcollection' || $context['containerType'] == 'objectbrick')) {
+        if (isset($context['containerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick')) {
             $this->db->query(
                 'CREATE TABLE IF NOT EXISTS `'.$table."` (
               `ooo_id` int(11) NOT NULL default '0',
@@ -718,10 +726,10 @@ QUERY;
 
         DataObject\ClassDefinition\Service::updateTableDefinitions($this->tableDefinitions, ([$table]));
 
-        if ($context && ($context['containerType'] == 'fieldcollection' || $context['containerType'] == 'objectbrick')) {
+        if (isset($context['containerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick')) {
             $protectedColumns = ['ooo_id', 'language', 'index', 'fieldname'];
             $containerKey = $context['containerKey'];
-            if ($context['containerType'] == 'fieldcollection') {
+            if ($context['containerType'] === 'fieldcollection') {
                 $container = DataObject\Fieldcollection\Definition::getByKey($containerKey);
             } else {
                 $container = DataObject\Objectbrick\Definition::getByKey($containerKey);

--- a/models/DataObject/Objectbrick/Data/AbstractData.php
+++ b/models/DataObject/Objectbrick/Data/AbstractData.php
@@ -95,7 +95,7 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
     }
 
     /**
-     * @return mixed
+     * @return DataObject\Objectbrick\Definition
      */
     public function getDefinition()
     {

--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -199,9 +199,11 @@ class Dao extends Model\Dao\AbstractDao
                         if (is_array($insertData)) {
                             $doInsert = false;
                             foreach ($insertData as $insertDataKey => $insertDataValue) {
-                                if ($isEmpty && $oldData[$insertDataKey] == $parentData[$insertDataKey]) {
+                                $oldDataValue = $oldData[$insertDataKey] ?? null;
+                                $parentDataValue = $parentData[$insertDataKey] ?? null;
+                                if ($isEmpty && $oldDataValue == $parentDataValue) {
                                     // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                } elseif ($oldData[$insertDataKey] != $insertDataValue) {
+                                } elseif ($oldDataValue != $insertDataValue) {
                                     $doInsert = true;
                                     break;
                                 }
@@ -211,25 +213,31 @@ class Dao extends Model\Dao\AbstractDao
                                 $this->inheritanceHelper->addRelationToCheck($key, $fd, array_keys($insertData));
                             }
                         } else {
-                            if ($isEmpty && $oldData[$key] == $parentData[$key]) {
+                            $oldDataValue = $oldData[$key] ?? null;
+                            $parentDataValue = $parentData[$key] ?? null;
+                            if ($isEmpty && $oldDataValue == $parentDataValue) {
                                 // do nothing, ... value is still empty and parent data is equal to current data in query table
-                            } elseif ($oldData[$key] != $insertData) {
+                            } elseif ($oldDataValue != $insertData) {
                                 $this->inheritanceHelper->addRelationToCheck($key, $fd);
                             }
                         }
                     } else {
                         if (is_array($insertData)) {
                             foreach ($insertData as $insertDataKey => $insertDataValue) {
-                                if ($isEmpty && $oldData[$insertDataKey] == $parentData[$insertDataKey]) {
+                                $oldDataValue = $oldData[$insertDataKey] ?? null;
+                                $parentDataValue = $parentData[$insertDataKey] ?? null;
+                                if ($isEmpty && $oldDataValue == $parentDataValue) {
                                     // do nothing, ... value is still empty and parent data is equal to current data in query table
-                                } elseif ($oldData[$insertDataKey] != $insertDataValue) {
+                                } elseif ($oldDataValue != $insertDataValue) {
                                     $this->inheritanceHelper->addFieldToCheck($insertDataKey, $fd);
                                 }
                             }
                         } else {
-                            if ($isEmpty && $oldData[$key] == $parentData[$key]) {
+                            $oldDataValue = $oldData[$key] ?? null;
+                            $parentDataValue = $parentData[$key] ?? null;
+                            if ($isEmpty && $oldDataValue == $parentDataValue) {
                                 // do nothing, ... value is still empty and parent data is equal to current data in query table
-                            } elseif ($oldData[$key] != $insertData) {
+                            } elseif ($oldDataValue != $insertData) {
                                 // data changed, do check and update
                                 $this->inheritanceHelper->addFieldToCheck($key, $fd);
                             }
@@ -305,12 +313,10 @@ class Dao extends Model\Dao\AbstractDao
                         continue;
                     }
 
-                    if ($fd->isRelationType()) {
-                        if ($oldData[$key] != null) {
+                    if (!empty($oldData[$key])) {
+                        if ($fd->isRelationType()) {
                             $this->inheritanceHelper->addRelationToCheck($key, $fd);
-                        }
-                    } else {
-                        if ($oldData[$key] != null) {
+                        } else {
                             $this->inheritanceHelper->addFieldToCheck($key, $fd);
                         }
                     }

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1357,9 +1357,9 @@ class Service extends Model\Element\Service
                 self::enrichLayoutPermissions($layout, $allowedView, $allowedEdit);
             }
 
-            if ($context['containerType'] === 'fieldcollection') {
+            if (isset($context['containerType']) && $context['containerType'] === 'fieldcollection') {
                 $context['subContainerType'] = 'localizedfield';
-            } elseif ($context['containerType'] === 'objectbrick') {
+            } elseif (isset($context['containerType']) && $context['containerType'] === 'objectbrick') {
                 $context['subContainerType'] = 'localizedfield';
             } else {
                 $context['ownerType'] = 'localizedfield';

--- a/models/DataObject/Traits/ObjectVarTrait.php
+++ b/models/DataObject/Traits/ObjectVarTrait.php
@@ -49,6 +49,10 @@ trait ObjectVarTrait
      */
     public function getObjectVar($var)
     {
+        if (!property_exists($this, $var)) {
+            return null;
+        }
+
         return $this->{$var};
     }
 

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -341,6 +341,7 @@ abstract class PageSnippet extends Model\Document
                 $loader = \Pimcore::getContainer()->get('pimcore.implementation_loader.document.tag');
                 $element = $loader->build($type);
 
+                $this->elements = $this->elements ?? [];
                 $this->elements[$name] = $element;
                 $this->elements[$name]->setDataFromEditmode($data);
                 $this->elements[$name]->setName($name);

--- a/models/Document/Tag/Areablock.php
+++ b/models/Document/Tag/Areablock.php
@@ -192,7 +192,7 @@ class Areablock extends Model\Document\Tag implements BlockInterface
             }
         }
 
-        if ($options['globalParams']) {
+        if (isset($options['globalParams'])) {
             $params = array_merge($options['globalParams'], (array)$params);
         }
 

--- a/models/Document/Tag/Image.php
+++ b/models/Document/Tag/Image.php
@@ -304,15 +304,15 @@ class Image extends Model\Document\Tag
             $data['hotspots'] = $rewritePath($data['hotspots']);
         }
 
-        $this->id = $data['id'];
-        $this->alt = $data['alt'];
-        $this->cropPercent = $data['cropPercent'];
-        $this->cropWidth = $data['cropWidth'];
-        $this->cropHeight = $data['cropHeight'];
-        $this->cropTop = $data['cropTop'];
-        $this->cropLeft = $data['cropLeft'];
-        $this->marker = $data['marker'];
-        $this->hotspots = $data['hotspots'];
+        $this->id = $data['id'] ?? null;
+        $this->alt = $data['alt'] ?? null;
+        $this->cropPercent = $data['cropPercent'] ?? null;
+        $this->cropWidth = $data['cropWidth'] ?? null;
+        $this->cropHeight = $data['cropHeight'] ?? null;
+        $this->cropTop = $data['cropTop'] ?? null;
+        $this->cropLeft = $data['cropLeft'] ?? null;
+        $this->marker = $data['marker'] ?? null;
+        $this->hotspots = $data['hotspots'] ?? null;
 
         return $this;
     }
@@ -353,15 +353,15 @@ class Image extends Model\Document\Tag
                 $data['hotspots'] = $rewritePath($data['hotspots']);
             }
 
-            $this->id = $data['id'];
-            $this->alt = $data['alt'];
-            $this->cropPercent = $data['cropPercent'];
-            $this->cropWidth = $data['cropWidth'];
-            $this->cropHeight = $data['cropHeight'];
-            $this->cropTop = $data['cropTop'];
-            $this->cropLeft = $data['cropLeft'];
-            $this->marker = $data['marker'];
-            $this->hotspots = $data['hotspots'];
+            $this->id = $data['id'] ?? null;
+            $this->alt = $data['alt'] ?? null;
+            $this->cropPercent = $data['cropPercent'] ?? null;
+            $this->cropWidth = $data['cropWidth'] ?? null;
+            $this->cropHeight = $data['cropHeight'] ?? null;
+            $this->cropTop = $data['cropTop'] ?? null;
+            $this->cropLeft = $data['cropLeft'] ?? null;
+            $this->marker = $data['marker'] ?? null;
+            $this->hotspots = $data['hotspots'] ?? null;
         }
 
         return $this;

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -875,13 +875,13 @@ class Service extends Model\AbstractModel
     public static function addTreeFilterJoins($cv, $childsList)
     {
         if ($cv) {
-            $childsList->onCreateQuery(function (QueryBuilder $select) use ($cv) {
-                $where = $cv['where'];
+            $childsList->onCreateQuery(static function (QueryBuilder $select) use ($cv) {
+                $where = $cv['where'] ?? null;
                 if ($where) {
                     $select->where($where);
                 }
 
-                $customViewJoins = $cv['joins'];
+                $customViewJoins = $cv['joins'] ?? null;
                 if ($customViewJoins) {
                     foreach ($customViewJoins as $joinConfig) {
                         $type = $joinConfig['type'];
@@ -893,7 +893,7 @@ class Service extends Model\AbstractModel
                     }
                 }
 
-                if ($cv['having']) {
+                if (!empty($cv['having'])) {
                     $select->having($cv['having']);
                 }
             });

--- a/models/Metadata/Predefined.php
+++ b/models/Metadata/Predefined.php
@@ -354,7 +354,7 @@ class Predefined extends Model\AbstractModel
             case 'document':
             case 'asset':
             case 'object':
-                {
+                $element = null;
                 if (is_numeric($this->data)) {
                     $element = Element\Service::getElementById($this->type, $this->data);
                 }
@@ -363,11 +363,6 @@ class Predefined extends Model\AbstractModel
                 } else {
                     $this->data = '';
                 }
-            }
-
-            break;
-            default:
-        //nothing to do
         }
     }
 }

--- a/models/Notification/Service/NotificationService.php
+++ b/models/Notification/Service/NotificationService.php
@@ -178,8 +178,9 @@ class NotificationService
 
         $listing->setOrderKey('creationDate');
         $listing->setOrder('DESC');
-        $offset = (int) $options['offset'] ?? 0;
-        $limit = (int) $options['limit'] ?? 0;
+        $options += ['offset' => 0, 'limit' => 0];
+        $offset = (int) $options['offset'];
+        $limit = (int) $options['limit'];
 
         $this->beginTransaction();
 

--- a/models/Translation/AbstractTranslation/Listing/Dao.php
+++ b/models/Translation/AbstractTranslation/Listing/Dao.php
@@ -108,7 +108,7 @@ abstract class Dao extends Model\Listing\Dao\AbstractDao implements Dao\DaoInter
             $translationsData = $this->db->fetchAll($select);
 
             foreach ($translationsData as $t) {
-                if (!$translations[$t['key']]) {
+                if (!isset($translations[$t['key']])) {
                     $translations[$t['key']] = new $itemClass();
                     $translations[$t['key']]->setKey($t['key']);
                 }

--- a/tests/_support/Util/TestHelper.php
+++ b/tests/_support/Util/TestHelper.php
@@ -704,27 +704,27 @@ class TestHelper
     }
 
     /**
-     * @param AbstractElement|null $root
+     * @param AbstractElement $root
      * @param string $type
      */
-    public static function cleanUpTree(AbstractElement $root = null, $type)
+    public static function cleanUpTree(AbstractElement $root, $type)
     {
-        if (!$root) {
-            return;
-        }
-
         if (!($root instanceof AbstractObject || $root instanceof Document || $root instanceof Asset)) {
             throw new \InvalidArgumentException(sprintf('Cleanup root type for %s needs to be one of: AbstractObject, Document, Asset', $type));
         }
 
-        if ($root and $root->hasChildren()) {
-            $childs = $root->getChildren();
+        if ($root instanceof AbstractObject) {
+            $children = $root->getChildren([], true);
+        } elseif ($root instanceof Document) {
+            $children = $root->getChildren(true);
+        } else {
+            $children = $root->getChildren();
+        }
 
-            /** @var AbstractElement|AbstractObject|Document|Asset $child */
-            foreach ($childs as $child) {
-                codecept_debug(sprintf('Deleting %s %s (%d)', $type, $child->getFullPath(), $child->getId()));
-                $child->delete();
-            }
+        /** @var AbstractElement|AbstractObject|Document|Asset $child */
+        foreach ($children as $child) {
+            codecept_debug(sprintf('Deleting %s %s (%d)', $type, $child->getFullPath(), $child->getId()));
+            $child->delete();
         }
     }
 

--- a/tests/rest/ObjectTest.php
+++ b/tests/rest/ObjectTest.php
@@ -58,7 +58,7 @@ class ObjectTest extends RestTestCase
 
         $result = $this->restClient->createObjectConcrete($unsavedObject);
 
-        $this->assertTrue($result->success, 'request not successful . ' . $result->msg);
+        $this->assertTrue($result->success, 'request not successful . ' . ($result->msg ?? ''));
         $this->assertEquals(2, TestHelper::getObjectCount());
 
         $id = $result->id;


### PR DESCRIPTION
## Changes in this pull request  
Partly resolves #4708

With this PR it is possible to set an PIMCORE_PHP_ERROR_REPORTING env to show all error inclusive notices in dev mode.

**.env.local.php**
```
<?php

return [
    'PIMCORE_PHP_ERROR_REPORTING' => E_ALL,
];

```