### PR TITLE
[PHPSTAN] Fill empty php doc param types (Asset)

### DIFF
--- a/lib/Document/Adapter/LibreOffice.php
+++ b/lib/Document/Adapter/LibreOffice.php
@@ -110,7 +110,7 @@ class LibreOffice extends Ghostscript
     /**
      * @param string|null $path
      *
-     * @return null|string|void
+     * @return null|string
      *
      * @throws \Exception
      */

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -410,10 +410,10 @@ class Asset extends Element\AbstractElement
     /**
      * returns the asset type of a filename and mimetype
      *
-     * @param $mimeType
-     * @param $filename
+     * @param string $mimeType
+     * @param string $filename
      *
-     * @return int|string
+     * @return string
      */
     public static function getTypeFromMimeMapping($mimeType, $filename)
     {
@@ -970,7 +970,7 @@ class Asset extends Element\AbstractElement
     }
 
     /**
-     * @param  $locked
+     * @param string $locked
      *
      * @return $this
      */
@@ -1305,7 +1305,7 @@ class Asset extends Element\AbstractElement
     }
 
     /**
-     * @param $stream
+     * @param resource|null $stream
      *
      * @return $this
      */
@@ -1423,9 +1423,9 @@ class Asset extends Element\AbstractElement
     }
 
     /**
-     * @param $name
-     * @param $type
-     * @param $data
+     * @param string $name
+     * @param string $type
+     * @param mixed $data
      * @param bool $inherited
      * @param bool $inheritable
      *
@@ -1551,7 +1551,7 @@ class Asset extends Element\AbstractElement
     }
 
     /**
-     * @param $key
+     * @param string $key
      *
      * @return null
      */
@@ -1565,7 +1565,7 @@ class Asset extends Element\AbstractElement
     }
 
     /**
-     * @param $key
+     * @param string $key
      */
     public function removeCustomSetting($key)
     {
@@ -1668,8 +1668,8 @@ class Asset extends Element\AbstractElement
     /**
      * @param string $name
      * @param string $type can be "folder", "image", "input", "audio", "video", "document", "archive" or "unknown"
-     * @param null $data
-     * @param null $language
+     * @param mixed $data
+     * @param string|null $language
      *
      * @return self
      */
@@ -1768,7 +1768,7 @@ class Asset extends Element\AbstractElement
     }
 
     /**
-     * @param $scheduledTasks
+     * @param array $scheduledTasks
      *
      * @return $this
      */

--- a/models/Asset/Dao.php
+++ b/models/Asset/Dao.php
@@ -29,7 +29,7 @@ class Dao extends Model\Element\Dao
     /**
      * Get the data for the object by id from database and assign it to the object (model)
      *
-     * @param $id
+     * @param int $id
      *
      * @throws \Exception
      */
@@ -153,7 +153,7 @@ class Dao extends Model\Element\Dao
     /**
      * @internal
      *
-     * @param $oldPath
+     * @param string $oldPath
      *
      * @return array
      */
@@ -383,6 +383,9 @@ class Dao extends Model\Element\Dao
         return false;
     }
 
+    /**
+     * @return array
+     */
     public function unlockPropagate()
     {
         $lockIds = $this->db->fetchCol('SELECT id from assets WHERE path LIKE ' . $this->db->quote($this->model->getRealFullPath() . '/%') . ' OR id = ' . $this->model->getId());
@@ -414,7 +417,7 @@ class Dao extends Model\Element\Dao
     }
 
     /**
-     * @param $type
+     * @param string $type
      * @param Model\User $user
      *
      * @return bool

--- a/models/Asset/Document.php
+++ b/models/Asset/Document.php
@@ -59,9 +59,7 @@ class Document extends Model\Asset
     }
 
     /**
-     * @param null $path
-     *
-     * @return |null
+     * @param string|null $path
      */
     public function processPageCount($path = null)
     {
@@ -73,7 +71,7 @@ class Document extends Model\Asset
         if (!\Pimcore\Document::isAvailable()) {
             Logger::error("Couldn't create image-thumbnail of document " . $this->getRealFullPath() . ' no document adapter is available');
 
-            return null;
+            return;
         }
 
         try {
@@ -100,7 +98,7 @@ class Document extends Model\Asset
     }
 
     /**
-     * @param $thumbnailName
+     * @param string $thumbnailName
      * @param int $page
      * @param bool $deferred $deferred deferred means that the image will be generated on-the-fly (details see below)
      *
@@ -125,9 +123,9 @@ class Document extends Model\Asset
     }
 
     /**
-     * @param null $page
+     * @param int|null $page
      *
-     * @return mixed|null
+     * @return string|null
      */
     public function getText($page = null)
     {

--- a/models/Asset/Document/ImageThumbnail.php
+++ b/models/Asset/Document/ImageThumbnail.php
@@ -34,8 +34,8 @@ class ImageThumbnail
     protected $page = 1;
 
     /**
-     * @param $asset
-     * @param $config
+     * @param Model\Asset\Document $asset
+     * @param string|array|Image\Thumbnail\Config $config
      * @param int $page
      * @param bool $deferred
      */
@@ -50,7 +50,7 @@ class ImageThumbnail
     /**
      * @param bool $deferredAllowed
      *
-     * @return mixed|string
+     * @return string
      */
     public function getPath($deferredAllowed = true)
     {
@@ -69,8 +69,6 @@ class ImageThumbnail
 
     /**
      * @param bool $deferredAllowed
-     *
-     * @return string
      */
     public function generate($deferredAllowed = true)
     {
@@ -138,9 +136,9 @@ class ImageThumbnail
     }
 
     /**
-     * @param $selector
+     * @param string|array|Image\Thumbnail\Config $selector
      *
-     * @return bool|static
+     * @return Image\Thumbnail\Config
      */
     protected function createConfig($selector)
     {

--- a/models/Asset/Folder.php
+++ b/models/Asset/Folder.php
@@ -33,7 +33,7 @@ class Folder extends Model\Asset
     /**
      * Contains the child elements
      *
-     * @var array
+     * @var Asset[]
      */
     protected $children;
 
@@ -47,7 +47,7 @@ class Folder extends Model\Asset
     /**
      * set the children of the document
      *
-     * @param $children
+     * @param Asset[] $children
      *
      * @return Folder
      */

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -308,7 +308,7 @@ EOT;
     }
 
     /**
-     * @param $name
+     * @param string $name
      */
     public function clearThumbnail($name)
     {
@@ -321,9 +321,9 @@ EOT;
     /**
      * Legacy method for backwards compatibility. Use getThumbnail($config)->getConfig() instead.
      *
-     * @param mixed $config
+     * @param string|array|Image\Thumbnail\Config $config
      *
-     * @return Image\Thumbnail|bool
+     * @return Image\Thumbnail\Config
      */
     public function getThumbnailConfig($config)
     {
@@ -335,7 +335,7 @@ EOT;
     /**
      * Returns a path to a given thumbnail or an thumbnail configuration.
      *
-     * @param null $config
+     * @param string|array|Image\Thumbnail\Config $config
      * @param bool $deferred
      *
      * @return Image\Thumbnail
@@ -392,7 +392,7 @@ EOT;
     }
 
     /**
-     * @param null $path
+     * @param string|null $path
      * @param bool $force
      *
      * @return array

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -35,8 +35,8 @@ class Thumbnail
     protected static $hasListenersCache = [];
 
     /**
-     * @param $asset
-     * @param null $config
+     * @param Image $asset
+     * @param string|array|Thumbnail\Config $config
      * @param bool $deferred
      */
     public function __construct($asset, $config = null, $deferred = true)
@@ -49,7 +49,7 @@ class Thumbnail
     /**
      * @param bool $deferredAllowed
      *
-     * @return mixed|string
+     * @return string
      */
     public function getPath($deferredAllowed = true)
     {
@@ -437,7 +437,7 @@ class Thumbnail
     /**
      * Get a thumbnail image configuration.
      *
-     * @param mixed $selector Name, array or object describing a thumbnail configuration.
+     * @param string|array|Thumbnail\Config $selector Name, array or object describing a thumbnail configuration.
      *
      * @return Thumbnail\Config
      */

--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -75,7 +75,7 @@ class Config extends Model\AbstractModel
     public $format = 'SOURCE';
 
     /**
-     * @var mixed
+     * @var int
      */
     public $quality = 85;
 
@@ -125,9 +125,9 @@ class Config extends Model\AbstractModel
     public $forcePictureTag = false;
 
     /**
-     * @param $config
+     * @param string|array|self $config
      *
-     * @return self|bool
+     * @return self|null
      */
     public static function getByAutoDetect($config)
     {
@@ -156,7 +156,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return null|Config
      */
@@ -280,9 +280,9 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $name
-     * @param $parameters
-     * @param $media
+     * @param string $name
+     * @param array $parameters
+     * @param string $media
      *
      * @return bool
      */
@@ -305,10 +305,10 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $position
-     * @param $name
-     * @param $parameters
-     * @param $media
+     * @param int $position
+     * @param string $name
+     * @param array $parameters
+     * @param string $media
      *
      * @return bool
      */
@@ -336,7 +336,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return bool
      */
@@ -439,7 +439,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param mixed $quality
+     * @param int $quality
      *
      * @return self
      */
@@ -453,7 +453,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getQuality()
     {
@@ -519,7 +519,7 @@ class Config extends Model\AbstractModel
     /**
      * @static
      *
-     * @param $config
+     * @param array $config
      *
      * @return self
      */
@@ -554,7 +554,7 @@ class Config extends Model\AbstractModel
      * @deprecated
      * @static
      *
-     * @param $config
+     * @param array $config
      *
      * @return self
      */
@@ -637,7 +637,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $asset
+     * @param Model\Asset\Image $asset
      *
      * @return array
      */
@@ -726,6 +726,8 @@ class Config extends Model\AbstractModel
     }
 
     /**
+     * @deprecated
+     *
      * @param string $colorspace
      */
     public function setColorspace($colorspace)
@@ -734,7 +736,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @return string
+     * @deprecated
      */
     public function getColorspace()
     {

--- a/models/Asset/Image/Thumbnail/Config/Dao.php
+++ b/models/Asset/Image/Thumbnail/Config/Dao.php
@@ -31,7 +31,7 @@ class Dao extends Model\Dao\PhpArrayTable
     }
 
     /**
-     * @param null $id
+     * @param string|null $id
      *
      * @throws \Exception
      */

--- a/models/Asset/Image/Thumbnail/Config/Listing.php
+++ b/models/Asset/Image/Thumbnail/Config/Listing.php
@@ -26,7 +26,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\JsonListing
 {
     /**
-     * @var array|null
+     * @var Model\Asset\Image\Thumbnail\Config[]|null
      */
     protected $thumbnails = null;
 
@@ -43,7 +43,7 @@ class Listing extends Model\Listing\JsonListing
     }
 
     /**
-     * @param $thumbnails
+     * @param Model\Asset\Image\Thumbnail\Config[]|null $thumbnails
      *
      * @return $this
      */

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -59,7 +59,7 @@ class Processor
     protected static $hasWebpSupport = null;
 
     /**
-     * @param $format
+     * @param string $format
      * @param array $allowed
      * @param string $fallback
      *
@@ -88,7 +88,7 @@ class Processor
     /**
      * @param Asset $asset
      * @param Config $config
-     * @param null $fileSystemPath
+     * @param string|null $fileSystemPath
      * @param bool $deferred deferred means that the image will be generated on-the-fly (details see below)
      * @param bool $returnAbsolutePath
      * @param bool $generated
@@ -386,10 +386,10 @@ class Processor
     }
 
     /**
-     * @param $path
-     * @param $absolute
+     * @param string $path
+     * @param bool $absolute
      *
-     * @return mixed
+     * @return string
      */
     protected static function returnPath($path, $absolute)
     {

--- a/models/Asset/Listing/Dao.php
+++ b/models/Asset/Listing/Dao.php
@@ -57,7 +57,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     }
 
     /**
-     * @param $columns
+     * @param array|string|Expression $columns
      *
      * @return \Pimcore\Db\ZendCompatibility\QueryBuilder
      */

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -51,10 +51,12 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param  Asset|Asset\Folder $target
-     * @param  Asset|Asset\Folder $source
+     * @param Asset $target
+     * @param Asset $source
      *
-     * @return Asset copied asset
+     * @return Asset|null copied asset
+     *
+     * @throws \Exception
      */
     public function copyRecursive($target, $source)
     {
@@ -64,7 +66,7 @@ class Service extends Model\Element\Service
             $this->_copyRecursiveIds = [];
         }
         if (in_array($source->getId(), $this->_copyRecursiveIds)) {
-            return;
+            return null;
         }
 
         $source->getProperties();
@@ -109,11 +111,14 @@ class Service extends Model\Element\Service
      * @param  Asset $source
      *
      * @return Asset copied asset
+     *
+     * @throws \Exception
      */
     public function copyAsChild($target, $source)
     {
         $source->getProperties();
 
+        /** @var Asset $new */
         $new = Element\Service::cloneMe($source);
         $new->setId(null);
 
@@ -143,8 +148,8 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $target
-     * @param $source
+     * @param Asset $target
+     * @param Asset $source
      *
      * @return mixed
      *
@@ -172,9 +177,9 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $asset
-     * @param null $fields
-     * @param null $requestedLanguage
+     * @param Asset $asset
+     * @param array|null $fields
+     * @param string|null $requestedLanguage
      * @param array $params
      *
      * @return array
@@ -229,7 +234,7 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $asset
+     * @param Asset $asset
      * @param array $params
      * @param bool $onlyMethod
      *
@@ -265,8 +270,8 @@ class Service extends Model\Element\Service
     /**
      * @static
      *
-     * @param $path
-     * @param null $type
+     * @param string $path
+     * @param string|null $type
      *
      * @return bool
      */
@@ -313,14 +318,13 @@ class Service extends Model\Element\Service
      *  "asset" => array(...)
      * )
      *
-     * @param $asset
-     * @param $rewriteConfig
+     * @param Asset $asset
+     * @param array $rewriteConfig
      *
      * @return Asset
      */
     public static function rewriteIds($asset, $rewriteConfig)
     {
-
         // rewriting properties
         $properties = $asset->getProperties();
         foreach ($properties as &$property) {
@@ -332,7 +336,7 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $metadata
+     * @param array $metadata
      *
      * @return array
      */
@@ -369,7 +373,7 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $metadata
+     * @param array $metadata
      *
      * @return array
      */
@@ -416,7 +420,7 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $item \Pimcore\Model\Asset
+     * @param Model\Asset $item
      * @param int $nr
      *
      * @return string

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -23,7 +23,7 @@ use Pimcore\Model\Asset\Image;
 trait ImageThumbnailTrait
 {
     /**
-     * @var \Pimcore\Model\Asset\Video
+     * @var Asset
      */
     protected $asset;
 
@@ -33,7 +33,7 @@ trait ImageThumbnailTrait
     protected $config;
 
     /**
-     * @var mixed|string
+     * @var string
      */
     protected $filesystemPath;
 
@@ -251,6 +251,11 @@ trait ImageThumbnailTrait
         return \Pimcore\File::getFileExtension($this->getFileSystemPath(true));
     }
 
+    /**
+     * @param string $filesystemPath
+     *
+     * @return string
+     */
     protected function convertToWebPath(string $filesystemPath): string
     {
         $path = preg_replace([

--- a/models/Asset/Video.php
+++ b/models/Asset/Video.php
@@ -91,7 +91,7 @@ class Video extends Model\Asset
     }
 
     /**
-     * @param string $config
+     * @param string|Video\Thumbnail\Config $config
      *
      * @return Video\Thumbnail\Config|null
      */
@@ -111,10 +111,10 @@ class Video extends Model\Asset
     /**
      * Returns a path to a given thumbnail or an thumbnail configuration
      *
-     * @param $thumbnailName
+     * @param string|Video\Thumbnail\Config $thumbnailName
      * @param array $onlyFormats
      *
-     * @return string
+     * @return array|null
      */
     public function getThumbnail($thumbnailName, $onlyFormats = [])
     {
@@ -152,13 +152,11 @@ class Video extends Model\Asset
     }
 
     /**
-     * @param $thumbnailName
-     * @param null $timeOffset
-     * @param null $imageAsset
+     * @param string|array|Image\Thumbnail\Config $thumbnailName
+     * @param int|null $timeOffset
+     * @param Image|null $imageAsset
      *
      * @return Video\ImageThumbnail
-     *
-     * @throws \Exception
      */
     public function getImageThumbnail($thumbnailName, $timeOffset = null, $imageAsset = null)
     {
@@ -174,7 +172,7 @@ class Video extends Model\Asset
     /**
      * @param string|null $filePath
      *
-     * @return string|null
+     * @return int|null
      *
      * @throws \Exception
      */
@@ -212,7 +210,7 @@ class Video extends Model\Asset
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getDuration()
     {

--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -40,10 +40,10 @@ class ImageThumbnail
     protected $imageAsset;
 
     /**
-     * @param $asset
-     * @param null $config
-     * @param null $timeOffset
-     * @param null $imageAsset
+     * @param Model\Asset\Video $asset
+     * @param string|array|Image\Thumbnail\Config|null $config
+     * @param int|null $timeOffset
+     * @param Image|null $imageAsset
      * @param bool $deferred
      */
     public function __construct($asset, $config = null, $timeOffset = null, $imageAsset = null, $deferred = true)
@@ -58,7 +58,7 @@ class ImageThumbnail
     /**
      * @param bool $deferredAllowed
      *
-     * @return mixed|string
+     * @return string
      */
     public function getPath($deferredAllowed = true)
     {
@@ -186,9 +186,9 @@ class ImageThumbnail
     }
 
     /**
-     * @param $selector
+     * @param string|array|Image\Thumbnail\Config $selector
      *
-     * @return bool|static
+     * @return Image\Thumbnail\Config|null
      */
     protected function createConfig($selector)
     {

--- a/models/Asset/Video/Thumbnail/Config.php
+++ b/models/Asset/Video/Thumbnail/Config.php
@@ -81,7 +81,7 @@ class Config extends Model\AbstractModel
     public $creationDate;
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return null|Config
      */
@@ -131,8 +131,8 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param  $name
-     * @param  $parameters
+     * @param string $name
+     * @param array $parameters
      *
      * @return bool
      */
@@ -147,9 +147,9 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $position
-     * @param $name
-     * @param $parameters
+     * @param int $position
+     * @param string $name
+     * @param array $parameters
      *
      * @return bool
      */
@@ -169,7 +169,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $description
+     * @param string $description
      *
      * @return $this
      */
@@ -189,7 +189,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $items
+     * @param array $items
      *
      * @return $this
      */
@@ -209,7 +209,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return $this
      */
@@ -229,7 +229,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $audioBitrate
+     * @param int $audioBitrate
      *
      * @return $this
      */
@@ -249,7 +249,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $videoBitrate
+     * @param int $videoBitrate
      *
      * @return $this
      */

--- a/models/Asset/Video/Thumbnail/Config/Dao.php
+++ b/models/Asset/Video/Thumbnail/Config/Dao.php
@@ -31,7 +31,7 @@ class Dao extends Model\Dao\PhpArrayTable
     }
 
     /**
-     * @param null $id
+     * @param string|null $id
      *
      * @throws \Exception
      */

--- a/models/Asset/Video/Thumbnail/Config/Listing.php
+++ b/models/Asset/Video/Thumbnail/Config/Listing.php
@@ -26,7 +26,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\JsonListing
 {
     /**
-     * @var null|array
+     * @var \Pimcore\Model\Asset\Video\Thumbnail\Config[]|null
      */
     protected $thumbnails = null;
 
@@ -43,7 +43,7 @@ class Listing extends Model\Listing\JsonListing
     }
 
     /**
-     * @param $thumbnails
+     * @param \Pimcore\Model\Asset\Video\Thumbnail\Config[]|null $thumbnails
      *
      * @return $this
      */

--- a/models/Asset/Video/Thumbnail/Processor.php
+++ b/models/Asset/Video/Thumbnail/Processor.php
@@ -61,7 +61,7 @@ class Processor
 
     /**
      * @param Model\Asset\Video $asset
-     * @param $config
+     * @param Config $config
      * @param array $onlyFormats
      *
      * @return Processor
@@ -179,7 +179,7 @@ class Processor
     }
 
     /**
-     * @param $processId
+     * @param string $processId
      */
     public static function execute($processId)
     {
@@ -262,7 +262,7 @@ class Processor
     }
 
     /**
-     * @param $processId
+     * @param string $processId
      *
      * @return string
      */
@@ -276,7 +276,7 @@ class Processor
     }
 
     /**
-     * @param $processId
+     * @param string $processId
      *
      * @return $this
      */
@@ -296,7 +296,7 @@ class Processor
     }
 
     /**
-     * @param $assetId
+     * @param int $assetId
      *
      * @return $this
      */
@@ -316,7 +316,7 @@ class Processor
     }
 
     /**
-     * @param $config
+     * @param Config $config
      *
      * @return $this
      */
@@ -336,7 +336,7 @@ class Processor
     }
 
     /**
-     * @param $queue
+     * @param array $queue
      *
      * @return $this
      */

--- a/models/Asset/WebDAV/File.php
+++ b/models/Asset/WebDAV/File.php
@@ -31,7 +31,7 @@ class File extends DAV\File
     private $asset;
 
     /**
-     * @param $asset
+     * @param Asset $asset
      */
     public function __construct($asset)
     {

--- a/models/Asset/WebDAV/Folder.php
+++ b/models/Asset/WebDAV/Folder.php
@@ -31,7 +31,7 @@ class Folder extends DAV\Collection
     private $asset;
 
     /**
-     * @param $asset
+     * @param Asset $asset
      */
     public function __construct($asset)
     {
@@ -110,9 +110,7 @@ class Folder extends DAV\Collection
 
     /**
      * @param string $name
-     * @param null $data
-     *
-     * @return null|string|void
+     * @param string|null $data
      *
      * @throws DAV\Exception\Forbidden
      */

--- a/models/Asset/WebDAV/Service.php
+++ b/models/Asset/WebDAV/Service.php
@@ -54,7 +54,7 @@ class Service
     }
 
     /**
-     * @param $log
+     * @param array $log
      */
     public static function saveDeleteLog($log)
     {


### PR DESCRIPTION
Fix all phpstan level 2 errors in Pimcore\Model\Asset namespace with following schema:
```
PHPDoc tag @param has invalid value ($xyz)
```
Before:
```
 [ERROR] Found 2731 errors
```
After:
```
 [ERROR] Found 2646 errors 
```