### PR TITLE
[ecommerceframework][elasticsearch] price sorting does not work with elasticsearch 6

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -629,7 +629,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
         unset($params['body']['sort']);     // don't send the sort parameter, because it doesn't exist with offline sorting
         $params['body']['size'] = 10000;    // won't work with more than 10000 items in the result (elasticsearch limit)
         $params['body']['from'] = 0;
-        $params['body']['fields'] = ['system.priceSystemName'];
+        $params['body']['_source'] = ['system.priceSystemName'];
         $result = $this->sendRequest($params);
         $objectRaws = [];
         if ($result['hits']) {


### PR DESCRIPTION
additional fix for #4916
(source filtering existed in ES version 2.x too => therefore this should work for all supported versions: https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-request-source-filtering.html)