### PR TITLE
Deprecated REST Webservice API

### DIFF
--- a/bundles/AdminBundle/Controller/Rest/AbstractRestController.php
+++ b/bundles/AdminBundle/Controller/Rest/AbstractRestController.php
@@ -26,6 +26,9 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Stopwatch\Stopwatch;
 
+/**
+ * @deprecated
+ */
 abstract class AbstractRestController extends AdminController
 {
     /**

--- a/bundles/AdminBundle/Controller/Rest/ClassController.php
+++ b/bundles/AdminBundle/Controller/Rest/ClassController.php
@@ -21,6 +21,9 @@ use Pimcore\Model\DataObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
+/**
+ * @deprecated
+ */
 class ClassController extends AbstractRestController
 {
     /**

--- a/bundles/AdminBundle/Controller/Rest/Element/AbstractElementController.php
+++ b/bundles/AdminBundle/Controller/Rest/Element/AbstractElementController.php
@@ -20,6 +20,9 @@ use Pimcore\Http\Exception\ResponseException;
 use Pimcore\Model\Element\AbstractElement;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @deprecated
+ */
 abstract class AbstractElementController extends AbstractRestController
 {
     const ELEMENT_DOES_NOT_EXIST = -1;

--- a/bundles/AdminBundle/Controller/Rest/Element/AssetController.php
+++ b/bundles/AdminBundle/Controller/Rest/Element/AssetController.php
@@ -23,6 +23,9 @@ use Pimcore\Model\Webservice\Data\Asset\Folder\In as WebserviceAssetFolderIn;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
+/**
+ * @deprecated
+ */
 class AssetController extends AbstractElementController
 {
     /**

--- a/bundles/AdminBundle/Controller/Rest/Element/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Rest/Element/DataObjectController.php
@@ -28,6 +28,8 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 /**
+ * @deprecated
+ *
  * end point for object related data.
  *
  * - get object by id

--- a/bundles/AdminBundle/Controller/Rest/Element/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Rest/Element/DocumentController.php
@@ -24,6 +24,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
+ * @deprecated
+ *
  * end point for document related data.
  * - get document by id
  *      GET http://[YOUR-DOMAIN]/webservice/rest/document/id/1281?apikey=[API-KEY]

--- a/bundles/AdminBundle/Controller/Rest/Element/TagController.php
+++ b/bundles/AdminBundle/Controller/Rest/Element/TagController.php
@@ -24,6 +24,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
+/**
+ * @deprecated
+ */
 class TagController extends AbstractElementController
 {
     const TAG_DOES_NOT_EXIST = -1;

--- a/bundles/AdminBundle/Controller/Rest/Helper.php
+++ b/bundles/AdminBundle/Controller/Rest/Helper.php
@@ -16,6 +16,9 @@ namespace Pimcore\Bundle\AdminBundle\Controller\Rest;
 
 use Pimcore\Db;
 
+/**
+ * @deprecated
+ */
 class Helper
 {
     public static function buildSqlCondition($q, $op = null, $subject = null)

--- a/bundles/AdminBundle/Controller/Rest/ImageController.php
+++ b/bundles/AdminBundle/Controller/Rest/ImageController.php
@@ -20,6 +20,9 @@ use Pimcore\Model\Asset\Image\Thumbnail\Config;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
+/**
+ * @deprecated
+ */
 class ImageController extends AbstractRestController
 {
     /**

--- a/bundles/AdminBundle/Controller/Rest/InfoController.php
+++ b/bundles/AdminBundle/Controller/Rest/InfoController.php
@@ -20,6 +20,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
+ * @deprecated
+ *
  * Contains actions to gather information about the API. The /user endpoint
  * is used in tests.
  */

--- a/bundles/AdminBundle/Resources/config/security_services.yml
+++ b/bundles/AdminBundle/Resources/config/security_services.yml
@@ -31,6 +31,7 @@ services:
 
     # guard implementation handling webservice login
     Pimcore\Bundle\AdminBundle\Security\Guard\WebserviceAuthenticator:
+        deprecated: ~
         public: false
         calls:
             - [setLogger, ['@logger']]

--- a/bundles/AdminBundle/Resources/config/services.yml
+++ b/bundles/AdminBundle/Resources/config/services.yml
@@ -25,7 +25,8 @@ services:
     # API
     #
 
-    Pimcore\Model\Webservice\Service: ~
+    Pimcore\Model\Webservice\Service:
+        deprecated: ~
 
     #
     # Notification Services

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/system.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/system.js
@@ -1003,6 +1003,10 @@ pimcore.settings.system = Class.create({
                         defaults: {width: 300},
                         items: [
                             {
+                                xtype: 'container',
+                                html: "<b>DEPRECATED! Will be removed in 7.0</b>"
+                            },
+                            {
                                 fieldLabel: t("webservice_enabled"),
                                 xtype: "checkbox",
                                 name: "webservice.enabled",

--- a/bundles/AdminBundle/Security/Guard/WebserviceAuthenticator.php
+++ b/bundles/AdminBundle/Security/Guard/WebserviceAuthenticator.php
@@ -28,6 +28,9 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 
+/**
+ * @deprecated
+ */
 class WebserviceAuthenticator extends AbstractGuardAuthenticator implements LoggerAwareInterface
 {
     use LoggerAwareTrait;

--- a/bundles/CoreBundle/Resources/config/services.yml
+++ b/bundles/CoreBundle/Resources/config/services.yml
@@ -94,10 +94,12 @@ services:
         factory: ['@Pimcore\Http\ClientFactory', createClient]
 
     pimcore.rest_client:
+        deprecated: ~
         alias: Pimcore\Tool\RestClient
         public: true
 
     Pimcore\Tool\RestClient:
+        deprecated: ~
         public: true
         arguments:
             - '@pimcore.http_client'

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,6 +1,7 @@
 # Upgrade Notes
 
 ## 6.4.0
+- Deprecated the REST Webservice API. The API will be removed in Pimcore 7, use the [Pimcore Data-Hub](https://github.com/pimcore/data-hub) instead.
 - Removed `Pimcore\Bundle\EcommerceFrameworkBundle\PricingManagerPricingManagerInterface::getRule()` and `Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager::getRule()`
 - The `DocumentRenderer::setEventDispatcher()` method has been removed. Pass event dispatcher to the constructor instead.
 - `RedirectHandler::setRequestHelper()` and `RedirectHandler::setSiteResolver()` methods have been removed. Pass instance of `Pimcore\Http\RequestHelper` & `Pimcore\Http\Request\Resolver\SiteResolver` to the constructor instead.

--- a/doc/Development_Documentation/24_Web_Services/README.md
+++ b/doc/Development_Documentation/24_Web_Services/README.md
@@ -1,4 +1,8 @@
-# REST Webservice API
+# REST Webservice API (deprecated)
+
+> **Important**  
+> The REST API is deprecated as of Pimcore 6.4 and will be removed in Pimcore 7. 
+> If you're using this API, please consider migrating to the [Pimcore Data-Hub](https://github.com/pimcore/data-hub)
 
 Pimcore provides a REST web service interface to many entities of the system, such as assets, documents, objects, class definitions, translations, etc. 
 The webservices are not enabled by default, you have to do this in *Settings* > *System Settings* > *Web Service API*.
@@ -17,7 +21,7 @@ add the `apikey` to the request if you have a valid user session from the admin 
   
 > **Important: Frontend Applications**  
 > The Pimcore REST API is not intended to be used as a data provider for frontend applications (Vue.js, React, Angular, ...), 
-> please build your own actions for that purpose or use any existing bundles. 
+> please use the [Pimcore Data-Hub](https://github.com/pimcore/data-hub) (GraphQL interface) or build your own actions for that purpose or use any existing bundles. 
   
 [TOC]
 

--- a/lib/Event/Webservice/FilterEvent.php
+++ b/lib/Event/Webservice/FilterEvent.php
@@ -20,6 +20,9 @@ namespace Pimcore\Event\Webservice;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @deprecated
+ */
 class FilterEvent extends Event
 {
     /** @var Request */

--- a/lib/Event/WebserviceEvents.php
+++ b/lib/Event/WebserviceEvents.php
@@ -14,6 +14,9 @@
 
 namespace Pimcore\Event;
 
+/**
+ * @deprecated
+ */
 final class WebserviceEvents
 {
     /**

--- a/lib/Http/Request/Resolver/PimcoreContextResolver.php
+++ b/lib/Http/Request/Resolver/PimcoreContextResolver.php
@@ -27,8 +27,12 @@ class PimcoreContextResolver extends AbstractRequestResolver
     const ATTRIBUTE_PIMCORE_CONTEXT = '_pimcore_context';
 
     const CONTEXT_ADMIN = 'admin';
-    const CONTEXT_WEBSERVICE = 'webservice';
     const CONTEXT_DEFAULT = 'default';
+
+    /**
+     * @deprecated
+     */
+    const CONTEXT_WEBSERVICE = 'webservice';
 
     /**
      * @var PimcoreContextGuesser

--- a/lib/Tool/RestClient.php
+++ b/lib/Tool/RestClient.php
@@ -20,6 +20,8 @@ use GuzzleHttp\Psr7\Uri;
 use Pimcore\Tool\RestClient\AbstractRestClient;
 
 /**
+ * @deprecated
+ *
  * Standard RestClient working with a Guzzle client
  */
 class RestClient extends AbstractRestClient

--- a/lib/Tool/RestClient/AbstractRestClient.php
+++ b/lib/Tool/RestClient/AbstractRestClient.php
@@ -26,6 +26,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 
+/**
+ * @deprecated
+ */
 abstract class AbstractRestClient implements LoggerAwareInterface
 {
     use LoggerAwareTrait;

--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -258,6 +258,7 @@ class Config extends Model\AbstractModel
 
     /**
      * Returns thumbnail config for webservice export.
+     * @deprecated
      */
     public function getForWebserviceExport()
     {

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -219,6 +219,7 @@ abstract class Data
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param DataObject\AbstractObject $object
      * @param mixed $params
      *
@@ -232,6 +233,7 @@ abstract class Data
     /**
      * converts data to be imported via webservices
      *
+     * @deprecated
      * @param mixed $value
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -505,6 +505,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
     }
 
     /**
+     * @deprecated
      * @param DataObject\AbstractObject $object
      * @param mixed $params
      *
@@ -537,6 +538,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -590,6 +590,7 @@ class AdvancedManyToManyRelation extends ManyToManyRelation
     }
 
     /**
+     * @deprecated
      * @param DataObject\AbstractObject $object
      * @param mixed $params
      *
@@ -622,6 +623,7 @@ class AdvancedManyToManyRelation extends ManyToManyRelation
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null $relatedObject
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -440,6 +440,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -478,6 +479,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null $relatedObject
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -247,6 +247,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -262,6 +263,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
     /**
      * converts data to be imported via webservices
      *
+     * @deprecated
      * @param mixed $value
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Checkbox.php
+++ b/models/DataObject/ClassDefinition/Data/Checkbox.php
@@ -226,6 +226,7 @@ class Checkbox extends Data implements ResourcePersistenceAwareInterface, QueryR
     }
 
     /**
+     * @deprecated
      * @param DataObject\AbstractObject $object
      * @param array $params
      *
@@ -241,6 +242,7 @@ class Checkbox extends Data implements ResourcePersistenceAwareInterface, QueryR
     /**
      * converts data to be imported via webservices
      *
+     * @deprecated
      * @param mixed $value
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -440,6 +440,7 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
     }
 
     /**
+     * @deprecated
      * @param DataObject\Concrete $object
      * @param mixed $params
      *
@@ -580,6 +581,7 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Consent.php
+++ b/models/DataObject/ClassDefinition/Data/Consent.php
@@ -338,6 +338,7 @@ class Consent extends Data implements ResourcePersistenceAwareInterface, QueryRe
     }
 
     /**
+     * @deprecated
      * @param DataObject\AbstractObject $object
      * @param array $params
      *
@@ -353,6 +354,7 @@ class Consent extends Data implements ResourcePersistenceAwareInterface, QueryRe
     /**
      * converts data to be imported via webservices
      *
+     * @deprecated
      * @param mixed $value
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Date.php
+++ b/models/DataObject/ClassDefinition/Data/Date.php
@@ -302,6 +302,7 @@ class Date extends Data implements ResourcePersistenceAwareInterface, QueryResou
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param DataObject\Concrete $object
      * @param mixed $params
      *
@@ -313,6 +314,7 @@ class Date extends Data implements ResourcePersistenceAwareInterface, QueryResou
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Datetime.php
+++ b/models/DataObject/ClassDefinition/Data/Datetime.php
@@ -271,6 +271,7 @@ class Datetime extends Data implements ResourcePersistenceAwareInterface, QueryR
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param Model\DataObject\Concrete $object
      * @param mixed $params
      *
@@ -282,6 +283,7 @@ class Datetime extends Data implements ResourcePersistenceAwareInterface, QueryR
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/EncryptedField.php
+++ b/models/DataObject/ClassDefinition/Data/EncryptedField.php
@@ -316,6 +316,7 @@ class EncryptedField extends Data implements ResourcePersistenceAwareInterface
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -336,6 +337,7 @@ class EncryptedField extends Data implements ResourcePersistenceAwareInterface
     /**
      * converts data to be imported via webservices
      *
+     * @deprecated
      * @param mixed $value
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/ExternalImage.php
+++ b/models/DataObject/ClassDefinition/Data/ExternalImage.php
@@ -277,6 +277,7 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -288,6 +289,7 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null $relatedObject
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -397,6 +397,7 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
     }
 
     /**
+     * @deprecated
      * @param Model\DataObject\AbstractObject $object
      * @param mixed $params
      *
@@ -439,6 +440,7 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
     }
 
     /**
+     * @deprecated
      * @param mixed $data
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Geobounds.php
+++ b/models/DataObject/ClassDefinition/Data/Geobounds.php
@@ -262,6 +262,7 @@ class Geobounds extends AbstractGeo implements ResourcePersistenceAwareInterface
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -283,6 +284,7 @@ class Geobounds extends AbstractGeo implements ResourcePersistenceAwareInterface
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Geopoint.php
+++ b/models/DataObject/ClassDefinition/Data/Geopoint.php
@@ -245,6 +245,7 @@ class Geopoint extends AbstractGeo implements ResourcePersistenceAwareInterface,
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -265,6 +266,7 @@ class Geopoint extends AbstractGeo implements ResourcePersistenceAwareInterface,
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Geopolygon.php
+++ b/models/DataObject/ClassDefinition/Data/Geopolygon.php
@@ -224,6 +224,7 @@ class Geopolygon extends AbstractGeo implements ResourcePersistenceAwareInterfac
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -240,6 +241,7 @@ class Geopolygon extends AbstractGeo implements ResourcePersistenceAwareInterfac
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Geopolyline.php
+++ b/models/DataObject/ClassDefinition/Data/Geopolyline.php
@@ -224,6 +224,7 @@ class Geopolyline extends AbstractGeo implements ResourcePersistenceAwareInterfa
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -240,6 +241,7 @@ class Geopolyline extends AbstractGeo implements ResourcePersistenceAwareInterfa
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Hotspotimage.php
+++ b/models/DataObject/ClassDefinition/Data/Hotspotimage.php
@@ -502,6 +502,7 @@ class Hotspotimage extends Model\DataObject\ClassDefinition\Data\Image
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -528,6 +529,7 @@ class Hotspotimage extends Model\DataObject\ClassDefinition\Data\Image
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null $object
      * @param array $params

--- a/models/DataObject/ClassDefinition/Data/Image.php
+++ b/models/DataObject/ClassDefinition/Data/Image.php
@@ -336,6 +336,7 @@ class Image extends Data implements ResourcePersistenceAwareInterface, QueryReso
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -350,6 +351,7 @@ class Image extends Data implements ResourcePersistenceAwareInterface, QueryReso
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null $object
      * @param array $params

--- a/models/DataObject/ClassDefinition/Data/ImageGallery.php
+++ b/models/DataObject/ClassDefinition/Data/ImageGallery.php
@@ -476,6 +476,7 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -505,6 +506,7 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null $object
      * @param array $params

--- a/models/DataObject/ClassDefinition/Data/InputQuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/InputQuantityValue.php
@@ -149,6 +149,7 @@ class InputQuantityValue extends QuantityValue
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null $object
      * @param array $params

--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -371,6 +371,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -395,6 +396,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null $relatedObject
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -411,6 +411,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
     }
 
     /**
+     * @deprecated
      * @param Model\DataObject\AbstractObject $object
      * @param mixed $params
      *
@@ -474,6 +475,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -467,6 +467,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
     }
 
     /**
+     * @deprecated
      * @param DataObject\AbstractObject $object
      * @param mixed $params
      *
@@ -493,6 +494,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
@@ -632,6 +632,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -659,6 +660,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null $relatedObject
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -504,6 +504,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -524,6 +525,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null $relatedObject
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Objectbricks.php
+++ b/models/DataObject/ClassDefinition/Data/Objectbricks.php
@@ -488,6 +488,7 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface
     }
 
     /**
+     * @deprecated
      * @param Model\DataObject\AbstractObject $object
      * @param mixed $params
      *
@@ -531,6 +532,7 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface
     }
 
     /**
+     * @deprecated
      * @param mixed $data
      * @param null $relatedObject
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Password.php
+++ b/models/DataObject/ClassDefinition/Data/Password.php
@@ -374,6 +374,7 @@ class Password extends Data implements ResourcePersistenceAwareInterface, QueryR
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -465,6 +465,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -488,6 +489,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
     /**
      * converts data to be imported via webservices
      *
+     * @deprecated
      * @param mixed $value
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/ReverseManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseManyToManyObjectRelation.php
@@ -264,6 +264,7 @@ class ReverseManyToManyObjectRelation extends ManyToManyObjectRelation
     }
 
     /**
+     * @deprecated
      * @param DataObject\AbstractObject $object
      * @param mixed $params
      *
@@ -277,6 +278,7 @@ class ReverseManyToManyObjectRelation extends ManyToManyObjectRelation
     /**
      * converts data to be imported via webservices
      *
+     * @deprecated
      * @param mixed $value
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/RgbaColor.php
+++ b/models/DataObject/ClassDefinition/Data/RgbaColor.php
@@ -237,6 +237,7 @@ class RgbaColor extends Data implements ResourcePersistenceAwareInterface, Query
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -256,6 +257,7 @@ class RgbaColor extends Data implements ResourcePersistenceAwareInterface, Query
     /**
      * converts data to be imported via webservices
      *
+     * @deprecated
      * @param mixed $value
      * @param null|Model\DataObject\AbstractObject $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/StructuredTable.php
+++ b/models/DataObject/ClassDefinition/Data/StructuredTable.php
@@ -473,6 +473,7 @@ class StructuredTable extends Data implements ResourcePersistenceAwareInterface,
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -499,6 +500,7 @@ class StructuredTable extends Data implements ResourcePersistenceAwareInterface,
     }
 
     /**
+     * @deprecated
      * @param mixed $value
      * @param null $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -609,6 +609,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
     }
 
     /** converts data to be imported via webservices
+     * @deprecated
      * @param mixed $value
      * @param null $object
      * @param mixed $params

--- a/models/DataObject/ClassDefinition/Data/Video.php
+++ b/models/DataObject/ClassDefinition/Data/Video.php
@@ -444,6 +444,7 @@ class Video extends Data implements ResourcePersistenceAwareInterface, QueryReso
     /**
      * converts data to be exposed via webservices
      *
+     * @deprecated
      * @param string $object
      * @param mixed $params
      *
@@ -460,6 +461,7 @@ class Video extends Data implements ResourcePersistenceAwareInterface, QueryReso
     /**
      * converts data to be imported via webservices
      *
+     * @deprecated
      * @param mixed $value
      * @param mixed $relatedObject
      * @param mixed $params

--- a/models/Document/Tag.php
+++ b/models/Document/Tag.php
@@ -597,7 +597,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
      * Receives a standard class object from webservice import and fills the current tag's data
      *
      * @abstract
-     *
+     * @deprecated
      * @param Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param array $params,
@@ -614,6 +614,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
     /**
      * Returns the current tag's data for web service export
      *
+     * @deprecated
      * @param $document
      * @param mixed $params
      * @abstract
@@ -758,6 +759,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
     }
 
     /**
+     * @deprecated
      * @param $data
      *
      * @return object

--- a/models/Document/Tag/Areablock.php
+++ b/models/Document/Tag/Areablock.php
@@ -574,6 +574,7 @@ class Areablock extends Model\Document\Tag implements BlockInterface
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params

--- a/models/Document/Tag/Block.php
+++ b/models/Document/Tag/Block.php
@@ -347,6 +347,7 @@ class Block extends Model\Document\Tag implements BlockInterface
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param null $document
      * @param mixed $params
@@ -355,8 +356,6 @@ class Block extends Model\Document\Tag implements BlockInterface
      * @return Model\Webservice\Data\Document\Element|void
      *
      * @throws \Exception
-     *
-     * @todo replace and with &&
      */
     public function getFromWebserviceImport($wsElement, $document = null, $params = [], $idMapper = null)
     {

--- a/models/Document/Tag/Checkbox.php
+++ b/models/Document/Tag/Checkbox.php
@@ -106,6 +106,7 @@ class Checkbox extends Model\Document\Tag
     }
 
     /**
+     * @deprecated 
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params

--- a/models/Document/Tag/Date.php
+++ b/models/Document/Tag/Date.php
@@ -150,6 +150,7 @@ class Date extends Model\Document\Tag
     /**
      * Receives a Webservice\Data\Document\Element from webservice import and fill the current tag's data
      *
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params
@@ -171,6 +172,7 @@ class Date extends Model\Document\Tag
     /**
      * Returns the current tag's data for web service export
      *
+     * @deprecated
      * @param $document
      * @param mixed $params
      * @abstract

--- a/models/Document/Tag/Embed.php
+++ b/models/Document/Tag/Embed.php
@@ -153,6 +153,7 @@ class Embed extends Model\Document\Tag
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params

--- a/models/Document/Tag/Image.php
+++ b/models/Document/Tag/Image.php
@@ -604,6 +604,7 @@ class Image extends Model\Document\Tag
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param null $document
      * @param mixed $params

--- a/models/Document/Tag/Input.php
+++ b/models/Document/Tag/Input.php
@@ -111,6 +111,7 @@ class Input extends Model\Document\Tag
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param null $document
      * @param mixed $params

--- a/models/Document/Tag/Link.php
+++ b/models/Document/Tag/Link.php
@@ -506,6 +506,7 @@ class Link extends Model\Document\Tag
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params
@@ -576,6 +577,7 @@ class Link extends Model\Document\Tag
     /**
      * Returns the current tag's data for web service export
      *
+     * @deprecated
      * @param $document
      * @param mixed $params
      * @abstract

--- a/models/Document/Tag/Multiselect.php
+++ b/models/Document/Tag/Multiselect.php
@@ -112,6 +112,7 @@ class Multiselect extends Model\Document\Tag
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params

--- a/models/Document/Tag/Numeric.php
+++ b/models/Document/Tag/Numeric.php
@@ -102,6 +102,7 @@ class Numeric extends Model\Document\Tag
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params

--- a/models/Document/Tag/Pdf.php
+++ b/models/Document/Tag/Pdf.php
@@ -245,6 +245,7 @@ HTML;
     }
 
     /**
+     * @deprecated 
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params

--- a/models/Document/Tag/Relation.php
+++ b/models/Document/Tag/Relation.php
@@ -250,6 +250,7 @@ class Relation extends Model\Document\Tag
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params

--- a/models/Document/Tag/Relations.php
+++ b/models/Document/Tag/Relations.php
@@ -254,6 +254,7 @@ class Relations extends Model\Document\Tag implements \Iterator
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params
@@ -412,6 +413,7 @@ class Relations extends Model\Document\Tag implements \Iterator
     /**
      * Returns the current tag's data for web service export
      *
+     * @deprecated
      * @param $document
      * @param mixed $params
      * @abstract

--- a/models/Document/Tag/Select.php
+++ b/models/Document/Tag/Select.php
@@ -98,6 +98,7 @@ class Select extends Model\Document\Tag
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params

--- a/models/Document/Tag/Snippet.php
+++ b/models/Document/Tag/Snippet.php
@@ -247,6 +247,7 @@ class Snippet extends Model\Document\Tag
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params

--- a/models/Document/Tag/Table.php
+++ b/models/Document/Tag/Table.php
@@ -115,6 +115,7 @@ class Table extends Model\Document\Tag
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params

--- a/models/Document/Tag/TagInterface.php
+++ b/models/Document/Tag/TagInterface.php
@@ -80,6 +80,7 @@ interface TagInterface
     /**
      * Returns the current tag's data for web service export
      *
+     * @deprecated
      * @param $document
      * @param mixed $params
      * @abstract

--- a/models/Document/Tag/Textarea.php
+++ b/models/Document/Tag/Textarea.php
@@ -115,6 +115,7 @@ class Textarea extends Model\Document\Tag
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params

--- a/models/Document/Tag/Video.php
+++ b/models/Document/Tag/Video.php
@@ -912,6 +912,7 @@ class Video extends Model\Document\Tag
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params

--- a/models/Document/Tag/Wysiwyg.php
+++ b/models/Document/Tag/Wysiwyg.php
@@ -119,6 +119,7 @@ class Wysiwyg extends Model\Document\Tag
     }
 
     /**
+     * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
      * @param $document
      * @param mixed $params

--- a/models/Element/Export/Service.php
+++ b/models/Element/Export/Service.php
@@ -23,6 +23,9 @@ use Pimcore\Model\Document;
 use Pimcore\Model\Element;
 use Pimcore\Model\Webservice;
 
+/**
+ * @deprecated
+ */
 class Service
 {
     /**

--- a/models/Element/Import/Service.php
+++ b/models/Element/Import/Service.php
@@ -24,6 +24,9 @@ use Pimcore\Model\Element;
 use Pimcore\Model\Webservice;
 use Pimcore\Tool;
 
+/**
+ * @deprecated
+ */
 class Service
 {
     /**

--- a/models/Translation/AbstractTranslation.php
+++ b/models/Translation/AbstractTranslation.php
@@ -409,6 +409,7 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
     }
 
     /**
+     * @deprecated
      * @param $data
      */
     public function getFromWebserviceImport($data)
@@ -420,6 +421,7 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
     }
 
     /**
+     * @deprecated
      * @return array
      */
     public function getForWebserviceExport()

--- a/models/Webservice/Data.php
+++ b/models/Webservice/Data.php
@@ -22,6 +22,9 @@ use Pimcore\Model;
 use Pimcore\Model\Element;
 use Pimcore\Model\Webservice;
 
+/**
+ * @deprecated
+ */
 abstract class Data
 {
     /**

--- a/models/Webservice/Data/Asset.php
+++ b/models/Webservice/Data/Asset.php
@@ -20,6 +20,9 @@ namespace Pimcore\Model\Webservice\Data;
 use Pimcore\Model;
 use Pimcore\Model\Webservice;
 
+/**
+ * @deprecated
+ */
 class Asset extends Model\Webservice\Data
 {
     /**

--- a/models/Webservice/Data/Asset/File.php
+++ b/models/Webservice/Data/Asset/File.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Asset;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class File extends Model\Webservice\Data\Asset
 {
     /**

--- a/models/Webservice/Data/Asset/File/In.php
+++ b/models/Webservice/Data/Asset/File/In.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Asset\File;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class In extends Model\Webservice\Data\Asset\File
 {
 }

--- a/models/Webservice/Data/Asset/File/Incoming.php
+++ b/models/Webservice/Data/Asset/File/Incoming.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Asset\File;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Incoming extends Model\Webservice\Data\Asset\File
 {
 }

--- a/models/Webservice/Data/Asset/File/Out.php
+++ b/models/Webservice/Data/Asset/File/Out.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Asset\File;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Out extends Model\Webservice\Data\Asset\File
 {
 }

--- a/models/Webservice/Data/Asset/File/Outgoing.php
+++ b/models/Webservice/Data/Asset/File/Outgoing.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Asset\File;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Outgoing extends Model\Webservice\Data\Asset\File
 {
 }

--- a/models/Webservice/Data/Asset/Folder.php
+++ b/models/Webservice/Data/Asset/Folder.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Asset;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Folder extends Model\Webservice\Data\Asset
 {
 }

--- a/models/Webservice/Data/Asset/Folder/In.php
+++ b/models/Webservice/Data/Asset/Folder/In.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Asset\Folder;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class In extends Model\Webservice\Data\Asset\Folder
 {
 }

--- a/models/Webservice/Data/Asset/Folder/Incoming.php
+++ b/models/Webservice/Data/Asset/Folder/Incoming.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Asset\Folder;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Incoming extends Model\Webservice\Data\Asset\Folder
 {
 }

--- a/models/Webservice/Data/Asset/Folder/Out.php
+++ b/models/Webservice/Data/Asset/Folder/Out.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Asset\Folder;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Out extends Model\Webservice\Data\Asset\Folder
 {
     /**

--- a/models/Webservice/Data/Asset/Listing/Item.php
+++ b/models/Webservice/Data/Asset/Listing/Item.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Asset\Listing;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Item extends Model\Webservice\Data\Element\Listing\Item
 {
 }

--- a/models/Webservice/Data/ClassDefinition.php
+++ b/models/Webservice/Data/ClassDefinition.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class ClassDefinition extends Model\Webservice\Data
 {
     /**

--- a/models/Webservice/Data/ClassDefinition/In.php
+++ b/models/Webservice/Data/ClassDefinition/In.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\ClassDefinition;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class In extends Model\Webservice\Data\ClassDefinition
 {
 }

--- a/models/Webservice/Data/ClassDefinition/Out.php
+++ b/models/Webservice/Data/ClassDefinition/Out.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\ClassDefinition;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Out extends Model\Webservice\Data\ClassDefinition
 {
 }

--- a/models/Webservice/Data/DataObject.php
+++ b/models/Webservice/Data/DataObject.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class DataObject extends Model\Webservice\Data
 {
     /**

--- a/models/Webservice/Data/DataObject/Concrete.php
+++ b/models/Webservice/Data/DataObject/Concrete.php
@@ -21,6 +21,9 @@ use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Webservice;
 
+/**
+ * @deprecated
+ */
 class Concrete extends Model\Webservice\Data\DataObject
 {
     /**

--- a/models/Webservice/Data/DataObject/Concrete/In.php
+++ b/models/Webservice/Data/DataObject/Concrete/In.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\DataObject\Concrete;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class In extends Model\Webservice\Data\DataObject\Concrete
 {
 }

--- a/models/Webservice/Data/DataObject/Concrete/Out.php
+++ b/models/Webservice/Data/DataObject/Concrete/Out.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\DataObject\Concrete;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Out extends Model\Webservice\Data\DataObject\Concrete
 {
     /**

--- a/models/Webservice/Data/DataObject/Element.php
+++ b/models/Webservice/Data/DataObject/Element.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\DataObject;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Element extends Model\Webservice\Data
 {
     /**

--- a/models/Webservice/Data/DataObject/Folder.php
+++ b/models/Webservice/Data/DataObject/Folder.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\DataObject;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Folder extends Model\Webservice\Data\DataObject
 {
 }

--- a/models/Webservice/Data/DataObject/Folder/In.php
+++ b/models/Webservice/Data/DataObject/Folder/In.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\DataObject\Folder;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class In extends Model\Webservice\Data\DataObject\Folder
 {
 }

--- a/models/Webservice/Data/DataObject/Folder/Out.php
+++ b/models/Webservice/Data/DataObject/Folder/Out.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\DataObject\Folder;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Out extends Model\Webservice\Data\DataObject\Folder
 {
     /**

--- a/models/Webservice/Data/DataObject/Listing/Item.php
+++ b/models/Webservice/Data/DataObject/Listing/Item.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\DataObject\Listing;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Item extends Model\Webservice\Data\Element\Listing\Item
 {
 }

--- a/models/Webservice/Data/Document.php
+++ b/models/Webservice/Data/Document.php
@@ -20,6 +20,9 @@ namespace Pimcore\Model\Webservice\Data;
 use Pimcore\Model;
 use Pimcore\Model\Webservice;
 
+/**
+ * @deprecated
+ */
 abstract class Document extends Model\Webservice\Data
 {
     /**

--- a/models/Webservice/Data/Document/Element.php
+++ b/models/Webservice/Data/Document/Element.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Element extends Model\Webservice\Data
 {
     /**

--- a/models/Webservice/Data/Document/Email.php
+++ b/models/Webservice/Data/Document/Email.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Email extends Model\Webservice\Data\Document\Snippet
 {
     /**

--- a/models/Webservice/Data/Document/Email/In.php
+++ b/models/Webservice/Data/Document/Email/In.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Email;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class In extends Model\Webservice\Data\Document\Snippet\Out
 {
 }

--- a/models/Webservice/Data/Document/Email/Out.php
+++ b/models/Webservice/Data/Document/Email/Out.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Email;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Out extends Model\Webservice\Data\Document\Snippet\Out
 {
     /**

--- a/models/Webservice/Data/Document/Folder.php
+++ b/models/Webservice/Data/Document/Folder.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Folder extends Model\Webservice\Data\Document
 {
 }

--- a/models/Webservice/Data/Document/Folder/In.php
+++ b/models/Webservice/Data/Document/Folder/In.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Folder;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class In extends Model\Webservice\Data\Document\Folder
 {
 }

--- a/models/Webservice/Data/Document/Folder/Out.php
+++ b/models/Webservice/Data/Document/Folder/Out.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Folder;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Out extends Model\Webservice\Data\Document\Folder
 {
     /**

--- a/models/Webservice/Data/Document/Hardlink.php
+++ b/models/Webservice/Data/Document/Hardlink.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Hardlink extends Model\Webservice\Data\Document
 {
     /**

--- a/models/Webservice/Data/Document/Hardlink/In.php
+++ b/models/Webservice/Data/Document/Hardlink/In.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Hardlink;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class In extends Model\Webservice\Data\Document\Link
 {
     public $sourceId;

--- a/models/Webservice/Data/Document/Hardlink/Out.php
+++ b/models/Webservice/Data/Document/Hardlink/Out.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Hardlink;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Out extends Model\Webservice\Data\Document\Link
 {
     /**

--- a/models/Webservice/Data/Document/Link.php
+++ b/models/Webservice/Data/Document/Link.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Link extends Model\Webservice\Data\Document
 {
     /**

--- a/models/Webservice/Data/Document/Link/In.php
+++ b/models/Webservice/Data/Document/Link/In.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Link;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class In extends Model\Webservice\Data\Document\Link
 {
 }

--- a/models/Webservice/Data/Document/Link/Out.php
+++ b/models/Webservice/Data/Document/Link/Out.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Link;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Out extends Model\Webservice\Data\Document\Link
 {
     /**

--- a/models/Webservice/Data/Document/Listing/Item.php
+++ b/models/Webservice/Data/Document/Listing/Item.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Listing;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Item extends Model\Webservice\Data\Element\Listing\Item
 {
 }

--- a/models/Webservice/Data/Document/Newsletter.php
+++ b/models/Webservice/Data/Document/Newsletter.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Newsletter extends Model\Webservice\Data\Document\Snippet
 {
     /**

--- a/models/Webservice/Data/Document/Newsletter/In.php
+++ b/models/Webservice/Data/Document/Newsletter/In.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Newsletter;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class In extends Model\Webservice\Data\Document\Snippet\Out
 {
 }

--- a/models/Webservice/Data/Document/Newsletter/Out.php
+++ b/models/Webservice/Data/Document/Newsletter/Out.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Newsletter;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Out extends Model\Webservice\Data\Document\Snippet\Out
 {
     /**

--- a/models/Webservice/Data/Document/Page.php
+++ b/models/Webservice/Data/Document/Page.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Page extends Model\Webservice\Data\Document\PageSnippet
 {
     /**

--- a/models/Webservice/Data/Document/Page/In.php
+++ b/models/Webservice/Data/Document/Page/In.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Page;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class In extends Model\Webservice\Data\Document\Page
 {
 }

--- a/models/Webservice/Data/Document/Page/Out.php
+++ b/models/Webservice/Data/Document/Page/Out.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Page;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Out extends Model\Webservice\Data\Document\Page
 {
     /**

--- a/models/Webservice/Data/Document/PageSnippet.php
+++ b/models/Webservice/Data/Document/PageSnippet.php
@@ -20,6 +20,9 @@ namespace Pimcore\Model\Webservice\Data\Document;
 use Pimcore\Model;
 use Pimcore\Model\Webservice;
 
+/**
+ * @deprecated
+ */
 class PageSnippet extends Model\Webservice\Data\Document
 {
     /**

--- a/models/Webservice/Data/Document/Printcontainer.php
+++ b/models/Webservice/Data/Document/Printcontainer.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document;
 
 use Pimcore\Model\Webservice\Data\Document;
 
+/**
+ * @deprecated
+ */
 class Printcontainer extends Document\PageSnippet
 {
     /**

--- a/models/Webservice/Data/Document/Printcontainer/In.php
+++ b/models/Webservice/Data/Document/Printcontainer/In.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Printcontainer;
 
 use Pimcore\Model\Webservice\Data\Document;
 
+/**
+ * @deprecated
+ */
 class In extends Document\Printcontainer
 {
 }

--- a/models/Webservice/Data/Document/Printcontainer/Out.php
+++ b/models/Webservice/Data/Document/Printcontainer/Out.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Printcontainer;
 
 use Pimcore\Model\Webservice\Data\Document;
 
+/**
+ * @deprecated
+ */
 class Out extends Document\Printcontainer
 {
     /**

--- a/models/Webservice/Data/Document/Printpage.php
+++ b/models/Webservice/Data/Document/Printpage.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document;
 
 use Pimcore\Model\Webservice\Data\Document;
 
+/**
+ * @deprecated
+ */
 class Printpage extends Document\PageSnippet
 {
     /**

--- a/models/Webservice/Data/Document/Printpage/In.php
+++ b/models/Webservice/Data/Document/Printpage/In.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Printpage;
 
 use Pimcore\Model\Webservice\Data\Document;
 
+/**
+ * @deprecated
+ */
 class In extends Document\Printpage
 {
 }

--- a/models/Webservice/Data/Document/Printpage/Out.php
+++ b/models/Webservice/Data/Document/Printpage/Out.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Printpage;
 
 use Pimcore\Model\Webservice\Data\Document;
 
+/**
+ * @deprecated
+ */
 class Out extends Document\Printpage
 {
     /**

--- a/models/Webservice/Data/Document/Snippet.php
+++ b/models/Webservice/Data/Document/Snippet.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Snippet extends Model\Webservice\Data\Document\PageSnippet
 {
 }

--- a/models/Webservice/Data/Document/Snippet/In.php
+++ b/models/Webservice/Data/Document/Snippet/In.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Snippet;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class In extends Model\Webservice\Data\Document\Snippet
 {
 }

--- a/models/Webservice/Data/Document/Snippet/Out.php
+++ b/models/Webservice/Data/Document/Snippet/Out.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Document\Snippet;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Out extends Model\Webservice\Data\Document\Snippet
 {
     /**

--- a/models/Webservice/Data/Element/Listing/Item.php
+++ b/models/Webservice/Data/Element/Listing/Item.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data\Element\Listing;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Item extends Model\Webservice\Data
 {
     /**

--- a/models/Webservice/Data/Mapper.php
+++ b/models/Webservice/Data/Mapper.php
@@ -20,6 +20,9 @@ namespace Pimcore\Model\Webservice\Data;
 use Pimcore\Model;
 use Pimcore\Tool;
 
+/**
+ * @deprecated
+ */
 abstract class Mapper
 {
     /**

--- a/models/Webservice/Data/Property.php
+++ b/models/Webservice/Data/Property.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice\Data;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated
+ */
 class Property extends Model\Webservice\Data
 {
     /**

--- a/models/Webservice/JsonEncoder.php
+++ b/models/Webservice/JsonEncoder.php
@@ -19,6 +19,9 @@ namespace Pimcore\Model\Webservice;
 
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @deprecated
+ */
 class JsonEncoder
 {
     /**

--- a/models/Webservice/Service.php
+++ b/models/Webservice/Service.php
@@ -25,6 +25,9 @@ use Pimcore\Model\User;
 use Pimcore\Model\Webservice;
 use Pimcore\Tool\Admin;
 
+/**
+ * @deprecated
+ */
 class Service
 {
     /**

--- a/models/Webservice/Tool.php
+++ b/models/Webservice/Tool.php
@@ -17,6 +17,9 @@
 
 namespace Pimcore\Model\Webservice;
 
+/**
+ * @deprecated
+ */
 class Tool
 {
     /**

--- a/tests/_support/Rest/BrowserKitRestClient.php
+++ b/tests/_support/Rest/BrowserKitRestClient.php
@@ -9,6 +9,9 @@ use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\BrowserKit\Request as BrowserKitRequest;
 use Symfony\Component\BrowserKit\Response as BrowserKitResponse;
 
+/**
+ * @deprecated
+ */
 class BrowserKitRestClient extends AbstractRestClient
 {
     /**


### PR DESCRIPTION
The API will be removed from the core in Pimcore 7, use the [Pimcore Data-Hub](https://github.com/pimcore/data-hub) instead.

Edit: 

Our motivation behind deprecating the REST API: 
- very limited functionality due to the antiqued architecture
- very inflexible due to the fixed and full-featured data-structures
- not compatible with nowadays requirements of a configurable API
- no permissions, no limitations, no transformations, just one big API endpoint

Even if this functionality is removed from the core, it does not mean that it cannot continue to exist as a bundle. If you're interested, please let us know, maybe we can form a task force for this topic 😊