### PR TITLE
[Asset] HTTP headers of the public thumbnail generation service shouldn't be overridden by the SessionListener

### DIFF
--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -28,15 +28,17 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
+use Symfony\Component\HttpKernel\EventListener\SessionListener;
 
 class PublicServicesController extends Controller
 {
     /**
      * @param Request $request
+     * @param SessionListener $sessionListener
      *
      * @return BinaryFileResponse
      */
-    public function thumbnailAction(Request $request)
+    public function thumbnailAction(Request $request, SessionListener $sessionListener)
     {
         $assetId = $request->get('assetId');
         $thumbnailName = $request->get('thumbnailName');
@@ -133,15 +135,26 @@ class PublicServicesController extends Controller
                     // see also: https://github.com/pimcore/pimcore/blob/1931860f0aea27de57e79313b2eb212dcf69ef13/.htaccess#L86-L86
                     $lifetime = 86400 * 7; // 1 week lifetime, same as direct delivery in .htaccess
 
-                    return new BinaryFileResponse($thumbnailFile, 200, [
-                        // in certain cases where an event listener starts a session (e.g. when there's a firewall
-                        // configured for the entire site /*) the session event listener shouldn't modify the
-                        // cache control headers of this response
-                        AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER => true,
+                    $headers = [
                         'Cache-Control' => 'public, max-age=' . $lifetime,
                         'Expires' => date('D, d M Y H:i:s T', time() + $lifetime),
                         'Content-Type' => $imageThumbnail->getMimeType()
-                    ]);
+                    ];
+
+                    // in certain cases where an event listener starts a session (e.g. when there's a firewall
+                    // configured for the entire site /*) the session event listener shouldn't modify the
+                    // cache control headers of this response
+                    if(defined('Symfony\Component\HttpKernel\EventListener\AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER')) {
+                        // this method of bypassing the session listener was introduced in Symfony 4, so we need
+                        // to check for the constant first
+                        $headers[AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER] = true;
+                    } else {
+                        // @TODO to be removed in Pimcore 7
+                        // Symfony 3.4 doesn't support bypassing the session listener, so we just remove it
+                        \Pimcore::getEventDispatcher()->removeSubscriber($sessionListener);
+                    }
+
+                    return new BinaryFileResponse($thumbnailFile, 200, $headers);
                 }
             } catch (\Exception $e) {
                 $message = "Thumbnail with name '" . $thumbnailName . "' doesn't exist";

--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -27,6 +27,7 @@ use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
 
 class PublicServicesController extends Controller
 {
@@ -133,6 +134,10 @@ class PublicServicesController extends Controller
                     $lifetime = 86400 * 7; // 1 week lifetime, same as direct delivery in .htaccess
 
                     return new BinaryFileResponse($thumbnailFile, 200, [
+                        // in certain cases where an event listener starts a session (e.g. when there's a firewall
+                        // configured for the entire site /*) the session event listener shouldn't modify the
+                        // cache control headers of this response
+                        AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER => true,
                         'Cache-Control' => 'public, max-age=' . $lifetime,
                         'Expires' => date('D, d M Y H:i:s T', time() + $lifetime),
                         'Content-Type' => $imageThumbnail->getMimeType()

--- a/bundles/CoreBundle/Resources/config/aliases.yml
+++ b/bundles/CoreBundle/Resources/config/aliases.yml
@@ -59,3 +59,5 @@ services:
     pimcore.event_listener.frontend.google_tag_manager: '@Pimcore\Bundle\CoreBundle\EventListener\Frontend\GoogleTagManagerListener'
     pimcore.event_listener.frontend.tag_manager: '@Pimcore\Bundle\CoreBundle\EventListener\Frontend\TagManagerListener'
     pimcore.event_listener.frontend.full_page_cache: '@Pimcore\Bundle\CoreBundle\EventListener\Frontend\FullPageCacheListener'
+
+    Symfony\Component\HttpKernel\EventListener\SessionListener: '@session_listener'

--- a/models/Document/Tag/Link.php
+++ b/models/Document/Tag/Link.php
@@ -191,7 +191,7 @@ class Link extends Model\Document\Tag
     public function checkValidity()
     {
         $sane = true;
-        if (is_array($this->data) && $this->data['internal']) {
+        if (is_array($this->data) && isset($this->data['internal']) && $this->data['internal']) {
             if ($this->data['internalType'] == 'document') {
                 $doc = Document::getById($this->data['internalId']);
                 if (!$doc) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -46,6 +46,9 @@ parameters:
             message: '/an undefined static method.*getParameter\(\)./'
             path: '**/Controller/Controller.php'
         -
+            message: '/NO_AUTO_CACHE_CONTROL_HEADER/'
+            path: '**/Controller/PublicServicesController.php'
+        -
             message: '/__construct\(\) does not call parent constructor/'
             path: '**/Migrations/Version.php'
         - '/class heidelpayPHP\\(Heidelpay|Resources|Exceptions)/'


### PR DESCRIPTION
In certain cases where an event listener starts a session (e.g. when there's a firewall configured for the entire site /*) the session event listener shouldn't modify the cache control headers of this response. 

This is especially useful when working with any kind of CDN or caching proxy. 