### PR TITLE
[Pimcore 5.8][Ecommerce] OnlineShopOrder class: change column length of field cartId to 190

### DIFF
--- a/bundles/CoreBundle/Resources/migrations/Version20200124170034.php
+++ b/bundles/CoreBundle/Resources/migrations/Version20200124170034.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+use Pimcore\Model\DataObject\ClassDefinition;
+
+class Version20200124170034 extends AbstractPimcoreMigration
+{
+    public function doesSqlMigrations(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $class = ClassDefinition::getByName('OnlineShopOrder');
+        if($class) {
+            /**
+             * @var $cartIdField ClassDefinition\Data\Input
+             */
+            $cartIdField = $class->getFieldDefinition('cartId');
+            $cartIdField->setColumnLength(190);
+            $class->save();
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $class = ClassDefinition::getByName('OnlineShopOrder');
+        if($class) {
+            /**
+             * @var $cartIdField ClassDefinition\Data\Input
+             */
+            $cartIdField = $class->getFieldDefinition('cartId');
+            $cartIdField->setColumnLength(255);
+            $class->save();
+        }
+    }
+}

--- a/bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
@@ -310,7 +310,13 @@ class OrderManager implements IOrderManager
 
             $order->setOrdernumber($tempOrdernumber);
             $order->setOrderdate(new \DateTime());
-            $order->setCartId($this->createCartId($cart));
+
+            $cartId = $this->createCartId($cart);
+            if(strlen($cartId) > 190) {
+                throw new \Exception('CartId cannot be longer than 190 characters');
+            }
+
+            $order->setCartId($cartId);
         }
 
         // check if pending payment. if one, do not update order from cart

--- a/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopOrder_export.json
+++ b/bundles/EcommerceFrameworkBundle/Resources/install/class_sources/class_OnlineShopOrder_export.json
@@ -554,7 +554,7 @@
                     "width": 400,
                     "queryColumnType": "varchar",
                     "columnType": "varchar",
-                    "columnLength": 255,
+                    "columnLength": 190,
                     "phpdocType": "string",
                     "regex": "",
                     "name": "cartId",

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5/README.md
@@ -1,5 +1,8 @@
 # Upgrade Notes for Upgrades within Pimcore 5
 
+## Version 5.8.10
+- Ecommerce: max length of `cartId` is now `190` characters instead of `255`
+
 ## Version 5.8.0
 - Add PathFormatter interface, static path formatters are now deprecated and will be removed with Version 6.0. You can read
  more about that [here](../../../05_Objects/01_Object_Classes/05_Class_Settings/14_Path_Formatter.md).


### PR DESCRIPTION
## Changes in this pull request  
Resolves #5477

## Additional info  

