### PR TITLE
[Translation] Fix pluralization

### DIFF
--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -16,7 +16,6 @@ namespace Pimcore\Translation;
 
 use Pimcore\Cache;
 use Pimcore\Model\Translation\AbstractTranslation;
-use Pimcore\Model\Translation\TranslationInterface;
 use Pimcore\Tool;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
@@ -25,14 +24,9 @@ use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Symfony\Contracts\Translation\TranslatorTrait;
 
 class Translator implements LegacyTranslatorInterface, TranslatorInterface, TranslatorBagInterface
 {
-    use TranslatorTrait {
-        trans as protected doTrans;
-    }
-
     /**
      * @var TranslatorInterface|TranslatorBagInterface
      */
@@ -103,7 +97,7 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
         $this->lazyInitialize($domain, $locale);
 
         if (isset($parameters['%count%'])) {
-            $id = $this->doTrans($id, $parameters, $domain, $locale);
+            $id = $this->translator->trans($id, $parameters, $domain, $locale);
         }
 
         $term = $this->getFromCatalogue($catalogue, $id, $domain, $locale);


### PR DESCRIPTION
## Changes in this pull request  
Partly resolves #4979

It isn't possible now to use translation pluralization from symfony.

message.de.xlf
```
<?xml version="1.0"?>
<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
    <file source-language="en" datatype="plaintext" original="file.ext">
        <body>
            <trans-unit id="1">
                <source>{0} Maximum number of participants reached.|{1} One registration possible.|]1,Inf[ %count% more registrations possible.</source>
                <target>{0} Maximale Teilnehmerzahl erreicht.|{1} Noch eine Anmeldung möglich.|]1,Inf[ Noch %count% Anmeldungen möglich.</target>
            </trans-unit>
        </body>
    </file>
</xliff>
```

template.html.twig
```
{{ '{0} Maximum number of participants reached.|{1} One registration possible.|]1,Inf[ %count% more registrations possible.'|trans({'%count%': count}) }}
```

## Additional info  
It would be nice to use always the trans method from symfony. So we can use the new pluralization format from symfony:
https://symfony.com/doc/4.4/translation/message_format.html
