### PR TITLE
Refactor PageController::checkPrettyUrlAction()

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -260,17 +260,17 @@ class PageController extends DocumentControllerBase
         // must start with /
         if (strpos($path, '/') !== 0) {
             $success = false;
-            $message .= "\n URL must start with /.";
+            $message = "URL must start with /.";
         }
 
         if (strlen($path) < 2) {
             $success = false;
-            $message .= "\n URL must be at least 2 characters long.";
+            $message .= "<br>URL must be at least 2 characters long.";
         }
 
         if (!Element\Service::isValidPath($path, 'document')) {
             $success = false;
-            $message .= "\n URL is invalid.";
+            $message .= "<br>URL is invalid.";
         }
 
         $list = new Document\Listing();

--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -256,7 +256,8 @@ class PageController extends DocumentControllerBase
             $message .= "\n URL must start with /.";
         }
 
-        if (strlen($path) < 2) {
+        // Cannot check for length <2, because that would falsely flag empty pretty URL/URL slugs
+        if (strlen($path) === 1) {
             $success = false;
             $message .= "\n URL must be at least 2 characters long.";
         }

--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -244,11 +244,18 @@ class PageController extends DocumentControllerBase
     public function checkPrettyUrlAction(Request $request)
     {
         $docId = $request->get('id');
-        $path = trim($request->get('path'));
+        $path = (string) trim($request->get('path'));
         $path = rtrim($path, '/');
 
         $success = true;
         $message = null;
+
+        if ($path === '') {
+            return $this->adminJson([
+                'success' => $success,
+                'message' => $message
+            ]);
+        }
 
         // must start with /
         if (strpos($path, '/') !== 0) {
@@ -256,8 +263,7 @@ class PageController extends DocumentControllerBase
             $message .= "\n URL must start with /.";
         }
 
-        // Cannot check for length <2, because that would falsely flag empty pretty URL/URL slugs
-        if (strlen($path) === 1) {
+        if (strlen($path) < 2) {
             $success = false;
             $message .= "\n URL must be at least 2 characters long.";
         }

--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -245,10 +245,8 @@ class PageController extends DocumentControllerBase
     {
         $docId = $request->get('id');
         $path = (string) trim($request->get('path'));
-        $path = rtrim($path, '/');
 
         $success = true;
-        $message = null;
 
         if ($path === '') {
             return $this->adminJson([
@@ -256,8 +254,11 @@ class PageController extends DocumentControllerBase
             ]);
         }
 
+        $message = '';
+        $path = rtrim($path, '/');
+
         // must start with /
-        if (strpos($path, '/') !== 0) {
+        if ($path !== '' && strpos($path, '/') !== 0) {
             $success = false;
             $message = "URL must start with /.";
         }
@@ -280,7 +281,7 @@ class PageController extends DocumentControllerBase
 
         if ($list->getTotalCount() > 0) {
             $success = false;
-            $message .= "\n URL path already exists.";
+            $message .= "<br>URL path already exists.";
         }
 
         return $this->adminJson([

--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -253,7 +253,6 @@ class PageController extends DocumentControllerBase
         if ($path === '') {
             return $this->adminJson([
                 'success' => $success,
-                'message' => $message
             ]);
         }
 

--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -254,23 +254,23 @@ class PageController extends DocumentControllerBase
             ]);
         }
 
-        $message = '';
+        $message = [];
         $path = rtrim($path, '/');
 
         // must start with /
         if ($path !== '' && strpos($path, '/') !== 0) {
             $success = false;
-            $message = "URL must start with /.";
+            $message[] = "URL must start with /.";
         }
 
         if (strlen($path) < 2) {
             $success = false;
-            $message .= "<br>URL must be at least 2 characters long.";
+            $message[] = "URL must be at least 2 characters long.";
         }
 
         if (!Element\Service::isValidPath($path, 'document')) {
             $success = false;
-            $message .= "<br>URL is invalid.";
+            $message[] = "URL is invalid.";
         }
 
         $list = new Document\Listing();
@@ -281,12 +281,12 @@ class PageController extends DocumentControllerBase
 
         if ($list->getTotalCount() > 0) {
             $success = false;
-            $message .= "<br>URL path already exists.";
+            $message[] = "URL path already exists.";
         }
 
         return $this->adminJson([
             'success' => $success,
-            'message' => $message
+            'message' => implode('<br>', $message),
         ]);
     }
 


### PR DESCRIPTION
You can verify the current behaviour on the error messages by switching to the *SEO & Settings* tab, then clicking in the *Pretty URL* input and then by clicking anywhere else, you will get an error message.

I considered first checking for string length in 1f64da0, but settled for an early exit due to edge cases.