### PR TITLE
respect error reporting in installer

### DIFF
--- a/bin/pimcore-install
+++ b/bin/pimcore-install
@@ -44,7 +44,7 @@ if (file_exists($a = getcwd() . '/vendor/autoload.php')) {
 Bootstrap::setProjectRoot();
 Bootstrap::defineConstants();
 
-Debug::enable();
+Debug::enable(PIMCORE_PHP_ERROR_REPORTING);
 
 $kernel = new InstallerKernel(PIMCORE_PROJECT_ROOT, Config::getEnvironment(), true);
 Pimcore::setKernel($kernel);


### PR DESCRIPTION
Regression of #5310 (@blankse): otherwise the installer uses `E_ALL` as default which will rise up all the notice errors while trying to boot the system. 