### PR TITLE
[Workflows] add option to force a object layout after a transition or global action was performed

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/workflow/transitionPanel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/workflow/transitionPanel.js
@@ -327,6 +327,6 @@ pimcore.workflow.transitionPanel = Class.create({
     },
 
     reloadObject: function() {
-        this.elementEditor.reload({layoutId: false});
+        this.elementEditor.reload({layoutId: this.transitionConfig.objectLayout});
     }
 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/workflow/transitions.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/workflow/transitions.js
@@ -32,7 +32,7 @@ pimcore.workflow.transitions.perform = function (ctype, cid, elementEditor, work
 
                 pimcore.helpers.showNotification(t("workflow_transition_applied_successfully"), transition.label, "success");
 
-                elementEditor.reload({layoutId: false});
+                elementEditor.reload({layoutId: transition.objectLayout});
 
             } else {
                 Ext.MessageBox.alert(data.message, data.reason);

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -1584,6 +1584,7 @@ class Configuration implements ConfigurationInterface
                                                         ->end()
                                                     ->end()
                                                     ->scalarNode('iconClass')->info('Css class to define the icon which will be used in the actions button in the backend.')->end()
+                                                    ->scalarNode('objectLayout')->defaultValue(false)->info('Forces an object layout after the transition was performed.')->end()
 
                                                     ->arrayNode('notificationSettings')
                                                         ->prototype('array')
@@ -1674,6 +1675,7 @@ class Configuration implements ConfigurationInterface
                                         ->children()
                                             ->scalarNode('label')->info('Nice name for the Pimcore backend.')->end()
                                             ->scalarNode('iconClass')->info('Css class to define the icon which will be used in the actions button in the backend.')->end()
+                                            ->scalarNode('objectLayout')->defaultValue(false)->info('Forces an object layout after the global action was performed.')->end()
                                             ->scalarNode('guard')
                                                 ->cannotBeEmpty()
                                                 ->info('An expression to block the action')

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -1584,7 +1584,7 @@ class Configuration implements ConfigurationInterface
                                                         ->end()
                                                     ->end()
                                                     ->scalarNode('iconClass')->info('Css class to define the icon which will be used in the actions button in the backend.')->end()
-                                                    ->scalarNode('objectLayout')->defaultValue(false)->info('Forces an object layout after the transition was performed.')->end()
+                                                    ->scalarNode('objectLayout')->defaultValue(false)->info('Forces an object layout after the transition was performed. This objectLayout setting overrules all objectLayout settings within the places configs.')->end()
 
                                                     ->arrayNode('notificationSettings')
                                                         ->prototype('array')
@@ -1675,7 +1675,7 @@ class Configuration implements ConfigurationInterface
                                         ->children()
                                             ->scalarNode('label')->info('Nice name for the Pimcore backend.')->end()
                                             ->scalarNode('iconClass')->info('Css class to define the icon which will be used in the actions button in the backend.')->end()
-                                            ->scalarNode('objectLayout')->defaultValue(false)->info('Forces an object layout after the global action was performed.')->end()
+                                            ->scalarNode('objectLayout')->defaultValue(false)->info('Forces an object layout after the global action was performed. This objectLayout setting overrules all objectLayout settings within the places configs.')->end()
                                             ->scalarNode('guard')
                                                 ->cannotBeEmpty()
                                                 ->info('An expression to block the action')

--- a/doc/Development_Documentation/07_Workflow_Management/01_Configuration_Details/README.md
+++ b/doc/Development_Documentation/07_Workflow_Management/01_Configuration_Details/README.md
@@ -225,6 +225,7 @@ pimcore:
                         # Css class to define the icon which will be used in the actions button in the backend.
                         iconClass:            ~
                         # Forces an object layout after the transition was performed.
+                        # This objectLayout setting overrules all objectLayout settings within the places configs.
                         objectLayout:            false
                         notificationSettings:
 
@@ -269,6 +270,7 @@ pimcore:
                     iconClass:            ~
                     
                     # Forces an object layout after the global action was performed.
+                    # This objectLayout setting overrules all objectLayout settings within the places configs.
                     objectLayout:         false
 
                     # An expression to block the action

--- a/doc/Development_Documentation/07_Workflow_Management/01_Configuration_Details/README.md
+++ b/doc/Development_Documentation/07_Workflow_Management/01_Configuration_Details/README.md
@@ -224,6 +224,8 @@ pimcore:
 
                         # Css class to define the icon which will be used in the actions button in the backend.
                         iconClass:            ~
+                        # Forces an object layout after the transition was performed.
+                        objectLayout:            false
                         notificationSettings:
 
                             # Prototype
@@ -265,6 +267,9 @@ pimcore:
 
                     # Css class to define the icon which will be used in the actions button in the backend.
                     iconClass:            ~
+                    
+                    # Forces an object layout after the global action was performed.
+                    objectLayout:         false
 
                     # An expression to block the action
                     guard:                ~ # Example: is_fully_authenticated() and has_role('ROLE_JOURNALIST') and subject.getTitle() == 'My first article'

--- a/lib/Workflow/ActionsButtonService.php
+++ b/lib/Workflow/ActionsButtonService.php
@@ -52,6 +52,7 @@ class ActionsButtonService
                 'name' => $transition->getName(),
                 'label' => $transition->getLabel(),
                 'iconCls' => $transition->getIconClass(),
+                'objectLayout' => $transition->getObjectLayout(),
                 'notes' => $notes
             ];
         }
@@ -78,6 +79,7 @@ class ActionsButtonService
                     'name' => $globalAction->getName(),
                     'label' => $globalAction->getLabel(),
                     'iconCls' => $globalAction->getIconClass(),
+                    'objectLayout' => $globalAction->getObjectLayout(),
                     'notes' => $notes
                 ];
             }

--- a/lib/Workflow/EventSubscriber/NotificationSubscriber.php
+++ b/lib/Workflow/EventSubscriber/NotificationSubscriber.php
@@ -101,7 +101,7 @@ class NotificationSubscriber implements EventSubscriberInterface
 
         $notificationSettings = $transition->getNotificationSettings();
         foreach ($notificationSettings as $notificationSetting) {
-            $condition = $notificationSetting['condition'];
+            $condition = $notificationSetting['condition'] ?? null;
 
             if (empty($condition) || $this->expressionService->evaluateExpression($workflow, $subject, $condition)) {
                 $notifyUsers = $notificationSetting['notifyUsers'] ?? [];

--- a/lib/Workflow/GlobalAction.php
+++ b/lib/Workflow/GlobalAction.php
@@ -70,6 +70,14 @@ class GlobalAction implements NotesAwareInterface
     }
 
     /**
+     * @return string|int|false
+     */
+    public function getObjectLayout()
+    {
+        return $this->options['objectLayout'] ?: false;
+    }
+
+    /**
      * @return array
      */
     public function getTos(): array

--- a/lib/Workflow/Notes/NotesAwareTrait.php
+++ b/lib/Workflow/Notes/NotesAwareTrait.php
@@ -42,7 +42,7 @@ trait NotesAwareTrait
 
     public function getNotesCommentSetterFn(): ?string
     {
-        return $this->options['notes']['commentSetterFn'];
+        return $this->options['notes']['commentSetterFn'] ?? null;
     }
 
     public function getNotesType(): string

--- a/lib/Workflow/Transition.php
+++ b/lib/Workflow/Transition.php
@@ -55,6 +55,14 @@ class Transition extends \Symfony\Component\Workflow\Transition implements Notes
         return $this->options['iconClass'] ?? 'pimcore_icon_workflow_action';
     }
 
+    /**
+     * @return string|int|false
+     */
+    public function getObjectLayout()
+    {
+        return $this->options['objectLayout'] ?: false;
+    }
+
     public function getChangePublishedState(): string
     {
         return (string) $this->options['changePublishedState'];


### PR DESCRIPTION
This PR adds a option for transitions and global layouts to force a object layout after the transition/action was performed via the actions button.

Additionally some PHP notices are fixed.