### PR TITLE
[PHPSTAN] Fill empty php doc param types (DataObject)

### DIFF
--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -197,7 +197,7 @@ class AbstractObject extends Model\Element\AbstractElement
     /**
      * @static
      *
-     * @param  $hideUnpublished
+     * @param bool $hideUnpublished
      */
     public static function setHideUnpublished($hideUnpublished)
     {
@@ -217,7 +217,7 @@ class AbstractObject extends Model\Element\AbstractElement
     /**
      * @static
      *
-     * @param  $getInheritedValues
+     * @param bool $getInheritedValues
      */
     public static function setGetInheritedValues($getInheritedValues)
     {
@@ -763,8 +763,8 @@ class AbstractObject extends Model\Element\AbstractElement
     }
 
     /**
-     * @param $isUpdate
-     * @param $params
+     * @param bool|null $isUpdate
+     * @param array $params
      *
      * @throws \Exception
      */
@@ -1177,9 +1177,9 @@ class AbstractObject extends Model\Element\AbstractElement
     }
 
     /**
-     * @param $name
-     * @param $type
-     * @param $data
+     * @param string $name
+     * @param string $type
+     * @param mixed $data
      * @param bool $inherited
      * @param bool $inheritable
      *
@@ -1297,8 +1297,8 @@ class AbstractObject extends Model\Element\AbstractElement
     }
 
     /**
-     * @param $method
-     * @param $args
+     * @param string $method
+     * @param array $args
      *
      * @return mixed
      *
@@ -1338,7 +1338,7 @@ class AbstractObject extends Model\Element\AbstractElement
 
     /**
      * @param string $fieldName
-     * @param null $language
+     * @param string|null $language
      *
      * @throws \Exception
      *
@@ -1355,8 +1355,8 @@ class AbstractObject extends Model\Element\AbstractElement
 
     /**
      * @param string $fieldName
-     * @param $value
-     * @param null $language
+     * @param mixed $value
+     * @param string|null $language
      *
      * @throws \Exception
      *

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -85,7 +85,7 @@ class Dao extends Model\Element\Dao
     }
 
     /**
-     * @param $isUpdate
+     * @param bool|null $isUpdate
      *
      * @throws \Exception
      */
@@ -352,9 +352,9 @@ class Dao extends Model\Element\Dao
     }
 
     /**
-     * @param $id
+     * @param int $id
      *
-     * @return mixed
+     * @return array
      */
     public function getTypeById($id)
     {
@@ -385,6 +385,9 @@ class Dao extends Model\Element\Dao
         return false;
     }
 
+    /**
+     * @return array
+     */
     public function unlockPropagate()
     {
         $lockIds = $this->db->fetchCol('SELECT o_id from objects WHERE o_path LIKE ' . $this->db->quote($this->model->getRealFullPath() . '/%') . ' OR o_id = ' . $this->model->getId());
@@ -428,8 +431,8 @@ class Dao extends Model\Element\Dao
     }
 
     /**
-     * @param $type
-     * @param $user
+     * @param string $type
+     * @param Model\User $user
      *
      * @return bool
      */
@@ -468,11 +471,11 @@ class Dao extends Model\Element\Dao
     }
 
     /**
-     * @param $type
-     * @param $user
+     * @param string $type
+     * @param Model\User $user
      * @param bool $quote
      *
-     * @return mixed|null
+     * @return array|null
      */
     public function getPermissions($type, $user, $quote = true)
     {
@@ -567,7 +570,7 @@ class Dao extends Model\Element\Dao
     }
 
     /**
-     * @param $index
+     * @param int $index
      */
     public function saveIndex($index)
     {

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -178,7 +178,7 @@ class ClassDefinition extends Model\AbstractModel
     ];
 
     /**
-     * @param $id
+     * @param string $id
      *
      * @return null|ClassDefinition
      *
@@ -616,9 +616,9 @@ class ClassDefinition extends Model\AbstractModel
     }
 
     /**
-     * @param $definition
-     * @param $text
-     * @param $level
+     * @param ClassDefinition|ClassDefinition\Data $definition
+     * @param string $text
+     * @param int $level
      *
      * @return string
      */
@@ -714,7 +714,7 @@ class ClassDefinition extends Model\AbstractModel
     }
 
     /**
-     * @param null $name
+     * @param string|null $name
      *
      * @return string
      */
@@ -1180,7 +1180,7 @@ class ClassDefinition extends Model\AbstractModel
     }
 
     /**
-     * @param $icon
+     * @param string $icon
      *
      * @return $this
      */
@@ -1200,7 +1200,7 @@ class ClassDefinition extends Model\AbstractModel
     }
 
     /**
-     * @param $propertyVisibility
+     * @param array $propertyVisibility
      *
      * @return $this
      */
@@ -1214,7 +1214,7 @@ class ClassDefinition extends Model\AbstractModel
     }
 
     /**
-     * @param $previewUrl
+     * @param string $previewUrl
      *
      * @return $this
      */
@@ -1250,7 +1250,7 @@ class ClassDefinition extends Model\AbstractModel
     }
 
     /**
-     * @param $description
+     * @param string $description
      *
      * @return $this
      */

--- a/models/DataObject/ClassDefinition/CustomLayout.php
+++ b/models/DataObject/ClassDefinition/CustomLayout.php
@@ -82,7 +82,7 @@ class CustomLayout extends Model\AbstractModel
     public $default;
 
     /**
-     * @param $id
+     * @param string $id
      *
      * @return null|CustomLayout
      */
@@ -127,7 +127,7 @@ class CustomLayout extends Model\AbstractModel
 
     /**
      * @param string $name
-     * @param int    $classId
+     * @param string $classId
      *
      * @return null|CustomLayout
      */
@@ -165,6 +165,8 @@ class CustomLayout extends Model\AbstractModel
                     }
                 }
             }
+
+            return null;
         };
 
         return $findElement($field, $this->getLayoutDefinitions());
@@ -311,7 +313,7 @@ class CustomLayout extends Model\AbstractModel
     }
 
     /**
-     * @param mixed $classId
+     * @param string $classId
      *
      * @return int|null
      */

--- a/models/DataObject/ClassDefinition/CustomLayout/Dao.php
+++ b/models/DataObject/ClassDefinition/CustomLayout/Dao.php
@@ -30,7 +30,7 @@ class Dao extends Model\Dao\AbstractDao
     protected $model;
 
     /**
-     * @param null $id
+     * @param string|null $id
      *
      * @throws \Exception
      */
@@ -70,7 +70,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param mixed $id
+     * @param string $id
      *
      * @return string|null
      */
@@ -89,7 +89,7 @@ class Dao extends Model\Dao\AbstractDao
 
     /**
      * @param string $name
-     * @param int    $classId
+     * @param string $classId
      *
      * @return int|null
      */
@@ -107,7 +107,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @return int|mixed
+     * @return int
      */
     public function getNewId()
     {
@@ -133,13 +133,13 @@ class Dao extends Model\Dao\AbstractDao
             }
         }
 
-        return;
+        return null;
     }
 
     /**
      * Get latest identifier
      *
-     * @param int $classId
+     * @param string $classId
      *
      * @return int
      */

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -38,7 +38,7 @@ class Dao extends Model\Dao\AbstractDao
     protected $tableDefinitions = null;
 
     /**
-     * @param mixed $id
+     * @param string $id
      *
      * @return string|null
      */
@@ -286,7 +286,7 @@ class Dao extends Model\Dao\AbstractDao
     /**
      * Update the class name in all object
      *
-     * @param $newName
+     * @param string $newName
      */
     public function updateClassNameInObjects($newName)
     {

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -36,7 +36,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
     public $visibleFields;
 
     /**
-     * @var string[]
+     * @var array
      */
     public $columns;
 
@@ -177,9 +177,9 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
     }
 
     /**
-     * @param $data
-     * @param null $object
-     * @param mixed $params
+     * @param array $data
+     * @param Model\DataObject\AbstractObject|null $object
+     * @param array $params
      *
      * @return string|null
      *
@@ -215,7 +215,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
      *
      * @param array $data
      * @param null|Model\DataObject\AbstractObject $object
-     * @param mixed $params
+     * @param array $params
      *
      * @return array
      */

--- a/models/DataObject/ClassDefinition/Data/Extension/Text.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Text.php
@@ -23,7 +23,7 @@ trait Text
     /**
      * Checks if data is valid for current data field
      *
-     * @param mixed $data
+     * @param string $data
      * @param bool $omitMandatoryCheck
      *
      * @throws \Exception
@@ -36,7 +36,7 @@ trait Text
     }
 
     /**
-     * @param $data
+     * @param string $data
      *
      * @return bool
      */
@@ -45,9 +45,11 @@ trait Text
         return strlen($data) < 1;
     }
 
-    /** True if change is allowed in edit mode.
-     * @param string $object
-     * @param mixed $params
+    /**
+     * True if change is allowed in edit mode.
+     *
+     * @param Model\DataObject\AbstractObject $object
+     * @param array $params
      *
      * @return bool
      */
@@ -61,7 +63,7 @@ trait Text
      *
      * @param string $data
      * @param null|Model\DataObject\AbstractObject $object
-     * @param mixed $params
+     * @param array $params
      *
      * @return string
      */

--- a/models/DataObject/ClassDefinition/Data/Geo/AbstractGeo.php
+++ b/models/DataObject/ClassDefinition/Data/Geo/AbstractGeo.php
@@ -50,7 +50,7 @@ abstract class AbstractGeo extends Model\DataObject\ClassDefinition\Data
     }
 
     /**
-     * @param $lat
+     * @param float $lat
      *
      * @return $this
      */
@@ -70,7 +70,7 @@ abstract class AbstractGeo extends Model\DataObject\ClassDefinition\Data
     }
 
     /**
-     * @param $lng
+     * @param float $lng
      *
      * @return $this
      */
@@ -90,7 +90,7 @@ abstract class AbstractGeo extends Model\DataObject\ClassDefinition\Data
     }
 
     /**
-     * @param $zoom
+     * @param int $zoom
      *
      * @return $this
      */
@@ -102,8 +102,8 @@ abstract class AbstractGeo extends Model\DataObject\ClassDefinition\Data
     }
 
     /**
-     * @param $value
-     * @param null $object
+     * @param mixed $value
+     * @param Model\DataObject\AbstractObject|null $object
      * @param array $params
      *
      * @return string
@@ -114,8 +114,8 @@ abstract class AbstractGeo extends Model\DataObject\ClassDefinition\Data
     }
 
     /**
-     * @param $value
-     * @param null $object
+     * @param string $value
+     * @param Model\DataObject\AbstractObject|null $object
      * @param array $params
      *
      * @return mixed

--- a/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
@@ -78,7 +78,7 @@ abstract class AbstractRelations extends Data implements CustomResourcePersistin
     }
 
     /**
-     * @param  $lazyLoading
+     * @param bool $lazyLoading
      *
      * @return $this
      */

--- a/models/DataObject/ClassDefinition/Helper/Dao.php
+++ b/models/DataObject/ClassDefinition/Helper/Dao.php
@@ -22,8 +22,8 @@ use Pimcore\Model\DataObject;
 trait Dao
 {
     /**
-     * @param $field
-     * @param $table
+     * @param DataObject\ClassDefinition\Data $field
+     * @param string $table
      * @param string $columnTypeGetter
      */
     protected function addIndexToField($field, $table, $columnTypeGetter = 'getColumnType', $considerUniqueIndex = false, $isLocalized = false, $isFieldcollection = false)
@@ -92,11 +92,11 @@ trait Dao
     }
 
     /**
-     * @param $table
-     * @param $colName
-     * @param $type
-     * @param $default
-     * @param $null
+     * @param string $table
+     * @param string $colName
+     * @param string $type
+     * @param string $default
+     * @param string $null
      */
     protected function addModifyColumn($table, $colName, $type, $default, $null)
     {
@@ -120,9 +120,9 @@ trait Dao
     }
 
     /**
-     * @param $table
-     * @param $columnsToRemove
-     * @param $protectedColumns
+     * @param string $table
+     * @param array $columnsToRemove
+     * @param array $protectedColumns
      */
     protected function removeUnusedColumns($table, $columnsToRemove, $protectedColumns)
     {

--- a/models/DataObject/ClassDefinition/Helper/LinkGeneratorResolver.php
+++ b/models/DataObject/ClassDefinition/Helper/LinkGeneratorResolver.php
@@ -21,9 +21,9 @@ use Pimcore\Model\DataObject\ClassDefinition\LinkGeneratorInterface;
 class LinkGeneratorResolver extends ClassResolver
 {
     /**
-     * @param $generatorClass
+     * @param string $generatorClass
      *
-     * @return LinkGeneratorInterface
+     * @return LinkGeneratorInterface|null
      */
     public static function resolveGenerator($generatorClass)
     {

--- a/models/DataObject/ClassDefinition/Helper/PathFormatterResolver.php
+++ b/models/DataObject/ClassDefinition/Helper/PathFormatterResolver.php
@@ -23,9 +23,9 @@ class PathFormatterResolver extends ClassResolver
     public static $formatterCache = [];
 
     /**
-     * @param $formatterClass
+     * @param string $formatterClass
      *
-     * @return PathFormatterInterface
+     * @return PathFormatterInterface|null
      */
     public static function resolvePathFormatter($formatterClass): ?PathFormatterInterface
     {

--- a/models/DataObject/ClassDefinition/Helper/VarExport.php
+++ b/models/DataObject/ClassDefinition/Helper/VarExport.php
@@ -19,7 +19,7 @@ namespace Pimcore\Model\DataObject\ClassDefinition\Helper;
 trait VarExport
 {
     /**
-     * @param $data
+     * @param array $data
      *
      * @return static
      */

--- a/models/DataObject/ClassDefinition/Layout.php
+++ b/models/DataObject/ClassDefinition/Layout.php
@@ -348,7 +348,7 @@ class Layout
     }
 
     /**
-     * @param $locked
+     * @param bool $locked
      *
      * @return $this
      */
@@ -360,7 +360,7 @@ class Layout
     }
 
     /**
-     * @param $collapsed
+     * @param bool $collapsed
      *
      * @return $this
      */
@@ -382,7 +382,7 @@ class Layout
     }
 
     /**
-     * @param $bodyStyle
+     * @param string $bodyStyle
      *
      * @return $this
      */
@@ -412,8 +412,9 @@ class Layout
         return $this;
     }
 
-    /** Override point for Enriching the layout definition before the layout is returned to the admin interface.
-     * @param $object Model\DataObject\Concrete
+    /**
+     * Override point for Enriching the layout definition before the layout is returned to the admin interface.
+     * @param Model\DataObject\Concrete $object
      * @param array $context additional contextual data
      */
     public function enrichLayoutDefinition($object, $context = [])

--- a/models/DataObject/ClassDefinition/Layout/Fieldcontainer.php
+++ b/models/DataObject/ClassDefinition/Layout/Fieldcontainer.php
@@ -45,7 +45,7 @@ class Fieldcontainer extends Model\DataObject\ClassDefinition\Layout
     public $fieldLabel;
 
     /**
-     * @param $labelWidth
+     * @param int $labelWidth
      *
      * @return $this
      */
@@ -67,7 +67,7 @@ class Fieldcontainer extends Model\DataObject\ClassDefinition\Layout
     }
 
     /**
-     * @param $layout
+     * @param string $layout
      *
      * @return $this
      */
@@ -87,7 +87,7 @@ class Fieldcontainer extends Model\DataObject\ClassDefinition\Layout
     }
 
     /**
-     * @param $fieldLabel
+     * @param string $fieldLabel
      *
      * @return $this
      */

--- a/models/DataObject/ClassDefinition/Layout/Fieldset.php
+++ b/models/DataObject/ClassDefinition/Layout/Fieldset.php
@@ -35,7 +35,7 @@ class Fieldset extends Model\DataObject\ClassDefinition\Layout
     public $labelWidth = 100;
 
     /**
-     * @param $labelWidth
+     * @param int $labelWidth
      *
      * @return $this
      */

--- a/models/DataObject/ClassDefinition/Layout/Iframe.php
+++ b/models/DataObject/ClassDefinition/Layout/Iframe.php
@@ -69,7 +69,7 @@ class Iframe extends Model\DataObject\ClassDefinition\Layout
     /**
      * Override point for Enriching the layout definition before the layout is returned to the admin interface.
      *
-     * @param $object Model\DataObject\Concrete
+     * @param Model\DataObject\Concrete $object
      * @param array $context additional contextual data
      *
      * @return self

--- a/models/DataObject/ClassDefinition/Layout/Panel.php
+++ b/models/DataObject/ClassDefinition/Layout/Panel.php
@@ -50,7 +50,7 @@ class Panel extends Model\DataObject\ClassDefinition\Layout
     public $icon;
 
     /**
-     * @param $labelWidth
+     * @param int $labelWidth
      *
      * @return $this
      */
@@ -72,7 +72,7 @@ class Panel extends Model\DataObject\ClassDefinition\Layout
     }
 
     /**
-     * @param $layout
+     * @param string $layout
      *
      * @return $this
      */

--- a/models/DataObject/ClassDefinition/Layout/Text.php
+++ b/models/DataObject/ClassDefinition/Layout/Text.php
@@ -57,7 +57,7 @@ class Text extends Model\DataObject\ClassDefinition\Layout
     }
 
     /**
-     * @param $html
+     * @param string $html
      *
      * @return $this
      */
@@ -69,7 +69,7 @@ class Text extends Model\DataObject\ClassDefinition\Layout
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getRenderingClass()
     {
@@ -77,7 +77,7 @@ class Text extends Model\DataObject\ClassDefinition\Layout
     }
 
     /**
-     * @param mixed $renderingClass
+     * @param string $renderingClass
      */
     public function setRenderingClass($renderingClass)
     {
@@ -85,7 +85,7 @@ class Text extends Model\DataObject\ClassDefinition\Layout
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getRenderingData()
     {
@@ -93,7 +93,7 @@ class Text extends Model\DataObject\ClassDefinition\Layout
     }
 
     /**
-     * @param mixed $renderingData
+     * @param string $renderingData
      */
     public function setRenderingData($renderingData)
     {
@@ -119,7 +119,7 @@ class Text extends Model\DataObject\ClassDefinition\Layout
     /**
      * Override point for Enriching the layout definition before the layout is returned to the admin interface.
      *
-     * @param $object Model\DataObject\Concrete
+     * @param Model\DataObject\Concrete $object
      * @param array $context additional contextual data
      *
      * @return self

--- a/models/DataObject/ClassDefinition/Listing.php
+++ b/models/DataObject/ClassDefinition/Listing.php
@@ -26,7 +26,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\DataObject\ClassDefinition[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $classes = null;
@@ -45,7 +45,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param $classes
+     * @param Model\DataObject\ClassDefinition[]|null $classes
      *
      * @return $this
      */

--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -330,12 +330,12 @@ class Service
     }
 
     /**
-     * @param $tableDefinitions
-     * @param $table
-     * @param $colName
-     * @param $type
-     * @param $default
-     * @param $null
+     * @param array $tableDefinitions
+     * @param string $table
+     * @param string $colName
+     * @param string $type
+     * @param string $default
+     * @param string $null
      *
      * @return bool
      */

--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -62,7 +62,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     }
 
     /**
-     * @param  $item
+     * @param array $item
      */
     public function addItem($item)
     {
@@ -144,9 +144,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     }
 
     /**
-     * @throws \Exception
-     *
-     * @param null $language
+     * @param string|null $language
      *
      * @return string
      */
@@ -160,10 +158,10 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     }
 
     /**
-     * @param $groupId
-     * @param $keyId
-     * @param $value
-     * @param null $language
+     * @param int $groupId
+     * @param int $keyId
+     * @param mixed $value
+     * @param string|null $language
      *
      * @return $this
      *
@@ -229,8 +227,10 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
         return $this;
     }
 
-    /** Removes the group with the given id
-     * @param $groupId
+    /**
+     * Removes the group with the given id
+     *
+     * @param int $groupId
      */
     public function removeGroupData($groupId)
     {
@@ -299,10 +299,10 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     }
 
     /**
-     * @param $groupId
-     * @param $keyId
-     * @param $language
-     * @param $fielddefinition
+     * @param int $groupId
+     * @param int $keyId
+     * @param string $language
+     * @param Model\DataObject\ClassDefinition\Data $fielddefinition
      *
      * @return null
      */
@@ -331,17 +331,15 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     }
 
     /**
-     * @param $keyId
-     * @param $groupId
+     * @param int $keyId
+     * @param int $groupId
      * @param string $language
-     * @param bool|false $ignoreFallbackLanguage
-     * @param bool|false $ignoreDefaultLanguage
+     * @param bool $ignoreFallbackLanguage
+     * @param bool $ignoreDefaultLanguage
      *
-     * @return null
+     * @return mixed
      *
      * @throws \Exception
-     *
-     * @todo: not sure if bool|false is actually allowed in phpdoc?
      */
     public function getLocalizedKeyValue($groupId, $keyId, $language = 'default', $ignoreFallbackLanguage = false, $ignoreDefaultLanguage = false)
     {
@@ -443,8 +441,8 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     }
 
     /**
-     * @param $groupId
-     * @param $collectionId
+     * @param int $groupId
+     * @param int $collectionId
      */
     public function setGroupCollectionMapping($groupId = null, $collectionId = null)
     {
@@ -454,14 +452,16 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     }
 
     /**
-     * @param $groupId
+     * @param int $groupId
      *
-     * @return mixed
+     * @return int|null
      */
     public function getGroupCollectionMapping($groupId)
     {
         if ($this->groupCollectionMapping) {
             return $this->groupCollectionMapping[$groupId];
         }
+
+        return null;
     }
 }

--- a/models/DataObject/Classificationstore/CollectionConfig.php
+++ b/models/DataObject/Classificationstore/CollectionConfig.php
@@ -78,7 +78,7 @@ class CollectionConfig extends Model\AbstractModel
     }
 
     /**
-     * @param $name
+     * @param string $name
      * @param int $storeId
      *
      * @return self|null
@@ -208,7 +208,7 @@ class CollectionConfig extends Model\AbstractModel
     }
 
     /**
-     * @param $modificationDate
+     * @param int $modificationDate
      *
      * @return $this
      */
@@ -228,7 +228,7 @@ class CollectionConfig extends Model\AbstractModel
     }
 
     /**
-     * @param $creationDate
+     * @param int $creationDate
      *
      * @return $this
      */

--- a/models/DataObject/Classificationstore/CollectionConfig/Dao.php
+++ b/models/DataObject/Classificationstore/CollectionConfig/Dao.php
@@ -49,7 +49,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param null $name
+     * @param string|null $name
      *
      * @throws \Exception
      */

--- a/models/DataObject/Classificationstore/CollectionConfig/Listing.php
+++ b/models/DataObject/Classificationstore/CollectionConfig/Listing.php
@@ -27,7 +27,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\DataObject\Classificationstore\CollectionConfig[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $list = null;
@@ -46,7 +46,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param array
+     * @param Model\DataObject\Classificationstore\CollectionConfig[]|null $theList
      *
      * @return $this
      */

--- a/models/DataObject/Classificationstore/CollectionGroupRelation/Dao.php
+++ b/models/DataObject/Classificationstore/CollectionGroupRelation/Dao.php
@@ -27,8 +27,8 @@ class Dao extends Model\Dao\AbstractDao
     const TABLE_NAME_RELATIONS = 'classificationstore_collectionrelations';
 
     /**
-     * @param null $colId
-     * @param null $groupId
+     * @param int|null $colId
+     * @param int|null $groupId
      */
     public function getById($colId = null, $groupId = null)
     {

--- a/models/DataObject/Classificationstore/CollectionGroupRelation/Listing.php
+++ b/models/DataObject/Classificationstore/CollectionGroupRelation/Listing.php
@@ -27,7 +27,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\DataObject\Classificationstore\CollectionGroupRelation[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $list = null;
@@ -46,7 +46,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param array
+     * @param Model\DataObject\Classificationstore\CollectionGroupRelation[]|null $theList
      *
      * @return $this
      */

--- a/models/DataObject/Classificationstore/Dao.php
+++ b/models/DataObject/Classificationstore/Dao.php
@@ -29,7 +29,7 @@ class Dao extends Model\Dao\AbstractDao
     use DataObject\ClassDefinition\Helper\Dao;
 
     /**
-     * @var null
+     * @var array|null
      */
     protected $tableDefinitions = null;
 

--- a/models/DataObject/Classificationstore/DefinitionCache.php
+++ b/models/DataObject/Classificationstore/DefinitionCache.php
@@ -25,10 +25,10 @@ class DefinitionCache
     public static $cache = [];
 
     /**
-     * @param $id
+     * @param int $id
      * @param string $type
      *
-     * @return mixed|KeyConfig
+     * @return KeyConfig|null
      */
     public static function get($id, $type = 'key')
     {
@@ -41,7 +41,7 @@ class DefinitionCache
         $config = KeyConfig::getById($id);
 
         if (!$config) {
-            return;
+            return null;
         }
         self::put($config);
 
@@ -49,7 +49,7 @@ class DefinitionCache
     }
 
     /**
-     * @param $config
+     * @param KeyConfig|GroupConfig $config
      */
     public static function put($config)
     {
@@ -62,7 +62,7 @@ class DefinitionCache
     }
 
     /**
-     * @param $config
+     * @param KeyConfig|GroupConfig $config
      */
     public static function clear($config)
     {

--- a/models/DataObject/Classificationstore/GroupConfig.php
+++ b/models/DataObject/Classificationstore/GroupConfig.php
@@ -99,7 +99,7 @@ class GroupConfig extends Model\AbstractModel
     }
 
     /**
-     * @param $name
+     * @param string $name
      * @param int $storeId
      *
      * @return self|null
@@ -261,7 +261,7 @@ class GroupConfig extends Model\AbstractModel
     }
 
     /**
-     * @param $modificationDate
+     * @param int $modificationDate
      *
      * @return $this
      */
@@ -281,7 +281,7 @@ class GroupConfig extends Model\AbstractModel
     }
 
     /**
-     * @param $creationDate
+     * @param int $creationDate
      *
      * @return $this
      */
@@ -300,8 +300,10 @@ class GroupConfig extends Model\AbstractModel
         return $this->creationDate;
     }
 
-    /** Returns all keys belonging to this group
-     * @return KeyGroupRelation
+    /**
+     * Returns all keys belonging to this group
+     *
+     * @return KeyGroupRelation[]
      */
     public function getRelations()
     {

--- a/models/DataObject/Classificationstore/GroupConfig/Dao.php
+++ b/models/DataObject/Classificationstore/GroupConfig/Dao.php
@@ -51,7 +51,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param null $name
+     * @param string|null $name
      *
      * @throws \Exception
      */

--- a/models/DataObject/Classificationstore/GroupConfig/Listing.php
+++ b/models/DataObject/Classificationstore/GroupConfig/Listing.php
@@ -27,7 +27,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\DataObject\Classificationstore\GroupConfig[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $list = null;
@@ -46,7 +46,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param array
+     * @param Model\DataObject\Classificationstore\GroupConfig[]|null $theList
      *
      * @return $this
      */

--- a/models/DataObject/Classificationstore/KeyConfig.php
+++ b/models/DataObject/Classificationstore/KeyConfig.php
@@ -144,12 +144,10 @@ class KeyConfig extends Model\AbstractModel
     }
 
     /**
-     * @param $name
+     * @param string $name
      * @param int $storeId
      *
      * @return self|null
-     *
-     * @internal param null $groupId
      */
     public static function getByName($name, $storeId = 1)
     {
@@ -380,7 +378,7 @@ class KeyConfig extends Model\AbstractModel
     }
 
     /**
-     * @return mixed
+     * @return bool
      */
     public function getEnabled()
     {
@@ -388,7 +386,7 @@ class KeyConfig extends Model\AbstractModel
     }
 
     /**
-     * @param mixed $enabled
+     * @param bool $enabled
      */
     public function setEnabled($enabled)
     {

--- a/models/DataObject/Classificationstore/KeyConfig/Dao.php
+++ b/models/DataObject/Classificationstore/KeyConfig/Dao.php
@@ -49,7 +49,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param null $name
+     * @param string|null $name
      *
      * @throws \Exception
      */

--- a/models/DataObject/Classificationstore/KeyConfig/Listing.php
+++ b/models/DataObject/Classificationstore/KeyConfig/Listing.php
@@ -27,7 +27,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\DataObject\Classificationstore\KeyConfig[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $list = null;
@@ -49,7 +49,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param array
+     * @param Model\DataObject\Classificationstore\KeyConfig[]|null $theList
      *
      * @return $this
      */

--- a/models/DataObject/Classificationstore/KeyGroupRelation.php
+++ b/models/DataObject/Classificationstore/KeyGroupRelation.php
@@ -230,8 +230,8 @@ class KeyGroupRelation extends Model\AbstractModel
     }
 
     /**
-     * @param $groupId
-     * @param $keyId
+     * @param int $groupId
+     * @param int $keyId
      *
      * @return KeyGroupRelation|null
      */

--- a/models/DataObject/Classificationstore/KeyGroupRelation/Dao.php
+++ b/models/DataObject/Classificationstore/KeyGroupRelation/Dao.php
@@ -27,8 +27,8 @@ class Dao extends Model\Dao\AbstractDao
     const TABLE_NAME_RELATIONS = 'classificationstore_relations';
 
     /**
-     * @param null $keyId
-     * @param null $groupId
+     * @param int|null $keyId
+     * @param int|null $groupId
      */
     public function getById($keyId = null, $groupId = null)
     {

--- a/models/DataObject/Classificationstore/KeyGroupRelation/Listing.php
+++ b/models/DataObject/Classificationstore/KeyGroupRelation/Listing.php
@@ -27,7 +27,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\DataObject\Classificationstore\KeyGroupRelation[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $list = null;
@@ -49,7 +49,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param array
+     * @param Model\DataObject\Classificationstore\KeyGroupRelation[]|null $theList
      *
      * @return $this
      */

--- a/models/DataObject/Classificationstore/Service.php
+++ b/models/DataObject/Classificationstore/Service.php
@@ -22,7 +22,7 @@ use Pimcore\Model\DataObject;
 class Service
 {
     /**
-     * @param $keyConfig
+     * @param KeyConfig $keyConfig
      *
      * @return DataObject\ClassDefinition\Data
      */
@@ -37,10 +37,10 @@ class Service
     }
 
     /**
-     * @param $definition
-     * @param $type
+     * @param array $definition
+     * @param string $type
      *
-     * @return DataObject\ClassDefinition\Data
+     * @return DataObject\ClassDefinition\Data|null
      */
     public static function getFieldDefinitionFromJson($definition, $type)
     {

--- a/models/DataObject/Classificationstore/StoreConfig.php
+++ b/models/DataObject/Classificationstore/StoreConfig.php
@@ -63,9 +63,9 @@ class StoreConfig extends Model\AbstractModel
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
-     * @return StoreConfig
+     * @return self|null
      */
     public static function getByName($name)
     {
@@ -110,16 +110,20 @@ class StoreConfig extends Model\AbstractModel
         return $this->name;
     }
 
-    /** Returns the description.
-     * @return mixed
+    /**
+     * Returns the description.
+     *
+     * @return string
      */
     public function getDescription()
     {
         return $this->description;
     }
 
-    /** Sets the description.
-     * @param $description
+    /**
+     * Sets the description.
+     *
+     * @param string $description
      *
      * @return Model\DataObject\Classificationstore\StoreConfig
      */

--- a/models/DataObject/Classificationstore/StoreConfig/Dao.php
+++ b/models/DataObject/Classificationstore/StoreConfig/Dao.php
@@ -44,12 +44,12 @@ class Dao extends Model\Dao\AbstractDao
         if ($data) {
             $this->assignVariablesToModel($data);
         } else {
-            throw new \Exception('StoreConfig with id: ' . $this->model->getd() . ' does not exist');
+            throw new \Exception('StoreConfig with id: ' . $this->model->getId() . ' does not exist');
         }
     }
 
     /**
-     * @param null $name
+     * @param string|null $name
      *
      * @throws \Exception
      */

--- a/models/DataObject/Classificationstore/StoreConfig/Listing.php
+++ b/models/DataObject/Classificationstore/StoreConfig/Listing.php
@@ -27,7 +27,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array
+     * @var Model\DataObject\Classificationstore\StoreConfig[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $list = null;
@@ -46,7 +46,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param array
+     * @param Model\DataObject\Classificationstore\StoreConfig[]|null $theList
      *
      * @return $this
      */

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -98,7 +98,7 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
     }
 
     /**
-     * @param $isUpdate
+     * @param bool|null $isUpdate
      * @param array $params additional parameters (e.g. "versionNote" for the version note)
      *
      * @throws \Exception
@@ -566,8 +566,8 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
     }
 
     /**
-     * @param $key
-     * @param null $params
+     * @param string $key
+     * @param mixed $params
      *
      * @return mixed
      *
@@ -614,7 +614,7 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
      *
      * @param string $fieldName
      * @param bool $forOwner
-     * @param $remoteClassId
+     * @param string $remoteClassId
      *
      * @return array
      */
@@ -626,8 +626,8 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
     }
 
     /**
-     * @param $method
-     * @param $arguments
+     * @param string $method
+     * @param array $arguments
      *
      * @return Model\Listing\AbstractListing|Concrete|null
      *
@@ -873,9 +873,9 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
     /**
      * @internal
      *
-     * @param $objectId
-     * @param $modificationDate
-     * @param $versionCount
+     * @param int $objectId
+     * @param int $modificationDate
+     * @param int $versionCount
      * @param bool $force
      *
      * @return Model\Version|void

--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -81,8 +81,8 @@ class Dao extends Model\DataObject\AbstractObject\Dao
 
     /**
      * @param string $field
-     * @param $forOwner
-     * @param $remoteClassId
+     * @param bool $forOwner
+     * @param string $remoteClassId
      *
      * @return array
      */
@@ -176,7 +176,7 @@ class Dao extends Model\DataObject\AbstractObject\Dao
     /**
      * Save changes to database, it's an good idea to use save() instead
      *
-     * @param $isUpdate
+     * @param bool|null $isUpdate
      */
     public function update($isUpdate = null)
     {

--- a/models/DataObject/Concrete/Dao/InheritanceHelper.php
+++ b/models/DataObject/Concrete/Dao/InheritanceHelper.php
@@ -184,8 +184,8 @@ class InheritanceHelper
     }
 
     /**
-     * @param $fieldname
-     * @param $fieldDefinition
+     * @param string $fieldname
+     * @param DataObject\ClassDefinition\Data $fieldDefinition
      */
     public function addFieldToCheck($fieldname, $fieldDefinition)
     {
@@ -195,9 +195,9 @@ class InheritanceHelper
     }
 
     /**
-     * @param $fieldname
-     * @param $fieldDefinition
-     * @param null $queryfields
+     * @param string $fieldname
+     * @param DataObject\ClassDefinition\Data $fieldDefinition
+     * @param array|null $queryfields
      */
     public function addRelationToCheck($fieldname, $fieldDefinition, $queryfields = null)
     {
@@ -212,7 +212,7 @@ class InheritanceHelper
     }
 
     /**
-     * @param $oo_id
+     * @param int $oo_id
      * @param bool $createMissingChildrenRows
      * @param array $params
      *
@@ -296,10 +296,11 @@ class InheritanceHelper
         }
     }
 
-    /** Currently solely used for object bricks. If a brick is removed, this info must be propagated to all
+    /**
+     * Currently solely used for object bricks. If a brick is removed, this info must be propagated to all
      * child elements.
      *
-     * @param $objectId
+     * @param int $objectId
      * @param array $params
      */
     public function doDelete($objectId, $params = [])
@@ -408,9 +409,9 @@ class InheritanceHelper
     }
 
     /**
-     * @param $currentParentId
+     * @param int $currentParentId
      * @param string $fields
-     * @param null $parentIdGroups
+     * @param array|null $parentIdGroups
      * @param array $params
      *
      * @return array
@@ -499,7 +500,7 @@ class InheritanceHelper
     }
 
     /**
-     * @param $node
+     * @param array $node
      * @param array $params
      *
      * @return mixed
@@ -539,8 +540,8 @@ class InheritanceHelper
     }
 
     /**
-     * @param $currentNode
-     * @param $fieldname
+     * @param array $currentNode
+     * @param string $fieldname
      * @param array $params
      */
     protected function getIdsToCheckForDeletionForValuefields($currentNode, $fieldname, $params = [])
@@ -561,8 +562,8 @@ class InheritanceHelper
     }
 
     /**
-     * @param $currentNode
-     * @param $fieldname
+     * @param array $currentNode
+     * @param string $fieldname
      */
     protected function getIdsToUpdateForValuefields($currentNode, $fieldname)
     {
@@ -578,8 +579,8 @@ class InheritanceHelper
     }
 
     /**
-     * @param $currentNode
-     * @param $fieldname
+     * @param array $currentNode
+     * @param string $fieldname
      */
     protected function getIdsToCheckForDeletionForRelationfields($currentNode, $fieldname)
     {
@@ -602,8 +603,8 @@ class InheritanceHelper
     }
 
     /**
-     * @param $currentNode
-     * @param $fieldname
+     * @param array $currentNode
+     * @param string $fieldname
      * @param array $params
      */
     protected function getIdsToUpdateForRelationfields($currentNode, $fieldname, $params = [])
@@ -625,9 +626,9 @@ class InheritanceHelper
     }
 
     /**
-     * @param $oo_id
-     * @param $ids
-     * @param $fieldname
+     * @param int $oo_id
+     * @param array $ids
+     * @param string $fieldname
      *
      * @throws \Exception
      */
@@ -640,9 +641,9 @@ class InheritanceHelper
     }
 
     /**
-     * @param $oo_id
-     * @param $ids
-     * @param $fieldname
+     * @param int $oo_id
+     * @param array $ids
+     * @param string $fieldname
      */
     protected function updateQueryTableOnDelete($oo_id, $ids, $fieldname)
     {

--- a/models/DataObject/Data/CalculatedValue.php
+++ b/models/DataObject/Data/CalculatedValue.php
@@ -52,7 +52,7 @@ class CalculatedValue implements OwnerAwareFieldInterface
     /**
      * CalculatedValue constructor.
      *
-     * @param $fieldname
+     * @param string $fieldname
      */
     public function __construct($fieldname)
     {
@@ -60,14 +60,16 @@ class CalculatedValue implements OwnerAwareFieldInterface
         $this->markMeDirty();
     }
 
-    /** Sets contextual information.
-     * @param $ownerType
-     * @param $ownerName
-     * @param $index
-     * @param $position
-     * @param null $groupId
-     * @param null $keyId
-     * @param null $keyDefinition
+    /**
+     * Sets contextual information.
+     *
+     * @param string $ownerType
+     * @param string $ownerName
+     * @param int $index
+     * @param string $position
+     * @param int $groupId
+     * @param int $keyId
+     * @param mixed $keyDefinition
      */
     public function setContextualData($ownerType, $ownerName, $index, $position, $groupId = null, $keyId = null, $keyDefinition = null)
     {

--- a/models/DataObject/Data/ElementMetadata.php
+++ b/models/DataObject/Data/ElementMetadata.php
@@ -53,7 +53,7 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
     protected $data = [];
 
     /**
-     * @param $fieldname
+     * @param string $fieldname
      * @param array $columns
      * @param null $element
      *
@@ -78,8 +78,8 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
     }
 
     /**
-     * @param $name
-     * @param $arguments
+     * @param string $name
+     * @param array $arguments
      *
      * @return mixed|void
      *
@@ -111,9 +111,9 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
     /**
      * @param $object
      * @param string $ownertype
-     * @param $ownername
-     * @param $position
-     * @param $index
+     * @param string $ownername
+     * @param int $position
+     * @param int $index
      */
     public function save($object, $ownertype = 'object', $ownername, $position, $index)
     {
@@ -124,15 +124,15 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
 
     /**
      * @param DataObject\Concrete $source
-     * @param $destinationId
-     * @param $fieldname
-     * @param $ownertype
-     * @param $ownername
-     * @param $position
-     * @param $index
-     * @param $destinationType
+     * @param int $destinationId
+     * @param string $fieldname
+     * @param string $ownertype
+     * @param string $ownername
+     * @param int $position
+     * @param int $index
+     * @param string $destinationType
      *
-     * @return mixed
+     * @return DataObject\Data\ElementMetadata|null
      */
     public function load(DataObject\Concrete $source, $destinationId, $fieldname, $ownertype, $ownername, $position, $index, $destinationType)
     {
@@ -140,7 +140,7 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
     }
 
     /**
-     * @param $fieldname
+     * @param string $fieldname
      *
      * @return $this
      */
@@ -171,7 +171,7 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
         if (!$element) {
             $this->setElementTypeAndId(null, null);
 
-            return;
+            return $this;
         }
 
         $elementType = Model\Element\Service::getType($element);
@@ -213,7 +213,7 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
     }
 
     /**
-     * @param $columns
+     * @param array $columns
      *
      * @return $this
      */
@@ -251,7 +251,7 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function __toString()
     {

--- a/models/DataObject/Data/ElementMetadata.php
+++ b/models/DataObject/Data/ElementMetadata.php
@@ -112,7 +112,7 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
      * @param $object
      * @param string $ownertype
      * @param string $ownername
-     * @param int $position
+     * @param string $position
      * @param int $index
      */
     public function save($object, $ownertype = 'object', $ownername, $position, $index)
@@ -128,7 +128,7 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
      * @param string $fieldname
      * @param string $ownertype
      * @param string $ownername
-     * @param int $position
+     * @param string $position
      * @param int $index
      * @param string $destinationType
      *

--- a/models/DataObject/Data/ElementMetadata/Dao.php
+++ b/models/DataObject/Data/ElementMetadata/Dao.php
@@ -26,15 +26,15 @@ class Dao extends DataObject\Data\ObjectMetadata\Dao
 {
     /**
      * @param DataObject\Concrete $source
-     * @param $destinationId
-     * @param $fieldname
-     * @param $ownertype
-     * @param $ownername
-     * @param $position
-     * @param $index
-     * @param $destinationType
+     * @param int $destinationId
+     * @param string $fieldname
+     * @param string $ownertype
+     * @param string $ownername
+     * @param int $position
+     * @param int $index
+     * @param string $destinationType
      *
-     * @return null|DataObject\AbstractObject
+     * @return DataObject\Data\ElementMetadata|null
      */
     public function load(DataObject\Concrete $source, $destinationId, $fieldname, $ownertype, $ownername, $position, $index, $destinationType = 'object')
     {

--- a/models/DataObject/Data/ElementMetadata/Dao.php
+++ b/models/DataObject/Data/ElementMetadata/Dao.php
@@ -30,7 +30,7 @@ class Dao extends DataObject\Data\ObjectMetadata\Dao
      * @param string $fieldname
      * @param string $ownertype
      * @param string $ownername
-     * @param int $position
+     * @param string $position
      * @param int $index
      * @param string $destinationType
      *

--- a/models/DataObject/Data/ExternalImage.php
+++ b/models/DataObject/Data/ExternalImage.php
@@ -30,7 +30,7 @@ class ExternalImage implements OwnerAwareFieldInterface
     /**
      * ExternalImage constructor.
      *
-     * @param null $url
+     * @param string|null $url
      */
     public function __construct($url = null)
     {

--- a/models/DataObject/Data/Geobounds.php
+++ b/models/DataObject/Data/Geobounds.php
@@ -35,8 +35,8 @@ class Geobounds implements OwnerAwareFieldInterface
     protected $southWest;
 
     /**
-     * @param null $northEast
-     * @param null $southWest
+     * @param Geopoint|null $northEast
+     * @param Geopoint|null $southWest
      */
     public function __construct($northEast = null, $southWest = null)
     {
@@ -58,7 +58,7 @@ class Geobounds implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $northEast
+     * @param Geopoint $northEast
      *
      * @return $this
      */
@@ -79,7 +79,7 @@ class Geobounds implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $southWest
+     * @param Geopoint $southWest
      *
      * @return $this
      */

--- a/models/DataObject/Data/Geopoint.php
+++ b/models/DataObject/Data/Geopoint.php
@@ -35,8 +35,8 @@ class Geopoint implements OwnerAwareFieldInterface
     protected $latitude;
 
     /**
-     * @param null $longitude
-     * @param null $latitude
+     * @param float|null $longitude
+     * @param float|null $latitude
      */
     public function __construct($longitude = null, $latitude = null)
     {
@@ -58,7 +58,7 @@ class Geopoint implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $longitude
+     * @param float $longitude
      *
      * @return $this
      */
@@ -83,7 +83,7 @@ class Geopoint implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $latitude
+     * @param float $latitude
      *
      * @return $this
      */

--- a/models/DataObject/Data/Hotspotimage.php
+++ b/models/DataObject/Data/Hotspotimage.php
@@ -45,7 +45,7 @@ class Hotspotimage implements OwnerAwareFieldInterface
     protected $crop;
 
     /**
-     * @param null $image
+     * @param Asset\Image|int|null $image
      * @param array $hotspots
      * @param array $marker
      * @param array $crop
@@ -79,7 +79,7 @@ class Hotspotimage implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $hotspots
+     * @param array[] $hotspots
      *
      * @return $this
      */
@@ -100,7 +100,7 @@ class Hotspotimage implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $marker
+     * @param array[] $marker
      *
      * @return $this
      */
@@ -138,7 +138,7 @@ class Hotspotimage implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $image
+     * @param Asset\Image $image
      *
      * @return $this
      */
@@ -151,7 +151,7 @@ class Hotspotimage implements OwnerAwareFieldInterface
     }
 
     /**
-     * @return Asset|Asset\Image
+     * @return Asset\Image
      */
     public function getImage()
     {
@@ -159,7 +159,7 @@ class Hotspotimage implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param null $thumbnailName
+     * @param string|array|Asset\Image\Thumbnail\Config $thumbnailName
      * @param bool $deferred
      *
      * @return Asset\Image\Thumbnail|string

--- a/models/DataObject/Data/ImageGallery.php
+++ b/models/DataObject/Data/ImageGallery.php
@@ -32,7 +32,7 @@ class ImageGallery implements \Iterator, OwnerAwareFieldInterface
     /**
      * ImageGallery constructor.
      *
-     * @param $items
+     * @param Hotspotimage[] $items
      */
     public function __construct($items)
     {

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -111,7 +111,7 @@ class Link implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $text
+     * @param string $text
      *
      * @return $this
      */
@@ -132,7 +132,7 @@ class Link implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $internalType
+     * @param string $internalType
      *
      * @return $this
      */
@@ -153,7 +153,7 @@ class Link implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $internal
+     * @param string $internal
      *
      * @return $this
      */
@@ -174,7 +174,7 @@ class Link implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $direct
+     * @param string $direct
      *
      * @return $this
      */
@@ -195,7 +195,7 @@ class Link implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $linktype
+     * @param string $linktype
      *
      * @return $this
      */
@@ -216,7 +216,7 @@ class Link implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $target
+     * @param string $target
      *
      * @return $this
      */
@@ -237,7 +237,7 @@ class Link implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $parameters
+     * @param string $parameters
      *
      * @return $this
      */
@@ -258,7 +258,7 @@ class Link implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $anchor
+     * @param string $anchor
      *
      * @return $this
      */
@@ -279,7 +279,7 @@ class Link implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $title
+     * @param string $title
      *
      * @return $this
      */
@@ -300,7 +300,7 @@ class Link implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $accesskey
+     * @param string $accesskey
      *
      * @return $this
      */
@@ -321,7 +321,7 @@ class Link implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $rel
+     * @param string $rel
      *
      * @return $this
      */
@@ -342,7 +342,7 @@ class Link implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $tabindex
+     * @param string $tabindex
      *
      * @return $this
      */
@@ -389,7 +389,7 @@ class Link implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $path
+     * @param string $path
      *
      * @return $this
      */
@@ -499,7 +499,7 @@ class Link implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $object
+     * @param ElementInterface $object
      *
      * @return $this
      */

--- a/models/DataObject/Data/ObjectMetadata.php
+++ b/models/DataObject/Data/ObjectMetadata.php
@@ -66,7 +66,7 @@ class ObjectMetadata extends Model\AbstractModel implements DataObject\OwnerAwar
     /**
      * @param DataObject\Concrete $object
      *
-     * @return $this|void
+     * @return $this
      */
     public function setObject($object)
     {
@@ -75,7 +75,7 @@ class ObjectMetadata extends Model\AbstractModel implements DataObject\OwnerAwar
         if (!$object) {
             $this->setObjectId(null);
 
-            return;
+            return $this;
         }
 
         $this->objectId = $object->getId();
@@ -118,7 +118,7 @@ class ObjectMetadata extends Model\AbstractModel implements DataObject\OwnerAwar
      * @param $object
      * @param string $ownertype
      * @param string $ownername
-     * @param int $position
+     * @param string $position
      * @param int $index
      */
     public function save($object, $ownertype, $ownername, $position, $index)
@@ -132,7 +132,7 @@ class ObjectMetadata extends Model\AbstractModel implements DataObject\OwnerAwar
      * @param string $fieldname
      * @param string $ownertype
      * @param string $ownername
-     * @param int $position
+     * @param string $position
      * @param int $index
      *
      * @return mixed

--- a/models/DataObject/Data/ObjectMetadata.php
+++ b/models/DataObject/Data/ObjectMetadata.php
@@ -84,8 +84,8 @@ class ObjectMetadata extends Model\AbstractModel implements DataObject\OwnerAwar
     }
 
     /**
-     * @param $name
-     * @param $arguments
+     * @param string $name
+     * @param array $arguments
      *
      * @return mixed|void
      *
@@ -117,23 +117,23 @@ class ObjectMetadata extends Model\AbstractModel implements DataObject\OwnerAwar
     /**
      * @param $object
      * @param string $ownertype
-     * @param $ownername
-     * @param $position
-     * @param $index
+     * @param string $ownername
+     * @param int $position
+     * @param int $index
      */
-    public function save($object, $ownertype = 'object', $ownername, $position, $index)
+    public function save($object, $ownertype, $ownername, $position, $index)
     {
         $this->getDao()->save($object, $ownertype, $ownername, $position, $index);
     }
 
     /**
      * @param DataObject\Concrete $source
-     * @param $destinationId
-     * @param $fieldname
-     * @param $ownertype
-     * @param $ownername
-     * @param $position
-     * @param $index
+     * @param int $destinationId
+     * @param string $fieldname
+     * @param string $ownertype
+     * @param string $ownername
+     * @param int $position
+     * @param int $index
      *
      * @return mixed
      */
@@ -143,7 +143,7 @@ class ObjectMetadata extends Model\AbstractModel implements DataObject\OwnerAwar
     }
 
     /**
-     * @param $fieldname
+     * @param string $fieldname
      *
      * @return $this
      */
@@ -201,7 +201,7 @@ class ObjectMetadata extends Model\AbstractModel implements DataObject\OwnerAwar
     }
 
     /**
-     * @param $columns
+     * @param array $columns
      *
      * @return $this
      */
@@ -239,7 +239,7 @@ class ObjectMetadata extends Model\AbstractModel implements DataObject\OwnerAwar
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function __toString()
     {

--- a/models/DataObject/Data/ObjectMetadata/Dao.php
+++ b/models/DataObject/Data/ObjectMetadata/Dao.php
@@ -36,7 +36,7 @@ class Dao extends Model\Dao\AbstractDao
      * @param DataObject\Concrete $object
      * @param string $ownertype
      * @param string $ownername
-     * @param int $position
+     * @param string $position
      * @param int $index
      * @param string $type
      *
@@ -80,7 +80,7 @@ class Dao extends Model\Dao\AbstractDao
      * @param string $fieldname
      * @param string $ownertype
      * @param string $ownername
-     * @param int $position
+     * @param string $position
      * @param int $index
      *
      * @return null|DataObject\Data\ObjectMetadata

--- a/models/DataObject/Data/ObjectMetadata/Dao.php
+++ b/models/DataObject/Data/ObjectMetadata/Dao.php
@@ -28,17 +28,17 @@ class Dao extends Model\Dao\AbstractDao
     use DataObject\ClassDefinition\Helper\Dao;
 
     /**
-     * @var null
+     * @var array|null
      */
     protected $tableDefinitions = null;
 
     /**
      * @param DataObject\Concrete $object
-     * @param $ownertype
-     * @param $ownername
-     * @param $position
-     * @param $index
-     * @param $type
+     * @param string $ownertype
+     * @param string $ownername
+     * @param int $position
+     * @param int $index
+     * @param string $type
      *
      * @throws \Exception
      */
@@ -65,7 +65,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * @param $object
+     * @param DataObject\Concrete $object
      *
      * @return string
      */
@@ -76,12 +76,12 @@ class Dao extends Model\Dao\AbstractDao
 
     /**
      * @param DataObject\Concrete $source
-     * @param $destinationId
-     * @param $fieldname
-     * @param $ownertype
-     * @param $ownername
-     * @param $position
-     * @param $index
+     * @param int $destinationId
+     * @param string $fieldname
+     * @param string $ownertype
+     * @param string $ownername
+     * @param int $position
+     * @param int $index
      *
      * @return null|DataObject\Data\ObjectMetadata
      */

--- a/models/DataObject/Data/QuantityValue.php
+++ b/models/DataObject/Data/QuantityValue.php
@@ -25,7 +25,7 @@ class QuantityValue implements OwnerAwareFieldInterface
     use OwnerAwareFieldTrait;
 
     /**
-     * @var float | string
+     * @var float
      */
     protected $value;
 
@@ -42,7 +42,7 @@ class QuantityValue implements OwnerAwareFieldInterface
     /**
      * QuantityValue constructor.
      *
-     * @param null $value
+     * @param float|null $value
      * @param int|Unit|null $unitId
      */
     public function __construct($value = null, $unitId = null)
@@ -61,7 +61,7 @@ class QuantityValue implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param  $unitId
+     * @param int $unitId
      */
     public function setUnitId($unitId)
     {
@@ -91,7 +91,7 @@ class QuantityValue implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param  $value
+     * @param float $value
      */
     public function setValue($value)
     {

--- a/models/DataObject/Data/RgbaColor.php
+++ b/models/DataObject/Data/RgbaColor.php
@@ -170,7 +170,7 @@ class RgbaColor implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $hexValue
+     * @param string $hexValue
      *
      * @throws \Exception
      */
@@ -196,10 +196,10 @@ class RgbaColor implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param null $r
-     * @param null $g
-     * @param null $b
-     * @param null $a
+     * @param int|null $r
+     * @param int|null $g
+     * @param int|null $b
+     * @param int|null $a
      */
     public function setRgba($r = null, $g = null, $b = null, $a = null)
     {

--- a/models/DataObject/Data/StructuredTable.php
+++ b/models/DataObject/Data/StructuredTable.php
@@ -40,7 +40,7 @@ class StructuredTable implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $data
+     * @param array $data
      *
      * @return $this
      */
@@ -61,8 +61,8 @@ class StructuredTable implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $name
-     * @param $arguments
+     * @param string $name
+     * @param array $arguments
      *
      * @return mixed
      *
@@ -155,8 +155,8 @@ class StructuredTable implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param $rowDefs
-     * @param $colDefs
+     * @param array $rowDefs
+     * @param array $colDefs
      *
      * @return string
      */

--- a/models/DataObject/DirtyIndicatorInterface.php
+++ b/models/DataObject/DirtyIndicatorInterface.php
@@ -25,7 +25,7 @@ interface DirtyIndicatorInterface
     public function hasDirtyFields();
 
     /**
-     * @param $key
+     * @param string $key
      *
      * @return bool
      */
@@ -34,7 +34,7 @@ interface DirtyIndicatorInterface
     /**
      * marks the given field as dirty
      *
-     * @param $field
+     * @param string $field
      * @param bool $dirty
      *
      * @return mixed

--- a/models/DataObject/Fieldcollection.php
+++ b/models/DataObject/Fieldcollection.php
@@ -27,7 +27,7 @@ class Fieldcollection extends Model\AbstractModel implements \Iterator, DirtyInd
     use Model\DataObject\Traits\DirtyIndicatorTrait;
 
     /**
-     * @var array
+     * @var Model\DataObject\Fieldcollection\Data\AbstractData[]
      */
     protected $items = [];
 
@@ -37,7 +37,7 @@ class Fieldcollection extends Model\AbstractModel implements \Iterator, DirtyInd
     protected $fieldname;
 
     /**
-     * @param array $items
+     * @param Model\DataObject\Fieldcollection\Data\AbstractData[] $items
      * @param string|null $fieldname
      */
     public function __construct($items = [], $fieldname = null)
@@ -53,7 +53,7 @@ class Fieldcollection extends Model\AbstractModel implements \Iterator, DirtyInd
     }
 
     /**
-     * @return array
+     * @return Model\DataObject\Fieldcollection\Data\AbstractData[]
      */
     public function getItems()
     {
@@ -61,7 +61,7 @@ class Fieldcollection extends Model\AbstractModel implements \Iterator, DirtyInd
     }
 
     /**
-     * @param $items
+     * @param Model\DataObject\Fieldcollection\Data\AbstractData[] $items
      *
      * @return $this
      */
@@ -107,10 +107,10 @@ class Fieldcollection extends Model\AbstractModel implements \Iterator, DirtyInd
     }
 
     /**
-     * @throws \Exception
-     *
+     * @param Concrete $object
      * @param array $params
-     * @param $object
+     *
+     * @throws \Exception
      */
     public function save($object, $params = [])
     {
@@ -151,7 +151,7 @@ class Fieldcollection extends Model\AbstractModel implements \Iterator, DirtyInd
     }
 
     /**
-     * @param $item
+     * @param Model\DataObject\Fieldcollection\Data\AbstractData $item
      */
     public function add($item)
     {
@@ -161,7 +161,7 @@ class Fieldcollection extends Model\AbstractModel implements \Iterator, DirtyInd
     }
 
     /**
-     * @param $index
+     * @param int $index
      */
     public function remove($index)
     {
@@ -173,33 +173,38 @@ class Fieldcollection extends Model\AbstractModel implements \Iterator, DirtyInd
     }
 
     /**
-     * @param $index
-     * @return Fieldcollection\Data\AbstractData|void
+     * @param int $index
+     *
+     * @return Fieldcollection\Data\AbstractData|null
      */
     public function get($index)
     {
         if ($this->items[$index]) {
             return $this->items[$index];
         }
+
+        return null;
     }
 
     /**
-     * @param $index
-     * @return Fieldcollection\Data\AbstractData|void
+     * @param int $index
+     *
+     * @return Fieldcollection\Data\AbstractData|null
      */
     public function getByOriginalIndex($index) {
         if ($index === null) {
-            return;
+            return null;
         }
 
         if (is_array($this->items)) {
-            /** @var Model\DataObject\Fieldcollection\Data\AbstractData $item */
             foreach ($this->items as $item) {
                 if ($item->getIndex() === $index) {
                     return $item;
                 }
             }
         }
+
+        return null;
     }
 
     /**
@@ -264,19 +269,15 @@ class Fieldcollection extends Model\AbstractModel implements \Iterator, DirtyInd
 
     /**
      * @param Concrete $object
-     * @param $type
-     * @param $fcField
-     * @param $index
-     * @param $field
+     * @param string $type
+     * @param string $fcField
+     * @param int $index
+     * @param string $field
      *
      * @throws \Exception
      */
     public function loadLazyField(Concrete $object, $type, $fcField, $index, $field)
     {
-        /**
-         * @var Model\DataObject\Fieldcollection\Data\AbstractData $item
-         */
-
         // lazy loading existing can be data if the item already had an index
         $item = $this->getByOriginalIndex($index);
         if ($item && !$item->isLazyKeyLoaded($field)) {

--- a/models/DataObject/Fieldcollection/Dao.php
+++ b/models/DataObject/Fieldcollection/Dao.php
@@ -30,7 +30,7 @@ class Dao extends Model\Dao\AbstractDao
 {
     /**
      * @param DataObject\Concrete $object
-     * @param $params mixed
+     * @param array $params
      *
      * @return array
      */
@@ -135,7 +135,7 @@ class Dao extends Model\Dao\AbstractDao
 
     /**
      * @param DataObject\Concrete $object
-     * @param $saveMode true if called from save method
+     * @param bool $saveMode true if called from save method
      *
      * @return array
      */

--- a/models/DataObject/Fieldcollection/Data/AbstractData.php
+++ b/models/DataObject/Fieldcollection/Data/AbstractData.php
@@ -83,7 +83,7 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
     }
 
     /**
-     * @param $fieldname
+     * @param string $fieldname
      *
      * @return $this
      */
@@ -139,7 +139,7 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
 
     /**
      * @param string $fieldName
-     * @param null $language
+     * @param string|null $language
      *
      * @return mixed
      */
@@ -150,8 +150,8 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
 
     /**
      * @param string $fieldName
-     * @param $value
-     * @param null $language
+     * @param mixed $value
+     * @param string|null $language
      *
      * @return mixed
      */

--- a/models/DataObject/Fieldcollection/Data/Dao.php
+++ b/models/DataObject/Fieldcollection/Data/Dao.php
@@ -29,7 +29,7 @@ class Dao extends Model\Dao\AbstractDao
     /**
      * @param Model\DataObject\Concrete $object
      * @param array $params
-     * @param $saveRelationalData
+     * @param bool $saveRelationalData
      *
      * @throws \Exception
      */

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -243,7 +243,7 @@ class Definition extends Model\AbstractModel
     }
 
     /**
-     * @param $key
+     * @param string $key
      *
      * @throws \Exception
      *
@@ -462,9 +462,9 @@ class Definition extends Model\AbstractModel
     }
 
     /**
-     * @param $definition
-     * @param $text
-     * @param $level
+     * @param Definition|DataObject\ClassDefinition\Data $definition
+     * @param string $text
+     * @param int $level
      *
      * @return string
      */

--- a/models/DataObject/Fieldcollection/Definition/Dao.php
+++ b/models/DataObject/Fieldcollection/Definition/Dao.php
@@ -28,7 +28,7 @@ class Dao extends Model\Dao\AbstractDao
     use DataObject\ClassDefinition\Helper\Dao;
 
     /**
-     * @var null
+     * @var array|null
      */
     protected $tableDefinitions = null;
 

--- a/models/DataObject/Folder.php
+++ b/models/DataObject/Folder.php
@@ -43,7 +43,7 @@ class Folder extends AbstractObject
     }
 
     /**
-     * @param null $isUpdate
+     * @param bool|null $isUpdate
      * @param array $params additional parameters (e.g. "versionNote" for the version note)
      *
      * @throws \Exception

--- a/models/DataObject/Listing.php
+++ b/models/DataObject/Listing.php
@@ -81,7 +81,7 @@ class Listing extends Model\Listing\AbstractListing implements AdapterInterface,
     }
 
     /**
-     * @param $unpublished
+     * @param bool $unpublished
      *
      * @return $this
      */
@@ -93,7 +93,7 @@ class Listing extends Model\Listing\AbstractListing implements AdapterInterface,
     }
 
     /**
-     * @param  $objectTypes
+     * @param array $objectTypes
      *
      * @return $this
      */
@@ -113,8 +113,8 @@ class Listing extends Model\Listing\AbstractListing implements AdapterInterface,
     }
 
     /**
-     * @param $key
-     * @param null $value
+     * @param string $key
+     * @param mixed $value
      * @param string $concatenator
      *
      * @return $this
@@ -133,8 +133,8 @@ class Listing extends Model\Listing\AbstractListing implements AdapterInterface,
     }
 
     /**
-     * @param $condition
-     * @param null $conditionVariables
+     * @param string $condition
+     * @param array|null $conditionVariables
      *
      * @return $this
      */
@@ -144,7 +144,7 @@ class Listing extends Model\Listing\AbstractListing implements AdapterInterface,
     }
 
     /**
-     * @param $groupBy
+     * @param string $groupBy
      * @param bool $qoute
      *
      * @return $this

--- a/models/DataObject/Listing/Concrete.php
+++ b/models/DataObject/Listing/Concrete.php
@@ -88,7 +88,7 @@ abstract class Concrete extends Model\DataObject\Listing
     }
 
     /**
-     * @param $className
+     * @param string $className
      *
      * @return $this
      */
@@ -157,8 +157,8 @@ abstract class Concrete extends Model\DataObject\Listing
     private $fieldCollectionConfigs = [];
 
     /**
-     * @param $type
-     * @param null $fieldname
+     * @param string $type
+     * @param string|null $fieldname
      *
      * @throws \Exception
      */
@@ -173,7 +173,7 @@ abstract class Concrete extends Model\DataObject\Listing
     }
 
     /**
-     * @param $fieldCollections
+     * @param array $fieldCollections
      *
      * @return $this
      *
@@ -204,7 +204,7 @@ abstract class Concrete extends Model\DataObject\Listing
     private $objectBrickConfigs = [];
 
     /**
-     * @param $type
+     * @param string $type
      *
      * @throws \Exception
      */
@@ -221,7 +221,7 @@ abstract class Concrete extends Model\DataObject\Listing
     }
 
     /**
-     * @param $objectbricks
+     * @param array $objectbricks
      *
      * @return $this
      *
@@ -255,5 +255,7 @@ abstract class Concrete extends Model\DataObject\Listing
         if (!empty($fieldCollections)) {
             return true;
         }
+
+        return false;
     }
 }

--- a/models/DataObject/Listing/Concrete/Dao.php
+++ b/models/DataObject/Listing/Concrete/Dao.php
@@ -98,7 +98,7 @@ class Dao extends Model\DataObject\Listing\Dao
     /**
      * @return int[]
      *
-     * @throws
+     * @throws \Exception
      */
     public function loadIdList()
     {
@@ -110,16 +110,14 @@ class Dao extends Model\DataObject\Listing\Dao
     }
 
     /**
-     * @param $e
+     * @param \Exception $e
      *
      * @return int[]
      *
-     * @throws
      * @throws \Exception
      */
     protected function exceptionHandler($e)
     {
-
         // create view if it doesn't exist already // HACK
         $pdoMySQL = preg_match('/Base table or view not found/', $e->getMessage());
         $Mysqli = preg_match("/Table (.*) doesn't exist/", $e->getMessage());
@@ -140,7 +138,6 @@ class Dao extends Model\DataObject\Listing\Dao
     /**
      * @return string
      *
-     * @throws \Exception
      * @throws \Exception
      */
     public function getLocalizedBrickLanguage()
@@ -172,7 +169,6 @@ class Dao extends Model\DataObject\Listing\Dao
     /**
      * @return string
      *
-     * @throws \Exception
      * @throws \Exception
      */
     public function getTableName()

--- a/models/DataObject/Listing/Dao.php
+++ b/models/DataObject/Listing/Dao.php
@@ -223,7 +223,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     }
 
     /**
-     * @param $callback Callable
+     * @param callable $callback
      */
     public function onCreateQuery(callable $callback)
     {

--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -55,7 +55,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
      */
     protected $class;
 
-    /** @var mixed */
+    /** @var array */
     protected $context;
 
     /** @var int */
@@ -131,7 +131,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
     }
 
     /**
-     * @param  $item
+     * @param mixed $item
      */
     public function addItem($item)
     {
@@ -167,7 +167,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
      *
      * @internal
      *
-     * @param $loadLazyFields
+     * @param bool $loadLazyFields
      *
      * @return array
      */
@@ -203,6 +203,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
 
     /**
      * @param Concrete $object
+     * @param bool $markAsDirty
      *
      * @return $this
      *
@@ -262,7 +263,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
     /**
      * @throws \Exception
      *
-     * @param null $language
+     * @param string|null $language
      *
      * @return string
      */
@@ -286,7 +287,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
     }
 
     /**
-     * @param $language
+     * @param string $language
      *
      * @return bool
      */
@@ -388,8 +389,8 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
     }
 
     /**
-     * @param $name
-     * @param null $language
+     * @param string $name
+     * @param string|null $language
      * @param bool $ignoreFallbackLanguage
      *
      * @return mixed
@@ -494,10 +495,10 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
     }
 
     /**
-     * @param $name
-     * @param $value
-     * @param null $language
-     * @param $markFieldAsDirty
+     * @param string $name
+     * @param mixed $value
+     * @param string|null $language
+     * @param bool $markFieldAsDirty
      *
      * @return $this
      *
@@ -602,7 +603,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
     }
 
     /**
-     * @return mixed
+     * @return array
      */
     public function getContext()
     {
@@ -610,7 +611,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
     }
 
     /**
-     * @param mixed $context
+     * @param array $context
      */
     public function setContext($context)
     {
@@ -630,9 +631,9 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
     }
 
     /**
-     * @param $language
+     * @param string $language
      *
-     * @return bool|mixed
+     * @return bool
      */
     public function isLanguageDirty($language)
     {
@@ -680,8 +681,8 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
     }
 
     /**
-     * @param $language
-     * @param $dirty
+     * @param string $language
+     * @param bool $dirty
      */
     public function markLanguageAsDirty($language, $dirty = true)
     {

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -34,7 +34,7 @@ class Dao extends Model\Dao\AbstractDao
     use DataObject\ClassDefinition\Helper\Dao;
 
     /**
-     * @var null
+     * @var array|null
      */
     protected $tableDefinitions = null;
 
@@ -394,6 +394,7 @@ class Dao extends Model\Dao\AbstractDao
 
     /**
      * @param bool $deleteQuery
+     * @param bool $isUpdate
      */
     public function delete($deleteQuery = true, $isUpdate = true)
     {

--- a/models/DataObject/Objectbrick.php
+++ b/models/DataObject/Objectbrick.php
@@ -97,7 +97,7 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
     }
 
     /**
-     * @param $items
+     * @param array $items
      *
      * @return $this
      */
@@ -118,7 +118,7 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
     }
 
     /**
-     * @param $fieldname
+     * @param string $fieldname
      *
      * @return $this
      */
@@ -349,7 +349,7 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
 
     /**
      * @param string $fieldName
-     * @param $value
+     * @param mixed $value
      *
      * @return mixed
      */
@@ -358,10 +358,11 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
         return $this->{'set'.ucfirst($fieldName)}($value);
     }
 
-    /** @internal
-     * @param $brick
-     * @param $brickField
-     * @param $field
+    /**
+     * @internal
+     * @param string $brick
+     * @param string $brickField
+     * @param string $field
      *
      * @throws \Exception
      */

--- a/models/DataObject/Objectbrick/Dao.php
+++ b/models/DataObject/Objectbrick/Dao.php
@@ -122,7 +122,7 @@ class Dao extends Model\DataObject\Fieldcollection\Dao
 
     /**
      * @param DataObject\Concrete $object
-     * @param $saveMode true if called from save method
+     * @param bool $saveMode true if called from save method
      */
     public function delete(DataObject\Concrete $object, $saveMode = false)
     {

--- a/models/DataObject/Objectbrick/Data/AbstractData.php
+++ b/models/DataObject/Objectbrick/Data/AbstractData.php
@@ -75,7 +75,7 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
     }
 
     /**
-     * @param $fieldname
+     * @param string $fieldname
      *
      * @return $this
      */
@@ -87,7 +87,7 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
     }
 
     /**
-     * @return
+     * @return string
      */
     public function getType()
     {
@@ -105,7 +105,7 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
     }
 
     /**
-     * @param $doDelete
+     * @param bool $doDelete
      *
      * @return $this
      */
@@ -160,7 +160,7 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
     }
 
     /**
-     * @param $key
+     * @param string $key
      *
      * @return mixed
      *
@@ -237,7 +237,7 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
 
     /**
      * @param string $fieldName
-     * @param $value
+     * @param mixed $value
      *
      * @return mixed
      */

--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -335,8 +335,8 @@ class Dao extends Model\Dao\AbstractDao
 
     /**
      * @param string $field
-     * @param $forOwner
-     * @param $remoteClassId
+     * @param bool $forOwner
+     * @param string $remoteClassId
      *
      * @return array
      */

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -75,7 +75,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
     /**
      * @static
      *
-     * @param $key
+     * @param string $key
      *
      * @return self|null
      */
@@ -288,7 +288,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
     }
 
     /**
-     * @param $definitions
+     * @param array $definitions
      *
      * @return array
      */
@@ -302,8 +302,10 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
         return $result;
     }
 
-    /** Returns a list of classes which need to be "rebuild" because they are affected of changes.
-     * @param $oldObject
+    /**
+     * Returns a list of classes which need to be "rebuild" because they are affected of changes.
+     *
+     * @param self $oldObject
      *
      * @return array
      */
@@ -329,7 +331,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
     }
 
     /**
-     * @param $serializedFilename
+     * @param string $serializedFilename
      */
     private function cleanupOldFiles($serializedFilename)
     {
@@ -432,8 +434,6 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
 
     /**
      * @throws \Exception
-     *
-     * @todo: creates a PHP-Dock with "@return void" (line 351)
      */
     private function createContainerClasses()
     {
@@ -557,8 +557,8 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
     }
 
     /**
-     * @param $classname
-     * @param $fieldname
+     * @param string $classname
+     * @param string $fieldname
      *
      * @return string
      */
@@ -568,8 +568,8 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
     }
 
     /**
-     * @param $classname
-     * @param $fieldname
+     * @param string $classname
+     * @param string $fieldname
      *
      * @return string
      */
@@ -579,7 +579,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
     }
 
     /**
-     * @param $classname
+     * @param string $classname
      *
      * @return string
      */

--- a/models/DataObject/OwnerAwareFieldInterface.php
+++ b/models/DataObject/OwnerAwareFieldInterface.php
@@ -20,11 +20,9 @@ namespace Pimcore\Model\DataObject;
 interface OwnerAwareFieldInterface
 {
     /**
-     * @param $owner
+     * @param mixed $owner
      * @param string $fieldname
-     * @param null $language
-     *
-     * @return mixed
+     * @param string|null $language
      */
     public function setOwner($owner, string $fieldname, $language = null);
 }

--- a/models/DataObject/QuantityValue/Unit/Listing.php
+++ b/models/DataObject/QuantityValue/Unit/Listing.php
@@ -27,7 +27,7 @@ use Pimcore\Model;
 class Listing extends Model\Listing\AbstractListing
 {
     /**
-     * @var array|null
+     * @var Model\DataObject\QuantityValue\Unit[]|null
      * @deprecated use getter/setter methods or $this->data
      */
     protected $units = null;
@@ -38,7 +38,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param $key
+     * @param string $key
      *
      * @return bool
      */
@@ -56,7 +56,7 @@ class Listing extends Model\Listing\AbstractListing
     }
 
     /**
-     * @param array $units
+     * @param Model\DataObject\QuantityValue\Unit[]|null $units
      *
      * @return static
      */

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -266,7 +266,7 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $field
+     * @param string $field
      *
      * @return bool
      */
@@ -278,9 +278,10 @@ class Service extends Model\Element\Service
     /**
      * Language only user for classification store !!!
      *
-     * @param  AbstractObject $object
-     * @param null $fields
-     * @param null $requestedLanguage
+     * @param AbstractObject $object
+     * @param array|null $fields
+     * @param string|null $requestedLanguage
+     * @param array $params
      *
      * @return array
      */
@@ -472,8 +473,8 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $helperDefinitions
-     * @param $key
+     * @param array $helperDefinitions
+     * @param string $key
      *
      * @return bool
      */
@@ -488,9 +489,9 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $helperDefinitions
-     * @param $key
-     * @param $context array
+     * @param array $helperDefinitions
+     * @param string $key
+     * @param array $context
      *
      * @return mixed|null|ConfigElementInterface|ConfigElementInterface[]
      */
@@ -521,10 +522,12 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $object
-     * @param $definition
+     * @param AbstractObject $object
+     * @param array $helperDefinitions
+     * @param string $key
+     * @param array $context
      *
-     * @return null
+     * @return \stdClass|null
      */
     public static function calculateCellValue($object, $helperDefinitions, $key, $context = [])
     {
@@ -565,9 +568,9 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $object
-     * @param $user
-     * @param $type
+     * @param AbstractObject $object
+     * @param Model\User $user
+     * @param string $type
      *
      * @return array|null
      */
@@ -602,8 +605,8 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $classId
-     * @param $permissionSet
+     * @param string $classId
+     * @param array $permissionSet
      *
      * @return array|null
      */
@@ -640,7 +643,7 @@ class Service extends Model\Element\Service
 
     /**
      * @param ClassDefinition $class
-     * @param $bricktype
+     * @param string $bricktype
      *
      * @return int|null|string
      */
@@ -765,7 +768,7 @@ class Service extends Model\Element\Service
     /**
      * @static
      *
-     * @param $object
+     * @param Concrete|string $object
      * @param string|ClassDefinition\Data\Select|ClassDefinition\Data\Multiselect $definition
      *
      * @return array
@@ -806,8 +809,8 @@ class Service extends Model\Element\Service
     /**
      * alias of getOptionsForMultiSelectField
      *
-     * @param $object
-     * @param $fieldname
+     * @param Concrete|string $object
+     * @param string|ClassDefinition\Data\Select|ClassDefinition\Data\Multiselect $fieldname
      *
      * @return array
      */
@@ -819,8 +822,8 @@ class Service extends Model\Element\Service
     /**
      * @static
      *
-     * @param $path
-     * @param null $type
+     * @param string $path
+     * @param string|null $type
      *
      * @return bool
      */
@@ -861,8 +864,8 @@ class Service extends Model\Element\Service
      *  "asset" => array(...)
      * )
      *
-     * @param $object
-     * @param $rewriteConfig
+     * @param AbstractObject $object
+     * @param array $rewriteConfig
      *
      * @return AbstractObject
      */
@@ -949,12 +952,12 @@ class Service extends Model\Element\Service
     /**
      * Returns the fields of a datatype container (e.g. block or localized fields)
      *
-     * @param $layout
-     * @param $targetClass
-     * @param $targetList
-     * @param $insideDataType
+     * @param ClassDefinition\Data $layout
+     * @param string $targetClass
+     * @param ClassDefinition\Data[] $targetList
+     * @param bool $insideDataType
      *
-     * @return mixed
+     * @return ClassDefinition\Data[]
      */
     public static function extractFieldDefinitions($layout, $targetClass, $targetList, $insideDataType)
     {
@@ -991,7 +994,7 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $layout
+     * @param ClassDefinition\Data $layout
      */
     public static function createSuperLayout(&$layout)
     {
@@ -1017,8 +1020,8 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $masterDefinition
-     * @param $layout
+     * @param ClassDefinition\Data[] $masterDefinition
+     * @param ClassDefinition\Data $layout
      *
      * @return bool
      */
@@ -1076,10 +1079,10 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $classId
-     * @param $objectId
+     * @param string $classId
+     * @param int $objectId
      *
-     * @return mixed|null
+     * @return array|null
      */
     public static function getCustomGridFieldDefinitions($classId, $objectId)
     {
@@ -1179,9 +1182,9 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $definition
+     * @param array $definition
      *
-     * @return mixed
+     * @return array
      */
     public static function cloneDefinition($definition)
     {
@@ -1192,9 +1195,9 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $mergedFieldDefinition
-     * @param $customFieldDefinitions
-     * @param $key
+     * @param array $mergedFieldDefinition
+     * @param array $customFieldDefinitions
+     * @param string $key
      */
     private static function mergeFieldDefinition(&$mergedFieldDefinition, &$customFieldDefinitions, $key)
     {
@@ -1222,8 +1225,8 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $layout
-     * @param $fieldDefinitions
+     * @param ClassDefinition\Data $layout
+     * @param ClassDefinition\Data[] $fieldDefinitions
      *
      * @return bool
      */
@@ -1299,10 +1302,10 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $item
+     * @param AbstractObject $item
      * @param int $nr
      *
-     * @return mixed|string
+     * @return string
      *
      * @throws \Exception
      */
@@ -1338,10 +1341,11 @@ class Service extends Model\Element\Service
         return $key;
     }
 
-    /** Enriches the layout definition before it is returned to the admin interface.
-     * @param $layout
-     * @param $object Concrete
-     * @param $context array
+    /**
+     * Enriches the layout definition before it is returned to the admin interface.
+     *
+     * @param Model\DataObject\ClassDefinition\Data $layout
+     * @param Concrete $object
      * @param array $context additional contextual data
      */
     public static function enrichLayoutDefinition(&$layout, $object = null, $context = [])
@@ -1381,9 +1385,9 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $layout
-     * @param $allowedView
-     * @param $allowedEdit
+     * @param Model\DataObject\ClassDefinition\Data $layout
+     * @param array $allowedView
+     * @param array $allowedEdit
      */
     public static function enrichLayoutPermissions(&$layout, $allowedView, $allowedEdit)
     {
@@ -1436,14 +1440,14 @@ class Service extends Model\Element\Service
     /**
      * @param Concrete $object
      * @param array $params
-     * @param $data Model\DataObject\Data\CalculatedValue
+     * @param Model\DataObject\Data\CalculatedValue $data
      *
      * @return string|null
      */
     public static function getCalculatedFieldValueForEditMode($object, $params = [], $data)
     {
         if (!$data) {
-            return;
+            return null;
         }
 
         $fieldname = $data->getFieldname();
@@ -1487,8 +1491,8 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $object
-     * @param $data Model\DataObject\Data\CalculatedValue
+     * @param Concrete $object
+     * @param Model\DataObject\Data\CalculatedValue $data
      *
      * @return mixed|null
      */
@@ -1546,7 +1550,7 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $objectId
+     * @param int $objectId
      *
      * @return mixed|AbstractObject
      */
@@ -1567,7 +1571,7 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $objectId
+     * @param int $objectId
      */
     public static function removeObjectFromSession($objectId)
     {
@@ -1578,8 +1582,8 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param $container
-     * @param $fd
+     * @param Concrete $container
+     * @param ClassDefinition\Data $fd
      */
     public static function doResetDirtyMap($container, $fd)
     {

--- a/models/DataObject/Traits/DirtyIndicatorTrait.php
+++ b/models/DataObject/Traits/DirtyIndicatorTrait.php
@@ -33,7 +33,7 @@ trait DirtyIndicatorTrait
     }
 
     /**
-     * @param $key
+     * @param string $key
      *
      * @return bool
      */
@@ -49,10 +49,8 @@ trait DirtyIndicatorTrait
     /**
      * marks the given field as dirty
      *
-     * @param $field
+     * @param string $field
      * @param bool $dirty
-     *
-     * @return mixed
      */
     public function markFieldDirty($field, $dirty = true)
     {

--- a/models/DataObject/Traits/ElementWithMetadataComparisonTrait.php
+++ b/models/DataObject/Traits/ElementWithMetadataComparisonTrait.php
@@ -23,8 +23,8 @@ use Pimcore\Model\Element\ElementInterface;
 trait ElementWithMetadataComparisonTrait
 {
     /**
-     * @param $array1
-     * @param $array2
+     * @param array $array1
+     * @param array $array2
      *
      * @return bool
      */

--- a/models/DataObject/Traits/ObjectVarTrait.php
+++ b/models/DataObject/Traits/ObjectVarTrait.php
@@ -43,7 +43,7 @@ trait ObjectVarTrait
     }
 
     /**
-     * @param $var
+     * @param string $var
      *
      * @return mixed
      */
@@ -57,11 +57,13 @@ trait ObjectVarTrait
     }
 
     /**
-     * @param $var mixed
-     * @param $value mixed
-     * @param $silent bool
+     * @param string $var
+     * @param mixed $value
+     * @param bool $silent
      *
      * @return $this
+     *
+     * @throws \Exception
      */
     public function setObjectVar($var, $value, bool $silent = false)
     {

--- a/models/DataObject/Traits/OwnerAwareFieldTrait.php
+++ b/models/DataObject/Traits/OwnerAwareFieldTrait.php
@@ -33,14 +33,14 @@ trait OwnerAwareFieldTrait
     protected $_fieldname;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $_language;
 
     /**
-     * @param $owner
+     * @param mixed $owner
      * @param string $fieldname
-     * @param string $language
+     * @param string|null $language
      */
     public function setOwner($owner, string $fieldname, $language = null)
     {

--- a/models/DataObject/Traits/SimpleComparisonTrait.php
+++ b/models/DataObject/Traits/SimpleComparisonTrait.php
@@ -20,8 +20,8 @@ namespace Pimcore\Model\DataObject\Traits;
 trait SimpleComparisonTrait
 {
     /**
-     * @param $oldValue
-     * @param $newValue
+     * @param mixed $oldValue
+     * @param mixed $newValue
      *
      * @return bool
      */


### PR DESCRIPTION
Fix many (not all) phpstan level 2 errors in Pimcore\Model\DataObject namespace with following schema:
```
PHPDoc tag @param has invalid value ($xyz)
```
Before:
```
 [ERROR] Found 2731 errors
```
After:
```
 [ERROR] Found 2267 errors
```