### PR TITLE
[Data objects] Allow %_locale in data object preview URL

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -2049,7 +2049,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 // replace named variables
                 $vars = $object->getObjectVars();
                 foreach ($vars as $key => $value) {
-                    if (!empty($value) && (is_string($value) || is_numeric($value))) {
+                    if (!empty($value) && \is_scalar($value)) {
                         $url = str_replace('%' . $key, urlencode($value), $url);
                     } else {
                         if (strpos($url, '%' . $key) !== false) {
@@ -2057,6 +2057,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                         }
                     }
                 }
+                $url = str_replace('%_locale', $this->getAdminUser()->getLanguage(), $url);
             } elseif ($linkGenerator = $object->getClass()->getLinkGenerator()) {
                 $url = $linkGenerator->generate($object, ['preview' => true, 'context' => $this]);
             }

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/05_Preview.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/05_Preview.md
@@ -20,6 +20,8 @@ example `o_id`, `o_key`, ...
 Placeholders have the same syntax as you already know from the custom routes, just put a `%` in front of the property 
 name. 
 
+If you want to use the current user's language you can use `%_locale` as placeholder.
+
 When opening the preview tab in an object, the placeholders are replaced with the current values of the object and the 
 URL is opened in the tab. Only if you configure a preview URL in the class configuration, the preview tab is shown!
 


### PR DESCRIPTION
Allow `%_locale` as variable in data object's preview URL. Of course you could use a link generator but often it is easier (and configurable via GUI) to enter a URL with placeholders.