### PR TITLE
Only use active env to rebuild cache in system settings save action

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/Controller/Admin/SettingsController.php
@@ -595,7 +595,7 @@ class SettingsController extends AdminController
         $this->forward(self::class . '::clearCacheAction', [
             'only_symfony_cache' => false,
             'only_pimcore_cache' => false,
-            'env' => array_unique(['dev', 'prod', \Pimcore::getKernel()->getEnvironment()])
+            'env' => [\Pimcore::getKernel()->getEnvironment()]
         ]);
 
         return $this->adminJson(['success' => true]);


### PR DESCRIPTION
As discussed (a lot 😄), this PR only uses the current environment to clear the symfony cache after system settings has been updated. This will improve three things:

- **Performance**: only one cache container gets regenerated instead of two or three
- **Security**: there will be no "dev" container on production or any other environment but on dev only!
- **Stability**: if "prod" is not available in a given installation, this action will fail completely (`Uncaught InvalidConfigurationException: File config_prod.yml  cannot be found`)
 