### PR TITLE
Update $context['fieldname'] to $context['containerKey']

### DIFF
--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -351,7 +351,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
             /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $container */
             $container = $brickDef->getFieldDefinition('localizedfields');
         } elseif (isset($context['containerType']) && $context['containerType'] === 'block') {
-            $containerKey = $context['fieldname'];
+            $containerKey = $context['containerKey'];
             $object = $this->getObject();
             /** @var Model\DataObject\ClassDefinition\Data\Block $block */
             $block = $object->getClass()->getFieldDefinition($containerKey);


### PR DESCRIPTION
Update a bug from previous changes for the Block element.
$context['fieldname'] to $context['containerKey']
Regression of #5471 