### PR TITLE
[Data objects] Minimizable modals for copying and deleting elements

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
@@ -141,6 +141,8 @@ pimcore.elementservice.deleteElementFromServer = function (r, options, button) {
                 text: t('initializing')
             });
 
+            var me = this;
+            var minimizedWindowListener;
             this.deleteWindow = new Ext.Window({
                 title: t("delete"),
                 layout:'fit',
@@ -149,6 +151,38 @@ pimcore.elementservice.deleteElementFromServer = function (r, options, button) {
                 closable:false,
                 plain: true,
                 modal: true,
+                minimizable: true,
+                listeners: {
+                    minimize: function() {
+                        this.toggleCollapse();
+                        if(this.getCollapsed()) {
+                            this.alignTo(Ext.getBody(), 'br-br');
+                            this.zIndexManager.mask.hide();
+                            this.modal = false;
+                            this.setTitle(t("delete")+': '+me.deleteProgressBar.getText());
+
+                            minimizedWindowListener = me.deleteProgressBar.on({
+                                destroyable: true,
+                                update: function(progressBar, value, text) {
+                                    this.setTitle(t("delete")+': '+text);
+                                }.bind(this)
+                            });
+                        } else {
+                            this.center();
+                            this.zIndexManager.mask.show();
+                            this.modal = true;
+                            this.setTitle(t("delete"));
+
+                            minimizedWindowListener.destroy();
+                            minimizedWindowListener = null;
+                        }
+                    },
+                    close: function() {
+                        if(minimizedWindowListener) {
+                            minimizedWindowListener.destroy();
+                        }
+                    }
+                },
                 items: [this.deleteProgressBar]
             });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
@@ -899,6 +899,8 @@ pimcore.object.tree = Class.create({
                     items: [record.pasteProgressBar]
                 });
 
+                record.pasteWindow.show();
+
                 var pj = new pimcore.tool.paralleljobs({
                     success: function () {
 
@@ -928,8 +930,6 @@ pimcore.object.tree = Class.create({
                     }.bind(this),
                     jobs: res.pastejobs
                 });
-
-                record.pasteWindow.show();
             } else {
                 throw "There are no pasting jobs";
             }


### PR DESCRIPTION
When copying or deleting elements in Pimcore backend GUI there is a progress bar modal with a backdrop which prevents any other interaction with the GUI. This PR makes this modal minimizable so the user is able to continue working in the GUI.