### PR TITLE
[Grid operators] PHPCode: Catch Exception if no class has been set

### DIFF
--- a/lib/DataObject/GridColumnConfig/Operator/PHPCode.php
+++ b/lib/DataObject/GridColumnConfig/Operator/PHPCode.php
@@ -60,7 +60,11 @@ class PHPCode extends AbstractOperator
 
     public function getLabeledValue($element)
     {
-        return $this->getInstance()->getLabeledValue($element);
+        try {
+            return $this->getInstance()->getLabeledValue($element);
+        } catch(\Exception $e) {
+            return null;
+        }
     }
 
     private function getInstance(): OperatorInterface
@@ -80,8 +84,7 @@ class PHPCode extends AbstractOperator
             $operatorInstance = new $phpClass($this->config, $this->context);
 
             return $operatorInstance;
-        } else {
-            throw new \Exception('PHPCode operator class does not exist: ' . $phpClass);
         }
+        throw new \Exception('PHPCode operator class does not exist: ' . $phpClass);
     }
 }


### PR DESCRIPTION
There is an uncaught exception if you 
1. go to a grid view
1. click "grid options"
1. add operator "Others > Operator PHP Code"