### PR TITLE
[Web2Print] Fix Notices: Undefined index, Save template errors in lastGenerateMessage

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/PrintpageControllerBase.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PrintpageControllerBase.php
@@ -261,13 +261,14 @@ class PrintpageControllerBase extends DocumentControllerBase
             $allParams['hostName'] = $_SERVER['HTTP_HOST'];
         }
 
-        $allParams['protocol'] = $_SERVER['HTTPS'] == 'on' ? 'https' : 'http';
+        $https = $_SERVER['HTTPS'] ?? 'off';
+        $allParams['protocol'] = $https === 'on' ? 'https' : 'http';
         $pdf = $document->getPdfFileName();
         if (is_file($pdf)) {
             unlink($pdf);
         }
 
-        $result = (bool)$document->generatePdf($allParams);
+        $result = $document->generatePdf($allParams);
 
         $this->saveProcessingOptions($document->getId(), $allParams);
 
@@ -319,7 +320,7 @@ class PrintpageControllerBase extends DocumentControllerBase
                 'label' => $option['name'],
                 'value' => $value,
                 'type' => $option['type'],
-                'values' => $option['values']
+                'values' => $option['values'] ?? [],
             ];
         }
 

--- a/bundles/AdminBundle/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/Controller/Admin/SettingsController.php
@@ -681,7 +681,7 @@ class SettingsController extends AdminController
                 $parts = explode(' ', substr($line, 2));
                 $key = trim($parts[0]);
                 if ($key) {
-                    $value = trim($parts[1]);
+                    $value = trim($parts[1] ?? '');
                     $optionArray[$key] = $value;
                 }
             }

--- a/models/Document/PrintAbstract.php
+++ b/models/Document/PrintAbstract.php
@@ -105,9 +105,9 @@ abstract class PrintAbstract extends Document\PageSnippet
     }
 
     /**
-     * @param mixed $config
+     * @param array $config
      *
-     * @return mixed
+     * @return bool
      */
     public function generatePdf($config)
     {


### PR DESCRIPTION
Fixes following notices:
- Notice: Undefined index: HTTPS
- Notice: Undefined index: disableBackgroundExecution
- Notice: Undefined index: cmd
- Notice: Array to string conversion
- Notice: Undefined index: document
- Notice: Undefined index: hostUrl
- Notice: Undefined index: 1
- Notice: Undefined index: values
- Notice: Undefined property: stdClass::$author
- Notice: Undefined property: stdClass::$title
- Notice: Undefined property: stdClass::$links
- Notice: Undefined property: stdClass::$bookmarks
- Notice: Undefined property: stdClass::$colorspace
- Notice: Undefined property: stdClass::$encryption
- Notice: Undefined property: stdClass::$tags
- Notice: Undefined property: stdClass::$loglevel
- Notice: Undefined property: stdClass::$addOverprint
- Notice: Undefined property: stdClass::$viewerPreference
- Notice: Undefined property: stdClass::$screenResolutionImages

Save errors in templates also in lastGenerateMessage. 
Before, only processor errors were visible in the backend