### PR TITLE
[Admin] Clear cache functionality only for available Symfony environments

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/IndexController.php
+++ b/bundles/AdminBundle/Controller/Admin/IndexController.php
@@ -246,6 +246,7 @@ class IndexController extends AdminController implements EventedControllerInterf
             'devmode' => \Pimcore::inDevMode(),
             'disableMinifyJs' => \Pimcore::disableMinifyJs(),
             'environment' => $kernel->getEnvironment(),
+            'cached_environments' => Tool::getCachedSymfonyEnvironments(),
             'sessionId' => htmlentities(Session::getSessionId(), ENT_QUOTES, 'UTF-8'),
         ]);
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
@@ -911,7 +911,7 @@ pimcore.layout.toolbar = Class.create({
                         cacheSubItems.push({
                             text: t("all_caches") + ' (Symfony + Data)',
                             iconCls: "pimcore_nav_icon_clear_cache",
-                            handler: this.clearCache.bind(this, {'env[]': ['dev','prod']})
+                            handler: this.clearCache.bind(this, {'env[]': pimcore.settings['cached_environments']})
                         });
                     }
 
@@ -924,22 +924,22 @@ pimcore.layout.toolbar = Class.create({
                     }
 
                     if (perspectiveCfg.inToolbar("settings.cache.clearSymfony")) {
-                        cacheSubItems.push({
-                            text: 'Symfony ' + t('environment') + ": prod",
-                            iconCls: "pimcore_nav_icon_clear_cache",
-                            handler: this.clearCache.bind(this, {'only_symfony_cache': true, 'env[]': 'prod'})
-                        });
 
-                        cacheSubItems.push({
-                            text: 'Symfony ' + t('environment') + ": " + pimcore.settings['environment'],
-                            iconCls: "pimcore_nav_icon_clear_cache",
-                            handler: this.clearCache.bind(this, {'only_symfony_cache': true, 'env[]': pimcore.settings['environment']})
-                        });
+                        pimcore.settings['cached_environments'].forEach(function(environment) {
+                            cacheSubItems.push({
+                                text: 'Symfony ' + t('environment') + ": " + environment,
+                                iconCls: "pimcore_nav_icon_clear_cache",
+                                handler: this.clearCache.bind(this, {
+                                    'only_symfony_cache': true,
+                                    'env[]': environment
+                                })
+                            });
+                        }.bind(this));
 
                         cacheSubItems.push({
                             text: 'Symfony ' + t('environment') + ": " + t('all'),
                             iconCls: "pimcore_nav_icon_clear_cache",
-                            handler: this.clearCache.bind(this, {'only_symfony_cache': true, 'env[]': ['dev','prod']})
+                            handler: this.clearCache.bind(this, {'only_symfony_cache': true, 'env[]': pimcore.settings['cached_environments']})
                         });
                     }
 

--- a/lib/Tool.php
+++ b/lib/Tool.php
@@ -700,6 +700,19 @@ class Tool
     }
 
     /**
+     * @return array
+     */
+    public static function getCachedSymfonyEnvironments():array
+    {
+        $dirs = glob(PIMCORE_SYMFONY_CACHE_DIRECTORY . '/*', GLOB_ONLYDIR);
+        if (($key = array_search(PIMCORE_CACHE_DIRECTORY, $dirs)) !== false) {
+            unset($dirs[$key]);
+        }
+        $dirs = array_map('basename', $dirs);
+        return $dirs;
+    }
+
+    /**
      * @param string $message
      */
     public static function exitWithError($message)


### PR DESCRIPTION
Currently it is hardcoded to `['dev','prod']`