### PR TITLE
Add tag event listeners

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/TagsController.php
+++ b/bundles/AdminBundle/Controller/Admin/TagsController.php
@@ -17,6 +17,8 @@ namespace Pimcore\Bundle\AdminBundle\Controller\Admin;
 use Pimcore\Bundle\AdminBundle\Controller\AdminController;
 use Pimcore\Event\AdminEvents;
 use Pimcore\Model\Element\Tag;
+use Pimcore\Event\TagEvents;
+use Pimcore\Event\Model\TagEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -208,8 +210,10 @@ class TagsController extends AdminController
 
         $tag = Tag::getById($tagId);
         if ($tag) {
+            $event = new TagEvent($tag, array('assignmentElementId' => $assginmentCId, 'assignmentElementType' => $assginmentCType));
+            \Pimcore::getEventDispatcher()->dispatch(TagEvents::PRE_ADD_TO_ELEMENT, $event);
             Tag::addTagToElement($assginmentCType, $assginmentCId, $tag);
-
+            \Pimcore::getEventDispatcher()->dispatch(TagEvents::POST_ADD_TO_ELEMENT, $event);
             return $this->adminJson(['success' => true, 'id' => $tag->getId()]);
         } else {
             return $this->adminJson(['success' => false]);
@@ -231,8 +235,10 @@ class TagsController extends AdminController
 
         $tag = Tag::getById($tagId);
         if ($tag) {
+            $event = new TagEvent($tag, array('assignmentElementId' => $assginmentCId, 'assignmentElementType' => $assginmentCType));
+            \Pimcore::getEventDispatcher()->dispatch(TagEvents::PRE_REMOVE_FROM_ELEMENT, $event);
             Tag::removeTagFromElement($assginmentCType, $assginmentCId, $tag);
-
+            \Pimcore::getEventDispatcher()->dispatch(TagEvents::POST_REMOVE_FROM_ELEMENT, $event);
             return $this->adminJson(['success' => true, 'id' => $tag->getId()]);
         } else {
             return $this->adminJson(['success' => false]);

--- a/lib/Event/Model/TagEvent.php
+++ b/lib/Event/Model/TagEvent.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Event\Model;
+
+use Pimcore\Model\Element\Tag;
+use Symfony\Component\EventDispatcher\Event;
+
+class TagEvent extends Event
+{
+
+    /**
+     * @var Tag
+     */
+    protected $tag;
+
+    /**
+     * DocumentEvent constructor.
+     *
+     * @param Tag $tag
+     * @param array $arguments
+     */
+    public function __construct(Tag $tag, array $arguments = [])
+    {
+        $this->tag = $tag;
+        $this->arguments = $arguments;
+    }
+
+    /**
+     * @return Tag
+     */
+    public function getTag()
+    {
+        return $this->tag;
+    }
+
+    /**
+     * @param Tag $tag
+     */
+    public function setTag($tag)
+    {
+        $this->tag = $tag;
+    }
+
+    /**
+     * @return Tag
+     */
+    public function getElement()
+    {
+        return $this->getTag();
+    }
+
+    /**
+     * @return Array
+     */
+    public function getArguments()
+    {
+        return $this->arguments;
+    }
+}

--- a/lib/Event/Model/TagEvent.php
+++ b/lib/Event/Model/TagEvent.php
@@ -62,7 +62,7 @@ class TagEvent extends Event
     }
 
     /**
-     * @return Array
+     * @return array
      */
     public function getArguments()
     {

--- a/lib/Event/TagEvents.php
+++ b/lib/Event/TagEvents.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Event;
+
+final class TagEvents
+{
+    /**
+     * @Event("Pimcore\Event\Model\TagEvent")
+     *
+     * @var string
+     */
+    const PRE_ADD_TO_ELEMENT = 'pimcore.tag.preAddToElement';
+
+    /**
+     * @Event("Pimcore\Event\Model\TagEvent")
+     *
+     * @var string
+     */
+    const POST_ADD_TO_ELEMENT = 'pimcore.tag.postAddToElement';
+
+    /**
+     * @Event("Pimcore\Event\Model\TagEvent")
+     *
+     * @var string
+     */
+    const PRE_REMOVE_FROM_ELEMENT = 'pimcore.tag.preRemoveFromElement';
+
+    /**
+     * @Event("Pimcore\Event\Model\TagEvent")
+     *
+     * @var string
+     */
+    const POST_REMOVE_FROM_ELEMENT = 'pimcore.tag.postRemoveFromElement';
+
+}


### PR DESCRIPTION
## Changes in this pull request  
I've added A TagEvents class and a TagEvent Event Model class. 
In the TagEvents class I declared `PRE_ADD_TO_ELEMENT`, `POST_ADD_TO_ELEMENT`, `PRE_REMOVE_FROM_ELEMENT`, `POST_REMOVE_FROM_ELEMENT` events.

Also I added event dispatchers that fire the above events before and after both tag addition and removal in the Admin's TagsController class.

### Resolves [#5368](https://github.com/pimcore/pimcore/issues/5368)



