### PR TITLE
[Web2Print] Preserve type of processing options

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/PrintpageControllerBase.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PrintpageControllerBase.php
@@ -250,12 +250,12 @@ class PrintpageControllerBase extends DocumentControllerBase
      */
     public function startPdfGenerationAction(Request $request)
     {
-        $document = Document\PrintAbstract::getById(intval($request->get('id')));
-        if (empty($document)) {
-            throw new \Exception('Document with id ' . $request->get('id') . ' not found.');
-        }
+        $allParams = json_decode($request->getContent(), true);
 
-        $allParams = array_merge($request->request->all(), $request->query->all());
+        $document = Document\PrintAbstract::getById($allParams['id']);
+        if (empty($document)) {
+            throw new \Exception('Document with id ' . $allParams['id'] . ' not found.');
+        }
 
         if (\Pimcore\Config::getSystemConfig()->general->domain) {
             $allParams['hostName'] = \Pimcore\Config::getSystemConfig()->general->domain;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/printpages/pdf_preview.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/printpages/pdf_preview.js
@@ -342,7 +342,7 @@ pimcore.document.printpages.pdfpreview = Class.create({
         Ext.Ajax.request({
             url: "/admin/printpage/start-pdf-generation",
             method: 'POST',
-            params: params,
+            jsonData: params,
             success: function(response) {
                 result = Ext.decode(response.responseText);
                 if(result.success) {

--- a/lib/Web2Print/Processor/PdfReactor8.php
+++ b/lib/Web2Print/Processor/PdfReactor8.php
@@ -177,8 +177,8 @@ class PdfReactor8 extends Processor
 
         $options[] = ['name' => 'author', 'type' => 'text', 'default' => ''];
         $options[] = ['name' => 'title', 'type' => 'text', 'default' => ''];
-        $options[] = ['name' => 'printermarks', 'type' => 'bool', 'default' => ''];
-        $options[] = ['name' => 'addOverprint', 'type' => 'bool', 'default' => ''];
+        $options[] = ['name' => 'printermarks', 'type' => 'bool', 'default' => false];
+        $options[] = ['name' => 'addOverprint', 'type' => 'bool', 'default' => false];
         $options[] = ['name' => 'links', 'type' => 'bool', 'default' => true];
         $options[] = ['name' => 'bookmarks', 'type' => 'bool', 'default' => true];
         $options[] = ['name' => 'tags', 'type' => 'bool', 'default' => true];


### PR DESCRIPTION
For processing options of type bool the value was incorrectly stored as
string. When loading previously stored options, a value "false" (string)
evaluated true and therefore the option was incorrectly checked.

This fix lets ExtJS encode the options as JSON (preserving types) and
the controller action JSON decodes the request body. When storing the
options, all types are preserved.
