### PR TITLE
Fix GridCellEditor Namespace

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
@@ -265,7 +265,7 @@ pimcore.object.helpers.grid = Class.create({
 
 
                     operatorColumnConfig.getEditor = function() {
-                        return new pimcore.object.helpers.gridCellEditor({
+                        return new pimcore.element.helpers.gridCellEditor({
                             fieldInfo: {
                                 layout: {
                                     noteditable: true


### PR DESCRIPTION
Use `new pimcore.element.helpers.gridCellEditor` instead of wrong `new pimcore.object.helpers.gridCellEditor` namespace.