### PR TITLE
Add indexedValues to the variables passed to view

### DIFF
--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/SelectCategory.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/SelectCategory.php
@@ -46,6 +46,7 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$filterDefinition->getField()],
             'values' => array_values($values),
+            'indexedValues' => $values,
             'document' => $this->request->get('contentDocument'),
             'fieldname' => $filterDefinition->getField(),
             'rootCategory' => $filterDefinition->getRootCategory(),


### PR DESCRIPTION
indexedValues was not added to the ElasticSearch version of the SelectCategory.php, which results in an error if using ElasticSearch instead of default MysqlSearch.

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

