### PR TITLE
Enable grid editing for ManyToManyObjectRelations

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -74,14 +74,20 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
 
                         // only show 10 relations in the grid
                         var maxAmount = 10;
+                        var result = [];
+                        var i;
+                        for (i = 0; i < value.length && i < maxAmount; i++) {
+                            var item = value[i];
+                            result.push(item["fullpath"]);
+                        }
                         if (value.length > maxAmount) {
-                            value.splice(maxAmount, (value.length - maxAmount));
-                            value.push("...");
+                            result.push("...");
                         }
 
-                        return value.join("<br />");
+                        return result.join("<br />");
                     }
-                }.bind(this, field.key)
+                }.bind(this, field.key),
+            getEditor: this.getWindowCellEditor.bind(this, field)
         };
     },
 
@@ -704,6 +710,10 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
             }
             this.requestNicePathData(toBeRequested);
         }
+    }
+    ,
+    getCellEditValue: function () {
+        return this.getValue();
     }
     ,
 

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -241,6 +241,20 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
     }
 
     /**
+     * @see Data::getDataFromEditmode
+     *
+     * @param array $data
+     * @param null|Model\DataObject\AbstractObject $object
+     * @param mixed $params
+     *
+     * @return array
+     */
+    public function getDataFromGridEditor($data, $object = null, $params = [])
+    {
+        return $this->getDataFromEditmode($data, $object, $params);
+    }
+
+    /**
      * @param $data
      * @param null $object
      * @param mixed $params
@@ -249,18 +263,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
      */
     public function getDataForGrid($data, $object = null, $params = [])
     {
-        if (is_array($data)) {
-            $pathes = [];
-            foreach ($data as $eo) {
-                if ($eo instanceof Element\ElementInterface) {
-                    $pathes[] = $eo->getRealFullPath();
-                }
-            }
-
-            return $pathes;
-        }
-
-        return null;
+        return $this->getDataForEditmode($data, $object, $params);
     }
 
     /**

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -303,7 +303,7 @@ class Service extends Model\Element\Service
 
             $user = AdminTool::getCurrentUser();
 
-            if (empty($fields)) {
+            if (is_null($fields)) {
                 $fields = array_keys($object->getclass()->getFieldDefinitions());
             }
 


### PR DESCRIPTION
Grid editing works for example for AdvancedManyToManyObjectRelations but not for ManyToManyObjectRelations. This PR adds the grid editing feature for ManyToManyObjectRelations.