### PR TITLE
[Data Objects] Relational Fields with Image Previews from Advanced Images are not automatically adjusting the grids height

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
@@ -54,7 +54,7 @@ pimcore.object.tags.hotspotimage = Class.create(pimcore.object.tags.image, {
         return {
             text: ts(field.label), width: 100, sortable: false, dataIndex: field.key,
             getEditor: this.getWindowCellEditor.bind(this, field),
-            renderer: function (key, value, metaData, record) {
+            renderer: function (key, value, metaData, record, rowIndex, colIndex, store, view) {
                 this.applyPermissionStyle(key, value, metaData, record);
 
                 if (record.data.inheritedFields[key] && record.data.inheritedFields[key].inherited == true) {
@@ -77,6 +77,14 @@ pimcore.object.tags.hotspotimage = Class.create(pimcore.object.tags.image, {
                         if (value.crop) {
                             var cropParams = Ext.Object.toQueryString(value.crop);
                             url = Ext.String.urlAppend(url, cropParams);
+                        }
+
+                        // unfortunately we have to use a timeout here to adjust the height of grids configured
+                        // with autoHeight: true, there are no other events that would work, see also: https://github.com/pimcore/pimcore/pull/4337/files
+                        if (!view['refreshTimeout']) {
+                            view.refreshTimeout = window.setTimeout(function () {
+                                view.refresh();
+                            }, 1000);
                         }
 
                         url = url + '" />';


### PR DESCRIPTION
This PR resolves the same problem discussed [here](https://github.com/pimcore/pimcore/pull/4337) but for hotspot images.

To reproduce:

1. Create class **A** and add an "Image Advanced" field
2. Create another class **B** and add an "Advanced Many to Many Object Relation" field, allow the first class and specify the image field as visible.
3. Create an object "A" and assign an image
4. Create another object "B" and assign "A" to the advanced many-to-many object relation. You will see something like this:
![before-pr](https://user-images.githubusercontent.com/43776120/70044382-8bb5af00-15c2-11ea-89c9-97b5af822df7.png)
5. After switching panel and get back to Edit panel:
![after-pr](https://user-images.githubusercontent.com/43776120/70044473-b99af380-15c2-11ea-96bb-4a0f6061e8d4.png)

The solution uses the same timeout (and the same idea, too) used by @BlackbitNeueMedien .


