### PR TITLE
Add configuration for the initial_markings to replace the deprecated …

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Compiler/WorkflowPass.php
+++ b/bundles/CoreBundle/DependencyInjection/Compiler/WorkflowPass.php
@@ -123,7 +123,9 @@ class WorkflowPass implements CompilerPassInterface
                 ]
             );
 
-            if (isset($workflowConfig['initial_place'])) {
+            if (isset($workflowConfig['initial_markings'])) {
+                $definitionDefinition->addArgument($workflowConfig['initial_markings']);
+            } else if (isset($workflowConfig['initial_place'])) {
                 $definitionDefinition->addArgument($workflowConfig['initial_place']);
             }
 

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -1434,6 +1434,7 @@ class Configuration implements ConfigurationInterface
                                     ->info('Will be applied when the current place is empty.')
                                 ->end()
                                 ->arrayNode('initial_markings')
+                                    ->info('Can be used to set the initial places (markings) for a workflow. Note that this option is Symfony 4.3+ only')
                                     ->beforeNormalization()
                                         ->ifString()
                                             ->then(function ($v) {

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -1433,6 +1433,18 @@ class Configuration implements ConfigurationInterface
                                     ->defaultNull()
                                     ->info('Will be applied when the current place is empty.')
                                 ->end()
+                                ->arrayNode('initial_markings')
+                                    ->beforeNormalization()
+                                        ->ifString()
+                                            ->then(function ($v) {
+                                                return [$v];
+                                            })
+                                        ->end()
+                                        ->requiresAtLeastOneElement()
+                                        ->prototype('scalar')
+                                        ->cannotBeEmpty()
+                                    ->end()
+                                ->end()
                                 ->arrayNode('places')
                                     ->prototype('array')
                                         ->children()

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -1431,6 +1431,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                                 ->scalarNode('initial_place')
                                     ->defaultNull()
+                                    ->setDeprecated('The "%node%" option is deprecated. Use "initial_markings" instead.')
                                     ->info('Will be applied when the current place is empty.')
                                 ->end()
                                 ->arrayNode('initial_markings')

--- a/doc/Development_Documentation/07_Workflow_Management/01_Configuration_Details/README.md
+++ b/doc/Development_Documentation/07_Workflow_Management/01_Configuration_Details/README.md
@@ -59,8 +59,12 @@ pimcore:
                 # Define a custom service to handle the logic. Take a look at the Symfony docs for more details.
                 service:              ~
 
-            # Will be applied when the current place is empty.
+            # Will get way over initial_place and adds the possibility to add multiple initial places.
+            initial_markings:     []
+
+            # DEPRECATED: Will be applied when the current place is empty.
             initial_place:        null
+
             places:
 
                 # Example:


### PR DESCRIPTION
…initial_place

<!--
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**

## Changes in this pull request  
Resolves #
The deprecation of initial_places in Symfony's workflow component. Using initial_markings instead while providing backward compatibility.

## Additional info  
None
