### PR TITLE
[DOCS] Areablock configuration controlsTrigger is wrong

### DIFF
--- a/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/README.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/README.md
@@ -105,7 +105,7 @@ And you can see the effect, below:
 | `limit`             | int    | Limit the amount of elements                                                                                                                                                                 |
 | `areablock_toolbar` | array  | Array with option that allows you to configure the toolbar. Possible options are `width`, `buttonWidth` and `buttonMaxCharacters`                                                            |
 | `controlsAlign`     | string | The position of the control button bar. Options are: `top`, `right` and `left`.                                                                                                              |
-| `controlsTrigger`   | string | Options are: `hover` and `fixed` (default).                                                                                                              |
+| `controlsTrigger`   | string | Options are: `hover`(default) and `fixed` .                                                                                                              |
 | `class`             | string | A CSS class that is added to the surrounding container of this element in editmode                                                                                                           |
 
 ## Brick-specific Configuration


### PR DESCRIPTION
hover seems to be the default value, see: https://github.com/pimcore/pimcore/blob/master/bundles/AdminBundle/Resources/public/js/pimcore/document/tags/areablock.js#L50

not sure if this is on purpose i would rather prefer fixed as the default value.