### PR TITLE
[Asset] Improvements for pimcore:thumbnails:image Command: high-res, webp and media queries support

### DIFF
--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -50,6 +50,21 @@ class ThumbnailsImageCommand extends AbstractCommand
                 'f',
                 InputOption::VALUE_NONE,
                 'recreate thumbnails, regardless if they exist already'
+            )->addOption(
+                'skip-webp',
+                null,
+                InputOption::VALUE_NONE,
+                'if target image format is set to auto in config, do not generate WEBP images for them'
+            )->addOption(
+                'skip-medias',
+                null,
+                InputOption::VALUE_NONE,
+                'if config has media queries defined, do not generate thumbnails for them'
+            )->addOption(
+                'skip-high-res',
+                null,
+                InputOption::VALUE_NONE,
+                'do not generate high-res (@2x) versions of thumbnails'
             );
     }
 
@@ -59,22 +74,48 @@ class ThumbnailsImageCommand extends AbstractCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $list = new Asset\Image\Thumbnail\Config\Listing();
-        $items = $list->getThumbnails();
-        $thumbnails = [];
-        foreach ($items as $item) {
-            $thumbnails[] = $item->getName();
-        }
+        $thumbnailConfigList = $list->getThumbnails();
 
         $allowedThumbs = [];
         if ($input->getOption('thumbnails')) {
             $allowedThumbs = explode(',', $input->getOption('thumbnails'));
         }
 
+        /**
+         * @var Asset\Image\Thumbnail\Config[] $thumbnailsToGenerate
+         */
         $thumbnailsToGenerate = [];
 
-        foreach ($thumbnails as $thumbnail) {
-            if (empty($allowedThumbs) || in_array($thumbnail, $allowedThumbs)) {
-                $thumbnailsToGenerate[] = $thumbnail;
+        foreach ($thumbnailConfigList as $thumbnailConfig) {
+            if (empty($allowedThumbs) || in_array($thumbnailConfig->getName(), $allowedThumbs)) {
+                $medias = array_merge(['default' => 'defaultMedia'], $thumbnailConfig->getMedias() ? : []);
+                foreach ($medias as $mediaName => $media) {
+                    $configMedia = clone $thumbnailConfig;
+                    if ($mediaName !== 'default') {
+                        $configMedia->selectMedia($mediaName);
+                    }
+
+                    if($input->getOption('skip-medias') && $mediaName !== 'default') {
+                        continue;
+                    }
+
+                    $resolutions = [1,2];
+                    if($input->getOption('skip-high-res')) {
+                        $resolutions = [1];
+                    }
+
+                    foreach ($resolutions as $resolution) {
+                        $resConfig = clone $configMedia;
+                        $resConfig->setHighResolution($resolution);
+                        $thumbnailsToGenerate[] = $resConfig;
+
+                        if(!$input->getOption('skip-webp') && $resConfig->getFormat() === 'SOURCE') {
+                            $webpConfig = clone $resConfig;
+                            $webpConfig->setFormat('webp');
+                            $thumbnailsToGenerate[] = $webpConfig;
+                        }
+                    }
+                }
             }
         }
 
@@ -82,8 +123,16 @@ class ThumbnailsImageCommand extends AbstractCommand
             if (!$input->getOption('thumbnails')) {
                 $thumbnailsToGenerate = [];
             }
-            $thumbnailsToGenerate[] = 'system';
+            $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig();
+        } elseif (!$input->getOption('thumbnails')) {
+            $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig();
         }
+
+        $thumbnailConfigNames = [];
+        foreach ($thumbnailsToGenerate as $thumbnailConfig) {
+            $thumbnailConfigNames[] = $thumbnailConfig->getName();
+        }
+        $thumbnailConfigNames = array_unique($thumbnailConfigNames);
 
         // get only images
         $conditions = ["type = 'image'"];
@@ -121,27 +170,21 @@ class ThumbnailsImageCommand extends AbstractCommand
                     continue;
                 }
 
-                foreach ($thumbnailsToGenerate as $thumbnailName) {
-                    $thumbnail = $thumbnailName;
-
-                    if ($thumbnailName === 'system') {
-                        $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig();
+                if ($input->getOption('force')) {
+                    foreach($thumbnailConfigNames as $thumbnailConfigName) {
+                        $image->clearThumbnail($thumbnailConfigName);
                     }
+                }
 
-                    if ($input->getOption('force')) {
-                        $image->clearThumbnail($thumbnailName);
-                    }
+                foreach ($thumbnailsToGenerate as $thumbnailConfig) {
+                    $thumbnail = $image->getThumbnail($thumbnailConfig);
 
                     $progress->setMessage(
                         sprintf(
-                            'generating thumbnail to image %s | %d | Thumbnail: %s',
-                            $image->getRealFullPath(),
+                            'generated thumbnail for image [%d] | file: %s',
                             $image->getId(),
-                            is_string($thumbnail) ? $thumbnailName : 'System Preview (tree)'
+                            $thumbnail->getPath(false)
                         )
-                    );
-                    $progress->setMessage(
-                        'generated thumbnail: ' . str_replace(PIMCORE_PROJECT_ROOT.'/', '', $image->getThumbnail($thumbnail)->getFilesystemPath())
                     );
 
                     $progress->advance(1);
@@ -151,5 +194,7 @@ class ThumbnailsImageCommand extends AbstractCommand
         }
 
         $progress->finish();
+
+        $output->writeln('');
     }
 }


### PR DESCRIPTION
The command now generates all necessary thumbnail files for the given configurations (incl. @2x, WebP and media queries) not only the main one. 
This is the expected behavior, so this is default. 

Introduced 3 new flags to give more control over the generation process: 
```
--skip-medias 
--skip-webp 
--skip-high-res
```

Resolves #5295
