### PR TITLE
Fix deprecated (PHP 7.4) parameter order of implode()

### DIFF
--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRangeSelection.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRangeSelection.php
@@ -59,7 +59,7 @@ class NumberRangeSelection extends \Pimcore\Bundle\EcommerceFrameworkBundle\Filt
 
         $currentValue = '';
         if ($currentFilter[$filterDefinition->getField()]['from'] || $currentFilter[$filterDefinition->getField()]['to']) {
-            $currentValue = implode($currentFilter[$filterDefinition->getField()], '-');
+            $currentValue = implode('-', $currentFilter[$filterDefinition->getField()]);
         }
 
         return $this->render($this->getTemplate($filterDefinition), [

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRangeSelection.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRangeSelection.php
@@ -55,7 +55,7 @@ class NumberRangeSelection extends AbstractFilterType
 
         $currentValue = '';
         if ($currentFilter[$field]['from'] || $currentFilter[$field]['to']) {
-            $currentValue = implode($currentFilter[$field], '-');
+            $currentValue = implode('-', $currentFilter[$field]);
         }
 
         return $this->render($this->getTemplate($filterDefinition), [

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractWorker.php
@@ -153,7 +153,7 @@ abstract class AbstractWorker implements WorkerInterface
     protected function convertArray($data)
     {
         if (is_array($data)) {
-            return WorkerInterface::MULTISELECT_DELIMITER . implode($data, WorkerInterface::MULTISELECT_DELIMITER) . WorkerInterface::MULTISELECT_DELIMITER;
+            return WorkerInterface::MULTISELECT_DELIMITER . implode(WorkerInterface::MULTISELECT_DELIMITER, $data) . WorkerInterface::MULTISELECT_DELIMITER;
         }
 
         return $data;


### PR DESCRIPTION
## Changes in this pull request  
Fixes the parameter order of `implode()` that has been [deprecated in PHP 7.4](https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.implode-reverse-parameters).