### PR TITLE
[Ecommerce][ElasticSerach] Fix unsupported mapping parameter "store"

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -267,7 +267,7 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
                     $mapping['store'] = false;
                 }
 
-                if ($type == 'object') {
+                if ($type == 'object' || $type == 'nested') {
                     unset($mapping['store']);
                 }
 


### PR DESCRIPTION
# Bugfix

In ES version 6.8.5 I get the following error using mapping type `nested`:

```
  {"error":{"root_cause":[{"type":"mapper_parsing_exception","reason":"Mapping definition for [myField] has unsupported parameters:  [store : false]"}],"type":"mapper_parsing_exception","reason":"Mapping definition for [sizes] has unsupported parameters:  [store : false  
  ]"},"status":400}                                                                                                                                                                                                                                                           ```