### PR TITLE
Fix: Multi page document thumbnails are not generated

### DIFF
--- a/models/Asset/Document.php
+++ b/models/Asset/Document.php
@@ -116,6 +116,7 @@ class Document extends Model\Asset
 
         if (!$this->getCustomSetting('document_page_count')) {
             Logger::info('Image thumbnail not yet available, processing is done asynchronously.');
+            TmpStore::add(sprintf('asset_document_conversion_%d', $this->getId()), $this->getId(), 'asset-document-conversion');
 
             return new Document\ImageThumbnail(null);
         }

--- a/models/Tool/TmpStore.php
+++ b/models/Tool/TmpStore.php
@@ -55,12 +55,12 @@ class TmpStore extends Model\AbstractModel
     public $serialized = false;
 
     /**
-     * @var Lock
+     * @var TmpStore
      */
     protected static $instance;
 
     /**
-     * @return Lock
+     * @return TmpStore
      */
     protected static function getInstance()
     {


### PR DESCRIPTION
The thumbnails are only generated during the update. Should be also generated if they are deleted.