### PR TITLE
JavaScript: Fix condition

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/tags/date.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/tags/date.js
@@ -20,9 +20,9 @@ pimcore.asset.tags.date = Class.create(pimcore.asset.tags.abstract, {
 
         this.data = null;
 
-        if (typeof data === "undefined" || data === null) {
+        if (typeof data !== "undefined" && data !== null) {
             this.data = data;
-        } else if ((typeof data === "undefined" || data === null) && fieldConfig.useCurrentDate) {
+        } else if (fieldConfig.useCurrentDate) {
             this.data = (new Date().getTime()) / 1000;
         }
 


### PR DESCRIPTION
## Changes in this pull request  
- `data` should be set if it **is not** `null` or `undefined`
- this check doesn't need to be repeated in the `else if` case