### PR TITLE
[Data object listings] Prevent name collision for field named "operator"

### DIFF
--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -1026,10 +1026,10 @@ abstract class Data
         $code = '/**' . "\n";
         $code .= '* Filter by ' . str_replace(['/**', '*/', '//'], '', $key) . ' (' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . ")\n";
 
-        $dataParamDoc = 'mixed $'.$key;
+        $dataParamDoc = 'mixed $data';
         $reflectionMethod = new \ReflectionMethod($this, 'addListingFilter');
         if(preg_match('/@param\s+([^\s]+)\s+\$data(.*)/', $reflectionMethod->getDocComment(), $dataParam)) {
-            $dataParamDoc = $dataParam[1].' $'.$key.' '.$dataParam[2];
+            $dataParamDoc = $dataParam[1].' $data '.$dataParam[2];
         }
 
         $operatorParamDoc = 'string $operator SQL comparison operator, e.g. =, <, >= etc. You can use "?" as placeholder, e.g. "IN (?)"';

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -1041,8 +1041,9 @@ abstract class Data
         $code .= '* @param '.$operatorParamDoc."\n";
         $code .= '* @return static'."\n";
         $code .= '*/' . "\n";
-        $code .= 'public function filterBy' . ucfirst($key) .' ($'.$key.', $operator = \'=\') {'."\n";
-        $code .= "\t" . '$this->getClass()->getFieldDefinition("' . $key . '")->addListingFilter($this, $' . $key . ', $operator);' . "\n";
+
+        $code .= 'public function filterBy' . ucfirst($key) .' ($data, $operator = \'=\') {'."\n";
+        $code .= "\t" . '$this->getClass()->getFieldDefinition("' . $key . '")->addListingFilter($this, $data, $operator);' . "\n";
         $code .= "\treturn " . '$this' . ";\n";
         $code .= "}\n\n";
 


### PR DESCRIPTION
Solves #5584 

Now the `filterByXYZ` method always uses parameters `$data`and `operator`. It was not necessary to use the real field name here.