### PR TITLE
ObjectMetadata as return / param doctype for advanced many-to-many object relation getters / setters

### DIFF
--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -1220,6 +1220,14 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
 
         return $elementType . $id;
     }
+
+    /**
+     * @return string
+     */
+    public function getPhpdocType()
+    {
+        return $this->phpdocType;
+    }
 }
 
 class_alias(AdvancedManyToManyObjectRelation::class, 'Pimcore\Model\DataObject\ClassDefinition\Data\ObjectsMetadata');


### PR DESCRIPTION
Analogous to advanced many-to-many relation, see https://github.com/pimcore/pimcore/blob/296fc17f0b00dc8f07926b5c34d127aa4ddb4f1b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php#L1103-L1106

Does anyone know a way to document getters / setters for meta columns of advanced relation fields?