### PR TITLE
[Asset] getMimeTime() on an image thumbnail may return the wrong type

### DIFF
--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -153,32 +153,6 @@ class Thumbnail
     }
 
     /**
-     * @return string
-     */
-    public function getFileExtension()
-    {
-        $mapping = [
-            'image/png' => 'png',
-            'image/jpeg' => 'jpg',
-            'image/gif' => 'gif',
-            'image/tiff' => 'tif',
-            'image/svg+xml' => 'svg',
-        ];
-
-        $mimeType = $this->getMimeType();
-
-        if (isset($mapping[$mimeType])) {
-            return $mapping[$mimeType];
-        }
-
-        if ($this->getAsset()) {
-            return \Pimcore\File::getFileExtension($this->getAsset()->getFilename());
-        }
-
-        return '';
-    }
-
-    /**
      * @param string $path
      * @param array $options
      * @param Image $asset

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -238,23 +238,12 @@ trait ImageThumbnailTrait
                 'gif' => 'image/gif',
                 'tiff' => 'image/tiff',
                 'svg' => 'image/svg+xml',
+                'webp' => 'image/webp',
             ];
 
-            $targetFormat = strtolower($this->getConfig()->getFormat());
-            $format = $targetFormat;
-            $fileExt = \Pimcore\File::getFileExtension($this->getAsset()->getFilename());
+            $format = $this->getFileExtension();
 
-            if ($targetFormat == 'source' || empty($targetFormat)) {
-                $format = Image\Thumbnail\Processor::getAllowedFormat($fileExt, ['jpeg', 'gif', 'png'], 'png');
-            } elseif ($targetFormat == 'print') {
-                $format = Image\Thumbnail\Processor::getAllowedFormat($fileExt, ['svg', 'jpeg', 'png', 'tiff'], 'png');
-                if (($format == 'tiff' || $format == 'svg') && \Pimcore\Tool::isFrontendRequestByAdmin()) {
-                    // return a webformat in admin -> tiff cannot be displayed in browser
-                    $format = 'png';
-                }
-            }
-
-            if (array_key_exists($format, $mapping)) {
+            if (isset($mapping[$format])) {
                 $this->mimetype = $mapping[$format];
             } else {
                 // unknown
@@ -263,6 +252,14 @@ trait ImageThumbnailTrait
         }
 
         return $this->mimetype;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileExtension()
+    {
+        return \Pimcore\File::getFileExtension($this->getFileSystemPath(true));
     }
 
     protected function convertToWebPath(string $filesystemPath): string


### PR DESCRIPTION
The result is that thumbnails which are generated on demand (because they do not exist on the filesystem and are served by `\Pimcore\Bundle\CoreBundle\Controller\PublicServicesController::thumbnailAction`)  may return the wrong mime-type, e.g. `image/jpg` instead of `image/webp`. 