### PR TITLE
[Data object] Copy visible fields when cloning many-to-many object relation field

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/manyToManyObjectRelation.js
@@ -235,7 +235,8 @@ pimcore.object.classes.data.manyToManyObjectRelation = Class.create(pimcore.obje
                     relationType: source.datax.relationType,
                     remoteOwner: source.datax.remoteOwner,
                     lazyLoading: source.datax.lazyLoading,
-                    classes: source.datax.classes
+                    classes: source.datax.classes,
+                    visibleFields: source.datax.visibleFields
                 });
         }
     }


### PR DESCRIPTION
To reproduce bug:
1. Create data object class
2. create many-to-many object relation field, allow a class an select some visible fields
3. clone the field
Visible fields have not been copied. This PR fixes that.