### PR TITLE
[PHPSTAN] Fill empty php doc param types (Document)

### DIFF
--- a/models/Document.php
+++ b/models/Document.php
@@ -140,6 +140,8 @@ class Document extends Element\AbstractElement
 
     /**
      * Permissions for the user which requested this document in editmode*
+     *
+     * @var array
      */
     protected $userPermissions;
 
@@ -645,11 +647,9 @@ class Document extends Element\AbstractElement
     /**
      * set the children of the document
      *
-     * @param $children
+     * @param self[] $children
      *
-     * @return array
-     *
-     * @todo: replace and with &&
+     * @return $this
      */
     public function setChildren($children)
     {
@@ -668,7 +668,7 @@ class Document extends Element\AbstractElement
     /**
      * Get a list of the children (not recursivly)
      *
-     * @param bool
+     * @param bool $unpublished
      *
      * @return self[]
      */
@@ -689,7 +689,7 @@ class Document extends Element\AbstractElement
     /**
      * Returns true if the document has at least one child
      *
-     * @param $unpublished
+     * @param bool $unpublished
      *
      * @return bool
      */
@@ -764,7 +764,7 @@ class Document extends Element\AbstractElement
     /**
      * Mark the document as locked.
      *
-     * @param  $locked
+     * @param string $locked
      *
      * @return Document
      */
@@ -923,9 +923,9 @@ class Document extends Element\AbstractElement
     }
 
     /**
-     * @param $path
+     * @param string $path
      *
-     * @return mixed
+     * @return string
      */
     protected function prepareFrontendPath($path)
     {
@@ -1435,7 +1435,7 @@ class Document extends Element\AbstractElement
     /**
      * Add document type to the $types array. It defines additional document types available in Pimcore.
      *
-     * @param $type
+     * @param string $type
      */
     public static function addDocumentType($type)
     {
@@ -1465,7 +1465,7 @@ class Document extends Element\AbstractElement
     }
 
     /**
-     * @param mixed $userPermissions
+     * @param array $userPermissions
      */
     public function setUserPermissions($userPermissions): void
     {

--- a/models/Document/Dao.php
+++ b/models/Document/Dao.php
@@ -29,7 +29,7 @@ class Dao extends Model\Element\Dao
     /**
      * Fetch a row by an id from the database and assign variables to the document model.
      *
-     * @param $id
+     * @param int $id
      *
      * @throws \Exception
      */
@@ -52,7 +52,7 @@ class Dao extends Model\Element\Dao
     /**
      * Fetch a row by a path from the database and assign variables to the model.
      *
-     * @param $path
+     * @param string $path
      *
      * @throws \Exception
      */
@@ -185,7 +185,7 @@ class Dao extends Model\Element\Dao
      *
      * @internal
      *
-     * @param $oldPath
+     * @param string $oldPath
      *
      * @return array
      */
@@ -434,6 +434,8 @@ class Dao extends Model\Element\Dao
 
     /**
      * Deletes locks from the document and its children.
+     *
+     * @return array
      */
     public function unlockPropagate()
     {
@@ -446,8 +448,8 @@ class Dao extends Model\Element\Dao
     /**
      * Checks if the action is allowed.
      *
-     * @param $type
-     * @param $user
+     * @param string $type
+     * @param Model\User $user
      *
      * @return bool
      */
@@ -498,9 +500,7 @@ class Dao extends Model\Element\Dao
     /**
      * Save the document index.
      *
-     * @param $index
-     *
-     * @throws \Exception
+     * @param int $index
      */
     public function saveIndex($index)
     {

--- a/models/Document/DocType.php
+++ b/models/Document/DocType.php
@@ -288,7 +288,7 @@ class DocType extends Model\AbstractModel
     }
 
     /**
-     * @param $module
+     * @param string $module
      *
      * @return $this
      */
@@ -308,7 +308,7 @@ class DocType extends Model\AbstractModel
     }
 
     /**
-     * @param $modificationDate
+     * @param int $modificationDate
      *
      * @return $this
      */
@@ -328,7 +328,7 @@ class DocType extends Model\AbstractModel
     }
 
     /**
-     * @param $creationDate
+     * @param int $creationDate
      *
      * @return $this
      */

--- a/models/Document/DocType/Dao.php
+++ b/models/Document/DocType/Dao.php
@@ -33,7 +33,7 @@ class Dao extends Model\Dao\PhpArrayTable
     /**
      * Get the data for the object from database for the given id
      *
-     * @param null $id
+     * @param int|null $id
      *
      * @throws \Exception
      */

--- a/models/Document/Email.php
+++ b/models/Document/Email.php
@@ -128,7 +128,7 @@ class Email extends Model\Document\PageSnippet
      *
      * @static
      *
-     * @param $emailAddress
+     * @param string $emailAddress
      *
      * @return string | null - returns "null" if the email address is invalid otherwise the email address is returned
      */

--- a/models/Document/Hardlink.php
+++ b/models/Document/Hardlink.php
@@ -107,7 +107,7 @@ class Hardlink extends Document
     }
 
     /**
-     * @param $childrenFromSource
+     * @param bool $childrenFromSource
      *
      * @return Hardlink
      */
@@ -127,7 +127,7 @@ class Hardlink extends Document
     }
 
     /**
-     * @param $sourceId
+     * @param int $sourceId
      *
      * @return $this
      */
@@ -147,7 +147,7 @@ class Hardlink extends Document
     }
 
     /**
-     * @param $propertiesFromSource
+     * @param bool $propertiesFromSource
      *
      * @return $this
      */

--- a/models/Document/Hardlink/Service.php
+++ b/models/Document/Hardlink/Service.php
@@ -113,9 +113,9 @@ class Service
 
     /**
      * @param Document\Hardlink $hardlink
-     * @param $path
+     * @param string $path
      *
-     * @return Document
+     * @return Document|null
      */
     public static function getNearestChildByPath(Document\Hardlink $hardlink, $path)
     {
@@ -154,5 +154,7 @@ class Service
                 }
             }
         }
+
+        return null;
     }
 }

--- a/models/Document/Link.php
+++ b/models/Document/Link.php
@@ -292,7 +292,7 @@ class Link extends Model\Document
     }
 
     /**
-     * @return Document|Asset
+     * @return Document|Asset|Model\DataObject\Concrete|null
      */
     public function getObject()
     {
@@ -304,11 +304,11 @@ class Link extends Model\Document
             }
         }
 
-        return false;
+        return null;
     }
 
     /**
-     * @param $object
+     * @param Document|Asset|Model\DataObject\Concrete $object
      *
      * @return $this
      */

--- a/models/Document/Listing.php
+++ b/models/Document/Listing.php
@@ -87,9 +87,9 @@ class Listing extends Model\Listing\AbstractListing implements AdapterInterface,
     /**
      * Set the unpublished flag for the document.
      *
-     * @param $unpublished
+     * @param bool $unpublished
      *
-     * @return bool
+     * @return $this
      */
     public function setUnpublished($unpublished)
     {

--- a/models/Document/Listing/Dao.php
+++ b/models/Document/Listing/Dao.php
@@ -58,7 +58,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     }
 
     /**
-     * @param $columns
+     * @param array|string|Expression $columns
      *
      * @return \Pimcore\Db\ZendCompatibility\QueryBuilder
      */

--- a/models/Document/Page.php
+++ b/models/Document/Page.php
@@ -148,7 +148,7 @@ class Page extends TargetingDocument
     }
 
     /**
-     * @param $metaData
+     * @param array $metaData
      *
      * @return $this
      */
@@ -191,7 +191,7 @@ class Page extends TargetingDocument
     }
 
     /**
-     * @param $prettyUrl
+     * @param string $prettyUrl
      *
      * @return $this
      */

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -113,7 +113,7 @@ abstract class PageSnippet extends Model\Document
     /**
      * @param bool $setModificationDate
      * @param bool $saveOnlyVersion
-     * @param $versionNote string version note
+     * @param string $versionNote
      *
      * @return null|Model\Version
      *
@@ -306,7 +306,7 @@ abstract class PageSnippet extends Model\Document
     }
 
     /**
-     * @param $module
+     * @param string $module
      *
      * @return $this
      */
@@ -370,7 +370,7 @@ abstract class PageSnippet extends Model\Document
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return $this
      */
@@ -471,7 +471,7 @@ abstract class PageSnippet extends Model\Document
     }
 
     /**
-     * @param $document
+     * @param Document $document
      *
      * @return $this
      */
@@ -487,7 +487,7 @@ abstract class PageSnippet extends Model\Document
     }
 
     /**
-     * @param  $name
+     * @param string $name
      *
      * @return bool
      */
@@ -573,8 +573,8 @@ abstract class PageSnippet extends Model\Document
     }
 
     /**
-     * @param null $hostname
-     * @param null $scheme
+     * @param string|null $hostname
+     * @param string|null $scheme
      *
      * @return string
      *

--- a/models/Document/PageSnippet/Dao.php
+++ b/models/Document/PageSnippet/Dao.php
@@ -84,7 +84,7 @@ abstract class Dao extends Model\Document\Dao
      *
      * @param bool $force
      *
-     * @return array
+     * @return Version|null
      */
     public function getLatestVersion($force = false)
     {
@@ -96,7 +96,7 @@ abstract class Dao extends Model\Document\Dao
             return $version;
         }
 
-        return;
+        return null;
     }
 
     /**

--- a/models/Document/PrintAbstract.php
+++ b/models/Document/PrintAbstract.php
@@ -73,7 +73,7 @@ abstract class PrintAbstract extends Document\PageSnippet
     }
 
     /**
-     * @param $lastGenerated
+     * @param int $lastGenerated
      */
     public function setLastGenerated($lastGenerated)
     {
@@ -89,7 +89,7 @@ abstract class PrintAbstract extends Document\PageSnippet
     }
 
     /**
-     * @param $lastGenerateMessage
+     * @param string $lastGenerateMessage
      */
     public function setLastGenerateMessage($lastGenerateMessage)
     {
@@ -105,7 +105,7 @@ abstract class PrintAbstract extends Document\PageSnippet
     }
 
     /**
-     * @param $config
+     * @param mixed $config
      *
      * @return mixed
      */
@@ -115,7 +115,7 @@ abstract class PrintAbstract extends Document\PageSnippet
     }
 
     /**
-     * @param $params
+     * @param array $params
      *
      * @return string
      */

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -104,9 +104,11 @@ class Service extends Model\Element\Service
     /**
      * Save document and all child documents
      *
-     * @param     $document
+     * @param Document $document
      * @param int $collectGarbageAfterIteration
      * @param int $saved
+     *
+     * @throws \Exception
      */
     public static function saveRecursive($document, $collectGarbageAfterIteration = 25, &$saved = 0)
     {
@@ -136,7 +138,9 @@ class Service extends Model\Element\Service
      * @param  Document $target
      * @param  Document $source
      *
-     * @return Document copied document
+     * @return Document|null copied document
+     *
+     * @throws \Exception
      */
     public function copyRecursive($target, $source)
     {
@@ -146,7 +150,7 @@ class Service extends Model\Element\Service
             $this->_copyRecursiveIds = [];
         }
         if (in_array($source->getId(), $this->_copyRecursiveIds)) {
-            return;
+            return null;
         }
 
         if (method_exists($source, 'getElements')) {
@@ -256,8 +260,8 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $target
-     * @param $source
+     * @param Document $target
+     * @param Document $source
      *
      * @return mixed
      *
@@ -320,7 +324,7 @@ class Service extends Model\Element\Service
     /**
      * @static
      *
-     * @param $doc
+     * @param Document $doc
      *
      * @return mixed
      */
@@ -342,8 +346,8 @@ class Service extends Model\Element\Service
     /**
      * @static
      *
-     * @param $path
-     * @param $type
+     * @param string $path
+     * @param string|null $type
      *
      * @return bool
      */
@@ -366,7 +370,7 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $type
+     * @param string $type
      *
      * @return bool
      */
@@ -386,8 +390,8 @@ class Service extends Model\Element\Service
      *  "asset" => array(...)
      * )
      *
-     * @param $document
-     * @param $rewriteConfig
+     * @param Document $document
+     * @param array $rewriteConfig
      * @param array $params
      *
      * @return Document
@@ -480,10 +484,10 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $item
+     * @param Document $item
      * @param int $nr
      *
-     * @return mixed|string
+     * @return string
      *
      * @throws \Exception
      */
@@ -595,7 +599,7 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $id
+     * @param int $id
      * @param Request $request
      * @param string $hostUrl
      *

--- a/models/Document/Service/Dao.php
+++ b/models/Document/Service/Dao.php
@@ -59,6 +59,7 @@ class Dao extends Model\Dao\AbstractDao
 
     /**
      * @param Document $document
+     * @param string $task
      *
      * @return array
      */
@@ -100,7 +101,7 @@ class Dao extends Model\Dao\AbstractDao
     /**
      * @param Document $document
      * @param Document $translation
-     * @param $language
+     * @param string|null $language
      */
     public function addTranslation(Document $document, Document $translation, $language = null)
     {

--- a/models/Document/Tag.php
+++ b/models/Document/Tag.php
@@ -79,7 +79,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
     /**
      * @deprecated Unused - will be removed in 7.0
      *
-     * @var null
+     * @var string|null
      */
     protected $controller;
 
@@ -101,13 +101,13 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
     protected $inherited = false;
 
     /**
-     * @param $type
-     * @param $name
-     * @param $documentId
-     * @param null $config
-     * @param null $controller
-     * @param null $view
-     * @param null $editmode
+     * @param string $type
+     * @param string $name
+     * @param int $documentId
+     * @param array|null $config
+     * @param string|null $controller
+     * @param ViewModel|null $view
+     * @param bool|null $editmode
      *
      * @return mixed
      */
@@ -404,7 +404,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
     /**
      * @deprecated
      *
-     * @param null $controller
+     * @param string|null $controller
      *
      * @return $this
      */
@@ -418,7 +418,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
     /**
      * @deprecated
      *
-     * @return null
+     * @return string|null
      */
     public function getController()
     {
@@ -565,7 +565,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
     }
 
     /**
-     * @return $this
+     * @return mixed
      */
     public function getDataForResource()
     {
@@ -575,7 +575,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
     }
 
     /**
-     * @param $ownerDocument
+     * @param Model\Document\PageSnippet $ownerDocument
      * @param array $tags
      *
      * @return array
@@ -599,7 +599,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
      * @abstract
      * @deprecated
      * @param Webservice\Data\Document\Element $wsElement
-     * @param $document
+     * @param Model\Document\PageSnippet $document
      * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
@@ -614,11 +614,11 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
      * Returns the current tag's data for web service export
      *
      * @deprecated
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet|null $document
+     * @param array $params
      * @abstract
      *
-     * @return array
+     * @return \stdClass
      */
     public function getForWebserviceExport($document = null, $params = [])
     {
@@ -654,7 +654,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
     }
 
     /**
-     * @param $inherited
+     * @param bool $inherited
      *
      * @return $this
      */
@@ -759,7 +759,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
 
     /**
      * @deprecated
-     * @param $data
+     * @param array|object $data
      *
      * @return object
      */

--- a/models/Document/Tag/Area/AbstractArea.php
+++ b/models/Document/Tag/Area/AbstractArea.php
@@ -62,7 +62,7 @@ abstract class AbstractArea
     }
 
     /**
-     * @param $config
+     * @param \Pimcore\Config\Config $config
      *
      * @return $this
      */
@@ -82,7 +82,7 @@ abstract class AbstractArea
     }
 
     /**
-     * @param $key
+     * @param string $key
      *
      * @return mixed
      */
@@ -91,6 +91,8 @@ abstract class AbstractArea
         if (array_key_exists($key, $this->params)) {
             return $this->params[$key];
         }
+
+        return null;
     }
 
     /**
@@ -102,8 +104,8 @@ abstract class AbstractArea
     }
 
     /**
-     * @param $key
-     * @param $value
+     * @param string $key
+     * @param mixed $value
      */
     public function addParam($key, $value)
     {
@@ -111,7 +113,7 @@ abstract class AbstractArea
     }
 
     /**
-     * @param $params
+     * @param array $params
      *
      * @return $this
      */

--- a/models/Document/Tag/Areablock.php
+++ b/models/Document/Tag/Areablock.php
@@ -95,7 +95,7 @@ class Areablock extends Model\Document\Tag implements BlockInterface
     }
 
     /**
-     * @param $index
+     * @param int $index
      */
     public function renderIndex($index)
     {
@@ -576,8 +576,8 @@ class Areablock extends Model\Document\Tag implements BlockInterface
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception

--- a/models/Document/Tag/Block.php
+++ b/models/Document/Tag/Block.php
@@ -349,11 +349,9 @@ class Block extends Model\Document\Tag implements BlockInterface
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param null $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
-     *
-     * @return Model\Webservice\Data\Document\Element|void
      *
      * @throws \Exception
      */

--- a/models/Document/Tag/Block/AbstractBlockItem.php
+++ b/models/Document/Tag/Block/AbstractBlockItem.php
@@ -63,8 +63,8 @@ abstract class AbstractBlockItem
     }
 
     /**
-     * @param $func
-     * @param $args
+     * @param string $func
+     * @param array $args
      *
      * @return Document\Tag|null
      */
@@ -76,5 +76,7 @@ abstract class AbstractBlockItem
         if (!strcasecmp(get_class($element), $class)) {
             return $element;
         }
+
+        return null;
     }
 }

--- a/models/Document/Tag/Block/Item.php
+++ b/models/Document/Tag/Block/Item.php
@@ -27,8 +27,8 @@ class Item extends AbstractBlockItem
     }
 
     /**
-     * @param $func
-     * @param $args
+     * @param string $func
+     * @param array $args
      *
      * @return Document\Tag|null
      */
@@ -42,5 +42,7 @@ class Item extends AbstractBlockItem
         } elseif ($element === null) {
             return new $class;
         }
+
+        return null;
     }
 }

--- a/models/Document/Tag/Checkbox.php
+++ b/models/Document/Tag/Checkbox.php
@@ -108,8 +108,8 @@ class Checkbox extends Model\Document\Tag
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception

--- a/models/Document/Tag/Date.php
+++ b/models/Document/Tag/Date.php
@@ -152,8 +152,8 @@ class Date extends Model\Document\Tag
      *
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception
@@ -173,11 +173,11 @@ class Date extends Model\Document\Tag
      * Returns the current tag's data for web service export
      *
      * @deprecated
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet|null $document
+     * @param array $params
      * @abstract
      *
-     * @return array
+     * @return int|null
      */
     public function getForWebserviceExport($document = null, $params = [])
     {
@@ -189,7 +189,7 @@ class Date extends Model\Document\Tag
     }
 
     /**
-     * @param $timestamp
+     * @param int $timestamp
      */
     protected function setDateFromTimestamp($timestamp)
     {

--- a/models/Document/Tag/Embed.php
+++ b/models/Document/Tag/Embed.php
@@ -51,6 +51,9 @@ class Embed extends Model\Document\Tag
         ];
     }
 
+    /**
+     * @return array
+     */
     public function getDataForResource()
     {
         return [
@@ -155,8 +158,8 @@ class Embed extends Model\Document\Tag
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception

--- a/models/Document/Tag/Image.php
+++ b/models/Document/Tag/Image.php
@@ -96,7 +96,7 @@ class Image extends Model\Document\Tag
     /**
      * @see TagInterface::getData
      *
-     * @return mixed
+     * @return array
      */
     public function getData()
     {
@@ -113,6 +113,9 @@ class Image extends Model\Document\Tag
         ];
     }
 
+    /**
+     * @return array
+     */
     public function getDataForResource()
     {
         return [
@@ -454,7 +457,7 @@ class Image extends Model\Document\Tag
     }
 
     /**
-     * @param $conf
+     * @param string|array|Asset\Image\Thumbnail\Config $conf
      * @param bool $deferred
      *
      * @return Asset\Image\Thumbnail|string
@@ -477,9 +480,7 @@ class Image extends Model\Document\Tag
     }
 
     /**
-     * @param $thumbConfig
-     *
-     * @return mixed
+     * @param Asset\Image\Thumbnail\Config $thumbConfig
      */
     protected function applyCustomCropping($thumbConfig)
     {
@@ -514,7 +515,7 @@ class Image extends Model\Document\Tag
     }
 
     /**
-     * @param $ownerDocument
+     * @param Model\Document\PageSnippet $ownerDocument
      * @param array $tags
      *
      * @return array|mixed
@@ -606,11 +607,9 @@ class Image extends Model\Document\Tag
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param null $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
-     *
-     * @return Model\Webservice\Data\Document\Element|void
      *
      * @throws \Exception
      */
@@ -645,7 +644,7 @@ class Image extends Model\Document\Tag
     }
 
     /**
-     * @param $cropHeight
+     * @param float $cropHeight
      *
      * @return $this
      */
@@ -665,7 +664,7 @@ class Image extends Model\Document\Tag
     }
 
     /**
-     * @param $cropLeft
+     * @param float $cropLeft
      *
      * @return $this
      */
@@ -685,7 +684,7 @@ class Image extends Model\Document\Tag
     }
 
     /**
-     * @param $cropPercent
+     * @param bool $cropPercent
      *
      * @return $this
      */
@@ -705,7 +704,7 @@ class Image extends Model\Document\Tag
     }
 
     /**
-     * @param $cropTop
+     * @param float $cropTop
      *
      * @return $this
      */
@@ -725,7 +724,7 @@ class Image extends Model\Document\Tag
     }
 
     /**
-     * @param $cropWidth
+     * @param float $cropWidth
      *
      * @return $this
      */

--- a/models/Document/Tag/Input.php
+++ b/models/Document/Tag/Input.php
@@ -113,8 +113,8 @@ class Input extends Model\Document\Tag
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param null $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception

--- a/models/Document/Tag/Link.php
+++ b/models/Document/Tag/Link.php
@@ -255,6 +255,7 @@ class Link extends Model\Document\Tag
 
     /**
      * @param bool $realPath
+     * @param bool $editmode
      */
     protected function updatePathFromInternal($realPath = false, $editmode = false)
     {
@@ -508,8 +509,8 @@ class Link extends Model\Document\Tag
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception
@@ -578,11 +579,10 @@ class Link extends Model\Document\Tag
      * Returns the current tag's data for web service export
      *
      * @deprecated
-     * @param $document
-     * @param mixed $params
-     * @abstract
+     * @param Model\Document\PageSnippet|null $document
+     * @param array $params
      *
-     * @return array
+     * @return \stdClass
      */
     public function getForWebserviceExport($document = null, $params = [])
     {

--- a/models/Document/Tag/Multiselect.php
+++ b/models/Document/Tag/Multiselect.php
@@ -114,8 +114,8 @@ class Multiselect extends Model\Document\Tag
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception

--- a/models/Document/Tag/Numeric.php
+++ b/models/Document/Tag/Numeric.php
@@ -104,8 +104,8 @@ class Numeric extends Model\Document\Tag
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception

--- a/models/Document/Tag/Pdf.php
+++ b/models/Document/Tag/Pdf.php
@@ -81,7 +81,7 @@ class Pdf extends Model\Document\Tag
     }
 
     /**
-     * @param $ownerDocument
+     * @param Model\Document\PageSnippet $ownerDocument
      * @param array $tags
      *
      * @return array|mixed
@@ -247,8 +247,8 @@ HTML;
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception

--- a/models/Document/Tag/Relation.php
+++ b/models/Document/Tag/Relation.php
@@ -252,8 +252,8 @@ class Relation extends Model\Document\Tag
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception

--- a/models/Document/Tag/Relations.php
+++ b/models/Document/Tag/Relations.php
@@ -256,8 +256,8 @@ class Relations extends Model\Document\Tag implements \Iterator
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception
@@ -414,11 +414,10 @@ class Relations extends Model\Document\Tag implements \Iterator
      * Returns the current tag's data for web service export
      *
      * @deprecated
-     * @param $document
-     * @param mixed $params
-     * @abstract
+     * @param Model\Document\PageSnippet|null $document
+     * @param array $params
      *
-     * @return array
+     * @return array|null
      */
     public function getForWebserviceExport($document = null, $params = [])
     {

--- a/models/Document/Tag/Renderlet.php
+++ b/models/Document/Tag/Renderlet.php
@@ -254,9 +254,9 @@ class Renderlet extends Model\Document\Tag
     /**
      * get correct type of object as string
      *
-     * @param null $object
+     * @param Element\ElementInterface|null $object
      *
-     * @return bool|string
+     * @return string|null
      *
      * @internal param mixed $data
      */
@@ -290,8 +290,8 @@ class Renderlet extends Model\Document\Tag
 
     /**
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception

--- a/models/Document/Tag/Scheduledblock.php
+++ b/models/Document/Tag/Scheduledblock.php
@@ -119,8 +119,8 @@ class Scheduledblock extends Block implements BlockInterface
     /**
      * Set cache lifetime to timestamp of next element
      *
-     * @param $outputTimestamp
-     * @param $nextElement
+     * @param int $outputTimestamp
+     * @param array $nextElement
      */
     protected function updateOutputCacheLifetime($outputTimestamp, $nextElement)
     {

--- a/models/Document/Tag/Select.php
+++ b/models/Document/Tag/Select.php
@@ -100,8 +100,8 @@ class Select extends Model\Document\Tag
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception

--- a/models/Document/Tag/Snippet.php
+++ b/models/Document/Tag/Snippet.php
@@ -249,8 +249,8 @@ class Snippet extends Model\Document\Tag
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception

--- a/models/Document/Tag/Table.php
+++ b/models/Document/Tag/Table.php
@@ -95,7 +95,7 @@ class Table extends Model\Document\Tag
     /**
      * @see TagInterface::setDataFromEditmode
      *
-     * @param mixed $data
+     * @param array $data
      *
      * @return $this
      */
@@ -117,8 +117,8 @@ class Table extends Model\Document\Tag
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception

--- a/models/Document/Tag/TagInterface.php
+++ b/models/Document/Tag/TagInterface.php
@@ -17,6 +17,8 @@
 
 namespace Pimcore\Model\Document\Tag;
 
+use Pimcore\Model\Document\PageSnippet;
+
 interface TagInterface
 {
     /**
@@ -68,8 +70,8 @@ interface TagInterface
      * Returns the current tag's data for web service export
      *
      * @deprecated
-     * @param $document
-     * @param mixed $params
+     * @param PageSnippet|null $document
+     * @param array $params
      * @abstract
      *
      * @return array

--- a/models/Document/Tag/Textarea.php
+++ b/models/Document/Tag/Textarea.php
@@ -117,8 +117,8 @@ class Textarea extends Model\Document\Tag
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception

--- a/models/Document/Tag/Video.php
+++ b/models/Document/Tag/Video.php
@@ -30,7 +30,7 @@ class Video extends Model\Document\Tag
     /**
      * contains depending on the type of the video the unique identifier eg. "http://www.youtube.com", "789", ...
      *
-     * @var mixed
+     * @var int|string
      */
     public $id;
 
@@ -59,7 +59,7 @@ class Video extends Model\Document\Tag
     public $description = '';
 
     /**
-     * @param $title
+     * @param string $title
      *
      * @return $this
      */
@@ -84,7 +84,7 @@ class Video extends Model\Document\Tag
     }
 
     /**
-     * @param $description
+     * @param string $description
      *
      * @return $this
      */
@@ -142,6 +142,9 @@ class Video extends Model\Document\Tag
         ];
     }
 
+    /**
+     * @return array
+     */
     public function getDataForResource()
     {
         return [
@@ -741,7 +744,7 @@ class Video extends Model\Document\Tag
 
     /**
      * @param array $urls
-     * @param null $thumbnail
+     * @param string|null $thumbnail
      *
      * @return string
      */
@@ -854,7 +857,7 @@ class Video extends Model\Document\Tag
     }
 
     /**
-     * @param null $thumbnail
+     * @param string|null $thumbnail
      *
      * @return string
      */
@@ -914,8 +917,8 @@ class Video extends Model\Document\Tag
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception
@@ -949,13 +952,15 @@ class Video extends Model\Document\Tag
     }
 
     /**
-     * @return Asset
+     * @return Asset|null
      */
     public function getVideoAsset()
     {
         if ($this->getVideoType() == 'asset') {
             return Asset::getById($this->id);
         }
+
+        return null;
     }
 
     /**
@@ -967,7 +972,7 @@ class Video extends Model\Document\Tag
     }
 
     /**
-     * @param $config
+     * @param string|Asset\Video\Thumbnail\Config $config
      *
      * @return string
      */
@@ -985,7 +990,7 @@ class Video extends Model\Document\Tag
     }
 
     /**
-     * @param $config
+     * @param string|Asset\Video\Thumbnail\Config $config
      *
      * @return array
      */
@@ -999,7 +1004,7 @@ class Video extends Model\Document\Tag
     }
 
     /**
-     * @param mixed $id
+     * @param int|string $id
      *
      * @return Video
      */
@@ -1011,11 +1016,11 @@ class Video extends Model\Document\Tag
     }
 
     /**
-     * @return mixed
+     * @return int|string
      */
     public function getId()
     {
-        return (int) $this->id;
+        return $this->id;
     }
 
     /**

--- a/models/Document/Tag/Wysiwyg.php
+++ b/models/Document/Tag/Wysiwyg.php
@@ -121,8 +121,8 @@ class Wysiwyg extends Model\Document\Tag
     /**
      * @deprecated
      * @param Model\Webservice\Data\Document\Element $wsElement
-     * @param $document
-     * @param mixed $params
+     * @param Model\Document\PageSnippet $document
+     * @param array $params
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *
      * @throws \Exception
@@ -147,7 +147,7 @@ class Wysiwyg extends Model\Document\Tag
     }
 
     /**
-     * @param $ownerDocument
+     * @param Model\Document\PageSnippet $ownerDocument
      * @param array $blockedTags
      *
      * @return array

--- a/models/Document/Traits/ScheduledTasksTrait.php
+++ b/models/Document/Traits/ScheduledTasksTrait.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Model\Document\Traits;
 
+use Pimcore\Model\Schedule\Task;
 use Pimcore\Model\Schedule\Task\Listing;
 
 trait ScheduledTasksTrait
@@ -24,12 +25,12 @@ trait ScheduledTasksTrait
     /**
      * Contains all scheduled tasks
      *
-     * @var array
+     * @var Task[]
      */
     public $scheduledTasks = null;
 
     /**
-     * @return array the $scheduledTasks
+     * @return Task[] the $scheduledTasks
      */
     public function getScheduledTasks()
     {
@@ -44,7 +45,7 @@ trait ScheduledTasksTrait
     }
 
     /**
-     * @param $scheduledTasks
+     * @param Task[] $scheduledTasks
      *
      * @return $this
      */


### PR DESCRIPTION
Fix all phpstan level 2 errors in Pimcore\Model\Document namespace with following schema:
```
PHPDoc tag @param has invalid value ($xyz)
```
Before:
```
 [ERROR] Found 2731 errors
```
After:
```
 [ERROR] Found 2632 errors
```