### PR TITLE
[Webservice] Convert stdclass metadata items to associative array

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1633,6 +1633,7 @@ class Asset extends Element\AbstractElement
         $this->setHasMetaData(false);
         if (!empty($metadata)) {
             foreach ((array)$metadata as $metaItem) {
+                $metaItem = (array)$metaItem; // also allow an object with appropriate keys (as it comes from
                 $this->addMetadata($metaItem['name'], $metaItem['type'], $metaItem['data'] ?? null, $metaItem['language'] ?? null);
             }
         }

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1623,7 +1623,7 @@ class Asset extends Element\AbstractElement
     }
 
     /**
-     * @param array|\stdClass $metadata mandatory keys: name, type - optional keys: data, language
+     * @param array|\stdClass[] $metadata for each array item: mandatory keys: name, type - optional keys: data, language
      *
      * @return self
      */

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1623,7 +1623,7 @@ class Asset extends Element\AbstractElement
     }
 
     /**
-     * @param array $metadata
+     * @param array $metadata mandatory keys: name, type - optional keys: data, language
      *
      * @return self
      */

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1623,7 +1623,7 @@ class Asset extends Element\AbstractElement
     }
 
     /**
-     * @param array $metadata mandatory keys: name, type - optional keys: data, language
+     * @param array|\stdClass $metadata mandatory keys: name, type - optional keys: data, language
      *
      * @return self
      */
@@ -1633,7 +1633,7 @@ class Asset extends Element\AbstractElement
         $this->setHasMetaData(false);
         if (!empty($metadata)) {
             foreach ((array)$metadata as $metaItem) {
-                $metaItem = (array)$metaItem; // also allow an object with appropriate keys (as it comes from
+                $metaItem = (array)$metaItem; // also allow object with appropriate keys (as it comes from Pimcore\Model\Webservice\Data\Asset\reverseMap)
                 $this->addMetadata($metaItem['name'], $metaItem['type'], $metaItem['data'] ?? null, $metaItem['language'] ?? null);
             }
         }

--- a/models/Webservice/Data/Asset.php
+++ b/models/Webservice/Data/Asset.php
@@ -142,9 +142,6 @@ class Asset extends Model\Webservice\Data
         if (is_array($metadata)) {
             $metadata = json_decode(json_encode($metadata), true);
 
-            foreach((array)$metadata as &$metaItem) {
-                $metaItem = (array)$metaItem;
-            }
             $object->setMetadata($metadata);
         }
     }

--- a/models/Webservice/Data/Asset.php
+++ b/models/Webservice/Data/Asset.php
@@ -141,6 +141,10 @@ class Asset extends Model\Webservice\Data
         $metadata = $this->metadata;
         if (is_array($metadata)) {
             $metadata = json_decode(json_encode($metadata), true);
+
+            foreach((array)$metadata as &$metaItem) {
+                $metaItem = (array)$metaItem;
+            }
             $object->setMetadata($metadata);
         }
     }


### PR DESCRIPTION
When fetching asset data via REST webservice you get something like
```json
{
  "success": true,
  "data": {
    "id": 22905,
    "parentId": 29682,
    "type": "image",
    ...
    "metadata": [
      {
        "name": "ItemCode",
        "type": "input",
        "data": "123",
        "language": ""
      },
      {
        "name": "Name des Artikels",
        "type": "input",
        "data": "abc",
        "language": "de"
      }
    ],
    ...
  }
}
```

When trying to convert this back to a `Pimcore\Model\Asset` via 
`Pimcore\Model\Webservice\Data\Asset\File` you get an array of stdclass items in https://github.com/pimcore/pimcore/blob/97a3f4de67c8c1bb35d6283b4eb06ed87f3126b3/models/Webservice/Data/Asset.php#L143-L144

Since #5076 this was not possible anymore - only associative array was. With this PR also an array of stdClass items is allowed (as it was before #5076).