### PR TITLE
[Ecommerce] OnlineShopOrder class: change column length of field cartId to 190 -> max. index length

### DIFF
--- a/bundles/CoreBundle/Resources/migrations/Version20191230104529.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20191230104529.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+use Pimcore\Model\DataObject\ClassDefinition;
+
+class Version20191230104529 extends AbstractPimcoreMigration
+{
+    public function doesSqlMigrations(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $class = ClassDefinition::getById('EF_OSO');
+        if($class) {
+            /**
+             * @var $cartIdField ClassDefinition\Data\Input
+             */
+            $cartIdField = $class->getFieldDefinition('cartId');
+            $cartIdField->setColumnLength(190);
+            $class->save();
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $class = ClassDefinition::getById('EF_OSO');
+        if($class) {
+            /**
+             * @var $cartIdField ClassDefinition\Data\Input
+             */
+            $cartIdField = $class->getFieldDefinition('cartId');
+            $cartIdField->setColumnLength(255);
+            $class->save();
+        }
+    }
+}

--- a/bundles/CoreBundle/Resources/migrations/Version20191230104529.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20191230104529.php
@@ -18,7 +18,7 @@ class Version20191230104529 extends AbstractPimcoreMigration
      */
     public function up(Schema $schema)
     {
-        $class = ClassDefinition::getById('EF_OSO');
+        $class = ClassDefinition::getByName('OnlineShopOrder');
         if($class) {
             /**
              * @var $cartIdField ClassDefinition\Data\Input
@@ -34,7 +34,7 @@ class Version20191230104529 extends AbstractPimcoreMigration
      */
     public function down(Schema $schema)
     {
-        $class = ClassDefinition::getById('EF_OSO');
+        $class = ClassDefinition::getByName('OnlineShopOrder');
         if($class) {
             /**
              * @var $cartIdField ClassDefinition\Data\Input

--- a/bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
@@ -316,7 +316,13 @@ class OrderManager implements OrderManagerInterface
 
             $order->setOrdernumber($tempOrdernumber);
             $order->setOrderdate(new \DateTime());
-            $order->setCartId($this->createCartId($cart));
+
+            $cartId = $this->createCartId($cart);
+            if(strlen($cartId) > 190) {
+                throw new \Exception('CartId cannot be longer than 190 characters');
+            }
+
+            $order->setCartId($cartId);
         }
 
         // check if pending payment. if one, do not update order from cart

--- a/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderManager.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderManager.php
@@ -86,7 +86,13 @@ class OrderManager extends \Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager
 
             $order->setOrdernumber($tempOrdernumber);
             $order->setOrderdate(new \DateTime());
-            $order->setCartId($this->createCartId($cart));
+
+            $cartId = $this->createCartId($cart);
+            if(strlen($cartId) > 190) {
+                throw new \Exception('CartId cannot be longer than 190 characters');
+            }
+
+            $order->setCartId($cartId);
         }
 
         // check if pending payment. if one, do not update order from cart

--- a/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopOrder_export.json
+++ b/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopOrder_export.json
@@ -588,7 +588,7 @@
                     "width": 400,
                     "queryColumnType": "varchar",
                     "columnType": "varchar",
-                    "columnLength": 255,
+                    "columnLength": 190,
                     "phpdocType": "string",
                     "regex": "",
                     "unique": false,

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -5,6 +5,7 @@
 - The `DocumentRenderer::setEventDispatcher()` method has been removed. Pass event dispatcher to the constructor instead.
 - `RedirectHandler::setRequestHelper()` and `RedirectHandler::setSiteResolver()` methods have been removed. Pass instance of `Pimcore\Http\RequestHelper` & `Pimcore\Http\Request\Resolver\SiteResolver` to the constructor instead.
 - The `ContainerService::setEventDispatcher()` method has been removed and DocumentRenderer event listeners moved to`Pimcore\Bundle\CoreBundle\EventListener\FrontendDocumentRendererListener`
+- Ecommerce: max length of `cartId` is now `190` characters instead of `255`
 
 ## 6.3.0
 - Asset Metadata: character `~` is not allowed anymore for (predefined/custom) metadata naming. All existing and new metadata name with '~' converts to '---'. This change is introduced to support Localized columns in asset grid [#5093](https://github.com/pimcore/pimcore/pull/5093)


### PR DESCRIPTION
Problem: 
Index on column `cartId` cannot be used by e.g. the following query: 
```sql
SELECT object_EF_OSO.o_id as o_id, `object_EF_OSO`.`o_type` FROM `object_EF_OSO` WHERE ((cartId = 'AppBundle\\Ecommerce\\CartManager\\Cart_2596' AND  object_EF_OSO.o_type IN ('object','folder')) AND object_EF_OSO.o_published = 1);
```

Suppressed error message when saving the `OnlineShopOrder` class: 
```
An exception occurred while executing 'ALTER TABLE `object_query_EF_OSO` ADD INDEX `p_index_cartId` (`cartId`);': SQLSTATE[HY000]: General error: 1709 Index column size too large. The maximum column size is 767 bytes.
```

