### PR TITLE
[PHPSTAN] Fix: Classes with incorrect case

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.php
@@ -175,7 +175,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
                 }
             }
             ?>
-        <?php } else if ($definition instanceof DataObject\ClassDefinition\Data\ObjectBricks) {
+        <?php } else if ($definition instanceof DataObject\ClassDefinition\Data\Objectbricks) {
             ?>
             <?php foreach ($definition->getAllowedTypes() as $asAllowedType) { ?>
                 <?php

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -1047,7 +1047,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
                 $this->visibleFieldDefinitions[$field]['fieldtype'] = $fd->getFieldType();
                 $this->visibleFieldDefinitions[$field]['noteditable'] = true;
 
-                if ($fd instanceof DataObject\ClassDefinition\Data\Select || $fd instanceof DataObject\ClassDefinition\Data\MultiSelect) {
+                if ($fd instanceof DataObject\ClassDefinition\Data\Select || $fd instanceof DataObject\ClassDefinition\Data\Multiselect) {
                     if ($fd->getOptionsProviderClass()) {
                         $this->visibleFieldDefinitions[$field]['optionsProviderClass'] = $fd->getOptionsProviderClass();
                     }

--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -406,7 +406,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
      */
     public function getFromWebserviceImport($value, $relatedObject = null, $params = [], $idMapper = null)
     {
-        if ($value instanceof \stdclass) {
+        if ($value instanceof \stdClass) {
             $value = (array) $value;
         }
 

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -756,7 +756,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
                 $this->visibleFieldDefinitions[$field]['fieldtype'] = $fd->getFieldType();
                 $this->visibleFieldDefinitions[$field]['noteditable'] = true;
 
-                if ($fd instanceof DataObject\ClassDefinition\Data\Select || $fd instanceof DataObject\ClassDefinition\Data\MultiSelect) {
+                if ($fd instanceof DataObject\ClassDefinition\Data\Select || $fd instanceof DataObject\ClassDefinition\Data\Multiselect) {
                     if ($fd->getOptionsProviderClass()) {
                         $this->visibleFieldDefinitions[$field]['optionsProviderClass'] = $fd->getOptionsProviderClass();
                     }

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -661,13 +661,15 @@ class Service extends Model\Element\Service
      *
      * @static
      *
-     * @param $object
-     * @param $key
-     * @param null $brickType
-     * @param null $brickKey
-     * @param null $fieldDefinition
+     * @param Concrete $object
+     * @param string $key
+     * @param string|null $brickType
+     * @param string|null $brickKey
+     * @param ClassDefinition\Data|null $fieldDefinition
+     * @param array $context
+     * @param array|null $brickDescriptor
      *
-     * @return \stdclass, value and objectid where the value comes from
+     * @return \stdClass, value and objectid where the value comes from
      */
     private static function getValueForObject($object, $key, $brickType = null, $brickKey = null, $fieldDefinition = null, $context = [], $brickDescriptor = null)
     {

--- a/models/Dependency.php
+++ b/models/Dependency.php
@@ -74,7 +74,7 @@ class Dependency extends AbstractModel
     }
 
     /**
-     * @param  Element\ELementInterface $element
+     * @param Element\ElementInterface $element
      */
     public function cleanAllForElement($element)
     {


### PR DESCRIPTION
Fix following phpstan level 2 errors:
```
  Line   bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.php
  178    Class Pimcore\Model\DataObject\ClassDefinition\Data\Objectbricks referenced with incorrect case: Pimcore\Model\DataObject\ClassDefinition\Data\ObjectBricks.  

  Line   models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
  1050   Class Pimcore\Model\DataObject\ClassDefinition\Data\Multiselect referenced with incorrect case: Pimcore\Model\DataObject\ClassDefinition\Data\MultiSelect.

  Line   models/DataObject/ClassDefinition/Data/Link.php
  409    Class stdClass referenced with incorrect case: stdclass.
  
  Line   models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
  759    Class Pimcore\Model\DataObject\ClassDefinition\Data\Multiselect referenced with incorrect case: Pimcore\Model\DataObject\ClassDefinition\Data\MultiSelect.

  Line   models/DataObject/Service.php
  672    Class stdClass referenced with incorrect case: stdclass.
  
  Line   models/Dependency.php
  79     Interface Pimcore\Model\Element\ElementInterface referenced with incorrect case: Pimcore\Model\Element\ELementInterface.
```