### PR TITLE
Fix array key in relation editable docs

### DIFF
--- a/doc/Development_Documentation/03_Documents/01_Editables/12_Relation_(Many-To-One).md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/12_Relation_(Many-To-One).md
@@ -70,7 +70,7 @@ options in the editable configuration.
 {{ pimcore_relation("myRelation",{
     "types": ["asset","object"],
     "subtypes": {
-        "assets": ["video", "image"],
+        "asset": ["video", "image"],
         "object": ["object"],
     },
     "classes": ["person"]


### PR DESCRIPTION
The array key is correct in the PHP code example (few lines above) but wrong in the Twig example.

It's wrong in the docs of v6.x, too. Should I create a PR with a fix targeting the master branch or do you merge the branches somehow?