### PR TITLE
[Core] Generic Data Object Param Converter

### DIFF
--- a/bundles/CoreBundle/Request/ParamConverter/DataObjectParamConverter.php
+++ b/bundles/CoreBundle/Request/ParamConverter/DataObjectParamConverter.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Request\ParamConverter;
+
+use Pimcore\Model\DataObject\AbstractObject;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class DataObjectParamConverter implements ParamConverterInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws NotFoundHttpException When invalid data object ID given
+     */
+    public function apply(Request $request, ParamConverter $configuration)
+    {
+        $param = $configuration->getName();
+
+        if (!$request->attributes->has($param)) {
+            return false;
+        }
+
+        $value = $request->attributes->get($param);
+
+        if (!$value && $configuration->isOptional()) {
+            $request->attributes->set($param, null);
+
+            return true;
+        }
+
+        $class = $configuration->getClass();
+
+        $object = $class::getById($value);
+        if (!$object) {
+            throw new NotFoundHttpException(sprintf('Invalid data object ID given for parameter "%s".', $param));
+        }
+
+        $request->attributes->set($param, $object);
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(ParamConverter $configuration)
+    {
+        if (null === $configuration->getClass()) {
+            return false;
+        }
+
+        return is_subclass_of($configuration->getClass(), AbstractObject::class);
+    }
+}

--- a/bundles/CoreBundle/Resources/config/services.yml
+++ b/bundles/CoreBundle/Resources/config/services.yml
@@ -196,3 +196,7 @@ services:
     Pimcore\Model\DataObject\QuantityValue\QuantityValueConverterInterface:
         public: true
         class: Pimcore\Model\DataObject\QuantityValue\DefaultConverter
+
+    Pimcore\Bundle\CoreBundle\Request\ParamConverter\DataObjectParamConverter:
+        tags:
+            - { name: request.param_converter, priority: -2, converter: data_object_converter }

--- a/doc/Development_Documentation/02_MVC/04_Routing_and_URLs/02_Custom_Routes.md
+++ b/doc/Development_Documentation/02_MVC/04_Routing_and_URLs/02_Custom_Routes.md
@@ -72,7 +72,7 @@ To use the param converter, simply type hint the argument (Symfony routing examp
     /**
      * @Route("/news/{news}")
      */
-    public function testAction(Request $request, RequestStack $requestStack, DataObject\News $news) {
+    public function testAction(DataObject\News $news) {
         return [
             'news' => $news
         ];

--- a/doc/Development_Documentation/02_MVC/04_Routing_and_URLs/02_Custom_Routes.md
+++ b/doc/Development_Documentation/02_MVC/04_Routing_and_URLs/02_Custom_Routes.md
@@ -62,6 +62,27 @@ class NewsController extends FrontendController
 
 The default variables can be accessed the same way.
 
+## Using Param Converter to convert request ID to Data Object
+Pimcore has a built-in [param converter](https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html)
+for converting data object IDs in the request parameters to actual objects. 
+
+To use the param converter, simply type hint the argument (Symfony routing example): 
+
+```php
+    /**
+     * @Route("/news/{news}")
+     */
+    public function testAction(Request $request, RequestStack $requestStack, DataObject\News $news) {
+        return [
+            'news' => $news
+        ];
+    }
+```
+
+Param converters work with Pimcore Custom Routes as well as with Symfony Routes. 
+Of course you can also configure the param converter using the `@ParamConverter`, for details please have a look at
+the official documentation for [param converters](https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html).
+
 
 ## Building URLs based on Custom Routes
 


### PR DESCRIPTION
Usage: 

```php
    /**
     * @Route("/news/{news}")
     */
    public function testAction(DataObject\News $news) {
        return [
            'news' => $news
        ];
    }
```

For details see docs page. 