### PR TITLE
FIX: PayPalSmartPaymentButton

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PayPalSmartPaymentButton.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PayPalSmartPaymentButton.php
@@ -164,7 +164,18 @@ class PayPalSmartPaymentButton extends AbstractPayment implements \Pimcore\Bundl
      */
     public function startPayment(OrderAgentInterface $orderAgent, PriceInterface $price, AbstractRequest $config): StartPaymentResponseInterface
     {
-        $json = $this->initPayment($price, $config->asArray());
+        $result = $this->initPayment($price, $config->asArray());
+
+        if ($result instanceof \stdClass) {
+            $json = json_encode($result);
+        } else {
+            json_decode($result);
+            if (json_last_error() == JSON_ERROR_NONE) {
+                $json = $result;
+            } else {
+                $json = $result;
+            }
+        }
 
         return new JsonResponse($orderAgent->getOrder(), $json);
     }
@@ -317,8 +328,7 @@ class PayPalSmartPaymentButton extends AbstractPayment implements \Pimcore\Bundl
             ->setDefault('user_action', 'PAY_NOW')
             ->setAllowedValues('user_action', ['CONTINUE', 'PAY_NOW'])
             ->setDefault('capture_strategy', self::CAPTURE_STRATEGY_AUTOMATIC)
-            ->setAllowedValues('capture_strategy', [self::CAPTURE_STRATEGY_AUTOMATIC, self::CAPTURE_STRATEGY_MANUAL])
-            ;
+            ->setAllowedValues('capture_strategy', [self::CAPTURE_STRATEGY_AUTOMATIC, self::CAPTURE_STRATEGY_MANUAL]);
 
         $notEmptyValidator = function ($value) {
             return !empty($value);

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PayPalSmartPaymentButton.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PayPalSmartPaymentButton.php
@@ -167,17 +167,17 @@ class PayPalSmartPaymentButton extends AbstractPayment implements \Pimcore\Bundl
         $result = $this->initPayment($price, $config->asArray());
 
         if ($result instanceof \stdClass) {
-            $json = json_encode($result);
-        } else {
-            json_decode($result);
-            if (json_last_error() == JSON_ERROR_NONE) {
-                $json = $result;
-            } else {
-                $json = $result;
+            if($json = json_encode($result)) {
+                return new JsonResponse($orderAgent->getOrder(), $json);
             }
         }
 
-        return new JsonResponse($orderAgent->getOrder(), $json);
+        json_decode($result);
+        if (json_last_error() == JSON_ERROR_NONE) {
+            return new JsonResponse($orderAgent->getOrder(), $result);
+        }
+
+        throw new \Exception("result of initPayment neither stdClass nor JSON");
     }
 
     /**


### PR DESCRIPTION
+ transform stdClass to json
+ check if return is json

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
PayPalSmartPaymentButton fix wrong Parameter-Type in `startPayment`

## Additional info  
In PayPalSmartPaymentButton `startPayment(...)` failed because 
`$this->initPayment(...)` returnes `stdClass` and `Pimcore\Bundle\EcommerceFrameworkBundle\PaymentManager\V7\Payment\StartPaymentResponse\JsonResponse` is only acception `string` as value.

Added check for json and encoding if necessary
