### PR TITLE
Fix wrong objectbricks phpdoc type

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Objectbricks.php
+++ b/models/DataObject/ClassDefinition/Data/Objectbricks.php
@@ -38,7 +38,7 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface
      *
      * @var string
      */
-    public $phpdocType = Objectbrick::class;
+    public $phpdocType = '\\' . Objectbrick::class;
 
     /**
      * @var array


### PR DESCRIPTION
After upgrade to 6.4.0 the return type in phpdocs of objectbricks are without \ at beginning.

![image](https://user-images.githubusercontent.com/998558/72326159-ef95c200-36ae-11ea-8440-eafaea344257.png)