### PR TITLE
[Ecommerce][PricingManager] Rules should not not be loaded multiple times if no active rules exist

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
@@ -208,7 +208,7 @@ class PricingManager implements PricingManagerInterface
      */
     public function getValidRules()
     {
-        if (empty($this->rules)) {
+        if (is_null($this->rules)) {
             /** @var Rule\Listing $rules */
             $rules = $this->getRuleListing();
             $rules->setCondition('active = 1');


### PR DESCRIPTION
Empty is not a valid check as an empty array is empty too.