### PR TITLE
While cloning a Select or Multiselect field, all attributes are not saved in cloned field.

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/multiselect.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/multiselect.js
@@ -320,7 +320,9 @@ pimcore.object.classes.data.multiselect = Class.create(pimcore.object.classes.da
                     width: source.datax.width,
                     height: source.datax.height,
                     maxItems: source.datax.maxItems,
-                    renderType: source.datax.renderType
+                    renderType: source.datax.renderType,
+                    optionsProviderClass: source.datax.optionsProviderClass,
+                    optionsProviderData: source.datax.optionsProviderData
                 });
         }
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/select.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/select.js
@@ -299,7 +299,9 @@ pimcore.object.classes.data.select = Class.create(pimcore.object.classes.data.da
                     options: source.datax.options,
                     width: source.datax.width,
                     optionsProviderClass: source.datax.optionsProviderClass,
-                    optionsProviderData: source.datax.optionsProviderData
+                    optionsProviderData: source.datax.optionsProviderData,
+                    defaultValue: source.datax.defaultValue,
+                    columnLength : source.datax.columnLength
                 });
         }
     },


### PR DESCRIPTION
- While cloning a select field default value and column length are not saved in the cloned field.
- While cloning a multi select field optionsProviderClass and optionsProviderData are not saved in the cloned field

