### PR TITLE
[Ecommerce][Productindex] Errorhandling

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
@@ -233,7 +233,7 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
                         if (is_array($data[$attribute->getName()])) {
                             $data[$attribute->getName()] = $this->convertArray($data[$attribute->getName()]);
                         }
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         $event = new PreprocessAttributeErrorEvent($attribute, $e);
                         $this->eventDispatcher->dispatch(IndexServiceEvents::ATTRIBUTE_PROCESSING_ERROR, $event);
 

--- a/lib/Event/Model/Ecommerce/IndexService/PreprocessAttributeErrorEvent.php
+++ b/lib/Event/Model/Ecommerce/IndexService/PreprocessAttributeErrorEvent.php
@@ -36,7 +36,7 @@ class PreprocessAttributeErrorEvent extends PreprocessErrorEvent
      * @param Attribute $attribute
      * @param bool $skipAttribute
      */
-    public function __construct(Attribute $attribute, \Exception $exception, bool $skipAttribute = true, bool $throwException = false)
+    public function __construct(Attribute $attribute, \Throwable $exception, bool $skipAttribute = true, bool $throwException = false)
     {
         parent::__construct($exception, $throwException);
         $this->attribute = $attribute;

--- a/lib/Event/Model/Ecommerce/IndexService/PreprocessErrorEvent.php
+++ b/lib/Event/Model/Ecommerce/IndexService/PreprocessErrorEvent.php
@@ -49,6 +49,14 @@ class PreprocessErrorEvent extends Event
     }
 
     /**
+     * @param bool $throwException
+     */
+    public function setThrowException(bool $throwException): void
+    {
+        $this->throwException = $throwException;
+    }
+    
+    /**
      * @return bool
      */
     public function doThrowException(): bool

--- a/lib/Event/Model/Ecommerce/IndexService/PreprocessErrorEvent.php
+++ b/lib/Event/Model/Ecommerce/IndexService/PreprocessErrorEvent.php
@@ -19,7 +19,7 @@ use Symfony\Component\EventDispatcher\Event;
 class PreprocessErrorEvent extends Event
 {
     /**
-     * @var \Exception
+     * @var \Throwable
      */
     protected $exception;
 
@@ -31,7 +31,7 @@ class PreprocessErrorEvent extends Event
     /**
      * PreprocessErrorEvent constructor.
      *
-     * @param \Exception $exception
+     * @param \Throwable $exception
      * @param bool $throwException
      */
     public function __construct(\Throwable $exception, bool $throwException = true)
@@ -41,9 +41,9 @@ class PreprocessErrorEvent extends Event
     }
 
     /**
-     * @return \Exception
+     * @return \Throwable
      */
-    public function getException(): \Exception
+    public function getException(): \Throwable
     {
         return $this->exception;
     }

--- a/lib/Event/Model/Ecommerce/IndexService/PreprocessErrorEvent.php
+++ b/lib/Event/Model/Ecommerce/IndexService/PreprocessErrorEvent.php
@@ -14,7 +14,7 @@
 
 namespace Pimcore\Event\Model\Ecommerce\IndexService;
 
-use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event;
 
 class PreprocessErrorEvent extends Event
 {

--- a/lib/Event/Model/Ecommerce/IndexService/PreprocessErrorEvent.php
+++ b/lib/Event/Model/Ecommerce/IndexService/PreprocessErrorEvent.php
@@ -34,7 +34,7 @@ class PreprocessErrorEvent extends Event
      * @param \Exception $exception
      * @param bool $throwException
      */
-    public function __construct(\Exception $exception, bool $throwException = true)
+    public function __construct(\Throwable $exception, bool $throwException = true)
     {
         $this->exception = $exception;
         $this->throwException = $throwException;


### PR DESCRIPTION
This PR 

- **fixes** the namespace of the error event - otherwise the `->dispatch()` of the error event will again throw an error

- **changes** the index preparation exception handling to also catch Errors not only Exceptions (i.e.:
`call to a member function XXX on null in ...`)
- **changes** adds a setter to the event whether to throw an exception or not

