### PR TITLE
Fix: Argument 1 passed to AbstractListing::setData() must be of the type array, null given

### DIFF
--- a/lib/Model/Listing/AbstractListing.php
+++ b/lib/Model/Listing/AbstractListing.php
@@ -84,6 +84,9 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
      */
     protected $conditionVariableTypes = [];
 
+    /**
+     * @var array|null
+     */
     protected $data;
 
     /**
@@ -469,9 +472,11 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
     }
 
     /**
+     * @param array|null $data
+     *
      * @return static
      */
-    public function setData(array $data): self
+    public function setData(array $data = null): self
     {
         $this->data = $data;
 

--- a/lib/Model/Listing/AbstractListing.php
+++ b/lib/Model/Listing/AbstractListing.php
@@ -476,7 +476,7 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
      *
      * @return static
      */
-    public function setData(array $data = null): self
+    public function setData(?array $data): self
     {
         $this->data = $data;
 

--- a/models/Notification/Listing.php
+++ b/models/Notification/Listing.php
@@ -32,11 +32,6 @@ class Listing extends AbstractListing
      */
     protected $notifications = null;
 
-    /**
-     * @var array
-     */
-    protected $data;
-
     public function __construct()
     {
         $this->notifications =& $this->data;


### PR DESCRIPTION
I have this error after upgrade the master branch. Regression from #5354

I have a wrapper class around the listing, which set the data to null if the the limit/offset is changed. Otherwise it is not possible to geht a new offset.

Now I can't set it to null...