### PR TITLE
[Versions] Fix fopen mode

### DIFF
--- a/models/Version.php
+++ b/models/Version.php
@@ -433,7 +433,7 @@ class Version extends AbstractModel
         }
 
         if ($data instanceof Asset && file_exists($this->getBinaryFilePath())) {
-            $binaryHandle = fopen($this->getBinaryFilePath(), 'r+', false, File::getContext());
+            $binaryHandle = fopen($this->getBinaryFilePath(), 'rb', false, File::getContext());
             $data->setStream($binaryHandle);
         } elseif ($data instanceof Asset && $data->data) {
             // this is for backward compatibility


### PR DESCRIPTION
When using AWS S3 for storing versions the version preview does not work.
To reproduce use the following `app/constants.php`:
```php
$s3BucketName = "bucket-name";
define("PIMCORE_VERSION_DIRECTORY", "s3://".$s3BucketName."/versions");
```

In app/startup.php:
```php
<?php

use Aws\S3\S3Client;

$config = [
	'version' => 'latest',
	'region' => 'eu-central-1', // choose your favorite region
];

$s3Client = new S3Client($config);

$s3Client->registerStreamWrapper();

// set default file context
\Pimcore\File::setContext(stream_context_create([
    's3' => [
        'seekable' => true,
        'ACL' => 'public-read',
        'StorageClass' => 'STANDARD_IA',
    ]
]));
```

When opening a version preview, an error occurs:
`User Warning: Mode not supported: r+. Use one 'r', 'w', 'a', or 'x'.`

This PR fixes that by using mode `rb` instead of `r+` because in `Version::loadData` it should not be necessary to write the version file.