### PR TITLE
JavaScript: Remove unused renderer

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/tags/select.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/tags/select.js
@@ -22,17 +22,12 @@ pimcore.asset.tags.select = Class.create(pimcore.asset.tags.abstract, {
     },
 
     getGridColumnConfig:function (field) {
-        var renderer = function (key, value, metaData, record) {
-            return replace_html_event_attributes(strip_tags(value, 'div,span,b,strong,em,i,small,sup,sub'));
-        }.bind(this, field.key);
-
         return {
             text: field.label,
             editable: false,
             width: this.getColumnWidth(field, 80),
             sortable: false,
             dataIndex: field.key,
-            renderer: renderer,
             filter: this.getGridColumnFilter(field),
             getEditor: this.getGridColumnEditor.bind(this, field),
             renderer: this.getRenderer(field)


### PR DESCRIPTION
## Changes in this pull request  

The renderer is overridden in the config object through the duplicate key in line 38. 

I'm not completely sure this is correct and if the custom one should be used instead of removing it, though.