### PR TITLE
[PHPSTAN] Fill empty php doc param types (lib) 

### DIFF
--- a/lib/Browser.php
+++ b/lib/Browser.php
@@ -225,7 +225,7 @@ class Browser
     /**
      * Set the name of the browser
      *
-     * @param $browser string The name of the Browser
+     * @param string $browser The name of the Browser
      */
     public function setBrowser($browser)
     {
@@ -345,7 +345,7 @@ class Browser
     /**
      * Set the browser to be from AOL
      *
-     * @param $isAol
+     * @param bool $isAol
      */
     public function setAol($isAol)
     {

--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -95,7 +95,7 @@ class Cache
     /**
      * Remove an item from the cache
      *
-     * @param $key
+     * @param string $key
      *
      * @return bool
      */

--- a/lib/Cache/Core/CacheQueueItem.php
+++ b/lib/Cache/Core/CacheQueueItem.php
@@ -54,7 +54,7 @@ class CacheQueueItem
     protected $force = false;
 
     /**
-     * @param $key
+     * @param string $key
      * @param mixed $data
      * @param array $tags
      * @param int|\DateInterval|null $lifetime

--- a/lib/Cache/Core/CoreHandler.php
+++ b/lib/Cache/Core/CoreHandler.php
@@ -256,7 +256,7 @@ class CoreHandler implements LoggerAwareInterface, CoreHandlerInterface
     /**
      * Load data from cache (retrieves data from cache item)
      *
-     * @param $key
+     * @param string $key
      *
      * @return bool|mixed
      */
@@ -281,7 +281,7 @@ class CoreHandler implements LoggerAwareInterface, CoreHandlerInterface
     /**
      * Get PSR-6 cache item
      *
-     * @param $key
+     * @param string $key
      *
      * @return PimcoreCacheItemInterface
      */
@@ -469,7 +469,7 @@ class CoreHandler implements LoggerAwareInterface, CoreHandlerInterface
      * Create tags for cache item - do this as late as possible as this is potentially expensive (nested items, dependencies)
      *
      * @param PimcoreCacheItemInterface $cacheItem
-     * @param $data
+     * @param mixed $data
      * @param array $tags
      *
      * @return null|PimcoreCacheItemInterface
@@ -581,7 +581,7 @@ class CoreHandler implements LoggerAwareInterface, CoreHandlerInterface
     /**
      * Remove a cache item
      *
-     * @param $key
+     * @param string $key
      *
      * @return bool
      */

--- a/lib/Cache/Core/CoreHandlerInterface.php
+++ b/lib/Cache/Core/CoreHandlerInterface.php
@@ -71,7 +71,7 @@ interface CoreHandlerInterface
     /**
      * Load data from cache (retrieves data from cache item)
      *
-     * @param $key
+     * @param string $key
      *
      * @return bool|mixed
      */
@@ -80,7 +80,7 @@ interface CoreHandlerInterface
     /**
      * Get PSR-6 cache item
      *
-     * @param $key
+     * @param string $key
      *
      * @return PimcoreCacheItemInterface
      */
@@ -103,7 +103,7 @@ interface CoreHandlerInterface
     /**
      * Remove a cache item
      *
-     * @param $key
+     * @param string $key
      *
      * @return bool
      */

--- a/lib/Cache/Pool/CacheItem.php
+++ b/lib/Cache/Pool/CacheItem.php
@@ -271,10 +271,10 @@ class CacheItem implements PimcoreCacheItemInterface, ItemInterface
      * @internal
      *
      * @param LoggerInterface $logger
-     * @param $message
+     * @param string $message
      * @param array $context
      */
-    public static function log(LoggerInterface $logger = null, $message, $context = [])
+    public static function log(LoggerInterface $logger, $message, $context = [])
     {
         if ($logger) {
             $logger->warning($message, $context);

--- a/lib/Cache/Pool/Doctrine.php
+++ b/lib/Cache/Pool/Doctrine.php
@@ -90,7 +90,7 @@ class Doctrine extends AbstractCacheItemPool implements PurgeableCacheItemPoolIn
     /**
      * Deletes all items in the pool.
      *
-     * @param string @namespace The prefix used for all identifiers managed by this pool
+     * @param string $namespace The prefix used for all identifiers managed by this pool
      *
      * @return bool True if the pool was successfully cleared, false otherwise
      */
@@ -245,7 +245,7 @@ SQL;
     /**
      * Remove all not matching tags from item
      *
-     * @param $id
+     * @param string $id
      * @param array $tags
      *
      * @return bool

--- a/lib/Cache/Pool/Redis.php
+++ b/lib/Cache/Pool/Redis.php
@@ -879,9 +879,9 @@ LUA;
     }
 
     /**
-     * @param $item
-     * @param $index
-     * @param $prefix
+     * @param string $item
+     * @param int $index
+     * @param string $prefix
      */
     protected function preprocess(&$item, $index, $prefix)
     {
@@ -889,7 +889,7 @@ LUA;
     }
 
     /**
-     * @param $ids
+     * @param array $ids
      *
      * @return array
      */
@@ -901,7 +901,7 @@ LUA;
     }
 
     /**
-     * @param $tags
+     * @param array $tags
      *
      * @return array
      */

--- a/lib/Cache/Pool/SymfonyAdapterProxy.php
+++ b/lib/Cache/Pool/SymfonyAdapterProxy.php
@@ -93,7 +93,7 @@ class SymfonyAdapterProxy extends AbstractCacheItemPool
     /**
      * Deletes all items in the pool.
      *
-     * @param string The prefix used for all identifiers managed by this pool
+     * @param string $namespace The prefix used for all identifiers managed by this pool
      *
      * @return bool True if the pool was successfully cleared, false otherwise
      */

--- a/lib/Cache/Runtime.php
+++ b/lib/Cache/Runtime.php
@@ -165,8 +165,8 @@ final class Runtime extends \ArrayObject
     /**
      * Alias of self::set() to be compatible with Pimcore\Cache
      *
-     * @param $data
-     * @param $id
+     * @param mixed $data
+     * @param string $id
      *
      * @return mixed
      */
@@ -178,7 +178,7 @@ final class Runtime extends \ArrayObject
     /**
      * Alias of self::get() to be compatible with Pimcore\Cache
      *
-     * @param $id
+     * @param string $id
      *
      * @return mixed
      */

--- a/lib/Cache/Tool/Warming.php
+++ b/lib/Cache/Tool/Warming.php
@@ -54,8 +54,8 @@ class Warming
     /**
      * @static
      *
-     * @param array $types
-     * @param null $classes
+     * @param array|null $types
+     * @param array|null $classes
      */
     public static function objects($types = null, $classes = null)
     {
@@ -94,7 +94,7 @@ class Warming
     /**
      * Adds a Pimcore Object/Asset/Document to the cache
      *
-     * @param $element
+     * @param Element\ElementInterface $element
      */
     public static function loadElementToCache($element)
     {

--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -101,8 +101,8 @@ class Composer
     }
 
     /**
-     * @param $event
-     * @param $consoleDir
+     * @param Event $event
+     * @param string $consoleDir
      */
     public static function clearDataCache($event, $consoleDir)
     {

--- a/lib/Composer/PackageInfo.php
+++ b/lib/Composer/PackageInfo.php
@@ -49,7 +49,7 @@ class PackageInfo
     }
 
     /**
-     * @return array|null
+     * @return array
      */
     private function readInstalledPackages(): array
     {

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -40,7 +40,7 @@ class Config
     private static $environmentConfig;
 
     /**
-     * @param $name - name of configuration file. slash is allowed for subdirectories.
+     * @param string $name - name of configuration file. slash is allowed for subdirectories.
      *
      * @return mixed
      */
@@ -120,7 +120,7 @@ class Config
     /**
      * @internal
      *
-     * @param null $languange
+     * @param string|null $languange
      *
      * @return string
      */
@@ -237,7 +237,7 @@ class Config
      * @internal
      *
      * @param Config\Config $config
-     * @param null $language
+     * @param string|null $language
      */
     public static function setWebsiteConfig(\Pimcore\Config\Config $config, $language = null)
     {
@@ -280,7 +280,7 @@ class Config
     }
 
     /**
-     * @param $config
+     * @param array $config
      *
      * @return array|Config\Config
      */
@@ -735,7 +735,7 @@ class Config
     /**
      * @internal
      *
-     * @param $name
+     * @param string $name
      *
      * @return array
      */
@@ -923,8 +923,8 @@ class Config
     /**
      * @internal
      *
-     * @param $runtimeConfig
-     * @param $key
+     * @param array $runtimeConfig
+     * @param string $key
      *
      * @return bool
      */

--- a/lib/Console/AbstractCommand.php
+++ b/lib/Console/AbstractCommand.php
@@ -90,7 +90,7 @@ abstract class AbstractCommand extends Command
     }
 
     /**
-     * @param $message
+     * @param string $message
      */
     protected function writeError($message)
     {

--- a/lib/Console/Dumper.php
+++ b/lib/Console/Dumper.php
@@ -76,7 +76,7 @@ class Dumper
     }
 
     /**
-     * @param $data
+     * @param mixed $data
      * @param null|int $flags
      */
     public function dump($data, $flags = null)

--- a/lib/Console/Traits/DryRun.php
+++ b/lib/Console/Traits/DryRun.php
@@ -23,7 +23,7 @@ trait DryRun
     /**
      * Configure --dry-run
      *
-     * @param null $description
+     * @param string|null $description
      *
      * @return $this
      */
@@ -60,7 +60,7 @@ trait DryRun
     /**
      * Prefix message with DRY-RUN
      *
-     * @param $message
+     * @param string $message
      * @param string $prefix
      *
      * @return string
@@ -77,7 +77,7 @@ trait DryRun
     /**
      * Prefix message with dry run if in dry-run mode
      *
-     * @param $message
+     * @param string $message
      * @param string $prefix
      *
      * @return string

--- a/lib/Controller/Config/ControllerDataProvider.php
+++ b/lib/Controller/Config/ControllerDataProvider.php
@@ -401,7 +401,7 @@ class ControllerDataProvider
     /**
      * Checks if bundle/controller namespace is not excluded (all core bundles should be excluded here)
      *
-     * @param $namespace
+     * @param string $namespace
      *
      * @return bool
      */

--- a/lib/Controller/FrontendController.php
+++ b/lib/Controller/FrontendController.php
@@ -161,7 +161,7 @@ abstract class FrontendController extends Controller implements EventedControlle
     }
 
     /**
-     * @param $view
+     * @param string $view
      * @param array $parameters
      * @param Response|null $response
      *

--- a/lib/DataObject/GridColumnConfig/Operator/AssetMetadataGetter.php
+++ b/lib/DataObject/GridColumnConfig/Operator/AssetMetadataGetter.php
@@ -83,7 +83,7 @@ class AssetMetadataGetter extends AbstractOperator
     }
 
     /**
-     * @param $value
+     * @param Hotspotimage|Asset $value
      *
      * @return mixed
      */

--- a/lib/DataObject/GridColumnConfig/Operator/StringContains.php
+++ b/lib/DataObject/GridColumnConfig/Operator/StringContains.php
@@ -80,9 +80,9 @@ class StringContains extends AbstractOperator
     }
 
     /**
-     * @param $value
+     * @param string $value
      *
-     * @return mixed
+     * @return bool
      */
     public function contains($value)
     {

--- a/lib/DataObject/GridColumnConfig/Operator/StringReplace.php
+++ b/lib/DataObject/GridColumnConfig/Operator/StringReplace.php
@@ -84,9 +84,9 @@ class StringReplace extends AbstractOperator
     }
 
     /**
-     * @param $value
+     * @param string $value
      *
-     * @return mixed
+     * @return string
      */
     public function replace($value)
     {

--- a/lib/DataObject/GridColumnConfig/Service.php
+++ b/lib/DataObject/GridColumnConfig/Service.php
@@ -61,7 +61,7 @@ class Service
 
     /**
      * @param \stdClass[] $jsonConfigs
-     * @param $config
+     * @param array $config
      * @param mixed|null $context
      *
      * @return ConfigElementInterface[]

--- a/lib/DataObject/GridColumnConfig/Value/DefaultValue.php
+++ b/lib/DataObject/GridColumnConfig/Value/DefaultValue.php
@@ -27,11 +27,11 @@ use Pimcore\Model\Element\ElementInterface;
 class DefaultValue extends AbstractValue
 {
     /**
-     * @param $object
-     * @param $key
-     * @param null $brickType
-     * @param null $brickKey
-     * @param null $fieldDefinition
+     * @param AbstractObject $object
+     * @param string $key
+     * @param string|null $brickType
+     * @param string|null $brickKey
+     * @param Data|null $fieldDefinition
      *
      * @return \stdClass
      *
@@ -93,7 +93,7 @@ class DefaultValue extends AbstractValue
     }
 
     /**
-     * @param $value
+     * @param mixed $value
      *
      * @return \stdClass
      */

--- a/lib/DataObject/Import/ColumnConfig/Operator/PHPCode.php
+++ b/lib/DataObject/Import/ColumnConfig/Operator/PHPCode.php
@@ -43,7 +43,7 @@ class PHPCode extends AbstractOperator
      * PHPCode constructor.
      *
      * @param \stdClass $config
-     * @param null $context
+     * @param mixed|null $context
      */
     public function __construct(\stdClass $config, $context = null)
     {

--- a/lib/DataObject/Import/Service.php
+++ b/lib/DataObject/Import/Service.php
@@ -31,6 +31,7 @@ use Pimcore\Db;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\GridConfig;
 use Pimcore\Model\ImportConfig;
+use Pimcore\Model\User;
 use Pimcore\Tool;
 use Psr\Container\ContainerInterface;
 
@@ -97,7 +98,7 @@ class Service
 
     /**
      * @param \stdClass[] $jsonConfigs
-     * @param $config
+     * @param ConfigElementInterface[] $config
      * @param mixed|null $context
      *
      * @return ConfigElementInterface[]
@@ -152,8 +153,8 @@ class Service
     }
 
     /**
-     * @param $user
-     * @param $classId
+     * @param User $user
+     * @param string $classId
      *
      * @return array|ImportConfig\Listing
      */
@@ -191,10 +192,10 @@ class Service
     }
 
     /**
-     * @param $user
-     * @param $classId
+     * @param User $user
+     * @param string $classId
      *
-     * @return ImportConfig\Listing
+     * @return ImportConfig[]
      */
     public function getMyOwnImportConfigs($user, $classId)
     {
@@ -214,7 +215,7 @@ class Service
     }
 
     /**
-     * @param $gridConfig GridConfig
+     * @param GridConfig $gridConfig
      *
      * @return \stdClass
      */
@@ -244,8 +245,8 @@ class Service
     }
 
     /**
-     * @param $class ClassDefinition
-     * @param $exportColumn
+     * @param ClassDefinition $class
+     * @param array $exportColumn
      *
      * @return array|\stdClass
      */

--- a/lib/Db/ConnectionInterface.php
+++ b/lib/Db/ConnectionInterface.php
@@ -42,8 +42,8 @@ interface ConnectionInterface extends Connection
 
     /**
      * @param string $query
-     * @param $params
-     * @param $types
+     * @param array $params
+     * @param array $types
      * @param QueryCacheProfile $qcp
      *
      * @return \Doctrine\DBAL\Driver\ResultStatement
@@ -96,7 +96,7 @@ interface ConnectionInterface extends Connection
     public function fetchRow($sql, $params = [], $types = []);
 
     /**
-     * @param $sql
+     * @param string $sql
      * @param array $params
      * @param array $types
      *
@@ -105,7 +105,7 @@ interface ConnectionInterface extends Connection
     public function fetchCol($sql, $params = [], $types = []);
 
     /**
-     * @param $sql
+     * @param string $sql
      * @param array $params
      * @param array $types
      *
@@ -114,7 +114,7 @@ interface ConnectionInterface extends Connection
     public function fetchOne($sql, $params = [], $types = []);
 
     /**
-     * @param $sql
+     * @param string $sql
      * @param array $params
      * @param array $types
      *
@@ -138,8 +138,8 @@ interface ConnectionInterface extends Connection
     public function quoteIdentifier($str);
 
     /**
-     * @param $text
-     * @param $value
+     * @param string $text
+     * @param mixed $value
      * @param string|null $type
      * @param int|null $count
      *
@@ -148,7 +148,7 @@ interface ConnectionInterface extends Connection
     public function quoteInto($text, $value, $type = null, $count = null);
 
     /**
-     * @param string $ident
+     * @param string|array $ident
      * @param string $alias
      *
      * @return string

--- a/lib/Db/PhpArrayFileTable.php
+++ b/lib/Db/PhpArrayFileTable.php
@@ -39,7 +39,7 @@ class PhpArrayFileTable
     protected $lastInsertId;
 
     /**
-     * @param $filePath
+     * @param string $filePath
      *
      * @return self
      */
@@ -65,7 +65,7 @@ class PhpArrayFileTable
     }
 
     /**
-     * @param $filePath
+     * @param string $filePath
      *
      * @throws \Exception
      */
@@ -91,7 +91,7 @@ class PhpArrayFileTable
     }
 
     /**
-     * @param $data
+     * @param array $data
      * @param string|int $id
      *
      * @throws \Exception
@@ -135,8 +135,8 @@ class PhpArrayFileTable
     }
 
     /**
-     * @param null $filter
-     * @param null $order
+     * @param callable|null $filter
+     * @param callable|null $order
      *
      * @return array
      */

--- a/lib/Db/PimcoreExtensionsTrait.php
+++ b/lib/Db/PimcoreExtensionsTrait.php
@@ -245,7 +245,7 @@ trait PimcoreExtensionsTrait
     /**
      * Fetches the first row of the SQL result.
      *
-     * @param $sql
+     * @param string $sql
      * @param array $params
      * @param array $types
      *
@@ -263,7 +263,7 @@ trait PimcoreExtensionsTrait
     /**
      * Fetches the first column of all SQL result rows as an array.
      *
-     * @param $sql
+     * @param string $sql
      * @param array $params
      * @param array $types
      *
@@ -290,7 +290,7 @@ trait PimcoreExtensionsTrait
     /**
      * Fetches the first column of the first row of the SQL result.
      *
-     * @param $sql
+     * @param string $sql
      * @param array $params
      * @param array $types
      *
@@ -309,7 +309,7 @@ trait PimcoreExtensionsTrait
      * The first column is the key, the second column is the
      * value.
      *
-     * @param $sql
+     * @param string $sql
      * @param array $params
      * @param array $types
      *
@@ -330,7 +330,7 @@ trait PimcoreExtensionsTrait
     }
 
     /**
-     * @param $table
+     * @param string $table
      * @param array $data
      *
      * @return int
@@ -546,7 +546,7 @@ trait PimcoreExtensionsTrait
     }
 
     /**
-     * @param $sql
+     * @param string $sql
      * @param array $exclusions
      *
      * @return \Doctrine\DBAL\Driver\Statement|int|null
@@ -572,7 +572,7 @@ trait PimcoreExtensionsTrait
     }
 
     /**
-     * @param $params
+     * @param array $params
      *
      * @return array
      */
@@ -586,7 +586,7 @@ trait PimcoreExtensionsTrait
     }
 
     /**
-     * @param $data
+     * @param array $data
      *
      * @return array
      */

--- a/lib/Document.php
+++ b/lib/Document.php
@@ -19,9 +19,9 @@ class Document
     /**
      * Singleton for Pimcore\Document
      *
-     * @param null $adapter
+     * @param string|null $adapter
      *
-     * @return bool|null|Document
+     * @return Document\Adapter|null
      *
      * @throws \Exception
      */
@@ -65,7 +65,7 @@ class Document
     /**
      * Checks if a file type is supported by the adapter.
      *
-     * @param $filetype
+     * @param string $filetype
      *
      * @return bool
      */
@@ -83,7 +83,7 @@ class Document
     /**
      * Returns adapter class if exists or false if doesn't exist
      *
-     * @return bool|\Pimcore\Document\Adapter
+     * @return Document\Adapter|null
      */
     public static function getDefaultAdapter()
     {

--- a/lib/Document/Adapter.php
+++ b/lib/Document/Adapter.php
@@ -24,7 +24,7 @@ abstract class Adapter
     protected $tmpFiles = [];
 
     /**
-     * @param $path
+     * @param string $path
      *
      * @return string
      */

--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -81,7 +81,7 @@ class Ghostscript extends Adapter
     }
 
     /**
-     * @param $path
+     * @param string $path
      *
      * @return $this
      *
@@ -109,7 +109,7 @@ class Ghostscript extends Adapter
     }
 
     /**
-     * @param null $path
+     * @param string|null $path
      *
      * @return null|string
      *
@@ -152,7 +152,7 @@ class Ghostscript extends Adapter
     }
 
     /**
-     * @param $path
+     * @param string $path
      * @param int $page
      * @param int $resolution
      *
@@ -182,8 +182,8 @@ class Ghostscript extends Adapter
     }
 
     /**
-     * @param null $page
-     * @param null $path
+     * @param int|null $page
+     * @param string|null $path
      *
      * @return bool|string
      */

--- a/lib/Document/Adapter/LibreOffice.php
+++ b/lib/Document/Adapter/LibreOffice.php
@@ -70,7 +70,7 @@ class LibreOffice extends Ghostscript
     }
 
     /**
-     * @param $path
+     * @param string $path
      *
      * @return $this
      *
@@ -108,7 +108,7 @@ class LibreOffice extends Ghostscript
     }
 
     /**
-     * @param null $path
+     * @param string|null $path
      *
      * @return null|string|void
      *
@@ -170,10 +170,10 @@ class LibreOffice extends Ghostscript
     }
 
     /**
-     * @param null $page
-     * @param null $path
+     * @param int|null $page
+     * @param string|null $path
      *
-     * @return bool|string
+     * @return string
      *
      * @throws \Exception
      */

--- a/lib/Document/Newsletter/AddressSourceAdapter/CsvList.php
+++ b/lib/Document/Newsletter/AddressSourceAdapter/CsvList.php
@@ -27,7 +27,7 @@ class CsvList implements AddressSourceAdapterInterface
     /**
      * IAddressSourceAdapter constructor.
      *
-     * @param $params
+     * @param array $params
      */
     public function __construct($params)
     {
@@ -76,8 +76,8 @@ class CsvList implements AddressSourceAdapterInterface
     /**
      * returns array of params to be set on mail for single sending
      *
-     * @param $limit
-     * @param $offset
+     * @param int $limit
+     * @param int $offset
      *
      * @return array
      */

--- a/lib/Document/Newsletter/AddressSourceAdapter/DefaultAdapter.php
+++ b/lib/Document/Newsletter/AddressSourceAdapter/DefaultAdapter.php
@@ -49,7 +49,7 @@ class DefaultAdapter implements AddressSourceAdapterInterface
     /**
      * IAddressSourceAdapter constructor.
      *
-     * @param $params
+     * @param array $params
      */
     public function __construct($params)
     {
@@ -190,8 +190,8 @@ class DefaultAdapter implements AddressSourceAdapterInterface
     /**
      * returns array of params to be set on mail for single sending
      *
-     * @param $limit
-     * @param $offset
+     * @param int $limit
+     * @param int $offset
      *
      * @return SendingParamContainer[]
      */

--- a/lib/Document/Newsletter/AddressSourceAdapter/ReportAdapter.php
+++ b/lib/Document/Newsletter/AddressSourceAdapter/ReportAdapter.php
@@ -22,7 +22,7 @@ use Pimcore\Model\Tool\CustomReport\Adapter\CustomReportAdapterInterface;
 class ReportAdapter implements AddressSourceAdapterInterface
 {
     /**
-     * @var string[]
+     * @var string
      */
     protected $emailFieldName;
 
@@ -47,7 +47,7 @@ class ReportAdapter implements AddressSourceAdapterInterface
     protected $list;
 
     /**
-     * @param $emailFieldName
+     * @param string $emailFieldName
      * @param CustomReportAdapterInterface $reportAdapter
      */
     public function __construct($emailFieldName, CustomReportAdapterInterface $reportAdapter)
@@ -128,8 +128,8 @@ class ReportAdapter implements AddressSourceAdapterInterface
     /**
      * returns array of params to be set on mail for single sending
      *
-     * @param $limit
-     * @param $offset
+     * @param int $limit
+     * @param int $offset
      *
      * @return SendingParamContainer[]
      */

--- a/lib/Document/Newsletter/AddressSourceAdapterFactoryInterface.php
+++ b/lib/Document/Newsletter/AddressSourceAdapterFactoryInterface.php
@@ -19,7 +19,7 @@ interface AddressSourceAdapterFactoryInterface
     /**
      * Configures and creates the AddressSourceAdapterInterface
      *
-     * @param $params
+     * @param array $params
      *
      * @return AddressSourceAdapterInterface
      */

--- a/lib/Document/Newsletter/AddressSourceAdapterInterface.php
+++ b/lib/Document/Newsletter/AddressSourceAdapterInterface.php
@@ -42,8 +42,8 @@ interface AddressSourceAdapterInterface
     /**
      * returns array of params to be set on mail for single sending
      *
-     * @param $limit
-     * @param $offset
+     * @param int $limit
+     * @param int $offset
      *
      * @return SendingParamContainer[]
      */

--- a/lib/Document/Newsletter/DefaultAddressSourceAdapterFactory.php
+++ b/lib/Document/Newsletter/DefaultAddressSourceAdapterFactory.php
@@ -16,10 +16,13 @@ namespace Pimcore\Document\Newsletter;
 
 class DefaultAddressSourceAdapterFactory implements AddressSourceAdapterFactoryInterface
 {
+    /**
+     * @var string
+     */
     private $className;
 
     /**
-     * @param $className
+     * @param string $className
      */
     public function __construct($className)
     {

--- a/lib/Document/Tag/NamingStrategy/Migration/Analyze/Element/AbstractBlock.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/Analyze/Element/AbstractBlock.php
@@ -37,7 +37,7 @@ abstract class AbstractBlock extends AbstractElement
     /**
      * Get a list of available child indexes from block data
      *
-     * @param null $data
+     * @param string|null $data
      *
      * @return array
      */

--- a/lib/Document/Tag/NamingStrategy/Migration/Analyze/Element/AbstractElement.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/Analyze/Element/AbstractElement.php
@@ -269,7 +269,7 @@ abstract class AbstractElement
     }
 
     /**
-     * @param AbstractBlock|null $parent
+     * @param AbstractBlock $parent
      *
      * @return AbstractBlock[]
      */

--- a/lib/Document/Tag/TagHandler.php
+++ b/lib/Document/Tag/TagHandler.php
@@ -305,7 +305,7 @@ class TagHandler implements TagHandlerInterface, LoggerAwareInterface
      * TemplateAreabrickInterface fall back to auto-resolving the template reference. See interface for examples.
      *
      * @param AreabrickInterface $brick
-     * @param $type
+     * @param string $type
      *
      * @return mixed|null|string
      */

--- a/lib/Event/Traits/ElementDeleteInfoEventTrait.php
+++ b/lib/Event/Traits/ElementDeleteInfoEventTrait.php
@@ -32,7 +32,7 @@ trait ElementDeleteInfoEventTrait
     protected $reason;
 
     /**
-     * @return mixed
+     * @return bool
      */
     public function getDeletionAllowed(): bool
     {

--- a/lib/Event/Webservice/FilterEvent.php
+++ b/lib/Event/Webservice/FilterEvent.php
@@ -43,10 +43,10 @@ class FilterEvent extends Event
     /**
      * FilterEvent constructor.
      *
-     * @param $request
-     * @param $type
-     * @param $action
-     * @param $list
+     * @param Request $request
+     * @param string $type
+     * @param string $action
+     * @param string $condition
      */
     public function __construct($request, $type, $action, $condition)
     {
@@ -65,7 +65,7 @@ class FilterEvent extends Event
     }
 
     /**
-     * @param mixed $request
+     * @param Request $request
      */
     public function setRequest($request): void
     {
@@ -73,7 +73,7 @@ class FilterEvent extends Event
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getType()
     {
@@ -81,7 +81,7 @@ class FilterEvent extends Event
     }
 
     /**
-     * @param mixed $type
+     * @param string $type
      */
     public function setType($type): void
     {
@@ -89,7 +89,7 @@ class FilterEvent extends Event
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getAction()
     {
@@ -97,7 +97,7 @@ class FilterEvent extends Event
     }
 
     /**
-     * @param mixed $action
+     * @param string $action
      */
     public function setAction($action): void
     {

--- a/lib/File.php
+++ b/lib/File.php
@@ -34,7 +34,7 @@ class File
     /**
      * @static
      *
-     * @param  $name
+     * @param string $name
      *
      * @return string
      */
@@ -53,8 +53,8 @@ class File
     /**
      * @static
      *
-     * @param  $tmpFilename
-     * @param null $language
+     * @param string $tmpFilename
+     * @param string|null $language
      * @param string $replacement
      *
      * @return string
@@ -75,7 +75,7 @@ class File
     /**
      * @static
      *
-     * @param  $filename
+     * @param string $filename
      *
      * @return bool
      */
@@ -103,7 +103,7 @@ class File
     }
 
     /**
-     * @param $mode
+     * @param int $mode
      */
     public static function setDefaultMode($mode)
     {
@@ -119,8 +119,8 @@ class File
     }
 
     /**
-     * @param $path
-     * @param $data
+     * @param string $path
+     * @param mixed $data
      *
      * @return int
      */
@@ -137,8 +137,8 @@ class File
     }
 
     /**
-     * @param $path
-     * @param $data
+     * @param string $path
+     * @param mixed $data
      */
     public static function putPhpFile($path, $data)
     {
@@ -150,8 +150,8 @@ class File
     }
 
     /**
-     * @param $path
-     * @param null $mode
+     * @param string $path
+     * @param int|null $mode
      * @param bool $recursive
      *
      * @return bool
@@ -205,8 +205,8 @@ class File
     }
 
     /**
-     * @param $oldPath
-     * @param $newPath
+     * @param string $oldPath
+     * @param string $newPath
      *
      * @return bool
      */

--- a/lib/Google/Api.php
+++ b/lib/Google/Api.php
@@ -96,7 +96,7 @@ class Api
     }
 
     /**
-     * @param null $scope
+     * @param array|null $scope
      *
      * @return bool|\Google_Client
      */
@@ -201,7 +201,7 @@ class Api
     }
 
     /**
-     * @param $type
+     * @param string $type
      *
      * @return array
      *

--- a/lib/Google/Cse.php
+++ b/lib/Google/Cse.php
@@ -23,11 +23,11 @@ use Zend\Paginator\AdapterAggregateInterface;
 class Cse implements \Iterator, AdapterInterface, AdapterAggregateInterface
 {
     /**
-     * @param $query
+     * @param string $query
      * @param int $offset
      * @param int $perPage
      * @param array $config
-     * @param null $facet
+     * @param string|null $facet
      *
      * @return Cse
      */
@@ -107,7 +107,7 @@ class Cse implements \Iterator, AdapterInterface, AdapterAggregateInterface
     }
 
     /**
-     * @var array
+     * @var Item[]
      */
     public $results = [];
 
@@ -229,7 +229,7 @@ class Cse implements \Iterator, AdapterInterface, AdapterAggregateInterface
     }
 
     /**
-     * @param $offset
+     * @param int $offset
      *
      * @return $this
      */
@@ -249,7 +249,7 @@ class Cse implements \Iterator, AdapterInterface, AdapterAggregateInterface
     }
 
     /**
-     * @param $raw
+     * @param array $raw
      *
      * @return $this
      */
@@ -269,7 +269,7 @@ class Cse implements \Iterator, AdapterInterface, AdapterAggregateInterface
     }
 
     /**
-     * @param $total
+     * @param int $total
      *
      * @return $this
      */
@@ -289,7 +289,7 @@ class Cse implements \Iterator, AdapterInterface, AdapterAggregateInterface
     }
 
     /**
-     * @param $perPage
+     * @param int $perPage
      *
      * @return $this
      */
@@ -309,7 +309,7 @@ class Cse implements \Iterator, AdapterInterface, AdapterAggregateInterface
     }
 
     /**
-     * @param $config
+     * @param array $config
      *
      * @return $this
      */
@@ -329,7 +329,7 @@ class Cse implements \Iterator, AdapterInterface, AdapterAggregateInterface
     }
 
     /**
-     * @param $query
+     * @param string $query
      *
      * @return $this
      */
@@ -349,7 +349,7 @@ class Cse implements \Iterator, AdapterInterface, AdapterAggregateInterface
     }
 
     /**
-     * @param $results
+     * @param Item[] $results
      *
      * @return $this
      */
@@ -363,7 +363,7 @@ class Cse implements \Iterator, AdapterInterface, AdapterAggregateInterface
     /**
      * @param bool $retry
      *
-     * @return array
+     * @return Item[]
      */
     public function getResults($retry = true)
     {
@@ -375,7 +375,7 @@ class Cse implements \Iterator, AdapterInterface, AdapterAggregateInterface
     }
 
     /**
-     * @param $facets
+     * @param array $facets
      *
      * @return $this
      */

--- a/lib/Google/Cse/Item.php
+++ b/lib/Google/Cse/Item.php
@@ -14,6 +14,8 @@
 
 namespace Pimcore\Google\Cse;
 
+use Pimcore\Model;
+
 class Item
 {
     /**
@@ -62,12 +64,12 @@ class Item
     public $htmlFormattedUrl;
 
     /**
-     * @var string
+     * @var Model\Asset\Image|string|null
      */
     public $image;
 
     /**
-     * @var string
+     * @var Model\Document|null
      */
     public $document;
 
@@ -101,8 +103,8 @@ class Item
     }
 
     /**
-     * @param  $key
-     * @param  $value
+     * @param string $key
+     * @param mixed $value
      *
      * @return $this
      */
@@ -117,7 +119,7 @@ class Item
     }
 
     /**
-     * @param $displayLink
+     * @param string $displayLink
      *
      * @return $this
      */
@@ -137,7 +139,7 @@ class Item
     }
 
     /**
-     * @param $document
+     * @param Model\Document $document
      *
      * @return $this
      */
@@ -149,7 +151,7 @@ class Item
     }
 
     /**
-     * @return string
+     * @return Model\Document|null
      */
     public function getDocument()
     {
@@ -157,7 +159,7 @@ class Item
     }
 
     /**
-     * @param $formattedUrl
+     * @param string $formattedUrl
      *
      * @return $this
      */
@@ -177,7 +179,7 @@ class Item
     }
 
     /**
-     * @param $htmlFormattedUrl
+     * @param string $htmlFormattedUrl
      *
      * @return $this
      */
@@ -197,7 +199,7 @@ class Item
     }
 
     /**
-     * @param $htmlSnippet
+     * @param string $htmlSnippet
      *
      * @return $this
      */
@@ -217,7 +219,7 @@ class Item
     }
 
     /**
-     * @param $htmlTitle
+     * @param string $htmlTitle
      *
      * @return $this
      */
@@ -237,7 +239,7 @@ class Item
     }
 
     /**
-     * @param $image
+     * @param Model\Asset\Image|string $image
      *
      * @return $this
      */
@@ -249,7 +251,7 @@ class Item
     }
 
     /**
-     * @return string
+     * @return Model\Asset\Image|string|null
      */
     public function getImage()
     {
@@ -257,7 +259,7 @@ class Item
     }
 
     /**
-     * @param $link
+     * @param string $link
      *
      * @return $this
      */
@@ -296,7 +298,7 @@ class Item
     }
 
     /**
-     * @param $snippet
+     * @param string $snippet
      *
      * @return $this
      */
@@ -316,7 +318,7 @@ class Item
     }
 
     /**
-     * @param $title
+     * @param string $title
      *
      * @return $this
      */
@@ -336,7 +338,7 @@ class Item
     }
 
     /**
-     * @param $type
+     * @param string $type
      *
      * @return $this
      */

--- a/lib/Google/Webmastertools.php
+++ b/lib/Google/Webmastertools.php
@@ -39,7 +39,7 @@ class Webmastertools
     }
 
     /**
-     * @param null $site
+     * @param Site|null $site
      *
      * @return bool
      */

--- a/lib/Helper/ContrastColor.php
+++ b/lib/Helper/ContrastColor.php
@@ -19,7 +19,7 @@ class ContrastColor
     /**
      * returns either hex code of black or white depending on the contrast to the given color
      *
-     * @param $hexColor
+     * @param string $hexColor
      *
      * @return string
      */

--- a/lib/Helper/Dashboard.php
+++ b/lib/Helper/Dashboard.php
@@ -129,8 +129,8 @@ class Dashboard
     }
 
     /**
-     * @param $key
-     * @param null $configuration
+     * @param string $key
+     * @param array|null $configuration
      */
     public function saveDashboard($key, $configuration = null)
     {
@@ -145,7 +145,7 @@ class Dashboard
     }
 
     /**
-     * @param $key
+     * @param string $key
      */
     public function deleteDashboard($key)
     {

--- a/lib/Helper/ImageChart.php
+++ b/lib/Helper/ImageChart.php
@@ -22,7 +22,7 @@ class ImageChart
     public static $serviceUrl = 'https://chart.googleapis.com/chart';
 
     /**
-     * @param $data
+     * @param array $data
      * @param string $parameters
      *
      * @return string

--- a/lib/Helper/Mail.php
+++ b/lib/Helper/Mail.php
@@ -22,7 +22,7 @@ use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 class Mail
 {
     /**
-     * @param $type
+     * @param string $type
      * @param MailClient $mail
      *
      * @return string
@@ -144,7 +144,7 @@ CSS;
 
     /**
      * @param MailClient $mail
-     * @param $recipients array
+     * @param array $recipients
      *
      * @return Model\Tool\Email\Log
      */
@@ -206,11 +206,11 @@ CSS;
     }
 
     /**
-     * @param $string
-     * @param null $document
-     * @param null $hostUrl
+     * @param string $string
+     * @param Model\Document $document
+     * @param string|null $hostUrl
      *
-     * @return mixed
+     * @return string
      *
      * @throws \Exception
      */
@@ -282,10 +282,10 @@ CSS;
     }
 
     /**
-     * @param $string
-     * @param null $document
+     * @param string $string
+     * @param Model\Document $document
      *
-     * @return mixed
+     * @return string
      *
      * @throws \Exception
      */
@@ -376,8 +376,8 @@ CSS;
     }
 
     /**
-     * @param $path
-     * @param null $document
+     * @param string $path
+     * @param Model\Document $document
      *
      * @return array
      *
@@ -408,7 +408,7 @@ CSS;
     /**
      * parses an email string in the following name/mail list annotation: 'Name 1 <address1@mail.com>, Name 2 <address2@mail.com>, ...'
      *
-     * @param $emailString
+     * @param string $emailString
      *
      * @return array
      */

--- a/lib/Helper/RobotsTxt.php
+++ b/lib/Helper/RobotsTxt.php
@@ -34,7 +34,7 @@ class RobotsTxt
     private $_rules = [];
 
     /**
-     * @param $domain
+     * @param string $domain
      */
     public function __construct($domain)
     {
@@ -54,7 +54,7 @@ class RobotsTxt
     }
 
     /**
-     * @param $url
+     * @param string $url
      * @param string $userAgent
      *
      * @return bool
@@ -99,7 +99,7 @@ class RobotsTxt
     }
 
     /**
-     * @param $robotsTxt
+     * @param string $robotsTxt
      *
      * @return array
      */
@@ -137,7 +137,7 @@ class RobotsTxt
     }
 
     /**
-     * @param $path
+     * @param string $path
      *
      * @return string
      */

--- a/lib/Image/Adapter.php
+++ b/lib/Image/Adapter.php
@@ -69,7 +69,7 @@ abstract class Adapter
     protected $resource;
 
     /**
-     * @param $height
+     * @param int $height
      *
      * @return $this
      */
@@ -89,7 +89,7 @@ abstract class Adapter
     }
 
     /**
-     * @param $width
+     * @param int $width
      *
      * @return $this
      */
@@ -124,7 +124,7 @@ abstract class Adapter
     }
 
     /**
-     * @param  $colorhex
+     * @param string $colorhex
      *
      * @return array
      */
@@ -138,8 +138,8 @@ abstract class Adapter
     }
 
     /**
-     * @param  $width
-     * @param  $height
+     * @param int $width
+     * @param int $height
      *
      * @return self
      */
@@ -149,8 +149,8 @@ abstract class Adapter
     }
 
     /**
-     * @param  $width
-     * @param  bool $forceResize
+     * @param int $width
+     * @param bool $forceResize
      *
      * @return self
      */
@@ -165,8 +165,8 @@ abstract class Adapter
     }
 
     /**
-     * @param  $height
-     * @param  bool $forceResize
+     * @param int $height
+     * @param bool $forceResize
      *
      * @return self
      */
@@ -181,9 +181,9 @@ abstract class Adapter
     }
 
     /**
-     * @param  $width
-     * @param  $height
-     * @param  bool $forceResize
+     * @param int $width
+     * @param int $height
+     * @param bool $forceResize
      *
      * @return self
      */
@@ -203,10 +203,10 @@ abstract class Adapter
     }
 
     /**
-     * @param  $width
-     * @param  $height
+     * @param int $width
+     * @param int $height
      * @param string $orientation
-     * @param  bool $forceResize
+     * @param bool $forceResize
      *
      * @return self
      */
@@ -277,9 +277,9 @@ abstract class Adapter
     }
 
     /**
-     * @param $width
-     * @param $height
-     * @param  bool $forceResize
+     * @param int $width
+     * @param int $height
+     * @param bool $forceResize
      *
      * @return $this
      */
@@ -289,7 +289,7 @@ abstract class Adapter
     }
 
     /**
-     * @param  int $tolerance
+     * @param int $tolerance
      *
      * @return self
      */
@@ -299,7 +299,7 @@ abstract class Adapter
     }
 
     /**
-     * @param $angle
+     * @param int $angle
      *
      * @return $this
      */
@@ -309,10 +309,10 @@ abstract class Adapter
     }
 
     /**
-     * @param  $x
-     * @param  $y
-     * @param  $width
-     * @param  $height
+     * @param int $x
+     * @param int $y
+     * @param int $width
+     * @param int $height
      *
      * @return self
      */
@@ -322,7 +322,7 @@ abstract class Adapter
     }
 
     /**
-     * @param  $color
+     * @param string $color
      *
      * @return self
      */
@@ -332,7 +332,7 @@ abstract class Adapter
     }
 
     /**
-     * @param  $image
+     * @param string $image
      *
      * @return self
      */
@@ -342,8 +342,8 @@ abstract class Adapter
     }
 
     /**
-     * @param $width
-     * @param $height
+     * @param int $width
+     * @param int $height
      *
      * @return $this
      */
@@ -368,7 +368,7 @@ abstract class Adapter
     }
 
     /**
-     * @param $image
+     * @param string $image
      * @param string $composite
      *
      * @return $this
@@ -379,7 +379,7 @@ abstract class Adapter
     }
 
     /**
-     * @param  $image
+     * @param string $image
      *
      * @return self
      */
@@ -389,10 +389,10 @@ abstract class Adapter
     }
 
     /**
-     * @param $width
-     * @param $height
-     * @param $x
-     * @param $y
+     * @param int $width
+     * @param int $height
+     * @param int $x
+     * @param int $y
      *
      * @return self
      */
@@ -440,7 +440,7 @@ abstract class Adapter
     }
 
     /**
-     * @param $mode
+     * @param string $mode
      *
      * @return self
      */
@@ -475,7 +475,7 @@ abstract class Adapter
     /**
      * @abstract
      *
-     * @param $imagePath
+     * @param string $imagePath
      * @param array $options
      *
      * @return self
@@ -483,11 +483,11 @@ abstract class Adapter
     abstract public function load($imagePath, $options = []);
 
     /**
-     * @param $path
-     * @param null $format
-     * @param null $quality
+     * @param string $path
+     * @param string|null $format
+     * @param int|null $quality
      *
-     * @return mixed
+     * @return $this
      */
     abstract public function save($path, $format = null, $quality = null);
 

--- a/lib/Image/Adapter/GD.php
+++ b/lib/Image/Adapter/GD.php
@@ -31,7 +31,7 @@ class GD extends Adapter
     protected $resource;
 
     /**
-     * @param $imagePath
+     * @param string $imagePath
      * @param array $options
      *
      * @return $this|self
@@ -76,11 +76,11 @@ class GD extends Adapter
     }
 
     /**
-     * @param $path
-     * @param null $format
-     * @param null $quality
+     * @param string $path
+     * @param string|null $format
+     * @param int|null $quality
      *
-     * @return $this|mixed
+     * @return $this
      */
     public function save($path, $format = null, $quality = null)
     {
@@ -155,8 +155,8 @@ class GD extends Adapter
     }
 
     /**
-     * @param $width
-     * @param $height
+     * @param int $width
+     * @param int $height
      *
      * @return resource
      */
@@ -173,8 +173,8 @@ class GD extends Adapter
     }
 
     /**
-     * @param  $width
-     * @param  $height
+     * @param int $width
+     * @param int $height
      *
      * @return self
      */
@@ -195,10 +195,10 @@ class GD extends Adapter
     }
 
     /**
-     * @param  $x
-     * @param  $y
-     * @param  $width
-     * @param  $height
+     * @param int $x
+     * @param int $y
+     * @param int $width
+     * @param int $height
      *
      * @return self
      */
@@ -225,9 +225,9 @@ class GD extends Adapter
     }
 
     /**
-     * @param  $width
-     * @param  $height
-     * @param  bool $forceResize
+     * @param int $width
+     * @param int $height
+     * @param bool $forceResize
      *
      * @return self
      */
@@ -255,7 +255,7 @@ class GD extends Adapter
     }
 
     /**
-     * @param  $color
+     * @param string $color
      *
      * @return Adapter
      */
@@ -282,7 +282,7 @@ class GD extends Adapter
     }
 
     /**
-     * @param $image
+     * @param string $image
      * @param null|string $mode
      *
      * @return $this
@@ -419,7 +419,7 @@ class GD extends Adapter
     }
 
     /**
-     * @param $angle
+     * @param int $angle
      *
      * @return $this|self
      */

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -43,7 +43,7 @@ class Imagick extends Adapter
     protected $imagePath;
 
     /**
-     * @param $imagePath
+     * @param string $imagePath
      * @param array $options
      *
      * @return $this|bool|self
@@ -169,11 +169,11 @@ class Imagick extends Adapter
     }
 
     /**
-     * @param $path
-     * @param null $format
-     * @param null $quality
+     * @param string $path
+     * @param string|null $format
+     * @param int|null $quality
      *
-     * @return $this|mixed
+     * @return $this
      *
      * @throws \Exception
      */
@@ -427,8 +427,8 @@ class Imagick extends Adapter
     }
 
     /**
-     * @param  $width
-     * @param  $height
+     * @param int $width
+     * @param int $height
      *
      * @return self
      */
@@ -477,10 +477,10 @@ class Imagick extends Adapter
     }
 
     /**
-     * @param  $x
-     * @param  $y
-     * @param  $width
-     * @param  $height
+     * @param int $x
+     * @param int $y
+     * @param int $width
+     * @param int $height
      *
      * @return self
      */
@@ -500,9 +500,9 @@ class Imagick extends Adapter
     }
 
     /**
-     * @param $width
-     * @param $height
-     * @param  bool $forceResize
+     * @param int $width
+     * @param int $height
+     * @param bool $forceResize
      *
      * @return $this
      */
@@ -530,7 +530,7 @@ class Imagick extends Adapter
     }
 
     /**
-     * @param  $tolerance
+     * @param float $tolerance
      *
      * @return self
      */
@@ -550,7 +550,7 @@ class Imagick extends Adapter
     }
 
     /**
-     * @param  $color
+     * @param string $color
      *
      * @return self
      */
@@ -570,11 +570,11 @@ class Imagick extends Adapter
     }
 
     /**
-     * @param $width
-     * @param $height
+     * @param int $width
+     * @param int $height
      * @param string $color
      *
-     * @return Imagick
+     * @return \Imagick
      */
     protected function createImage($width, $height, $color = 'transparent')
     {
@@ -586,7 +586,7 @@ class Imagick extends Adapter
     }
 
     /**
-     * @param $angle
+     * @param int $angle
      *
      * @return $this
      */
@@ -606,8 +606,8 @@ class Imagick extends Adapter
     }
 
     /**
-     * @param $width
-     * @param $height
+     * @param int $width
+     * @param int $height
      *
      * @return $this
      */
@@ -631,8 +631,8 @@ class Imagick extends Adapter
     /**
      * Workaround for Imagick PHP extension v3.4.4 which removed Imagick::roundCorners
      *
-     * @param $width
-     * @param $height
+     * @param int $width
+     * @param int $height
      */
     protected function internalRoundCorners($width, $height)
     {
@@ -651,7 +651,7 @@ class Imagick extends Adapter
     }
 
     /**
-     * @param $image
+     * @param string $image
      * @param null|string $mode
      *
      * @return $this
@@ -751,7 +751,7 @@ class Imagick extends Adapter
     }
 
     /**
-     * @param $image
+     * @param string $image
      * @param string $composite
      *
      * @return $this
@@ -771,7 +771,7 @@ class Imagick extends Adapter
     }
 
     /**
-     * @param  $image
+     * @param string $image
      *
      * @return self
      */
@@ -870,7 +870,7 @@ class Imagick extends Adapter
     }
 
     /**
-     * @param $mode
+     * @param string $mode
      *
      * @return $this|Adapter
      */
@@ -890,7 +890,7 @@ class Imagick extends Adapter
     }
 
     /**
-     * @param null $imagePath
+     * @param string|null $imagePath
      *
      * @return bool
      */

--- a/lib/Image/HtmlToImage.php
+++ b/lib/Image/HtmlToImage.php
@@ -43,8 +43,8 @@ class HtmlToImage
     }
 
     /**
-     * @param $url
-     * @param $outputFile
+     * @param string $url
+     * @param string $outputFile
      * @param int $screenWidth
      * @param string $format
      *

--- a/lib/Image/ImageOptimizerInterface.php
+++ b/lib/Image/ImageOptimizerInterface.php
@@ -19,7 +19,7 @@ use Pimcore\Image\Optimizer\OptimizerInterface;
 interface ImageOptimizerInterface
 {
     /**
-     * @param $path
+     * @param string $path
      */
     public function optimizeImage($path);
 

--- a/lib/Image/Optimizer.php
+++ b/lib/Image/Optimizer.php
@@ -92,7 +92,7 @@ class Optimizer implements ImageOptimizerInterface
     }
 
     /**
-     * @param null $type
+     * @param string|null $type
      *
      * @return string
      */
@@ -107,7 +107,7 @@ class Optimizer implements ImageOptimizerInterface
     }
 
     /**
-     * @param $path
+     * @param string $path
      */
     public static function optimize($path)
     {

--- a/lib/Image/Optimizer/OptimizerInterface.php
+++ b/lib/Image/Optimizer/OptimizerInterface.php
@@ -14,6 +14,8 @@
 
 namespace Pimcore\Image\Optimizer;
 
+use Pimcore\Exception\ImageOptimizationFailedException;
+
 interface OptimizerInterface
 {
     /**
@@ -22,7 +24,7 @@ interface OptimizerInterface
      *
      * @return string
      *
-     * @throws
+     * @throws ImageOptimizationFailedException
      */
     public function optimizeImage(string $input, string $output): string;
 

--- a/lib/Loader/ImplementationLoader/PrefixLoader.php
+++ b/lib/Loader/ImplementationLoader/PrefixLoader.php
@@ -84,7 +84,7 @@ class PrefixLoader extends AbstractClassNameLoader
     /**
      * Iterates prefixes and tries to find the class name
      *
-     * @param $name
+     * @param string $name
      *
      * @return mixed|string
      */

--- a/lib/Localization/IntlFormatter.php
+++ b/lib/Localization/IntlFormatter.php
@@ -57,7 +57,7 @@ class IntlFormatter
     protected $currencyFormats = [];
 
     /**
-     * @param $locale
+     * @param LocaleServiceInterface $locale
      */
     public function __construct(LocaleServiceInterface $locale)
     {
@@ -102,7 +102,7 @@ class IntlFormatter
     }
 
     /**
-     * @param $format
+     * @param string $format
      *
      * @return \IntlDateFormatter|\Symfony\Component\Intl\DateFormatter\IntlDateFormatter
      */
@@ -191,7 +191,7 @@ class IntlFormatter
     /**
      * formats given value as number based on current locale
      *
-     * @param $value
+     * @param int|float $value
      *
      * @return bool|string
      */
@@ -207,9 +207,9 @@ class IntlFormatter
     /**
      * formats given value as currency string with given currency based on current locale
      *
-     * @param $value
-     * @param $currency
-     * @param $pattern
+     * @param float $value
+     * @param string $currency
+     * @param string $pattern
      *
      * @return string
      */

--- a/lib/Localization/LocaleService.php
+++ b/lib/Localization/LocaleService.php
@@ -45,7 +45,7 @@ class LocaleService implements LocaleServiceInterface
     }
 
     /**
-     * @param $locale
+     * @param string $locale
      *
      * @return bool
      */
@@ -101,7 +101,7 @@ class LocaleService implements LocaleServiceInterface
     }
 
     /**
-     * @param null $locale
+     * @param string|null $locale
      *
      * @return array
      */

--- a/lib/Log/ApplicationLogger.php
+++ b/lib/Log/ApplicationLogger.php
@@ -80,7 +80,7 @@ class ApplicationLogger implements LoggerInterface
     }
 
     /**
-     * @param $writer
+     * @param object $writer
      */
     public function addWriter($writer)
     {
@@ -118,7 +118,7 @@ class ApplicationLogger implements LoggerInterface
     /**
      * @deprecated
      *
-     * @param \\Pimcore\Model\DataObject\AbstractObject | \Pimcore\Model\Document | \Pimcore\Model\Asset | int $relatedObject
+     * @param \Pimcore\Model\DataObject\AbstractObject|\Pimcore\Model\Document|\Pimcore\Model\Asset|int $relatedObject
      */
     public function setRelatedObject($relatedObject)
     {
@@ -329,9 +329,9 @@ class ApplicationLogger implements LoggerInterface
     }
 
     /**
-     * @param $level
-     * @param $message
-     * @param $params
+     * @param mixed $level
+     * @param string $message
+     * @param array $params
      */
     protected function handleLog($level, $message, $params)
     {
@@ -362,11 +362,11 @@ class ApplicationLogger implements LoggerInterface
     }
 
     /**
-     * @param $message
+     * @param string $message
      * @param \Throwable $exceptionObject
      * @param string $priority
-     * @param null $relatedObject
-     * @param null $component
+     * @param \Pimcore\Model\DataObject\AbstractObject|null $relatedObject
+     * @param string|null $component
      */
     public function logException($message, $exceptionObject, $priority = 'alert', $relatedObject = null, $component = null)
     {
@@ -393,7 +393,7 @@ class ApplicationLogger implements LoggerInterface
      * @param string $message
      * @param \Throwable $exception
      * @param mixed $level
-     * @param null $relatedObject
+     * @param \Pimcore\Model\DataObject\AbstractObject|null $relatedObject
      * @param array $context
      */
     public static function logExceptionObject(

--- a/lib/Log/Simple.php
+++ b/lib/Log/Simple.php
@@ -19,8 +19,8 @@ use Pimcore\File;
 class Simple
 {
     /**
-     * @param $name
-     * @param $message
+     * @param string $name
+     * @param string $message
      */
     public static function log($name, $message)
     {

--- a/lib/Logger.php
+++ b/lib/Logger.php
@@ -17,7 +17,7 @@ namespace Pimcore;
 class Logger
 {
     /**
-     * @param $message
+     * @param string $message
      * @param string $level
      * @param array $context
      *
@@ -36,7 +36,7 @@ class Logger
      **/
 
     /**
-     * @param $m
+     * @param string $m
      * @param array $context
      */
     public static function emergency($m, $context = [])
@@ -45,7 +45,7 @@ class Logger
     }
 
     /**
-     * @param $m
+     * @param string $m
      * @param array $context
      */
     public static function emerg($m, $context = [])
@@ -54,7 +54,7 @@ class Logger
     }
 
     /**
-     * @param $m
+     * @param string $m
      * @param array $context
      */
     public static function alert($m, $context = [])
@@ -63,7 +63,7 @@ class Logger
     }
 
     /**
-     * @param $m
+     * @param string $m
      * @param array $context
      */
     public static function critical($m, $context = [])
@@ -72,7 +72,7 @@ class Logger
     }
 
     /**
-     * @param $m
+     * @param string $m
      * @param array $context
      */
     public static function crit($m, $context = [])
@@ -81,7 +81,7 @@ class Logger
     }
 
     /**
-     * @param $m
+     * @param string $m
      * @param array $context
      */
     public static function error($m, $context = [])
@@ -90,7 +90,7 @@ class Logger
     }
 
     /**
-     * @param $m
+     * @param string $m
      * @param array $context
      */
     public static function err($m, $context = [])
@@ -99,7 +99,7 @@ class Logger
     }
 
     /**
-     * @param $m
+     * @param string $m
      * @param array $context
      */
     public static function warning($m, $context = [])
@@ -108,7 +108,7 @@ class Logger
     }
 
     /**
-     * @param $m
+     * @param string $m
      * @param array $context
      */
     public static function warn($m, $context = [])
@@ -117,7 +117,7 @@ class Logger
     }
 
     /**
-     * @param $m
+     * @param string $m
      * @param array $context
      */
     public static function notice($m, $context = [])
@@ -126,7 +126,7 @@ class Logger
     }
 
     /**
-     * @param $m
+     * @param string $m
      * @param array $context
      */
     public static function info($m, $context = [])
@@ -135,7 +135,7 @@ class Logger
     }
 
     /**
-     * @param $m
+     * @param string $m
      * @param array $context
      */
     public static function debug($m, $context = [])

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -65,7 +65,7 @@ class Mail extends \Swift_Message
     /**
      * html2text from mbayer is installed (http://www.mbayer.de/html2text/)
      *
-     * @var bool
+     * @var bool|null
      */
     protected static $html2textInstalled = null;
 
@@ -118,7 +118,7 @@ class Mail extends \Swift_Message
      *
      * @see MailHelper::setAbsolutePaths()
      *
-     * @var null
+     * @var string|null
      */
     protected $hostUrl = null;
 
@@ -157,7 +157,7 @@ class Mail extends \Swift_Message
     protected $lastLogEntry;
 
     /**
-     * @param $url
+     * @param string $url
      *
      * @return $this
      */
@@ -169,7 +169,7 @@ class Mail extends \Swift_Message
     }
 
     /**
-     * @return null
+     * @return string|null
      */
     public function getHostUrl()
     {
@@ -179,10 +179,10 @@ class Mail extends \Swift_Message
     /**
      * Mail constructor.
      *
-     * @param null $subject
-     * @param null $body
-     * @param null $contentType
-     * @param null $charset
+     * @param array|string|null $subject
+     * @param string|null $body
+     * @param string|null $contentType
+     * @param string|null $charset
      */
     public function __construct($subject = null, $body = null, $contentType = null, $charset = null)
     {
@@ -234,7 +234,7 @@ class Mail extends \Swift_Message
     }
 
     /**
-     * @param $value
+     * @param bool $value
      *
      * @return $this
      */
@@ -270,7 +270,7 @@ class Mail extends \Swift_Message
     }
 
     /**
-     * @param $value
+     * @param bool $value
      *
      * @return $this
      */
@@ -687,7 +687,7 @@ class Mail extends \Swift_Message
      *
      * @static
      *
-     * @param $emailAddress
+     * @param string $emailAddress
      *
      * @return bool
      */
@@ -789,7 +789,7 @@ class Mail extends \Swift_Message
     }
 
     /**
-     * @param $document
+     * @param Model\Document|int|string $document
      *
      * @return $this
      *
@@ -873,7 +873,7 @@ class Mail extends \Swift_Message
      * @static
      * returns  html2text binary installation status
      *
-     * @return bool || null
+     * @return bool
      */
     public static function getHtml2textInstalled()
     {
@@ -885,7 +885,7 @@ class Mail extends \Swift_Message
     }
 
     /**
-     * @param $htmlContent
+     * @param string $htmlContent
      *
      * @return string
      */
@@ -919,7 +919,7 @@ class Mail extends \Swift_Message
     }
 
     /**
-     * @param $bodyText
+     * @param string $bodyText
      *
      * @return $this
      */
@@ -931,7 +931,7 @@ class Mail extends \Swift_Message
     }
 
     /**
-     * @param $body
+     * @param string $body
      *
      * @return \Pimcore\Mail
      */
@@ -975,12 +975,10 @@ class Mail extends \Swift_Message
     }
 
     /**
-     *
-     *
-     * @param $data
-     * @param null $mimeType
-     * @param null $disposition
-     * @param null $filename
+     * @param string|\Swift_OutputByteStream $data
+     * @param string|null $mimeType
+     * @param string|null $filename
+     * @param string|null $disposition
      *
      * @return \Swift_Mime_Attachment
      */

--- a/lib/Maintenance/ExecutorInterface.php
+++ b/lib/Maintenance/ExecutorInterface.php
@@ -19,14 +19,14 @@ interface ExecutorInterface
     /**
      * Execute the Maintenance Task
      *
-     * @param array|null $validJobs
-     * @param array|null $excludedJobs
-     * @param bool       $force
+     * @param array $validJobs
+     * @param array $excludedJobs
+     * @param bool $force
      */
     public function executeMaintenance(array $validJobs = [], array $excludedJobs = [], bool $force = false);
 
     /**
-     * @param               $name
+     * @param string $name
      * @param TaskInterface $task
      */
     public function registerTask($name, TaskInterface $task);

--- a/lib/Maintenance/Tasks/HousekeepingTask.php
+++ b/lib/Maintenance/Tasks/HousekeepingTask.php
@@ -36,8 +36,8 @@ final class HousekeepingTask implements TaskInterface
     }
 
     /**
-     * @param $folder
-     * @param $days
+     * @param string $folder
+     * @param int $days
      */
     protected function deleteFilesInFolderOlderThanDays($folder, $days)
     {

--- a/lib/Migrations/Migration/AbstractPimcoreMigration.php
+++ b/lib/Migrations/Migration/AbstractPimcoreMigration.php
@@ -53,7 +53,7 @@ abstract class AbstractPimcoreMigration extends AbstractMigration implements Pim
     /**
      * Writes a log message in the same format as a DB migration does (prefixed with ->)
      *
-     * @param $message
+     * @param string $message
      */
     protected function writeMessage($message)
     {
@@ -63,7 +63,7 @@ abstract class AbstractPimcoreMigration extends AbstractMigration implements Pim
     /**
      * Prefixes message with DRY-RUN: if in dry-run mode
      *
-     * @param $message
+     * @param string $message
      * @param string $prefix
      *
      * @return string

--- a/lib/Migrations/Version.php
+++ b/lib/Migrations/Version.php
@@ -49,7 +49,7 @@ class Version extends \Doctrine\DBAL\Migrations\Version
     /**
      * The version in timestamp format (YYYYMMDDHHMMSS)
      *
-     * @param int
+     * @var int
      */
     private $version;
 
@@ -477,8 +477,8 @@ class Version extends \Doctrine\DBAL\Migrations\Version
     /**
      * Formats a set of sql parameters for output with dry run.
      *
-     * @param $params The query parameters
-     * @param $types The types of the query params. Default type is a string
+     * @param array $params The query parameters
+     * @param array $types The types of the query params. Default type is a string
      *
      * @return string|null a string of the parameters present.
      */

--- a/lib/Model/AbstractModel.php
+++ b/lib/Model/AbstractModel.php
@@ -56,7 +56,7 @@ abstract class AbstractModel
     }
 
     /**
-     * @param $dao
+     * @param \Pimcore\Model\Dao\AbstractDao $dao
      *
      * @return self
      */
@@ -68,7 +68,7 @@ abstract class AbstractModel
     }
 
     /**
-     * @param null $key
+     * @param string|null $key
      * @param bool $forceDetection
      *
      * @throws \Exception
@@ -188,8 +188,8 @@ abstract class AbstractModel
     }
 
     /**
-     * @param  $key
-     * @param  $value
+     * @param string $key
+     * @param mixed $value
      *
      * @return $this
      */
@@ -226,8 +226,8 @@ abstract class AbstractModel
     }
 
     /**
-     * @param $method
-     * @param $args
+     * @param string $method
+     * @param array $args
      *
      * @return mixed
      *

--- a/lib/Model/Dao/AbstractDao.php
+++ b/lib/Model/Dao/AbstractDao.php
@@ -78,8 +78,10 @@ abstract class AbstractDao implements DaoInterface
         return $columns;
     }
 
-    /** Clears the column information for the given table.
-     * @param $table
+    /**
+     * Clears the column information for the given table.
+     *
+     * @param string $table
      */
     public function resetValidTableColumnsCache($table)
     {

--- a/lib/Model/Dao/PhpArrayTable.php
+++ b/lib/Model/Dao/PhpArrayTable.php
@@ -31,7 +31,7 @@ abstract class PhpArrayTable implements DaoInterface
     }
 
     /**
-     * @param $name
+     * @param string $name
      */
     protected function setFile($name)
     {

--- a/lib/Model/Factory.php
+++ b/lib/Model/Factory.php
@@ -42,7 +42,7 @@ class Factory extends ImplementationLoader implements FactoryInterface
      * @param string $name
      * @param array $params
      *
-     * @return AbstractModel|AbstractListing
+     * @return AbstractModel
      */
     public function build(string $name, array $params = []): AbstractModel
     {

--- a/lib/Model/Listing/AbstractListing.php
+++ b/lib/Model/Listing/AbstractListing.php
@@ -110,7 +110,7 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
     }
 
     /**
-     * @param  $key
+     * @param string $key
      *
      * @return bool
      */
@@ -144,7 +144,7 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
     }
 
     /**
-     * @param  $limit
+     * @param int $limit
      *
      * @return $this
      */
@@ -158,7 +158,7 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
     }
 
     /**
-     * @param  $offset
+     * @param int $offset
      *
      * @return $this
      */
@@ -172,7 +172,7 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
     }
 
     /**
-     * @param  $order
+     * @param array|string $order
      *
      * @return $this
      */
@@ -234,8 +234,8 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
     }
 
     /**
-     * @param $key
-     * @param null $value
+     * @param string $key
+     * @param mixed $value
      * @param string $concatenator
      *
      * @return $this
@@ -331,8 +331,8 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
     }
 
     /**
-     * @param $condition
-     * @param null $conditionVariables
+     * @param string $condition
+     * @param array|null $conditionVariables
      *
      * @return $this
      */
@@ -367,7 +367,7 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
     }
 
     /**
-     * @param $groupBy
+     * @param string $groupBy
      * @param bool $qoute
      *
      * @return $this
@@ -386,7 +386,7 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
     }
 
     /**
-     * @param $validOrders
+     * @param array $validOrders
      *
      * @return $this
      */
@@ -398,8 +398,8 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
     }
 
     /**
-     * @param $value
-     * @param $type
+     * @param mixed $value
+     * @param int|null $type
      *
      * @return string
      */
@@ -411,7 +411,7 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
     }
 
     /**
-     * @param $conditionVariables
+     * @param array $conditionVariables
      *
      * @return $this
      */
@@ -432,7 +432,7 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
     }
 
     /**
-     * @param $conditionVariables
+     * @param array $conditionVariables
      *
      * @return $this
      */

--- a/lib/Navigation/Builder.php
+++ b/lib/Navigation/Builder.php
@@ -53,9 +53,9 @@ class Builder
 
     /**
      * @param Document $activeDocument
-     * @param null $navigationRootDocument
-     * @param null $htmlMenuIdPrefix
-     * @param null $pageCallback
+     * @param Document|null $navigationRootDocument
+     * @param string|null $htmlMenuIdPrefix
+     * @param \Closure|null $pageCallback
      * @param bool|string $cache
      *
      * @return mixed|\Pimcore\Navigation\Container
@@ -206,7 +206,7 @@ class Builder
     }
 
     /**
-     * @param $pageClass
+     * @param string $pageClass
      *
      * @return $this
      */

--- a/lib/Navigation/Page/Document.php
+++ b/lib/Navigation/Page/Document.php
@@ -54,7 +54,7 @@ class Document extends Url
     protected $customSettings = [];
 
     /**
-     * @param  $tabindex
+     * @param string $tabindex
      *
      * @return $this
      */
@@ -74,7 +74,7 @@ class Document extends Url
     }
 
     /**
-     * @param null $character
+     * @param string|null $character
      *
      * @return $this
      */
@@ -94,7 +94,7 @@ class Document extends Url
     }
 
     /**
-     * @param  $relation
+     * @param string $relation
      *
      * @return $this
      */
@@ -114,7 +114,7 @@ class Document extends Url
     }
 
     /**
-     * @param $document
+     * @param Model\Document $document
      *
      * @return $this
      */
@@ -162,7 +162,7 @@ class Document extends Url
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getDocumentType()
     {
@@ -170,7 +170,7 @@ class Document extends Url
     }
 
     /**
-     * @param mixed $documentType
+     * @param string $documentType
      */
     public function setDocumentType($documentType)
     {
@@ -194,8 +194,8 @@ class Document extends Url
     }
 
     /**
-     * @param $name
-     * @param $value
+     * @param string $name
+     * @param mixed $value
      *
      * @return $this
      */
@@ -207,9 +207,9 @@ class Document extends Url
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
-     * @return null
+     * @return mixed|null
      */
     public function getCustomSetting($name)
     {

--- a/lib/Navigation/Renderer/AbstractRenderer.php
+++ b/lib/Navigation/Renderer/AbstractRenderer.php
@@ -131,7 +131,7 @@ abstract class AbstractRenderer implements RendererInterface
     }
 
     /**
-     * @param null $maxDepth
+     * @param int|null $maxDepth
      *
      * @return $this
      */
@@ -155,7 +155,7 @@ abstract class AbstractRenderer implements RendererInterface
     }
 
     /**
-     * @param $indent
+     * @param string $indent
      *
      * @return $this
      */
@@ -183,7 +183,7 @@ abstract class AbstractRenderer implements RendererInterface
     }
 
     /**
-     * @param $prefix
+     * @param string $prefix
      *
      * @return $this
      */
@@ -247,7 +247,7 @@ abstract class AbstractRenderer implements RendererInterface
 
     /**
      * @param Container $container
-     * @param null $minDepth
+     * @param int|null $minDepth
      * @param int $maxDepth
      *
      * @return array

--- a/lib/Navigation/Renderer/Breadcrumbs.php
+++ b/lib/Navigation/Renderer/Breadcrumbs.php
@@ -210,7 +210,7 @@ class Breadcrumbs extends AbstractRenderer
      * @param Container $container
      * @param string|null $partial
      *
-     * @return mixed
+     * @return string
      *
      * @throws \Exception
      */
@@ -254,10 +254,10 @@ class Breadcrumbs extends AbstractRenderer
     /**
      * Alias of renderTemplate() for ZF1 backward compatibility
      *
-     * @param Container|null $container
+     * @param Container $container
      * @param string|null $partial
      *
-     * @return mixed
+     * @return string
      */
     public function renderPartial(Container $container, string $partial = null)
     {

--- a/lib/Navigation/Renderer/Menu.php
+++ b/lib/Navigation/Renderer/Menu.php
@@ -359,7 +359,7 @@ class Menu extends AbstractRenderer
     /**
      * Alias of setTemplate()
      *
-     * @param $partial
+     * @param array|string $partial
      *
      * @return $this
      */
@@ -1006,7 +1006,7 @@ class Menu extends AbstractRenderer
      * <code>echo 'Number of pages: ', count($this->container);</code>.
      *
      * @param  Container $container
-     * @param  string|array             $partial     [optional] partial view
+     * @param  string|array|null $partial     [optional] partial view
      *                                               script to use. Default is to
      *                                               use the partial registered
      *                                               in the helper. If an array
@@ -1042,7 +1042,7 @@ class Menu extends AbstractRenderer
      * Alias of renderTemplate()
      *
      * @param Container $container
-     * @param null $partial
+     * @param string|array|null $partial
      *
      * @return string
      */

--- a/lib/Navigation/Renderer/RendererInterface.php
+++ b/lib/Navigation/Renderer/RendererInterface.php
@@ -47,7 +47,7 @@ interface RendererInterface
     public function getRenderInvisible();
 
     /**
-     * @param  bool
+     * @param bool $renderInvisible
      *
      * @return AbstractRenderer
      */

--- a/lib/Placeholder.php
+++ b/lib/Placeholder.php
@@ -45,7 +45,7 @@ class Placeholder
     protected $document;
 
     /**
-     * @param $classPrefix
+     * @param string $classPrefix
      *
      * @throws \Exception
      */
@@ -115,7 +115,7 @@ class Placeholder
     }
 
     /**
-     * @param $suffix
+     * @param string $suffix
      *
      * @throws \Exception
      */

--- a/lib/Placeholder/AbstractPlaceholder.php
+++ b/lib/Placeholder/AbstractPlaceholder.php
@@ -67,7 +67,7 @@ abstract class AbstractPlaceholder
     protected $locale = null;
 
     /**
-     * @param $string
+     * @param string $string
      *
      * @return $this
      */
@@ -87,7 +87,7 @@ abstract class AbstractPlaceholder
     }
 
     /**
-     * @param $key
+     * @param string $key
      *
      * @return $this
      */
@@ -131,7 +131,7 @@ abstract class AbstractPlaceholder
     }
 
     /**
-     * @param $params
+     * @param array $params
      *
      * @return $this
      */
@@ -171,7 +171,7 @@ abstract class AbstractPlaceholder
     }
 
     /**
-     * @param $contentString
+     * @param string $contentString
      *
      * @return $this
      */
@@ -205,7 +205,7 @@ abstract class AbstractPlaceholder
     }
 
     /**
-     * @param $document
+     * @param Document $document
      *
      * @return $this
      */
@@ -245,7 +245,7 @@ abstract class AbstractPlaceholder
     /**
      * Try to set the locale from different sources
      *
-     * @param $locale
+     * @param string|null $locale
      *
      * @return $this
      */

--- a/lib/Routing/Dynamic/DocumentRouteHandler.php
+++ b/lib/Routing/Dynamic/DocumentRouteHandler.php
@@ -346,7 +346,7 @@ class DocumentRouteHandler implements DynamicRouteHandlerInterface
     /**
      * Check if document is can be used to generate a route
      *
-     * @param $document
+     * @param Document\PageSnippet $document
      *
      * @return bool
      */

--- a/lib/Security/User/ObjectUserProvider.php
+++ b/lib/Security/User/ObjectUserProvider.php
@@ -60,7 +60,7 @@ class ObjectUserProvider implements UserProviderInterface
     }
 
     /**
-     * @param $className
+     * @param string $className
      */
     protected function setClassName($className)
     {

--- a/lib/Targeting/Document/DocumentTargetingConfigurator.php
+++ b/lib/Targeting/Document/DocumentTargetingConfigurator.php
@@ -208,7 +208,7 @@ class DocumentTargetingConfigurator
      * Resolves valid target groups for a document. A target group is seen as valid
      * if it has at least one element configured for that target group.
      *
-     * @param Document|Document\TargetingDocument|TargetingDocumentInterface $document
+     * @param Document $document
      *
      * @return array
      */

--- a/lib/Targeting/Maintenance/TargetingStorageTask.php
+++ b/lib/Targeting/Maintenance/TargetingStorageTask.php
@@ -24,12 +24,12 @@ use Pimcore\Targeting\Storage\TargetingStorageInterface;
 class TargetingStorageTask implements TaskInterface
 {
     /**
-     * @var TargetingStorageInterface|MaintenanceStorageInterface
+     * @var TargetingStorageInterface
      */
     private $targetingStorage;
 
     /**
-     * @param MaintenanceStorageInterface|TargetingStorageInterface $targetingStorage
+     * @param TargetingStorageInterface $targetingStorage
      */
     public function __construct(TargetingStorageInterface $targetingStorage)
     {

--- a/lib/Templating/Helper/Cache.php
+++ b/lib/Templating/Helper/Cache.php
@@ -60,8 +60,8 @@ class Cache extends Helper
     }
 
     /**
-     * @param $name
-     * @param null $lifetime
+     * @param string $name
+     * @param int|null $lifetime
      * @param bool $force
      *
      * @return mixed
@@ -135,7 +135,7 @@ class Cache extends Helper
     /**
      * Output the content.
      *
-     * @param $content the content, either rendered or retrieved directly from the cache.
+     * @param string $content the content, either rendered or retrieved directly from the cache.
      * @param string $key the cache key
      * @param bool $isLoadedFromCache true if the content origins from the cache and hasn't been created "live".
      */
@@ -147,9 +147,9 @@ class Cache extends Helper
     /**
      * Save the (rendered) content to to cache. May be overriden to add custom markup / code, or specific tags, etc.
      *
-     * @param $content
+     * @param string $content
      * @param string $key
-     * @param $tags
+     * @param array $tags
      */
     protected function saveContentToCache($content, string $key, array $tags)
     {

--- a/lib/Templating/Helper/Device.php
+++ b/lib/Templating/Helper/Device.php
@@ -20,7 +20,7 @@ use Symfony\Component\Templating\Helper\Helper;
 class Device extends Helper
 {
     /**
-     * @param null $default
+     * @param string|null $default
      *
      * @return DeviceDetector
      */

--- a/lib/Templating/Helper/HeadTitle.php
+++ b/lib/Templating/Helper/HeadTitle.php
@@ -65,8 +65,8 @@ class HeadTitle extends AbstractHelper
     }
 
     /**
-     * @param null $title
-     * @param null $setType
+     * @param string|null $title
+     * @param string|null $setType
      *
      * @return $this
      */

--- a/lib/Templating/Helper/Navigation.php
+++ b/lib/Templating/Helper/Navigation.php
@@ -117,8 +117,8 @@ class Navigation extends Helper
      *
      * @param Container $container
      * @param string $rendererName
-     * @param string|null $renderMethod     Optional render method to use (e.g. menu -> renderMenu)
-     * @param array $rendererArguments      Option arguments to pass to the render method after the container
+     * @param string $renderMethod     Optional render method to use (e.g. menu -> renderMenu)
+     * @param array<int, mixed> $rendererArguments      Option arguments to pass to the render method after the container
      *
      * @return string
      */

--- a/lib/Templating/Helper/PimcoreUrl.php
+++ b/lib/Templating/Helper/PimcoreUrl.php
@@ -43,7 +43,7 @@ class PimcoreUrl extends Helper
 
     /**
      * @param array $urlOptions
-     * @param null $name
+     * @param string|null $name
      * @param bool $reset
      * @param bool $encode
      * @param bool $relative

--- a/lib/Templating/Helper/Placeholder/Container.php
+++ b/lib/Templating/Helper/Placeholder/Container.php
@@ -374,7 +374,7 @@ class Container extends \ArrayObject
     /**
      * Render the placeholder
      *
-     * @param null $indent
+     * @param int|string|null $indent
      *
      * @return string
      */

--- a/lib/Templating/Helper/Translate.php
+++ b/lib/Templating/Helper/Translate.php
@@ -45,10 +45,10 @@ class Translate extends Helper
     }
 
     /**
-     * @param $key
+     * @param string $key
      * @param array $parameters
-     * @param null $domain
-     * @param null $locale
+     * @param string|null $domain
+     * @param string|null $locale
      *
      * @return string
      */

--- a/lib/Templating/Model/ViewModel.php
+++ b/lib/Templating/Model/ViewModel.php
@@ -76,7 +76,7 @@ class ViewModel implements ViewModelInterface
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return mixed
      */
@@ -86,8 +86,8 @@ class ViewModel implements ViewModelInterface
     }
 
     /**
-     * @param $name
-     * @param $value
+     * @param string $name
+     * @param mixed $value
      */
     public function __set($name, $value)
     {
@@ -95,7 +95,7 @@ class ViewModel implements ViewModelInterface
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return bool
      */

--- a/lib/Templating/PhpEngine.php
+++ b/lib/Templating/PhpEngine.php
@@ -182,7 +182,7 @@ class PhpEngine extends BasePhpEngine
     /**
      * Renders template with current parameters
      *
-     * @param $name
+     * @param string $name
      * @param array $parameters
      *
      * @return string
@@ -213,8 +213,8 @@ class PhpEngine extends BasePhpEngine
     /**
      * Get a view model parameter
      *
-     * @param $name
-     * @param null $default
+     * @param string $name
+     * @param mixed|null $default
      *
      * @return mixed|null
      */

--- a/lib/Templating/Renderer/ActionRenderer.php
+++ b/lib/Templating/Renderer/ActionRenderer.php
@@ -65,9 +65,9 @@ class ActionRenderer
     /**
      * Create a controller reference
      *
-     * @param $bundle
-     * @param $controller
-     * @param $action
+     * @param string $bundle
+     * @param string $controller
+     * @param string $action
      * @param array $attributes
      * @param array $query
      *
@@ -111,7 +111,7 @@ class ActionRenderer
      *
      * @param Document\PageSnippet $document
      * @param array $attributes
-     * @param string|null $context
+     * @param string $context
      *
      * @return array
      */

--- a/lib/Templating/Renderer/IncludeRenderer.php
+++ b/lib/Templating/Renderer/IncludeRenderer.php
@@ -46,7 +46,7 @@ class IncludeRenderer
     /**
      * Renders a document include
      *
-     * @param $include
+     * @param mixed $include
      * @param array $params
      * @param bool $editmode
      * @param bool $cacheEnabled
@@ -150,7 +150,7 @@ class IncludeRenderer
 
     /**
      * @param PageSnippet $include
-     * @param $params
+     * @param array $params
      *
      * @return string
      */
@@ -167,7 +167,7 @@ class IncludeRenderer
      * if there's no first level HTML container => add one (wrapper)
      *
      * @param PageSnippet $include
-     * @param $content
+     * @param string $content
      *
      * @return string
      */

--- a/lib/Templating/Renderer/TagRenderer.php
+++ b/lib/Templating/Renderer/TagRenderer.php
@@ -47,7 +47,7 @@ class TagRenderer implements LoggerAwareInterface
     }
 
     /**
-     * @param $type
+     * @param string $type
      *
      * @return bool
      */
@@ -60,8 +60,8 @@ class TagRenderer implements LoggerAwareInterface
      * Loads a document tag
      *
      * @param PageSnippet $document
-     * @param $type
-     * @param $inputName
+     * @param string $type
+     * @param string $inputName
      * @param array $options
      * @param bool|null $editmode
      *
@@ -126,8 +126,8 @@ class TagRenderer implements LoggerAwareInterface
      * Renders a tag
      *
      * @param PageSnippet $document
-     * @param $type
-     * @param $inputName
+     * @param string $type
+     * @param string $inputName
      * @param array $options
      * @param bool|null $editmode
      *

--- a/lib/Tool.php
+++ b/lib/Tool.php
@@ -67,7 +67,7 @@ class Tool
     /**
      * @static
      *
-     * @param  $path
+     * @param string $path
      *
      * @return bool
      */
@@ -138,7 +138,7 @@ class Tool
     }
 
     /**
-     * @param $language
+     * @param string $language
      *
      * @return array
      */
@@ -220,8 +220,8 @@ class Tool
     }
 
     /**
-     * @param $language
-     * @param $absolutePath
+     * @param string $language
+     * @param bool $absolutePath
      *
      * @return string
      */
@@ -553,9 +553,9 @@ class Tool
     }
 
     /**
-     * @param null $recipients
-     * @param null $subject
-     * @param null $charset
+     * @param array|string|null $recipients
+     * @param string|null $subject
+     * @param string|null $charset
      *
      * @return Mail
      *
@@ -586,7 +586,7 @@ class Tool
     /**
      * @static
      *
-     * @param $url
+     * @param string $url
      * @param array $paramsGet
      * @param array $paramsPost
      * @param array $options
@@ -636,7 +636,7 @@ class Tool
     /**
      * @static
      *
-     * @param $class
+     * @param string $class
      *
      * @return bool
      */
@@ -648,7 +648,7 @@ class Tool
     /**
      * @static
      *
-     * @param $class
+     * @param string $class
      *
      * @return bool
      */
@@ -658,8 +658,8 @@ class Tool
     }
 
     /**
-     * @param $class
-     * @param $type
+     * @param string $class
+     * @param string $type
      *
      * @return bool
      */
@@ -700,7 +700,7 @@ class Tool
     }
 
     /**
-     * @param $message
+     * @param string $message
      */
     public static function exitWithError($message)
     {

--- a/lib/Tool/Admin.php
+++ b/lib/Tool/Admin.php
@@ -86,7 +86,7 @@ class Admin
     /**
      * @static
      *
-     * @param  $scriptContent
+     * @param string $scriptContent
      *
      * @return mixed
      */
@@ -107,7 +107,7 @@ class Admin
     }
 
     /**
-     * @param $file
+     * @param string $file
      *
      * @return \stdClass
      */
@@ -155,7 +155,7 @@ class Admin
     }
 
     /**
-     * @param null $sessionId
+     * @param string|null $sessionId
      *
      * @throws \Exception
      */

--- a/lib/Tool/Archive.php
+++ b/lib/Tool/Archive.php
@@ -19,8 +19,8 @@ use Pimcore\File;
 class Archive
 {
     /**
-     * @param $sourceDir
-     * @param $destinationFile
+     * @param string $sourceDir
+     * @param string $destinationFile
      * @param array $excludeFilePattern
      * @param array $options
      *
@@ -88,8 +88,8 @@ class Archive
     }
 
     /**
-     * @param $sourceDir
-     * @param $destinationFile
+     * @param string $sourceDir
+     * @param string $destinationFile
      * @param array $excludeFilePattern
      * @param array $options
      *
@@ -133,8 +133,8 @@ class Archive
     }
 
     /**
-     * @param $sourceDir
-     * @param $destinationFile
+     * @param string $sourceDir
+     * @param string $destinationFile
      *
      * @return array
      *

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -24,8 +24,8 @@ use Symfony\Component\HttpFoundation\Request;
 class Authentication
 {
     /**
-     * @param $username
-     * @param $password
+     * @param string $username
+     * @param string $password
      *
      * @return null|User
      */
@@ -114,7 +114,7 @@ class Authentication
     }
 
     /**
-     * @param $token
+     * @param string $token
      * @param bool $adminRequired
      *
      * @return null|User
@@ -152,7 +152,7 @@ class Authentication
 
     /**
      * @param User $user
-     * @param $password
+     * @param string $password
      *
      * @return bool
      */
@@ -175,7 +175,7 @@ class Authentication
     }
 
     /**
-     * @param $user
+     * @param User|null $user
      *
      * @return bool
      */
@@ -189,8 +189,8 @@ class Authentication
     }
 
     /**
-     * @param $username
-     * @param $plainTextPassword
+     * @param string $username
+     * @param string $plainTextPassword
      *
      * @return bool|false|string
      *
@@ -207,8 +207,8 @@ class Authentication
     }
 
     /**
-     * @param $username
-     * @param $plainTextPassword
+     * @param string $username
+     * @param string $plainTextPassword
      *
      * @return string
      */
@@ -220,7 +220,7 @@ class Authentication
     }
 
     /**
-     * @param $username
+     * @param string $username
      *
      * @return string
      */
@@ -235,7 +235,7 @@ class Authentication
     }
 
     /**
-     * @param $token
+     * @param string $token
      *
      * @return array
      */

--- a/lib/Tool/Cast.php
+++ b/lib/Tool/Cast.php
@@ -17,8 +17,8 @@ namespace Pimcore\Tool;
 class Cast
 {
     /**
-     * @param $class
-     * @param $object
+     * @param string $class
+     * @param object $object
      *
      * @return mixed
      */

--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -56,7 +56,7 @@ class Console
     }
 
     /**
-     * @param $name
+     * @param string $name
      * @param bool $throwException
      *
      * @return bool|mixed|string
@@ -202,7 +202,7 @@ class Console
     }
 
     /**
-     * @param $process
+     * @param string $process
      *
      * @return bool
      */
@@ -250,8 +250,8 @@ class Console
     }
 
     /**
-     * @param $script
-     * @param $arguments
+     * @param string $script
+     * @param string $arguments
      *
      * @return string
      */
@@ -273,10 +273,10 @@ class Console
     }
 
     /**
-     * @param $script
-     * @param $arguments
-     * @param $outputFile
-     * @param $timeout
+     * @param string $script
+     * @param string $arguments
+     * @param string|null $outputFile
+     * @param int|null $timeout
      *
      * @return string
      */
@@ -289,9 +289,9 @@ class Console
     }
 
     /**
-     * @param $script
-     * @param $arguments
-     * @param $outputFile
+     * @param string $script
+     * @param string $arguments
+     * @param string|null $outputFile
      *
      * @return string
      */
@@ -304,9 +304,9 @@ class Console
     }
 
     /**
-     * @param $cmd
-     * @param null $outputFile
-     * @param null $timeout
+     * @param string $cmd
+     * @param string|null $outputFile
+     * @param int|null $timeout
      *
      * @return string
      */
@@ -469,7 +469,7 @@ class Console
     }
 
     /**
-     * @param $options
+     * @param array $options
      * @param string $concatenator
      * @param string $arrayConcatenator
      *

--- a/lib/Tool/DeviceDetector.php
+++ b/lib/Tool/DeviceDetector.php
@@ -57,7 +57,7 @@ class DeviceDetector
     protected $wasUsed = false;
 
     /**
-     * @param null $default
+     * @param string|null $default
      *
      * @return DeviceDetector
      */
@@ -71,7 +71,7 @@ class DeviceDetector
     }
 
     /**
-     * @param null $default
+     * @param string|null $default
      */
     public function __construct($default = null)
     {
@@ -119,7 +119,7 @@ class DeviceDetector
     }
 
     /**
-     * @param $wasUsed
+     * @param bool $wasUsed
      */
     public function setWasUsed($wasUsed)
     {

--- a/lib/Tool/Glossary/Processor.php
+++ b/lib/Tool/Glossary/Processor.php
@@ -196,7 +196,7 @@ class Processor
     }
 
     /**
-     * @param $data
+     * @param array $data
      *
      * @return array
      */

--- a/lib/Tool/Mime.php
+++ b/lib/Tool/Mime.php
@@ -17,8 +17,8 @@ namespace Pimcore\Tool;
 class Mime
 {
     /**
-     * @param $file
-     * @param null $filename
+     * @param string $file
+     * @param string|null $filename
      *
      * @return mixed|string
      *

--- a/lib/Tool/Newsletter.php
+++ b/lib/Tool/Newsletter.php
@@ -179,9 +179,9 @@ class Newsletter
     }
 
     /**
-     * @param $email
+     * @param string $email
      *
-     * @return mixed
+     * @return string
      */
     protected static function obfuscateEmail($email)
     {
@@ -193,8 +193,8 @@ class Newsletter
     /**
      * @param Model\Document\Newsletter $newsletter
      * @param DataObject\Concrete $object
-     * @param null $emailAddress
-     * @param null $hostUrl
+     * @param string|null $emailAddress
+     * @param string|null $hostUrl
      *
      * @throws Exception
      *
@@ -272,7 +272,7 @@ class Newsletter
     }
 
     /**
-     * @param null $classId
+     * @param string|null $classId
      *
      * @throws Exception
      */
@@ -323,9 +323,9 @@ class Newsletter
     }
 
     /**
-     * @param $params
+     * @param array $params
      *
-     * @return mixed
+     * @return DataObject\Concrete
      *
      * @throws Exception
      */
@@ -388,8 +388,8 @@ class Newsletter
     }
 
     /**
-     * @param $object
-     * @param $mailDocument
+     * @param DataObject\Concrete $object
+     * @param Document $mailDocument
      * @param array $params
      *
      * @throws Exception
@@ -415,7 +415,7 @@ class Newsletter
     }
 
     /**
-     * @param $token
+     * @param string $token
      *
      * @return DataObject\Concrete|null
      */
@@ -528,8 +528,8 @@ class Newsletter
     }
 
     /**
-     * @param $object
-     * @param $title
+     * @param DataObject\Concrete $object
+     * @param string $title
      */
     public function addNoteOnObject($object, $title): void
     {

--- a/lib/Tool/RestClient/AbstractRestClient.php
+++ b/lib/Tool/RestClient/AbstractRestClient.php
@@ -44,7 +44,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     protected $enableProfiling = false;
 
     /**
-     * @var mixed
+     * @var object|null
      */
     protected $profilingInfo;
 
@@ -153,8 +153,8 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param  $key
-     * @param  $value
+     * @param string $key
+     * @param mixed $value
      *
      * @return $this
      */
@@ -171,7 +171,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param $disableMappingExceptions
+     * @param bool $disableMappingExceptions
      *
      * @return $this
      */
@@ -191,7 +191,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param $condense
+     * @param bool $condense
      *
      * @return $this
      */
@@ -211,7 +211,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param $enableProfiling
+     * @param bool $enableProfiling
      *
      * @return $this
      */
@@ -231,7 +231,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @return mixed
+     * @return object|null
      */
     public function getProfilingInfo()
     {
@@ -255,7 +255,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param $apikey
+     * @param string $apikey
      *
      * @return $this
      */
@@ -494,16 +494,16 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param null $condition
-     * @param null $order
-     * @param null $orderKey
-     * @param null $offset
-     * @param null $limit
-     * @param null $groupBy
+     * @param string|null $condition
+     * @param string|null $order
+     * @param string|null $orderKey
+     * @param int|null $offset
+     * @param int|null $limit
+     * @param string|null $groupBy
      * @param bool $decode
-     * @param null $objectClass
+     * @param string|null $objectClass
      *
-     * @return Object[]
+     * @return DataObject\AbstractObject[]
      *
      * @throws Exception
      */
@@ -533,12 +533,12 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param null $condition
-     * @param null $order
-     * @param null $orderKey
-     * @param null $offset
-     * @param null $limit
-     * @param null $groupBy
+     * @param string|null $condition
+     * @param string|null $order
+     * @param string|null $orderKey
+     * @param int|null $offset
+     * @param int|null $limit
+     * @param string|null $groupBy
      * @param bool $decode
      *
      * @return Asset[]
@@ -573,12 +573,12 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param null $condition
-     * @param null $order
-     * @param null $orderKey
-     * @param null $offset
-     * @param null $limit
-     * @param null $groupBy
+     * @param string|null $condition
+     * @param string|null $order
+     * @param string|null $orderKey
+     * @param int|null $offset
+     * @param int|null $limit
+     * @param string|null $groupBy
      * @param bool $decode
      *
      * @return Document[]
@@ -618,11 +618,11 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param      $id
+     * @param int $id
      * @param bool $decode
      * @param Webservice\IdMapperInterface|null $idMapper
      *
-     * @return mixed|DataObject\Folder
+     * @return DataObject\AbstractObject|null
      *
      * @throws Exception
      */
@@ -677,14 +677,16 @@ abstract class AbstractRestClient implements LoggerAwareInterface
                 throw new Exception("Unable to decode object, could not instantiate Object with given class name [ $classname ]");
             }
         }
+
+        return null;
     }
 
     /**
-     * @param      $id
+     * @param int $id
      * @param bool $decode
      * @param Webservice\IdMapperInterface|null $idMapper
      *
-     * @return mixed
+     * @return Document|null
      *
      * @throws Exception
      */
@@ -719,20 +721,20 @@ abstract class AbstractRestClient implements LoggerAwareInterface
                 return $document;
             }
         }
+
+        return null;
     }
 
     /**
-     * TODO
-     *
-     * @param        $id
-     * @param bool   $decode
+     * @param int $id
+     * @param bool $decode
      * @param Webservice\IdMapperInterface|null $idMapper
-     * @param bool   $light
-     * @param null   $thumbnail
-     * @param bool   $tolerant
+     * @param bool $light
+     * @param string|null $thumbnail
+     * @param bool $tolerant
      * @param string $protocol
      *
-     * @return mixed|Asset\Folder
+     * @return Asset|null
      *
      * @throws Exception
      */
@@ -835,6 +837,8 @@ abstract class AbstractRestClient implements LoggerAwareInterface
                 return $asset;
             }
         }
+
+        return null;
     }
 
     /**
@@ -842,7 +846,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
      *
      * @param Document $document
      *
-     * @return mixed json encoded success value and id
+     * @return object json encoded success value and id
      */
     public function createDocument(Document $document)
     {
@@ -886,7 +890,6 @@ abstract class AbstractRestClient implements LoggerAwareInterface
      *
      * @return mixed|null|string
      *
-     * @throws Exception
      * @throws \Exception
      */
     public function createAsset(Asset $asset)
@@ -908,7 +911,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     /**
      * Deletes an object.
      *
-     * @param $objectId
+     * @param int $objectId
      *
      * @return mixed json encoded success value and id
      */
@@ -922,7 +925,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     /**
      * Deletes an asset.
      *
-     * @param $assetId
+     * @param int $assetId
      *
      * @return mixed json encoded success value and id
      */
@@ -936,7 +939,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     /**
      * Deletes a document.
      *
-     * @param $documentId
+     * @param int $documentId
      *
      * @return mixed json encoded success value and id
      */
@@ -984,7 +987,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param      $id
+     * @param string $id
      * @param bool $decode
      *
      * @return mixed|null|DataObject\ClassDefinition|string
@@ -1009,7 +1012,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param      $id
+     * @param int $id
      * @param bool $decode
      *
      * @return mixed|DataObject\ClassDefinition
@@ -1034,8 +1037,8 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param null $condition
-     * @param null $groupBy
+     * @param string|null $condition
+     * @param string|null $groupBy
      *
      * @return mixed
      *
@@ -1056,8 +1059,8 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param null $condition
-     * @param null $groupBy
+     * @param string|null $condition
+     * @param string|null $groupBy
      *
      * @return mixed
      *
@@ -1078,9 +1081,9 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param null $condition
-     * @param null $groupBy
-     * @param null $objectClass
+     * @param string|null $condition
+     * @param string|null $groupBy
+     * @param string|null $objectClass
      *
      * @return mixed
      *
@@ -1126,7 +1129,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return mixed|null|string
      *
@@ -1166,7 +1169,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     /**
      * Returns the given object brick definition
      *
-     * @param $id
+     * @param int $id
      *
      * @return mixed
      */
@@ -1204,7 +1207,7 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     /**
      * Returns the image thumbnail configuration with the given ID.
      *
-     * @param $id
+     * @param int $id
      *
      * @return mixed
      */
@@ -1232,8 +1235,8 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param $wsData
-     * @param $data
+     * @param object $wsData
+     * @param \stdClass $data
      *
      * @return mixed
      *
@@ -1267,8 +1270,8 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param $class
-     * @param $data
+     * @param string $class
+     * @param \stdClass $data
      *
      * @return mixed
      *
@@ -1288,8 +1291,8 @@ abstract class AbstractRestClient implements LoggerAwareInterface
     }
 
     /**
-     * @param $filename
-     * @param $extension
+     * @param string $filename
+     * @param string $extension
      *
      * @return string
      */

--- a/lib/Tool/Serialize.php
+++ b/lib/Tool/Serialize.php
@@ -36,7 +36,7 @@ class Serialize
     /**
      * @static
      *
-     * @param $data
+     * @param string $data
      *
      * @return mixed
      */
@@ -63,7 +63,7 @@ class Serialize
      * this is a special json encoder that avoids recursion errors
      * especially for pimcore models that contain massive self referencing objects
      *
-     * @param $data
+     * @param mixed $data
      *
      * @return string
      */
@@ -74,7 +74,7 @@ class Serialize
     }
 
     /**
-     * @param $element
+     * @param mixed $element
      *
      * @return mixed
      */

--- a/lib/Tool/Session.php
+++ b/lib/Tool/Session.php
@@ -44,7 +44,7 @@ class Session
     }
 
     /**
-     * @param $func
+     * @param callable $func
      * @param string $namespace
      *
      * @return mixed

--- a/lib/Tool/StopWatch.php
+++ b/lib/Tool/StopWatch.php
@@ -30,7 +30,7 @@ class StopWatch
     protected static $laps = [];
 
     /**
-     * @param $component string
+     * @param string $component
      * @static
      */
     public static function start($component = 'default')
@@ -42,7 +42,7 @@ class StopWatch
     /**
      * @static
      *
-     * @param $label
+     * @param string $label
      * @param string $component
      */
     public static function lap($label, $component = 'default')

--- a/lib/Tool/Text.php
+++ b/lib/Tool/Text.php
@@ -35,9 +35,10 @@ class Text
     }
 
     /**
-     * @param $text
+     * @param string $text
+     * @param array $params
      *
-     * @return mixed
+     * @return string
      */
     public static function wysiwygText($text, $params = [])
     {
@@ -267,7 +268,7 @@ class Text
     /**
      * @static
      *
-     * @param $text
+     * @param string $text
      *
      * @return array
      */
@@ -334,7 +335,7 @@ class Text
     }
 
     /**
-     * @param $text
+     * @param string $text
      * @param array $tags
      *
      * @return array
@@ -357,7 +358,7 @@ class Text
     }
 
     /**
-     * @param $text
+     * @param string $text
      *
      * @return string
      */
@@ -372,7 +373,7 @@ class Text
     }
 
     /**
-     * @param $text
+     * @param string $text
      *
      * @return string
      */
@@ -456,7 +457,7 @@ class Text
     }
 
     /**
-     * @param $string
+     * @param string $string
      *
      * @return string
      */
@@ -472,8 +473,8 @@ class Text
     }
 
     /**
-     * @param $string
-     * @param $length
+     * @param string $string
+     * @param int $length
      *
      * @return string
      */

--- a/lib/Tool/Text/Csv.php
+++ b/lib/Tool/Text/Csv.php
@@ -19,7 +19,7 @@ namespace Pimcore\Tool\Text;
 class Csv
 {
     /**
-     * @param $data
+     * @param string $data
      *
      * @return \stdClass
      *
@@ -56,7 +56,7 @@ class Csv
     }
 
     /**
-     * @param $data
+     * @param string $data
      *
      * @return string
      */
@@ -84,7 +84,7 @@ class Csv
     }
 
     /**
-     * @param $data
+     * @param string $data
      *
      * @return array
      */
@@ -125,9 +125,9 @@ class Csv
     }
 
     /**
-     * @param $data
-     * @param $linefeed
-     * @param $quotechar
+     * @param string $data
+     * @param string $linefeed
+     * @param string $quotechar
      *
      * @return bool|string
      */
@@ -225,7 +225,7 @@ class Csv
     }
 
     /**
-     * @param $array
+     * @param array $array
      *
      * @return float
      */

--- a/lib/Tool/Transliteration.php
+++ b/lib/Tool/Transliteration.php
@@ -19,14 +19,13 @@ class Transliteration
     /**
      * @static
      *
-     * @param $value
-     * @param null $language
+     * @param string $value
+     * @param string|null $language
      *
      * @return string
      */
     public static function toASCII($value, $language = null)
     {
-
         // the transliteration is based on the locale
         // äüö is in EN auo in DE  aeueoe
         if (!$language) {
@@ -60,9 +59,9 @@ class Transliteration
     /**
      * @static
      *
-     * @param $string
+     * @param string $string
      * @param string $unknown
-     * @param null $source_langcode
+     * @param string|null $source_langcode
      *
      * @return string
      */

--- a/lib/Translation/ExportDataExtractorService/DataExtractor/DataObjectDataExtractor.php
+++ b/lib/Translation/ExportDataExtractorService/DataExtractor/DataObjectDataExtractor.php
@@ -167,13 +167,7 @@ class DataObjectDataExtractor extends AbstractElementDataExtractor
 
     /**
      * @param Localizedfields $fd
-     * @param AttributeSet $result
-     * @param array|null $exportAttributes
-     */
-
-    /**
-     * @param Localizedfields $fd
-     * @param $definition
+     * @param Data $definition
      * @param DataObject\Concrete $object
      * @param AttributeSet $result
      * @param array|null $exportAttributes

--- a/lib/Translation/ExportService/Exporter/Xliff12Exporter.php
+++ b/lib/Translation/ExportService/Exporter/Xliff12Exporter.php
@@ -99,12 +99,12 @@ class Xliff12Exporter implements ExporterInterface
     }
 
     /**
-     * @param $xml
-     * @param $name
-     * @param $sourceContent
-     * @param $sourceLang
-     * @param $targetContent
-     * @param $targetLang
+     * @param \SimpleXMLElement $xml
+     * @param string $name
+     * @param string $sourceContent
+     * @param string $sourceLang
+     * @param string $targetContent
+     * @param string $targetLang
      */
     protected function addTransUnitNode(\SimpleXMLElement $xml, $name, $sourceContent, $sourceLang, $targetContent, $targetLang)
     {

--- a/lib/Translation/ImportDataExtractor/ImportDataExtractorInterface.php
+++ b/lib/Translation/ImportDataExtractor/ImportDataExtractorInterface.php
@@ -22,7 +22,7 @@ interface ImportDataExtractorInterface
      * @param string $importId
      * @param int $stepId
      *
-     * @return ?AttributeSet
+     * @return AttributeSet
      *
      * @throws \Exception
      */

--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -363,7 +363,7 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
     }
 
     /**
-     * @param $domain
+     * @param string $domain
      *
      * @return string
      */

--- a/lib/Twig/Extension/NavigationExtension.php
+++ b/lib/Twig/Extension/NavigationExtension.php
@@ -97,7 +97,7 @@ class NavigationExtension extends AbstractExtension
      * @param Container $container
      * @param string $rendererName
      * @param string|null $renderMethod     Optional render method to use (e.g. menu -> renderMenu)
-     * @param array $rendererArguments      Option arguments to pass to the render method after the container
+     * @param array<int, mixed> $rendererArguments      Option arguments to pass to the render method after the container
      *
      * @return string
      */

--- a/lib/Video.php
+++ b/lib/Video.php
@@ -17,9 +17,9 @@ namespace Pimcore;
 class Video
 {
     /**
-     * @param null $adapter
+     * @param string|null $adapter
      *
-     * @return bool|null|Video\Adapter
+     * @return Video\Adapter|null
      *
      * @throws \Exception
      */
@@ -59,7 +59,7 @@ class Video
     }
 
     /**
-     * @return bool
+     * @return Video\Adapter|null
      */
     public static function getDefaultAdapter()
     {

--- a/lib/Video/Adapter.php
+++ b/lib/Video/Adapter.php
@@ -49,7 +49,7 @@ abstract class Adapter
     public $length;
 
     /**
-     * @param $audioBitrate
+     * @param int $audioBitrate
      *
      * @return $this
      */
@@ -69,7 +69,7 @@ abstract class Adapter
     }
 
     /**
-     * @param $videoBitrate
+     * @param int $videoBitrate
      *
      * @return $this
      */
@@ -89,23 +89,23 @@ abstract class Adapter
     }
 
     /**
-     * @param $file
+     * @param string $file
      * @param array $options
      *
-     * @return mixed
+     * @return $this
      */
     abstract public function load($file, $options = []);
 
     /**
-     * @return mixed
+     * @return bool
      */
     abstract public function save();
 
     /**
      * @abstract
      *
-     * @param $file
-     * @param $timeOffset
+     * @param string $file
+     * @param int|null $timeOffset
      */
     abstract public function saveImage($file, $timeOffset = null);
 
@@ -115,7 +115,7 @@ abstract class Adapter
     abstract public function destroy();
 
     /**
-     * @param $format
+     * @param string $format
      *
      * @return $this
      */
@@ -135,7 +135,7 @@ abstract class Adapter
     }
 
     /**
-     * @param $destinationFile
+     * @param string $destinationFile
      *
      * @return $this
      */
@@ -155,7 +155,7 @@ abstract class Adapter
     }
 
     /**
-     * @param $length
+     * @param int $length
      *
      * @return $this
      */

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -71,10 +71,10 @@ class Ffmpeg extends Adapter
     }
 
     /**
-     * @param $file
+     * @param string $file
      * @param array $options
      *
-     * @return $this|mixed
+     * @return $this
      */
     public function load($file, $options = [])
     {
@@ -91,7 +91,7 @@ class Ffmpeg extends Adapter
     }
 
     /**
-     * @return mixed|void
+     * @return bool
      *
      * @throws \Exception
      */
@@ -165,8 +165,8 @@ class Ffmpeg extends Adapter
     }
 
     /**
-     * @param $file
-     * @param null $timeOffset
+     * @param string $file
+     * @param int|null $timeOffset
      */
     public function saveImage($file, $timeOffset = null)
     {
@@ -263,7 +263,7 @@ class Ffmpeg extends Adapter
     }
 
     /**
-     * @param $processId
+     * @param string $processId
      *
      * @return $this
      */
@@ -291,8 +291,8 @@ class Ffmpeg extends Adapter
     }
 
     /**
-     * @param $key
-     * @param $value
+     * @param string $key
+     * @param string $value
      */
     public function addArgument($key, $value)
     {
@@ -300,7 +300,7 @@ class Ffmpeg extends Adapter
     }
 
     /**
-     * @param $videoBitrate
+     * @param int $videoBitrate
      *
      * @return $this
      */
@@ -320,7 +320,7 @@ class Ffmpeg extends Adapter
     }
 
     /**
-     * @param $audioBitrate
+     * @param int $audioBitrate
      *
      * @return $this
      */
@@ -340,8 +340,8 @@ class Ffmpeg extends Adapter
     }
 
     /**
-     * @param $width
-     * @param $height
+     * @param int $width
+     * @param int $height
      */
     public function resize($width, $height)
     {
@@ -352,7 +352,7 @@ class Ffmpeg extends Adapter
     }
 
     /**
-     * @param $width
+     * @param int $width
      */
     public function scaleByWidth($width)
     {
@@ -362,7 +362,7 @@ class Ffmpeg extends Adapter
     }
 
     /**
-     * @param $height
+     * @param int $height
      */
     public function scaleByHeight($height)
     {

--- a/lib/Web2Print/Processor.php
+++ b/lib/Web2Print/Processor.php
@@ -45,8 +45,8 @@ abstract class Processor
     }
 
     /**
-     * @param $documentId
-     * @param $config
+     * @param int $documentId
+     * @param mixed $config
      *
      * @return mixed
      *
@@ -88,7 +88,7 @@ abstract class Processor
     }
 
     /**
-     * @param $documentId
+     * @param int $documentId
      *
      * @return mixed|null
      */
@@ -134,14 +134,16 @@ abstract class Processor
 
     /**
      * @param Document\PrintAbstract $document
-     * @param $config
+     * @param object $config
      *
-     * @return mixed
+     * @return string
+     *
+     * @throws \Exception
      */
     abstract protected function buildPdf(Document\PrintAbstract $document, $config);
 
     /**
-     * @param $jobConfig
+     * @param \stdClass $jobConfig
      *
      * @return bool
      */
@@ -153,7 +155,7 @@ abstract class Processor
     }
 
     /**
-     * @param $documentId
+     * @param int $documentId
      *
      * @return \stdClass
      */
@@ -165,7 +167,7 @@ abstract class Processor
     }
 
     /**
-     * @param $documentId
+     * @param int $documentId
      *
      * @return Document\Printpage
      *
@@ -182,7 +184,7 @@ abstract class Processor
     }
 
     /**
-     * @param $processId
+     * @param int $processId
      *
      * @return string
      */
@@ -197,9 +199,9 @@ abstract class Processor
     abstract public function getProcessingOptions();
 
     /**
-     * @param $documentId
-     * @param $status
-     * @param $statusUpdate
+     * @param int $documentId
+     * @param int $status
+     * @param string $statusUpdate
      */
     protected function updateStatus($documentId, $status, $statusUpdate)
     {
@@ -210,7 +212,7 @@ abstract class Processor
     }
 
     /**
-     * @param $documentId
+     * @param int $documentId
      *
      * @return array
      */
@@ -226,7 +228,7 @@ abstract class Processor
     }
 
     /**
-     * @param $documentId
+     * @param int $documentId
      *
      * @throws \Exception
      */
@@ -240,6 +242,12 @@ abstract class Processor
         Model\Tool\TmpStore::delete($document->getLockKey());
     }
 
+    /**
+     * @param string $html
+     * @param array $params
+     *
+     * @return string
+     */
     protected function processHtml($html, $params)
     {
         $placeholder = new \Pimcore\Placeholder();

--- a/lib/Web2Print/Processor/PdfReactor8.php
+++ b/lib/Web2Print/Processor/PdfReactor8.php
@@ -26,7 +26,7 @@ class PdfReactor8 extends Processor
     /**
      * returns the default web2print config
      *
-     * @param $config
+     * @param object $config
      *
      * @return array
      */

--- a/lib/Web2Print/Processor/WkHtmlToPdf.php
+++ b/lib/Web2Print/Processor/WkHtmlToPdf.php
@@ -72,7 +72,7 @@ class WkHtmlToPdf extends Processor
 
     /**
      * @param Document\PrintAbstract $document
-     * @param $config
+     * @param object $config
      *
      * @return string
      *

--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -177,7 +177,7 @@ class Manager
     }
 
     /**
-     * @param $subject
+     * @param object $subject
      *
      * @return Workflow[]
      */
@@ -226,7 +226,7 @@ class Manager
 
     /**
      * @param Workflow $workflow
-     * @param $subject
+     * @param object $subject
      * @param string $transition
      * @param array $additionalData
      * @param bool $saveSubject
@@ -257,7 +257,7 @@ class Manager
 
     /**
      * @param Workflow $workflow
-     * @param $subject
+     * @param object $subject
      * @param string $globalAction
      * @param array $additionalData
      * @param bool $saveSubject

--- a/lib/Workflow/MarkingStore/DataObjectMultipleStateMarkingStore.php
+++ b/lib/Workflow/MarkingStore/DataObjectMultipleStateMarkingStore.php
@@ -59,7 +59,7 @@ class DataObjectMultipleStateMarkingStore extends MultipleStateMarkingStore
     }
 
     /**
-     * @param $subject
+     * @param object $subject
      *
      * @return Concrete
      */

--- a/lib/Workflow/MarkingStore/DataObjectSplittedStateMarkingStore.php
+++ b/lib/Workflow/MarkingStore/DataObjectSplittedStateMarkingStore.php
@@ -152,7 +152,7 @@ class DataObjectSplittedStateMarkingStore implements MarkingStoreInterface
     }
 
     /**
-     * @param $subject
+     * @param object $subject
      *
      * @return Concrete
      */

--- a/lib/Workflow/MarkingStore/StateTableMarkingStore.php
+++ b/lib/Workflow/MarkingStore/StateTableMarkingStore.php
@@ -88,7 +88,7 @@ class StateTableMarkingStore implements MarkingStoreInterface
     }
 
     /**
-     * @param $subject
+     * @param object $subject
      *
      * @return ElementInterface
      */

--- a/lib/Workflow/Notes/NotesAwareTrait.php
+++ b/lib/Workflow/Notes/NotesAwareTrait.php
@@ -17,7 +17,7 @@ namespace Pimcore\Workflow\Notes;
 /**
  * @method getLabel()
  *
- * @property array options
+ * @property array $options
  */
 trait NotesAwareTrait
 {

--- a/lib/Workflow/Notification/AbstractNotificationService.php
+++ b/lib/Workflow/Notification/AbstractNotificationService.php
@@ -41,8 +41,8 @@ class AbstractNotificationService
     /**
      * Returns a list of distinct users given an user- and role array containing their respective names
      *
-     * @param $users
-     * @param $roles
+     * @param array $users
+     * @param array $roles
      *
      * @return User[][]
      */

--- a/lib/Workflow/Place/StatusInfo.php
+++ b/lib/Workflow/Place/StatusInfo.php
@@ -81,10 +81,10 @@ class StatusInfo
     }
 
     /**
-     * @param $subject
+     * @param object $subject
      * @param bool $visibleInHeaderOnly
      *
-     * @return PlaceConfig
+     * @return PlaceConfig[]
      */
     private function getAllPlaces($subject, bool $visibleInHeaderOnly = false, string $workflowName = null): array
     {

--- a/lib/Workflow/Service.php
+++ b/lib/Workflow/Service.php
@@ -21,8 +21,8 @@ use Pimcore\Model\User;
 class Service
 {
     /**
-     * @param $fc - The field configuration from the Workflow
-     * @param $value - The value
+     * @param array $fc - The field configuration from the Workflow
+     * @param mixed $value - The value
      *
      * @return array
      */
@@ -68,8 +68,8 @@ class Service
     }
 
     /**
-     * @param $data
-     * @param $pimcoreTagName
+     * @param mixed $data
+     * @param string $pimcoreTagName
      *
      * @return mixed|null
      */
@@ -99,7 +99,7 @@ class Service
      * @param string $title
      * @param string $description
      * @param array $noteData
-     * @param null $user
+     * @param User|null $user
      *
      * @return Element\Note $note
      */

--- a/lib/helper-functions.php
+++ b/lib/helper-functions.php
@@ -27,11 +27,11 @@ function xmlToArray($file)
 }
 
 /**
- * @param $source
- * @param null $level
- * @param null $target
+ * @param string $source
+ * @param int|null $level
+ * @param string|null $target
  *
- * @return bool|null|string
+ * @return bool|string
  */
 function gzcompressfile($source, $level = null, $target = null)
 {
@@ -61,13 +61,13 @@ function gzcompressfile($source, $level = null, $target = null)
 
     if ($error) {
         return false;
-    } else {
-        return $dest;
     }
+
+    return $dest;
 }
 
 /**
- * @param $string
+ * @param string $string
  *
  * @return bool
  */
@@ -83,7 +83,7 @@ function is_json($string)
 }
 
 /**
- * @param $path
+ * @param string $path
  *
  * @return int
  */
@@ -110,8 +110,8 @@ function foldersize($path)
 }
 
 /**
- * @param $string
- * @param $values
+ * @param string $string
+ * @param string[] $values
  *
  * @return mixed
  */
@@ -130,7 +130,7 @@ function replace_pcre_backreferences($string, $values)
 }
 
 /**
- * @param  $array
+ * @param array $array
  *
  * @return array
  */
@@ -161,7 +161,7 @@ function in_arrayi(string $needle, array $haystack)
 }
 
 /**
- * @param  $node
+ * @param object $node
  *
  * @return array
  */
@@ -178,7 +178,7 @@ function object2array($node)
 }
 
 /**
- * @param  $args
+ * @param array $args
  *
  * @return false|string
  */
@@ -194,7 +194,7 @@ function array_urlencode($args)
 /**
  * same as  array_urlencode but no urlencode()
  *
- * @param  $args
+ * @param array $args
  *
  * @return false|string
  */
@@ -208,7 +208,7 @@ function array_toquerystring($args)
 }
 
 /**
- * @param $array
+ * @param array $array
  *
  * @return string
  */
@@ -280,7 +280,7 @@ function return_bytes($val)
 }
 
 /**
- * @param  $bytes
+ * @param int $bytes
  * @param int $precision
  *
  * @return string
@@ -299,7 +299,7 @@ function formatBytes($bytes, $precision = 2)
 }
 
 /**
- * @param  $str
+ * @param string $str
  *
  * @return float|int
  */
@@ -379,7 +379,7 @@ function explode_and_trim($delimiter, $string = '', $limit = '', $useArrayFilter
 }
 
 /**
- * @param $directory
+ * @param string $directory
  * @param bool $empty
  *
  * @return bool
@@ -423,11 +423,13 @@ function recursiveDelete($directory, $empty = true)
     } elseif (is_file($directory)) {
         return unlink($directory);
     }
+
+    return false;
 }
 
 /**
- * @param $source
- * @param $destination
+ * @param string $source
+ * @param string $destination
  *
  * @return bool
  */
@@ -470,29 +472,11 @@ function p_r()
 }
 
 /**
- * @param  $errno
- * @param  $errstr
- * @param  $errfile
- * @param  $errline
- * @param  $errcontext
- *
- * @return bool
- */
-function pimcore_error_handler($errno, $errstr, $errfile, $errline, $errcontext)
-{
-
-    //Log::info($errno . " | " . $errstr . " in " . $errfile . " on line: " .$errline );
-
-    // enable php internal error handling
-    return false;
-}
-
-/**
- * @param $array
+ * @param array $array
  * @param string $prefix
  * @param string $suffix
  *
- * @return mixed
+ * @return array
  */
 function wrapArrayElements($array, $prefix = "'", $suffix = "'")
 {
@@ -518,7 +502,7 @@ function isAssocArray(array $arr)
 /**
  * this is an alternative for realpath() which isn't able to handle symlinks correctly
  *
- * @param $filename
+ * @param string $filename
  *
  * @return string
  */
@@ -573,8 +557,10 @@ function closureHash(Closure $closure)
     return $hash;
 }
 
-/** Checks if the given directory is empty
- * @param $dir
+/**
+ * Checks if the given directory is empty
+ *
+ * @param string $dir
  *
  * @return bool|null
  */
@@ -594,10 +580,10 @@ function is_dir_empty($dir)
 }
 
 /**
- * @param $var
+ * @param mixed $var
  * @param string $indent
  *
- * @return mixed|string
+ * @return string
  */
 function var_export_pretty($var, $indent = '')
 {
@@ -622,7 +608,7 @@ function var_export_pretty($var, $indent = '')
 }
 
 /**
- * @param $contents
+ * @param mixed $contents
  *
  * @return string
  */


### PR DESCRIPTION
Fix all phpstan level 2 errors in lib/ with following schema:
```
PHPDoc tag @param has invalid value ($xyz)
```
Before:
```
 [ERROR] Found 3539 errors
```
After:
```
 [ERROR] Found 3051 errors 
```