### PR TITLE
fixed #5259 - [IndexService][ElasticSearch] - Duplicate entries (same  _id) in elastic search

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
@@ -47,8 +47,9 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
     /**
      * @param $objectId
      * @param null $data
+     * @param null $metadata
      */
-    abstract protected function doUpdateIndex($objectId, $data = null);
+    abstract protected function doUpdateIndex($objectId, $data = null, $metadata = null);
 
     /**
      * creates store table
@@ -446,7 +447,7 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
             //statement can take several seconds on large-scale systems.
 
             $this->db->beginTransaction();
-            $query = "SELECT o_id, data FROM {$this->getStoreTableName()} 
+            $query = "SELECT o_id, data, metadata FROM {$this->getStoreTableName()} 
                   WHERE (crc_current != crc_index OR ISNULL(crc_index)) AND tenant = ? AND (ISNULL(worker_timestamp) OR worker_timestamp < ?) LIMIT "
                 . intval($limit) . " FOR UPDATE";
 
@@ -472,7 +473,7 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
         foreach ($entries as $entry) {
             Logger::info("Worker $workerId updating index for element " . $entry['id']);
             $data = json_decode($entry['data'], true);
-            $this->doUpdateIndex($entry['o_id'], $data);
+            $this->doUpdateIndex($entry['o_id'], $data, $entry['metadata']);
         }
 
         return count($entries);

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/DefaultFactFinder.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/DefaultFactFinder.php
@@ -290,8 +290,9 @@ class DefaultFactFinder extends AbstractMockupCacheWorker implements WorkerInter
      *
      * @param $objectId
      * @param null $data
+     * @param null $metadata
      */
-    protected function doUpdateIndex($objectId, $data = null)
+    protected function doUpdateIndex($objectId, $data = null, $metadata = null)
     {
     }
 

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/DefaultFindologic.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/DefaultFindologic.php
@@ -96,8 +96,9 @@ class DefaultFindologic extends AbstractMockupCacheWorker implements WorkerInter
     /**
      * @param      $objectId
      * @param null $data
+     * @param null $metadata
      */
-    protected function doUpdateIndex($objectId, $data = null)
+    protected function doUpdateIndex($objectId, $data = null, $metadata = null)
     {
         $xml = $this->createXMLElement();
 

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/OptimizedMysql.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/OptimizedMysql.php
@@ -109,8 +109,9 @@ class OptimizedMysql extends AbstractMockupCacheWorker implements BatchProcessin
      *
      * @param $objectId
      * @param null $data
+     * @param null $metadata
      */
-    public function doUpdateIndex($objectId, $data = null)
+    public function doUpdateIndex($objectId, $data = null, $metadata = null)
     {
         if (empty($data)) {
             $data = $this->db->fetchOne('SELECT data FROM ' . self::STORE_TABLE_NAME . ' WHERE o_id = ? AND tenant = ?', [$objectId, $this->name]);


### PR DESCRIPTION
resolves #5259 

- store previous routing for each element to store table in metadata field
- when routing changes, add delete to bulk update before new index row of element.
