### PR TITLE
[QuantityValue] fix default limit on ExtJs BaseUnit store

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
@@ -100,6 +100,8 @@ pimcore.object.quantityValue.unitsettings = Class.create({
                 }
 
             },
+            // disable client pagination, default: 25
+            pageSize: 0,
             listeners: {
                 load: function (store, records) {
                     var storeData = records;


### PR DESCRIPTION
this PR fixes https://github.com/pimcore/pimcore/issues/5648

Background: Ext.data.JsonStore has a default pagination limit of 25, setting it to 0 disables it.