### PR TITLE
[Assets] Set type to unknown for assets without data

### DIFF
--- a/lib/Model/Listing/AbstractListing.php
+++ b/lib/Model/Listing/AbstractListing.php
@@ -32,7 +32,7 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
     protected $order;
 
     /**
-     * @var string|array
+     * @var array
      */
     protected $orderKey;
 
@@ -199,7 +199,7 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
     }
 
     /**
-     * @return array|string
+     * @return array
      */
     public function getOrderKey()
     {

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -753,7 +753,7 @@ class Asset extends Element\AbstractElement
         }
 
         if(!$this->getType()) {
-            throw new \Exception('Asset type could not be determined');
+            $this->setType('unknown');
         }
 
         $this->postPersistData();

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -752,7 +752,7 @@ class Asset extends Element\AbstractElement
             }
         }
 
-        if(!$type) {
+        if(!$this->getType()) {
             throw new \Exception('Asset type could not be determined');
         }
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -752,6 +752,10 @@ class Asset extends Element\AbstractElement
             }
         }
 
+        if(!$type) {
+            throw new \Exception('Asset type could not be determined');
+        }
+
         $this->postPersistData();
 
         // save properties

--- a/models/Asset/Listing/Dao.php
+++ b/models/Asset/Listing/Dao.php
@@ -88,7 +88,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function loadIdList()
     {
-        $select = $this->getQuery(['id', 'type']);
+        $select = $this->getQuery(['id']);
         $assetIds = $this->db->fetchCol($select, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         return array_map('intval', $assetIds);


### PR DESCRIPTION
Currently in https://github.com/pimcore/pimcore/blob/5cb4a06b041e8b3f45337743836ef3430602e7b0/models/Asset/Listing/Dao.php#L47-L51
only assets with non-empty type get loaded.

I have the following script:
```php
<?php
$asset = new \Pimcore\Model\Asset();
$asset->setFilename('abc.txt');
$asset->setParent(\Pimcore\Model\Asset::getByPath('/'));
$asset->save();

$listing = $asset->getList();
$listing->addConditionParam('Filename = ?', 'abc.txt');
var_dump($listing->loadIdList()); // returns array including id of above asset
var_dump($listing->load()); // returns empty array
```

The array does not appear in the Pimcore backend (because of above's restriction in the Dao) - so I cannot delete the asset in the GUI.
Executing above script again results in a primary key collision because there already is a dataset with the same path and filename.

This PR solves that by setting the `type` of an asset to "unknown" if it is empty. We could also set `unknown` as initial value for the `type` class attribute but this is not as secure as checking the value on save.

PS: Alternatively we could prohibit creating assets without data / file. Please report if this is the way to go, then I will change this PR.