### PR TITLE
[Data objects] Open element when double-clicking relation item

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/abstractRelations.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/abstractRelations.js
@@ -194,6 +194,13 @@ pimcore.object.tags.abstractRelations = Class.create(pimcore.object.tags.abstrac
         }
 
         this.batchWin.close();
-    }
+    },
 
+    gridRowDblClickHandler: function(component, record) {
+        var subtype = record.get('subtype');
+        if (record.get('type') === "object" && record.get('subtype') !== "folder") {
+            subtype = "object";
+        }
+        pimcore.helpers.openElement(record.get('id'), record.get('type'), subtype);
+    }
 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -398,13 +398,7 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
                 this.cellEditing
             ],
             listeners: {
-                rowdblclick: function(component, record) {
-                    var subtype = record.get('subtype');
-                    if (record.get('type') == "object" && record.get('subtype') != "folder") {
-                        subtype = "object";
-                    }
-                    pimcore.helpers.openElement(record.get('id'), record.get('type'), subtype);
-                }
+                rowdblclick: this.gridRowDblClickHandler
             }
         });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -396,7 +396,16 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
             bodyCls: "pimcore_object_tag_objects pimcore_editable_grid",
             plugins: [
                 this.cellEditing
-            ]
+            ],
+            listeners: {
+                rowdblclick: function(component, record) {
+                    var subtype = record.get('subtype');
+                    if (record.get('type') == "object" && record.get('subtype') != "folder") {
+                        subtype = "object";
+                    }
+                    pimcore.helpers.openElement(record.get('id'), record.get('type'), subtype);
+                }
+            }
         });
 
         if (!readOnly) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -389,7 +389,16 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
             bodyCls: "pimcore_object_tag_objects pimcore_editable_grid",
             plugins: [
                 this.cellEditing
-            ]
+            ],
+            listeners: {
+                rowdblclick: function(component, record) {
+                    var subtype = record.get('subtype');
+                    if (record.get('type') == "object" && record.get('subtype') != "folder") {
+                        subtype = "object";
+                    }
+                    pimcore.helpers.openObject(record.get('id'), record.get('type'), subtype);
+                }
+            }
         });
 
         this.component.on("rowcontextmenu", this.onRowContextmenu.bind(this));

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -391,13 +391,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
                 this.cellEditing
             ],
             listeners: {
-                rowdblclick: function(component, record) {
-                    var subtype = record.get('subtype');
-                    if (record.get('type') == "object" && record.get('subtype') != "folder") {
-                        subtype = "object";
-                    }
-                    pimcore.helpers.openObject(record.get('id'), record.get('type'), subtype);
-                }
+                rowdblclick: this.gridRowDblClickHandler
             }
         });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -457,13 +457,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
             },
             bodyCssClass: "pimcore_object_tag_objects",
             listeners: {
-                rowdblclick: function(component, record) {
-                    var subtype = record.get('subtype');
-                    if (record.get('type') == "object" && record.get('subtype') != "folder") {
-                        subtype = "object";
-                    }
-                    pimcore.helpers.openElement(record.get('id'), record.get('type'), subtype);
-                }
+                rowdblclick: this.gridRowDblClickHandler
             }
         });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -455,7 +455,16 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                 ctCls: "pimcore_force_auto_width",
                 cls: "pimcore_force_auto_width"
             },
-            bodyCssClass: "pimcore_object_tag_objects"
+            bodyCssClass: "pimcore_object_tag_objects",
+            listeners: {
+                rowdblclick: function(component, record) {
+                    var subtype = record.get('subtype');
+                    if (record.get('type') == "object" && record.get('subtype') != "folder") {
+                        subtype = "object";
+                    }
+                    pimcore.helpers.openElement(record.get('id'), record.get('type'), subtype);
+                }
+            }
         });
 
         this.component.on("rowcontextmenu", this.onRowContextmenu);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -409,6 +409,15 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
                         this.requestNicePathData(this.store.data);
                     }.bind(this)
                 }
+            },
+            listeners: {
+                rowdblclick: function(component, record) {
+                    var subtype = record.get('subtype');
+                    if (record.get('type') == "object" && record.get('subtype') != "folder") {
+                        subtype = "object";
+                    }
+                    pimcore.helpers.openElement(record.get('id'), record.get('type'), subtype);
+                }
             }
         });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -411,13 +411,7 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
                 }
             },
             listeners: {
-                rowdblclick: function(component, record) {
-                    var subtype = record.get('subtype');
-                    if (record.get('type') == "object" && record.get('subtype') != "folder") {
-                        subtype = "object";
-                    }
-                    pimcore.helpers.openElement(record.get('id'), record.get('type'), subtype);
-                }
+                rowdblclick: this.gridRowDblClickHandler
             }
         });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -87,7 +87,6 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
             this.component.addCls("strikeThrough");
         }
         this.component.on("render", function (el) {
-
             // add drop zone
             new Ext.dd.DropZone(el.getEl(), {
                 reference: this,
@@ -108,6 +107,14 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
 
             el.getEl().on("contextmenu", this.onContextMenu.bind(this));
 
+            el.getEl().on('dblclick', function(){
+                var subtype = this.data.subtype;
+                if (this.data.type == "object" && this.data.subtype != "folder") {
+                    subtype = "object";
+                }
+
+                pimcore.helpers.openElement(this.data.id, this.data.type, subtype);
+            }.bind(this));
         }.bind(this));
 
         // disable typing into the textfield

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/reverseManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/reverseManyToManyObjectRelation.js
@@ -204,13 +204,7 @@ pimcore.object.tags.reverseManyToManyObjectRelation = Class.create(pimcore.objec
                 }
             },
             listeners: {
-                rowdblclick: function(component, record) {
-                    var subtype = record.get('subtype');
-                    if (record.get('type') == "object" && record.get('subtype') != "folder") {
-                        subtype = "object";
-                    }
-                    pimcore.helpers.openObject(record.get('id'), record.get('type'), subtype);
-                }
+                rowdblclick: this.gridRowDblClickHandler
             }
         });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/reverseManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/reverseManyToManyObjectRelation.js
@@ -202,6 +202,15 @@ pimcore.object.tags.reverseManyToManyObjectRelation = Class.create(pimcore.objec
                         this.requestNicePathData(this.store.data);
                     }.bind(this)
                 }
+            },
+            listeners: {
+                rowdblclick: function(component, record) {
+                    var subtype = record.get('subtype');
+                    if (record.get('type') == "object" && record.get('subtype') != "folder") {
+                        subtype = "object";
+                    }
+                    pimcore.helpers.openObject(record.get('id'), record.get('type'), subtype);
+                }
             }
         });
 


### PR DESCRIPTION
Originally I was annoyed of an advanced many-to-many relation with a lot of meta fields. When you want to open the related object you have to scroll to the complete right. This PR adds support for opening the related element via double-click.
To be consistent I also implemented this behaviour for all other relational types.