### PR TITLE
[Migration] Fix compatibility with MySQL

### DIFF
--- a/bundles/CoreBundle/Resources/migrations/Version20191126130004.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20191126130004.php
@@ -17,7 +17,10 @@ class Version20191126130004 extends AbstractPimcoreMigration
     public function up(Schema $schema)
     {
         if (PimcoreEcommerceFrameworkBundle::isEnabled()) {
-            $this->addSql('CREATE INDEX IF NOT EXISTS ecommerceframework_cart_userid_index on ecommerceframework_cart (userid);');
+            $table = $schema->getTable('ecommerceframework_cart');
+            if(!$table->hasIndex('ecommerceframework_cart_userid_index')) {
+                $table->addIndex(['userid'], 'ecommerceframework_cart_userid_index');
+            }
         }
     }
 
@@ -27,7 +30,10 @@ class Version20191126130004 extends AbstractPimcoreMigration
     public function down(Schema $schema)
     {
         if (PimcoreEcommerceFrameworkBundle::isEnabled()) {
-            $this->addSql('DROP INDEX IF EXISTS ecommerceframework_cart_userid_index on ecommerceframework_cart;');
+            $table = $schema->getTable('ecommerceframework_cart');
+            if($table->hasIndex('ecommerceframework_cart_userid_index')) {
+                $table->dropIndex('ecommerceframework_cart_userid_index');
+            }
         }
     }
 }


### PR DESCRIPTION
`CREATE INDEX IF NOT EXISTS <index_name> on <table> (<column>);');` is not valid in MySQL.
Results in `SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'IF NOT EXISTS ecommerceframework_cart_user  
  id_index on ecommerceframework_cart (u' at line 1`