### PR TITLE
Fix: Error image path

### DIFF
--- a/models/Asset/Document/ImageThumbnail.php
+++ b/models/Asset/Document/ImageThumbnail.php
@@ -55,7 +55,17 @@ class ImageThumbnail
     public function getPath($deferredAllowed = true)
     {
         $fsPath = $this->getFileSystemPath($deferredAllowed);
-        $path = str_replace(PIMCORE_TEMPORARY_DIRECTORY . '/image-thumbnails', '', $fsPath);
+        $path = str_replace(
+            [
+                PIMCORE_TEMPORARY_DIRECTORY . '/image-thumbnails',
+                PIMCORE_WEB_ROOT,
+            ],
+            [
+                '',
+                '',
+            ],
+            $fsPath
+        );
         $path = urlencode_ignore_slash($path);
 
         $event = new GenericEvent($this, [


### PR DESCRIPTION
If the image thumbnail could not be generated, the error image have the absolute filesystem path.
