### PR TITLE
Fix: Cannot instantiate abstract class Pimcore\Model\User\AbstractUser

### DIFF
--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -24,7 +24,7 @@ use Pimcore\Model;
 /**
  * @method \Pimcore\Model\User\AbstractUser\Dao getDao()
  */
-abstract class AbstractUser extends Model\AbstractModel
+class AbstractUser extends Model\AbstractModel
 {
     /**
      * @var int


### PR DESCRIPTION
Regression from #5356 

The error occurs when trying to save a user