### PR TITLE
Remove duplicate indexes

### DIFF
--- a/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
@@ -3,8 +3,12 @@
 namespace Pimcore\Bundle\CoreBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaException;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PimcoreEcommerceFrameworkBundle;
 use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\ClassDefinition\Listing;
+use Pimcore\Model\DataObject\Fieldcollection\Definition;
 
 /**
  * Auto-generated Migration: Please modify to your needs!
@@ -135,6 +139,60 @@ class Version20191208175348 extends AbstractPimcoreMigration
         if($users_workspaces_objectTable->hasIndex('cid')) {
             $users_workspaces_objectTable->dropIndex('cid');
         }
+
+        /** @var ClassDefinition $classDefinition */
+        foreach(new Listing as $classDefinition) {
+            try {
+                $table = $schema->getTable('object_metadata_'.$classDefinition->getId());
+                if ($table->hasIndex('o_id')) {
+                    $table->dropIndex('o_id');
+                }
+            } catch(SchemaException $e) {}
+
+            $localizedFieldsDefinition = $classDefinition->getFieldDefinition('localizedfields');
+            if($localizedFieldsDefinition instanceof ClassDefinition\Data\Localizedfields) {
+                try {
+                    $table = $schema->getTable('object_localized_query_'.$classDefinition->getId());
+                    if ($table->hasIndex('ooo_id')) {
+                        $table->dropIndex('ooo_id');
+                    }
+                } catch(SchemaException $e) {}
+
+                try {
+                    $table = $schema->getTable('object_localized_data_'.$classDefinition->getId());
+                    if ($table->hasIndex('ooo_id')) {
+                        $table->dropIndex('ooo_id');
+                    }
+                } catch(SchemaException $e) {}
+
+                /** @var \Pimcore\Model\DataObject\Objectbrick\Definition $brickListing */
+                foreach(new \Pimcore\Model\DataObject\Objectbrick\Definition\Listing() as $brickListing) {
+                    try {
+                        $table = $schema->getTable('object_brick_localized_query_'.$brickListing->getKey().'_'.$classDefinition->getId());
+                        if ($table->hasIndex('ooo_id')) {
+                            $table->dropIndex('ooo_id');
+                        }
+                    } catch(SchemaException $e) {}
+
+                    try {
+                        $table = $schema->getTable('object_brick_localized_'.$brickListing->getKey().'_'.$classDefinition->getId());
+                        if ($table->hasIndex('ooo_id')) {
+                            $table->dropIndex('ooo_id');
+                        }
+                    } catch(SchemaException $e) {}
+                }
+            }
+
+            /** @var Definition $fieldCollectionDefinition */
+            foreach(new \Pimcore\Model\DataObject\Fieldcollection\Definition\Listing() as $fieldCollectionDefinition) {
+                try {
+                    $table = $schema->getTable($fieldCollectionDefinition->getDao()->getTableName($classDefinition));
+                    if ($table->hasIndex('o_id')) {
+                        $table->dropIndex('o_id');
+                    }
+                } catch(SchemaException $e) {}
+            }
+        }
     }
 
     /**
@@ -255,6 +313,60 @@ class Version20191208175348 extends AbstractPimcoreMigration
         $users_workspaces_objectTable = $schema->getTable('users_workspaces_object');
         if(!$users_workspaces_objectTable->hasIndex('cid')) {
             $users_workspaces_objectTable->addIndex(['cid'], 'cid');
+        }
+
+        /** @var ClassDefinition $classDefinition */
+        foreach(new Listing as $classDefinition) {
+            try {
+                $table = $schema->getTable('object_metadata_'.$classDefinition->getId());
+                if (!$table->hasIndex('o_id')) {
+                    $table->addIndex(['o_id'], 'o_id');
+                }
+            } catch(SchemaException $e) {}
+
+            $localizedFieldsDefinition = $classDefinition->getFieldDefinition('localizedfields');
+            if($localizedFieldsDefinition instanceof ClassDefinition\Data\Localizedfields) {
+                try {
+                    $table = $schema->getTable('object_localized_query_'.$classDefinition->getId());
+                    if (!$table->hasIndex('ooo_id')) {
+                        $table->addIndex(['ooo_id'], 'ooo_id');
+                    }
+                } catch(SchemaException $e) {}
+
+                try {
+                    $table = $schema->getTable('object_localized_data_'.$classDefinition->getId());
+                    if (!$table->hasIndex('ooo_id')) {
+                        $table->addIndex(['ooo_id'], 'ooo_id');
+                    }
+                } catch(SchemaException $e) {}
+
+                /** @var \Pimcore\Model\DataObject\Objectbrick\Definition $brickListing */
+                foreach(new \Pimcore\Model\DataObject\Objectbrick\Definition\Listing() as $brickListing) {
+                    try {
+                        $table = $schema->getTable('object_brick_localized_query_'.$brickListing->getKey().'_'.$classDefinition->getId());
+                        if (!$table->hasIndex('ooo_id')) {
+                            $table->addIndex(['ooo_id'], 'ooo_id');
+                        }
+                    } catch(SchemaException $e) {}
+
+                    try {
+                        $table = $schema->getTable('object_brick_localized_'.$brickListing->getKey().'_'.$classDefinition->getId());
+                        if (!$table->hasIndex('ooo_id')) {
+                            $table->addIndex(['ooo_id'], 'ooo_id');
+                        }
+                    } catch(SchemaException $e) {}
+                }
+            }
+
+            /** @var Definition $fieldCollectionDefinition */
+            foreach(new \Pimcore\Model\DataObject\Fieldcollection\Definition\Listing() as $fieldCollectionDefinition) {
+                try {
+                    $table = $schema->getTable($fieldCollectionDefinition->getDao()->getTableName($classDefinition));
+                    if (!$table->hasIndex('o_id')) {
+                        $table->addIndex(['o_id'], 'o_id');
+                    }
+                } catch(SchemaException $e) {}
+            }
         }
     }
 }

--- a/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
@@ -148,6 +148,13 @@ class Version20191208175348 extends AbstractPimcoreMigration
                 }
             } catch(SchemaException $e) {}
 
+            try {
+                $table = $schema->getTable('object_relations_'.$classDefinition->getId());
+                if ($table->hasIndex('src_id')) {
+                    $table->dropIndex('src_id');
+                }
+            } catch(SchemaException $e) {}
+
             $localizedFieldsDefinition = $classDefinition->getFieldDefinition('localizedfields');
             if($localizedFieldsDefinition instanceof ClassDefinition\Data\Localizedfields) {
                 try {
@@ -258,8 +265,8 @@ class Version20191208175348 extends AbstractPimcoreMigration
         }
 
         $importconfig_sharesTable = $schema->getTable('importconfig_shares');
-        if(!$importconfig_sharesTable->hasIndex('data.sharedRoleIds')) {
-            $importconfig_sharesTable->addIndex(['importConfigId'], 'data.sharedRoleIds');
+        if(!$importconfig_sharesTable->hasIndex('sharedRoleIds')) {
+            $importconfig_sharesTable->addIndex(['importConfigId'], 'sharedRoleIds');
         }
 
         $propertiesTable = $schema->getTable('properties');
@@ -317,6 +324,13 @@ class Version20191208175348 extends AbstractPimcoreMigration
                 $table = $schema->getTable('object_metadata_'.$classDefinition->getId());
                 if (!$table->hasIndex('o_id')) {
                     $table->addIndex(['o_id'], 'o_id');
+                }
+            } catch(SchemaException $e) {}
+
+            try {
+                $table = $schema->getTable('object_relations_'.$classDefinition->getId());
+                if (!$table->hasIndex('src_id')) {
+                    $table->addIndex(['src_id'], 'src_id');
                 }
             } catch(SchemaException $e) {}
 

--- a/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
@@ -121,8 +121,8 @@ class Version20191208175348 extends AbstractPimcoreMigration
         }
 
         $tree_locksTable = $schema->getTable('tree_locks');
-        if($tree_locksTable->hasIndex('cid')) {
-            $tree_locksTable->dropIndex('cid');
+        if($tree_locksTable->hasIndex('id')) {
+            $tree_locksTable->dropIndex('id');
         }
 
         $users_workspaces_assetTable = $schema->getTable('users_workspaces_asset');

--- a/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
@@ -87,7 +87,7 @@ class Version20191208175348 extends AbstractPimcoreMigration
 
         $importconfig_sharesTable = $schema->getTable('importconfig_shares');
         if($importconfig_sharesTable->hasIndex('data.sharedRoleIds')) {
-            $importconfig_sharesTable->dropIndex('data.sharedRoleIds');
+            $this->addSql('DROP INDEX `data.sharedRoleIds` ON importconfig_shares');
         }
 
         $propertiesTable = $schema->getTable('properties');

--- a/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
@@ -140,8 +140,7 @@ class Version20191208175348 extends AbstractPimcoreMigration
             $users_workspaces_objectTable->dropIndex('cid');
         }
 
-        /** @var ClassDefinition $classDefinition */
-        foreach(new Listing as $classDefinition) {
+        foreach((new Listing)->load() as $classDefinition) {
             try {
                 $table = $schema->getTable('object_metadata_'.$classDefinition->getId());
                 if ($table->hasIndex('o_id')) {
@@ -165,8 +164,7 @@ class Version20191208175348 extends AbstractPimcoreMigration
                     }
                 } catch(SchemaException $e) {}
 
-                /** @var \Pimcore\Model\DataObject\Objectbrick\Definition $brickListing */
-                foreach(new \Pimcore\Model\DataObject\Objectbrick\Definition\Listing() as $brickListing) {
+                foreach((new \Pimcore\Model\DataObject\Objectbrick\Definition\Listing())->load() as $brickListing) {
                     try {
                         $table = $schema->getTable('object_brick_localized_query_'.$brickListing->getKey().'_'.$classDefinition->getId());
                         if ($table->hasIndex('ooo_id')) {
@@ -183,8 +181,7 @@ class Version20191208175348 extends AbstractPimcoreMigration
                 }
             }
 
-            /** @var Definition $fieldCollectionDefinition */
-            foreach(new \Pimcore\Model\DataObject\Fieldcollection\Definition\Listing() as $fieldCollectionDefinition) {
+            foreach((new \Pimcore\Model\DataObject\Fieldcollection\Definition\Listing())->load() as $fieldCollectionDefinition) {
                 try {
                     $table = $schema->getTable($fieldCollectionDefinition->getDao()->getTableName($classDefinition));
                     if ($table->hasIndex('o_id')) {
@@ -315,8 +312,7 @@ class Version20191208175348 extends AbstractPimcoreMigration
             $users_workspaces_objectTable->addIndex(['cid'], 'cid');
         }
 
-        /** @var ClassDefinition $classDefinition */
-        foreach(new Listing as $classDefinition) {
+        foreach((new Listing)->load() as $classDefinition) {
             try {
                 $table = $schema->getTable('object_metadata_'.$classDefinition->getId());
                 if (!$table->hasIndex('o_id')) {
@@ -340,8 +336,7 @@ class Version20191208175348 extends AbstractPimcoreMigration
                     }
                 } catch(SchemaException $e) {}
 
-                /** @var \Pimcore\Model\DataObject\Objectbrick\Definition $brickListing */
-                foreach(new \Pimcore\Model\DataObject\Objectbrick\Definition\Listing() as $brickListing) {
+                foreach((new \Pimcore\Model\DataObject\Objectbrick\Definition\Listing())->load() as $brickListing) {
                     try {
                         $table = $schema->getTable('object_brick_localized_query_'.$brickListing->getKey().'_'.$classDefinition->getId());
                         if (!$table->hasIndex('ooo_id')) {
@@ -358,8 +353,7 @@ class Version20191208175348 extends AbstractPimcoreMigration
                 }
             }
 
-            /** @var Definition $fieldCollectionDefinition */
-            foreach(new \Pimcore\Model\DataObject\Fieldcollection\Definition\Listing() as $fieldCollectionDefinition) {
+            foreach((new \Pimcore\Model\DataObject\Fieldcollection\Definition\Listing())->load() as $fieldCollectionDefinition) {
                 try {
                     $table = $schema->getTable($fieldCollectionDefinition->getDao()->getTableName($classDefinition));
                     if (!$table->hasIndex('o_id')) {

--- a/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
@@ -110,6 +110,31 @@ class Version20191208175348 extends AbstractPimcoreMigration
         if($translations_adminTable->hasIndex('key')) {
             $translations_adminTable->dropIndex('key');
         }
+
+        $translations_websiteTable = $schema->getTable('translations_website');
+        if($translations_websiteTable->hasIndex('key')) {
+            $translations_websiteTable->dropIndex('key');
+        }
+
+        $tree_locksTable = $schema->getTable('tree_locks');
+        if($tree_locksTable->hasIndex('id')) {
+            $tree_locksTable->dropIndex('id');
+        }
+
+        $users_workspaces_assetTable = $schema->getTable('users_workspaces_asset');
+        if($users_workspaces_assetTable->hasIndex('cid')) {
+            $users_workspaces_assetTable->dropIndex('cid');
+        }
+
+        $users_workspaces_documentTable = $schema->getTable('users_workspaces_document');
+        if($users_workspaces_documentTable->hasIndex('cid')) {
+            $users_workspaces_documentTable->dropIndex('cid');
+        }
+
+        $users_workspaces_objectTable = $schema->getTable('users_workspaces_object');
+        if($users_workspaces_objectTable->hasIndex('cid')) {
+            $users_workspaces_objectTable->dropIndex('cid');
+        }
     }
 
     /**
@@ -205,6 +230,31 @@ class Version20191208175348 extends AbstractPimcoreMigration
         $translations_adminTable = $schema->getTable('translations_admin');
         if(!$translations_adminTable->hasIndex('key')) {
             $translations_adminTable->addIndex(['key'], 'key');
+        }
+
+        $translations_websiteTable = $schema->getTable('translations_website');
+        if(!$translations_websiteTable->hasIndex('key')) {
+            $translations_websiteTable->addIndex(['key'], 'key');
+        }
+
+        $tree_locksTable = $schema->getTable('tree_locks');
+        if(!$tree_locksTable->hasIndex('id')) {
+            $tree_locksTable->addIndex(['id'], 'id');
+        }
+
+        $users_workspaces_assetTable = $schema->getTable('users_workspaces_asset');
+        if(!$users_workspaces_assetTable->hasIndex('cid')) {
+            $users_workspaces_assetTable->addIndex(['cid'], 'cid');
+        }
+
+        $users_workspaces_documentTable = $schema->getTable('users_workspaces_document');
+        if(!$users_workspaces_documentTable->hasIndex('cid')) {
+            $users_workspaces_documentTable->addIndex(['cid'], 'cid');
+        }
+
+        $users_workspaces_objectTable = $schema->getTable('users_workspaces_object');
+        if(!$users_workspaces_objectTable->hasIndex('cid')) {
+            $users_workspaces_objectTable->addIndex(['cid'], 'cid');
         }
     }
 }

--- a/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
@@ -121,8 +121,8 @@ class Version20191208175348 extends AbstractPimcoreMigration
         }
 
         $tree_locksTable = $schema->getTable('tree_locks');
-        if($tree_locksTable->hasIndex('id')) {
-            $tree_locksTable->dropIndex('id');
+        if($tree_locksTable->hasIndex('cid')) {
+            $tree_locksTable->dropIndex('cid');
         }
 
         $users_workspaces_assetTable = $schema->getTable('users_workspaces_asset');

--- a/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20191208175348.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Bundle\EcommerceFrameworkBundle\PimcoreEcommerceFrameworkBundle;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20191208175348 extends AbstractPimcoreMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $objectsTable = $schema->getTable('objects');
+        if($objectsTable->hasIndex('path')) {
+            $objectsTable->dropIndex('path');
+        }
+
+        $assetsTable = $schema->getTable('assets');
+        if($assetsTable->hasIndex('path')) {
+            $assetsTable->dropIndex('path');
+        }
+
+        $assetsMetaTable = $schema->getTable('assets_metadata');
+        if($assetsMetaTable->hasIndex('cid')) {
+            $assetsMetaTable->dropIndex('cid');
+        }
+
+        $cacheTagsTable = $schema->getTable('cache_tags');
+        if($cacheTagsTable->hasIndex('id')) {
+            $cacheTagsTable->dropIndex('id');
+        }
+
+        $classificationstore_collectionrelationsTable = $schema->getTable('classificationstore_collectionrelations');
+        if($classificationstore_collectionrelationsTable->hasIndex('colId')) {
+            $classificationstore_collectionrelationsTable->dropIndex('colId');
+        }
+
+        $classificationstore_relationsTable = $schema->getTable('classificationstore_relations');
+        if($classificationstore_relationsTable->hasIndex('groupId')) {
+            $classificationstore_relationsTable->dropIndex('groupId');
+        }
+
+        $dependenciesTable = $schema->getTable('dependencies');
+        if($dependenciesTable->hasIndex('sourcetype')) {
+            $dependenciesTable->dropIndex('sourcetype');
+        }
+
+        $documentsTable = $schema->getTable('documents');
+        if($documentsTable->hasIndex('path')) {
+            $documentsTable->dropIndex('path');
+        }
+
+        $documents_elementsTable = $schema->getTable('documents_elements');
+        if($documents_elementsTable->hasIndex('documentId')) {
+            $documents_elementsTable->dropIndex('documentId');
+        }
+
+        $documents_translationsTable = $schema->getTable('documents_translations');
+        if($documents_translationsTable->hasIndex('sourceId')) {
+            $documents_translationsTable->dropIndex('sourceId');
+        }
+
+        $edit_lockTable = $schema->getTable('edit_lock');
+        if($edit_lockTable->hasIndex('cid')) {
+            $edit_lockTable->dropIndex('cid');
+        }
+
+        $gridconfig_favouritesTable = $schema->getTable('gridconfig_favourites');
+        if($gridconfig_favouritesTable->hasIndex('ownerId')) {
+            $gridconfig_favouritesTable->dropIndex('ownerId');
+        }
+
+        $gridconfig_sharesTable = $schema->getTable('gridconfig_shares');
+        if($gridconfig_sharesTable->hasIndex('gridConfigId')) {
+            $gridconfig_sharesTable->dropIndex('gridConfigId');
+        }
+
+        $importconfig_sharesTable = $schema->getTable('importconfig_shares');
+        if($importconfig_sharesTable->hasIndex('data.sharedRoleIds')) {
+            $importconfig_sharesTable->dropIndex('data.sharedRoleIds');
+        }
+
+        $propertiesTable = $schema->getTable('properties');
+        if($propertiesTable->hasIndex('cid')) {
+            $propertiesTable->dropIndex('cid');
+        }
+
+        $search_backend_dataTable = $schema->getTable('search_backend_data');
+        if($search_backend_dataTable->hasIndex('id')) {
+            $search_backend_dataTable->dropIndex('id');
+        }
+
+        $tags_assignmentTable = $schema->getTable('tags_assignment');
+        if($tags_assignmentTable->hasIndex('tagid')) {
+            $tags_assignmentTable->dropIndex('tagid');
+        }
+
+        $targeting_storageTable = $schema->getTable('targeting_storage');
+        if($targeting_storageTable->hasIndex('targeting_storage_visitorId_index')) {
+            $targeting_storageTable->dropIndex('targeting_storage_visitorId_index');
+        }
+
+        $translations_adminTable = $schema->getTable('translations_admin');
+        if($translations_adminTable->hasIndex('key')) {
+            $translations_adminTable->dropIndex('key');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $objectsTable = $schema->getTable('objects');
+        if(!$objectsTable->hasIndex('path')) {
+            $objectsTable->addIndex(['o_path'], 'path');
+        }
+
+        $assetsTable = $schema->getTable('assets');
+        if(!$assetsTable->hasIndex('path')) {
+            $assetsTable->addIndex(['path'], 'path');
+        }
+
+        $assetsMetaTable = $schema->getTable('assets_metadata');
+        if(!$assetsMetaTable->hasIndex('cid')) {
+            $assetsMetaTable->addIndex(['cid'], 'cid');
+        }
+
+        $cacheTagsTable = $schema->getTable('cache_tags');
+        if(!$cacheTagsTable->hasIndex('id')) {
+            $cacheTagsTable->addIndex(['id'], 'id');
+        }
+
+        $classificationstore_collectionrelationsTable = $schema->getTable('classificationstore_collectionrelations');
+        if(!$classificationstore_collectionrelationsTable->hasIndex('colId')) {
+            $classificationstore_collectionrelationsTable->addIndex(['colId'], 'colId');
+        }
+
+        $classificationstore_relationsTable = $schema->getTable('classificationstore_relations');
+        if(!$classificationstore_relationsTable->hasIndex('groupId')) {
+            $classificationstore_relationsTable->addIndex(['groupId'], 'groupId');
+        }
+
+        $dependenciesTable = $schema->getTable('dependencies');
+        if(!$dependenciesTable->hasIndex('sourcetype')) {
+            $dependenciesTable->addIndex(['sourcetype'], 'sourcetype');
+        }
+
+        $documentsTable = $schema->getTable('documents');
+        if(!$documentsTable->hasIndex('path')) {
+            $documentsTable->addIndex(['path'], 'path');
+        }
+
+        $documents_elementsTable = $schema->getTable('documents_elements');
+        if(!$documents_elementsTable->hasIndex('documentId')) {
+            $documents_elementsTable->addIndex(['documentId'], 'documentId');
+        }
+
+        $documents_translationsTable = $schema->getTable('documents_translations');
+        if(!$documents_translationsTable->hasIndex('sourceId')) {
+            $documents_translationsTable->addIndex(['sourceId'], 'sourceId');
+        }
+
+        $edit_lockTable = $schema->getTable('edit_lock');
+        if(!$edit_lockTable->hasIndex('cid')) {
+            $edit_lockTable->addIndex(['cid'], 'cid');
+        }
+
+        $gridconfig_favouritesTable = $schema->getTable('gridconfig_favourites');
+        if(!$gridconfig_favouritesTable->hasIndex('ownerId')) {
+            $gridconfig_favouritesTable->addIndex(['ownerId'], 'ownerId');
+        }
+
+        $importconfig_sharesTable = $schema->getTable('importconfig_shares');
+        if(!$importconfig_sharesTable->hasIndex('data.sharedRoleIds')) {
+            $importconfig_sharesTable->addIndex(['importConfigId'], 'data.sharedRoleIds');
+        }
+
+        $propertiesTable = $schema->getTable('properties');
+        if(!$propertiesTable->hasIndex('cid')) {
+            $propertiesTable->addIndex(['cid'], 'cid');
+        }
+
+        $search_backend_dataTable = $schema->getTable('search_backend_data');
+        if(!$search_backend_dataTable->hasIndex('id')) {
+            $search_backend_dataTable->addIndex(['id'], 'id');
+        }
+
+        $tags_assignmentTable = $schema->getTable('tags_assignment');
+        if(!$tags_assignmentTable->hasIndex('tagid')) {
+            $tags_assignmentTable->addIndex(['tagid'], 'tagid');
+        }
+
+        $targeting_storageTable = $schema->getTable('targeting_storage');
+        if(!$targeting_storageTable->hasIndex('targeting_storage_visitorId_index')) {
+            $targeting_storageTable->addIndex(['visitorId'], 'targeting_storage_visitorId_index');
+        }
+
+        $translations_adminTable = $schema->getTable('translations_admin');
+        if(!$translations_adminTable->hasIndex('key')) {
+            $translations_adminTable->addIndex(['key'], 'key');
+        }
+    }
+}

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -624,7 +624,6 @@ CREATE TABLE `tree_locks` (
   `type` enum('asset','document','object') NOT NULL DEFAULT 'asset',
   `locked` enum('self','propagate') default NULL,
   PRIMARY KEY (`id`,`type`),
-  KEY `id` (`id`),
   KEY `type` (`type`),
   KEY `locked` (`locked`)
 ) DEFAULT CHARSET=utf8mb4;

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -468,7 +468,6 @@ CREATE TABLE `search_backend_data` (
   `data` longtext,
   `properties` text,
   PRIMARY KEY (`id`,`maintype`),
-  KEY `id` (`id`),
   KEY `fullpath` (`fullpath`),
   KEY `maintype` (`maintype`),
   KEY `type` (`type`),

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -41,7 +41,6 @@ CREATE TABLE `assets` (
   UNIQUE KEY `fullpath` (`path`,`filename`),
   KEY `parentId` (`parentId`),
   KEY `filename` (`filename`),
-  KEY `path` (`path`),
   KEY `modificationDate` (`modificationDate`)
 ) AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 
@@ -53,8 +52,7 @@ CREATE TABLE `assets_metadata` (
   `type` ENUM('input','textarea','asset','document','object','date','select','checkbox') DEFAULT NULL,
   `data` text,
   PRIMARY KEY (`cid`, `name`, `language`),
-	INDEX `name` (`name`),
-	INDEX `cid` (`cid`)
+	INDEX `name` (`name`)
 ) DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `cache`;
@@ -71,7 +69,6 @@ CREATE TABLE `cache_tags` (
   `id` varchar(165) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL DEFAULT '',
   `tag` varchar(165) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`,`tag`),
-  INDEX `id` (`id`),
   INDEX `tag` (`tag`)
 ) DEFAULT CHARSET=ascii;
 
@@ -107,7 +104,6 @@ CREATE TABLE `dependencies` (
   PRIMARY KEY (`sourcetype`,`sourceid`,`targetid`,`targettype`),
   KEY `sourceid` (`sourceid`),
   KEY `targetid` (`targetid`),
-  KEY `sourcetype` (`sourcetype`),
   KEY `targettype` (`targettype`)
 ) DEFAULT CHARSET=utf8mb4;
 
@@ -129,7 +125,6 @@ CREATE TABLE `documents` (
   UNIQUE KEY `fullpath` (`path`,`key`),
   KEY `parentId` (`parentId`),
   KEY `key` (`key`),
-  KEY `path` (`path`),
   KEY `published` (`published`),
   KEY `modificationDate` (`modificationDate`)
 ) AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
@@ -140,8 +135,7 @@ CREATE TABLE `documents_elements` (
   `name` varchar(750) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL DEFAULT '',
   `type` varchar(50) DEFAULT NULL,
   `data` longtext,
-  PRIMARY KEY (`documentId`,`name`),
-  KEY `documentId` (`documentId`)
+  PRIMARY KEY (`documentId`,`name`)
 ) DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `documents_email`;
@@ -233,7 +227,6 @@ CREATE TABLE `documents_translations` (
   `language` varchar(10) NOT NULL DEFAULT '',
   PRIMARY KEY (`sourceId`,`language`),
   KEY `id` (`id`),
-  KEY `sourceId` (`sourceId`),
   KEY `language` (`language`)
 ) DEFAULT CHARSET=utf8mb4;
 
@@ -260,7 +253,6 @@ CREATE TABLE `edit_lock` (
   `sessionId` varchar(255) default NULL,
   `date` int(11) unsigned default NULL,
   PRIMARY KEY  (`id`),
-  KEY `cid` (`cid`),
   KEY `ctype` (`ctype`),
   KEY `cidtype` (`cid`,`ctype`)
 ) DEFAULT CHARSET=utf8mb4;
@@ -381,7 +373,6 @@ CREATE TABLE `objects` (
   PRIMARY KEY (`o_id`),
   UNIQUE KEY `fullpath` (`o_path`,`o_key`),
   KEY `key` (`o_key`),
-  KEY `path` (`o_path`),
   KEY `index` (`o_index`),
   KEY `published` (`o_published`),
   KEY `parentId` (`o_parentId`),
@@ -401,8 +392,7 @@ CREATE TABLE `properties` (
   PRIMARY KEY (`cid`,`ctype`,`name`),
   KEY `cpath` (`cpath`),
   KEY `inheritable` (`inheritable`),
-  KEY `ctype` (`ctype`),
-  KEY `cid` (`cid`)
+  KEY `ctype` (`ctype`)
 ) DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `recyclebin`;
@@ -519,8 +509,7 @@ CREATE TABLE `tags_assignment` (
   `ctype` enum('document','asset','object') NOT NULL,
   PRIMARY KEY (`tagid`,`cid`,`ctype`),
   KEY `ctype` (`ctype`),
-  KEY `ctype_cid` (`cid`,`ctype`),
-  KEY `tagid` (`tagid`)
+  KEY `ctype_cid` (`cid`,`ctype`)
 ) DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `targeting_rules`;
@@ -546,8 +535,7 @@ CREATE TABLE `targeting_storage` (
   `modificationDate` datetime DEFAULT NULL,
   PRIMARY KEY (`visitorId`,`scope`,`name`),
   KEY `targeting_storage_scope_index` (`scope`),
-  KEY `targeting_storage_name_index` (`name`),
-  KEY `targeting_storage_visitorId_index` (`visitorId`)
+  KEY `targeting_storage_name_index` (`name`)
 ) DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `targeting_target_groups`;
@@ -616,8 +604,7 @@ CREATE TABLE `translations_admin` (
   `creationDate` int(11) unsigned DEFAULT NULL,
   `modificationDate` int(11) unsigned DEFAULT NULL,
   PRIMARY KEY (`key`,`language`),
-  KEY `language` (`language`),
-  KEY `key` (`key`)
+  KEY `language` (`language`)
 ) DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `translations_website`;
@@ -628,8 +615,7 @@ CREATE TABLE `translations_website` (
   `creationDate` int(11) unsigned DEFAULT NULL,
   `modificationDate` int(11) unsigned DEFAULT NULL,
   PRIMARY KEY (`key`,`language`),
-  KEY `language` (`language`),
-  KEY `key` (`key`)
+  KEY `language` (`language`)
 ) DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `tree_locks`;
@@ -702,7 +688,6 @@ CREATE TABLE `users_workspaces_asset` (
   `versions` tinyint(1) DEFAULT '0',
   `properties` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`cid`, `userId`),
-  KEY `cid` (`cid`),
   KEY `userId` (`userId`)
 ) DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 
@@ -723,7 +708,6 @@ CREATE TABLE `users_workspaces_document` (
   `versions` tinyint(1) unsigned DEFAULT '0',
   `properties` tinyint(1) unsigned DEFAULT '0',
   PRIMARY KEY (`cid`, `userId`),
-  KEY `cid` (`cid`),
   KEY `userId` (`userId`)
 ) DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 
@@ -747,7 +731,6 @@ CREATE TABLE `users_workspaces_object` (
   `lView` text,
   `layouts` text,
   PRIMARY KEY (`cid`, `userId`),
-  KEY `cid` (`cid`),
   KEY `userId` (`userId`)
 ) DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 
@@ -834,7 +817,6 @@ CREATE TABLE `classificationstore_relations` (
 	`mandatory` TINYINT(1) NULL DEFAULT NULL,
 	PRIMARY KEY (`groupId`, `keyId`),
 	INDEX `FK_classificationstore_relations_classificationstore_keys` (`keyId`),
-	INDEX `groupId` (`groupId`),
 	INDEX `mandatory` (`mandatory`),
 	CONSTRAINT `FK_classificationstore_relations_classificationstore_groups` FOREIGN KEY (`groupId`) REFERENCES `classificationstore_groups` (`id`) ON DELETE CASCADE,
 	CONSTRAINT `FK_classificationstore_relations_classificationstore_keys` FOREIGN KEY (`keyId`) REFERENCES `classificationstore_keys` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
@@ -858,7 +840,6 @@ CREATE TABLE `classificationstore_collectionrelations` (
 	`groupId` INT(11) unsigned NOT NULL,
     `sorter` INT(10) NULL DEFAULT '0',
 	PRIMARY KEY (`colId`, `groupId`),
-	INDEX `colId` (`colId`),
 	CONSTRAINT `FK_classificationstore_collectionrelations_groups` FOREIGN KEY (`groupId`) REFERENCES `classificationstore_groups` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
 ) DEFAULT CHARSET=utf8mb4;
 
@@ -921,7 +902,6 @@ CREATE TABLE `gridconfig_favourites` (
 	`searchType` VARCHAR(50) NOT NULL DEFAULT '',
 	`type` enum('asset','object') NOT NULL DEFAULT 'object',
   PRIMARY KEY (`ownerId`, `classId`, `searchType`, `objectId`),
-	INDEX `ownerId` (`ownerId`),
 	INDEX `classId` (`classId`),
 	INDEX `searchType` (`searchType`)
 )
@@ -933,7 +913,6 @@ CREATE TABLE `gridconfig_shares` (
 	`gridConfigId` INT(11) NOT NULL,
 	`sharedWithUserId` INT(11) NOT NULL,
 	PRIMARY KEY (`gridConfigId`, `sharedWithUserId`),
-	INDEX `gridConfigId` (`gridConfigId`),
 	INDEX `sharedWithUserId` (`sharedWithUserId`)
 )
 DEFAULT CHARSET=utf8mb4;
@@ -963,7 +942,6 @@ CREATE TABLE `importconfig_shares` (
 	`importConfigId` INT(11) NOT NULL,
 	`sharedWithUserId` INT(11) NOT NULL,
 	PRIMARY KEY (`importConfigId`, `sharedWithUserId`),
-	INDEX `data.sharedRoleIds` (`importConfigId`),
 	INDEX `sharedWithUserId` (`sharedWithUserId`)
 )
 DEFAULT CHARSET=utf8mb4;

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -140,7 +140,6 @@ class Dao extends Model\Dao\AbstractDao
           `position` varchar(70) NOT NULL DEFAULT '0',
           PRIMARY KEY (`src_id`,`dest_id`,`ownertype`,`ownername`,`fieldname`,`type`,`position`, `index`),
           KEY `index` (`index`),
-          KEY `src_id` (`src_id`),
           KEY `dest_id` (`dest_id`),
           KEY `fieldname` (`fieldname`),
           KEY `position` (`position`),

--- a/models/DataObject/Classificationstore/Dao.php
+++ b/models/DataObject/Classificationstore/Dao.php
@@ -222,7 +222,6 @@ class Dao extends Model\Dao\AbstractDao
             `type` VARCHAR(50) NULL,
             PRIMARY KEY (`groupId`, `keyId`, `o_id`, `fieldname`, `language`),
             INDEX `o_id` (`o_id`),
-            INDEX `groupId` (`groupId`),
             INDEX `keyId` (`keyId`),
             INDEX `fieldname` (`fieldname`),
             INDEX `language` (`language`)

--- a/models/DataObject/Concrete/Dao/InheritanceHelper.php
+++ b/models/DataObject/Concrete/Dao/InheritanceHelper.php
@@ -368,7 +368,7 @@ class InheritanceHelper
 
         if (!$parentIdGroups) {
             $object = DataObject::getById($currentParentId);
-            $query = "SELECT b.o_id AS id $fields, b.o_type AS type, b.o_classId AS classId, b.o_parentId AS parentId, o_path, o_key FROM objects b LEFT JOIN " . $this->storetable . ' a ON b.o_id = a.' . $this->idField . ' WHERE o_path LIKE '.\Pimcore\Db::get()->quote($object->getRealFullPath().'/%') . (($this->idField !== self::ID_FIELD)?' GROUP BY b.o_id':'').' ORDER BY LENGTH(o_path) ASC';
+            $query = "SELECT b.o_id AS id $fields, b.o_type AS type, b.o_classId AS classId, b.o_parentId AS parentId, o_path, o_key FROM objects b LEFT JOIN " . $this->storetable . ' a ON b.o_id = a.' . $this->idField . ' WHERE o_path LIKE '.\Pimcore\Db::get()->quote($object->getRealFullPath().'/%') . ' GROUP BY b.o_id ORDER BY LENGTH(o_path) ASC';
             $queryCacheKey = 'tree_'.md5($query);
 
             if (self::$useRuntimeCache) {

--- a/models/DataObject/Concrete/Dao/InheritanceHelper.php
+++ b/models/DataObject/Concrete/Dao/InheritanceHelper.php
@@ -368,7 +368,7 @@ class InheritanceHelper
 
         if (!$parentIdGroups) {
             $object = DataObject::getById($currentParentId);
-            $query = "SELECT b.o_id AS id $fields, b.o_type AS type, b.o_classId AS classId, b.o_parentId AS parentId, o_path, o_key FROM objects b LEFT JOIN " . $this->storetable . ' a ON b.o_id = a.' . $this->idField . ' WHERE o_path LIKE '.\Pimcore\Db::get()->quote($object->getRealFullPath().'/%') . ' GROUP BY b.o_id ORDER BY LENGTH(o_path) ASC';
+            $query = "SELECT b.o_id AS id $fields, b.o_type AS type, b.o_classId AS classId, b.o_parentId AS parentId, o_path, o_key FROM objects b LEFT JOIN " . $this->storetable . ' a ON b.o_id = a.' . $this->idField . ' WHERE o_path LIKE '.\Pimcore\Db::get()->quote($object->getRealFullPath().'/%') . (($this->idField !== self::ID_FIELD)?' GROUP BY b.o_id':'').' ORDER BY LENGTH(o_path) ASC';
             $queryCacheKey = 'tree_'.md5($query);
 
             if (self::$useRuntimeCache) {

--- a/models/DataObject/Data/ObjectMetadata/Dao.php
+++ b/models/DataObject/Data/ObjectMetadata/Dao.php
@@ -128,7 +128,6 @@ class Dao extends Model\Dao\AbstractDao
               `position` VARCHAR(70) NOT NULL DEFAULT '0',
               `index` int(11) unsigned NOT NULL DEFAULT '0',
               PRIMARY KEY (`o_id`, `dest_id`, `type`, `fieldname`, `column`, `ownertype`, `ownername`, `position`, `index`),
-              INDEX `o_id` (`o_id`),
               INDEX `dest_id` (`dest_id`),
               INDEX `fieldname` (`fieldname`),
               INDEX `column` (`column`),

--- a/models/DataObject/Fieldcollection/Definition/Dao.php
+++ b/models/DataObject/Fieldcollection/Definition/Dao.php
@@ -73,7 +73,6 @@ class Dao extends Model\Dao\AbstractDao
 		  `index` int(11) default '0',
           `fieldname` varchar(190) default '',
           PRIMARY KEY (`o_id`,`index`,`fieldname`(190)),
-          INDEX `o_id` (`o_id`),
           INDEX `index` (`index`),
           INDEX `fieldname` (`fieldname`)
 		) DEFAULT CHARSET=utf8mb4;");

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -703,7 +703,6 @@ QUERY;
               `fieldname` VARCHAR(190) NOT NULL DEFAULT '',
               `language` varchar(10) NOT NULL DEFAULT '',
               PRIMARY KEY (`ooo_id`, `language`, `index`, `fieldname`),
-              INDEX `ooo_id` (`ooo_id`),
               INDEX `index` (`index`),
               INDEX `fieldname` (`fieldname`),
               INDEX `language` (`language`)
@@ -715,7 +714,6 @@ QUERY;
               `ooo_id` int(11) NOT NULL default '0',
               `language` varchar(10) NOT NULL DEFAULT '',
               PRIMARY KEY (`ooo_id`,`language`),
-              INDEX `ooo_id` (`ooo_id`),
               INDEX `language` (`language`)
             ) DEFAULT CHARSET=utf8mb4;"
             );
@@ -777,7 +775,6 @@ QUERY;
                       `ooo_id` int(11) NOT NULL default '0',
                       `language` varchar(10) NOT NULL DEFAULT '',
                       PRIMARY KEY (`ooo_id`,`language`),
-                      INDEX `ooo_id` (`ooo_id`),
                       INDEX `language` (`language`)
                     ) DEFAULT CHARSET=utf8mb4;"
                 );


### PR DESCRIPTION
There is no advantage in single-column database indexes when there also exists a composite index which has the same column(s) as prefix. For example index on column A does not make any sense if you additionally have an index on columns A,B. - see for example https://stackoverflow.com/questions/51046457/find-duplicate-index-in-mysql-using-query#answer-51048636

As example the query execution plan for the following query stays the same - with or without the removed index:
```mysql
explain select * from objects where o_path='abc'
```
Including the index path(o_path):

id | select_type | table | partitions | type | possible_keys | key | key_len | ref | rows | filtered | Extra
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | SIMPLE | objects | NULL | ref | fullpath,path | fullpath | 2298 | const | 1 | 100.00 | NULL

Removed index path(o_path)

id | select_type | table | partitions | type | possible_keys | key | key_len | ref | rows | filtered | Extra
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | SIMPLE | objects | NULL | ref | fullpath | fullpath | 2298 | const | 1 | 100.00 | NULL

This PR removes all those redundant / duplicate indexes to improve write performance.