### PR TITLE
[Elements] Sanitize path via getValidKey()

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -224,7 +224,7 @@ class Asset extends Element\AbstractElement
      */
     public static function getByPath($path, $force = false)
     {
-        $path = Element\Service::correctPath($path);
+        $path = Element\Service::correctPath($path, 'asset');
 
         try {
             $asset = new Asset();

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -277,7 +277,7 @@ class Service extends Model\Element\Service
      */
     public static function pathExists($path, $type = null)
     {
-        $path = Element\Service::correctPath($path);
+        $path = Element\Service::correctPath($path, 'asset');
 
         try {
             $asset = new Asset();

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -327,7 +327,7 @@ class AbstractObject extends Model\Element\AbstractElement
      */
     public static function getByPath($path, $force = false)
     {
-        $path = Model\Element\Service::correctPath($path);
+        $path = Model\Element\Service::correctPath($path, 'object');
 
         try {
             $object = new self();

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -831,7 +831,7 @@ class Service extends Model\Element\Service
      */
     public static function pathExists($path, $type = null)
     {
-        $path = Element\Service::correctPath($path);
+        $path = Element\Service::correctPath($path, 'object');
 
         try {
             $object = new AbstractObject();

--- a/models/Document.php
+++ b/models/Document.php
@@ -217,7 +217,7 @@ class Document extends Element\AbstractElement
      */
     public static function getByPath($path, $force = false)
     {
-        $path = Element\Service::correctPath($path);
+        $path = Element\Service::correctPath($path, 'document');
 
         $cacheKey = 'document_path_' . md5($path);
 

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -340,7 +340,7 @@ class Service extends Model\Element\Service
      */
     public static function pathExists($path, $type = null)
     {
-        $path = Element\Service::correctPath($path);
+        $path = Element\Service::correctPath($path, 'document');
 
         try {
             $document = new Document();

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -734,13 +734,14 @@ class Service extends Model\AbstractModel
      * @static
      *
      * @param string $path
+     * @param string $elementType object / asset / document
      *
      * @return string
      */
-    public static function correctPath($path)
+    public static function correctPath($path, $elementType = null)
     {
         // remove trailing slash
-        if ($path != '/') {
+        if ($path !== '/') {
             $path = rtrim($path, '/ ');
         }
 
@@ -750,6 +751,12 @@ class Service extends Model\AbstractModel
         if (strpos($path, '%') !== false) {
             $path = rawurldecode($path);
         }
+
+        $pathParts = explode('/', $path);
+        $pathParts = array_map(static function($pathPart) use ($elementType) {
+            return self::getValidKey($pathPart, $elementType);
+        }, $pathParts);
+        $path = implode('/', $pathParts);
 
         return $path;
     }


### PR DESCRIPTION
This PR enables Pimcore\Model\Element\Service::correctPath() to sanitize the path via getValidKey method of each path part. This allows querying objects like 
```php
Concrete::getByPath('/trailing-whitespace /abc')
```
This will find an object with path `/trailing-whitespace/abc`