### PR TITLE
Thumbnail config name should be copyable

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/thumbnail/item.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/thumbnail/item.js
@@ -92,7 +92,7 @@ pimcore.settings.thumbnail.item = Class.create({
                 value: this.data.name,
                 fieldLabel: t("name"),
                 width: 450,
-                disabled: true
+                readOnly: true
             },
                 {
                     xtype: "textarea",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/videothumbnail/item.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/videothumbnail/item.js
@@ -99,7 +99,7 @@ pimcore.settings.videothumbnail.item = Class.create({
                 value: this.data.name,
                 fieldLabel: t("name"),
                 width: 450,
-                disabled: true
+                readOnly: true
             }, {
                 xtype: "textarea",
                 name: "description",


### PR DESCRIPTION
(Image / Video) Thumbnail config name should be copyable.