### PR TITLE
Do not use master for downloads

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/01_Upgrade_from_4_to_5/01_Basic_Migration.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/01_Upgrade_from_4_to_5/01_Basic_Migration.md
@@ -5,8 +5,8 @@ to the Pimcore 4 compatibility bridge or the Symfony Stack.
 
 - **Backup your system!**
 
-- Replace your `composer.json` with [this one](https://github.com/pimcore/skeleton/blob/master/composer.json) and re-add your custom dependencies. 
-- Add `/app/AppKernel.php` from [here](https://github.com/pimcore/skeleton/blob/master/app/AppKernel.php)
+- Replace your `composer.json` with [this one](https://raw.githubusercontent.com/pimcore/skeleton/v1.3.0/composer.json) and re-add your custom dependencies. 
+- Add `/app/AppKernel.php` from [here](https://raw.githubusercontent.com/pimcore/skeleton/v1.3.0/app/AppKernel.php)
   
 - Run `COMPOSER_MEMORY_LIMIT=-1 composer update`
 If you encounter errors, please fix them until the command works properly.


### PR DESCRIPTION
It will download Pimcore 6 instead of Pimcore 5. I used 1.3.0 as pimcore.phar does use the same now.
