### PR TITLE
adding DIRECTORY_SEPARATOR resolves #5518

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/LogController.php
+++ b/bundles/AdminBundle/Controller/Admin/LogController.php
@@ -240,7 +240,7 @@ class LogController extends AdminController implements EventedControllerInterfac
     public function showFileObjectAction(Request $request)
     {
         $filePath = $request->get('filePath');
-        $filePath = PIMCORE_PROJECT_ROOT . '/' . $filePath;
+        $filePath = PIMCORE_PROJECT_ROOT . DIRECTORY_SEPARATOR . $filePath;
         $filePath = realpath($filePath);
         $fileObjectPath = realpath(PIMCORE_LOG_FILEOBJECT_DIRECTORY);
 


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
fixing directory bug 

## Additional info  
The problem is that, on Windows, file paths contains the backslash "\" character instead of the slash "/" as linux. now it can work on both 
