### PR TITLE
Adding extended return type declaration

### DIFF
--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -333,7 +333,7 @@ class AbstractObject extends Model\Element\AbstractElement
      * @param string $path
      * @param bool $force
      *
-     * @return static
+     * @return static|null
      */
     public static function getByPath($path, $force = false)
     {


### PR DESCRIPTION
The method returns not just the Object but also null. 
I just added it to this one currently, but it should be added to every single model to satisfy phpstan

## Changes in this pull request  
Resolves errors with phpstan and null comparison on model methods

## Additional info  

Reproduce with:
- phpstan active: we have max level activated
- write something like Object::getByPath('/') === null

this results in:
Strict comparison using === between null and                            
         Pimcore\Model\DataObject\AbstractObject will always evaluate to false.