### PR TITLE
[Asset] Image Thumbnails: deliver the requested image format when using auto format (ignore detection, webp, ...)

### DIFF
--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -40,6 +40,7 @@ class PublicServicesController extends Controller
         $assetId = $request->get('assetId');
         $thumbnailName = $request->get('thumbnailName');
         $filename = $request->get('filename');
+        $requestedFileExtension = strtolower(File::getFileExtension($filename));
         $asset = Asset::getById($assetId);
 
         $prefix = preg_replace('@^cache-buster\-[\d]+\/@', '', $request->get('prefix'));
@@ -72,6 +73,14 @@ class PublicServicesController extends Controller
 
                 if (!$thumbnailConfig) {
                     throw $this->createNotFoundException("Thumbnail '" . $thumbnailName . "' file doesn't exist");
+                }
+
+                if(strcasecmp($thumbnailConfig->getFormat(), 'SOURCE') === 0) {
+                    $formatOverride = $requestedFileExtension;
+                    if(in_array($requestedFileExtension, ['jpg', 'jpeg'])) {
+                        $formatOverride = 'pjpeg';
+                    }
+                    $thumbnailConfig->setFormat($formatOverride);
                 }
 
                 if ($asset instanceof Asset\Video) {
@@ -113,7 +122,6 @@ class PublicServicesController extends Controller
                 }
 
                 if ($imageThumbnail && $thumbnailFile && file_exists($thumbnailFile)) {
-                    $requestedFileExtension = File::getFileExtension($filename);
                     $actualFileExtension = File::getFileExtension($thumbnailFile);
 
                     if ($actualFileExtension !== $requestedFileExtension) {


### PR DESCRIPTION
Currently it could happen that the requested format is different from the delivered format. 
Example use case: 

AWS CloudFront: 
The format delivered to the browser is WebP because of the built-in WebP browser support detection, but when CloudFront requests the thumbnail from the backend, the detection fails and so the fallback format get's delivered, which doesn't make sense at all. 