### PR TITLE
[Translations] Bugfix: "undefined" translation for new language

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/translations.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/translations.js
@@ -93,7 +93,7 @@ pimcore.settings.translations = Class.create({
         ];
 
         for (var i = 0; i < languages.length; i++) {
-            readerFields.push({name: "_" + languages[i]});
+            readerFields.push({name: "_" + languages[i], defaultValue: ''});
 
             var columnConfig = {
                 cls: "x-column-header_" + languages[i].toLowerCase(),


### PR DESCRIPTION
Steps to reproduce bug:
1. Add language via system settings > localization
2. Go to shared translations
3. All translations for the newly added language show "undefined"

<img width="1296" alt="Bildschirmfoto 2019-12-03 um 21 13 11" src="https://user-images.githubusercontent.com/8749138/70086021-bd099b80-1611-11ea-92fa-7c9d32e5601b.png">

Fortunately this is only a display error: When you access a translation for the new language it is handled as empty translation.