### PR TITLE
[Ecommerce] fix index events namespaces in annotations

### DIFF
--- a/lib/Event/Ecommerce/IndexServiceEvents.php
+++ b/lib/Event/Ecommerce/IndexServiceEvents.php
@@ -19,7 +19,7 @@ final class IndexServiceEvents
     /**
      * Fired when error occurs during processing attributes for index. Event can influence handling of that error (like ignoring, throwing exceptions, etc.)
      *
-     * @Event("Pimcore\Event\Model\Ecommerce\PreprocessAttributeErrorEvent")
+     * @Event("Pimcore\Event\Model\Ecommerce\IndexService\PreprocessAttributeErrorEvent")
      *
      * @var string
      */
@@ -28,7 +28,7 @@ final class IndexServiceEvents
     /**
      * Fired when error occurs during pre processing index data. Event can influence handling of that error (like throwing exceptions, etc.)
      *
-     * @Event("Pimcore\Event\Model\Ecommerce\PreprocessErrorEvent")
+     * @Event("Pimcore\Event\Model\Ecommerce\IndexService\PreprocessErrorEvent")
      *
      * @var string
      */


### PR DESCRIPTION
# Bugfix
This PR fixes the namespaces in the annotations of the indexservice events.