### PR TITLE
[PHPSTAN] Fill empty php doc param types (bundles)

### DIFF
--- a/bundles/AdminBundle/Controller/Rest/AbstractRestController.php
+++ b/bundles/AdminBundle/Controller/Rest/AbstractRestController.php
@@ -209,7 +209,7 @@ abstract class AbstractRestController extends AdminController
      * Get ID either as parameter or from request
      *
      * @param Request $request
-     * @param null    $id
+     * @param int|null $id
      *
      * @return mixed|null
      *

--- a/bundles/CoreBundle/Command/Definition/Import/CustomLayoutCommand.php
+++ b/bundles/CoreBundle/Command/Definition/Import/CustomLayoutCommand.php
@@ -97,8 +97,8 @@ class CustomLayoutCommand extends AbstractStructureImportCommand
     }
 
     /**
-     * @param null|AbstractModel|CustomLayout $customLayout
-     * @param null                            $json
+     * @param AbstractModel|CustomLayout|null $customLayout
+     * @param string|null $json
      *
      * @return bool
      */

--- a/bundles/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
@@ -92,7 +92,7 @@ class FullPageCacheListener
     }
 
     /**
-     * @param null $reason
+     * @param string|null $reason
      *
      * @return bool
      */

--- a/bundles/CoreBundle/Resources/migrations/Version20181115114003.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20181115114003.php
@@ -88,7 +88,7 @@ class Version20181115114003 extends AbstractPimcoreMigration
     }
 
     /**
-     * @param null $name
+     * @param string $layoutId
      *
      * @return string
      */

--- a/bundles/EcommerceFrameworkBundle/AvailabilitySystem/Availability.php
+++ b/bundles/EcommerceFrameworkBundle/AvailabilitySystem/Availability.php
@@ -32,6 +32,7 @@ class Availability implements AvailabilityInterface
     private $available;
 
     /**
+     * @param CheckoutableInterface $product
      * @param bool $available
      */
     public function __construct(CheckoutableInterface $product, bool $available)

--- a/bundles/EcommerceFrameworkBundle/AvailabilitySystem/AvailabilitySystemInterface.php
+++ b/bundles/EcommerceFrameworkBundle/AvailabilitySystem/AvailabilitySystemInterface.php
@@ -23,7 +23,7 @@ interface AvailabilitySystemInterface
      *
      * @param CheckoutableInterface $product
      * @param int $quantityScale
-     * @param null $products
+     * @param array|null $products
      *
      * @return AvailabilityInterface
      */

--- a/bundles/EcommerceFrameworkBundle/CartManager/AbstractCart.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/AbstractCart.php
@@ -212,12 +212,12 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
 
     /**
      * @param CheckoutableInterface $product
-     * @param $count
-     * @param null $itemKey
+     * @param int $count
+     * @param string|null $itemKey
      * @param bool $replace
      * @param array $params
      * @param AbstractSetProductEntry[] $subProducts
-     * @param null $comment
+     * @param string|null $comment
      *
      * @return mixed
      */
@@ -237,15 +237,15 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
     }
 
     /**
-     * @param $itemKey
+     * @param string $itemKey
      * @param CheckoutableInterface $product
-     * @param $count
+     * @param int $count
      * @param bool $replace
      * @param array $params
      * @param AbstractSetProductEntry[] $subProducts
-     * @param null $comment
+     * @param string|null $comment
      *
-     * @return mixed
+     * @return string
      */
     public function updateItem($itemKey, CheckoutableInterface $product, $count, $replace = false, $params = [], $subProducts = [], $comment = null)
     {
@@ -322,12 +322,12 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
 
     /**
      * @param CheckoutableInterface $product
-     * @param int                                  $count
-     * @param null                                 $itemKey
-     * @param bool                                 $replace
-     * @param array                                $params
-     * @param array                                $subProducts
-     * @param null                                 $comment
+     * @param int $count
+     * @param string|null $itemKey
+     * @param bool $replace
+     * @param array $params
+     * @param array $subProducts
+     * @param string|null $comment
      *
      * @return string
      */
@@ -347,13 +347,13 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
     }
 
     /**
-     * @param string                               $itemKey
+     * @param string $itemKey
      * @param CheckoutableInterface $product
-     * @param int                                  $count
-     * @param bool                                 $replace
-     * @param array                                $params
-     * @param array                                $subProducts
-     * @param null                                 $comment
+     * @param int $count
+     * @param bool $replace
+     * @param array $params
+     * @param array $subProducts
+     * @param string|null $comment
      *
      * @return string
      */
@@ -612,7 +612,7 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
     }
 
     /**
-     * @param $id
+     * @param int $id
      */
     public function setId($id)
     {
@@ -620,7 +620,7 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getId()
     {
@@ -656,7 +656,7 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
     }
 
     /**
-     * @param $creationDateTimestamp
+     * @param int $creationDateTimestamp
      */
     public function setCreationDateTimestamp($creationDateTimestamp)
     {
@@ -703,7 +703,7 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
     }
 
     /**
-     * @param $modificationDateTimestamp
+     * @param int $modificationDateTimestamp
      */
     public function setModificationDateTimestamp($modificationDateTimestamp)
     {
@@ -748,7 +748,7 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
     abstract public function delete();
 
     /**
-     * @param  $key string
+     * @param string $key
      *
      * @return string
      */
@@ -763,10 +763,8 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
     }
 
     /**
-     * @param  $key string
-     * @param  $data string
-     *
-     * @return void
+     * @param string $key
+     * @param string $data
      */
     public function setCheckoutData($key, $data)
     {
@@ -842,7 +840,7 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
     /**
      * sorts all items in cart according to a given callback function
      *
-     * @param $value_compare_func
+     * @param callable $value_compare_func
      *
      * @return CartItemInterface[]
      */
@@ -883,7 +881,7 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
     /**
      * Checks if an error code is a defined Voucher Error Code.
      *
-     * @param $errorCode
+     * @param int $errorCode
      *
      * @return bool
      */

--- a/bundles/EcommerceFrameworkBundle/CartManager/AbstractCartItem.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/AbstractCartItem.php
@@ -35,10 +35,22 @@ abstract class AbstractCartItem extends \Pimcore\Model\AbstractModel implements 
      * @var CheckoutableInterface
      */
     protected $product;
-    protected $productId = null;
+
+    /**
+     * @var int
+     */
+    protected $productId;
+
+    /**
+     * @var string
+     */
     protected $itemKey;
     protected $count;
     protected $comment;
+
+    /**
+     * @var string
+     */
     protected $parentItemKey = '';
 
     protected $subItems = null;
@@ -113,7 +125,7 @@ abstract class AbstractCartItem extends \Pimcore\Model\AbstractModel implements 
     abstract public function getCart();
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getCartId()
     {
@@ -121,7 +133,7 @@ abstract class AbstractCartItem extends \Pimcore\Model\AbstractModel implements 
     }
 
     /**
-     * @param $cartId
+     * @param int $cartId
      */
     public function setCartId($cartId)
     {
@@ -141,7 +153,7 @@ abstract class AbstractCartItem extends \Pimcore\Model\AbstractModel implements 
     }
 
     /**
-     * @param $productId
+     * @param int $productId
      */
     public function setProductId($productId)
     {
@@ -153,7 +165,7 @@ abstract class AbstractCartItem extends \Pimcore\Model\AbstractModel implements 
     }
 
     /**
-     * @param $parentItemKey
+     * @param string $parentItemKey
      */
     public function setParentItemKey($parentItemKey)
     {
@@ -169,7 +181,7 @@ abstract class AbstractCartItem extends \Pimcore\Model\AbstractModel implements 
     }
 
     /**
-     * @param $itemKey
+     * @param string $itemKey
      */
     public function setItemKey($itemKey)
     {
@@ -177,7 +189,7 @@ abstract class AbstractCartItem extends \Pimcore\Model\AbstractModel implements 
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getItemKey()
     {

--- a/bundles/EcommerceFrameworkBundle/CartManager/CartInterface.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/CartInterface.php
@@ -29,9 +29,7 @@ interface CartInterface
     public function getId();
 
     /**
-     * @param $id int
-     *
-     * @return void
+     * @param int $id
      */
     public function setId($id);
 
@@ -78,11 +76,11 @@ interface CartInterface
     /**
      * @param CheckoutableInterface $product
      * @param int $count
-     * @param null $itemKey
+     * @param string|null $itemKey
      * @param bool $replace replace if item with same key exists
      * @param array $params optional additional item information
      * @param AbstractSetProductEntry[] $subProducts
-     * @param string $comment
+     * @param string|null $comment
      *
      * @return string $itemKey
      */
@@ -95,7 +93,7 @@ interface CartInterface
      * @param bool $replace replace if item with same key exists
      * @param array $params optional additional item information
      * @param array $subProducts
-     * @param null $comment
+     * @param string|null $comment
      *
      * @return string $itemKey
      */
@@ -104,8 +102,8 @@ interface CartInterface
     /**
      * updates count of specific cart item
      *
-     * @param $itemKey
-     * @param $count
+     * @param string $itemKey
+     * @param int $count
      *
      * @return mixed
      */
@@ -114,11 +112,11 @@ interface CartInterface
     /**
      * @param CheckoutableInterface $product
      * @param int $count
-     * @param null $itemKey
+     * @param string|null $itemKey
      * @param bool $replace replace if item with same key exists
      * @param array $params optional additional item information
      * @param AbstractSetProductEntry[] $subProducts
-     * @param string $comment
+     * @param string|null $comment
      *
      * @return string $itemKey
      */
@@ -131,7 +129,7 @@ interface CartInterface
      * @param bool $replace replace if item with same key exists
      * @param array $params optional additional item information
      * @param array $subProducts
-     * @param null $comment
+     * @param string|null $comment
      *
      * @return string $itemKey
      */
@@ -196,17 +194,15 @@ interface CartInterface
      * Set custom checkout data for cart.
      * can be used for delivery information, ...
      *
-     * @param  $key string
-     * @param  $data string
-     *
-     * @return void
+     * @param string $key
+     * @param string $data
      */
     public function setCheckoutData($key, $data);
 
     /**
      * Get custom checkout data for cart with given key.
      *
-     * @param  $key string
+     * @param string $key
      *
      * @return string
      */
@@ -222,7 +218,7 @@ interface CartInterface
     /**
      * set name of cart.
      *
-     * @param $name
+     * @param string $name
      *
      * @return void
      */
@@ -286,7 +282,7 @@ interface CartInterface
     /**
      * @static
      *
-     * @param $id
+     * @param int $id
      *
      * @return CartInterface
      */
@@ -297,7 +293,7 @@ interface CartInterface
      *
      * @static
      *
-     * @param $userId
+     * @param int $userId
      *
      * @return CartInterface[]
      */

--- a/bundles/EcommerceFrameworkBundle/CartManager/CartItemInterface.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/CartItemInterface.php
@@ -118,8 +118,8 @@ interface CartItemInterface
     /**
      * @static
      *
-     * @param $cartId
-     * @param $itemKey
+     * @param int $cartId
+     * @param string $itemKey
      * @param string $parentKey
      *
      * @return CartItemInterface
@@ -129,9 +129,7 @@ interface CartItemInterface
     /**
      * @static
      *
-     * @param $cartId
-     *
-     * @return void
+     * @param int $cartId
      */
     public static function removeAllFromCart($cartId);
 

--- a/bundles/EcommerceFrameworkBundle/CartManager/MultiCartManager.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/MultiCartManager.php
@@ -133,12 +133,12 @@ class MultiCartManager implements CartManagerInterface
     /**
      * @param CheckoutableInterface $product
      * @param float $count
-     * @param null $key
-     * @param null $itemKey
+     * @param string|null $key
+     * @param string|null $itemKey
      * @param bool $replace
      * @param array $params
      * @param array $subProducts
-     * @param null $comment
+     * @param string|null $comment
      *
      * @return null|string
      *
@@ -181,7 +181,7 @@ class MultiCartManager implements CartManagerInterface
     }
 
     /**
-     * @param null $key
+     * @param string|null $key
      */
     public function deleteCart($key = null)
     {
@@ -221,7 +221,7 @@ class MultiCartManager implements CartManagerInterface
     }
 
     /**
-     * @param null $key
+     * @param string|null $key
      *
      * @throws InvalidConfigException
      */
@@ -240,7 +240,7 @@ class MultiCartManager implements CartManagerInterface
     }
 
     /**
-     * @param null $key
+     * @param string|null $key
      *
      * @return CartInterface
      *
@@ -308,7 +308,7 @@ class MultiCartManager implements CartManagerInterface
 
     /**
      * @param string $itemKey
-     * @param null $key
+     * @param string|null $key
      *
      * @throws InvalidConfigException
      */

--- a/bundles/EcommerceFrameworkBundle/CheckoutManager/CheckoutManager.php
+++ b/bundles/EcommerceFrameworkBundle/CheckoutManager/CheckoutManager.php
@@ -109,8 +109,8 @@ class CheckoutManager implements CheckoutManagerInterface
      * @param OrderManagerLocatorInterface $orderManagers
      * @param CommitOrderProcessorLocatorInterface $commitOrderProcessors
      * @param array $checkoutSteps
+     * @param EventDispatcherInterface $eventDispatcher
      * @param PaymentInterface|null $paymentProvider
-     * @param EventDispatcherInterface|null $eventDispatcher
      */
     public function __construct(
         CartInterface $cart,

--- a/bundles/EcommerceFrameworkBundle/CheckoutManager/CheckoutManagerInterface.php
+++ b/bundles/EcommerceFrameworkBundle/CheckoutManager/CheckoutManagerInterface.php
@@ -137,7 +137,7 @@ interface CheckoutManagerInterface
      *
      * Delegates to commit order processor
      *
-     * @param $paymentResponseParams
+     * @param array|StatusInterface $paymentResponseParams
      *
      * @return AbstractOrder
      */

--- a/bundles/EcommerceFrameworkBundle/CheckoutManager/CheckoutStepInterface.php
+++ b/bundles/EcommerceFrameworkBundle/CheckoutManager/CheckoutStepInterface.php
@@ -40,7 +40,7 @@ interface CheckoutStepInterface
     /**
      * Sets delivered data and commits step
      *
-     * @param $data
+     * @param mixed $data
      *
      * @return bool
      */

--- a/bundles/EcommerceFrameworkBundle/CheckoutManager/CommitOrderProcessor.php
+++ b/bundles/EcommerceFrameworkBundle/CheckoutManager/CommitOrderProcessor.php
@@ -90,7 +90,7 @@ class CommitOrderProcessor implements CommitOrderProcessorInterface
     protected $lastPaymentStatus = null;
 
     /**
-     * @param $paymentResponseParams
+     * @param array|StatusInterface $paymentResponseParams
      * @param PaymentInterface $paymentProvider
      *
      * @return Status|StatusInterface

--- a/bundles/EcommerceFrameworkBundle/CheckoutManager/CommitOrderProcessorInterface.php
+++ b/bundles/EcommerceFrameworkBundle/CheckoutManager/CommitOrderProcessorInterface.php
@@ -42,7 +42,7 @@ interface CommitOrderProcessorInterface
      *
      * Can be used by controllers to commit orders with payment
      *
-     * @param $paymentResponseParams
+     * @param array|StatusInterface $paymentResponseParams
      * @param PaymentInterface $paymentProvider
      *
      * @return AbstractOrder

--- a/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelection.php
+++ b/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelection.php
@@ -289,9 +289,9 @@ class IndexFieldSelection extends Data implements ResourcePersistenceAwareInterf
      *
      * @param string $importValue
      * @param null|\Pimcore\Model\DataObject\AbstractObject $object
-     * @param mixed $params
+     * @param array $params
      *
-     * @return ObjectData\IndexFieldSelection
+     * @return ObjectData\IndexFieldSelection|null
      */
     public function getFromCsvImport($importValue, $object = null, $params = [])
     {
@@ -309,7 +309,7 @@ class IndexFieldSelection extends Data implements ResourcePersistenceAwareInterf
     /**
      * converts data to be exposed via webservices
      *
-     * @param string $object
+     * @param \Pimcore\Model\DataObject\AbstractObject $object
      * @param mixed $params
      *
      * @return mixed
@@ -343,9 +343,11 @@ class IndexFieldSelection extends Data implements ResourcePersistenceAwareInterf
      *
      * @deprecated
      * @param mixed $value
-     * @param mixed $relatedObject
+     * @param \Pimcore\Model\DataObject\AbstractObject|null $relatedObject
      * @param mixed $params
      * @param \Pimcore\Model\Webservice\IdMapperInterface|null $idMapper
+     *
+     * @throws \Exception
      *
      * @return mixed
      */
@@ -360,8 +362,10 @@ class IndexFieldSelection extends Data implements ResourcePersistenceAwareInterf
         }
     }
 
-    /** True if change is allowed in edit mode.
-     * @param string $object
+    /**
+     * True if change is allowed in edit mode.
+     *
+     * @param \Pimcore\Model\DataObject\AbstractObject $object
      * @param mixed $params
      *
      * @return bool

--- a/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionField.php
+++ b/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionField.php
@@ -60,7 +60,7 @@ class IndexFieldSelectionField extends Textarea
     }
 
     /**
-     * @param $data
+     * @param mixed $data
      *
      * @return bool
      */

--- a/bundles/EcommerceFrameworkBundle/CoreExtensions/ObjectData/IndexFieldSelection.php
+++ b/bundles/EcommerceFrameworkBundle/CoreExtensions/ObjectData/IndexFieldSelection.php
@@ -32,9 +32,9 @@ class IndexFieldSelection
     public $preSelect;
 
     /**
-     * @param $field
-     * @param $preSelect
-     * @param $tenant
+     * @param string $tenant
+     * @param string $field
+     * @param string|string[] $preSelect
      */
     public function __construct($tenant, $field, $preSelect)
     {

--- a/bundles/EcommerceFrameworkBundle/Environment.php
+++ b/bundles/EcommerceFrameworkBundle/Environment.php
@@ -281,7 +281,7 @@ class Environment implements EnvironmentInterface
     /**
      * sets current assortment tenant which is used for indexing and product lists
      *
-     * @param $tenant string
+     * @param string $tenant
      */
     public function setCurrentAssortmentTenant($tenant)
     {
@@ -305,7 +305,7 @@ class Environment implements EnvironmentInterface
     /**
      * sets current assortment sub tenant which is used for indexing and product lists
      *
-     * @param $subTenant mixed
+     * @param mixed $subTenant
      *
      * @return mixed
      */

--- a/bundles/EcommerceFrameworkBundle/EnvironmentInterface.php
+++ b/bundles/EcommerceFrameworkBundle/EnvironmentInterface.php
@@ -48,8 +48,8 @@ interface EnvironmentInterface extends ComponentInterface
      * Sets custom item to environment - which is saved to the session then
      * save()-call is needed to save the custom items
      *
-     * @param $key
-     * @param $value
+     * @param string $key
+     * @param mixed $value
      */
     public function setCustomItem($key, $value);
 
@@ -57,15 +57,15 @@ interface EnvironmentInterface extends ComponentInterface
      * Removes custom item from the environment
      * save()-call is needed to save the custom items
      *
-     * @param $key
+     * @param string $key
      */
     public function removeCustomItem($key);
 
     /**
      * Returns custom saved item from environment
      *
-     * @param $key
-     * @param $defaultValue
+     * @param string $key
+     * @param mixed $defaultValue
      *
      * @return mixed
      */

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterGroupHelper.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterGroupHelper.php
@@ -36,7 +36,7 @@ class FilterGroupHelper
      *
      * might be overwritten, if new column groups are necessary
      *
-     * @param $columnGroup
+     * @param string $columnGroup
      *
      * @return string
      */
@@ -48,7 +48,7 @@ class FilterGroupHelper
     /**
      * returns all possible group by values for given column group, product list and field combination
      *
-     * @param $columnGroup
+     * @param string $columnGroup
      * @param ProductListInterface $productList
      * @param string $field
      *

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterService.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterService.php
@@ -104,9 +104,8 @@ class FilterService
      * Returns filter frontend script for given filter type (delegates )
      *
      * @param AbstractFilterDefinitionType $filterDefinition filter definition to get frontend script for
-     * @param ProductListInterface $productList                      current product list (with all set filters) to get
-     *                                                       available options and counts
-     * @param $currentFilter                                 array current filter for this filter definition
+     * @param ProductListInterface $productList current product list (with all set filters) to get available options and counts
+     * @param array $currentFilter current filter for this filter definition
      *
      * @return string view snippet
      */
@@ -122,8 +121,8 @@ class FilterService
      *
      * @param AbstractFilterDefinitionType $filterDefinition
      * @param ProductListInterface $productList
-     * @param $currentFilter
-     * @param $params
+     * @param array $currentFilter
+     * @param array $params
      * @param bool $isPrecondition
      *
      * @return array updated currentFilter array

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/AbstractFilterType.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/AbstractFilterType.php
@@ -47,7 +47,7 @@ abstract class AbstractFilterType
     protected $request;
 
     /**
-     * @param $translator TranslatorInterface
+     * @param TranslatorInterface $translator
      * @param EngineInterface $templatingEngine
      * @param string $template for rendering the filter frontend
      * @param array $options for additional options
@@ -112,7 +112,7 @@ abstract class AbstractFilterType
      *
      * @param AbstractFilterDefinitionType $filterDefinition
      * @param ProductListInterface $productList
-     * @param $currentFilter
+     * @param array $currentFilter
      *
      * @return string
      */
@@ -125,8 +125,8 @@ abstract class AbstractFilterType
      *
      * @param AbstractFilterDefinitionType $filterDefinition
      * @param ProductListInterface $productList
-     * @param $currentFilter
-     * @param $params
+     * @param array $currentFilter
+     * @param array $params
      * @param bool $isPrecondition
      *
      * @return array

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/MultiSelectFromMultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/MultiSelectFromMultiSelect.php
@@ -28,10 +28,10 @@ class MultiSelectFromMultiSelect extends \Pimcore\Bundle\EcommerceFrameworkBundl
 
     /**
      * @param AbstractFilterDefinitionType $filterDefinition
-     * @param ProductListInterface                  $productList
-     * @param array                                             $currentFilter
-     * @param                                                   $params
-     * @param bool                                              $isPrecondition
+     * @param ProductListInterface $productList
+     * @param array $currentFilter
+     * @param array $params
+     * @param bool $isPrecondition
      *
      * @return string[]
      */

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/FactFinder/NumberRange.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/FactFinder/NumberRange.php
@@ -29,10 +29,10 @@ class NumberRange extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService
 
     /**
      * @param AbstractFilterDefinitionType $filterDefinition
-     * @param ProductListInterface                 $productList
-     * @param                                                   $currentFilter
-     * @param                                                   $params
-     * @param bool                                              $isPrecondition
+     * @param ProductListInterface $productList
+     * @param array $currentFilter
+     * @param array $params
+     * @param bool $isPrecondition
      *
      * @return mixed
      */

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectFromMultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectFromMultiSelect.php
@@ -22,8 +22,8 @@ class MultiSelectFromMultiSelect extends \Pimcore\Bundle\EcommerceFrameworkBundl
 {
     /**
      * @param AbstractFilterDefinitionType $filterDefinition
-     * @param ProductListInterface                  $productList
-     * @param                                                   $currentFilter
+     * @param ProductListInterface $productList
+     * @param array $currentFilter
      *
      * @return string
      */
@@ -59,10 +59,10 @@ class MultiSelectFromMultiSelect extends \Pimcore\Bundle\EcommerceFrameworkBundl
 
     /**
      * @param AbstractFilterDefinitionType $filterDefinition
-     * @param ProductListInterface                  $productList
-     * @param array                                             $currentFilter
-     * @param                                                   $params
-     * @param bool                                              $isPrecondition
+     * @param ProductListInterface $productList
+     * @param array $currentFilter
+     * @param array $params
+     * @param bool $isPrecondition
      *
      * @return string[]
      */

--- a/bundles/EcommerceFrameworkBundle/FilterService/Helper.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/Helper.php
@@ -27,7 +27,7 @@ class Helper
     /**
      * @param \Pimcore\Model\DataObject\FilterDefinition $filterDefinition
      * @param ProductListInterface $productList
-     * @param $params
+     * @param array $params
      * @param ViewModel $viewModel
      * @param FilterService $filterService
      * @param bool $loadFullPage
@@ -139,7 +139,7 @@ class Helper
     }
 
     /**
-     * @param $page
+     * @param int $page
      *
      * @return string
      */
@@ -164,7 +164,7 @@ class Helper
     }
 
     /**
-     * @param $conditions
+     * @param array $conditions
      *
      * @return AbstractCategory
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/AbstractConfig.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/AbstractConfig.php
@@ -274,7 +274,7 @@ abstract class AbstractConfig implements ConfigInterface
 
     /**
      * @param IndexableInterface $object
-     * @param null $subObjectId
+     * @param int|null $subObjectId
      *
      * @return AbstractCategory[]
      */
@@ -314,7 +314,7 @@ abstract class AbstractConfig implements ConfigInterface
      * default is getOSParentId
      *
      * @param IndexableInterface $object
-     * @param $subId
+     * @param int $subId
      *
      * @return mixed
      */
@@ -327,8 +327,8 @@ abstract class AbstractConfig implements ConfigInterface
      * Gets object by id, can consider subIds and therefore return e.g. an array of values
      * always returns object itself - see also getObjectMockupById
      *
-     * @param $objectId
-     * @param $onlyMainObject - only returns main object
+     * @param int $objectId
+     * @param bool $onlyMainObject - only returns main object
      *
      * @return mixed
      */
@@ -341,9 +341,9 @@ abstract class AbstractConfig implements ConfigInterface
      * Gets object mockup by id, can consider subIds and therefore return e.g. an array of values
      * always returns a object mockup if available
      *
-     * @param $objectId
+     * @param int $objectId
      *
-     * @return IndexableInterface | array
+     * @return IndexableInterface|array
      */
     public function getObjectMockupById($objectId)
     {
@@ -353,7 +353,7 @@ abstract class AbstractConfig implements ConfigInterface
     /**
      * returns column type for id
      *
-     * @param $isPrimary
+     * @param bool $isPrimary
      *
      * @return string
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/ConfigInterface.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/ConfigInterface.php
@@ -74,7 +74,7 @@ interface ConfigInterface
      * Possible hook to filter categories for specific tenants.
      *
      * @param IndexableInterface $object
-     * @param null $subObjectId
+     * @param int|null $subObjectId
      *
      * @return \Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractCategory[]
      */
@@ -84,7 +84,7 @@ interface ConfigInterface
      * in case of subtenants returns a data structure containing all sub tenants
      *
      * @param IndexableInterface $object
-     * @param null $subObjectId
+     * @param int|null $subObjectId
      *
      * @return mixed $subTenantData
      */
@@ -145,7 +145,7 @@ interface ConfigInterface
      * default is getOSParentId
      *
      * @param IndexableInterface $object
-     * @param $subId
+     * @param int $subId
      *
      * @return mixed
      */
@@ -155,8 +155,8 @@ interface ConfigInterface
      * Gets object by id, can consider subIds and therefore return e.g. an array of values
      * always returns object itself - see also getObjectMockupById
      *
-     * @param $objectId
-     * @param $onlyMainObject - only returns main object
+     * @param int $objectId
+     * @param bool $onlyMainObject - only returns main object
      *
      * @return mixed
      */
@@ -166,7 +166,7 @@ interface ConfigInterface
      * Gets object mockup by id, can consider subIds and therefore return e.g. an array of values
      * always returns a object mockup if available
      *
-     * @param $objectId
+     * @param int $objectId
      *
      * @return IndexableInterface | array
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultElasticSearchSubTenantConfig.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultElasticSearchSubTenantConfig.php
@@ -42,7 +42,7 @@ class DefaultElasticSearchSubTenantConfig extends ElasticSearch
      * This method extracts assigned tenants and returns an array of subtenant-IDs
      *
      * @param IndexableInterface $object
-     * @param null $subObjectId
+     * @param int|null $subObjectId
      *
      * @return array $subTenantData
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultFactFinder.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultFactFinder.php
@@ -81,7 +81,7 @@ class DefaultFactFinder extends AbstractConfig implements FactFinderConfigInterf
      * in case of subtenants returns a data structure containing all sub tenants
      *
      * @param IndexableInterface $object
-     * @param null                                              $subObjectId
+     * @param int|null $subObjectId
      *
      * @return mixed $subTenantData
      */
@@ -130,9 +130,9 @@ class DefaultFactFinder extends AbstractConfig implements FactFinderConfigInterf
     /**
      * creates object mockup for given data
      *
-     * @param $objectId
-     * @param $data
-     * @param $relations
+     * @param int $objectId
+     * @param mixed $data
+     * @param array $relations
      *
      * @return mixed
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultFindologic.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultFindologic.php
@@ -81,7 +81,7 @@ class DefaultFindologic extends AbstractConfig implements FindologicConfigInterf
      * in case of subtenants returns a data structure containing all sub tenants
      *
      * @param IndexableInterface $object
-     * @param null                                              $subObjectId
+     * @param int|null $subObjectId
      *
      * @return mixed $subTenantData
      */
@@ -130,9 +130,9 @@ class DefaultFindologic extends AbstractConfig implements FindologicConfigInterf
     /**
      * creates object mockup for given data
      *
-     * @param $objectId
-     * @param $data
-     * @param $relations
+     * @param int $objectId
+     * @param mixed $data
+     * @param array $relations
      *
      * @return mixed
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultMysql.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultMysql.php
@@ -79,7 +79,7 @@ class DefaultMysql extends AbstractConfig implements MysqlConfigInterface
      * in case of subtenants returns a data structure containing all sub tenants
      *
      * @param IndexableInterface $object
-     * @param null $subObjectId
+     * @param int|null $subObjectId
      *
      * @return mixed $subTenantData
      */
@@ -105,7 +105,7 @@ class DefaultMysql extends AbstractConfig implements MysqlConfigInterface
     /**
      * returns column type for id
      *
-     * @param $isPrimary
+     * @param bool $isPrimary
      *
      * @return string
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultMysqlSubTenantConfig.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultMysqlSubTenantConfig.php
@@ -139,7 +139,7 @@ class DefaultMysqlSubTenantConfig extends DefaultMysql
      * This method extracts assigned tenants and returns an array of [object-ID, subtenant-ID]
      *
      * @param IndexableInterface $object
-     * @param null $subObjectId
+     * @param int|null $subObjectId
      *
      * @return mixed $subTenantData
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/Definition/Attribute.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/Definition/Attribute.php
@@ -194,7 +194,7 @@ class Attribute
      * Get value from object, running through getter if defined
      *
      * @param IndexableInterface $object
-     * @param null $subObjectId
+     * @param int|null $subObjectId
      * @param ConfigInterface|null $tenantConfig
      * @param mixed $default
      *

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
@@ -143,7 +143,7 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
     }
 
     /**
-     * @param $fieldName
+     * @param string $fieldName
      *
      * @return array
      */
@@ -166,8 +166,8 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
     /**
      * returns the full field name
      *
-     * @param $fieldName
-     * @param $considerSubFieldNames - activate to consider subfield names like name.analyzed or score definitions like name^3
+     * @param string $fieldName
+     * @param bool $considerSubFieldNames - activate to consider subfield names like name.analyzed or score definitions like name^3
      *
      * @return string
      */
@@ -194,7 +194,7 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
      * returns short field name based on full field name
      * also considers subfield names like name.analyzed etc.
      *
-     * @param $fullFieldName
+     * @param string $fullFieldName
      *
      * @return false|int|string
      */
@@ -271,7 +271,7 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
      * in case of subtenants returns a data structure containing all sub tenants
      *
      * @param IndexableInterface $object
-     * @param null $subObjectId
+     * @param int|null $subObjectId
      *
      * @return array $subTenantData
      */
@@ -327,9 +327,9 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
     /**
      * creates object mockup for given data
      *
-     * @param $objectId
-     * @param $data
-     * @param $relations
+     * @param int $objectId
+     * @param mixed $data
+     * @param array $relations
      *
      * @return mixed
      */
@@ -342,7 +342,7 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
      * Gets object mockup by id, can consider subIds and therefore return e.g. an array of values
      * always returns a object mockup if available
      *
-     * @param $objectId
+     * @param int $objectId
      *
      * @return IndexableInterface | array
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/MockupConfigInterface.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/MockupConfigInterface.php
@@ -22,9 +22,9 @@ interface MockupConfigInterface
     /**
      * creates object mockup for given data
      *
-     * @param $objectId
-     * @param $data
-     * @param $relations
+     * @param int $objectId
+     * @param mixed $data
+     * @param array $relations
      *
      * @return mixed
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/MysqlConfigInterface.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/MysqlConfigInterface.php
@@ -57,7 +57,7 @@ interface MysqlConfigInterface extends ConfigInterface
     /**
      * returns column type for id
      *
-     * @param $isPrimary
+     * @param bool $isPrimary
      *
      * @return string
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/OptimizedMysql.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/OptimizedMysql.php
@@ -28,9 +28,9 @@ class OptimizedMysql extends DefaultMysql implements MockupConfigInterface
     /**
      * creates object mockup for given data
      *
-     * @param $objectId
-     * @param $data
-     * @param $relations
+     * @param int $objectId
+     * @param mixed $data
+     * @param array $relations
      *
      * @return DefaultMockup
      */
@@ -43,7 +43,7 @@ class OptimizedMysql extends DefaultMysql implements MockupConfigInterface
      * Gets object mockup by id, can consider subIds and therefore return e.g. an array of values
      * always returns a object mockup if available
      *
-     * @param $objectId
+     * @param int $objectId
      *
      * @return IndexableInterface | array
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Getter/DefaultClassificationAttributeGetter.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Getter/DefaultClassificationAttributeGetter.php
@@ -17,8 +17,8 @@ class DefaultClassificationAttributeGetter implements GetterInterface
      * ** fieldname - name of the field upon which the classification store is saved on the specific object [defaults to attributes]
      * note that this getter does not support localization at the moment
      *
-     * @param $object
-     * @param null $config
+     * @param object $object
+     * @param array|null $config
      *
      * @return mixed
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/IndexService.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/IndexService.php
@@ -186,7 +186,7 @@ class IndexService
      * Returns all index attributes
      *
      * @param bool $considerHideInFieldList
-     * @param string $tenant
+     * @param string|null $tenant
      *
      * @return array
      *
@@ -207,7 +207,7 @@ class IndexService
      * @deprecated
      *
      * @param bool $considerHideInFieldList
-     * @param null $tenant
+     * @param string|null $tenant
      *
      * @return mixed
      *
@@ -241,8 +241,8 @@ class IndexService
     /**
      * Returns all index attributes for a given filter group
      *
-     * @param $filterType
-     * @param string $tenant
+     * @param string $filterType
+     * @param string|null $tenant
      *
      * @return array
      *
@@ -262,8 +262,8 @@ class IndexService
     /**
      * @deprecated
      *
-     * @param $filterType
-     * @param null $tenant
+     * @param string $filterType
+     * @param string|null $tenant
      *
      * @return mixed
      *

--- a/bundles/EcommerceFrameworkBundle/IndexService/Interpreter/DefaultClassificationStore.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Interpreter/DefaultClassificationStore.php
@@ -19,8 +19,8 @@ use Pimcore\Model\DataObject\Classificationstore;
 class DefaultClassificationStore implements InterpreterInterface
 {
     /**
-     * @param $value
-     * @param null $config
+     * @param Classificationstore|null $value
+     * @param array|null $config
      *
      * @return array|void
      *

--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFactFinder.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFactFinder.php
@@ -117,7 +117,7 @@ class DefaultFactFinder implements ProductListInterface
     protected $conditions = [];
 
     /**
-     * @var string[]
+     * @var array
      */
     protected $queryConditions = [];
 
@@ -301,7 +301,7 @@ class DefaultFactFinder implements ProductListInterface
      * Fieldname is optional but highly recommended - needed for resetting condition based on fieldname
      * and exclude functionality in group by results
      *
-     * @param $condition
+     * @param string $condition
      * @param string $fieldname
      */
     public function addQueryCondition($condition, $fieldname = '')
@@ -313,9 +313,7 @@ class DefaultFactFinder implements ProductListInterface
     /**
      * Reset query condition for fieldname
      *
-     * @param $fieldname
-     *
-     * @return mixed
+     * @param string $fieldname
      */
     public function resetQueryCondition($fieldname)
     {
@@ -391,7 +389,7 @@ class DefaultFactFinder implements ProductListInterface
     }
 
     /**
-     * @param $orderKey string | array  - either single field name, or array of field names or array of arrays (field name, direction)
+     * @param string|array $orderKey either single field name, or array of field names or array of arrays (field name, direction)
      */
     public function setOrderKey($orderKey)
     {
@@ -720,7 +718,7 @@ class DefaultFactFinder implements ProductListInterface
     /**
      * loads group by values based on relation fieldname either from local variable if prepared or directly from product index
      *
-     * @param      $fieldname
+     * @param string $fieldname
      * @param bool $countValues
      * @param bool $fieldnameShouldBeExcluded => set to false for and-conditions
      *
@@ -734,7 +732,7 @@ class DefaultFactFinder implements ProductListInterface
     }
 
     /**
-     * @param      $fieldname
+     * @param string $fieldname
      * @param bool $countValues
      * @param bool $fieldnameShouldBeExcluded
      *
@@ -866,7 +864,7 @@ class DefaultFactFinder implements ProductListInterface
     }
 
     /**
-     * @return null
+     * @return string|null
      */
     public function getFollowSearchParam()
     {
@@ -874,7 +872,7 @@ class DefaultFactFinder implements ProductListInterface
     }
 
     /**
-     * @param null $followSearchParam
+     * @param string|null $followSearchParam
      *
      * @return $this
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFindologic.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFindologic.php
@@ -103,7 +103,7 @@ class DefaultFindologic implements ProductListInterface
     protected $conditions = [];
 
     /**
-     * @var string[]
+     * @var array
      */
     protected $queryConditions = [];
 
@@ -196,7 +196,7 @@ class DefaultFindologic implements ProductListInterface
      * Fieldname is optional but highly recommended - needed for resetting condition based on fieldname
      * and exclude functionality in group by results
      *
-     * @param $condition
+     * @param string $condition
      * @param string $fieldname
      */
     public function addQueryCondition($condition, $fieldname = '')
@@ -208,9 +208,7 @@ class DefaultFindologic implements ProductListInterface
     /**
      * Reset query condition for fieldname
      *
-     * @param $fieldname
-     *
-     * @return mixed
+     * @param string $fieldname
      */
     public function resetQueryCondition($fieldname)
     {
@@ -286,7 +284,7 @@ class DefaultFindologic implements ProductListInterface
     }
 
     /**
-     * @param $orderKey string | array  - either single field name, or array of field names or array of arrays (field name, direction)
+     * @param string|array $orderKey either single field name, or array of field names or array of arrays (field name, direction)
      */
     public function setOrderKey($orderKey)
     {
@@ -602,7 +600,7 @@ class DefaultFindologic implements ProductListInterface
     /**
      * loads group by values based on relation fieldname either from local variable if prepared or directly from product index
      *
-     * @param      $fieldname
+     * @param string $fieldname
      * @param bool $countValues
      * @param bool $fieldnameShouldBeExcluded => set to false for and-conditions
      *
@@ -616,7 +614,7 @@ class DefaultFindologic implements ProductListInterface
     }
 
     /**
-     * @param      $fieldname
+     * @param string $fieldname
      * @param bool $countValues
      * @param bool $fieldnameShouldBeExcluded
      *

--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultMysql.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultMysql.php
@@ -173,7 +173,7 @@ class DefaultMysql implements ProductListInterface
      * Fieldname is optional but highly recommended - needed for resetting condition based on fieldname
      * and exclude functionality in group by results
      *
-     * @param $condition
+     * @param string $condition
      * @param string $fieldname
      */
     public function addQueryCondition($condition, $fieldname = '')
@@ -185,9 +185,7 @@ class DefaultMysql implements ProductListInterface
     /**
      * Reset query condition for fieldname
      *
-     * @param $fieldname
-     *
-     * @return mixed
+     * @param string $fieldname
      */
     public function resetQueryCondition($fieldname)
     {
@@ -243,7 +241,7 @@ class DefaultMysql implements ProductListInterface
     }
 
     /**
-     * @param $orderKey string | array  - either single field name, or array of field names or array of arrays (field name, direction)
+     * @param string|array $orderKey either single field name, or array of field names or array of arrays (field name, direction)
      */
     public function setOrderKey($orderKey)
     {
@@ -424,7 +422,7 @@ class DefaultMysql implements ProductListInterface
     /**
      * loads element by id
      *
-     * @param $elementId
+     * @param int $elementId
      *
      * @return array|\Pimcore\Model\DataObject\AbstractObject
      */
@@ -485,7 +483,7 @@ class DefaultMysql implements ProductListInterface
     /**
      * loads group by values based on relation fieldname either from local variable if prepared or directly from product index
      *
-     * @param      $fieldname
+     * @param string $fieldname
      * @param bool $countValues
      * @param bool $fieldnameShouldBeExcluded => set to false for and-conditions
      *
@@ -499,7 +497,7 @@ class DefaultMysql implements ProductListInterface
     }
 
     /**
-     * @param $fieldname
+     * @param string $fieldname
      * @param bool $countValues
      * @param bool $fieldnameShouldBeExcluded => set to false for and-conditions
      *
@@ -521,7 +519,7 @@ class DefaultMysql implements ProductListInterface
     }
 
     /**
-     * @param      $fieldname
+     * @param string $fieldname
      * @param bool $countValues
      * @param bool $fieldnameShouldBeExcluded => set to false for and-conditions
      *
@@ -711,8 +709,8 @@ class DefaultMysql implements ProductListInterface
      * returns order by statement for simularity calculations based on given fields and object ids
      * returns cosine simularity calculation
      *
-     * @param $fields
-     * @param $objectId
+     * @param array $fields
+     * @param int $objectId
      *
      * @return string
      */
@@ -724,8 +722,8 @@ class DefaultMysql implements ProductListInterface
     /**
      * returns where statement for fulltext search index
      *
-     * @param $fields
-     * @param $searchstring
+     * @param array $fields
+     * @param string $searchstring
      *
      * @return string
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultMysql/Dao.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultMysql/Dao.php
@@ -223,8 +223,8 @@ class Dao
     /**
      * returns order by statement for simularity calculations based on given fields and object ids
      *
-     * @param $fields
-     * @param $objectId
+     * @param array $fields
+     * @param int $objectId
      *
      * @return string
      */
@@ -282,8 +282,8 @@ class Dao
     /**
      * returns where statement for fulltext search index
      *
-     * @param $fields
-     * @param $searchstring
+     * @param array $fields
+     * @param string $searchstring
      *
      * @return string
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -256,9 +256,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     /**
      * Reset condition for fieldname
      *
-     * @param $fieldname
-     *
-     * @return mixed
+     * @param string $fieldname
      */
     public function resetCondition($fieldname)
     {
@@ -297,7 +295,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
      * Fieldname is optional but highly recommended - needed for resetting condition based on fieldname
      * and exclude functionality in group by results
      *
-     * @param $condition
+     * @param string $condition
      * @param string $fieldname - must be set for elastic search
      */
     public function addQueryCondition($condition, $fieldname = '')
@@ -310,9 +308,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     /**
      * Reset query condition for fieldname
      *
-     * @param $fieldname
-     *
-     * @return mixed
+     * @param string $fieldname
      */
     public function resetQueryCondition($fieldname)
     {
@@ -358,7 +354,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     /**
      * sets order direction
      *
-     * @param $order
+     * @param string $order
      *
      * @return void
      */
@@ -381,7 +377,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     /**
      * sets order key
      *
-     * @param $orderKey string | array  - either single field name, or array of field names or array of arrays (field name, direction)
+     * @param string|array $orderKey either single field name, or array of field names or array of arrays (field name, direction)
      *
      * @return void
      */
@@ -408,7 +404,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     /**
      * Pass "unlimited" to do da Scroll Request
      *
-     * @param $limit int
+     * @param int $limit
      *
      * @return void
      */
@@ -436,7 +432,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     }
 
     /**
-     * @param $offset int
+     * @param int $offset
      *
      * @return void
      */
@@ -457,7 +453,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     }
 
     /**
-     * @param $category
+     * @param AbstractCategory $category
      *
      * @return void
      */
@@ -477,7 +473,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     }
 
     /**
-     * @param $variantMode
+     * @param string $variantMode
      *
      * @return void
      */
@@ -759,8 +755,8 @@ abstract class AbstractElasticSearch implements ProductListInterface
     /**
      * builds relation conditions of user specific query conditions
      *
-     * @param $boolFilters
-     * @param $excludedFieldnames
+     * @param array $boolFilters
+     * @param array $excludedFieldnames
      *
      * @return array
      */
@@ -784,8 +780,8 @@ abstract class AbstractElasticSearch implements ProductListInterface
     /**
      * builds filter condition of user specific conditions
      *
-     * @param $boolFilters
-     * @param $excludedFieldnames
+     * @param array $boolFilters
+     * @param array $excludedFieldnames
      *
      * @return array
      */
@@ -809,8 +805,8 @@ abstract class AbstractElasticSearch implements ProductListInterface
     /**
      * builds query condition of query filters
      *
-     * @param $queryFilters
-     * @param $excludedFieldnames
+     * @param array $queryFilters
+     * @param array $excludedFieldnames
      *
      * @return array
      */
@@ -847,7 +843,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     /**
      * loads element by id
      *
-     * @param $elementId
+     * @param int $elementId
      *
      * @return array|IndexableInterface
      */
@@ -873,7 +869,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     }
 
     /**
-     * @param $fieldname
+     * @param string $fieldname
      * @param bool $countValues
      * @param bool $fieldnameShouldBeExcluded
      * @param array $aggregationConfig
@@ -941,7 +937,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     /**
      * loads group by values based on system either from local variable if prepared or directly from product index
      *
-     * @param $fieldname
+     * @param string $fieldname
      * @param bool $countValues
      * @param bool $fieldnameShouldBeExcluded => set to false for and-conditions
      *
@@ -957,7 +953,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     /**
      * loads group by values based on fieldname either from local variable if prepared or directly from product index
      *
-     * @param $fieldname
+     * @param string $fieldname
      * @param bool $countValues
      * @param bool $fieldnameShouldBeExcluded => set to false for and-conditions
      *
@@ -973,7 +969,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     /**
      * loads group by values based on relation fieldname either from local variable if prepared or directly from product index
      *
-     * @param      $fieldname
+     * @param string $fieldname
      * @param bool $countValues
      * @param bool $fieldnameShouldBeExcluded => set to false for and-conditions
      *
@@ -989,7 +985,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     /**
      * checks if group by values are loaded and returns them
      *
-     * @param $fieldname
+     * @param string $fieldname
      * @param bool $countValues
      * @param bool $fieldnameShouldBeExcluded
      *

--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ProductListInterface.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ProductListInterface.php
@@ -75,7 +75,7 @@ interface ProductListInterface extends \Iterator, AdapterInterface, AdapterAggre
      * Fieldname is optional but highly recommended - needed for resetting condition based on fieldname
      * and exclude functionality in group by results
      *
-     * @param $condition
+     * @param string $condition
      * @param string $fieldname
      */
     public function addQueryCondition($condition, $fieldname = '');
@@ -83,7 +83,7 @@ interface ProductListInterface extends \Iterator, AdapterInterface, AdapterAggre
     /**
      * Reset filter condition for fieldname
      *
-     * @param $fieldname
+     * @param string $fieldname
      *
      * @return mixed
      */
@@ -92,9 +92,7 @@ interface ProductListInterface extends \Iterator, AdapterInterface, AdapterAggre
     /**
      * Reset query condition for fieldname
      *
-     * @param $fieldname
-     *
-     * @return mixed
+     * @param string $fieldname
      */
     public function resetQueryCondition($fieldname);
 
@@ -134,9 +132,7 @@ interface ProductListInterface extends \Iterator, AdapterInterface, AdapterAggre
     /**
      * sets order direction
      *
-     * @param $order
-     *
-     * @return void
+     * @param string $order
      */
     public function setOrder($order);
 
@@ -150,9 +146,7 @@ interface ProductListInterface extends \Iterator, AdapterInterface, AdapterAggre
     /**
      * sets order key
      *
-     * @param $orderKey string | array  - either single field name, or array of field names or array of arrays (field name, direction)
-     *
-     * @return void
+     * @param string|array $orderKey either single field name, or array of field names or array of arrays (field name, direction)
      */
     public function setOrderKey($orderKey);
 
@@ -162,9 +156,7 @@ interface ProductListInterface extends \Iterator, AdapterInterface, AdapterAggre
     public function getOrderKey();
 
     /**
-     * @param $limit int
-     *
-     * @return void
+     * @param int $limit
      */
     public function setLimit($limit);
 
@@ -174,9 +166,7 @@ interface ProductListInterface extends \Iterator, AdapterInterface, AdapterAggre
     public function getLimit();
 
     /**
-     * @param $offset int
-     *
-     * @return void
+     * @param int $offset
      */
     public function setOffset($offset);
 
@@ -186,9 +176,7 @@ interface ProductListInterface extends \Iterator, AdapterInterface, AdapterAggre
     public function getOffset();
 
     /**
-     * @param $category
-     *
-     * @return void
+     * @param AbstractCategory $category
      */
     public function setCategory(AbstractCategory $category);
 
@@ -198,9 +186,7 @@ interface ProductListInterface extends \Iterator, AdapterInterface, AdapterAggre
     public function getCategory();
 
     /**
-     * @param $variantMode
-     *
-     * @return void
+     * @param string $variantMode
      */
     public function setVariantMode($variantMode);
 
@@ -262,7 +248,7 @@ interface ProductListInterface extends \Iterator, AdapterInterface, AdapterAggre
     /**
      * loads group by values based on fieldname either from local variable if prepared or directly from product index
      *
-     * @param $fieldname
+     * @param string $fieldname
      * @param bool $countValues
      * @param bool $fieldnameShouldBeExcluded => set to false for and-conditions
      *
@@ -275,7 +261,7 @@ interface ProductListInterface extends \Iterator, AdapterInterface, AdapterAggre
     /**
      * loads group by values based on relation fieldname either from local variable if prepared or directly from product index
      *
-     * @param      $fieldname
+     * @param string $fieldname
      * @param bool $countValues
      * @param bool $fieldnameShouldBeExcluded => set to false for and-conditions
      *
@@ -288,7 +274,7 @@ interface ProductListInterface extends \Iterator, AdapterInterface, AdapterAggre
     /**
      * loads group by values based on relation fieldname either from local variable if prepared or directly from product index
      *
-     * @param      $fieldname
+     * @param string $fieldname
      * @param bool $countValues
      * @param bool $fieldnameShouldBeExcluded => set to false for and-conditions
      *

--- a/bundles/EcommerceFrameworkBundle/IndexService/Tool/IndexUpdater.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Tool/IndexUpdater.php
@@ -50,7 +50,7 @@ class IndexUpdater
      * Runs update index for all tenants
      *  - but does not run processPreparationQueue or processUpdateIndexQueue
      *
-     * @param $objectListClass
+     * @param string $objectListClass
      * @param string $condition
      * @param bool $updateIndexStructures
      * @param string $loggername
@@ -163,7 +163,7 @@ class IndexUpdater
     /**
      * Runs processUpdateIndexQueue for given tenants or for all tenants
      *
-     * @param null $tenants
+     * @param array|null $tenants
      * @param int $maxRounds - max rounds after process returns. null for infinite run until no work is left
      * @param string $loggername
      * @param int $indexItemsPerRound - number of items to index per round
@@ -228,8 +228,8 @@ class IndexUpdater
     }
 
     /**
-     * @param $timeout
-     * @param $startTime
+     * @param int $timeout
+     * @param int $startTime
      *
      * @throws \Exception
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
@@ -44,9 +44,9 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
     abstract protected function getStoreTableName();
 
     /**
-     * @param $objectId
-     * @param null $data
-     * @param null $metadata
+     * @param int $objectId
+     * @param array|null $data
+     * @param array|null $metadata
      */
     abstract protected function doUpdateIndex($objectId, $data = null, $metadata = null);
 
@@ -86,7 +86,7 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
     /**
      * deletes element from store table
      *
-     * @param $objectId
+     * @param int $objectId
      */
     protected function deleteFromStoreTable($objectId)
     {
@@ -97,7 +97,7 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
      * prepare data for index creation and store is in store table
      *
      * @param IndexableInterface $object
-     * @param $subObjectId
+     * @param int $subObjectId
      *
      * @return array
      */
@@ -340,8 +340,8 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
     /**
      * Inserts the data do the store table
      *
-     * @param $data
-     * @param $subObjectId
+     * @param array $data
+     * @param int $subObjectId
      */
     protected function insertDataToIndex($data, $subObjectId)
     {

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractMockupCacheWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractMockupCacheWorker.php
@@ -35,7 +35,7 @@ abstract class AbstractMockupCacheWorker extends AbstractBatchProcessingWorker
     /**
      * creates mockup cache key
      *
-     * @param $objectId
+     * @param int $objectId
      *
      * @return string
      */
@@ -47,7 +47,7 @@ abstract class AbstractMockupCacheWorker extends AbstractBatchProcessingWorker
     /**
      * deletes element from mockup cache
      *
-     * @param $objectId
+     * @param int $objectId
      */
     protected function deleteFromMockupCache($objectId)
     {
@@ -58,8 +58,8 @@ abstract class AbstractMockupCacheWorker extends AbstractBatchProcessingWorker
     /**
      * updates mockup cache, delegates creation of mockup object to tenant config
      *
-     * @param $objectId
-     * @param null $data
+     * @param int $objectId
+     * @param array|null $data
      *
      * @return DefaultMockup
      *
@@ -105,7 +105,7 @@ abstract class AbstractMockupCacheWorker extends AbstractBatchProcessingWorker
     /**
      * gets mockup from cache and if not in cache, adds it to cache
      *
-     * @param $objectId
+     * @param int $objectId
      *
      * @return DefaultMockup
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractWorker.php
@@ -136,17 +136,15 @@ abstract class AbstractWorker implements WorkerInterface
     /**
      * actually deletes all sub entries from index. original object is delivered too, but keep in mind, that this might be empty.
      *
-     * @param $subObjectId
-     * @param IndexableInterface $object - might be empty (when object doesn't exist any more in pimcore
-     *
-     * @return mixed
+     * @param int $subObjectId
+     * @param IndexableInterface|null $object - might be empty (when object doesn't exist any more in pimcore
      */
     abstract protected function doDeleteFromIndex($subObjectId, IndexableInterface $object = null);
 
     /**
      * Checks if given data is array and returns converted data suitable for search backend. For mysql it is a string with special delimiter.
      *
-     * @param $data
+     * @param array|string $data
      *
      * @return string
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/BatchProcessingWorkerInterface.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/BatchProcessingWorkerInterface.php
@@ -44,7 +44,7 @@ interface BatchProcessingWorkerInterface extends WorkerInterface
      *
      * @param int $limit
      *
-     * @return $int number of entries processed
+     * @return int number of entries processed
      */
     public function processUpdateIndexQueue($limit = 200);
 }

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/DefaultFactFinder.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/DefaultFactFinder.php
@@ -289,19 +289,17 @@ class DefaultFactFinder extends AbstractMockupCacheWorker implements WorkerInter
     /**
      * only prepare data for updating index
      *
-     * @param $objectId
-     * @param null $data
-     * @param null $metadata
+     * @param int $objectId
+     * @param array|null $data
+     * @param array|null $metadata
      */
     protected function doUpdateIndex($objectId, $data = null, $metadata = null)
     {
     }
 
     /**
-     * @param $subObjectId
+     * @param int $subObjectId
      * @param IndexableInterface|null $object
-     *
-     * @return mixed|void
      */
     protected function doDeleteFromIndex($subObjectId, IndexableInterface $object = null)
     {

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/DefaultFindologic.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/DefaultFindologic.php
@@ -94,9 +94,9 @@ class DefaultFindologic extends AbstractMockupCacheWorker implements WorkerInter
     }
 
     /**
-     * @param      $objectId
-     * @param null $data
-     * @param null $metadata
+     * @param int $objectId
+     * @param array|null $data
+     * @param array|null $metadata
      */
     protected function doUpdateIndex($objectId, $data = null, $metadata = null)
     {
@@ -131,8 +131,8 @@ class DefaultFindologic extends AbstractMockupCacheWorker implements WorkerInter
          * Adds a child with $value inside CDATA
          *
          * @param \SimpleXMLElement $parent
-         * @param string           $name
-         * @param null             $value
+         * @param string $name
+         * @param string|null $value
          *
          * @return \SimpleXMLElement
          */
@@ -261,6 +261,7 @@ class DefaultFindologic extends AbstractMockupCacheWorker implements WorkerInter
 
     /**
      * @param int $objectId
+     * @param IndexableInterface|null $object
      */
     protected function doDeleteFromIndex($objectId, IndexableInterface $object = null)
     {

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -441,7 +441,7 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
      * override this method if you need to add custom data
      * which should not be stored in the store data
      *
-     * @param $data
+     * @param array|string $data
      *
      * @return mixed
      */
@@ -648,7 +648,7 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
      *
      * return array in this case
      *
-     * @param $data
+     * @param array|string $data
      *
      * @return string
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/DefaultElasticSearch5.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/DefaultElasticSearch5.php
@@ -295,9 +295,9 @@ class DefaultElasticSearch5 extends AbstractElasticSearch
     /**
      * only prepare data for updating index
      *
-     * @param $objectId
-     * @param null $data
-     * @param null $metadata
+     * @param int $objectId
+     * @param array|null $data
+     * @param array|null $metadata
      */
     protected function doUpdateIndex($objectId, $data = null, $metadata = null)
     {

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/OptimizedMysql.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/OptimizedMysql.php
@@ -107,9 +107,9 @@ class OptimizedMysql extends AbstractMockupCacheWorker implements BatchProcessin
     /**
      * updates all index tables, delegates subtenant updates to tenant config and updates mockup cache
      *
-     * @param $objectId
-     * @param null $data
-     * @param null $metadata
+     * @param int $objectId
+     * @param array|null $data
+     * @param array|null $metadata
      */
     public function doUpdateIndex($objectId, $data = null, $metadata = null)
     {

--- a/bundles/EcommerceFrameworkBundle/Model/AbstractOrder.php
+++ b/bundles/EcommerceFrameworkBundle/Model/AbstractOrder.php
@@ -275,7 +275,7 @@ class AbstractOrder extends \Pimcore\Model\DataObject\Concrete
     }
 
     /**
-     * @return string
+     * @return int
      */
     public function getCartId()
     {
@@ -283,7 +283,7 @@ class AbstractOrder extends \Pimcore\Model\DataObject\Concrete
     }
 
     /**
-     * @param string $cartId
+     * @param int $cartId
      *
      * @return void
      */
@@ -491,7 +491,7 @@ class AbstractOrder extends \Pimcore\Model\DataObject\Concrete
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getDeliveryEMail()
     {
@@ -509,7 +509,7 @@ class AbstractOrder extends \Pimcore\Model\DataObject\Concrete
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getDeliveryCountry()
     {
@@ -527,7 +527,7 @@ class AbstractOrder extends \Pimcore\Model\DataObject\Concrete
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getDeliveryCity()
     {
@@ -545,7 +545,7 @@ class AbstractOrder extends \Pimcore\Model\DataObject\Concrete
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getDeliveryZip()
     {
@@ -563,7 +563,7 @@ class AbstractOrder extends \Pimcore\Model\DataObject\Concrete
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getDeliveryStreet()
     {
@@ -581,7 +581,7 @@ class AbstractOrder extends \Pimcore\Model\DataObject\Concrete
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getDeliveryCompany()
     {

--- a/bundles/EcommerceFrameworkBundle/Model/AbstractSetProduct.php
+++ b/bundles/EcommerceFrameworkBundle/Model/AbstractSetProduct.php
@@ -122,8 +122,8 @@ class AbstractSetProduct extends AbstractProduct
      *
      * @throws UnsupportedException
      *
-     * @param null $quantityScale
-     * @param null $products
+     * @param int $quantityScale
+     * @param array|null $products
      *
      * @return PriceInterface
      */
@@ -142,7 +142,7 @@ class AbstractSetProduct extends AbstractProduct
      * @throws UnsupportedException
      *
      * @param int $quantityScale
-     * @param null $products
+     * @param array|null $products
      *
      * @return PriceInfoInterface|AbstractPriceInfo
      */
@@ -157,7 +157,7 @@ class AbstractSetProduct extends AbstractProduct
 
     /**
      * @param int $quantity
-     * @param $products AbstractSetProductEntry[]
+     * @param AbstractSetProductEntry[] $products
      *
      * @return AvailabilityInterface
      */

--- a/bundles/EcommerceFrameworkBundle/Model/Currency.php
+++ b/bundles/EcommerceFrameworkBundle/Model/Currency.php
@@ -70,7 +70,7 @@ class Currency
     /**
      * Currency constructor.
      *
-     * @param $currencyShortName string
+     * @param string $currencyShortName
      */
     public function __construct($currencyShortName)
     {

--- a/bundles/EcommerceFrameworkBundle/Model/DefaultMockup.php
+++ b/bundles/EcommerceFrameworkBundle/Model/DefaultMockup.php
@@ -44,7 +44,7 @@ class DefaultMockup implements ProductInterface
     }
 
     /**
-     * @param $key
+     * @param string $key
      *
      * @return mixed
      */
@@ -54,7 +54,7 @@ class DefaultMockup implements ProductInterface
     }
 
     /**
-     * @param mixed $params
+     * @param array $params
      *
      * @return $this
      */

--- a/bundles/EcommerceFrameworkBundle/OfferTool/AbstractOffer.php
+++ b/bundles/EcommerceFrameworkBundle/OfferTool/AbstractOffer.php
@@ -237,7 +237,7 @@ class AbstractOffer extends Concrete
     /**
      * @throws UnsupportedException
      *
-     * @param string $cartId
+     * @param int $cartId
      */
     public function setCartId($cartId)
     {

--- a/bundles/EcommerceFrameworkBundle/OfferTool/DefaultService.php
+++ b/bundles/EcommerceFrameworkBundle/OfferTool/DefaultService.php
@@ -18,6 +18,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItemInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Factory;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Type\Decimal;
+use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\Folder;
 use Pimcore\Model\DataObject\Service;
 
@@ -151,7 +152,7 @@ class DefaultService implements ServiceInterface
 
     /**
      * @param CartItemInterface $item
-     * @param $parent
+     * @param AbstractObject $parent
      *
      * @return AbstractOfferItem
      */

--- a/bundles/EcommerceFrameworkBundle/OrderManager/AbstractOrderList.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/AbstractOrderList.php
@@ -177,7 +177,8 @@ abstract class AbstractOrderList implements OrderListInterface
     }
 
     /**
-     * @param $limit
+     * @param int $limit
+     * @param int $offset
      *
      * @return $this
      */

--- a/bundles/EcommerceFrameworkBundle/OrderManager/Order/Listing.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/Order/Listing.php
@@ -321,7 +321,7 @@ SUBQUERY
     }
 
     /**
-     * @param $field
+     * @param string $field
      *
      * @return $this
      */

--- a/bundles/EcommerceFrameworkBundle/OrderManager/Order/Listing/Item.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/Order/Listing/Item.php
@@ -30,8 +30,8 @@ class Item extends AbstractOrderListItem implements OrderListItemInterface
     }
 
     /**
-     * @param $method
-     * @param $args
+     * @param string $method
+     * @param array $args
      *
      * @return mixed
      *

--- a/bundles/EcommerceFrameworkBundle/OrderManager/OrderListInterface.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/OrderListInterface.php
@@ -155,7 +155,7 @@ interface OrderListInterface extends SeekableIterator, Countable, ArrayAccess, A
     public function addCondition($condition, $value = null);
 
     /**
-     * @param $field
+     * @param string $field
      *
      * @return $this
      */

--- a/bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
@@ -31,6 +31,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Type\Decimal;
 use Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\VoucherServiceInterface;
 use Pimcore\File;
 use Pimcore\Logger;
+use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\Folder;
 use Pimcore\Model\DataObject\Service;
 use Pimcore\Model\FactoryInterface;
@@ -568,7 +569,7 @@ class OrderManager implements OrderManagerInterface
      *
      * @param string $customerId
      * @param PaymentInterface $paymentProvider
-     * @param null $paymentMethod
+     * @param string|null $paymentMethod
      *
      * @return mixed
      */
@@ -615,7 +616,7 @@ class OrderManager implements OrderManagerInterface
 
     /**
      * @param CartItemInterface $item
-     * @param $parent
+     * @param AbstractObject $parent
      * @param bool $isGiftItem
      *
      * @return AbstractOrderItem
@@ -733,9 +734,9 @@ class OrderManager implements OrderManagerInterface
     /**
      * Build list class name, try namespaced first and fall back to legacy naming
      *
-     * @param $className
+     * @param string $className
      *
-     * @return mixed
+     * @return string
      *
      * @throws \Exception
      */

--- a/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderManager.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderManager.php
@@ -26,6 +26,7 @@ use Pimcore\Event\Ecommerce\OrderManagerEvents;
 use Pimcore\Event\Model\Ecommerce\OrderManagerEvent;
 use Pimcore\Event\Model\Ecommerce\OrderManagerItemEvent;
 use Pimcore\File;
+use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\Fieldcollection;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -337,7 +338,7 @@ class OrderManager extends \Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager
 
     /**
      * @param CartItemInterface $item
-     * @param $parent
+     * @param AbstractObject $parent
      * @param bool $isGiftItem
      *
      * @return \Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractOrderItem

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Datatrans.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Datatrans.php
@@ -388,7 +388,7 @@ class Datatrans extends AbstractPayment implements \Pimcore\Bundle\EcommerceFram
     }
 
     /**
-     * @param $response
+     * @param array $response
      *
      * @return array
      */

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Klarna.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Klarna.php
@@ -257,7 +257,7 @@ class Klarna extends AbstractPayment implements \Pimcore\Bundle\EcommerceFramewo
      *
      * @param PriceInterface $price
      * @param string $reference
-     * @param $transactionId
+     * @param string $transactionId
      *
      * @return StatusInterface
      *

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Mpay24Seamless.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Mpay24Seamless.php
@@ -179,7 +179,7 @@ class Mpay24Seamless extends AbstractPayment implements \Pimcore\Bundle\Ecommerc
     /**
      * Get payment redirect URL after payment form has been submitted with a post.
      *
-     * @param $config
+     * @param array $config
      *
      * @return string[] first parameter contains redirect URL, second parameter contains error message if there is any.
      * if there is an error message is it up to you to redirect to the suggested URL, which might not
@@ -467,7 +467,7 @@ class Mpay24Seamless extends AbstractPayment implements \Pimcore\Bundle\Ecommerc
      *
      * @param PriceInterface $price
      * @param string $reference
-     * @param $transactionId
+     * @param string $transactionId
      *
      * @return StatusInterface
      *

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/OGone.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/OGone.php
@@ -332,8 +332,8 @@ class OGone extends AbstractPayment implements \Pimcore\Bundle\EcommerceFramewor
      * Helper method for adding hidden fields to a form.
      *
      * @param FormBuilderInterface $form
-     * @param $name
-     * @param $value
+     * @param string $name
+     * @param string $value
      *
      * @return FormBuilderInterface
      */
@@ -440,7 +440,7 @@ class OGone extends AbstractPayment implements \Pimcore\Bundle\EcommerceFramewor
      *
      * @param PriceInterface $price
      * @param string $reference
-     * @param $transactionId
+     * @param string $transactionId
      *
      * @return StatusInterface
      *

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PayPalSmartPaymentButton.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PayPalSmartPaymentButton.php
@@ -298,7 +298,7 @@ class PayPalSmartPaymentButton extends AbstractPayment implements \Pimcore\Bundl
      *
      * @param PriceInterface $price
      * @param string $reference
-     * @param $transactionId
+     * @param string $transactionId
      *
      * @return StatusInterface
      */

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PaymentInterface.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PaymentInterface.php
@@ -66,8 +66,8 @@ interface PaymentInterface
     /**
      * Executes payment
      *
-     * @param PriceInterface $price
-     * @param string $reference
+     * @param PriceInterface|null $price
+     * @param string|null $reference
      *
      * @return StatusInterface
      */
@@ -78,7 +78,7 @@ interface PaymentInterface
      *
      * @param PriceInterface $price
      * @param string $reference
-     * @param $transactionId
+     * @param string $transactionId
      *
      * @return StatusInterface
      */
@@ -95,7 +95,7 @@ interface PaymentInterface
 
     /**
      * @param AbstractOrder $sourceOrder
-     * @param $paymentBrick
+     * @param object $paymentBrick
      *
      * @todo Pimcore 7 remove this method as it moved to RecurringPaymentInterface
      *

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/QPay.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/QPay.php
@@ -546,7 +546,7 @@ class QPay extends AbstractPayment implements \Pimcore\Bundle\EcommerceFramework
      *
      * @param PriceInterface $price
      * @param string $reference
-     * @param $transactionId
+     * @param string $transactionId
      *
      * @return StatusInterface
      *
@@ -644,7 +644,7 @@ class QPay extends AbstractPayment implements \Pimcore\Bundle\EcommerceFramework
     /**
      * Compute MD5 fingerprint
      *
-     * @param $data
+     * @param string $data
      *
      * @return string
      */
@@ -656,7 +656,7 @@ class QPay extends AbstractPayment implements \Pimcore\Bundle\EcommerceFramework
     /**
      * Calculate HMAC_SHA512 fingerprint
      *
-     * @param $data
+     * @param string $data
      *
      * @return string
      */
@@ -666,8 +666,8 @@ class QPay extends AbstractPayment implements \Pimcore\Bundle\EcommerceFramework
     }
 
     /**
-     * @param $url
-     * @param $params
+     * @param string $url
+     * @param array $params
      *
      * @return string[]
      */

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/WirecardSeamless.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/WirecardSeamless.php
@@ -425,9 +425,9 @@ class WirecardSeamless extends AbstractPayment implements \Pimcore\Bundle\Ecomme
      * This method adds additional fields to Wirecard Seamless, so that order items
      * can be transmitted and visualized in Paypal (during the payment process and in the Paypal invoice email).
      *
-     * @param $fields
+     * @param array $fields
      * @param \Pimcore\Model\DataObject\OnlineShopOrder $order
-     * @param $config
+     * @param array $config
      *
      * @return array
      */
@@ -654,7 +654,7 @@ class WirecardSeamless extends AbstractPayment implements \Pimcore\Bundle\Ecomme
      * execute payment
      *
      * @param PriceInterface|null $price
-     * @param null $reference
+     * @param string|null $reference
      *
      * @throws \Exception
      *
@@ -722,7 +722,7 @@ class WirecardSeamless extends AbstractPayment implements \Pimcore\Bundle\Ecomme
      *
      * @param PriceInterface $price
      * @param string $reference
-     * @param $transactionId
+     * @param string $transactionId
      *
      * @throws \Exception
      *
@@ -734,9 +734,9 @@ class WirecardSeamless extends AbstractPayment implements \Pimcore\Bundle\Ecomme
     }
 
     /**
-     * @param $reference
-     * @param $transactionId
-     * @param $paymentType
+     * @param string $reference
+     * @param string $transactionId
+     * @param string $paymentType
      *
      * @return bool|Status
      */
@@ -798,8 +798,8 @@ class WirecardSeamless extends AbstractPayment implements \Pimcore\Bundle\Ecomme
     }
 
     /**
-     * @param $url
-     * @param $params
+     * @param string $url
+     * @param array $params
      *
      * @return string[]
      */
@@ -827,7 +827,7 @@ class WirecardSeamless extends AbstractPayment implements \Pimcore\Bundle\Ecomme
     /**
      * Environment was kept optional for backwards compatibility, but should be passed if possible
      *
-     * @param $response
+     * @param array $response
      * @param EnvironmentInterface|null $environment
      *
      * @return CartInterface|null

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/V7/Payment/RecurringPaymentInterface.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/V7/Payment/RecurringPaymentInterface.php
@@ -28,7 +28,7 @@ interface RecurringPaymentInterface
 
     /**
      * @param AbstractOrder $sourceOrder
-     * @param $paymentBrick
+     * @param object $paymentBrick
      *
      * @return mixed
      */

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/V7/Payment/StartPaymentRequest/AbstractRequest.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/V7/Payment/StartPaymentRequest/AbstractRequest.php
@@ -24,8 +24,8 @@ class AbstractRequest implements \ArrayAccess
     }
 
     /**
-     * @param $name
-     * @param $value
+     * @param string $name
+     * @param mixed $value
      */
     public function set($name, $value)
     {
@@ -33,7 +33,7 @@ class AbstractRequest implements \ArrayAccess
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return mixed
      */

--- a/bundles/EcommerceFrameworkBundle/PriceSystem/AttributePriceInfo.php
+++ b/bundles/EcommerceFrameworkBundle/PriceSystem/AttributePriceInfo.php
@@ -52,8 +52,8 @@ class AttributePriceInfo extends AbstractPriceInfo implements PriceInfoInterface
     /**
      * Try to delegate all other functions to the product
      *
-     * @param $name
-     * @param $arguments
+     * @param string $name
+     * @param array $arguments
      *
      * @return mixed
      */

--- a/bundles/EcommerceFrameworkBundle/PriceSystem/CachingPriceSystemInterface.php
+++ b/bundles/EcommerceFrameworkBundle/PriceSystem/CachingPriceSystemInterface.php
@@ -22,8 +22,8 @@ interface CachingPriceSystemInterface extends PriceSystemInterface
     /**
      * Loads price infos once for given product entries and caches them
      *
-     * @param $productEntries
-     * @param $options
+     * @param array $productEntries
+     * @param array $options
      *
      * @return mixed
      */
@@ -32,8 +32,8 @@ interface CachingPriceSystemInterface extends PriceSystemInterface
     /**
      * Clears cached price infos
      *
-     * @param $productEntries
-     * @param $options
+     * @param array $productEntries
+     * @param array $options
      *
      * @return mixed
      */

--- a/bundles/EcommerceFrameworkBundle/PriceSystem/PriceSystemInterface.php
+++ b/bundles/EcommerceFrameworkBundle/PriceSystem/PriceSystemInterface.php
@@ -37,12 +37,12 @@ interface PriceSystemInterface
     /**
      * Filters and orders given product IDs based on price information
      *
-     * @param $productIds
-     * @param $fromPrice
-     * @param $toPrice
-     * @param $order
-     * @param $offset
-     * @param $limit
+     * @param array $productIds
+     * @param float $fromPrice
+     * @param float $toPrice
+     * @param string $order
+     * @param int $offset
+     * @param int $limit
      *
      * @return mixed
      */

--- a/bundles/EcommerceFrameworkBundle/PriceSystem/TaxManagement/TaxEntry.php
+++ b/bundles/EcommerceFrameworkBundle/PriceSystem/TaxManagement/TaxEntry.php
@@ -45,7 +45,7 @@ class TaxEntry
     protected $taxId;
 
     /**
-     * @param $percent
+     * @param float $percent
      * @param Decimal $amount
      * @param string|null $taxId
      * @param TaxEntryFieldcollection|null $entry

--- a/bundles/EcommerceFrameworkBundle/PricingManager/Condition/AbstractObjectListCondition.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Condition/AbstractObjectListCondition.php
@@ -21,8 +21,8 @@ abstract class AbstractObjectListCondition
     /**
      * Handle serializing of object list to list of IDs
      *
-     * @param $objectProperty
-     * @param $idProperty
+     * @param string $objectProperty
+     * @param string $idProperty
      *
      * @return array
      */
@@ -43,8 +43,8 @@ abstract class AbstractObjectListCondition
     /**
      * Handle loading of object list from serialized list of IDs
      *
-     * @param $objectProperty
-     * @param $idProperty
+     * @param string $objectProperty
+     * @param string $idProperty
      */
     protected function handleWakeup($objectProperty, $idProperty)
     {

--- a/bundles/EcommerceFrameworkBundle/PricingManager/Condition/TargetGroup.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Condition/TargetGroup.php
@@ -20,7 +20,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\EnvironmentInterface;
 class TargetGroup implements ConditionInterface
 {
     /**
-     * @var int[]
+     * @var int
      */
     protected $targetGroupId;
 
@@ -107,7 +107,7 @@ class TargetGroup implements ConditionInterface
     /**
      * @return int
      */
-    public function getTargetGroupId(): array
+    public function getTargetGroupId(): int
     {
         return $this->targetGroupId;
     }

--- a/bundles/EcommerceFrameworkBundle/PricingManager/Condition/VoucherToken.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Condition/VoucherToken.php
@@ -121,7 +121,7 @@ class VoucherToken implements ConditionInterface
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return Concrete|null
      */

--- a/bundles/EcommerceFrameworkBundle/PricingManager/EnvironmentInterface.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/EnvironmentInterface.php
@@ -125,7 +125,7 @@ interface EnvironmentInterface
     /**
      * sets execution mode of system - either product or cart
      *
-     * @param $executionMode
+     * @param string $executionMode
      */
     public function setExecutionMode($executionMode);
 

--- a/bundles/EcommerceFrameworkBundle/PricingManager/PriceInfo.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/PriceInfo.php
@@ -259,8 +259,8 @@ class PriceInfo implements PriceInfoInterface
     /**
      * loop through any other calls
      *
-     * @param $name
-     * @param $arguments
+     * @param string $name
+     * @param array $arguments
      *
      * @return mixed
      */

--- a/bundles/EcommerceFrameworkBundle/PricingManager/PriceInfoInterface.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/PriceInfoInterface.php
@@ -53,7 +53,7 @@ interface PriceInfoInterface extends PriceSystemPriceInfoInterface
     public function setAmount(Decimal $amount);
 
     /**
-     * @return PriceInfoInterface
+     * @return Decimal
      */
     public function getAmount(): Decimal;
 

--- a/bundles/EcommerceFrameworkBundle/PricingManager/PricingManagerInterface.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/PricingManagerInterface.php
@@ -62,7 +62,7 @@ interface PricingManagerInterface
     /**
      * Factory
      *
-     * @param $type
+     * @param string $type
      *
      * @return ActionInterface
      */

--- a/bundles/EcommerceFrameworkBundle/PricingManager/Rule.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Rule.php
@@ -99,8 +99,8 @@ class Rule extends AbstractModel implements RuleInterface
     /**
      * load model with serializes data from db
      *
-     * @param  $key
-     * @param  $value
+     * @param string $key
+     * @param mixed $value
      *
      * @return AbstractModel
      */
@@ -136,7 +136,7 @@ class Rule extends AbstractModel implements RuleInterface
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return $this|RuleInterface
      */
@@ -187,8 +187,8 @@ class Rule extends AbstractModel implements RuleInterface
     }
 
     /**
-     * @param $name
-     * @param string $locale
+     * @param string $name
+     * @param string|null $locale
      *
      * @return RuleInterface
      */
@@ -404,7 +404,7 @@ class Rule extends AbstractModel implements RuleInterface
     /**
      * gets current language
      *
-     * @param $language
+     * @param string|null $language
      *
      * @return string
      */

--- a/bundles/EcommerceFrameworkBundle/PricingManager/Rule/Dao.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Rule/Dao.php
@@ -48,7 +48,7 @@ class Dao extends AbstractDao
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @throws \Exception
      */

--- a/bundles/EcommerceFrameworkBundle/PricingManager/Rule/Listing.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Rule/Listing.php
@@ -49,7 +49,7 @@ class Listing extends \Pimcore\Model\Listing\AbstractListing
     }
 
     /**
-     * @param $key
+     * @param string $key
      *
      * @return bool
      */

--- a/bundles/EcommerceFrameworkBundle/PricingManager/RuleInterface.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/RuleInterface.php
@@ -22,7 +22,7 @@ interface RuleInterface
     public function getId();
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return RuleInterface
      */
@@ -56,22 +56,22 @@ interface RuleInterface
     public function getLabel($locale = null);
 
     /**
-     * @param $description
-     * @param string $locale
+     * @param string $description
+     * @param string|null $locale
      *
      * @return RuleInterface
      */
     public function setDescription($description, $locale = null);
 
     /**
-     * @param string $locale
+     * @param string|null $locale
      *
      * @return string mixed
      */
     public function getDescription($locale = null);
 
     /**
-     * @param ConditionInterface
+     * @param ConditionInterface $condition
      *
      * @return RuleInterface
      */
@@ -107,7 +107,7 @@ interface RuleInterface
     public function getActive();
 
     /**
-     * @param $behavior
+     * @param string $behavior
      *
      * @return RuleInterface
      */

--- a/bundles/EcommerceFrameworkBundle/Tracking/AbstractData.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/AbstractData.php
@@ -75,8 +75,8 @@ abstract class AbstractData implements \JsonSerializable
     /**
      * Add an additional attribute.
      *
-     * @param $attribute
-     * @param $value
+     * @param string $attribute
+     * @param mixed $value
      *
      * @return $this
      */
@@ -90,9 +90,9 @@ abstract class AbstractData implements \JsonSerializable
     /**
      * Get an additional attribute.
      *
-     * @param $attribute
+     * @param string $attribute
      *
-     * @return
+     * @return mixed
      */
     public function getAdditionalAttribute($attribute)
     {

--- a/bundles/EcommerceFrameworkBundle/Tracking/CheckoutStepInterface.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/CheckoutStepInterface.php
@@ -24,8 +24,8 @@ interface CheckoutStepInterface
      *
      * @param CheckoutManagerCheckoutStepInterface $step
      * @param CartInterface $cart
-     * @param null $stepNumber
-     * @param null $checkoutOption
+     * @param string|null $stepNumber
+     * @param string|null $checkoutOption
      */
     public function trackCheckoutStep(CheckoutManagerCheckoutStepInterface $step, CartInterface $cart, $stepNumber = null, $checkoutOption = null);
 }

--- a/bundles/EcommerceFrameworkBundle/Tracking/Tracker/Analytics/EnhancedEcommerce.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/Tracker/Analytics/EnhancedEcommerce.php
@@ -157,8 +157,8 @@ class EnhancedEcommerce extends AbstractAnalyticsTracker implements
     }
 
     /**
-     * @param $product
-     * @param $action
+     * @param ProductInterface $product
+     * @param string $action
      * @param int|float $quantity
      */
     protected function trackProductAction($product, $action, $quantity = 1)
@@ -199,8 +199,8 @@ class EnhancedEcommerce extends AbstractAnalyticsTracker implements
     /**
      * @param CheckoutManagerCheckoutStepInterface $step
      * @param CartInterface $cart
-     * @param null $stepNumber
-     * @param null $checkoutOption
+     * @param string|null $stepNumber
+     * @param string|null $checkoutOption
      */
     public function trackCheckoutStep(CheckoutManagerCheckoutStepInterface $step, CartInterface $cart, $stepNumber = null, $checkoutOption = null)
     {

--- a/bundles/EcommerceFrameworkBundle/Tracking/Tracker/GoogleTagManager.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/Tracker/GoogleTagManager.php
@@ -298,7 +298,7 @@ class GoogleTagManager extends Tracker implements
 
 
     /**
-     * @param $price
+     * @param int|float|string $price
      * @return mixed
      */
     private function formatPrice($price = null)

--- a/bundles/EcommerceFrameworkBundle/Tracking/TrackingItemBuilder.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/TrackingItemBuilder.php
@@ -34,7 +34,7 @@ class TrackingItemBuilder implements TrackingItemBuilderInterface
     /**
      * Build a product impression object
      *
-     * @param ProductInterface|ElementInterface $product
+     * @param ProductInterface $product
      * @param string $list
      *
      * @return ProductImpression
@@ -62,7 +62,7 @@ class TrackingItemBuilder implements TrackingItemBuilderInterface
     /**
      * Build a product view object
      *
-     * @param ProductInterface|ElementInterface $product
+     * @param ProductInterface $product
      *
      * @return ProductAction
      */
@@ -95,7 +95,7 @@ class TrackingItemBuilder implements TrackingItemBuilderInterface
     /**
      * Build a product action item
      *
-     * @param ProductInterface|ElementInterface $product
+     * @param ProductInterface $product
      * @param int $quantity
      *
      * @return ProductAction

--- a/bundles/EcommerceFrameworkBundle/Tracking/TrackingItemBuilderInterface.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/TrackingItemBuilderInterface.php
@@ -25,7 +25,7 @@ interface TrackingItemBuilderInterface
     /**
      * Build a product view object
      *
-     * @param ProductInterface|ElementInterface $product
+     * @param ProductInterface $product
      *
      * @return ProductAction
      */
@@ -34,7 +34,7 @@ interface TrackingItemBuilderInterface
     /**
      * Build a product action item object
      *
-     * @param ProductInterface|ElementInterface $product
+     * @param ProductInterface $product
      *
      * @param int $quantity
      * @return ProductAction
@@ -44,7 +44,7 @@ interface TrackingItemBuilderInterface
     /**
      * Build a product impression object
      *
-     * @param ProductInterface|ElementInterface $product
+     * @param ProductInterface $product
      * @param string $list
      *
      * @return ProductImpression

--- a/bundles/EcommerceFrameworkBundle/Tracking/TrackingManager.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/TrackingManager.php
@@ -305,8 +305,8 @@ class TrackingManager implements TrackingManagerInterface
      *
      * @param CheckoutManagerCheckoutStepInterface $step
      * @param CartInterface $cart
-     * @param null $stepNumber
-     * @param null $checkoutOption
+     * @param string|null $stepNumber
+     * @param string|null $checkoutOption
      */
     public function trackCheckoutStep(CheckoutManagerCheckoutStepInterface $step, CartInterface $cart, $stepNumber = null, $checkoutOption = null)
     {

--- a/bundles/EcommerceFrameworkBundle/Type/Decimal.php
+++ b/bundles/EcommerceFrameworkBundle/Type/Decimal.php
@@ -86,7 +86,7 @@ class Decimal
      *
      * Adapted from moneyphp/money PhpCalculator
      *
-     * @param $amount
+     * @param int $amount
      *
      * @throws \OverflowException  If integer overflow occured
      * @throws \UnderflowException If integer underflow occured
@@ -103,7 +103,7 @@ class Decimal
     /**
      * Round value to int value if needed
      *
-     * @param $value
+     * @param mixed $value
      * @param int|null $roundingMode
      *
      * @return int
@@ -688,7 +688,7 @@ class Decimal
      *
      * @example Decimal::create(100)->discount(15) = 85
      *
-     * @param $discount
+     * @param int|float|Decimal $discount
      * @param int|null $roundingMode
      *
      * @return Decimal

--- a/bundles/EcommerceFrameworkBundle/VoucherService/DefaultService.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/DefaultService.php
@@ -309,7 +309,7 @@ class DefaultService implements VoucherServiceInterface
     }
 
     /**
-     * @param $code
+     * @param string $code
      *
      * @return bool|TokenManager\TokenManagerInterface
      */

--- a/bundles/EcommerceFrameworkBundle/VoucherService/Reservation.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/Reservation.php
@@ -25,7 +25,7 @@ class Reservation extends AbstractModel
     public $cart_id;
 
     /**
-     * @param $code
+     * @param string $code
      * @param CartInterface $cart
      *
      * @return bool|Reservation

--- a/bundles/EcommerceFrameworkBundle/VoucherService/Statistic.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/Statistic.php
@@ -48,7 +48,8 @@ class Statistic extends \Pimcore\Model\AbstractModel
     }
 
     /**
-     * @param $seriesId
+     * @param int $seriesId
+     * @param int|null $usagePeriod
      *
      * @throws \Exception
      *
@@ -78,7 +79,7 @@ class Statistic extends \Pimcore\Model\AbstractModel
     }
 
     /**
-     * @param $seriesId
+     * @param int $seriesId
      *
      * @return bool
      */

--- a/bundles/EcommerceFrameworkBundle/VoucherService/Token.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/Token.php
@@ -124,7 +124,7 @@ class Token extends AbstractModel
     }
 
     /**
-     * @param $code
+     * @param string $code
      *
      * @return bool
      */

--- a/bundles/EcommerceFrameworkBundle/VoucherService/Token/Dao.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/Token/Dao.php
@@ -29,7 +29,7 @@ class Dao extends \Pimcore\Model\Dao\AbstractDao
     }
 
     /**
-     * @param $code
+     * @param string $code
      *
      * @return bool
      */

--- a/bundles/EcommerceFrameworkBundle/VoucherService/Token/Listing.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/Token/Listing.php
@@ -27,7 +27,7 @@ use Zend\Paginator\AdapterAggregateInterface;
 class Listing extends \Pimcore\Model\Listing\AbstractListing implements AdapterInterface, AdapterAggregateInterface
 {
     /**
-     * @var array
+     * @var Token[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     public $tokens;
@@ -38,7 +38,7 @@ class Listing extends \Pimcore\Model\Listing\AbstractListing implements AdapterI
     }
 
     /**
-     * @param  $key
+     * @param string $key
      *
      * @return bool
      */
@@ -52,7 +52,7 @@ class Listing extends \Pimcore\Model\Listing\AbstractListing implements AdapterI
     }
 
     /**
-     * @param $seriesId
+     * @param int|null $seriesId
      * @param array $filter
      *
      * @throws \Exception
@@ -227,7 +227,7 @@ class Listing extends \Pimcore\Model\Listing\AbstractListing implements AdapterI
     }
 
     /**
-     * @param $length
+     * @param int $length
      * @param null|string $seriesId
      *
      * @return null|string
@@ -324,7 +324,7 @@ class Listing extends \Pimcore\Model\Listing\AbstractListing implements AdapterI
     }
 
     /**
-     * @param $codes
+     * @param array|string $codes
      *
      * @return bool
      */
@@ -348,7 +348,7 @@ class Listing extends \Pimcore\Model\Listing\AbstractListing implements AdapterI
     }
 
     /**
-     * @return mixed
+     * @return array
      */
     public function getTokens()
     {
@@ -356,7 +356,7 @@ class Listing extends \Pimcore\Model\Listing\AbstractListing implements AdapterI
     }
 
     /**
-     * @param mixed $tokens
+     * @param array $tokens
      */
     public function setTokens($tokens)
     {

--- a/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/AbstractTokenManager.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/AbstractTokenManager.php
@@ -102,7 +102,7 @@ abstract class AbstractTokenManager implements TokenManagerInterface
     /**
      * Once per cart setting
      *
-     * @param $code
+     * @param string $code
      * @param CartInterface $cart
      *
      * @throws VoucherServiceException
@@ -150,7 +150,7 @@ abstract class AbstractTokenManager implements TokenManagerInterface
     /**
      * Export tokens to CSV
      *
-     * @param $params
+     * @param array $params
      *
      * @return mixed
      * @implements IExportableTokenManager
@@ -197,7 +197,7 @@ abstract class AbstractTokenManager implements TokenManagerInterface
     /**
      * Export tokens to plain text list
      *
-     * @param $params
+     * @param array $params
      *
      * @return mixed
      * @implements IExportableTokenManager
@@ -264,7 +264,7 @@ abstract class AbstractTokenManager implements TokenManagerInterface
     abstract public function releaseToken($code, CartInterface $cart);
 
     /**
-     * @param null $filter
+     * @param array|null $filter
      *
      * @return array|bool
      */
@@ -302,7 +302,7 @@ abstract class AbstractTokenManager implements TokenManagerInterface
     abstract public function cleanUpReservations($duration = 0);
 
     /**
-     * @param $viewParamsBag
+     * @param array $viewParamsBag
      * @param array $params
      *
      * @return string The path of the template to display

--- a/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/Pattern.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/Pattern.php
@@ -381,7 +381,7 @@ class Pattern extends AbstractTokenManager implements ExportableTokenManagerInte
     /**
      * Builds an insert query for an array of tokens.
      *
-     * @param $insertTokens
+     * @param array $insertTokens
      *
      * @return string
      */
@@ -502,7 +502,7 @@ class Pattern extends AbstractTokenManager implements ExportableTokenManagerInte
      * Creates an array with the indices of days of the given usage period.
      *
      * @param array $data
-     * @param $usagePeriod
+     * @param int $usagePeriod
      */
     protected function prepareUsageStatisticData(&$data, $usagePeriod)
     {
@@ -519,7 +519,7 @@ class Pattern extends AbstractTokenManager implements ExportableTokenManagerInte
     /**
      * Prepares the view and returns the according template for rendering.
      *
-     * @param $viewParamsBag
+     * @param array $viewParamsBag
      * @param array $params
      *
      * @return string
@@ -626,7 +626,7 @@ class Pattern extends AbstractTokenManager implements ExportableTokenManagerInte
      * Checks whether an index for the given name parameter exists in
      * the character pool member array.
      *
-     * @param $poolName
+     * @param string $poolName
      *
      * @return bool
      */

--- a/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/Single.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/Single.php
@@ -62,7 +62,7 @@ class Single extends AbstractTokenManager implements ExportableTokenManagerInter
     }
 
     /**
-     * @param $viewParamsBag
+     * @param array $viewParamsBag
      * @param array $params
      *
      * @return string

--- a/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/TokenManagerInterface.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/TokenManagerInterface.php
@@ -147,7 +147,7 @@ interface TokenManagerInterface
      * Gets the codes according to paging and filter params and sets
      * error/success messages, settings and statistics for view.
      *
-     * @param $viewParamsBag
+     * @param array $viewParamsBag
      * @param array $params All params, especially for filtering and ordering token codes.
      *
      * @return string The path of the template to display.

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/08_Dynamic_Select_Types.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/08_Dynamic_Select_Types.md
@@ -43,8 +43,8 @@ use Pimcore\Model\DataObject\ClassDefinition\DynamicOptionsProvider\SelectOption
 class OptionsProvider implements SelectOptionsProviderInterface
 {
     /**
-     * @param $context array
-     * @param $fieldDefinition Data
+     * @param array $context 
+     * @param Data $fieldDefinition 
      * @return array
      */
     public function getOptions($context, $fieldDefinition) {
@@ -62,8 +62,8 @@ class OptionsProvider implements SelectOptionsProviderInterface
 
     /**
      * Returns the value which is defined in the 'Default value' field  
-     * @param $context array
-     * @param $fieldDefinition Data
+     * @param array $context 
+     * @param Data $fieldDefinition 
      * @return mixed
      */
     public function getDefaultValue($context, $fieldDefinition) {
@@ -71,8 +71,8 @@ class OptionsProvider implements SelectOptionsProviderInterface
     }
 
     /**
-     * @param $context array
-     * @param $fieldDefinition Data
+     * @param array $context 
+     * @param Data $fieldDefinition 
      * @return bool
      */
     public function hasStaticOptions($context, $fieldDefinition) {

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/03_Layout_Elements/01_Dynamic_Text_Labels.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/03_Layout_Elements/01_Dynamic_Text_Labels.md
@@ -21,9 +21,9 @@ use Pimcore\Model\DataObject\Concrete;
 class CustomRenderer
 {
     /**
-     * @param $data string as provided in the class definition
-     * @param $object Concrete
-     * @param $params mixed
+     * @param string $data as provided in the class definition
+     * @param Concrete $object 
+     * @param mixed $params 
      * @return string
      */
     public static function renderLayoutText($data, $object, $params) {

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/14_Path_Formatter.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/14_Path_Formatter.md
@@ -40,11 +40,12 @@ use Pimcore\Model\DataObject\News;
 class TheFormatter implements PathFormatterInterface
 {
     /**
-     * @param $result array containing the nice path info. Modify it or leave it as it is. Pass it out afterwards!
+     * @param array $result containing the nice path info. Modify it or leave it as it is. Pass it out afterwards!
      * @param ElementInterface $source the source object
-     * @param $targets list of nodes describing the target elements
-     * @param $params optional parameters. may contain additional context information in the future. to be defined.
-     * @return mixed list of display names.
+     * @param array $targets list of nodes describing the target elements
+     * @param array $params optional parameters. may contain additional context information in the future. to be defined.
+     * 
+     * @return array list of display names.
      */
     public function formatPath(array $result, ElementInterface $source, array $targets, array $params): array
     {

--- a/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/03_Assortment_Tenant_Configuration.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/03_Assortment_Tenant_Configuration.md
@@ -49,7 +49,7 @@ provides following methods to set the current Assortment Tenant when working wit
     /**
      * sets current assortment tenant which is used for indexing and product lists
      *
-     * @param $tenant string
+     * @param string $tenant
      * @return mixed
      */
     public function setCurrentAssortmentTenant($tenant);
@@ -64,7 +64,7 @@ provides following methods to set the current Assortment Tenant when working wit
     /**
      * sets current assortment sub tenant which is used for indexing and product lists
      *
-     * @param $subTenant string
+     * @param string $subTenant
      * @return mixed
      */
     public function setCurrentAssortmentSubTenant($subTenant);
@@ -135,7 +135,7 @@ In order to populate the additional mapping data, also following methods have to
      * in case of subtenants returns a data structure containing all sub tenants
      *
      * @param IndexableInterface $object
-     * @param null $subObjectId
+     * @param int|null $subObjectId
      *
      * @return mixed $subTenantData
      */
@@ -165,7 +165,7 @@ In order to populate the additional mapping data, the following method has to be
      * in case of subtenants returns a data structure containing all sub tenants
      *
      * @param IndexableInterface $object
-     * @param null $subObjectId
+     * @param int|null $subObjectId
      *
      * @return array $subTenantData
      */

--- a/doc/Development_Documentation/10_E-Commerce_Framework/07_Filter_Service/03_Elastic_Search/02_Filter_Nested_Documents.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/07_Filter_Service/03_Elastic_Search/02_Filter_Nested_Documents.md
@@ -118,7 +118,7 @@ class SelectMyAttribute extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterS
     /**
      * @param AbstractFilterDefinitionType $filterDefinition
      * @param IProductList $productList
-     * @param $currentFilter
+     * @param array $currentFilter
      * @return string
      * @throws \Exception
      */

--- a/doc/Development_Documentation/10_E-Commerce_Framework/13_Checkout_Manager/03_Checkout_Steps.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/13_Checkout_Manager/03_Checkout_Steps.md
@@ -44,7 +44,7 @@ class DeliveryAddress extends AbstractStep implements CheckoutStepInterface
     /**
      * sets delivered data and commits step
      *
-     * @param  $data
+     * @param mixed $data
      *
      * @return bool
      */

--- a/doc/Development_Documentation/18_Tools_and_Features/09_Tags.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/09_Tags.md
@@ -36,8 +36,8 @@ For accessing and working with tags via API, take a look into `Pimcore\Model\Ele
 /**
  * returns all assigned tags for element
  *
- * @param $cType
- * @param $cId
+ * @param string $cType
+ * @param int $cId
  * @return Tag[]
  */
 public static function getTagsForElement($cType, $cId)
@@ -50,8 +50,8 @@ public static function getTagsForElement($cType, $cId)
 /**
  * adds given tag to element
  *
- * @param $cType
- * @param $cId
+ * @param string $cType
+ * @param int $cId
  * @param Tag $tag
  */
 public static function addTagToElement($cType, $cId, Tag $tag)
@@ -62,8 +62,8 @@ public static function addTagToElement($cType, $cId, Tag $tag)
 /**
  * removes given tag from element
  *
- * @param $cType
- * @param $cId
+ * @param string $cType
+ * @param int $cId
  * @param Tag $tag
  */
 public static function removeTagFromElement($cType, $cId, Tag $tag)
@@ -75,9 +75,9 @@ public static function removeTagFromElement($cType, $cId, Tag $tag)
  * sets given tags to element and removes all other tags
  * to remove all tags from element, provide empty array of tags
  *
- * @param $cType
- * @param $cId
- * @param Tag[] $tag
+ * @param string $cType
+ * @param int $cId
+ * @param Tag[] $tags
  */
 public static function setTagsForElement($cType, $cId, array $tags)
 {

--- a/doc/Development_Documentation/20_Extending_Pimcore/17_Custom_Persistent_Models.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/17_Custom_Persistent_Models.md
@@ -66,7 +66,7 @@ class Vote extends AbstractModel {
     /**
      * get score by id
      *
-     * @param $id
+     * @param int $id
      * @return null|self
      */
     public static function getById($id) {
@@ -83,7 +83,7 @@ class Vote extends AbstractModel {
     }
  
     /**
-     * @param $score
+     * @param int $score
      */
     public function setScore($score) {
         $this->score = $score;
@@ -97,7 +97,7 @@ class Vote extends AbstractModel {
     }
  
     /**
-     * @param $username
+     * @param string $username
      */
     public function setUsername($username) {
         $this->username = $username;
@@ -111,7 +111,7 @@ class Vote extends AbstractModel {
     }
  
     /**
-     * @param $id
+     * @param int $id
      */
     public function setId($id) {
         $this->id = $id;
@@ -154,7 +154,7 @@ class Dao extends AbstractDao {
     /**
      * get vote by id
      *
-     * @param null $id
+     * @param int|null $id
      * @throws \Exception
      */
     public function getById($id = null) {

--- a/doc/Development_Documentation/26_Best_Practice/02_Advanced_Pricing_System.md
+++ b/doc/Development_Documentation/26_Best_Practice/02_Advanced_Pricing_System.md
@@ -103,12 +103,12 @@ Following sample implementation does that by using a sql query:
     /**
      * Filters and orders given product IDs based on price information
      *
-     * @param $productIds  - contains all productId that apply filter criteria without limit & offset
-     * @param $fromPrice   - optional filter for 'fromPrice'
-     * @param $toPrice     - optional filter for 'toPrice'
-     * @param $order       - order for sorting (asc|desc)
-     * @param $offset
-     * @param $limit
+     * @param array $productIds  - contains all productId that apply filter criteria without limit & offset
+     * @param float $fromPrice   - optional filter for 'fromPrice'
+     * @param float $toPrice     - optional filter for 'toPrice'
+     * @param string $order       - order for sorting (asc|desc)
+     * @param int $offset
+     * @param int $limit
      * @return array
      */
     public function filterProductIds($productIds, $fromPrice, $toPrice, $order, $offset, $limit)

--- a/tests/_support/Helper/ClassManager.php
+++ b/tests/_support/Helper/ClassManager.php
@@ -132,7 +132,7 @@ class ClassManager extends Module
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return ObjectbrickDefinition|null
      */

--- a/tests/_support/Helper/DataType/TestDataHelper.php
+++ b/tests/_support/Helper/DataType/TestDataHelper.php
@@ -795,7 +795,7 @@ class TestDataHelper extends Module
     }
 
     /**
-     * @param $seed
+     * @param int $seed
      *
      * @return array
      */
@@ -1027,8 +1027,8 @@ class TestDataHelper extends Module
     }
 
     /**
-     * @param $field
-     * @param $seed
+     * @param string $field
+     * @param int $seed
      *
      * @return DataObject\Data\ObjectMetadata[]
      */
@@ -1334,7 +1334,7 @@ class TestDataHelper extends Module
     }
 
     /**
-     * @param null $condition
+     * @param string|null $condition
      *
      * @return Concrete[]
      */

--- a/tests/_support/Util/TestHelper.php
+++ b/tests/_support/Util/TestHelper.php
@@ -363,9 +363,9 @@ class TestHelper
 
     /**
      * @param string $keyPrefix
-     * @param bool   $save
-     * @param bool   $publish
-     * @param null   $type
+     * @param bool $save
+     * @param bool $publish
+     * @param string|null $type
      *
      * @return Concrete|Unittest
      */

--- a/tests/cache/Core/AbstractCoreHandlerTest.php
+++ b/tests/cache/Core/AbstractCoreHandlerTest.php
@@ -201,7 +201,7 @@ abstract class AbstractCoreHandlerTest extends TestCase
      * @dataProvider invalidKeys
      * @expectedException InvalidArgumentException
      *
-     * @param $key
+     * @param string $key
      */
     public function testExceptionOnInvalidItemKeySave($key)
     {
@@ -214,7 +214,7 @@ abstract class AbstractCoreHandlerTest extends TestCase
      * @dataProvider invalidKeys
      * @expectedException InvalidArgumentException
      *
-     * @param $key
+     * @param string $key
      */
     public function testExceptionOnInvalidItemKeyRemove($key)
     {

--- a/tests/ecommerce/PricingManager/ConditionTest.php
+++ b/tests/ecommerce/PricingManager/ConditionTest.php
@@ -94,7 +94,7 @@ class ConditionTest extends EcommerceTestCase
     }
 
     /**
-     * @param $path
+     * @param string $path
      *
      * @return AbstractCategory
      */
@@ -176,8 +176,8 @@ class ConditionTest extends EcommerceTestCase
     }
 
     /**
-     * @param $id
-     * @param null $parentId
+     * @param int $id
+     * @param int|null $parentId
      *
      * @return AbstractProduct
      */

--- a/tests/ecommerce/PricingManager/Rule/AbstractRuleTest.php
+++ b/tests/ecommerce/PricingManager/Rule/AbstractRuleTest.php
@@ -70,7 +70,7 @@ class AbstractRuleTest extends EcommerceTestCase
     }
 
     /**
-     * @param $value
+     * @param int|float|string|Decimal $value
      *
      * @return PriceInterface
      *
@@ -123,9 +123,9 @@ class AbstractRuleTest extends EcommerceTestCase
     }
 
     /**
-     * @param $id
-     * @param $grossPrice
-     * @param $pricingManager
+     * @param int $id
+     * @param float $grossPrice
+     * @param PricingManagerInterface $pricingManager
      * @param array $categories
      * @param array $taxes
      * @param string $combinationType
@@ -280,7 +280,7 @@ class AbstractRuleTest extends EcommerceTestCase
     }
 
     /**
-     * @param $actionDefinitions
+     * @param array $definitions
      *
      * @return ActionInterface[]
      */
@@ -305,7 +305,7 @@ class AbstractRuleTest extends EcommerceTestCase
     }
 
     /**
-     * @param $conditionDefinitions
+     * @param mixed $conditionDefinitions
      *
      * @return ConditionInterface
      */
@@ -343,7 +343,7 @@ class AbstractRuleTest extends EcommerceTestCase
     }
 
     /**
-     * @param $ruleDefinitions
+     * @param array $ruleDefinitions
      *
      * @return RuleInterface[]
      */

--- a/tests/ecommerce/Type/DecimalTest.php
+++ b/tests/ecommerce/Type/DecimalTest.php
@@ -350,9 +350,9 @@ class DecimalTest extends TestCase
     /**
      * @dataProvider immutableOperationProvider
      *
-     * @param $input
-     * @param $expected
-     * @param $operation
+     * @param int $input
+     * @param int $expected
+     * @param string $operation
      * @param array ...$arguments
      */
     public function testImmutableOperations(int $input, int $expected, $operation, ...$arguments)
@@ -639,7 +639,7 @@ class DecimalTest extends TestCase
     /**
      * Pairs for price operations (add, sub)
      *
-     * @param $expected
+     * @param int $expected
      *
      * @return array
      */
@@ -666,7 +666,7 @@ class DecimalTest extends TestCase
     /**
      * Pairs for scalar operations (mul, div)
      *
-     * @param $expected
+     * @param int|float $expected
      *
      * @return array
      */
@@ -698,7 +698,7 @@ class DecimalTest extends TestCase
      * Mixes pairs (creates one pair per possible combination)
      *
      * @param array $input
-     * @param $expected
+     * @param int|float $expected
      *
      * @return array
      */

--- a/tests/model/Classificationstore/AbstractClassificationStoreTest.php
+++ b/tests/model/Classificationstore/AbstractClassificationStoreTest.php
@@ -33,7 +33,7 @@ abstract class AbstractClassificationStoreTest extends ModelTestCase
     }
 
     /**
-     * @param $store Classificationstore\StoreConfig
+     * @param Classificationstore\StoreConfig $store
      */
     protected function configureStore(Classificationstore\StoreConfig $store)
     {

--- a/tests/model/LazyLoading/AbstractLazyLoadingTest.php
+++ b/tests/model/LazyLoading/AbstractLazyLoadingTest.php
@@ -2,6 +2,7 @@
 
 namespace Pimcore\Tests\Model\LazyLoading;
 
+use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\LazyLoading;
 use Pimcore\Model\DataObject\RelationTest;
@@ -66,7 +67,7 @@ class AbstractLazyLoadingTest extends ModelTestCase
     }
 
     /**
-     * @param $parent
+     * @param AbstractObject $parent
      *
      * @return LazyLoading
      *

--- a/tests/service/Element/VersionTest.php
+++ b/tests/service/Element/VersionTest.php
@@ -131,7 +131,7 @@ class VersionTest extends TestCase
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return Version
      */


### PR DESCRIPTION
Fix all phpstan level 2 errors in bundles/ (also doc/ und tests/ ...) with following schema:
```
PHPDoc tag @param has invalid value ($xyz)
```
Before:
```
 [ERROR] Found 3539 errors
```
After:
```
 [ERROR] Found 3251 errors
```