### PR TITLE
Simplification of the ecommerce tracking for custom product data

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Tracking/AbstractData.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/AbstractData.php
@@ -22,6 +22,11 @@ abstract class AbstractData implements \JsonSerializable
     protected $id;
 
     /**
+     * @var array
+     */
+    protected $additionalAttributes = [];
+
+    /**
      * @return string
      */
     public function getId()
@@ -65,6 +70,34 @@ abstract class AbstractData implements \JsonSerializable
         }
 
         return $this;
+    }
+
+    /**
+     * Add an additional attribute.
+     * @param $attribute
+     * @param $value
+     * @return $this
+     */
+    public function addAdditionalAttribute($attribute, $value) {
+        $this->additionalAttributes[$attribute] = $value;
+        return $this;
+    }
+
+    /**
+     * Get an additional attribute.
+     * @param $attribute
+     * @return
+     */
+    public function getAdditionalAttribute($attribute) {
+        return $this->additionalAttributes[$attribute];
+    }
+
+    /**
+     * Get all additional attributes.
+     * @return array
+     */
+    public function getAdditionalAttributes() {
+        return $this->additionalAttributes;
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/Tracking/Tracker/Analytics/EnhancedEcommerce.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/Tracker/Analytics/EnhancedEcommerce.php
@@ -124,7 +124,6 @@ class EnhancedEcommerce extends AbstractAnalyticsTracker implements
     public function trackProductActionAdd(ProductInterface $product, $quantity = 1)
     {
         $this->ensureDependencies();
-
         $this->trackProductAction($product, 'add', $quantity);
     }
 
@@ -145,7 +144,6 @@ class EnhancedEcommerce extends AbstractAnalyticsTracker implements
     public function trackProductActionRemove(ProductInterface $product, $quantity = 1)
     {
         $this->ensureDependencies();
-
         $this->trackProductAction($product, 'remove', $quantity);
     }
 
@@ -271,14 +269,16 @@ class EnhancedEcommerce extends AbstractAnalyticsTracker implements
      */
     protected function transformTransaction(Transaction $transaction)
     {
-        return [
+        return array_merge([
             'id' => $transaction->getId(),                           // order ID - required
             'affiliation' => $transaction->getAffiliation() ?: '',            // affiliation or store name
             'revenue' => round($transaction->getTotal(), 2),     // total - required
             'tax' => round($transaction->getTax(), 2),       // tax
             'coupon' => $transaction->getCoupon(), // voucher code - optional
             'shipping' => round($transaction->getShipping(), 2),  // shipping
-        ];
+        ],
+            $transaction->getAdditionalAttributes()
+        );
     }
 
     protected function buildCheckoutCalls(array $items)
@@ -300,17 +300,20 @@ class EnhancedEcommerce extends AbstractAnalyticsTracker implements
      */
     protected function transformProductAction(ProductAction $item)
     {
-        return $this->filterNullValues([
-            'id' => $item->getId(),
-            'name' => $item->getName(),
-            'category' => $item->getCategory(),
-            'brand' => $item->getBrand(),
-            'variant' => $item->getVariant(),
-            'price' => round($item->getPrice(), 2),
-            'quantity' => $item->getQuantity() ?: 1,
-            'position' => $item->getPosition(),
-            'coupon' => $item->getCoupon()
-        ]);
+        return $this->filterNullValues(
+            array_merge([
+                'id' => $item->getId(),
+                'name' => $item->getName(),
+                'category' => $item->getCategory(),
+                'brand' => $item->getBrand(),
+                'variant' => $item->getVariant(),
+                'price' => round($item->getPrice(), 2),
+                'quantity' => $item->getQuantity() ?: 1,
+                'position' => $item->getPosition(),
+                'coupon' => $item->getCoupon()
+            ],
+                $item->getAdditionalAttributes())
+        );
     }
 
     /**
@@ -322,7 +325,7 @@ class EnhancedEcommerce extends AbstractAnalyticsTracker implements
      */
     protected function transformProductImpression(ProductImpression $item)
     {
-        return $this->filterNullValues([
+        $data = $this->filterNullValues(array_merge([
             'id' => $item->getId(),
             'name' => $item->getName(),
             'category' => $item->getCategory(),
@@ -331,7 +334,9 @@ class EnhancedEcommerce extends AbstractAnalyticsTracker implements
             'price' => round($item->getPrice(), 2),
             'list' => $item->getList(),
             'position' => $item->getPosition()
-        ]);
+        ], $item->getAdditionalAttributes()));
+
+        return $data;
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/Tracking/Tracker/Analytics/UniversalEcommerce.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/Tracker/Analytics/UniversalEcommerce.php
@@ -83,13 +83,15 @@ class UniversalEcommerce extends AbstractAnalyticsTracker implements CheckoutCom
      */
     protected function transformTransaction(Transaction $transaction)
     {
-        return $this->filterNullValues([
+        return $this->filterNullValues(array_merge([
             'id' => $transaction->getId(),                     // Transaction ID. Required.
             'affiliation' => $transaction->getAffiliation() ?: '',      // Affiliation or store name.
             'revenue' => $transaction->getTotal(),                  // Grand Total.
             'shipping' => round($transaction->getShipping(), 2),               // Shipping.
             'tax' => round($transaction->getTax(), 2)                     // Tax.
-        ]);
+        ],
+                $transaction->getAdditionalAttributes())
+        );
     }
 
     /**
@@ -101,13 +103,13 @@ class UniversalEcommerce extends AbstractAnalyticsTracker implements CheckoutCom
      */
     protected function transformProductAction(ProductAction $item)
     {
-        return $this->filterNullValues([
+        return $this->filterNullValues(array_merge([
             'id' => $item->getTransactionId(),                    // Transaction ID. Required.
             'sku' => $item->getId(),                               // SKU/code.
             'name' => $item->getName(),                             // Product name. Required.
             'category' => $item->getCategory(),                         // Category or variation.
             'price' => round($item->getPrice(), 2),                            // Unit price.
             'quantity' => $item->getQuantity() ?: 1,                    // Quantity.
-        ]);
+        ], $item->getAdditionalAttributes()));
     }
 }

--- a/bundles/EcommerceFrameworkBundle/Tracking/TrackingItemBuilder.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/TrackingItemBuilder.php
@@ -41,6 +41,8 @@ class TrackingItemBuilder implements TrackingItemBuilderInterface
     public function buildProductImpressionItem(ProductInterface $product)
     {
         $item = new ProductImpression();
+        $this->addProductAttributes($item, $product);
+
         $item
             ->setId($product->getId())
             ->setName($this->normalizeName($product->getOSName()))
@@ -67,6 +69,25 @@ class TrackingItemBuilder implements TrackingItemBuilderInterface
     }
 
     /**
+     * Init common product action attributes and add additional application-specific product action attributes.
+     * @param AbstractProductData $item the tracking item that is going to be serialized later on.
+     * @param ProductInterface $product
+     */
+    protected function addProductAttributes(AbstractProductData $item, ProductInterface $product) {
+        $item
+            ->setId($product->getOSProductNumber())
+            ->setName($this->normalizeName($product->getOSName()))
+            ->setCategories($this->getProductCategories($product))
+            ->setBrand($this->getProductBrand($product))
+        ;
+
+        //
+        //Add additional data to tracking items of type "product".
+        //Example: $item->addAdditionalAttribute("ean", "test-EAN");
+        //
+    }
+
+    /**
      * Build a product action item
      *
      * @param ProductInterface|ElementInterface $product
@@ -77,11 +98,9 @@ class TrackingItemBuilder implements TrackingItemBuilderInterface
     public function buildProductActionItem(ProductInterface $product, $quantity = 1)
     {
         $item = new ProductAction();
-        $item
-            ->setId($product->getId())
-            ->setName($this->normalizeName($product->getOSName()))
-            ->setCategories($this->getProductCategories($product))
-            ->setQuantity($quantity);
+        $item->setQuantity($quantity);
+
+        $this->addProductAttributes($item, $product);
 
         // set price if product is ready to check out
         if ($product instanceof CheckoutableInterface) {
@@ -176,13 +195,11 @@ class TrackingItemBuilder implements TrackingItemBuilderInterface
 
         $item = new ProductAction();
         $item
-            ->setId($orderItem->getProductNumber())
             ->setTransactionId($order->getOrdernumber())
-            ->setName($this->normalizeName($orderItem->getProductName()))
-            ->setCategories($this->getProductCategories($product))
-            ->setBrand($this->getProductBrand($product))
             ->setPrice(Decimal::create($orderItem->getTotalPrice())->div($orderItem->getAmount())->asNumeric())
             ->setQuantity($orderItem->getAmount());
+
+        $this->addProductAttributes($item, $product);
 
         return $item;
     }
@@ -200,13 +217,10 @@ class TrackingItemBuilder implements TrackingItemBuilderInterface
         $product = $cartItem->getProduct();
 
         $item = new ProductAction();
-        $item
-            ->setId($product->getId())
-            ->setName($this->normalizeName($product->getOSName()))
-            ->setCategories($this->getProductCategories($product))
-            ->setBrand($this->getProductBrand($product))
-            ->setPrice($cartItem->getTotalPrice()->getAmount()->div($cartItem->getCount())->asNumeric())
+        $item->setPrice($cartItem->getTotalPrice()->getAmount()->div($cartItem->getCount())->asNumeric())
             ->setQuantity($cartItem->getCount());
+
+        $this->addProductAttributes($item, $product);
 
         return $item;
     }

--- a/bundles/EcommerceFrameworkBundle/Tracking/TrackingItemBuilder.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/TrackingItemBuilder.php
@@ -41,7 +41,7 @@ class TrackingItemBuilder implements TrackingItemBuilderInterface
     public function buildProductImpressionItem(ProductInterface $product)
     {
         $item = new ProductImpression();
-        $this->addProductAttributes($item, $product);
+        $this->initProductAttributes($item, $product);
 
         $item
             ->setId($product->getId())
@@ -73,7 +73,7 @@ class TrackingItemBuilder implements TrackingItemBuilderInterface
      * @param AbstractProductData $item the tracking item that is going to be serialized later on.
      * @param ProductInterface $product
      */
-    protected function addProductAttributes(AbstractProductData $item, ProductInterface $product) {
+    protected function initProductAttributes(AbstractProductData $item, ProductInterface $product) {
         $item
             ->setId($product->getOSProductNumber())
             ->setName($this->normalizeName($product->getOSName()))
@@ -100,7 +100,7 @@ class TrackingItemBuilder implements TrackingItemBuilderInterface
         $item = new ProductAction();
         $item->setQuantity($quantity);
 
-        $this->addProductAttributes($item, $product);
+        $this->initProductAttributes($item, $product);
 
         // set price if product is ready to check out
         if ($product instanceof CheckoutableInterface) {
@@ -199,7 +199,7 @@ class TrackingItemBuilder implements TrackingItemBuilderInterface
             ->setPrice(Decimal::create($orderItem->getTotalPrice())->div($orderItem->getAmount())->asNumeric())
             ->setQuantity($orderItem->getAmount());
 
-        $this->addProductAttributes($item, $product);
+        $this->initProductAttributes($item, $product);
 
         return $item;
     }
@@ -220,7 +220,7 @@ class TrackingItemBuilder implements TrackingItemBuilderInterface
         $item->setPrice($cartItem->getTotalPrice()->getAmount()->div($cartItem->getCount())->asNumeric())
             ->setQuantity($cartItem->getCount());
 
-        $this->addProductAttributes($item, $product);
+        $this->initProductAttributes($item, $product);
 
         return $item;
     }


### PR DESCRIPTION
# Feature Request
Simplify custom product data attribute tracking. 
 
The method ``addProductAttributes`` has been introduced. It
- initializes the most common product data tracking attributes on one site,
- provides a hook to override the default behavior: just call ``item->addAdditionalAttribute('ean', 'test-ean');`` to add your custom attributes.

In addition, each tracking item has an additional ``addAdditionalAttribute`` method. This method can be used to add custom attributes not only to product data, but also to transactions, checkout steps etc.