### PR TITLE
[Assets] Fix: Wrong document thumbnail if thumbnail generation is locked

### DIFF
--- a/models/Asset/Document/ImageThumbnail.php
+++ b/models/Asset/Document/ImageThumbnail.php
@@ -69,8 +69,6 @@ class ImageThumbnail
 
     /**
      * @param bool $deferredAllowed
-     *
-     * @return string
      */
     public function generate($deferredAllowed = true)
     {
@@ -102,7 +100,8 @@ class ImageThumbnail
                         $generated = true;
                         Model\Tool\Lock::release($lockKey);
                     } elseif (Model\Tool\Lock::isLocked($lockKey)) {
-                        return '/bundles/pimcoreadmin/img/please-wait.png';
+                        $this->filesystemPath = PIMCORE_WEB_ROOT . '/bundles/pimcoreadmin/img/please-wait.png';
+                        return;
                     }
                 }
 


### PR DESCRIPTION
ImageThumbnail::generate() method must set the filesystemPath argument. A return value is not taken into account.
