### PR TITLE
Remove duplicate JavaScript object keys

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
@@ -222,7 +222,6 @@ pimcore.object.helpers.customLayoutEditor = Class.create({
             triggerAction: "all",
             selectOnFocus: true,
             forceSelection: true,
-            editable: false,
             store: this.layoutComboStore,
             displayField: 'name',
             valueField: 'id' ,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/definitions/analytics.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/definitions/analytics.js
@@ -18,7 +18,7 @@ pimcore.report.custom.definition.analytics = Class.create({
     sourceDefinitionData: null,
 
     initialize: function (sourceDefinitionData, key, deleteControl, columnSettingsCallback) {
-        sourceDefinitionData = sourceDefinitionData ? sourceDefinitionData : {filters: '', sort: '', startDate: '', relativeStartDate: '', relativeEndDate: '', endDate: '', relativeStartDate: '', dimension: '', metric: '', segment: '', profileId: ''};
+        sourceDefinitionData = sourceDefinitionData ? sourceDefinitionData : {filters: '', sort: '', startDate: '', relativeStartDate: '', relativeEndDate: '', endDate: '', dimension: '', metric: '', segment: '', profileId: ''};
 
         if (sourceDefinitionData.startDate) {
             var startDate = new Date();


### PR DESCRIPTION
## Changes in this pull request  
This PR removes some duplicate keys in JavaScript objects.

When there are duplicate keys in an object, the last one wins. 
Thus, I deleted the first one (if values are different).