### PR TITLE
[Data objects] Add field index recommendations

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
@@ -297,7 +297,7 @@ pimcore.object.classes.data.data = Class.create({
 
         var data = this.getData();
         data.name = trim(data.name);
-        var regresult = data.name.match(/[a-zA-Z][a-zA-Z0-9_]*/);
+        var regresult = data.name.match(/[a-zA-Z]\w*/);
 
         if (data.name.length > 1 && regresult == data.name
                             && in_array(data.name.toLowerCase(), this.forbiddenNames) == false) {

--- a/models/DataObject/Listing/Dao.php
+++ b/models/DataObject/Listing/Dao.php
@@ -201,11 +201,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
                         if (count($indexCandidates) > 0) {
                             Logger::info(
-                                'Query execution plan for "'.$query
-                                .'" seems not to be optimal, please consider adding an index to field(s) '.implode(
-                                    ',', $indexCandidates
-                                ).' of data object class '.$classDefinition->getName()
-                            );
+                                'Query execution plan for "'.$query.'" seems not to be optimal, please consider adding an index to field(s) "'.implode('", "', $indexCandidates).'" of data object class "'.$classDefinition->getName().'"');
                         }
                     }
                 }

--- a/models/DataObject/Listing/Dao.php
+++ b/models/DataObject/Listing/Dao.php
@@ -193,8 +193,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
                         foreach ($columnNames as $columnName) {
                             $fieldDefinition = $classDefinition->getFieldDefinition($columnName['columnName']);
 
-                            if ($fieldDefinition instanceof DataObject\ClassDefinition\Data
-                                && !$fieldDefinition->getIndex()) {
+                            if ($fieldDefinition instanceof DataObject\ClassDefinition\Data && !$fieldDefinition->getIndex() && !$fieldDefinition->getUnique()) {
                                 $indexCandidates[] = $fieldDefinition->getName();
                             }
                         }

--- a/models/DataObject/Listing/Dao.php
+++ b/models/DataObject/Listing/Dao.php
@@ -202,7 +202,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
                         if (count($indexCandidates) > 0) {
                             Logger::info(
                                 'Query execution plan for "'.$query
-                                .'" seems not to be optimal, please consider adding an index to fields '.implode(
+                                .'" seems not to be optimal, please consider adding an index to field(s) '.implode(
                                     ',', $indexCandidates
                                 ).' of data object class '.$classDefinition->getName()
                             );

--- a/models/DataObject/Listing/Dao.php
+++ b/models/DataObject/Listing/Dao.php
@@ -202,7 +202,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
                         if (count($indexCandidates) > 0) {
                             Logger::info(
                                 'Query execution plan for "'.$query
-                                .'" seems not to be optimal, please considier adding an index to fields '.implode(
+                                .'" seems not to be optimal, please consider adding an index to fields '.implode(
                                     ',', $indexCandidates
                                 ).' of data object class '.$classDefinition->getName()
                             );

--- a/models/DataObject/Listing/Dao.php
+++ b/models/DataObject/Listing/Dao.php
@@ -200,8 +200,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
                         }
 
                         if (count($indexCandidates) > 0) {
-                            Logger::info(
-                                'Query execution plan for "'.$query.'" seems not to be optimal, please consider adding an index to field(s) "'.implode('", "', $indexCandidates).'" of data object class "'.$classDefinition->getName().'"');
+                            Logger::info('Query execution plan for "'.$query.'" seems not to be optimal, please consider adding an index to field(s) "'.implode('", "', $indexCandidates).'" of data object class "'.$classDefinition->getName().'"');
                         }
                     }
                 }


### PR DESCRIPTION
Pimcore offers the option to add indexes to data object class fields. To help developers adding indexes based on the application's queries this PR analyzes executed data object listing queries (when Pimcore is in debug mode) and gives hints if a column index could help to enhance the query performance.
Example:
```Query execution plan for "SELECT object_1.o_id as o_id, `object_1`.`o_type` FROM `object_1` WHERE ((article_number = ? AND object_1.o_type IN ('object','folder')) AND object_1.o_published = 1)" seems not to be optimal, please consider adding an index to field(s) "article_number" of data object class "Product"```