### PR TITLE
[PHPSTAN] Fill empty php doc param types (Model)

### DIFF
--- a/models/Dependency.php
+++ b/models/Dependency.php
@@ -99,8 +99,8 @@ class Dependency extends AbstractModel
     }
 
     /**
-     * @param null $offset
-     * @param null $limit
+     * @param int|null $offset
+     * @param int|null $limit
      *
      * @return array
      */
@@ -110,8 +110,8 @@ class Dependency extends AbstractModel
     }
 
     /**
-     * @param null $offset
-     * @param null $limit
+     * @param int|null $offset
+     * @param int|null $limit
      *
      * @return array
      */

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -83,7 +83,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
     }
 
     /**
-     * @param  $name
+     * @param string $name
      *
      * @return bool
      */
@@ -100,7 +100,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
     abstract public function setProperties($properties);
 
     /**
-     * @param  $name
+     * @param string $name
      */
     public function removeProperty($name)
     {
@@ -281,7 +281,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
     }
 
     /**
-     * @param null $versionNote
+     * @param string|null $versionNote
      * @param bool $saveOnlyVersion
      *
      * @return Model\Version

--- a/models/Element/AdminStyle.php
+++ b/models/Element/AdminStyle.php
@@ -32,12 +32,12 @@ class AdminStyle
     protected $elementIcon;
 
     /**
-     * @var string string
+     * @var string
      */
     protected $elementIconClass;
 
     /**
-     * @var array sring
+     * @var array
      */
     protected $elementQtipConfig;
 
@@ -68,7 +68,7 @@ class AdminStyle
     }
 
     /**
-     * @param $elementCssClass
+     * @param string $elementCssClass
      *
      * @return $this
      */
@@ -88,7 +88,7 @@ class AdminStyle
     }
 
     /**
-     * @param $elementIcon
+     * @param string $elementIcon
      *
      * @return $this
      */
@@ -108,7 +108,7 @@ class AdminStyle
     }
 
     /**
-     * @param $elementIconClass
+     * @param string $elementIconClass
      *
      * @return $this
      */
@@ -136,7 +136,7 @@ class AdminStyle
     }
 
     /**
-     * @param $elementQtipConfig
+     * @param array $elementQtipConfig
      */
     public function setElementQtipConfig($elementQtipConfig)
     {

--- a/models/Element/Dao.php
+++ b/models/Element/Dao.php
@@ -53,7 +53,7 @@ abstract class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $fullpath
+     * @param string $fullpath
      *
      * @return array
      */

--- a/models/Element/Data/MarkerHotspotItem.php
+++ b/models/Element/Data/MarkerHotspotItem.php
@@ -82,7 +82,7 @@ class MarkerHotspotItem implements \ArrayAccess
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getValue()
     {
@@ -90,7 +90,7 @@ class MarkerHotspotItem implements \ArrayAccess
     }
 
     /**
-     * @param mixed $value
+     * @param int $value
      */
     public function setValue($value)
     {

--- a/models/Element/Editlock.php
+++ b/models/Element/Editlock.php
@@ -61,8 +61,8 @@ class Editlock extends Model\AbstractModel
     public $cpath;
 
     /**
-     * @param $cid
-     * @param $ctype
+     * @param int $cid
+     * @param string $ctype
      *
      * @return bool
      */
@@ -83,8 +83,8 @@ class Editlock extends Model\AbstractModel
     }
 
     /**
-     * @param $cid
-     * @param $ctype
+     * @param int $cid
+     * @param string $ctype
      *
      * @return null|Editlock
      */
@@ -101,7 +101,7 @@ class Editlock extends Model\AbstractModel
     }
 
     /**
-     * @param $sessionId
+     * @param string $sessionId
      *
      * @return bool|null
      */
@@ -118,8 +118,8 @@ class Editlock extends Model\AbstractModel
     }
 
     /**
-     * @param $cid
-     * @param $ctype
+     * @param int $cid
+     * @param string $ctype
      *
      * @return bool|Editlock
      */
@@ -143,8 +143,8 @@ class Editlock extends Model\AbstractModel
     }
 
     /**
-     * @param $cid
-     * @param $ctype
+     * @param int $cid
+     * @param string $ctype
      *
      * @return bool
      */

--- a/models/Element/Editlock/Dao.php
+++ b/models/Element/Editlock/Dao.php
@@ -25,8 +25,8 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $cid
-     * @param $ctype
+     * @param int $cid
+     * @param string $ctype
      *
      * @throws \Exception
      */
@@ -85,7 +85,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $sessionId
+     * @param string $sessionId
      */
     public function clearSession($sessionId)
     {

--- a/models/Element/ElementInterface.php
+++ b/models/Element/ElementInterface.php
@@ -106,7 +106,7 @@ interface ElementInterface
 
     /**
      *
-     * @param $id
+     * @param int $id
      *
      * @return ElementInterface $resource
      */

--- a/models/Element/Export/Service.php
+++ b/models/Element/Export/Service.php
@@ -67,9 +67,9 @@ class Service
 
     /**
      * @param DataObject\AbstractObject|Document|Asset $element
-     * @param $apiElementKeys
-     * @param $recursive
-     * @param $includeRelations
+     * @param array $apiElementKeys
+     * @param bool $recursive
+     * @param bool $includeRelations
      *
      * @return array
      */

--- a/models/Element/Import/Service.php
+++ b/models/Element/Import/Service.php
@@ -45,7 +45,7 @@ class Service
     protected $user;
 
     /**
-     * @param $user
+     * @param Model\User $user
      */
     public function __construct($user)
     {
@@ -73,12 +73,12 @@ class Service
     /**
      * @throws \Exception
      *
-     * @param  $rootElement
-     * @param  $apiKey
-     * @param  $path
-     * @param  $apiElement
-     * @param  bool $overwrite
-     * @param  $elementCounter
+     * @param Element\ElementInterface $rootElement
+     * @param string $apiKey
+     * @param string $path
+     * @param Model\Webservice\Data $apiElement
+     * @param bool $overwrite
+     * @param string $elementCounter
      *
      * @return Element\ElementInterface
      */
@@ -271,8 +271,8 @@ class Service
     }
 
     /**
-     * @param  Webservice\Data\DataObject\Concrete $apiElement
-     * @param $idMapping
+     * @param Webservice\Data\DataObject\Concrete $apiElement
+     * @param array $idMapping
      */
     public function correctObjectRelations($apiElement, $idMapping)
     {
@@ -340,7 +340,7 @@ class Service
     }
 
     /**
-     * @param $element
+     * @param Element\ElementInterface $element
      * @param bool $creation
      *
      * @return $this

--- a/models/Element/Note.php
+++ b/models/Element/Note.php
@@ -74,7 +74,7 @@ class Note extends Model\AbstractModel
     /**
      * @static
      *
-     * @param $id
+     * @param int $id
      *
      * @return Note
      */
@@ -138,7 +138,7 @@ class Note extends Model\AbstractModel
     }
 
     /**
-     * @param $cid
+     * @param int $cid
      *
      * @return $this
      */
@@ -158,7 +158,7 @@ class Note extends Model\AbstractModel
     }
 
     /**
-     * @param $ctype
+     * @param string $ctype
      *
      * @return $this
      */
@@ -178,7 +178,7 @@ class Note extends Model\AbstractModel
     }
 
     /**
-     * @param $data
+     * @param array $data
      *
      * @return $this
      */
@@ -198,7 +198,7 @@ class Note extends Model\AbstractModel
     }
 
     /**
-     * @param $date
+     * @param int $date
      *
      * @return $this
      */
@@ -218,7 +218,7 @@ class Note extends Model\AbstractModel
     }
 
     /**
-     * @param $description
+     * @param string $description
      *
      * @return $this
      */
@@ -238,7 +238,7 @@ class Note extends Model\AbstractModel
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return $this
      */
@@ -258,7 +258,7 @@ class Note extends Model\AbstractModel
     }
 
     /**
-     * @param $title
+     * @param string $title
      *
      * @return $this
      */
@@ -278,7 +278,7 @@ class Note extends Model\AbstractModel
     }
 
     /**
-     * @param $type
+     * @param string $type
      *
      * @return $this
      */
@@ -298,7 +298,7 @@ class Note extends Model\AbstractModel
     }
 
     /**
-     * @param $user
+     * @param int $user
      *
      * @return $this
      */

--- a/models/Element/Note/Dao.php
+++ b/models/Element/Note/Dao.php
@@ -28,7 +28,7 @@ use Pimcore\Model\Document;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $id
+     * @param int $id
      *
      * @throws \Exception
      */

--- a/models/Element/Note/Listing.php
+++ b/models/Element/Note/Listing.php
@@ -29,7 +29,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\Element\Note[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $notes = null;
@@ -40,7 +40,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param $notes
+     * @param Model\Element\Note[]|null $notes
      *
      * @return $this
      */

--- a/models/Element/PermissionChecker.php
+++ b/models/Element/PermissionChecker.php
@@ -210,9 +210,9 @@ class PermissionChecker
     }
 
     /**
-     * @param $user User\
-     * @param $element
-     * @param $details
+     * @param User $user
+     * @param ElementInterface $element
+     * @param array $details
      */
     protected static function getLanguagePermissions($user, $element, &$details)
     {

--- a/models/Element/Recyclebin/Item.php
+++ b/models/Element/Recyclebin/Item.php
@@ -90,7 +90,7 @@ class Item extends Model\AbstractModel
     /**
      * @static
      *
-     * @param $id
+     * @param int $id
      *
      * @return self|null
      */
@@ -107,7 +107,7 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param null $user
+     * @param Model\User|null $user
      *
      * @throws \Exception
      */
@@ -252,7 +252,7 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param Element\ElementInterface|Element\ElementDumpStateInterface $element
+     * @param Element\ElementInterface $element
      */
     public function loadChildren(Element\ElementInterface $element)
     {
@@ -338,7 +338,7 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param $element
+     * @param Element\ElementInterface $element
      *
      * @return string
      */
@@ -356,7 +356,7 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return $this
      */
@@ -376,7 +376,7 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param $path
+     * @param string $path
      *
      * @return $this
      */
@@ -396,7 +396,7 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param $type
+     * @param string $type
      *
      * @return $this
      */
@@ -416,7 +416,7 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param $subtype
+     * @param string $subtype
      *
      * @return $this
      */
@@ -436,7 +436,7 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param $amount
+     * @param int $amount
      *
      * @return $this
      */
@@ -456,7 +456,7 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param $date
+     * @param int $date
      *
      * @return $this
      */
@@ -476,7 +476,7 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param $element
+     * @param Element\ElementInterface $element
      *
      * @return $this
      */
@@ -488,7 +488,7 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param $username
+     * @param string $username
      *
      * @return $this
      */

--- a/models/Element/Recyclebin/Item/Dao.php
+++ b/models/Element/Recyclebin/Item/Dao.php
@@ -26,7 +26,7 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $id
+     * @param int $id
      *
      * @throws \Exception
      */

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -113,7 +113,7 @@ class Service extends Model\AbstractModel
     /**
      * @static
      *
-     * @param $list array | \Pimcore\Model\Listing\AbstractListing
+     * @param array|\Pimcore\Model\Listing\AbstractListing $list
      * @param string $idGetter
      *
      * @return int[]
@@ -245,7 +245,7 @@ class Service extends Model\AbstractModel
     }
 
     /**
-     * @param $data
+     * @param array $data
      *
      * @return array
      *
@@ -407,8 +407,8 @@ class Service extends Model\AbstractModel
     /**
      * @static
      *
-     * @param $type
-     * @param $path
+     * @param string $path
+     * @param string|null $type
      *
      * @return bool
      */
@@ -422,7 +422,7 @@ class Service extends Model\AbstractModel
             return DataObject\Service::pathExists($path);
         }
 
-        return;
+        return false;
     }
 
     /**
@@ -451,7 +451,7 @@ class Service extends Model\AbstractModel
     /**
      * @static
      *
-     * @param  ElementInterface $element $element
+     * @param ElementInterface $element
      *
      * @return string
      */
@@ -499,7 +499,7 @@ class Service extends Model\AbstractModel
     /**
      * @static
      *
-     * @param  $props
+     * @param array $props
      *
      * @return array
      */
@@ -624,7 +624,7 @@ class Service extends Model\AbstractModel
      * find all elements which the user may not list and therefore may never be shown to the user
      *
      * @param string $type asset|object|document
-     * @param $user
+     * @param Model\User $user
      *
      * @return array
      */
@@ -789,7 +789,7 @@ class Service extends Model\AbstractModel
     }
 
     /**
-     * @param $path
+     * @param string $path
      * @param array $options
      *
      * @return Asset\Folder|Document\Folder|DataObject\Folder
@@ -873,8 +873,8 @@ class Service extends Model\AbstractModel
     }
 
     /** Changes the query according to the custom view config
-     * @param $cv array
-     * @param $childsList
+     * @param array $cv
+     * @param Model\Asset\Listing|Model\DataObject\Listing|Model\Document\Listing $childsList
      */
     public static function addTreeFilterJoins($cv, $childsList)
     {
@@ -905,9 +905,9 @@ class Service extends Model\AbstractModel
     }
 
     /**
-     * @param $id
+     * @param string $id
      *
-     * @return mixed
+     * @return array|null
      */
     public static function getCustomViewById($id)
     {
@@ -919,13 +919,15 @@ class Service extends Model\AbstractModel
                 }
             }
         }
+
+        return null;
     }
 
     /**
      * @param string $key
-     * @param null $type
+     * @param string $type
      *
-     * @return mixed|string
+     * @return string
      */
     public static function getValidKey($key, $type)
     {
@@ -995,9 +997,9 @@ class Service extends Model\AbstractModel
     /**
      * returns a unique key for an element
      *
-     * @param $element
+     * @param ElementInterface $element
      *
-     * @return string
+     * @return string|null
      */
     public static function getUniqueKey($element)
     {
@@ -1012,13 +1014,15 @@ class Service extends Model\AbstractModel
         if ($element instanceof Asset) {
             return Asset\Service::getUniqueKey($element);
         }
+
+        return null;
     }
 
     /**
-     * @param $data
-     * @param $type
+     * @param array $data
+     * @param string $type
      *
-     * @return array|string
+     * @return array
      */
     public static function fixAllowedTypes($data, $type)
     {

--- a/models/Element/Tag/Dao.php
+++ b/models/Element/Tag/Dao.php
@@ -26,7 +26,7 @@ use Pimcore\Model\Element\Tag;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $id
+     * @param int $id
      *
      * @throws \Exception
      */
@@ -42,7 +42,7 @@ class Dao extends Model\Dao\AbstractDao
     /**
      * Save object to database
      *
-     * @return bool|null
+     * @return bool
      *
      * @throws \Exception
      *
@@ -114,8 +114,8 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $cType
-     * @param $cId
+     * @param string $cType
+     * @param int $cId
      *
      * @return Model\Element\Tag[]
      */
@@ -137,8 +137,8 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $cType
-     * @param $cId
+     * @param string $cType
+     * @param int $cId
      */
     public function addTagToElement($cType, $cId)
     {
@@ -146,9 +146,9 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $tagId
-     * @param $cType
-     * @param $cId
+     * @param int $tagId
+     * @param string $cType
+     * @param int $cId
      */
     protected function doAddTagToElement($tagId, $cType, $cId)
     {
@@ -161,8 +161,8 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $cType
-     * @param $cId
+     * @param string $cType
+     * @param int $cId
      */
     public function removeTagFromElement($cType, $cId)
     {
@@ -174,8 +174,8 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $cType
-     * @param $cId
+     * @param string $cType
+     * @param int $cId
      * @param array $tags
      *
      * @throws \Exception
@@ -198,10 +198,10 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $cType
+     * @param string $cType
      * @param array $cIds
      * @param array $tagIds
-     * @param $replace
+     * @param bool $replace
      */
     public function batchAssignTagsToElement($cType, array $cIds, array $tagIds, $replace)
     {

--- a/models/Element/Tag/Listing.php
+++ b/models/Element/Tag/Listing.php
@@ -29,7 +29,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\Element\Tag[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $tags = null;
@@ -40,7 +40,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param $tags
+     * @param Model\Element\Tag[]|null $tags
      *
      * @return $this
      */

--- a/models/Element/ValidationException.php
+++ b/models/Element/ValidationException.php
@@ -47,7 +47,7 @@ class ValidationException extends \Exception
     }
 
     /**
-     * @param $context
+     * @param string $context
      */
     public function addContext($context)
     {

--- a/models/Element/WorkflowState/Listing.php
+++ b/models/Element/WorkflowState/Listing.php
@@ -27,7 +27,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array
+     * @var Model\Element\WorkflowState[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $workflowStates = null;
@@ -38,7 +38,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param $workflowStates
+     * @param Model\Element\WorkflowState[]|null $workflowStates
      *
      * @return $this
      */

--- a/models/Glossary.php
+++ b/models/Glossary.php
@@ -227,7 +227,7 @@ class Glossary extends AbstractModel
     }
 
     /**
-     * @param $casesensitive
+     * @param bool $casesensitive
      *
      * @return $this
      */
@@ -247,7 +247,7 @@ class Glossary extends AbstractModel
     }
 
     /**
-     * @param $exactmatch
+     * @param bool $exactmatch
      *
      * @return $this
      */
@@ -267,7 +267,7 @@ class Glossary extends AbstractModel
     }
 
     /**
-     * @param $site
+     * @param Site|int $site
      *
      * @return $this
      */
@@ -290,7 +290,7 @@ class Glossary extends AbstractModel
     }
 
     /**
-     * @param $modificationDate
+     * @param int $modificationDate
      *
      * @return $this
      */
@@ -310,7 +310,7 @@ class Glossary extends AbstractModel
     }
 
     /**
-     * @param $creationDate
+     * @param int $creationDate
      *
      * @return $this
      */

--- a/models/Glossary/Dao.php
+++ b/models/Glossary/Dao.php
@@ -27,7 +27,7 @@ class Dao extends Model\Dao\AbstractDao
     /**
      * Get the data for the object from database for the given id, or from the ID which is set in the object
      *
-     * @param int $id
+     * @param int|null $id
      */
     public function getById($id = null)
     {
@@ -89,8 +89,6 @@ class Dao extends Model\Dao\AbstractDao
 
     /**
      * Create a new record for the object in database
-     *
-     * @return bool
      */
     public function create()
     {

--- a/models/Glossary/Listing.php
+++ b/models/Glossary/Listing.php
@@ -27,7 +27,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\Glossary[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $glossary = null;
@@ -46,7 +46,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param $glossary
+     * @param Model\Glossary[]|null $glossary
      *
      * @return $this
      */

--- a/models/GridConfig/Dao.php
+++ b/models/GridConfig/Dao.php
@@ -25,7 +25,7 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $id
+     * @param int $id
      *
      * @throws \Exception
      */

--- a/models/GridConfig/Listing.php
+++ b/models/GridConfig/Listing.php
@@ -27,7 +27,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\GridConfig[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $gridConfigs = null;
@@ -46,7 +46,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param $gridConfigs
+     * @param Model\GridConfig[]|null $gridConfigs
      *
      * @return $this
      */

--- a/models/GridConfigFavourite.php
+++ b/models/GridConfigFavourite.php
@@ -53,9 +53,10 @@ class GridConfigFavourite extends AbstractModel
     public $type;
 
     /**
-     * @param $ownerId
-     * @param $classId
-     * @param null $searchType
+     * @param int $ownerId
+     * @param string $classId
+     * @param int|null $objectId
+     * @param string|null $searchType
      *
      * @return GridConfigFavourite
      */

--- a/models/GridConfigFavourite/Dao.php
+++ b/models/GridConfigFavourite/Dao.php
@@ -25,10 +25,10 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $ownerId
-     * @param $classId
-     * @param null $objectId
-     * @param null $searchType
+     * @param int $ownerId
+     * @param string $classId
+     * @param int|null $objectId
+     * @param string|null $searchType
      *
      * @throws \Exception
      */
@@ -53,7 +53,7 @@ class Dao extends Model\Dao\AbstractDao
     /**
      * Save object to database
      *
-     * @return int
+     * @return Model\GridConfigFavourite
      */
     public function save()
     {

--- a/models/GridConfigShare.php
+++ b/models/GridConfigShare.php
@@ -33,8 +33,8 @@ class GridConfigShare extends AbstractModel
     public $sharedWithUserId;
 
     /**
-     * @param $gridConfigId
-     * @param $sharedWithUserId
+     * @param int $gridConfigId
+     * @param int $sharedWithUserId
      *
      * @return GridConfigShare
      */

--- a/models/GridConfigShare/Dao.php
+++ b/models/GridConfigShare/Dao.php
@@ -25,8 +25,8 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $gridConfigId
-     * @param $sharedWithUserId
+     * @param int $gridConfigId
+     * @param int $sharedWithUserId
      *
      * @throws \Exception
      */

--- a/models/ImportConfig/Dao.php
+++ b/models/ImportConfig/Dao.php
@@ -25,7 +25,7 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $id
+     * @param int $id
      *
      * @throws \Exception
      */

--- a/models/ImportConfigShare.php
+++ b/models/ImportConfigShare.php
@@ -33,8 +33,8 @@ class ImportConfigShare extends AbstractModel
     public $sharedWithUserId;
 
     /**
-     * @param $importConfigId
-     * @param $sharedWithUserId
+     * @param int $importConfigId
+     * @param int $sharedWithUserId
      *
      * @return ImportConfigShare
      */

--- a/models/ImportConfigShare/Dao.php
+++ b/models/ImportConfigShare/Dao.php
@@ -25,8 +25,8 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $importConfigId
-     * @param $sharedWithUserId
+     * @param int $importConfigId
+     * @param int $sharedWithUserId
      *
      * @throws \Exception
      */

--- a/models/Metadata/Predefined.php
+++ b/models/Metadata/Predefined.php
@@ -235,7 +235,7 @@ class Predefined extends Model\AbstractModel
     }
 
     /**
-     * @param $creationDate
+     * @param int $creationDate
      *
      * @return $this
      */
@@ -255,7 +255,7 @@ class Predefined extends Model\AbstractModel
     }
 
     /**
-     * @param $modificationDate
+     * @param int $modificationDate
      *
      * @return $this
      */

--- a/models/Metadata/Predefined/Dao.php
+++ b/models/Metadata/Predefined/Dao.php
@@ -31,7 +31,7 @@ class Dao extends Model\Dao\PhpArrayTable
     }
 
     /**
-     * @param null $id
+     * @param int|null $id
      *
      * @throws \Exception
      */
@@ -51,8 +51,8 @@ class Dao extends Model\Dao\PhpArrayTable
     }
 
     /**
-     * @param null $name
-     * @param null $language
+     * @param string|null $name
+     * @param string|null $language
      *
      * @throws \Exception
      */

--- a/models/Metadata/Predefined/Listing.php
+++ b/models/Metadata/Predefined/Listing.php
@@ -24,7 +24,7 @@ namespace Pimcore\Model\Metadata\Predefined;
 class Listing extends \Pimcore\Model\Listing\JsonListing
 {
     /**
-     * @var array|null
+     * @var \Pimcore\Model\Metadata\Predefined[]|null
      */
     protected $definitions = null;
 
@@ -41,7 +41,7 @@ class Listing extends \Pimcore\Model\Listing\JsonListing
     }
 
     /**
-     * @param $definitions
+     * @param \Pimcore\Model\Metadata\Predefined[]|null $definitions
      *
      * @return $this
      */
@@ -53,8 +53,8 @@ class Listing extends \Pimcore\Model\Listing\JsonListing
     }
 
     /**
-     * @param $type
-     * @param $subTypes
+     * @param string $type
+     * @param array $subTypes
      *
      * @return \Pimcore\Model\Metadata\Predefined[]
      *
@@ -91,9 +91,9 @@ class Listing extends \Pimcore\Model\Listing\JsonListing
     }
 
     /**
-     * @param $key
-     * @param $language
-     * @param null $targetSubtype
+     * @param string $key
+     * @param string $language
+     * @param string|null $targetSubtype
      *
      * @return \Pimcore\Model\Metadata\Predefined|null
      */

--- a/models/Property/Dao.php
+++ b/models/Property/Dao.php
@@ -25,7 +25,7 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @return null
+     * @return mixed
      */
     public function getRawData()
     {

--- a/models/Property/Predefined/Dao.php
+++ b/models/Property/Predefined/Dao.php
@@ -31,7 +31,7 @@ class Dao extends Model\Dao\PhpArrayTable
     }
 
     /**
-     * @param null $id
+     * @param int|null $id
      *
      * @throws \Exception
      */
@@ -51,7 +51,7 @@ class Dao extends Model\Dao\PhpArrayTable
     }
 
     /**
-     * @param null $key
+     * @param string|null $key
      *
      * @throws \Exception
      */

--- a/models/Redirect.php
+++ b/models/Redirect.php
@@ -308,7 +308,7 @@ class Redirect extends AbstractModel
     }
 
     /**
-     * @param $expiry
+     * @param int|string $expiry
      *
      * @return $this
      */
@@ -344,7 +344,7 @@ class Redirect extends AbstractModel
     }
 
     /**
-     * @param $regex
+     * @param bool $regex
      *
      * @return $this
      */
@@ -368,7 +368,7 @@ class Redirect extends AbstractModel
     }
 
     /**
-     * @param $active
+     * @param bool $active
      *
      * @return $this
      */
@@ -384,7 +384,7 @@ class Redirect extends AbstractModel
     }
 
     /**
-     * @param $sourceSite
+     * @param int $sourceSite
      *
      * @return $this
      */
@@ -408,7 +408,7 @@ class Redirect extends AbstractModel
     }
 
     /**
-     * @param $targetSite
+     * @param int $targetSite
      *
      * @return $this
      */
@@ -432,7 +432,7 @@ class Redirect extends AbstractModel
     }
 
     /**
-     * @param $passThroughParameters
+     * @param bool $passThroughParameters
      *
      * @return Redirect
      */
@@ -456,7 +456,7 @@ class Redirect extends AbstractModel
     }
 
     /**
-     * @param $modificationDate
+     * @param int $modificationDate
      *
      * @return $this
      */
@@ -476,7 +476,7 @@ class Redirect extends AbstractModel
     }
 
     /**
-     * @param $creationDate
+     * @param int $creationDate
      *
      * @return $this
      */

--- a/models/Redirect/Dao.php
+++ b/models/Redirect/Dao.php
@@ -25,7 +25,7 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param null $id
+     * @param int|null $id
      *
      * @throws \Exception
      */

--- a/models/Schedule/Task.php
+++ b/models/Schedule/Task.php
@@ -156,7 +156,7 @@ class Task extends Model\AbstractModel
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return $this
      */
@@ -168,7 +168,7 @@ class Task extends Model\AbstractModel
     }
 
     /**
-     * @param $cid
+     * @param int $cid
      *
      * @return $this
      */
@@ -180,7 +180,7 @@ class Task extends Model\AbstractModel
     }
 
     /**
-     * @param $ctype
+     * @param string $ctype
      *
      * @return $this
      */
@@ -192,7 +192,7 @@ class Task extends Model\AbstractModel
     }
 
     /**
-     * @param $date
+     * @param int $date
      *
      * @return $this
      */
@@ -204,7 +204,7 @@ class Task extends Model\AbstractModel
     }
 
     /**
-     * @param $action
+     * @param string $action
      *
      * @return $this
      */
@@ -216,7 +216,7 @@ class Task extends Model\AbstractModel
     }
 
     /**
-     * @param $version
+     * @param int $version
      *
      * @return $this
      */
@@ -236,7 +236,7 @@ class Task extends Model\AbstractModel
     }
 
     /**
-     * @param $active
+     * @param bool $active
      *
      * @return $this
      */

--- a/models/Schedule/Task/Dao.php
+++ b/models/Schedule/Task/Dao.php
@@ -25,7 +25,7 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $id
+     * @param int $id
      *
      * @throws \Exception
      */

--- a/models/Schedule/Task/Listing.php
+++ b/models/Schedule/Task/Listing.php
@@ -27,7 +27,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\Schedule\Task[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $tasks = null;
@@ -46,7 +46,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param array $tasks
+     * @param Model\Schedule\Task[]|null $tasks
      *
      * @return $this
      */

--- a/models/Search/Backend/Data.php
+++ b/models/Search/Backend/Data.php
@@ -102,7 +102,7 @@ class Data extends \Pimcore\Model\AbstractModel
     public $properties;
 
     /**
-     * @param null $element
+     * @param Element\ElementInterface $element
      */
     public function __construct($element = null)
     {
@@ -134,7 +134,7 @@ class Data extends \Pimcore\Model\AbstractModel
     }
 
     /**
-     * @param $id
+     * @param Data\Id $id
      *
      * @return $this
      */
@@ -174,7 +174,7 @@ class Data extends \Pimcore\Model\AbstractModel
     }
 
     /**
-     * @param $type
+     * @param string $type
      *
      * @return $this
      */
@@ -194,7 +194,7 @@ class Data extends \Pimcore\Model\AbstractModel
     }
 
     /**
-     * @param $subtype
+     * @param string $subtype
      *
      * @return $this
      */
@@ -214,7 +214,7 @@ class Data extends \Pimcore\Model\AbstractModel
     }
 
     /**
-     * @param $creationDate
+     * @param int $creationDate
      *
      * @return $this
      */
@@ -354,7 +354,7 @@ class Data extends \Pimcore\Model\AbstractModel
     }
 
     /**
-     * @param $element
+     * @param Element\ElementInterface $element
      *
      * @return $this
      */
@@ -493,9 +493,9 @@ class Data extends \Pimcore\Model\AbstractModel
     }
 
     /**
-     * @param $data
+     * @param string $data
      *
-     * @return mixed|string
+     * @return string
      */
     protected function cleanupData($data)
     {
@@ -520,7 +520,7 @@ class Data extends \Pimcore\Model\AbstractModel
     }
 
     /**
-     * @param $element
+     * @param Element\ElementInterface $element
      *
      * @return Data
      */

--- a/models/Search/Backend/Data/Dao.php
+++ b/models/Search/Backend/Data/Dao.php
@@ -23,9 +23,7 @@ use Pimcore\Model;
 class Dao extends \Pimcore\Model\Dao\AbstractDao
 {
     /**
-     * @param $element
-     *
-     * @throws
+     * @param Model\Element\ElementInterface $element
      */
     public function getForElement($element)
     {

--- a/models/Search/Backend/Data/Id.php
+++ b/models/Search/Backend/Data/Id.php
@@ -29,7 +29,7 @@ class Id
     public $type;
 
     /**
-     * @param $webResource
+     * @param Element\ElementInterface $webResource
      */
     public function __construct($webResource)
     {

--- a/models/Search/Backend/Data/Listing.php
+++ b/models/Search/Backend/Data/Listing.php
@@ -24,7 +24,7 @@ use Pimcore\Model\Search\Backend\Data;
 class Listing extends \Pimcore\Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Data[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $entries = null;
@@ -38,7 +38,7 @@ class Listing extends \Pimcore\Model\Listing\AbstractListing
     }
 
     /**
-     * @param $entries
+     * @param Data[]|null $entries
      *
      * @return $this
      */

--- a/models/Search/Backend/Data/Listing/Dao.php
+++ b/models/Search/Backend/Data/Listing/Dao.php
@@ -63,11 +63,11 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     }
 
     /**
-     * @return string
+     * @return int
      */
     public function getTotalCount()
     {
-        $amount = $this->db->fetchOne('SELECT COUNT(*) as amount FROM search_backend_data' . $this->getCondition() . $this->getGroupBy(), $this->model->getConditionVariables());
+        $amount = (int)$this->db->fetchOne('SELECT COUNT(*) as amount FROM search_backend_data' . $this->getCondition() . $this->getGroupBy(), $this->model->getConditionVariables());
 
         return $amount;
     }

--- a/models/Site.php
+++ b/models/Site.php
@@ -132,7 +132,7 @@ class Site extends AbstractModel
     }
 
     /**
-     * @param $domain
+     * @param string $domain
      *
      * @return Site|null
      */
@@ -164,7 +164,7 @@ class Site extends AbstractModel
     }
 
     /**
-     * @param $mixed
+     * @param mixed $mixed
      *
      * @return Site|null
      */
@@ -323,7 +323,7 @@ class Site extends AbstractModel
     }
 
     /**
-     * @param $path
+     * @param string $path
      *
      * @return $this
      */
@@ -406,7 +406,7 @@ class Site extends AbstractModel
     }
 
     /**
-     * @param $modificationDate
+     * @param int $modificationDate
      *
      * @return $this
      */
@@ -426,7 +426,7 @@ class Site extends AbstractModel
     }
 
     /**
-     * @param $creationDate
+     * @param int $creationDate
      *
      * @return $this
      */

--- a/models/Site/Dao.php
+++ b/models/Site/Dao.php
@@ -25,7 +25,7 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $id
+     * @param int $id
      *
      * @throws \Exception
      */
@@ -39,7 +39,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @throws \Exception
      */
@@ -53,7 +53,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $domain
+     * @param string $domain
      *
      * @throws \Exception
      */

--- a/models/Site/Listing.php
+++ b/models/Site/Listing.php
@@ -27,7 +27,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\Site[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $sites = null;
@@ -46,7 +46,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param array $sites
+     * @param Model\Site[]|null $sites
      *
      * @return $this
      */

--- a/models/Staticroute.php
+++ b/models/Staticroute.php
@@ -117,7 +117,7 @@ class Staticroute extends AbstractModel
     /**
      * @static
      *
-     * @param $route
+     * @param Staticroute $route
      */
     public static function setCurrentRoute($route)
     {
@@ -164,7 +164,7 @@ class Staticroute extends AbstractModel
 
     /**
      * @param string $name
-     * @param null $siteId
+     * @param int|null $siteId
      *
      * @return Staticroute
      */
@@ -695,7 +695,7 @@ class Staticroute extends AbstractModel
     }
 
     /**
-     * @param $modificationDate
+     * @param int $modificationDate
      *
      * @return $this
      */
@@ -715,7 +715,7 @@ class Staticroute extends AbstractModel
     }
 
     /**
-     * @param $creationDate
+     * @param int $creationDate
      *
      * @return $this
      */

--- a/models/Staticroute/Dao.php
+++ b/models/Staticroute/Dao.php
@@ -31,7 +31,7 @@ class Dao extends Model\Dao\PhpArrayTable
     }
 
     /**
-     * @param null $id
+     * @param int|null $id
      *
      * @throws \Exception
      */
@@ -51,8 +51,8 @@ class Dao extends Model\Dao\PhpArrayTable
     }
 
     /**
-     * @param null $name
-     * @param null $siteId
+     * @param string|null $name
+     * @param int|null $siteId
      *
      * @throws \Exception
      */

--- a/models/Staticroute/Listing.php
+++ b/models/Staticroute/Listing.php
@@ -25,7 +25,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\JsonListing
 {
     /**
-     * @var array|null
+     * @var \Pimcore\Model\Staticroute[]|null
      */
     protected $routes = null;
 
@@ -42,7 +42,7 @@ class Listing extends Model\Listing\JsonListing
     }
 
     /**
-     * @param array $routes
+     * @param \Pimcore\Model\Staticroute[]|null $routes
      *
      * @return $this
      */

--- a/models/Tool/CustomReport/Adapter/AbstractAdapter.php
+++ b/models/Tool/CustomReport/Adapter/AbstractAdapter.php
@@ -17,14 +17,19 @@
 
 namespace Pimcore\Model\Tool\CustomReport\Adapter;
 
+use Pimcore\Model\Tool\CustomReport\Config;
+
 abstract class AbstractAdapter implements CustomReportAdapterInterface
 {
+    /** @var \stdClass */
     protected $config;
+
+    /** @var Config|null */
     protected $fullConfig;
 
     /**
-     * @param $config
-     * @param null $fullConfig
+     * @param \stdClass $config
+     * @param Config|null $fullConfig
      */
     public function __construct($config, $fullConfig = null)
     {

--- a/models/Tool/CustomReport/Adapter/Analytics.php
+++ b/models/Tool/CustomReport/Adapter/Analytics.php
@@ -17,20 +17,19 @@ namespace Pimcore\Model\Tool\CustomReport\Adapter;
 class Analytics extends AbstractAdapter
 {
     /**
-     * @param $filters
-     * @param $sort
-     * @param $dir
-     * @param $offset
-     * @param $limit
-     * @param null $fields
-     * @param null $drillDownFilters
-     * @param null $fullConfig
+     * @param array|null $filters
+     * @param string|null $sort
+     * @param string|null $dir
+     * @param int|null $offset
+     * @param int|null $limit
+     * @param array|null $fields
+     * @param array|null $drillDownFilters
      *
      * @return array
      *
      * @throws \Exception
      */
-    public function getData($filters, $sort, $dir, $offset, $limit, $fields = null, $drillDownFilters = null, $fullConfig = null)
+    public function getData($filters, $sort, $dir, $offset, $limit, $fields = null, $drillDownFilters = null)
     {
         $this->setFilters($filters, $drillDownFilters);
 
@@ -54,9 +53,9 @@ class Analytics extends AbstractAdapter
     }
 
     /**
-     * @param $configuration
+     * @param \stdClass $configuration
      *
-     * @return array|mixed
+     * @return array
      *
      * @throws \Exception
      */
@@ -73,7 +72,7 @@ class Analytics extends AbstractAdapter
     }
 
     /**
-     * @param $filters
+     * @param array $filters
      * @param array $drillDownFilters
      */
     protected function setFilters($filters, $drillDownFilters = [])
@@ -117,8 +116,8 @@ class Analytics extends AbstractAdapter
     }
 
     /**
-     * @param null $fields
-     * @param null $drillDownFilters
+     * @param array|null $fields
+     * @param array|null $drillDownFilters
      * @param bool $useDimensionHandling
      *
      * @return mixed
@@ -188,7 +187,7 @@ class Analytics extends AbstractAdapter
     }
 
     /**
-     * @param $results
+     * @param array $results
      *
      * @return array
      */
@@ -210,8 +209,8 @@ class Analytics extends AbstractAdapter
     }
 
     /**
-     * @param $configuration
-     * @param $fields
+     * @param \stdClass $configuration
+     * @param array $fields
      *
      * @return mixed
      */
@@ -237,9 +236,9 @@ class Analytics extends AbstractAdapter
     }
 
     /**
-     * @param $configuration
+     * @param \stdClass $configuration
      *
-     * @return mixed
+     * @return \stdClass
      */
     protected function handleDimensions($configuration)
     {
@@ -261,10 +260,10 @@ class Analytics extends AbstractAdapter
     }
 
     /**
-     * @param $date
-     * @param $relativeDate
+     * @param int $date
+     * @param string $relativeDate
      *
-     * @return float|int|string
+     * @return int
      */
     protected function calcDate($date, $relativeDate)
     {
@@ -303,11 +302,11 @@ class Analytics extends AbstractAdapter
     }
 
     /**
-     * @param $filters
-     * @param $field
-     * @param $drillDownFilters
+     * @param array $filters
+     * @param string $field
+     * @param array $drillDownFilters
      *
-     * @return array|mixed
+     * @return array
      *
      * @throws \Exception
      */

--- a/models/Tool/CustomReport/Adapter/CustomReportAdapterFactoryInterface.php
+++ b/models/Tool/CustomReport/Adapter/CustomReportAdapterFactoryInterface.php
@@ -17,13 +17,15 @@
 
 namespace Pimcore\Model\Tool\CustomReport\Adapter;
 
+use Pimcore\Model\Tool\CustomReport\Config;
+
 interface CustomReportAdapterFactoryInterface
 {
     /**
      * Create a CustomReport Adapter
      *
-     * @param $config
-     * @param $fullConfig
+     * @param \stdClass $config
+     * @param Config|null $fullConfig
      *
      * @return CustomReportAdapterInterface
      */

--- a/models/Tool/CustomReport/Adapter/CustomReportAdapterInterface.php
+++ b/models/Tool/CustomReport/Adapter/CustomReportAdapterInterface.php
@@ -22,13 +22,13 @@ interface CustomReportAdapterInterface
     /**
      * returns data for given parameters
      *
-     * @param $filters
-     * @param $sort
-     * @param $dir
-     * @param $offset
-     * @param $limit
-     * @param null $fields - if set, only in fields specified columns are returned
-     * @param null $drillDownFilters - if set, additional filters are set
+     * @param array|null $filters
+     * @param string|null $sort
+     * @param string|null $dir
+     * @param int|null $offset
+     * @param int|null $limit
+     * @param array|null $fields - if set, only in fields specified columns are returned
+     * @param array|null $drillDownFilters - if set, additional filters are set
      *
      * @return array
      */
@@ -37,20 +37,20 @@ interface CustomReportAdapterInterface
     /**
      * returns available columns for given configuration
      *
-     * @param $configuration
+     * @param \stdClass $configuration
      *
-     * @return mixed
+     * @return array
      */
     public function getColumns($configuration);
 
     /**
      * returns all available values for given field with given filters and drillDownFilters
      *
-     * @param $filters
-     * @param $field
-     * @param $drillDownFilters
+     * @param array $filters
+     * @param string $field
+     * @param array $drillDownFilters
      *
-     * @return mixed
+     * @return array
      */
     public function getAvailableOptions($filters, $field, $drillDownFilters);
 }

--- a/models/Tool/CustomReport/Adapter/Sql.php
+++ b/models/Tool/CustomReport/Adapter/Sql.php
@@ -22,13 +22,13 @@ use Pimcore\Db;
 class Sql extends AbstractAdapter
 {
     /**
-     * @param $filters
-     * @param $sort
-     * @param $dir
-     * @param $offset
-     * @param $limit
-     * @param null $fields
-     * @param null $drillDownFilters
+     * @param array|null $filters
+     * @param string|null $sort
+     * @param string|null $dir
+     * @param int|null $offset
+     * @param int|null $limit
+     * @param array|null $fields
+     * @param array|null $drillDownFilters
      *
      * @return array
      */
@@ -60,9 +60,9 @@ class Sql extends AbstractAdapter
     }
 
     /**
-     * @param $configuration
+     * @param \stdClass $configuration
      *
-     * @return array|mixed|null
+     * @return array
      *
      * @throws \Exception
      */
@@ -151,13 +151,13 @@ class Sql extends AbstractAdapter
     }
 
     /**
-     * @param $filters
-     * @param $fields
+     * @param array $filters
+     * @param array $fields
      * @param bool $ignoreSelectAndGroupBy
-     * @param null $drillDownFilters
-     * @param null $selectField
+     * @param array|null $drillDownFilters
+     * @param string|null $selectField
      *
-     * @return array
+     * @return array|null
      */
     protected function getBaseQuery($filters, $fields, $ignoreSelectAndGroupBy = false, $drillDownFilters = null, $selectField = null)
     {
@@ -222,7 +222,7 @@ class Sql extends AbstractAdapter
                 $data = 'SELECT * FROM (' . $sql . ') AS somerandxyz WHERE ' . $condition;
             }
         } else {
-            return;
+            return null;
         }
 
         return [
@@ -232,11 +232,11 @@ class Sql extends AbstractAdapter
     }
 
     /**
-     * @param $filters
-     * @param $field
-     * @param $drillDownFilters
+     * @param array $filters
+     * @param string $field
+     * @param array $drillDownFilters
      *
-     * @return array|mixed
+     * @return array
      */
     public function getAvailableOptions($filters, $field, $drillDownFilters)
     {

--- a/models/Tool/CustomReport/Config.php
+++ b/models/Tool/CustomReport/Config.php
@@ -125,7 +125,7 @@ class Config extends Model\AbstractModel implements \JsonSerializable
     public $sharedRoleNames;
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return null|Config
      */
@@ -168,8 +168,8 @@ class Config extends Model\AbstractModel implements \JsonSerializable
     }
 
     /**
-     * @param $configuration
-     * @param null $fullConfig
+     * @param \stdClass $configuration
+     * @param Config|null $fullConfig
      *
      * @deprecated Use ServiceLocator with id 'pimcore.custom_report.adapter.factories' to determine the factory for the adapter instead
      *
@@ -327,7 +327,7 @@ class Config extends Model\AbstractModel implements \JsonSerializable
     }
 
     /**
-     * @return string[]
+     * @return \stdClass|null
      */
     public function getDataSourceConfig()
     {

--- a/models/Tool/CustomReport/Config/Dao.php
+++ b/models/Tool/CustomReport/Config/Dao.php
@@ -31,7 +31,7 @@ class Dao extends Model\Dao\PhpArrayTable
     }
 
     /**
-     * @param null $id
+     * @param string|null $id
      *
      * @throws \Exception
      */

--- a/models/Tool/CustomReport/Config/Listing.php
+++ b/models/Tool/CustomReport/Config/Listing.php
@@ -25,16 +25,16 @@ use Pimcore\Model;
 class Listing extends Model\Listing\JsonListing
 {
     /**
-     * @var array|null
+     * @var Model\Tool\CustomReport\Config[]|null
      */
     protected $reports = null;
 
     /**
-     * @return \Pimcore\Model\Tool\CustomReport\Config[]
+     * @return Model\Tool\CustomReport\Config[]
      */
     public function getReports()
     {
-        if ($this->reports == null) {
+        if ($this->reports === null) {
             $this->getDao()->load();
         }
 
@@ -42,7 +42,7 @@ class Listing extends Model\Listing\JsonListing
     }
 
     /**
-     * @param $reports
+     * @param Model\Tool\CustomReport\Config[]|null $reports
      *
      * @return $this
      */

--- a/models/Tool/Email/Blacklist.php
+++ b/models/Tool/Email/Blacklist.php
@@ -25,7 +25,7 @@ use Pimcore\Model;
 class Blacklist extends Model\AbstractModel
 {
     /**
-     * @var int
+     * @var string
      */
     public $address;
 
@@ -40,7 +40,7 @@ class Blacklist extends Model\AbstractModel
     public $modificationDate;
 
     /**
-     * @param $addr
+     * @param string $addr
      *
      * @return null|Blacklist
      */
@@ -57,7 +57,7 @@ class Blacklist extends Model\AbstractModel
     }
 
     /**
-     * @param int $address
+     * @param string $address
      */
     public function setAddress($address)
     {
@@ -65,7 +65,7 @@ class Blacklist extends Model\AbstractModel
     }
 
     /**
-     * @return int
+     * @return string
      */
     public function getAddress()
     {

--- a/models/Tool/Email/Blacklist/Dao.php
+++ b/models/Tool/Email/Blacklist/Dao.php
@@ -25,7 +25,7 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $address
+     * @param string $address
      *
      * @throws \Exception
      */

--- a/models/Tool/Email/Blacklist/Listing.php
+++ b/models/Tool/Email/Blacklist/Listing.php
@@ -27,7 +27,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\Tool\Email\Blacklist[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $items = null;
@@ -38,7 +38,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param $items
+     * @param Model\Tool\Email\Blacklist[]|null $items
      *
      * @return $this
      */

--- a/models/Tool/Email/Log.php
+++ b/models/Tool/Email/Log.php
@@ -139,7 +139,7 @@ class Log extends Model\AbstractModel
     public $subject;
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return $this
      */
@@ -151,7 +151,7 @@ class Log extends Model\AbstractModel
     }
 
     /**
-     * @param $requestUri
+     * @param string $requestUri
      *
      * @return $this
      */
@@ -183,7 +183,7 @@ class Log extends Model\AbstractModel
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return $this
      */
@@ -195,7 +195,7 @@ class Log extends Model\AbstractModel
     }
 
     /**
-     * @param $subject
+     * @param string $subject
      *
      * @return $this
      */
@@ -251,7 +251,7 @@ class Log extends Model\AbstractModel
     }
 
     /**
-     * @param $params
+     * @param array $params
      *
      * @return $this
      */
@@ -265,7 +265,7 @@ class Log extends Model\AbstractModel
     /**
      * Returns the dynamic parameter
      *
-     * @return string
+     * @return array
      */
     public function getParams()
     {
@@ -417,7 +417,7 @@ class Log extends Model\AbstractModel
     }
 
     /**
-     * @param $to
+     * @param string $to
      *
      * @return $this
      */
@@ -439,7 +439,7 @@ class Log extends Model\AbstractModel
     }
 
     /**
-     * @param $cc
+     * @param string $cc
      *
      * @return $this
      */
@@ -461,7 +461,7 @@ class Log extends Model\AbstractModel
     }
 
     /**
-     * @param $bcc
+     * @param string $bcc
      *
      * @return $this
      */
@@ -483,7 +483,7 @@ class Log extends Model\AbstractModel
     }
 
     /**
-     * @param $from
+     * @param string $from
      *
      * @return $this
      */
@@ -505,7 +505,7 @@ class Log extends Model\AbstractModel
     }
 
     /**
-     * @param $replyTo
+     * @param string $replyTo
      *
      * @return $this
      */
@@ -527,7 +527,7 @@ class Log extends Model\AbstractModel
     }
 
     /**
-     * @param $html
+     * @param string $html
      *
      * @return $this
      */
@@ -549,7 +549,7 @@ class Log extends Model\AbstractModel
     }
 
     /**
-     * @param $text
+     * @param string $text
      *
      * @return $this
      */

--- a/models/Tool/Email/Log/Dao.php
+++ b/models/Tool/Email/Log/Dao.php
@@ -35,7 +35,7 @@ class Dao extends Model\Dao\AbstractDao
     /**
      * Get the data for the object from database for the given id, or from the ID which is set in the object
      *
-     * @param int $id
+     * @param int|null $id
      */
     public function getById($id = null)
     {
@@ -109,7 +109,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $data
+     * @param array|string $data
      *
      * @return array|string
      */
@@ -131,8 +131,8 @@ class Dao extends Model\Dao\AbstractDao
      * Creates the basic logging for the treeGrid in the backend
      * Data will be enhanced with live-data in the backend
      *
-     * @param $key
-     * @param $value
+     * @param string $key
+     * @param mixed $value
      *
      * @return \stdClass
      */

--- a/models/Tool/Lock.php
+++ b/models/Tool/Lock.php
@@ -93,7 +93,7 @@ class Lock extends Model\AbstractModel
     }
 
     /**
-     * @param $key
+     * @param string $key
      * @param int $expire
      *
      * @return mixed
@@ -106,7 +106,7 @@ class Lock extends Model\AbstractModel
     }
 
     /**
-     * @param $key
+     * @param string $key
      *
      * @return Lock
      */

--- a/models/Tool/Lock/Dao.php
+++ b/models/Tool/Lock/Dao.php
@@ -26,7 +26,7 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $key
+     * @param string $key
      * @param int $expire
      *
      * @return bool
@@ -55,7 +55,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $key
+     * @param string $key
      * @param int $expire
      * @param int $refreshInterval
      *
@@ -85,7 +85,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $key
+     * @param string $key
      */
     public function release($key)
     {
@@ -94,7 +94,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $key
+     * @param string $key
      * @param bool $force
      */
     public function lock($key, $force = true)
@@ -110,7 +110,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $key
+     * @param string $key
      */
     public function getById($key)
     {

--- a/models/Tool/Qrcode/Config/Dao.php
+++ b/models/Tool/Qrcode/Config/Dao.php
@@ -31,7 +31,7 @@ class Dao extends Model\Dao\PhpArrayTable
     }
 
     /**
-     * @param null $id
+     * @param string|null $id
      *
      * @throws \Exception
      */

--- a/models/Tool/Qrcode/Config/Listing.php
+++ b/models/Tool/Qrcode/Config/Listing.php
@@ -25,12 +25,12 @@ use Pimcore\Model;
 class Listing extends Model\Listing\JsonListing
 {
     /**
-     * @var array|null
+     * @var Model\Tool\Qrcode\Config[]|null
      */
     protected $codes = null;
 
     /**
-     * @return \Pimcore\Model\Tool\Qrcode\Config[]
+     * @return Model\Tool\Qrcode\Config[]
      */
     public function getCodes()
     {
@@ -42,7 +42,7 @@ class Listing extends Model\Listing\JsonListing
     }
 
     /**
-     * @param $codes
+     * @param Model\Tool\Qrcode\Config[]|null $codes
      *
      * @return $this
      */

--- a/models/Tool/Tag/Config.php
+++ b/models/Tool/Tag/Config.php
@@ -87,7 +87,7 @@ class Config extends Model\AbstractModel
     public $creationDate;
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return Config
      *
@@ -117,7 +117,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $parameters
+     * @param array $parameters
      *
      * @return bool
      */
@@ -129,8 +129,8 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $position
-     * @param $parameters
+     * @param int $position
+     * @param array $parameters
      *
      * @return bool
      */
@@ -147,7 +147,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $description
+     * @param string $description
      *
      * @return $this
      */
@@ -167,7 +167,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $items
+     * @param array $items
      *
      * @return $this
      */
@@ -187,7 +187,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return $this
      */
@@ -207,7 +207,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $httpMethod
+     * @param string $httpMethod
      *
      * @return $this
      */
@@ -227,7 +227,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $urlPattern
+     * @param string $urlPattern
      *
      * @return $this
      */
@@ -263,7 +263,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $params
+     * @param array $params
      *
      * @return $this
      */
@@ -283,7 +283,7 @@ class Config extends Model\AbstractModel
     }
 
     /**
-     * @param $textPattern
+     * @param string $textPattern
      *
      * @return $this
      */

--- a/models/Tool/Tag/Config/Dao.php
+++ b/models/Tool/Tag/Config/Dao.php
@@ -31,7 +31,7 @@ class Dao extends Model\Dao\PhpArrayTable
     }
 
     /**
-     * @param null $id
+     * @param string|null $id
      *
      * @throws \Exception
      */

--- a/models/Tool/Tag/Config/Listing.php
+++ b/models/Tool/Tag/Config/Listing.php
@@ -25,12 +25,12 @@ use Pimcore\Model;
 class Listing extends Model\Listing\JsonListing
 {
     /**
-     * @var array|null
+     * @var Model\Tool\Tag\Config[]|null
      */
     protected $tags = null;
 
     /**
-     * @return \Pimcore\Model\Tool\Tag\Config[]
+     * @return Model\Tool\Tag\Config[]
      */
     public function getTags()
     {
@@ -42,7 +42,7 @@ class Listing extends Model\Listing\JsonListing
     }
 
     /**
-     * @param $tags
+     * @param Model\Tool\Tag\Config[] $tags
      *
      * @return $this
      */

--- a/models/Tool/Targeting/Rule.php
+++ b/models/Tool/Targeting/Rule.php
@@ -71,7 +71,7 @@ class Rule extends Model\AbstractModel
     public $actions = [];
 
     /**
-     * @param $target
+     * @param mixed $target
      *
      * @return bool
      */
@@ -117,7 +117,7 @@ class Rule extends Model\AbstractModel
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return null|Rule
      */
@@ -134,7 +134,7 @@ class Rule extends Model\AbstractModel
     }
 
     /**
-     * @param $description
+     * @param string $description
      *
      * @return $this
      */
@@ -154,7 +154,7 @@ class Rule extends Model\AbstractModel
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return $this
      */
@@ -174,7 +174,7 @@ class Rule extends Model\AbstractModel
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return $this
      */
@@ -218,7 +218,7 @@ class Rule extends Model\AbstractModel
     }
 
     /**
-     * @param $conditions
+     * @param array $conditions
      *
      * @return $this
      */

--- a/models/Tool/Targeting/Rule/Dao.php
+++ b/models/Tool/Targeting/Rule/Dao.php
@@ -27,7 +27,7 @@ use Pimcore\Tool\Serialize;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param null $id
+     * @param int|null $id
      *
      * @throws \Exception
      */

--- a/models/Tool/Targeting/TargetGroup.php
+++ b/models/Tool/Targeting/TargetGroup.php
@@ -50,7 +50,7 @@ class TargetGroup extends Model\AbstractModel
     public $active = true;
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return null|TargetGroup
      */
@@ -67,7 +67,7 @@ class TargetGroup extends Model\AbstractModel
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return TargetGroup|null
      */
@@ -84,7 +84,7 @@ class TargetGroup extends Model\AbstractModel
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return bool
      */
@@ -100,7 +100,7 @@ class TargetGroup extends Model\AbstractModel
     }
 
     /**
-     * @param $description
+     * @param string $description
      *
      * @return $this
      */
@@ -120,7 +120,7 @@ class TargetGroup extends Model\AbstractModel
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return $this
      */
@@ -140,7 +140,7 @@ class TargetGroup extends Model\AbstractModel
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return $this
      */

--- a/models/Tool/TmpStore.php
+++ b/models/Tool/TmpStore.php
@@ -80,12 +80,12 @@ class TmpStore extends Model\AbstractModel
     }
 
     /**
-     * @param $id
-     * @param $data
-     * @param null $tag
-     * @param null $lifetime
+     * @param string $id
+     * @param mixed $data
+     * @param string|null $tag
+     * @param int|null $lifetime
      *
-     * @return mixed
+     * @return bool
      */
     public static function add($id, $data, $tag = null, $lifetime = null)
     {
@@ -103,12 +103,12 @@ class TmpStore extends Model\AbstractModel
     }
 
     /**
-     * @param $id
-     * @param $data
-     * @param null $tag
-     * @param null $lifetime
+     * @param string $id
+     * @param mixed $data
+     * @param string|null $tag
+     * @param int|null $lifetime
      *
-     * @return mixed
+     * @return bool
      */
     public static function set($id, $data, $tag = null, $lifetime = null)
     {
@@ -122,7 +122,7 @@ class TmpStore extends Model\AbstractModel
     }
 
     /**
-     * @param $id
+     * @param string $id
      *
      * @return mixed
      */
@@ -134,7 +134,7 @@ class TmpStore extends Model\AbstractModel
     }
 
     /**
-     * @param $id
+     * @param string $id
      *
      * @return null|TmpStore
      */
@@ -153,7 +153,7 @@ class TmpStore extends Model\AbstractModel
     }
 
     /**
-     * @param $tag
+     * @param string $tag
      *
      * @return array
      */
@@ -206,7 +206,7 @@ class TmpStore extends Model\AbstractModel
     }
 
     /**
-     * @param string $data
+     * @param mixed $data
      */
     public function setData($data)
     {
@@ -262,7 +262,7 @@ class TmpStore extends Model\AbstractModel
     }
 
     /**
-     * @param null $lifetime
+     * @param int|null $lifetime
      *
      * @return mixed
      */

--- a/models/Tool/TmpStore/Dao.php
+++ b/models/Tool/TmpStore/Dao.php
@@ -25,10 +25,10 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $id
-     * @param $data
-     * @param $tag
-     * @param $lifetime
+     * @param string $id
+     * @param mixed $data
+     * @param string $tag
+     * @param int $lifetime
      *
      * @return bool
      */
@@ -57,7 +57,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $id
+     * @param string $id
      */
     public function delete($id)
     {
@@ -65,7 +65,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $id
+     * @param string $id
      *
      * @return bool
      */
@@ -87,7 +87,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $tag
+     * @param string $tag
      *
      * @return array
      */

--- a/models/Tool/Tracking/Event.php
+++ b/models/Tool/Tracking/Event.php
@@ -55,7 +55,7 @@ class Event extends Model\AbstractModel
     public $data;
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return Event|null
      */
@@ -72,12 +72,12 @@ class Event extends Model\AbstractModel
     }
 
     /**
-     * @param $category
-     * @param $action
-     * @param $label
-     * @param $day
-     * @param $month
-     * @param $year
+     * @param string $category
+     * @param string $action
+     * @param string $label
+     * @param int $day
+     * @param int $month
+     * @param int $year
      *
      * @return Event
      */
@@ -97,7 +97,7 @@ class Event extends Model\AbstractModel
     }
 
     /**
-     * @param $action
+     * @param string $action
      *
      * @return $this
      */
@@ -117,7 +117,7 @@ class Event extends Model\AbstractModel
     }
 
     /**
-     * @param $category
+     * @param string $category
      *
      * @return $this
      */
@@ -137,7 +137,7 @@ class Event extends Model\AbstractModel
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return $this
      */
@@ -157,7 +157,7 @@ class Event extends Model\AbstractModel
     }
 
     /**
-     * @param $label
+     * @param string $label
      *
      * @return $this
      */
@@ -177,7 +177,7 @@ class Event extends Model\AbstractModel
     }
 
     /**
-     * @param $timestamp
+     * @param int $timestamp
      *
      * @return $this
      */
@@ -197,7 +197,7 @@ class Event extends Model\AbstractModel
     }
 
     /**
-     * @param $data
+     * @param string $data
      *
      * @return $this
      */

--- a/models/Tool/Tracking/Event/Dao.php
+++ b/models/Tool/Tracking/Event/Dao.php
@@ -25,7 +25,7 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $id
+     * @param int $id
      *
      * @throws \Exception
      */
@@ -39,12 +39,12 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $category
-     * @param $action
-     * @param $label
-     * @param $day
-     * @param $month
-     * @param $year
+     * @param string $category
+     * @param string $action
+     * @param string $label
+     * @param int $day
+     * @param int $month
+     * @param int $year
      *
      * @throws \Exception
      */

--- a/models/Tool/UUID.php
+++ b/models/Tool/UUID.php
@@ -50,7 +50,7 @@ class UUID extends Model\AbstractModel
     protected $item;
 
     /**
-     * @param $instanceIdentifier
+     * @param string $instanceIdentifier
      *
      * @return $this
      */
@@ -62,7 +62,7 @@ class UUID extends Model\AbstractModel
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getInstanceIdentifier()
     {
@@ -86,7 +86,7 @@ class UUID extends Model\AbstractModel
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return $this
      */
@@ -98,7 +98,7 @@ class UUID extends Model\AbstractModel
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getItemId()
     {
@@ -106,7 +106,7 @@ class UUID extends Model\AbstractModel
     }
 
     /**
-     * @param $type
+     * @param string $type
      *
      * @return $this
      */
@@ -118,7 +118,7 @@ class UUID extends Model\AbstractModel
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getType()
     {
@@ -143,7 +143,7 @@ class UUID extends Model\AbstractModel
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getUuid()
     {
@@ -151,7 +151,7 @@ class UUID extends Model\AbstractModel
     }
 
     /**
-     * @param $uuid
+     * @param string $uuid
      */
     public function setUuid($uuid)
     {
@@ -159,7 +159,7 @@ class UUID extends Model\AbstractModel
     }
 
     /**
-     * @param $item
+     * @param mixed $item
      *
      * @return $this
      */
@@ -179,7 +179,7 @@ class UUID extends Model\AbstractModel
     }
 
     /**
-     * @param $item
+     * @param int $item
      *
      * @return UUID
      *
@@ -195,7 +195,7 @@ class UUID extends Model\AbstractModel
     }
 
     /**
-     * @param $uuid
+     * @param string $uuid
      *
      * @return mixed
      */
@@ -207,7 +207,7 @@ class UUID extends Model\AbstractModel
     }
 
     /**
-     * @param $item
+     * @param mixed $item
      *
      * @return static
      *

--- a/models/Tool/UUID/Dao.php
+++ b/models/Tool/UUID/Dao.php
@@ -52,7 +52,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $uuid
+     * @param string $uuid
      *
      * @return Model\Tool\UUID
      */

--- a/models/Translation/AbstractTranslation.php
+++ b/models/Translation/AbstractTranslation.php
@@ -34,7 +34,7 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
     public $key;
 
     /**
-     * @var array
+     * @var string[]
      */
     public $translations;
 
@@ -65,7 +65,7 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
     }
 
     /**
-     * @param $key
+     * @param string $key
      *
      * @return $this
      */
@@ -77,7 +77,7 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getTranslations()
     {
@@ -85,7 +85,7 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
     }
 
     /**
-     * @param $translations
+     * @param string[] $translations
      *
      * @return $this
      */
@@ -97,7 +97,7 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
     }
 
     /**
-     * @param $date
+     * @param int $date
      *
      * @return $this
      */
@@ -117,7 +117,7 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
     }
 
     /**
-     * @param $date
+     * @param int $date
      *
      * @return $this
      */
@@ -137,7 +137,7 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
     }
 
     /**
-     * @param $date
+     * @param int $date
      *
      * @return $this
      */
@@ -158,9 +158,9 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
     }
 
     /**
-     * @param  $language
+     * @param string $language
      *
-     * @return array
+     * @return string
      */
     public function getTranslation($language)
     {
@@ -183,7 +183,7 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
     }
 
     /**
-     * @param $id
+     * @param string $id
      * @param bool $create
      * @param bool $returnIdIfEmpty
      *
@@ -240,7 +240,7 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
      *
      * @static
      *
-     * @param $id - translation key
+     * @param string $id - translation key
      * @param bool $create - creates an empty translation entry if the key doesn't exists
      * @param bool $returnIdIfEmpty - returns $id if no translation is available
      * @param string $language
@@ -294,7 +294,7 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
      *
      * @static
      *
-     * @param $file - path to the csv file
+     * @param string $file - path to the csv file
      * @param bool $replaceExistingTranslations
      * @param array $languages
      * @param array $dialect
@@ -410,7 +410,7 @@ abstract class AbstractTranslation extends Model\AbstractModel implements Transl
 
     /**
      * @deprecated
-     * @param $data
+     * @param array $data
      */
     public function getFromWebserviceImport($data)
     {

--- a/models/Translation/AbstractTranslation/Dao.php
+++ b/models/Translation/AbstractTranslation/Dao.php
@@ -25,7 +25,7 @@ use Pimcore\Model;
 abstract class Dao extends Model\Dao\AbstractDao implements Dao\DaoInterface
 {
     /**
-     * @param $key
+     * @param string $key
      *
      * @throws \Exception
      */

--- a/models/Translation/Admin.php
+++ b/models/Translation/Admin.php
@@ -33,10 +33,10 @@ class Admin extends AbstractTranslation
     }
 
     /**
-     * @param $id
+     * @param string $id
      * @param bool $create
      * @param bool $returnIdIfEmpty
-     * @param null $language
+     * @param string|null $language
      *
      * @return string
      *

--- a/models/Translation/TranslationInterface.php
+++ b/models/Translation/TranslationInterface.php
@@ -29,14 +29,14 @@ interface TranslationInterface
     /**
      * Detemines if backend can handle the language
      *
-     * @param $locale
+     * @param string $locale
      *
      * @return bool
      */
     public static function isValidLanguage($locale): bool;
 
     /**
-     * @param $id
+     * @param string $id
      *
      * @return mixed
      */

--- a/models/User.php
+++ b/models/User.php
@@ -549,8 +549,8 @@ class User extends User\UserRole
     }
 
     /**
-     * @param null $width
-     * @param null $height
+     * @param int|null $width
+     * @param int|null $height
      *
      * @return string
      */
@@ -993,7 +993,7 @@ class User extends User\UserRole
     }
 
     /**
-     * @param null $key
+     * @param string|null $key
      *
      * @return array|mixed|null|string
      */

--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -243,7 +243,7 @@ class AbstractUser extends Model\AbstractModel
     }
 
     /**
-     * @param $type
+     * @param string $type
      *
      * @return $this
      */

--- a/models/User/AbstractUser/Dao.php
+++ b/models/User/AbstractUser/Dao.php
@@ -28,7 +28,7 @@ class Dao extends Model\Dao\AbstractDao
     use Model\Element\ChildsCompatibilityTrait;
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @throws \Exception
      */
@@ -48,7 +48,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @throws \Exception
      */

--- a/models/User/Permission/Definition.php
+++ b/models/User/Permission/Definition.php
@@ -36,7 +36,7 @@ class Definition extends Model\AbstractModel
     public $category;
 
     /**
-     * @param array
+     * @param array $data
      */
     public function __construct($data = [])
     {
@@ -54,7 +54,7 @@ class Definition extends Model\AbstractModel
     }
 
     /**
-     * @param $key
+     * @param string $key
      *
      * @return $this
      */
@@ -86,7 +86,7 @@ class Definition extends Model\AbstractModel
     }
 
     /**
-     * @param $permission
+     * @param string $permission
      *
      * @return mixed
      *
@@ -108,7 +108,7 @@ class Definition extends Model\AbstractModel
     }
 
     /**
-     * @param $permission
+     * @param string $permission
      *
      * @return mixed|static
      *

--- a/models/User/Permission/Definition/Listing.php
+++ b/models/User/Permission/Definition/Listing.php
@@ -27,7 +27,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\User\Permission\Definition[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $definitions = null;
@@ -38,7 +38,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param $definitions
+     * @param Model\User\Permission\Definition[] $definitions
      *
      * @return $this
      */

--- a/models/User/Service.php
+++ b/models/User/Service.php
@@ -24,7 +24,7 @@ class Service
      *
      * @static
      *
-     * @param $type
+     * @param string $type
      *
      * @return string
      */

--- a/models/User/UserRole.php
+++ b/models/User/UserRole.php
@@ -32,17 +32,17 @@ class UserRole extends AbstractUser
     public $permissions = [];
 
     /**
-     * @var array
+     * @var Asset[]
      */
     public $workspacesAsset = [];
 
     /**
-     * @var array
+     * @var DataObject[]
      */
     public $workspacesObject = [];
 
     /**
-     * @var array
+     * @var Document[]
      */
     public $workspacesDocument = [];
 
@@ -100,8 +100,8 @@ class UserRole extends AbstractUser
     }
 
     /**
-     * @param $permissionName
-     * @param null $value
+     * @param string $permissionName
+     * @param bool|null $value
      *
      * @return $this
      */
@@ -126,7 +126,7 @@ class UserRole extends AbstractUser
     }
 
     /**
-     * @param $permissionName
+     * @param string $permissionName
      *
      * @return bool
      */
@@ -161,7 +161,7 @@ class UserRole extends AbstractUser
     }
 
     /**
-     * @param $permissions
+     * @param string|array $permissions
      *
      * @return $this
      */
@@ -177,7 +177,7 @@ class UserRole extends AbstractUser
     }
 
     /**
-     * @param $workspacesAsset
+     * @param Asset[] $workspacesAsset
      *
      * @return $this
      */
@@ -197,7 +197,7 @@ class UserRole extends AbstractUser
     }
 
     /**
-     * @param $workspacesDocument
+     * @param Document[] $workspacesDocument
      *
      * @return $this
      */
@@ -217,7 +217,7 @@ class UserRole extends AbstractUser
     }
 
     /**
-     * @param $workspacesObject
+     * @param DataObject[] $workspacesObject
      *
      * @return $this
      */
@@ -330,7 +330,7 @@ class UserRole extends AbstractUser
      * checks if given parameter is string and if so splits it creates array
      * returns empty array if empty parameter is given
      *
-     * @param $array
+     * @param array $array
      *
      * @return array|string
      */

--- a/models/User/UserRole/Dao.php
+++ b/models/User/UserRole/Dao.php
@@ -26,7 +26,7 @@ use Pimcore\Model\Element;
 class Dao extends Model\User\AbstractUser\Dao
 {
     /**
-     * @param $id
+     * @param int $id
      *
      * @throws \Exception
      */
@@ -40,7 +40,7 @@ class Dao extends Model\User\AbstractUser\Dao
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @throws \Exception
      */

--- a/models/User/UserRole/Folder.php
+++ b/models/User/UserRole/Folder.php
@@ -32,7 +32,7 @@ class Folder extends Model\User\AbstractUser
     public $hasChilds;
 
     /**
-     * @param $state
+     * @param bool $state
      *
      * @return $this
      */

--- a/models/User/Workspace/AbstractWorkspace.php
+++ b/models/User/Workspace/AbstractWorkspace.php
@@ -85,7 +85,7 @@ class AbstractWorkspace extends Model\AbstractModel
     public $properties = false;
 
     /**
-     * @param $create
+     * @param bool $create
      *
      * @return $this
      */
@@ -105,7 +105,7 @@ class AbstractWorkspace extends Model\AbstractModel
     }
 
     /**
-     * @param $delete
+     * @param bool $delete
      *
      * @return $this
      */
@@ -125,7 +125,7 @@ class AbstractWorkspace extends Model\AbstractModel
     }
 
     /**
-     * @param $list
+     * @param bool $list
      *
      * @return $this
      */
@@ -145,7 +145,7 @@ class AbstractWorkspace extends Model\AbstractModel
     }
 
     /**
-     * @param $properties
+     * @param bool $properties
      *
      * @return $this
      */
@@ -165,7 +165,7 @@ class AbstractWorkspace extends Model\AbstractModel
     }
 
     /**
-     * @param $publish
+     * @param bool $publish
      *
      * @return $this
      */
@@ -185,7 +185,7 @@ class AbstractWorkspace extends Model\AbstractModel
     }
 
     /**
-     * @param $rename
+     * @param bool $rename
      *
      * @return $this
      */
@@ -205,7 +205,7 @@ class AbstractWorkspace extends Model\AbstractModel
     }
 
     /**
-     * @param $settings
+     * @param bool $settings
      *
      * @return $this
      */
@@ -225,7 +225,7 @@ class AbstractWorkspace extends Model\AbstractModel
     }
 
     /**
-     * @param $versions
+     * @param bool $versions
      *
      * @return $this
      */
@@ -245,7 +245,7 @@ class AbstractWorkspace extends Model\AbstractModel
     }
 
     /**
-     * @param $view
+     * @param bool $view
      *
      * @return $this
      */
@@ -265,7 +265,7 @@ class AbstractWorkspace extends Model\AbstractModel
     }
 
     /**
-     * @param $cid
+     * @param int $cid
      *
      * @return $this
      */
@@ -285,7 +285,7 @@ class AbstractWorkspace extends Model\AbstractModel
     }
 
     /**
-     * @param $userId
+     * @param int $userId
      *
      * @return $this
      */
@@ -305,7 +305,7 @@ class AbstractWorkspace extends Model\AbstractModel
     }
 
     /**
-     * @param $cpath
+     * @param string $cpath
      *
      * @return $this
      */

--- a/models/User/Workspace/DataObject.php
+++ b/models/User/Workspace/DataObject.php
@@ -48,7 +48,7 @@ class DataObject extends AbstractWorkspace
     public $layouts = null;
 
     /**
-     * @param $save
+     * @param bool $save
      *
      * @return $this
      */
@@ -68,7 +68,7 @@ class DataObject extends AbstractWorkspace
     }
 
     /**
-     * @param $unpublish
+     * @param bool $unpublish
      *
      * @return $this
      */

--- a/models/User/Workspace/Document.php
+++ b/models/User/Workspace/Document.php
@@ -33,7 +33,7 @@ class Document extends AbstractWorkspace
     public $unpublish = false;
 
     /**
-     * @param $save
+     * @param bool $save
      *
      * @return $this
      */
@@ -53,7 +53,7 @@ class Document extends AbstractWorkspace
     }
 
     /**
-     * @param $unpublish
+     * @param bool $unpublish
      *
      * @return $this
      */

--- a/models/Version.php
+++ b/models/Version.php
@@ -311,7 +311,7 @@ class Version extends AbstractModel
     }
 
     /**
-     * @param $data
+     * @param ElementInterface $data
      *
      * @return mixed
      */
@@ -380,7 +380,7 @@ class Version extends AbstractModel
     /**
      * Object
      *
-     * @param $renewReferences
+     * @param bool $renewReferences
      *
      * @return mixed
      */
@@ -534,7 +534,7 @@ class Version extends AbstractModel
     }
 
     /**
-     * @param $cid
+     * @param int $cid
      *
      * @return $this
      */

--- a/models/Version/Dao.php
+++ b/models/Version/Dao.php
@@ -26,7 +26,7 @@ use Pimcore\Model;
 class Dao extends Model\Dao\AbstractDao
 {
     /**
-     * @param $id
+     * @param int $id
      *
      * @throws \Exception
      */
@@ -122,7 +122,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $elementTypes
+     * @param array $elementTypes
      * @param array $ignoreIds
      *
      * @return array

--- a/models/Version/Listing.php
+++ b/models/Version/Listing.php
@@ -27,7 +27,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\Version[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $versions = null;
@@ -46,7 +46,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param $versions
+     * @param Model\Version[]|null $versions
      *
      * @return $this
      */

--- a/models/Version/MarshalMatcher.php
+++ b/models/Version/MarshalMatcher.php
@@ -23,15 +23,17 @@ use Pimcore\Model\Element\Service;
 
 class MarshalMatcher extends TypeMatcher
 {
+    /** @var string */
     private $sourceType;
 
+    /** @var int */
     private $sourceId;
 
     /**
      * MarshalMatcher constructor.
      *
-     * @param $sourceType
-     * @param $sourceId
+     * @param string $sourceType
+     * @param int $sourceId
      */
     public function __construct($sourceType, $sourceId)
     {

--- a/models/Webservice/Data.php
+++ b/models/Webservice/Data.php
@@ -28,8 +28,8 @@ use Pimcore\Model\Webservice;
 abstract class Data
 {
     /**
-     * @param $object
-     * @param null $options
+     * @param mixed $object
+     * @param array|null $options
      *
      * @throws \Exception
      */
@@ -121,7 +121,7 @@ abstract class Data
     }
 
     /**
-     * @param $object
+     * @param mixed $object
      * @param bool $disableMappingExceptions
      * @param Webservice\IdMapperInterface|null $idMapper
      *

--- a/models/Webservice/Data/Asset.php
+++ b/models/Webservice/Data/Asset.php
@@ -101,8 +101,8 @@ class Asset extends Model\Webservice\Data
     public $childs;
 
     /**
-     * @param Asset|Asset\Folder $object
-     * @param null $options
+     * @param Model\Asset $object
+     * @param array|null $options
      */
     public function map($object, $options = null)
     {
@@ -131,7 +131,7 @@ class Asset extends Model\Webservice\Data
     }
 
     /**
-     * @param $object
+     * @param Model\Asset $object
      * @param bool $disableMappingExceptions
      * @param Webservice\IdMapperInterface|null $idMapper
      *

--- a/models/Webservice/Data/Asset/File.php
+++ b/models/Webservice/Data/Asset/File.php
@@ -30,8 +30,8 @@ class File extends Model\Webservice\Data\Asset
     public $data;
 
     /**
-     * @param $object
-     * @param null $options
+     * @param Model\Asset $object
+     * @param array|null $options
      */
     public function map($object, $options = null)
     {
@@ -45,7 +45,7 @@ class File extends Model\Webservice\Data\Asset
     }
 
     /**
-     * @param $object
+     * @param Model\Asset $object
      * @param bool $disableMappingExceptions
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      */

--- a/models/Webservice/Data/ClassDefinition.php
+++ b/models/Webservice/Data/ClassDefinition.php
@@ -113,7 +113,7 @@ class ClassDefinition extends Model\Webservice\Data
     public $fieldDefinitions;
 
     /**
-     * @var array
+     * @var Model\DataObject\ClassDefinition\Layout
      */
     public $layoutDefinitions;
 

--- a/models/Webservice/Data/DataObject.php
+++ b/models/Webservice/Data/DataObject.php
@@ -82,8 +82,8 @@ class DataObject extends Model\Webservice\Data
     public $childs;
 
     /**
-     * @param $object
-     * @param null $options
+     * @param Model\DataObject\AbstractObject $object
+     * @param array|null $options
      */
     public function map($object, $options = null)
     {

--- a/models/Webservice/Data/DataObject/Concrete.php
+++ b/models/Webservice/Data/DataObject/Concrete.php
@@ -37,8 +37,8 @@ class Concrete extends Model\Webservice\Data\DataObject
     public $className;
 
     /**
-     * @param $object
-     * @param null $options
+     * @param Model\DataObject\Concrete $object
+     * @param array|null $options
      */
     public function map($object, $options = null)
     {
@@ -68,7 +68,7 @@ class Concrete extends Model\Webservice\Data\DataObject
     }
 
     /**
-     * @param $object
+     * @param Model\DataObject\Concrete $object
      * @param bool $disableMappingExceptions
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *

--- a/models/Webservice/Data/Document.php
+++ b/models/Webservice/Data/Document.php
@@ -76,8 +76,8 @@ abstract class Document extends Model\Webservice\Data
     public $childs;
 
     /**
-     * @param $object
-     * @param null $options
+     * @param Model\Document $object
+     * @param array|null $options
      */
     public function map($object, $options = null)
     {

--- a/models/Webservice/Data/Document/Hardlink/In.php
+++ b/models/Webservice/Data/Document/Hardlink/In.php
@@ -27,7 +27,7 @@ class In extends Model\Webservice\Data\Document\Link
     public $sourceId;
 
     /**
-     * @param $object Model\Document\Link
+     * @param Model\Document\Hardlink $object
      * @param bool $disableMappingExceptions
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      */

--- a/models/Webservice/Data/Document/PageSnippet.php
+++ b/models/Webservice/Data/Document/PageSnippet.php
@@ -46,8 +46,8 @@ class PageSnippet extends Model\Webservice\Data\Document
     public $elements;
 
     /**
-     * @param $object
-     * @param null $options
+     * @param Model\Document\PageSnippet $object
+     * @param array|null $options
      */
     public function map($object, $options = null)
     {
@@ -69,7 +69,7 @@ class PageSnippet extends Model\Webservice\Data\Document
     }
 
     /**
-     * @param $object Model\Document\PageSnippet
+     * @param Model\Document\PageSnippet $object
      * @param bool $disableMappingExceptions
      * @param Model\Webservice\IdMapperInterface|null $idMapper
      *

--- a/models/Webservice/Data/Mapper.php
+++ b/models/Webservice/Data/Mapper.php
@@ -26,8 +26,8 @@ use Pimcore\Tool;
 abstract class Mapper
 {
     /**
-     * @param $object
-     * @param $type
+     * @param mixed $object
+     * @param string $type
      *
      * @return null|string
      *
@@ -76,12 +76,12 @@ abstract class Mapper
     }
 
     /**
-     * @param $object
-     * @param $apiclass
-     * @param $type
-     * @param null $options
+     * @param mixed $object
+     * @param string $apiclass
+     * @param string $type
+     * @param array|null $options
      *
-     * @return array|string
+     * @return mixed
      *
      * @throws \Exception
      */
@@ -112,7 +112,7 @@ abstract class Mapper
     }
 
     /**
-     * @param $el
+     * @param object|array $el
      *
      * @return \stdClass
      */

--- a/models/Webservice/JsonEncoder.php
+++ b/models/Webservice/JsonEncoder.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
 class JsonEncoder
 {
     /**
-     * @param $data
+     * @param mixed $data
      * @param bool $returnData
      *
      * @return string
@@ -46,7 +46,7 @@ class JsonEncoder
     }
 
     /**
-     * @param $data
+     * @param string $data
      *
      * @return mixed
      */

--- a/models/Webservice/Service.php
+++ b/models/Webservice/Service.php
@@ -21,6 +21,7 @@ use Pimcore\Logger;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Document;
+use Pimcore\Model\Element\AbstractElement;
 use Pimcore\Model\User;
 use Pimcore\Model\Webservice;
 use Pimcore\Tool\Admin;
@@ -45,7 +46,7 @@ class Service
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return array|string
      *
@@ -70,7 +71,7 @@ class Service
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return array|string
      *
@@ -95,7 +96,7 @@ class Service
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return array|string
      *
@@ -120,7 +121,7 @@ class Service
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return array|string
      *
@@ -145,7 +146,7 @@ class Service
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return array|string
      *
@@ -199,12 +200,12 @@ class Service
     }
 
     /**
-     * @param null $condition
-     * @param null $order
-     * @param null $orderKey
-     * @param null $offset
-     * @param null $limit
-     * @param null $groupBy
+     * @param string|null $condition
+     * @param string|null $order
+     * @param string|null $orderKey
+     * @param int|null $offset
+     * @param int|null $limit
+     * @param string|null $groupBy
      *
      * @return array
      *
@@ -268,7 +269,7 @@ class Service
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return bool
      *
@@ -293,7 +294,7 @@ class Service
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
      * @return bool
      *
@@ -317,7 +318,7 @@ class Service
     }
 
     /**
-     * @param $wsDocument
+     * @param Webservice\Data\Document\Page\In $wsDocument
      *
      * @return bool
      *
@@ -338,7 +339,7 @@ class Service
     }
 
     /**
-     * @param $wsDocument
+     * @param Webservice\Data\Document\Folder\In $wsDocument
      *
      * @return bool
      *
@@ -359,7 +360,7 @@ class Service
     }
 
     /**
-     * @param $wsDocument
+     * @param Webservice\Data\Document\Snippet\In $wsDocument
      *
      * @return bool
      *
@@ -380,7 +381,7 @@ class Service
     }
 
     /**
-     * @param $wsDocument
+     * @param Webservice\Data\Document\Link\In $wsDocument
      *
      * @return bool
      *
@@ -401,7 +402,7 @@ class Service
     }
 
     /**
-     * @param $wsDocument
+     * @param Webservice\Data\Document\Hardlink\In $wsDocument
      *
      * @return bool
      *
@@ -422,7 +423,7 @@ class Service
     }
 
     /**
-     * @param $wsDocument
+     * @param Webservice\Data\Document\Email\In $wsDocument
      *
      * @return bool
      *
@@ -443,7 +444,7 @@ class Service
     }
 
     /**
-     * @param $wsDocument
+     * @param Webservice\Data\DataObject\Folder\In $wsDocument
      *
      * @return bool
      *
@@ -464,7 +465,7 @@ class Service
     }
 
     /**
-     * @param $wsDocument
+     * @param Webservice\Data\DataObject\Concrete\In $wsDocument
      *
      * @return bool
      *
@@ -506,7 +507,7 @@ class Service
     }
 
     /**
-     * @param $wsDocument
+     * @param Webservice\Data\Asset\File\In $wsDocument
      *
      * @return bool
      *
@@ -800,7 +801,7 @@ class Service
 
     /**
      * @param int $id
-     * @param null $options
+     * @param array|null $options
      *
      * @return array|string
      *
@@ -824,12 +825,12 @@ class Service
     }
 
     /**
-     * @param null $condition
-     * @param null $order
-     * @param null $orderKey
-     * @param null $offset
-     * @param null $limit
-     * @param null $groupBy
+     * @param string|null $condition
+     * @param string|null $order
+     * @param string|null $orderKey
+     * @param int|null $offset
+     * @param int|null $limit
+     * @param string|null $groupBy
      *
      * @return array
      *
@@ -974,13 +975,13 @@ class Service
     }
 
     /**
-     * @param null $condition
-     * @param null $order
-     * @param null $orderKey
-     * @param null $offset
-     * @param null $limit
-     * @param null $groupBy
-     * @param null $objectClass
+     * @param string|null $condition
+     * @param string|null $order
+     * @param string|null $orderKey
+     * @param int|null $offset
+     * @param int|null $limit
+     * @param string|null $groupBy
+     * @param string|null $objectClass
      *
      * @return array
      *
@@ -1110,8 +1111,8 @@ class Service
     }
 
     /**
-     * @param $wsDocument
-     * @param $element
+     * @param Webservice\Data\Document $wsDocument
+     * @param AbstractElement $element
      *
      * @return mixed
      *
@@ -1134,9 +1135,9 @@ class Service
     }
 
     /**
-     * @param $element
-     * @param $key
-     * @param $path
+     * @param AbstractElement $element
+     * @param string $key
+     * @param string $path
      *
      * @return string
      */
@@ -1162,7 +1163,7 @@ class Service
     }
 
     /**
-     * @param $wsDocument
+     * @param Webservice\Data\Document $wsDocument
      *
      * @return bool
      *
@@ -1189,7 +1190,7 @@ class Service
     }
 
     /**
-     * @param $wsDocument
+     * @param Webservice\Data\DataObject $wsDocument
      *
      * @return bool
      *
@@ -1220,7 +1221,7 @@ class Service
     }
 
     /**
-     * @param $wsDocument
+     * @param Webservice\Data\Asset $wsDocument
      *
      * @return bool
      *
@@ -1246,7 +1247,7 @@ class Service
     }
 
     /**
-     * @param $element
+     * @param AbstractElement $element
      * @param bool $creation
      *
      * @return $this
@@ -1320,8 +1321,8 @@ class Service
     }
 
     /**
-     * @param $type
-     * @param $params
+     * @param string $type
+     * @param array $params
      *
      * @return array
      *

--- a/models/Webservice/Tool.php
+++ b/models/Webservice/Tool.php
@@ -68,7 +68,7 @@ class Tool
     }
 
     /**
-     * @param $data
+     * @param mixed $data
      *
      * @return array
      */

--- a/models/WebsiteSetting/Dao.php
+++ b/models/WebsiteSetting/Dao.php
@@ -28,7 +28,7 @@ class Dao extends Model\Dao\PhpArrayTable
     }
 
     /**
-     * @param null $id
+     * @param int|null $id
      *
      * @throws \Exception
      */
@@ -48,9 +48,9 @@ class Dao extends Model\Dao\PhpArrayTable
     }
 
     /**
-     * @param null $name
-     * @param null $siteId
-     * @param null $language
+     * @param string|null $name
+     * @param int|null $siteId
+     * @param string|null $language
      *
      * @throws \Exception
      */

--- a/models/Workflow.php
+++ b/models/Workflow.php
@@ -256,7 +256,7 @@ class Workflow extends AbstractModel
     /**
      * Returns whether or not a state name is valid within the workflow
      *
-     * @param $stateName
+     * @param string $stateName
      *
      * @return bool
      */
@@ -299,7 +299,7 @@ class Workflow extends AbstractModel
     /**
      * Returns whether or not a status name is valid within the workflow
      *
-     * @param $statusName
+     * @param string $statusName
      *
      * @return bool
      */
@@ -325,7 +325,7 @@ class Workflow extends AbstractModel
     /**
      * Returns whether or not an action is valid in this workflow
      *
-     * @param $actionName
+     * @param string $actionName
      *
      * @return bool
      */
@@ -337,7 +337,7 @@ class Workflow extends AbstractModel
     /**
      * Returns whether or not an action name is a global action
      *
-     * @param $actionName
+     * @param string $actionName
      *
      * @return bool
      */
@@ -347,7 +347,7 @@ class Workflow extends AbstractModel
     }
 
     /**
-     * @param $stateName
+     * @param string $stateName
      *
      * @return bool|mixed
      */
@@ -363,7 +363,7 @@ class Workflow extends AbstractModel
     }
 
     /**
-     * @param $statusName
+     * @param string $statusName
      *
      * @return bool|mixed
      */
@@ -395,7 +395,7 @@ class Workflow extends AbstractModel
     }
 
     /**
-     * @param $statusName
+     * @param string $statusName
      *
      * @return array
      */
@@ -462,8 +462,8 @@ class Workflow extends AbstractModel
      * Returns a configuration for an action
      * If a status is given then the configuration for the status will be applied too
      *
-     * @param $actionName
-     * @param $statusName
+     * @param string $actionName
+     * @param string|null $statusName
      *
      * @return array|null
      *
@@ -500,8 +500,8 @@ class Workflow extends AbstractModel
      * Returns all of the valid users for an action
      * if a status is given it will be taken into consideration.
      *
-     * @param $actionName
-     * @param $statusName
+     * @param string $actionName
+     * @param string|null $statusName
      *
      * @return array|null
      */
@@ -518,8 +518,8 @@ class Workflow extends AbstractModel
     /**
      * Returns additional fields for an action.
      *
-     * @param $actionName
-     * @param $statusName
+     * @param string $actionName
+     * @param string|null $statusName
      *
      * @return array
      */

--- a/models/Workflow/Dao.php
+++ b/models/Workflow/Dao.php
@@ -31,7 +31,7 @@ class Dao extends Model\Dao\PhpArrayTable
     }
 
     /**
-     * @param null $id
+     * @param int|null $id
      *
      * @throws \Exception
      */


### PR DESCRIPTION
Fix all phpstan level 2 errors in Pimcore\Model namespace (without Asset|DataObject|Document) with following schema:
```
PHPDoc tag @param has invalid value ($xyz)
```
Before:
```
 [ERROR] Found 2731 errors
```
After:
```
 [ERROR] Found 2318 errors
```