### PR TITLE
Simplify JavaScript array/object instantiation

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/object.js
@@ -29,7 +29,7 @@ pimcore.element.selector.object = Class.create(pimcore.element.selector.abstract
         var i;
 
         //set "Home" object ID for search grid column configuration
-        this.object  = new Object();
+        this.object  = {};
         this.object.id = 1;
 
         this.searchType = "search";

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
@@ -310,7 +310,7 @@ pimcore.object.classes.klass = Class.create({
                         if (!in_array(group, groupNames)) {
                             groupNames.push(group);
                         }
-                        groups[group] = new Array();
+                        groups[group] = [];
                     }
                     var handler;
                     if (editMode) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/plugin/broker.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/plugin/broker.js
@@ -14,7 +14,7 @@
 pimcore.registerNS("pimcore.plugin.broker");
 pimcore.plugin.broker = {
 
-    plugins: new Array(),
+    plugins: [],
 
     initialize: function() {
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
@@ -340,9 +340,9 @@ Ext.onReady(function () {
     }
 
     //translation admin keys
-    pimcore.globalmanager.add("translations_admin_missing", new Array());
-    pimcore.globalmanager.add("translations_admin_added", new Array());
-    pimcore.globalmanager.add("translations_admin_translated_values", new Array());
+    pimcore.globalmanager.add("translations_admin_missing", []);
+    pimcore.globalmanager.add("translations_admin_added", []);
+    pimcore.globalmanager.add("translations_admin_translated_values", []);
 
 
     var objectClassFields = [

--- a/bundles/CoreBundle/EventListener/Frontend/EditmodeListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/EditmodeListener.php
@@ -266,7 +266,7 @@ class EditmodeListener implements EventSubscriberInterface
 
         // set var for editable configurations which is filled by Document\Tag::admin()
         $headHtml .= '<script>
-            var editableConfigurations = new Array();
+            var editableConfigurations = [];
             var pimcore_document_id = ' . $document->getId() . ';
         </script>';
 


### PR DESCRIPTION
## Changes in this pull request  
There are some places where `new Array()` / `new Object()` are used wheras everywhere else `[]` / `{}` are used. This PR adjusts the code to use the latter everywhere.