### PR TITLE
[Block] Localized fields inside Block cannot be updated via API

### DIFF
--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -351,7 +351,7 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
             /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $container */
             $container = $brickDef->getFieldDefinition('localizedfields');
         } elseif (isset($context['containerType']) && $context['containerType'] === 'block') {
-            $containerKey = $context['fieldname'];
+            $containerKey = $context['containerKey'];
             $object = $this->getObject();
             /** @var Model\DataObject\ClassDefinition\Data\Block $block */
             $block = $object->getClass()->getFieldDefinition($containerKey);


### PR DESCRIPTION
If you had a localizedfield in the Block "containerType" in your Object, and would insert some Data, you get an error about the fieldDefinition.
So after change to "containerType" they can find the correct fieldDefinition
See: #5581 