### PR TITLE
[CustomReport] Fix wrong sql text

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/definitions/sql.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/definitions/sql.js
@@ -113,6 +113,7 @@ pimcore.report.custom.definition.sql = Class.create({
     getValues: function() {
         var values = this.element.getForm().getFieldValues();
         values.type = "sql";
+        delete values["sqlText"];
         return values;
     },
 
@@ -132,28 +133,28 @@ pimcore.report.custom.definition.sql = Class.create({
         if(this.sqlText) {
             var sqlText = "";
             if(values.sql) {
-                if(values.sql.indexOf("SELECT") < 0 || values.sql.indexOf("SELECT") > 5) {
+                if(values.sql.trim().indexOf("SELECT") !== 0) {
                     sqlText += "SELECT ";
                 }
                 sqlText += values.sql;
             }
 
             if(values.from) {
-                if(values.from.indexOf("FROM") < 0) {
+                if(values.from.trim().indexOf("FROM") !== 0) {
                     sqlText += " FROM ";
                 }
                 sqlText += values.from;
             }
 
             if(values.where) {
-                if(values.where.indexOf("WHERE") < 0) {
+                if(values.where.trim().indexOf("WHERE") !== 0) {
                     sqlText += " WHERE ";
                 }
                 sqlText += values.where;
             }
 
             if(values.groupby) {
-                if(values.groupby.indexOf("GROUP BY") < 0) {
+                if(values.groupby.trim().indexOf("GROUP BY") !== 0) {
                     sqlText += " GROUP BY ";
                 }
                 sqlText += values.groupby;

--- a/models/Tool/CustomReport/Adapter/Sql.php
+++ b/models/Tool/CustomReport/Adapter/Sql.php
@@ -90,10 +90,10 @@ class Sql extends AbstractAdapter
     }
 
     /**
-     * @param $config
+     * @param \stdClass $config
      * @param bool $ignoreSelectAndGroupBy
-     * @param null $drillDownFilters
-     * @param null $selectField
+     * @param array|null $drillDownFilters
+     * @param string|null $selectField
      *
      * @return string
      */
@@ -101,8 +101,8 @@ class Sql extends AbstractAdapter
     {
         $config = (array)$config;
         $sql = '';
-        if ($config['sql'] && !$ignoreSelectAndGroupBy) {
-            if (strpos(strtoupper(trim($config['sql'])), 'SELECT') === false || strpos(strtoupper(trim($config['sql'])), 'SELECT') > 5) {
+        if (!empty($config['sql']) && !$ignoreSelectAndGroupBy) {
+            if (strpos(strtoupper(trim($config['sql'])), 'SELECT') !== 0) {
                 $sql .= 'SELECT ';
             }
             $sql .= str_replace("\n", ' ', $config['sql']);
@@ -112,15 +112,18 @@ class Sql extends AbstractAdapter
         } else {
             $sql .= 'SELECT *';
         }
-        if ($config['from']) {
-            if (strpos(strtoupper(trim($config['from'])), 'FROM') === false) {
+        if (!empty($config['from'])) {
+            if (strpos(strtoupper(trim($config['from'])), 'FROM') !== 0) {
                 $sql .= ' FROM ';
             }
             $sql .= ' ' . str_replace("\n", ' ', $config['from']);
         }
-        if ($config['where'] || $drillDownFilters) {
+        if (!empty($config['where']) || $drillDownFilters) {
             $whereParts = [];
-            if ($config['where']) {
+            if (!empty($config['where'])) {
+                if (strpos(strtoupper(trim($config['where'])), 'WHERE') === 0) {
+                    $config['where'] = preg_replace('/^\s*WHERE\s*/', '', $config['where']);
+                }
                 $whereParts[] = '(' . str_replace("\n", ' ', $config['where']) . ')';
             }
 
@@ -134,19 +137,11 @@ class Sql extends AbstractAdapter
             }
 
             if ($whereParts) {
-                if ($config['where']) {
-                    $sql .= ' WHERE ';
-                } else {
-                    if (strpos(strtoupper(trim($config['where'])), 'WHERE') === false) {
-                        $sql .= ' WHERE ';
-                    }
-                }
-
-                $sql .= ' ' . implode(' AND ', $whereParts);
+                $sql .= ' WHERE ' . implode(' AND ', $whereParts);
             }
         }
-        if ($config['groupby'] && !$ignoreSelectAndGroupBy) {
-            if (strpos(strtoupper($config['groupby']), 'GROUP BY') === false) {
+        if (!empty($config['groupby']) && !$ignoreSelectAndGroupBy) {
+            if (strpos(strtoupper(trim($config['groupby'])), 'GROUP BY') !== 0) {
                 $sql .= ' GROUP BY ';
             }
             $sql .= ' ' . str_replace("\n", ' ', $config['groupby']);
@@ -263,8 +258,8 @@ class Sql extends AbstractAdapter
         return [
             'data' => array_merge(
                 [
-                        ['value' => null]
-                      ],
+                    ['value' => null]
+                ],
                 $filteredData
             )
         ];


### PR DESCRIPTION
If you use a sub select in the where field the SQL text is wrong. It should only check for SELECT/FROM/WHERE/GROUP BY at the beginning of the value.

It's also not necessary to save it.

Example in the demo:
![image](https://user-images.githubusercontent.com/998558/70998394-8fbff180-20d7-11ea-8079-6dbef9d5424d.png)
