### PR TITLE
Consistently getFieldDefinition(s) method name

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1709,6 +1709,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
 
                             if ($brickDescriptor) {
                                 $brickDefinition = Model\DataObject\Objectbrick\Definition::getByKey($brickType);
+                                /** @var DataObject\ClassDefinition\Data\Localizedfields $fieldDefinitionLocalizedFields */
                                 $fieldDefinitionLocalizedFields = $brickDefinition->getFieldDefinition('localizedfields');
                                 $fieldDefinition = $fieldDefinitionLocalizedFields->getFieldDefinition($brickKey);
                             } else {
@@ -1801,7 +1802,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
     }
 
     /**
-     * @param string $class
+     * @param DataObject\ClassDefinition $class
      * @param string $key
      *
      * @return DataObject\ClassDefinition\Data

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1805,7 +1805,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
      * @param DataObject\ClassDefinition $class
      * @param string $key
      *
-     * @return DataObject\ClassDefinition\Data
+     * @return DataObject\ClassDefinition\Data|null
      */
     protected function getFieldDefinition($class, $key)
     {

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1815,7 +1815,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
 
         $localized = $class->getFieldDefinition('localizedfields');
         if ($localized instanceof DataObject\ClassDefinition\Data\Localizedfields) {
-            $fieldDefinition = $localized->getFielddefinition($key);
+            $fieldDefinition = $localized->getFieldDefinition($key);
         }
 
         return $fieldDefinition;

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -556,6 +556,7 @@ class DataObjectHelperController extends AdminController
 
                             if ($brickDescriptor) {
                                 $innerContainer = $brickDescriptor['innerContainer'] ? $brickDescriptor['innerContainer'] : 'localizedfields';
+                                /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedFields */
                                 $localizedFields = $brickClass->getFieldDefinition($innerContainer);
                                 $fd = $localizedFields->getFieldDefinition($brickDescriptor['brickfield']);
                             } else {
@@ -2096,6 +2097,7 @@ class DataObjectHelperController extends AdminController
                     $brickClass = DataObject\Objectbrick\Definition::getByKey($brickType);
 
                     if ($brickDescriptor) {
+                        /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedFields */
                         $localizedFields = $brickClass->getFieldDefinition($innerContainer);
                         $fieldDefinition = $localizedFields->getFieldDefinition($brickDescriptor['brickfield']);
                     } else {

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -2427,7 +2427,7 @@ class DataObjectHelperController extends AdminController
                 $fds = $class->getFieldDefinitions();
 
                 $additionalFieldNames = array_keys($fds);
-                /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedFields */
+                /** @var DataObject\ClassDefinition\Data\Localizedfields|null $localizedFields */
                 $localizedFields = $class->getFieldDefinition('localizedfields');
                 if ($localizedFields) {
                     $lfNames = array_keys($localizedFields->getFieldDefinitions());

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -2427,6 +2427,7 @@ class DataObjectHelperController extends AdminController
                 $fds = $class->getFieldDefinitions();
 
                 $additionalFieldNames = array_keys($fds);
+                /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedFields */
                 $localizedFields = $class->getFieldDefinition('localizedfields');
                 if ($localizedFields) {
                     $lfNames = array_keys($localizedFields->getFieldDefinitions());

--- a/bundles/AdminBundle/Controller/Admin/ElementController.php
+++ b/bundles/AdminBundle/Controller/Admin/ElementController.php
@@ -766,8 +766,8 @@ class ElementController extends AdminController
             $containerKey = $context['containerKey'];
             $fdCollection = DataObject\Fieldcollection\Definition::getByKey($containerKey);
             if ($context['subContainerType'] == 'localizedfield') {
+                /** @var DataObject\ClassDefinition\Data\Localizedfields $fdLocalizedFields */
                 $fdLocalizedFields = $fdCollection->getFieldDefinition('localizedfields');
-                /** @var DataObject\ClassDefinition\Data\Localizedfields $fd */
                 $fd = $fdLocalizedFields->getFieldDefinition($fieldname);
             } else {
                 $fd = $fdCollection->getFieldDefinition($fieldname);

--- a/bundles/AdminBundle/Controller/Admin/ElementController.php
+++ b/bundles/AdminBundle/Controller/Admin/ElementController.php
@@ -767,6 +767,7 @@ class ElementController extends AdminController
             $fdCollection = DataObject\Fieldcollection\Definition::getByKey($containerKey);
             if ($context['subContainerType'] == 'localizedfield') {
                 $fdLocalizedFields = $fdCollection->getFieldDefinition('localizedfields');
+                /** @var DataObject\ClassDefinition\Data\Localizedfields $fd */
                 $fd = $fdLocalizedFields->getFieldDefinition($fieldname);
             } else {
                 $fd = $fdCollection->getFieldDefinition($fieldname);

--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -1066,7 +1066,9 @@ class TranslationController extends AdminController
                 } elseif ($element instanceof DataObject\Concrete) {
                     $hasContent = false;
 
-                    if ($fd = $element->getClass()->getFieldDefinition('localizedfields')) {
+                    /** @var DataObject\ClassDefinition\Data\Localizedfields|null $fd */
+                    $fd = $element->getClass()->getFieldDefinition('localizedfields');
+                    if ($fd) {
                         $definitions = $fd->getFieldDefinitions();
 
                         $locale = str_replace('-', '_', $source);

--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -1067,7 +1067,7 @@ class TranslationController extends AdminController
                     $hasContent = false;
 
                     if ($fd = $element->getClass()->getFieldDefinition('localizedfields')) {
-                        $definitions = $fd->getFielddefinitions();
+                        $definitions = $fd->getFieldDefinitions();
 
                         $locale = str_replace('-', '_', $source);
                         if (!Tool::isValidLanguage($locale)) {

--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -213,9 +213,11 @@ class GridHelperService
                         $brickClass = Objectbrick\Definition::getByKey($brickType);
 
                         if ($brickDescriptor) {
-                            /** @var ClassDefinition\Data\Localizedfields $localizedFields */
+                            /** @var ClassDefinition\Data\Localizedfields|null $localizedFields */
                             $localizedFields = $brickClass->getFieldDefinition('localizedfields');
-                            $brickField = $localizedFields->getFieldDefinition($brickDescriptor['brickfield']);
+                            if ($localizedFields) {
+                                $brickField = $localizedFields->getFieldDefinition($brickDescriptor['brickfield']);
+                            }
                         } else {
                             $brickField = $brickClass->getFieldDefinition($brickKey);
                         }

--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -213,7 +213,9 @@ class GridHelperService
                         $brickClass = Objectbrick\Definition::getByKey($brickType);
 
                         if ($brickDescriptor) {
-                            $brickField = $brickClass->getFieldDefinition('localizedfields')->getFieldDefinition($brickDescriptor['brickfield']);
+                            /** @var ClassDefinition\Data\Localizedfields $localizedFields */
+                            $localizedFields = $brickClass->getFieldDefinition('localizedfields');
+                            $brickField = $localizedFields->getFieldDefinition($brickDescriptor['brickfield']);
                         } else {
                             $brickField = $brickClass->getFieldDefinition($brickKey);
                         }

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/13_Locking_Fields.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/13_Locking_Fields.md
@@ -11,7 +11,7 @@ The following example will lock every field inside the class with the ID 7.
 
 ```php
 $class = DataObject\ClassDefinition::getById(7);
-$fields = $class->getFielddefinitions();
+$fields = $class->getFieldDefinitions();
  
 foreach ($fields as $field) {
    $field->setLocked(true);

--- a/lib/Translation/ExportDataExtractorService/DataExtractor/DataObjectDataExtractor.php
+++ b/lib/Translation/ExportDataExtractorService/DataExtractor/DataObjectDataExtractor.php
@@ -128,7 +128,7 @@ class DataObjectDataExtractor extends AbstractElementDataExtractor
          * @var Localizedfields $fd
          */
         if ($fd = $object->getClass()->getFieldDefinition('localizedfields')) {
-            $definitions = $fd->getFielddefinitions();
+            $definitions = $fd->getFieldDefinitions();
 
             $locale = str_replace('-', '_', $result->getSourceLanguage());
             if (!Tool::isValidLanguage($locale)) {
@@ -224,7 +224,7 @@ class DataObjectDataExtractor extends AbstractElementDataExtractor
             if ($fd instanceof DataObject\ClassDefinition\Data\Block) {
 
                 /** @var DataObject\ClassDefinition\Data\Localizedfields $blockLocalizedFieldDefinition */
-                $blockLocalizedFieldDefinition = $fd->getFielddefinition('localizedfields');
+                $blockLocalizedFieldDefinition = $fd->getFieldDefinition('localizedfields');
                 if ($blockLocalizedFieldDefinition) {
                     $blockLocalizedFieldsDefinitions = $blockLocalizedFieldDefinition->getFieldDefinitions();
 

--- a/lib/Translation/ExportDataExtractorService/DataExtractor/DataObjectDataExtractor.php
+++ b/lib/Translation/ExportDataExtractorService/DataExtractor/DataObjectDataExtractor.php
@@ -115,8 +115,9 @@ class DataObjectDataExtractor extends AbstractElementDataExtractor
     }
 
     /**
-     * @param (DataObject\Concrete $document
+     * @param DataObject\Concrete $object
      * @param AttributeSet $result
+     * @param array|null $exportAttributes
      *
      * @return DataObjectDataExtractor
      *
@@ -124,10 +125,9 @@ class DataObjectDataExtractor extends AbstractElementDataExtractor
      */
     protected function addLocalizedFields(DataObject\Concrete $object, AttributeSet $result, array $exportAttributes = null): DataObjectDataExtractor
     {
-        /**
-         * @var Localizedfields $fd
-         */
-        if ($fd = $object->getClass()->getFieldDefinition('localizedfields')) {
+        /** @var Localizedfields|null $fd */
+        $fd = $object->getClass()->getFieldDefinition('localizedfields');
+        if ($fd) {
             $definitions = $fd->getFieldDefinitions();
 
             $locale = str_replace('-', '_', $result->getSourceLanguage());
@@ -307,16 +307,16 @@ class DataObjectDataExtractor extends AbstractElementDataExtractor
                 foreach ($fieldDefinition->getAllowedTypes() ?: [] as $brickType) {
                     $brickGetter = 'get' . ucfirst($brickType);
 
-                    /**
-                     * @var DataObject\Objectbrick\Data\AbstractData $brick
-                     */
+                    /** @var DataObject\Objectbrick\Data\AbstractData $brick */
                     if (!$brick = $brickContainer->$brickGetter()) {
                         continue;
                     }
 
                     $brickDefinition = DataObject\Objectbrick\Definition::getByKey($brickType);
 
-                    if (!$localizedFieldsDefinition = $brickDefinition->getFieldDefinition('localizedfields')) {
+                    /** @var Localizedfields $localizedFieldsDefinition */
+                    $localizedFieldsDefinition = $brickDefinition->getFieldDefinition('localizedfields');
+                    if (!$localizedFieldsDefinition) {
                         continue;
                     }
 
@@ -391,7 +391,9 @@ class DataObjectDataExtractor extends AbstractElementDataExtractor
                         continue;
                     }
 
-                    if (!$localizedFieldsDefinition = $definition->getFieldDefinition('localizedfields')) {
+                    /** @var Localizedfields $localizedFieldsDefinition */
+                    $localizedFieldsDefinition = $definition->getFieldDefinition('localizedfields');
+                    if (!$localizedFieldsDefinition) {
                         continue;
                     }
 

--- a/lib/Translation/ExportDataExtractorService/DataExtractor/DataObjectDataExtractor.php
+++ b/lib/Translation/ExportDataExtractorService/DataExtractor/DataObjectDataExtractor.php
@@ -314,7 +314,7 @@ class DataObjectDataExtractor extends AbstractElementDataExtractor
 
                     $brickDefinition = DataObject\Objectbrick\Definition::getByKey($brickType);
 
-                    /** @var Localizedfields $localizedFieldsDefinition */
+                    /** @var Localizedfields|null $localizedFieldsDefinition */
                     $localizedFieldsDefinition = $brickDefinition->getFieldDefinition('localizedfields');
                     if (!$localizedFieldsDefinition) {
                         continue;

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -876,7 +876,7 @@ class ClassDefinition extends Model\AbstractModel
      * @param string $key
      * @param array $context
      *
-     * @return DataObject\ClassDefinition\Data|bool
+     * @return DataObject\ClassDefinition\Data|null
      */
     public function getFieldDefinition($key, $context = [])
     {
@@ -889,7 +889,7 @@ class ClassDefinition extends Model\AbstractModel
             return $fieldDefinition;
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -1015,7 +1015,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
             if (!$fd) {
                 $fieldFound = false;
                 /** @var Localizedfields|null $localizedfields */
-                $localizedfields = $class->getFieldDefinition('localizedfields');
+                $localizedfields = $class->getFieldDefinitions($context)['localizedfields'] ?? null;
                 if ($localizedfields) {
                     if ($fd = $localizedfields->getFieldDefinition($field)) {
                         $this->visibleFieldDefinitions[$field]['name'] = $fd->getName();

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -1014,7 +1014,9 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
 
             if (!$fd) {
                 $fieldFound = false;
-                if ($localizedfields = $class->getFieldDefinitions($context)['localizedfields'] ?? false) {
+                /** @var Localizedfields|null $localizedfields */
+                $localizedfields = $class->getFieldDefinition('localizedfields');
+                if ($localizedfields) {
                     if ($fd = $localizedfields->getFieldDefinition($field)) {
                         $this->visibleFieldDefinitions[$field]['name'] = $fd->getName();
                         $this->visibleFieldDefinitions[$field]['title'] = $fd->getTitle();

--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -126,7 +126,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
 
                 /** @var DataObject\Data\BlockElement $blockElement */
                 foreach ($blockElements as $elementName => $blockElement) {
-                    $fd = $this->getFielddefinition($elementName);
+                    $fd = $this->getFieldDefinition($elementName);
                     if (!$fd) {
                         // class definition seems to have changed
                         Logger::warn('class definition seems to have changed, element name: ' . $elementName);
@@ -171,7 +171,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
             foreach ($unserializedData as $blockElements) {
                 $items = [];
                 foreach ($blockElements as $elementName => $blockElementRaw) {
-                    $fd = $this->getFielddefinition($elementName);
+                    $fd = $this->getFieldDefinition($elementName);
                     if (!$fd) {
                         // class definition seems to have changed
                         Logger::warn('class definition seems to have changed, element name: ' . $elementName);
@@ -238,7 +238,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
 
                 /** @var DataObject\Data\BlockElement $blockElement */
                 foreach ($blockElements as $elementName => $blockElement) {
-                    $fd = $this->getFielddefinition($elementName);
+                    $fd = $this->getFieldDefinition($elementName);
                     if (!$fd) {
                         // class definition seems to have changed
                         Logger::warn('class definition seems to have changed, element name: ' . $elementName);
@@ -458,7 +458,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
 
                 /** @var DataObject\Data\BlockElement $blockElement */
                 foreach ($blockElements as $elementName => $blockElement) {
-                    $fd = $this->getFielddefinition($elementName);
+                    $fd = $this->getFieldDefinition($elementName);
                     if (!$fd) {
                         // class definition seems to have changed
                         Logger::warn('class definition seems to have changed, element name: ' . $elementName);
@@ -496,7 +496,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
                 $resultElement = [];
 
                 foreach ($blockElementsData as $elementName => $blockElementDataRaw) {
-                    $fd = $this->getFielddefinition($elementName);
+                    $fd = $this->getFieldDefinition($elementName);
                     if (!$fd) {
                         // class definition seems to have changed
                         Logger::warn('class definition seems to have changed, element name: ' . $elementName);
@@ -721,7 +721,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
      *
      * @return DataObject\ClassDefinition\Data|null
      */
-    public function getFielddefinition($name, $context = [])
+    public function getFieldDefinition($name, $context = [])
     {
         $fds = $this->getFieldDefinitions();
         if (isset($fds[$name])) {
@@ -798,7 +798,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
 
         foreach ($data as $blockElements) {
             foreach ($blockElements as $elementName => $blockElement) {
-                $fd = $this->getFielddefinition($elementName);
+                $fd = $this->getFieldDefinition($elementName);
                 if (!$fd) {
                     // class definition seems to have changed
                     Logger::warn('class definition seems to have changed, element name: ' . $elementName);
@@ -835,7 +835,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
 
         foreach ($data as $blockElements) {
             foreach ($blockElements as $elementName => $blockElement) {
-                $fd = $this->getFielddefinition($elementName);
+                $fd = $this->getFieldDefinition($elementName);
                 if (!$fd) {
                     // class definition seems to have changed
                     Logger::warn('class definition seems to have changed, element name: ' . $elementName);
@@ -933,7 +933,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
     {
         $this->markLazyloadedFieldAsLoaded($object);
 
-        $lf = $this->getFielddefinition('localizedfields');
+        $lf = $this->getFieldDefinition('localizedfields');
         if ($lf && is_array($data)) {
             /** @var DataObject\Data\BlockElement $item */
             foreach ($data as $item) {

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -141,7 +141,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
         // replace the real data with the data for the editmode
         foreach ($result['data'] as $language => &$data) {
             foreach ($data as $key => &$value) {
-                $fieldDefinition = $this->getFielddefinition($key);
+                $fieldDefinition = $this->getFieldDefinition($key);
                 if ($fieldDefinition instanceof CalculatedValue) {
                     $childData = new DataObject\Data\CalculatedValue($fieldDefinition->getName());
                     $childData->setContextualData('localizedfield', $this->getName(), null, $language);
@@ -300,7 +300,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
         if (is_array($data)) {
             foreach ($data as $language => $fields) {
                 foreach ($fields as $name => $fdata) {
-                    $fd = $this->getFielddefinition($name);
+                    $fd = $this->getFieldDefinition($name);
                     $params['language'] = $language;
                     $localizedFields->setLocalizedValue(
                         $name,
@@ -536,7 +536,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
                         ).' ]'
                     );
                 }
-                $fd = $this->getFielddefinition($field->name);
+                $fd = $this->getFieldDefinition($field->name);
                 if (!$fd instanceof DataObject\ClassDefinition\Data) {
                     if ($idMapper && $idMapper->ignoreMappingFailures()) {
                         continue;
@@ -554,7 +554,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
 
                 $localizedFields->setLocalizedValue(
                     $field->name,
-                    $this->getFielddefinition($field->name)->getFromWebserviceImport(
+                    $this->getFieldDefinition($field->name)->getFromWebserviceImport(
                         $field->value,
                         $object,
                         $params,
@@ -832,7 +832,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
      *
      * @return DataObject\ClassDefinition\Data|null
      */
-    public function getFielddefinition($name, $context = [])
+    public function getFieldDefinition($name, $context = [])
     {
         $fds = $this->getFieldDefinitions($context);
         if (isset($fds[$name])) {
@@ -1247,7 +1247,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
 
         foreach ($mapping as $language => $fields) {
             foreach ($fields as $key => $value) {
-                $fd = $this->getFielddefinition($key);
+                $fd = $this->getFieldDefinition($key);
                 if ($fd & $fd->isDiffChangeAllowed($object)) {
                     if ($value == null) {
                         unset($localData[$language][$key]);
@@ -1406,7 +1406,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
                 foreach ($items as $language => $languageData) {
                     $languageResult = [];
                     foreach ($languageData as $elementName => $elementData) {
-                        $fd = $this->getFielddefinition($elementName);
+                        $fd = $this->getFieldDefinition($elementName);
                         if (!$fd) {
                             // class definition seems to have changed
                             Logger::warn('class definition seems to have changed, element name: '.$elementName);
@@ -1444,7 +1444,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
             foreach ($value as $language => $languageData) {
                 $languageResult = [];
                 foreach ($languageData as $elementName => $elementData) {
-                    $fd = $this->getFielddefinition($elementName);
+                    $fd = $this->getFieldDefinition($elementName);
                     if (!$fd) {
                         // class definition seems to have changed
                         Logger::warn('class definition seems to have changed, element name: '.$elementName);

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -722,7 +722,8 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
             if (!$fd) {
                 $fieldFound = false;
                 /** @var Localizedfields|null $localizedfields */
-                if ($localizedfields = $class->getFieldDefinition('localizedfields')) {
+                $localizedfields = $class->getFieldDefinition('localizedfields');
+                if ($localizedfields) {
                     if ($fd = $localizedfields->getFieldDefinition($field)) {
                         $this->visibleFieldDefinitions[$field]['name'] = $fd->getName();
                         $this->visibleFieldDefinitions[$field]['title'] = $fd->getTitle();

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -721,7 +721,9 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
 
             if (!$fd) {
                 $fieldFound = false;
-                if ($localizedfields = $class->getFieldDefinitions($context)['localizedfields']) {
+                /** @var Localizedfields|null $localizedfields */
+                $localizedfields = $class->getFieldDefinition('localizedfields');
+                if ($localizedfields) {
                     if ($fd = $localizedfields->getFieldDefinition($field)) {
                         $this->visibleFieldDefinitions[$field]['name'] = $fd->getName();
                         $this->visibleFieldDefinitions[$field]['title'] = $fd->getTitle();

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -722,8 +722,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
             if (!$fd) {
                 $fieldFound = false;
                 /** @var Localizedfields|null $localizedfields */
-                $localizedfields = $class->getFieldDefinition('localizedfields');
-                if ($localizedfields) {
+                if ($localizedfields = $class->getFieldDefinition('localizedfields')) {
                     if ($fd = $localizedfields->getFieldDefinition($field)) {
                         $this->visibleFieldDefinitions[$field]['name'] = $fd->getName();
                         $this->visibleFieldDefinitions[$field]['title'] = $fd->getTitle();

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -722,7 +722,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
             if (!$fd) {
                 $fieldFound = false;
                 /** @var Localizedfields|null $localizedfields */
-                $localizedfields = $class->getFieldDefinition('localizedfields');
+                $localizedfields = $class->getFieldDefinitions($context)['localizedfields'] ?? null;
                 if ($localizedfields) {
                     if ($fd = $localizedfields->getFieldDefinition($field)) {
                         $this->visibleFieldDefinitions[$field]['name'] = $fd->getName();

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -661,7 +661,7 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
 
                 list($localizedPropertyName, $value, $locale, $limit, $offset) = $arguments;
 
-                $localizedField = $field->getFielddefinition($localizedPropertyName);
+                $localizedField = $field->getFieldDefinition($localizedPropertyName);
 
                 if (!$localizedField instanceof Model\DataObject\ClassDefinition\Data) {
                     Logger::error('Class: DataObject\\Concrete => call to undefined static method ' . $method);

--- a/models/DataObject/Fieldcollection/Dao.php
+++ b/models/DataObject/Fieldcollection/Dao.php
@@ -179,7 +179,7 @@ class Dao extends Model\Dao\AbstractDao
                 }
             }
 
-            $childDefinitions = $definition->getFielddefinitions(['suppressEnrichment' => true]);
+            $childDefinitions = $definition->getFieldDefinitions(['suppressEnrichment' => true]);
 
             if (is_array($childDefinitions)) {
                 foreach ($childDefinitions as $fd) {

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -185,10 +185,10 @@ class Definition extends Model\AbstractModel
     }
 
     /**
-     * @param $key
+     * @param string $key
      * @param array $context additional contextual data
      *
-     * @return DataObject\ClassDefinition\Data|bool
+     * @return DataObject\ClassDefinition\Data|null
      */
     public function getFieldDefinition($key, $context = [])
     {
@@ -202,7 +202,7 @@ class Definition extends Model\AbstractModel
             return $fieldDefinition;
         }
 
-        return false;
+        return null;
     }
 
     protected function doEnrichFieldDefinition($fieldDefinition, $context = [])

--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -310,10 +310,15 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
             $object = $this->getObject();
             $container = $object->getClass();
         }
-        /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $localizedFields */
+
+        /** @var Model\DataObject\ClassDefinition\Data\Localizedfields|null $localizedFields */
         $localizedFields = $container->getFieldDefinition('localizedfields');
 
-        return $localizedFields->getFieldDefinition($name);
+        if ($localizedFields) {
+            return $localizedFields->getFieldDefinition($name);
+        }
+
+        return null;
     }
 
     /**

--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -310,9 +310,10 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
             $object = $this->getObject();
             $container = $object->getClass();
         }
-        $fieldDefinition = $container->getFieldDefinition('localizedfields')->getFieldDefinition($name);
+        /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $localizedFields */
+        $localizedFields = $container->getFieldDefinition('localizedfields');
 
-        return $fieldDefinition;
+        return $localizedFields->getFieldDefinition($name);
     }
 
     /**
@@ -336,10 +337,10 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
         } elseif (isset($context['containerType']) && $context['containerType'] === 'block') {
             $containerKey = $context['fieldname'];
             $object = $this->getObject();
-            /**
-             * @var Model\DataObject\ClassDefinition\Data\Block $container
-             */
-            $container = $object->getClass()->getFieldDefinition($containerKey)->getFieldDefinition('localizedfields');
+            /** @var Model\DataObject\ClassDefinition\Data\Block $block */
+            $block = $object->getClass()->getFieldDefinition($containerKey);
+            /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $container */
+            $container = $block->getFieldDefinition('localizedfields');
         } else {
             $container = $this->getObject()->getClass()->getFieldDefinition('localizedfields');
         }
@@ -512,7 +513,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
             $containerDefinition = ClassDefinition::getById($classId);
             $blockDefinition = $containerDefinition->getFieldDefinition($contextInfo['fieldname']);
 
-            /** @var Model\DataObject\ClassDefinition\Data $fieldDefinition */
+            /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $fieldDefinition */
             $fieldDefinition = $blockDefinition->getFieldDefinition('localizedfields');
         } else {
             if (isset($contextInfo['containerType']) && $contextInfo['containerType'] === 'fieldcollection') {

--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -329,10 +329,12 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
         if (isset($context['containerType']) && $context['containerType'] === 'fieldcollection') {
             $containerKey = $context['containerKey'];
             $fcDef = Model\DataObject\Fieldcollection\Definition::getByKey($containerKey);
+            /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $container */
             $container = $fcDef->getFieldDefinition('localizedfields');
         } elseif (isset($context['containerType']) && $context['containerType'] === 'objectbrick') {
             $containerKey = $context['containerKey'];
             $brickDef = Model\DataObject\Objectbrick\Definition::getByKey($containerKey);
+            /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $container */
             $container = $brickDef->getFieldDefinition('localizedfields');
         } elseif (isset($context['containerType']) && $context['containerType'] === 'block') {
             $containerKey = $context['fieldname'];
@@ -342,6 +344,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
             /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $container */
             $container = $block->getFieldDefinition('localizedfields');
         } else {
+            /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $container */
             $container = $this->getObject()->getClass()->getFieldDefinition('localizedfields');
         }
 

--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -514,6 +514,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
         if (isset($contextInfo['containerType']) && $contextInfo['containerType'] === 'block') {
             $classId = $contextInfo['classId'];
             $containerDefinition = ClassDefinition::getById($classId);
+            /** @var Model\DataObject\ClassDefinition\Data\Block $blockDefinition */
             $blockDefinition = $containerDefinition->getFieldDefinition($contextInfo['fieldname']);
 
             /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $fieldDefinition */
@@ -529,6 +530,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
                 $containerDefinition = $this->getObject()->getClass();
             }
 
+            /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $localizedFieldDefinition */
             $localizedFieldDefinition = $containerDefinition->getFieldDefinition('localizedfields');
             $fieldDefinition = $localizedFieldDefinition->getFieldDefinition($name, ['object' => $this->getObject()]);
         }

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -108,7 +108,7 @@ class Dao extends Model\Dao\AbstractDao
             $container = $this->model->getClass();
         }
 
-        $fieldDefinitions = $container->getFielddefinition('localizedfields')->getFielddefinitions(
+        $fieldDefinitions = $container->getFieldDefinition('localizedfields')->getFieldDefinitions(
             ['suppressEnrichment' => true]
         );
 
@@ -417,7 +417,7 @@ class Dao extends Model\Dao\AbstractDao
             }
 
             $fieldDefinition = $container->getFieldDefinition('localizedfields', ['suppressEnrichment' => true]);
-            $childDefinitions = $fieldDefinition->getFielddefinitions(['suppressEnrichment' => true]);
+            $childDefinitions = $fieldDefinition->getFieldDefinitions(['suppressEnrichment' => true]);
 
             if (is_array($childDefinitions)) {
                 foreach ($childDefinitions as $fd) {
@@ -543,7 +543,7 @@ class Dao extends Model\Dao\AbstractDao
         }
 
         foreach ($data as $row) {
-            foreach ($container->getFielddefinition('localizedfields')->getFielddefinitions(
+            foreach ($container->getFieldDefinition('localizedfields')->getFieldDefinitions(
                 ['object' => $object, 'suppressEnrichment' => true]
             ) as $key => $fd) {
                 if ($fd) {
@@ -739,8 +739,8 @@ QUERY;
             $container = $this->model->getClass();
         }
 
-        $localizedFieldDefinition = $container->getFielddefinition('localizedfields', ['suppressEnrichment' => true]);
-        foreach ($localizedFieldDefinition->getFielddefinitions(['suppressEnrichment' => true]) as $value) {
+        $localizedFieldDefinition = $container->getFieldDefinition('localizedfields', ['suppressEnrichment' => true]);
+        foreach ($localizedFieldDefinition->getFieldDefinitions(['suppressEnrichment' => true]) as $value) {
             if ($value instanceof ResourcePersistenceAwareInterface || method_exists($value, 'getDataForResource')) {
                 if ($value->getColumnType()) {
                     $key = $value->getName();
@@ -792,15 +792,15 @@ QUERY;
                 if ($container instanceof DataObject\Objectbrick\Definition) {
                     $containerKey = $context['containerKey'];
                     $container = DataObject\Objectbrick\Definition::getByKey($containerKey);
-                    $fieldDefinitions = $container->getFielddefinition(
+                    $fieldDefinitions = $container->getFieldDefinition(
                         'localizedfields',
                         ['suppressEnrichment' => true]
-                    )->getFielddefinitions(['suppressEnrichment' => true]);
+                    )->getFieldDefinitions(['suppressEnrichment' => true]);
                 } else {
-                    $fieldDefinitions = $this->model->getClass()->getFielddefinition(
+                    $fieldDefinitions = $this->model->getClass()->getFieldDefinition(
                         'localizedfields',
                         ['suppressEnrichment' => true]
-                    )->getFielddefinitions(['suppressEnrichment' => true]);
+                    )->getFieldDefinitions(['suppressEnrichment' => true]);
                 }
 
                 // add non existing columns in the table

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -108,7 +108,9 @@ class Dao extends Model\Dao\AbstractDao
             $container = $this->model->getClass();
         }
 
-        $fieldDefinitions = $container->getFieldDefinition('localizedfields')->getFieldDefinitions(
+        /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedfields */
+        $localizedfields = $container->getFieldDefinition('localizedfields');
+        $fieldDefinitions = $localizedfields->getFieldDefinitions(
             ['suppressEnrichment' => true]
         );
 
@@ -416,6 +418,7 @@ class Dao extends Model\Dao\AbstractDao
                 }
             }
 
+            /** @var DataObject\ClassDefinition\Data\Localizedfields $fieldDefinition */
             $fieldDefinition = $container->getFieldDefinition('localizedfields', ['suppressEnrichment' => true]);
             $childDefinitions = $fieldDefinition->getFieldDefinitions(['suppressEnrichment' => true]);
 
@@ -543,7 +546,9 @@ class Dao extends Model\Dao\AbstractDao
         }
 
         foreach ($data as $row) {
-            foreach ($container->getFieldDefinition('localizedfields')->getFieldDefinitions(
+            /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedfields */
+            $localizedfields = $container->getFieldDefinition('localizedfields');
+            foreach ($localizedfields->getFieldDefinitions(
                 ['object' => $object, 'suppressEnrichment' => true]
             ) as $key => $fd) {
                 if ($fd) {
@@ -739,6 +744,7 @@ QUERY;
             $container = $this->model->getClass();
         }
 
+        /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedFieldDefinition */
         $localizedFieldDefinition = $container->getFieldDefinition('localizedfields', ['suppressEnrichment' => true]);
         foreach ($localizedFieldDefinition->getFieldDefinitions(['suppressEnrichment' => true]) as $value) {
             if ($value instanceof ResourcePersistenceAwareInterface || method_exists($value, 'getDataForResource')) {
@@ -792,15 +798,13 @@ QUERY;
                 if ($container instanceof DataObject\Objectbrick\Definition) {
                     $containerKey = $context['containerKey'];
                     $container = DataObject\Objectbrick\Definition::getByKey($containerKey);
-                    $fieldDefinitions = $container->getFieldDefinition(
-                        'localizedfields',
-                        ['suppressEnrichment' => true]
-                    )->getFieldDefinitions(['suppressEnrichment' => true]);
+                    /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedfields */
+                    $localizedfields = $container->getFieldDefinition('localizedfields', ['suppressEnrichment' => true]);
+                    $fieldDefinitions = $localizedfields->getFieldDefinitions(['suppressEnrichment' => true]);
                 } else {
-                    $fieldDefinitions = $this->model->getClass()->getFieldDefinition(
-                        'localizedfields',
-                        ['suppressEnrichment' => true]
-                    )->getFieldDefinitions(['suppressEnrichment' => true]);
+                    /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedfields */
+                    $localizedfields = $this->model->getClass()->getFieldDefinition('localizedfields', ['suppressEnrichment' => true]);
+                    $fieldDefinitions = $localizedfields->getFieldDefinitions(['suppressEnrichment' => true]);
                 }
 
                 // add non existing columns in the table

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -392,7 +392,8 @@ class Service extends Model\Element\Service
                     // if the definition is not set try to get the definition from localized fields
                     if (!$def) {
                         /** @var Model\DataObject\ClassDefinition\Data\Localizedfields|null $locFields */
-                        if ($locFields = $object->getClass()->getFieldDefinition('localizedfields')) {
+                        $locFields = $object->getClass()->getFieldDefinition('localizedfields');
+                        if ($locFields) {
                             $def = $locFields->getFieldDefinition($key, $context);
                             if ($def) {
                                 $needLocalizedPermissions = true;

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -782,7 +782,7 @@ class Service extends Model\Element\Service
                 /**
                  * @var ClassDefinition\Data\Select $definition
                  */
-                $definition = $class->getFielddefinition($definition);
+                $definition = $class->getFieldDefinition($definition);
             }
 
             if ($definition instanceof ClassDefinition\Data\Select || $definition instanceof ClassDefinition\Data\Multiselect) {

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -376,6 +376,7 @@ class Service extends Model\Element\Service
 
                     if ($brickDescriptor) {
                         $innerContainer = $brickDescriptor['innerContainer'] ? $brickDescriptor['innerContainer'] : 'localizedfields';
+                        /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $localizedFields */
                         $localizedFields = $brickClass->getFieldDefinition($innerContainer);
                         $def = $localizedFields->getFieldDefinition($brickDescriptor['brickfield']);
                     } else {
@@ -390,6 +391,7 @@ class Service extends Model\Element\Service
 
                     // if the definition is not set try to get the definition from localized fields
                     if (!$def) {
+                        /** @var Model\DataObject\ClassDefinition\Data\Localizedfields|null $locFields */
                         if ($locFields = $object->getClass()->getFieldDefinition('localizedfields')) {
                             $def = $locFields->getFieldDefinition($key, $context);
                             if ($def) {
@@ -678,6 +680,7 @@ class Service extends Model\Element\Service
                     $innerContainer = $brickDescriptor['innerContainer'] ? $brickDescriptor['innerContainer'] : 'localizedfields';
                     $localizedFields = $value->{'get' . ucfirst($innerContainer)}();
                     $brickDefinition = Model\DataObject\Objectbrick\Definition::getByKey($brickType);
+                    /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $fieldDefinitionLocalizedFields */
                     $fieldDefinitionLocalizedFields = $brickDefinition->getFieldDefinition('localizedfields');
                     $fieldDefinition = $fieldDefinitionLocalizedFields->getFieldDefinition($brickKey);
                     $value = $localizedFields->getLocalizedValue($brickDescriptor['brickfield']);


### PR DESCRIPTION
This PR set all getFieldDefinition(s) consinstently. This is no BC, because PHP function names are case-insensitive (https://www.php.net/manual/en/functions.user-defined.php)

It corrects also all phpstan level 2 errors:

- `Cannot call method getFieldDefinition() on bool|Pimcore\Model\DataObject\ClassDefinition\Data`
- `Call to an undefined method Pimcore\Model\DataObject\ClassDefinition\Data::getFieldDefinitions()`
- `Call to an undefined method Pimcore\Model\DataObject\ClassDefinition\Data::getFieldDefinition()`