### PR TITLE
[PHPSTAN] Ignore EventDispatcherInterface errors

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -57,3 +57,4 @@ parameters:
         - '/class heidelpayPHP\\(Heidelpay|Resources|Exceptions)/'
         - '/Heidelpay::fetchPayment\(\) has invalid type heidelpayPHP/'
         - '~^Method Doctrine\\DBAL(\\.*)?Connection::query\(\) invoked with \d+ parameters?, 0 required\.\z~'
+        - '~^Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required\.\z~'


### PR DESCRIPTION
Ignores all phpstan level 2 errors with:
```
Method Symfony\Contracts\EventDispatcher\EventDispatcherInterface::dispatch() invoked with 2 parameters, 1 required.
```