### PR TITLE
[Cache] Cleanup in maintenance should only be executed once within a day

### DIFF
--- a/lib/Maintenance/Tasks/CacheCleanupTask.php
+++ b/lib/Maintenance/Tasks/CacheCleanupTask.php
@@ -16,6 +16,8 @@ namespace Pimcore\Maintenance\Tasks;
 
 use Pimcore\Cache\Core\CoreHandlerInterface;
 use Pimcore\Maintenance\TaskInterface;
+use Pimcore\Model\Tool\Lock;
+use Psr\Log\LoggerInterface;
 
 final class CacheCleanupTask implements TaskInterface
 {
@@ -25,13 +27,20 @@ final class CacheCleanupTask implements TaskInterface
     private $cacheHandler;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * CacheCleanupTask constructor.
      *
      * @param CoreHandlerInterface $cacheHandler
+     * @param LoggerInterface $logger
      */
-    public function __construct(CoreHandlerInterface $cacheHandler)
+    public function __construct(CoreHandlerInterface $cacheHandler, LoggerInterface $logger)
     {
         $this->cacheHandler = $cacheHandler;
+        $this->logger = $logger;
     }
 
     /**
@@ -39,6 +48,13 @@ final class CacheCleanupTask implements TaskInterface
      */
     public function execute()
     {
-        $this->cacheHandler->purge();
+        $lockId = self::class;
+        if(!Lock::isLocked($lockId, 86400)) {
+            Lock::lock($lockId);
+            $this->logger->debug('Execute purge() on cache handler');
+            $this->cacheHandler->purge();
+        } else {
+            $this->logger->debug('Skip purge execution, was done within the last 24 hours');
+        }
     }
 }


### PR DESCRIPTION
This reduces the load significantly on the cache backend (Redis or Database). 