### PR TITLE
[PHPSTAN] Fix: Wrong binary operations

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFactFinder.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFactFinder.php
@@ -782,9 +782,9 @@ class DefaultFactFinder implements ProductListInterface
         $client = \Pimcore::getContainer()->get('pimcore.http_client');
         $response = $client->request('GET', $url);
 
-        $factFinderTimeout = $response->getHeader('X-FF-Timeout');
+        $factFinderTimeout = $response->getHeaderLine('X-FF-Timeout');
         if ($factFinderTimeout === 'true') {
-            $errorMessage = 'FactFinder Read timeout:' . $url.' X-FF-RefKey: ' . $response->getHeader('X-FF-RefKey').' Tried: ' . ($trys + 1);
+            $errorMessage = 'FactFinder Read timeout:' . $url.' X-FF-RefKey: ' . $response->getHeaderLine('X-FF-RefKey').' Tried: ' . ($trys + 1);
             $this->getLogger()->err($errorMessage);
             $trys++;
             if ($trys > 2) {

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PayU.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PayU.php
@@ -168,7 +168,7 @@ class PayU extends AbstractPayment implements \Pimcore\Bundle\EcommerceFramework
             'email' => $order->getCustomer()->getEmail()
         ];
         $orderData['currencyCode'] = $price->getCurrency()->getShortName();
-        $orderData['totalAmount'] = (string) round($price->getAmount()->asNumeric(), 2) * 100;
+        $orderData['totalAmount'] = round($price->getAmount()->asNumeric(), 2) * 100;
         $orderData['products'] = $this->setProducts($order->getItems());
 
         $orderData = $this->setAdditionalData($orderData);
@@ -195,7 +195,7 @@ class PayU extends AbstractPayment implements \Pimcore\Bundle\EcommerceFramework
             $product = $item->getProduct();
 
             $products[$key]['name'] = $product->getName();
-            $products[$key]['unitPrice'] = (string) round($product->getOSPrice()->getAmount()->asNumeric(), 2) * 100;
+            $products[$key]['unitPrice'] = round($product->getOSPrice()->getAmount()->asNumeric(), 2) * 100;
             $products[$key]['quantity'] = $item->getAmount();
         }
 

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PayU.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PayU.php
@@ -168,7 +168,7 @@ class PayU extends AbstractPayment implements \Pimcore\Bundle\EcommerceFramework
             'email' => $order->getCustomer()->getEmail()
         ];
         $orderData['currencyCode'] = $price->getCurrency()->getShortName();
-        $orderData['totalAmount'] = round($price->getAmount()->asNumeric(), 2) * 100;
+        $orderData['totalAmount'] = (string) (round($price->getAmount()->asNumeric(), 2) * 100);
         $orderData['products'] = $this->setProducts($order->getItems());
 
         $orderData = $this->setAdditionalData($orderData);
@@ -195,7 +195,7 @@ class PayU extends AbstractPayment implements \Pimcore\Bundle\EcommerceFramework
             $product = $item->getProduct();
 
             $products[$key]['name'] = $product->getName();
-            $products[$key]['unitPrice'] = round($product->getOSPrice()->getAmount()->asNumeric(), 2) * 100;
+            $products[$key]['unitPrice'] = (string) (round($product->getOSPrice()->getAmount()->asNumeric(), 2) * 100);
             $products[$key]['quantity'] = $item->getAmount();
         }
 

--- a/lib/helper-functions.php
+++ b/lib/helper-functions.php
@@ -256,26 +256,27 @@ function urlencode_ignore_slash($var)
 }
 
 /**
- * @param  $val
+ * @param string $val
  *
- * @return int|string
+ * @return int
  */
 function return_bytes($val)
 {
     $val = trim($val);
     $last = strtolower($val[strlen($val) - 1]);
+    $bytes = (int)$val;
     switch ($last) {
         case 'g':
-            $val *= 1024;
+            $bytes *= 1024;
             // no break
         case 'm':
-            $val *= 1024;
+            $bytes *= 1024;
             // no break
         case 'k':
-            $val *= 1024;
+            $bytes *= 1024;
     }
 
-    return $val;
+    return $bytes;
 }
 
 /**

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1701,11 +1701,11 @@ class Asset extends Element\AbstractElement
     }
 
     /**
-     * @param null $name
-     * @param null $language
+     * @param string|null $name
+     * @param string|null $language
      * @param bool $strictMatch
      *
-     * @return array|null
+     * @return array|string|null
      */
     public function getMetadata($name = null, $language = null, $strictMatch = false)
     {

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -1259,7 +1259,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface
         foreach ($mapping as $language => $fields) {
             foreach ($fields as $key => $value) {
                 $fd = $this->getFieldDefinition($key);
-                if ($fd & $fd->isDiffChangeAllowed($object)) {
+                if ($fd && $fd->isDiffChangeAllowed($object)) {
                     if ($value == null) {
                         unset($localData[$language][$key]);
                     } else {

--- a/models/Document/Tag/Video.php
+++ b/models/Document/Tag/Video.php
@@ -433,7 +433,7 @@ class Video extends Model\Document\Tag
     {
         $width = $this->getWidth();
         if (strpos($this->getWidth(), '%') === false) {
-            $width = ($this->getWidth() - 1) . 'px';
+            $width = ((int)$this->getWidth() - 1) . 'px';
         }
 
         // only display error message in debug mode

--- a/models/Webservice/Data/Document/Element.php
+++ b/models/Webservice/Data/Document/Element.php
@@ -27,7 +27,7 @@ class Element extends Model\Webservice\Data
     public $type;
 
     /**
-     * @var object[]
+     * @var object
      */
     public $value;
 


### PR DESCRIPTION
Fix following phpstan level 2 errors:
```
  Line   bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFactFinder.php
  787    Binary operation "." between string and array<string> results in an error.
  
  Line   bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PayU.php
  171    Binary operation "*" between string and 100 results in an error.
  198    Binary operation "*" between string and 100 results in an error.

  Line   lib/helper-functions.php
  269    Binary operation "*=" between string and 1024 results in an error.

  Line   models/Asset/Image/Thumbnail.php                                                                                        
  246    Binary operation "." between '© ' and array|null results in an error.                                            
  247    Binary operation "." between '© ' and array|null results in an error.                                            
  
  Line   models/DataObject/ClassDefinition/Data/Localizedfields.php                                                                                      
  1262   Binary operation "&" between Pimcore\Model\DataObject\ClassDefinition\Data|null and bool results in an error.                            

  Line   models/Document/Tag/Date.php                                                                                                    
  167    Binary operation "." between 'cannot get document…' and array<object> results in an error.                               
 
  Line   models/Document/Tag/Video.php                                                                                                       
  436    Binary operation "-" between string and 1 results in an error.                                                               
```

