### PR TITLE
[Ecommerce][FilterService] Improve extensibility of filter types

### DIFF
--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterService.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterService.php
@@ -125,7 +125,7 @@ class FilterService
      *
      * @return array
      */
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         return $this
             ->getFilterType($filterDefinition->getType())

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterService.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterService.php
@@ -120,9 +120,8 @@ class FilterService
      * Returns filter data for given filter type (delegates)
      *
      * @param AbstractFilterDefinitionType $filterDefinition filter definition to get frontend script for
-     * @param ProductListInterface $productList                      current product list (with all set filters) to get
-     *                                                       available options and counts
-     * @param array $currentFilter                           current filter for this filter definition
+     * @param ProductListInterface $productList current product list (with all set filters) to get available options and counts
+     * @param array $currentFilter current filter for this filter definition
      *
      * @return array
      */

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterService.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterService.php
@@ -101,7 +101,7 @@ class FilterService
     }
 
     /**
-     * Returns filter frontend script for given filter type (delegates )
+     * Returns filter frontend script for given filter type (delegates)
      *
      * @param AbstractFilterDefinitionType $filterDefinition filter definition to get frontend script for
      * @param ProductListInterface $productList current product list (with all set filters) to get available options and counts
@@ -114,6 +114,23 @@ class FilterService
         return $this
             ->getFilterType($filterDefinition->getType())
             ->getFilterFrontend($filterDefinition, $productList, $currentFilter);
+    }
+
+    /**
+     * Returns filter data for given filter type (delegates)
+     *
+     * @param AbstractFilterDefinitionType $filterDefinition filter definition to get frontend script for
+     * @param ProductListInterface $productList                      current product list (with all set filters) to get
+     *                                                       available options and counts
+     * @param array $currentFilter                           current filter for this filter definition
+     *
+     * @return array
+     */
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    {
+        return $this
+            ->getFilterType($filterDefinition->getType())
+            ->getFilterArray($filterDefinition, $productList, $currentFilter);
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterService.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterService.php
@@ -126,11 +126,11 @@ class FilterService
      *
      * @return array
      */
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         return $this
             ->getFilterType($filterDefinition->getType())
-            ->getFilterArray($filterDefinition, $productList, $currentFilter);
+            ->getFilterValues($filterDefinition, $productList, $currentFilter);
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/AbstractFilterType.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/AbstractFilterType.php
@@ -108,15 +108,33 @@ abstract class AbstractFilterType
      * renders and returns the rendered html snippet for the current filter
      * based on settings in the filter definition and the current filter params.
      *
-     * @abstract
-     *
      * @param AbstractFilterDefinitionType $filterDefinition
      * @param ProductListInterface $productList
      * @param array $currentFilter
      *
      * @return string
      */
-    abstract public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter);
+    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    {
+        return $this->render(
+            $this->getTemplate($filterDefinition),
+            $this->getFilterArray($filterDefinition, $productList, $currentFilter)
+        );
+    }
+
+    /**
+     * returns the raw data for the current filter based on settings in the
+     * filter definition and the current filter params.
+     *
+     * @abstract
+     *
+     * @param AbstractFilterDefinitionType $filterDefinition
+     * @param ProductListInterface $productList
+     * @param array $currentFilter
+     *
+     * @return array
+     */
+    abstract public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter);
 
     /**
      * adds necessary conditions to the product list implementation based on the currently set filter params.

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/AbstractFilterType.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/AbstractFilterType.php
@@ -134,7 +134,7 @@ abstract class AbstractFilterType
      *
      * @return array
      */
-    abstract public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter);
+    abstract public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array;
 
     /**
      * adds necessary conditions to the product list implementation based on the currently set filter params.

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/AbstractFilterType.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/AbstractFilterType.php
@@ -118,7 +118,7 @@ abstract class AbstractFilterType
     {
         return $this->render(
             $this->getTemplate($filterDefinition),
-            $this->getFilterArray($filterDefinition, $productList, $currentFilter)
+            $this->getFilterValues($filterDefinition, $productList, $currentFilter)
         );
     }
 
@@ -134,7 +134,7 @@ abstract class AbstractFilterType
      *
      * @return array
      */
-    abstract public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter);
+    abstract public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter);
 
     /**
      * adds necessary conditions to the product list implementation based on the currently set filter params.

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/SelectCategory.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/SelectCategory.php
@@ -35,7 +35,7 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
      *
      * @throws \Exception
      */
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $rawValues = $productList->getGroupBySystemValues($filterDefinition->getField(), true);
         $values = [];

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/SelectCategory.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/SelectCategory.php
@@ -31,11 +31,11 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
      * @param ProductListInterface $productList
      * @param array $currentFilter
      *
-     * @return string
+     * @return array
      *
      * @throws \Exception
      */
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $rawValues = $productList->getGroupBySystemValues($filterDefinition->getField(), true);
         $values = [];
@@ -44,7 +44,7 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
             $values[$v['value']] = ['value' => $v['value'], 'count' => $v['count']];
         }
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$filterDefinition->getField()],
@@ -54,7 +54,7 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
             'fieldname' => $filterDefinition->getField(),
             'rootCategory' => $filterDefinition->getRootCategory(),
             'resultCount' => $productList->count(),
-        ]);
+        ];
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/SelectCategory.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/SelectCategory.php
@@ -35,7 +35,7 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
      *
      * @throws \Exception
      */
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $rawValues = $productList->getGroupBySystemValues($filterDefinition->getField(), true);
         $values = [];

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/SelectClassificationStoreAttributes.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/SelectClassificationStoreAttributes.php
@@ -85,10 +85,7 @@ class SelectClassificationStoreAttributes extends AbstractFilterType
         }
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
         $keysField = $field . '.keys';
@@ -118,13 +115,13 @@ class SelectClassificationStoreAttributes extends AbstractFilterType
 
         $keyCollection = $this->sortResult($filterDefinition, $keyCollection);
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'label' => $filterDefinition->getLabel(),
             'fieldname' => $field,
             'currentValue' => $currentFilter[$field],
             'values' => $keyCollection,
             'metaData' => $filterDefinition->getMetaData(),
-        ]);
+        ];
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/SelectClassificationStoreAttributes.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/SelectClassificationStoreAttributes.php
@@ -85,7 +85,7 @@ class SelectClassificationStoreAttributes extends AbstractFilterType
         }
     }
 
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $field = $this->getField($filterDefinition);
         $keysField = $field . '.keys';

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/SelectClassificationStoreAttributes.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/SelectClassificationStoreAttributes.php
@@ -85,7 +85,7 @@ class SelectClassificationStoreAttributes extends AbstractFilterType
         }
     }
 
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
         $keysField = $field . '.keys';

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelect.php
@@ -30,7 +30,7 @@ class MultiSelect extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService
      *
      * @throws \Exception
      */
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $field = $this->getField($filterDefinition);
 

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelect.php
@@ -30,7 +30,7 @@ class MultiSelect extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService
      *
      * @throws \Exception
      */
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
 

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelect.php
@@ -26,11 +26,11 @@ class MultiSelect extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService
      * @param ProductListInterface $productList
      * @param array $currentFilter
      *
-     * @return string
+     * @return array
      *
      * @throws \Exception
      */
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
 
@@ -59,22 +59,22 @@ class MultiSelect extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService
             }
         }
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$field],
             'values' => $values,
             'fieldname' => $field,
             'resultCount' => $productList->count(),
-        ]);
+        ];
     }
 
     /**
      * @param FilterMultiSelect $filterDefinition
-     * @param ProductListInterface                 $productList
-     * @param array                                             $currentFilter
-     * @param array                                             $params
-     * @param bool                                              $isPrecondition
+     * @param ProductListInterface $productList
+     * @param array $currentFilter
+     * @param array $params
+     * @param bool $isPrecondition
      *
      * @return mixed
      */

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelectRelation.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelectRelation.php
@@ -32,7 +32,7 @@ class MultiSelectRelation extends \Pimcore\Bundle\EcommerceFrameworkBundle\Filte
      *
      * @throws \Exception
      */
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
         $values = $productList->getGroupByValues($field, true, !$filterDefinition->getUseAndCondition());

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelectRelation.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelectRelation.php
@@ -28,11 +28,11 @@ class MultiSelectRelation extends \Pimcore\Bundle\EcommerceFrameworkBundle\Filte
      * @param ProductListInterface $productList
      * @param array $currentFilter
      *
-     * @return string
+     * @return array
      *
      * @throws \Exception
      */
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
         $values = $productList->getGroupByValues($field, true, !$filterDefinition->getUseAndCondition());
@@ -74,7 +74,7 @@ class MultiSelectRelation extends \Pimcore\Bundle\EcommerceFrameworkBundle\Filte
 
         Logger::info('done.');
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$field],
@@ -82,7 +82,7 @@ class MultiSelectRelation extends \Pimcore\Bundle\EcommerceFrameworkBundle\Filte
             'objects' => $objects,
             'fieldname' => $field,
             'resultCount' => $productList->count(),
-        ]);
+        ];
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelectRelation.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelectRelation.php
@@ -32,7 +32,7 @@ class MultiSelectRelation extends \Pimcore\Bundle\EcommerceFrameworkBundle\Filte
      *
      * @throws \Exception
      */
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $field = $this->getField($filterDefinition);
         $values = $productList->getGroupByValues($field, true, !$filterDefinition->getUseAndCondition());

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRange.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRange.php
@@ -30,11 +30,11 @@ class NumberRange extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService
      * @param ProductListInterface $productList
      * @param array $currentFilter
      *
-     * @return string
+     * @return array
      *
      * @throws \Exception
      */
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $currentField = $this->getField($filterDefinition);
         $values = [];
@@ -62,7 +62,7 @@ class NumberRange extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService
             }
         }
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$this->getField($filterDefinition)],
@@ -70,7 +70,7 @@ class NumberRange extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService
             'definition' => $filterDefinition,
             'fieldname' => $this->getField($filterDefinition),
             'resultCount' => $productList->count(),
-        ]);
+        ];
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRange.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRange.php
@@ -34,7 +34,7 @@ class NumberRange extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService
      *
      * @throws \Exception
      */
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $currentField = $this->getField($filterDefinition);
         $values = [];

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRange.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRange.php
@@ -34,7 +34,7 @@ class NumberRange extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService
      *
      * @throws \Exception
      */
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $currentField = $this->getField($filterDefinition);
         $values = [];

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRangeSelection.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRangeSelection.php
@@ -35,7 +35,7 @@ class NumberRangeSelection extends \Pimcore\Bundle\EcommerceFrameworkBundle\Filt
      *
      * @throws \Exception
      */
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $ranges = $filterDefinition->getRanges();
         $groupByValues = $productList->getGroupByValues($filterDefinition->getField(), true);

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRangeSelection.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRangeSelection.php
@@ -35,7 +35,7 @@ class NumberRangeSelection extends \Pimcore\Bundle\EcommerceFrameworkBundle\Filt
      *
      * @throws \Exception
      */
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $ranges = $filterDefinition->getRanges();
         $groupByValues = $productList->getGroupByValues($filterDefinition->getField(), true);

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRangeSelection.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRangeSelection.php
@@ -31,11 +31,11 @@ class NumberRangeSelection extends \Pimcore\Bundle\EcommerceFrameworkBundle\Filt
      * @param ProductListInterface $productList
      * @param array $currentFilter
      *
-     * @return string
+     * @return array
      *
      * @throws \Exception
      */
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $ranges = $filterDefinition->getRanges();
         $groupByValues = $productList->getGroupByValues($filterDefinition->getField(), true);
@@ -72,7 +72,7 @@ class NumberRangeSelection extends \Pimcore\Bundle\EcommerceFrameworkBundle\Filt
             $currentValue = implode('-', $currentFilter[$filterDefinition->getField()]);
         }
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentValue,
@@ -82,7 +82,7 @@ class NumberRangeSelection extends \Pimcore\Bundle\EcommerceFrameworkBundle\Filt
             'definition' => $filterDefinition,
             'fieldname' => $filterDefinition->getField(),
             'resultCount' => $productList->count(),
-        ]);
+        ];
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/SelectCategory.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/SelectCategory.php
@@ -34,11 +34,11 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
      * @param ProductListInterface $productList
      * @param array $currentFilter
      *
-     * @return string
+     * @return array
      *
      * @throws \Exception
      */
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $rawValues = $productList->getGroupByValues(self::FIELDNAME, true);
         $values = [];
@@ -47,7 +47,7 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
             $values[$v['label']] = ['value' => $v['label'], 'count' => $v['count']];
         }
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$filterDefinition->getField()],
@@ -55,7 +55,7 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
             'fieldname' => self::FIELDNAME,
             'rootCategory' => $filterDefinition->getRootCategory(),
             'resultCount' => $productList->count(),
-        ]);
+        ];
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/SelectCategory.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/SelectCategory.php
@@ -38,7 +38,7 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
      *
      * @throws \Exception
      */
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $rawValues = $productList->getGroupByValues(self::FIELDNAME, true);
         $values = [];

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/SelectCategory.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/SelectCategory.php
@@ -38,7 +38,7 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
      *
      * @throws \Exception
      */
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $rawValues = $productList->getGroupByValues(self::FIELDNAME, true);
         $values = [];

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/SelectRelation.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/SelectRelation.php
@@ -33,11 +33,11 @@ class SelectRelation extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
      * @param ProductListInterface $productList
      * @param array $currentFilter
      *
-     * @return string
+     * @return array
      *
      * @throws \Exception
      */
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
 
@@ -58,7 +58,7 @@ class SelectRelation extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
         }
         Logger::info('done.');
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$field],
@@ -66,7 +66,7 @@ class SelectRelation extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
             'objects' => $objects,
             'fieldname' => $field,
             'resultCount' => $productList->count(),
-        ]);
+        ];
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/SelectRelation.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/SelectRelation.php
@@ -37,7 +37,7 @@ class SelectRelation extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
      *
      * @throws \Exception
      */
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $field = $this->getField($filterDefinition);
 

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/SelectRelation.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/SelectRelation.php
@@ -37,7 +37,7 @@ class SelectRelation extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
      *
      * @throws \Exception
      */
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
 

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Input.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Input.php
@@ -19,7 +19,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class Input extends AbstractFilterType
 {
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
 

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Input.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Input.php
@@ -19,17 +19,17 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class Input extends AbstractFilterType
 {
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$field],
             'fieldname' => $field,
             'metaData' => $filterDefinition->getMetaData(),
-        ]);
+        ];
     }
 
     public function addCondition(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter, $params, $isPrecondition = false)

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Input.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Input.php
@@ -19,7 +19,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class Input extends AbstractFilterType
 {
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $field = $this->getField($filterDefinition);
 

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelect.php
@@ -19,7 +19,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class MultiSelect extends AbstractFilterType
 {
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $field = $this->getField($filterDefinition);
 

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelect.php
@@ -19,11 +19,11 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class MultiSelect extends AbstractFilterType
 {
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$field],
@@ -31,7 +31,7 @@ class MultiSelect extends AbstractFilterType
             'fieldname' => $field,
             'metaData' => $filterDefinition->getMetaData(),
             'resultCount' => $productList->count(),
-        ]);
+        ];
     }
 
     public function addCondition(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter, $params, $isPrecondition = false)

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelect.php
@@ -19,7 +19,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class MultiSelect extends AbstractFilterType
 {
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
 

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectCategory.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectCategory.php
@@ -19,7 +19,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class MultiSelectCategory extends AbstractFilterType
 {
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $rawValues = $productList->getGroupByValues($filterDefinition->getField(), true);
         $values = [];
@@ -45,7 +45,7 @@ class MultiSelectCategory extends AbstractFilterType
             }
         }
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$filterDefinition->getField()],
@@ -53,7 +53,7 @@ class MultiSelectCategory extends AbstractFilterType
             'fieldname' => $filterDefinition->getField(),
             'metaData' => $filterDefinition->getMetaData(),
             'resultCount' => $productList->count(),
-        ]);
+        ];
     }
 
     public function addCondition(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter, $params, $isPrecondition = false)

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectCategory.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectCategory.php
@@ -19,7 +19,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class MultiSelectCategory extends AbstractFilterType
 {
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $rawValues = $productList->getGroupByValues($filterDefinition->getField(), true);
         $values = [];

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectCategory.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectCategory.php
@@ -19,7 +19,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class MultiSelectCategory extends AbstractFilterType
 {
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $rawValues = $productList->getGroupByValues($filterDefinition->getField(), true);
         $values = [];

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectFromMultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectFromMultiSelect.php
@@ -20,13 +20,6 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class MultiSelectFromMultiSelect extends SelectFromMultiSelect
 {
-    /**
-     * @param AbstractFilterDefinitionType $filterDefinition
-     * @param ProductListInterface $productList
-     * @param array $currentFilter
-     *
-     * @return array
-     */
     public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectFromMultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectFromMultiSelect.php
@@ -20,7 +20,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class MultiSelectFromMultiSelect extends SelectFromMultiSelect
 {
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
         $rawValues = $productList->getGroupByValues($field, true, !$filterDefinition->getUseAndCondition());

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectFromMultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectFromMultiSelect.php
@@ -18,16 +18,16 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\ProductList\ProductList
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Worker\WorkerInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
-class MultiSelectFromMultiSelect extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\FilterType\SelectFromMultiSelect
+class MultiSelectFromMultiSelect extends SelectFromMultiSelect
 {
     /**
      * @param AbstractFilterDefinitionType $filterDefinition
      * @param ProductListInterface $productList
      * @param array $currentFilter
      *
-     * @return string
+     * @return array
      */
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
         $rawValues = $productList->getGroupByValues($field, true, !$filterDefinition->getUseAndCondition());
@@ -46,7 +46,7 @@ class MultiSelectFromMultiSelect extends \Pimcore\Bundle\EcommerceFrameworkBundl
             }
         }
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$field],
@@ -54,7 +54,7 @@ class MultiSelectFromMultiSelect extends \Pimcore\Bundle\EcommerceFrameworkBundl
             'fieldname' => $field,
             'metaData' => $filterDefinition->getMetaData(),
             'resultCount' => $productList->count(),
-        ]);
+        ];
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectFromMultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectFromMultiSelect.php
@@ -20,7 +20,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class MultiSelectFromMultiSelect extends SelectFromMultiSelect
 {
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $field = $this->getField($filterDefinition);
         $rawValues = $productList->getGroupByValues($field, true, !$filterDefinition->getUseAndCondition());

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectRelation.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectRelation.php
@@ -28,11 +28,11 @@ class MultiSelectRelation extends AbstractFilterType
      * @param ProductListInterface $productList
      * @param array $currentFilter
      *
-     * @return string
+     * @return array
      *
      * @throws \Exception
      */
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
         $values = $productList->getGroupByRelationValues($field, true, !$filterDefinition->getUseAndCondition());
@@ -51,7 +51,7 @@ class MultiSelectRelation extends AbstractFilterType
         }
         Logger::info('done.');
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$field],
@@ -60,7 +60,7 @@ class MultiSelectRelation extends AbstractFilterType
             'fieldname' => $field,
             'metaData' => $filterDefinition->getMetaData(),
             'resultCount' => $productList->count(),
-        ]);
+        ];
     }
 
     protected function loadAllAvailableRelations($availableRelations, $availableRelationsArray = [])

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectRelation.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectRelation.php
@@ -32,7 +32,7 @@ class MultiSelectRelation extends AbstractFilterType
      *
      * @throws \Exception
      */
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $field = $this->getField($filterDefinition);
         $values = $productList->getGroupByRelationValues($field, true, !$filterDefinition->getUseAndCondition());

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectRelation.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectRelation.php
@@ -32,7 +32,7 @@ class MultiSelectRelation extends AbstractFilterType
      *
      * @throws \Exception
      */
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
         $values = $productList->getGroupByRelationValues($field, true, !$filterDefinition->getUseAndCondition());

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRange.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRange.php
@@ -29,7 +29,7 @@ class NumberRange extends AbstractFilterType
      *
      * @throws \Exception
      */
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         return [
               'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRange.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRange.php
@@ -29,7 +29,7 @@ class NumberRange extends AbstractFilterType
      *
      * @throws \Exception
      */
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         return [
               'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRange.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRange.php
@@ -25,13 +25,13 @@ class NumberRange extends AbstractFilterType
      * @param ProductListInterface $productList
      * @param array $currentFilter
      *
-     * @return string
+     * @return array
      *
      * @throws \Exception
      */
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
               'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
               'label' => $filterDefinition->getLabel(),
               'currentValue' => $currentFilter[$this->getField($filterDefinition)],
@@ -40,7 +40,7 @@ class NumberRange extends AbstractFilterType
               'fieldname' => $this->getField($filterDefinition),
               'metaData' => $filterDefinition->getMetaData(),
               'resultCount' => $productList->count(),
-         ]);
+         ];
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRangeSelection.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRangeSelection.php
@@ -29,7 +29,7 @@ class NumberRangeSelection extends AbstractFilterType
      *
      * @throws \Exception
      */
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $field = $this->getField($filterDefinition);
         $ranges = $filterDefinition->getRanges();

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRangeSelection.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRangeSelection.php
@@ -29,7 +29,7 @@ class NumberRangeSelection extends AbstractFilterType
      *
      * @throws \Exception
      */
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
         $ranges = $filterDefinition->getRanges();

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRangeSelection.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRangeSelection.php
@@ -25,11 +25,11 @@ class NumberRangeSelection extends AbstractFilterType
      * @param ProductListInterface $productList
      * @param array $currentFilter
      *
-     * @return string
+     * @return array
      *
      * @throws \Exception
      */
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
         $ranges = $filterDefinition->getRanges();
@@ -68,7 +68,7 @@ class NumberRangeSelection extends AbstractFilterType
             $currentValue = implode('-', $currentFilter[$field]);
         }
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentValue,
@@ -79,7 +79,7 @@ class NumberRangeSelection extends AbstractFilterType
             'fieldname' => $field,
             'metaData' => $filterDefinition->getMetaData(),
             'resultCount' => $productList->count(),
-        ]);
+        ];
     }
 
     private function createLabel($data)

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Select.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Select.php
@@ -19,7 +19,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class Select extends AbstractFilterType
 {
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
 

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Select.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Select.php
@@ -19,11 +19,11 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class Select extends AbstractFilterType
 {
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$field],
@@ -31,7 +31,7 @@ class Select extends AbstractFilterType
             'fieldname' => $field,
             'metaData' => $filterDefinition->getMetaData(),
             'resultCount' => $productList->count(),
-        ]);
+        ];
     }
 
     public function addCondition(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter, $params, $isPrecondition = false)

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Select.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Select.php
@@ -19,7 +19,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class Select extends AbstractFilterType
 {
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $field = $this->getField($filterDefinition);
 

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectCategory.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectCategory.php
@@ -25,11 +25,11 @@ class SelectCategory extends AbstractFilterType
      * @param ProductListInterface $productList
      * @param array $currentFilter
      *
-     * @return string
+     * @return array
      *
      * @throws \Exception
      */
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $rawValues = $productList->getGroupByValues($filterDefinition->getField(), true);
         $values = [];
@@ -57,7 +57,7 @@ class SelectCategory extends AbstractFilterType
 
         $request = \Pimcore::getContainer()->get('request_stack')->getCurrentRequest();
 
-        $parameters = [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$filterDefinition->getField()],
@@ -69,8 +69,6 @@ class SelectCategory extends AbstractFilterType
             'document' => $request->get('contentDocument'),
             'resultCount' => $productList->count(),
         ];
-
-        return $this->render($this->getTemplate($filterDefinition), $parameters);
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectCategory.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectCategory.php
@@ -29,7 +29,7 @@ class SelectCategory extends AbstractFilterType
      *
      * @throws \Exception
      */
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $rawValues = $productList->getGroupByValues($filterDefinition->getField(), true);
         $values = [];

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectCategory.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectCategory.php
@@ -29,7 +29,7 @@ class SelectCategory extends AbstractFilterType
      *
      * @throws \Exception
      */
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $rawValues = $productList->getGroupByValues($filterDefinition->getField(), true);
         $values = [];

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectFromMultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectFromMultiSelect.php
@@ -20,7 +20,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class SelectFromMultiSelect extends AbstractFilterType
 {
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
         $rawValues = $productList->getGroupByValues($field, true);
@@ -39,7 +39,7 @@ class SelectFromMultiSelect extends AbstractFilterType
             }
         }
 
-        return $this->render($this->getTemplate($filterDefinition), [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$field],
@@ -47,7 +47,7 @@ class SelectFromMultiSelect extends AbstractFilterType
             'fieldname' => $field,
             'metaData' => $filterDefinition->getMetaData(),
             'resultCount' => $productList->count(),
-        ]);
+        ];
     }
 
     public function addCondition(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter, $params, $isPrecondition = false)

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectFromMultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectFromMultiSelect.php
@@ -20,7 +20,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class SelectFromMultiSelect extends AbstractFilterType
 {
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
         $rawValues = $productList->getGroupByValues($field, true);

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectFromMultiSelect.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectFromMultiSelect.php
@@ -20,7 +20,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinitionType;
 
 class SelectFromMultiSelect extends AbstractFilterType
 {
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $field = $this->getField($filterDefinition);
         $rawValues = $productList->getGroupByValues($field, true);

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectRelation.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectRelation.php
@@ -32,7 +32,7 @@ class SelectRelation extends AbstractFilterType
      *
      * @throws \Exception
      */
-    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
 

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectRelation.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectRelation.php
@@ -28,11 +28,11 @@ class SelectRelation extends AbstractFilterType
      * @param ProductListInterface $productList
      * @param array $currentFilter
      *
-     * @return string
+     * @return array
      *
      * @throws \Exception
      */
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterArray(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
 
@@ -53,13 +53,7 @@ class SelectRelation extends AbstractFilterType
         }
         Logger::info('done.');
 
-        if ($filterDefinition->getScriptPath()) {
-            $script = $filterDefinition->getScriptPath();
-        } else {
-            $script = $this->template;
-        }
-
-        return $this->render($script, [
+        return [
             'hideFilter' => $filterDefinition->getRequiredFilterField() && empty($currentFilter[$filterDefinition->getRequiredFilterField()]),
             'label' => $filterDefinition->getLabel(),
             'currentValue' => $currentFilter[$field],
@@ -68,7 +62,7 @@ class SelectRelation extends AbstractFilterType
             'fieldname' => $field,
             'metaData' => $filterDefinition->getMetaData(),
             'resultCount' => $productList->count(),
-        ]);
+        ];
     }
 
     protected function loadAllAvailableRelations($availableRelations, $availableRelationsArray = [])

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectRelation.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectRelation.php
@@ -32,7 +32,7 @@ class SelectRelation extends AbstractFilterType
      *
      * @throws \Exception
      */
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $field = $this->getField($filterDefinition);
 

--- a/doc/Development_Documentation/10_E-Commerce_Framework/07_Filter_Service/03_Elastic_Search/02_Filter_Nested_Documents.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/07_Filter_Service/03_Elastic_Search/02_Filter_Nested_Documents.md
@@ -122,7 +122,7 @@ class SelectMyAttribute extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterS
      * @return string
      * @throws \Exception
      */
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
     {
         $field = $this->getField($filterDefinition);
         $this->prepareGroupByValues($filterDefinition, $productList);

--- a/doc/Development_Documentation/10_E-Commerce_Framework/07_Filter_Service/03_Elastic_Search/02_Filter_Nested_Documents.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/07_Filter_Service/03_Elastic_Search/02_Filter_Nested_Documents.md
@@ -119,7 +119,7 @@ class SelectMyAttribute extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterS
      * @param AbstractFilterDefinitionType $filterDefinition
      * @param ProductListInterface $productList
      * @param array $currentFilter
-     * @return string
+     * @return array
      * @throws \Exception
      */
     public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
@@ -128,12 +128,13 @@ class SelectMyAttribute extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterS
         $this->prepareGroupByValues($filterDefinition, $productList);
 
         $values = $productList->getGroupByValues($field, true, !$filterDefinition->getUseAndCondition());
-        return $this->render($this->getTemplate($filterDefinition), [
+
+        return [
             'label' => $filterDefinition->getLabel(),
             'values' => $values,
             'metaData' => $filterDefinition->getMetaData(),
-            'hasValue' => $this->hasValue
-        ]);
+            'hasValue' => $this->hasValue,
+        ];
     }
 
 }

--- a/doc/Development_Documentation/10_E-Commerce_Framework/07_Filter_Service/03_Elastic_Search/02_Filter_Nested_Documents.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/07_Filter_Service/03_Elastic_Search/02_Filter_Nested_Documents.md
@@ -115,14 +115,7 @@ class SelectMyAttribute extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterS
         $productList->addCondition($condition, $this->getField($filterDefinition));
     }
 
-    /**
-     * @param AbstractFilterDefinitionType $filterDefinition
-     * @param ProductListInterface $productList
-     * @param array $currentFilter
-     * @return array
-     * @throws \Exception
-     */
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter)
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array
     {
         $field = $this->getField($filterDefinition);
         $this->prepareGroupByValues($filterDefinition, $productList);
@@ -136,7 +129,6 @@ class SelectMyAttribute extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterS
             'hasValue' => $this->hasValue,
         ];
     }
-
 }
 ```
 

--- a/doc/Development_Documentation/10_E-Commerce_Framework/07_Filter_Service/README.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/07_Filter_Service/README.md
@@ -23,7 +23,7 @@ The backend implementation of Filter Types takes place in php classes which exte
 the correct filter conditions based on the Product Index implementation and rendering the filter output to the frontend. 
 
 Therefore `\Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\FilterType\AbstractFilterType` expects the two methods 
-`getFilterFrontend()` and `addCondition()` to be implemented. 
+`getFilterValues()` and `addCondition()` to be implemented. 
 
 Each Filter Type needs to be defined as service and registered on the `pimcore_ecommerce_framework.filter_service` configuration.
 The framework already defines a number of core filter types in [filter_service_filter_types.yml](https://github.com/pimcore/pimcore/blob/master/bundles/EcommerceFrameworkBundle/Resources/config/filter_service_filter_types.yml).

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -15,7 +15,7 @@
     ```
     After:
     ```php
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter) 
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, array $currentFilter): array 
     {
         // ...
         return [

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -143,6 +143,30 @@ pimcore:
 - `\Pimcore\Config::getSystemConfig()` is now marked as deprecated and will be removed in Pimcore 7. Use `Pimcore\Config` service or `\Pimcore\Config::getSystemConfiguration()` method instead.
 - Javascript function `ts(key)` (alias of `t(key)`) is marked as deprecated and will be removed in v7. Please use `t(key)` instead. 
 
+## unreleased
+- Added `Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\FilterType\AbstractFilterType::getFilterValues()` with the same signature as `getFilterFrontend()`. To upgrade, rename `getFilterFrontend()` to `getFilterValues()` and remove the rendering stuff to just return the data array.
+
+    Before:
+    ```php
+    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter) 
+    {
+        // ...
+        return $this->render($this->getTemplate($filterDefinition), [
+            //...
+        ]);
+    }
+    ```
+    After:
+    ```php
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter) 
+    {
+        // ...
+        return [
+            //...
+        ];
+    }
+    ```
+
 ## 6.4.0
 - Deprecated the REST Webservice API. The API will be removed in Pimcore 7, use the [Pimcore Datahub](https://github.com/pimcore/data-hub) instead.
 - Removed `Pimcore\Bundle\EcommerceFrameworkBundle\PricingManagerPricingManagerInterface::getRule()` and `Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager::getRule()`

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,4 +1,29 @@
 # Upgrade Notes
+
+## 10.0.0
+- Added `Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\FilterType\AbstractFilterType::getFilterValues()` with the same signature as `getFilterFrontend()`. To upgrade, rename `getFilterFrontend()` to `getFilterValues()` and remove the rendering stuff to just return the data array.
+
+    Before:
+    ```php
+    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter) 
+    {
+        // ...
+        return $this->render($this->getTemplate($filterDefinition), [
+            //...
+        ]);
+    }
+    ```
+    After:
+    ```php
+    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter) 
+    {
+        // ...
+        return [
+            //...
+        ];
+    }
+    ```
+
 ## 6.9.0
 - [Ecommerce] Ecommerce tracking `*.js.php` templates are deprecated and will not supported on Pimcore 7. Please use Twig `*.js.twig` templates. Also `Tracker::templateExtension` property is deprecated and will be removed in Pimcore 7. 
 - Config option and container parameter `pimcore.routing.defaults` is deprecated, use `pimcore.documents.default_controller` instead. 
@@ -142,30 +167,6 @@ pimcore:
 - The built in cookie info bar (in system settings) is now marked as deprecated and will be removed in Pimcore 7. 
 - `\Pimcore\Config::getSystemConfig()` is now marked as deprecated and will be removed in Pimcore 7. Use `Pimcore\Config` service or `\Pimcore\Config::getSystemConfiguration()` method instead.
 - Javascript function `ts(key)` (alias of `t(key)`) is marked as deprecated and will be removed in v7. Please use `t(key)` instead. 
-
-## unreleased
-- Added `Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\FilterType\AbstractFilterType::getFilterValues()` with the same signature as `getFilterFrontend()`. To upgrade, rename `getFilterFrontend()` to `getFilterValues()` and remove the rendering stuff to just return the data array.
-
-    Before:
-    ```php
-    public function getFilterFrontend(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter) 
-    {
-        // ...
-        return $this->render($this->getTemplate($filterDefinition), [
-            //...
-        ]);
-    }
-    ```
-    After:
-    ```php
-    public function getFilterValues(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter) 
-    {
-        // ...
-        return [
-            //...
-        ];
-    }
-    ```
 
 ## 6.4.0
 - Deprecated the REST Webservice API. The API will be removed in Pimcore 7, use the [Pimcore Datahub](https://github.com/pimcore/data-hub) instead.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -216,7 +216,7 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelect.php
 
 		-
-			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\Findologic\\\\MultiSelect\\:\\:getFilterFrontend\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterMultiSelect\\.$#"
+			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\Findologic\\\\MultiSelect\\:\\:getFilterValues\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterMultiSelect\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelect.php
 
@@ -231,7 +231,7 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelectRelation.php
 
 		-
-			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\Findologic\\\\MultiSelectRelation\\:\\:getFilterFrontend\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterMultiRelation\\.$#"
+			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\Findologic\\\\MultiSelectRelation\\:\\:getFilterValues\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterMultiRelation\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/MultiSelectRelation.php
 
@@ -256,7 +256,7 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRange.php
 
 		-
-			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\Findologic\\\\NumberRange\\:\\:getFilterFrontend\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterNumberRange\\.$#"
+			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\Findologic\\\\NumberRange\\:\\:getFilterValues\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterNumberRange\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRange.php
 
@@ -291,7 +291,7 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRangeSelection.php
 
 		-
-			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\Findologic\\\\NumberRangeSelection\\:\\:getFilterFrontend\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterNumberRangeSelection\\.$#"
+			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\Findologic\\\\NumberRangeSelection\\:\\:getFilterValues\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterNumberRangeSelection\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRangeSelection.php
 
@@ -336,7 +336,7 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/SelectRelation.php
 
 		-
-			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\Findologic\\\\SelectRelation\\:\\:getFilterFrontend\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterRelation\\.$#"
+			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\Findologic\\\\SelectRelation\\:\\:getFilterValues\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterRelation\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/SelectRelation.php
 
@@ -401,7 +401,7 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectRelation.php
 
 		-
-			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\MultiSelectRelation\\:\\:getFilterFrontend\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterMultiRelation\\.$#"
+			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\MultiSelectRelation\\:\\:getFilterValues\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterMultiRelation\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectRelation.php
 
@@ -431,7 +431,7 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRange.php
 
 		-
-			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\NumberRange\\:\\:getFilterFrontend\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterNumberRange\\.$#"
+			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\NumberRange\\:\\:getFilterValues\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterNumberRange\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRange.php
 
@@ -461,7 +461,7 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRangeSelection.php
 
 		-
-			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\NumberRangeSelection\\:\\:getFilterFrontend\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterNumberRangeSelection\\.$#"
+			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\NumberRangeSelection\\:\\:getFilterValues\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterNumberRangeSelection\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRangeSelection.php
 
@@ -526,7 +526,7 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectRelation.php
 
 		-
-			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\SelectRelation\\:\\:getFilterFrontend\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterRelation\\.$#"
+			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\SelectRelation\\:\\:getFilterValues\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterRelation\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/SelectRelation.php
 


### PR DESCRIPTION
## Changes in this pull request  
This PR splits filter value generation and rendering into two methods.

This removes code duplication (the rendering calls are always the same) and improves extensibility, because when creating a REST API you need the raw filter values to send them as e.g. JSON to the frontend where they can be rendered by some JavaScript framework.

## Additional info
This is a breaking change, because it introduces a new abstract method: `Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\FilterType\AbstractFilterType::getFilterValues()`

---
@m0nken you may like this
