### PR TITLE
[PHPSTAN] Ignore Doctrine\DBAL\Driver\Connection::query() errors

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -56,3 +56,4 @@ parameters:
             path: '**/Migrations/Version.php'
         - '/class heidelpayPHP\\(Heidelpay|Resources|Exceptions)/'
         - '/Heidelpay::fetchPayment\(\) has invalid type heidelpayPHP/'
+        - '~^Method Doctrine\\DBAL(\\.*)?Connection::query\(\) invoked with \d+ parameters?, 0 required\.\z~'


### PR DESCRIPTION
Ignores all phpstan level 2 errors:
`Method Doctrine\DBAL\Driver\Connection::query() invoked with 1 parameter, 0 required`

Line is from https://github.com/doctrine/dbal/blob/master/phpstan.neon.dist