### PR TITLE
fixed Inconsistency in versioning system

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1206,6 +1206,9 @@ class DataObjectController extends ElementControllerBase implements EventedContr
      */
     public function saveAction(Request $request)
     {
+        /**
+         * @var $object DataObject\Concrete
+         */
         $object = DataObject::getById($request->get('id'));
         $originalModificationDate = $object->getModificationDate();
 
@@ -1323,8 +1326,22 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             }, 'pimcore_objects');
 
             return $this->adminJson(['success' => true]);
+            
+        } elseif ($request->get('task') == 'scheduler') {
+
+            if($object->isAllowed('settings')) {
+                $object->saveScheduledTasks();
+                return $this->adminJson(['success' => true]);
+            }
+
         } elseif ($object->isAllowed('save')) {
-            $object->saveVersion();
+
+            if($object->isPublished()) {
+                $object->saveVersion();
+            } else {
+                $object->save();
+            }
+            
             $treeData = $this->getTreeNodeConfig($object);
 
             $newObject = DataObject\AbstractObject::getById($object->getId(), true);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/page_snippet.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/page_snippet.js
@@ -111,12 +111,20 @@ pimcore.document.page_snippet = Class.create(pimcore.document.document, {
                 iconCls: "pimcore_icon_save_white",
                 cls: "pimcore_save_button",
                 scale: "medium",
-                handler: this.unpublish.bind(this),
-                menu: [{
-                    text: t('save_close'),
-                    iconCls: "pimcore_icon_save",
-                    handler: this.save.bind(this)
-                }]
+                handler: this.save.bind(this),
+                menu: [
+                    {
+                        text: t('save_close'),
+                        iconCls: "pimcore_icon_save",
+                        handler: this.saveClose.bind(this)
+                    },
+                    {
+                        text: t('save_only_scheduled_tasks'),
+                        iconCls: "pimcore_icon_save",
+                        handler: this.save.bind(this, "scheduler","scheduler"),
+                        hidden: !this.isAllowed("settings") || this.data.published
+                    }
+                ]
             });
 
 
@@ -135,13 +143,13 @@ pimcore.document.page_snippet = Class.create(pimcore.document.document, {
                         text: t('save_only_new_version'),
                         iconCls: "pimcore_icon_save",
                         handler: this.save.bind(this),
-                        hidden: !this.isAllowed("save")
+                        hidden: !this.isAllowed("save") || !this.data.published
                     },
                     {
                         text: t('save_only_scheduled_tasks'),
                         iconCls: "pimcore_icon_save",
                         handler: this.save.bind(this, "scheduler","scheduler"),
-                        hidden: !this.isAllowed("settings")
+                        hidden: !this.isAllowed("settings") || !this.data.published
                     }
                 ]
             });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
@@ -368,11 +368,22 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                 cls: "pimcore_save_button",
                 scale: "medium",
                 handler: this.save.bind(this, "version"),
-                menu: [{
-                    text: t('save_close'),
-                    iconCls: "pimcore_icon_save",
-                    handler: this.unpublishClose.bind(this)
-                }]
+                menu: [
+                    {
+                        text: t('save_close'),
+                        iconCls: "pimcore_icon_save",
+                        handler: function() {
+                            this.save("version");
+                            this.close();
+                        }.bind(this)
+                    },
+                    {
+                        text: t('save_only_scheduled_tasks'),
+                        iconCls: "pimcore_icon_save",
+                        handler: this.save.bind(this, "scheduler", "scheduler"),
+                        hidden: !this.isAllowed("settings") || this.data.general.o_published
+                    }
+                ]
             });
 
 
@@ -383,21 +394,21 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                 scale: "medium",
                 handler: this.publish.bind(this),
                 menu: [{
-                    text: t('save_pubish_close'),
-                    iconCls: "pimcore_icon_save",
-                    handler: this.publishClose.bind(this)
-                },
+                        text: t('save_pubish_close'),
+                        iconCls: "pimcore_icon_save",
+                        handler: this.publishClose.bind(this)
+                    },
                     {
                         text: t('save_only_new_version'),
                         iconCls: "pimcore_icon_save",
                         handler: this.save.bind(this, "version"),
-                        hidden: !this.isAllowed("save")
+                        hidden: !this.isAllowed("save") || !this.data.general.o_published
                     },
                     {
                         text: t('save_only_scheduled_tasks'),
                         iconCls: "pimcore_icon_save",
                         handler: this.save.bind(this, "scheduler", "scheduler"),
-                        hidden: !this.isAllowed("settings")
+                        hidden: !this.isAllowed("settings") || !this.data.general.o_published
                     }
                 ]
             });
@@ -642,17 +653,20 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
         return data;
     },
 
+    close: function() {
+        var tabPanel = Ext.getCmp("pimcore_panel_tabs");
+        tabPanel.remove(this.tab);
+    },
+
     saveClose: function (only) {
         if (this.save()) {
-            var tabPanel = Ext.getCmp("pimcore_panel_tabs");
-            tabPanel.remove(this.tab);
+            this.close();
         }
     },
 
     publishClose: function () {
         this.publish(null, function () {
-            var tabPanel = Ext.getCmp("pimcore_panel_tabs");
-            tabPanel.remove(this.tab);
+            this.close();
         }.bind(this))
     },
 
@@ -693,8 +707,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
 
     unpublishClose: function () {
         this.unpublish();
-        var tabPanel = Ext.getCmp("pimcore_panel_tabs");
-        tabPanel.remove(this.tab);
+        this.close();
     },
 
     saveToSession: function (callback) {


### PR DESCRIPTION
fixing #5136 

- if element `published` -> save button (which is visible to users with `save` but without publish permission only) calls `saveVersion()` and does not update DB/grid data
- if element `not published` -> save button (which is visible to all users with at least `save` permission) calls `save()` and does update DB/grid data