### PR TITLE
AbstractElement::isAllowed() doesn't work in commands

### DIFF
--- a/lib/Tool/Admin.php
+++ b/lib/Tool/Admin.php
@@ -237,7 +237,7 @@ class Admin
     /**
      * @static
      *
-     * @return \Pimcore\Model\User
+     * @return \Pimcore\Model\User|null
      */
     public static function getCurrentUser()
     {

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -18,6 +18,7 @@
 namespace Pimcore\Model\Element;
 
 use Pimcore\Model;
+use Pimcore\Tool\Admin;
 
 /**
  * @method \Pimcore\Model\Element\Dao getDao()
@@ -198,7 +199,16 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
      */
     public function isAllowed($type)
     {
-        $currentUser = \Pimcore\Tool\Admin::getCurrentUser();
+        if (php_sapi_name() === 'cli') {
+            return true;
+        }
+
+        $currentUser = Admin::getCurrentUser();
+
+        if (!$currentUser) {
+            return false;
+        }
+
         //everything is allowed for admin
         if ($currentUser->isAdmin()) {
             return true;


### PR DESCRIPTION
In cli mode the isAllowed function throws an error
```
Error thrown while running command
In AbstractElement.php line 203:
Call to a member function isAdmin() on null
```

I think its ok, when it returns true in cli