### PR TITLE
Make the housekeeping maintenance task configurable

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -151,6 +151,7 @@ class Configuration implements ConfigurationInterface
             ->end();
 
         $this->addGeneralNode($rootNode);
+        $this->addMaintenanceNode($rootNode);
         $this->addServicesNode($rootNode);
         $this->addObjectsNode($rootNode);
         $this->addAssetNode($rootNode);
@@ -175,6 +176,30 @@ class Configuration implements ConfigurationInterface
         $this->addApplicationLogNode($rootNode);
 
         return $treeBuilder;
+    }
+
+    /**
+     * Add maintenance config
+     *
+     * @param ArrayNodeDefinition $rootNode
+     */
+    private function addMaintenanceNode(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->children()
+            ->arrayNode('maintenance')
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->arrayNode('housekeeping')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->integerNode('cleanup_tmp_files_atime_older_than')
+                        ->defaultValue(7776000) // 90 days
+                    ->end()
+                    ->integerNode('cleanup_profiler_files_atime_older_than')
+                        ->defaultValue(1800)
+                    ->end()
+        ;
     }
 
     /**

--- a/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -79,6 +79,9 @@ class PimcoreCoreExtension extends ConfigurableExtension implements PrependExten
 
         $container->setParameter('pimcore.mime.extensions', $config['mime']['extensions']);
 
+        $container->setParameter('pimcore.maintenance.housekeeping.cleanup_tmp_files_atime_older_than', $config['maintenance']['housekeeping']['cleanup_tmp_files_atime_older_than']);
+        $container->setParameter('pimcore.maintenance.housekeeping.cleanup_profiler_files_atime_older_than', $config['maintenance']['housekeeping']['cleanup_profiler_files_atime_older_than']);
+
         // register pimcore config on container
         // TODO is this bad practice?
         // TODO only extract what we need as parameter?

--- a/bundles/CoreBundle/Resources/config/maintenance.yml
+++ b/bundles/CoreBundle/Resources/config/maintenance.yml
@@ -93,6 +93,9 @@ services:
             - { name: pimcore.maintenance.task, type: asset_document_convert }
 
     Pimcore\Maintenance\Tasks\HousekeepingTask:
+        arguments:
+            - '%pimcore.maintenance.housekeeping.cleanup_tmp_files_atime_older_than'
+            - '%pimcore.maintenance.housekeeping.cleanup_profiler_files_atime_older_than'
         tags:
             - { name: pimcore.maintenance.task, type: housekeeping }
 

--- a/bundles/CoreBundle/Resources/config/maintenance.yml
+++ b/bundles/CoreBundle/Resources/config/maintenance.yml
@@ -94,8 +94,8 @@ services:
 
     Pimcore\Maintenance\Tasks\HousekeepingTask:
         arguments:
-            - '%pimcore.maintenance.housekeeping.cleanup_tmp_files_atime_older_than'
-            - '%pimcore.maintenance.housekeeping.cleanup_profiler_files_atime_older_than'
+            - '%pimcore.maintenance.housekeeping.cleanup_tmp_files_atime_older_than%'
+            - '%pimcore.maintenance.housekeeping.cleanup_profiler_files_atime_older_than%'
         tags:
             - { name: pimcore.maintenance.task, type: housekeeping }
 

--- a/lib/Maintenance/Tasks/HousekeepingTask.php
+++ b/lib/Maintenance/Tasks/HousekeepingTask.php
@@ -20,35 +20,55 @@ use Pimcore\Maintenance\TaskInterface;
 final class HousekeepingTask implements TaskInterface
 {
     /**
+     * @var int
+     */
+    protected $tmpFileTime;
+
+    /**
+     * @var int
+     */
+    protected $profilerTime;
+
+    /**
+     * @param int $tmpFileTime
+     * @param int $profilerTime
+     */
+    public function __construct(int $tmpFileTime, int $profilerTime)
+    {
+        $this->tmpFileTime = $tmpFileTime;
+        $this->profilerTime = $profilerTime;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function execute()
     {
-        $this->deleteFilesInFolderOlderThanDays(PIMCORE_TEMPORARY_DIRECTORY, 90);
+        $this->deleteFilesInFolderOlderThanSeconds(PIMCORE_TEMPORARY_DIRECTORY, $this->tmpFileTime);
 
         $environments = Config::getEnvironmentConfig()->getProfilerHousekeepingEnvironments();
 
         foreach ($environments as $environment) {
             $profilerDir = sprintf('%s/cache/%s/profiler', PIMCORE_PRIVATE_VAR, $environment);
 
-            $this->deleteFilesInFolderOlderThanDays($profilerDir, 4);
+            $this->deleteFilesInFolderOlderThanSeconds($profilerDir, $this->profilerTime);
         }
     }
 
     /**
      * @param string $folder
-     * @param int $days
+     * @param int $seconds
      */
-    protected function deleteFilesInFolderOlderThanDays($folder, $days)
+    protected function deleteFilesInFolderOlderThanSeconds($folder, $seconds)
     {
         if (!is_dir($folder)) {
             return;
         }
 
         $directory = new \RecursiveDirectoryIterator($folder);
-        $filter = new \RecursiveCallbackFilterIterator($directory, function (\SplFileInfo $current, $key, $iterator) use ($days) {
+        $filter = new \RecursiveCallbackFilterIterator($directory, function (\SplFileInfo $current, $key, $iterator) use ($seconds) {
             if ($current->isFile()) {
-                if ($current->getATime() && $current->getATime() < (time() - ($days * 86400))) {
+                if ($current->getATime() && $current->getATime() < (time() - $seconds)) {
                     return true;
                 }
             } else {


### PR DESCRIPTION
```yml
pimcore: 
  maintenance: 
    housekeeping: 
      cleanup_tmp_files_atime_older_than: 1234 # in seconds
      cleanup_profiler_files_atime_older_than: 6789 # in seconds 
```

Also changed the default value for profiling files to 30 minutes, which should be sufficient for most cases. 