### PR TITLE
[Advanced object relation] Removed hard-coded visible field "ID"

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -108,7 +108,6 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
         var visibleFields = this.visibleFields;
 
         var columns = [];
-        columns.push({text: 'ID', dataIndex: 'id', width: 50});
 
         for (i = 0; i < visibleFields.length; i++) {
             if (!empty(this.fieldConfig.visibleFieldDefinitions) && !empty(visibleFields[i])) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -42,10 +42,6 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
         }
 
         var fields = [];
-        if (typeof this.fieldConfig.visibleFields != "string") {
-            this.fieldConfig.visibleFields = "";
-        }
-
         var visibleFields = Ext.isString(this.fieldConfig.visibleFields) ? this.fieldConfig.visibleFields.split(",") : [];
         this.visibleFields = visibleFields;
 
@@ -105,9 +101,12 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
         var cls = 'object_field';
         var i;
 
-        var visibleFields = this.visibleFields;
+        var visibleFields = this.visibleFields || [];
 
-        var columns = [];
+        var columns = [
+            {text: 'ID', dataIndex: 'id', width: 50, hidden: !!visibleFields.length},
+            {text: t("reference"), dataIndex: 'fullpath', flex: 200, renderer:this.fullPathRenderCheck.bind(this), hidden: !!visibleFields.length}
+        ];
 
         for (i = 0; i < visibleFields.length; i++) {
             if (!empty(this.fieldConfig.visibleFieldDefinitions) && !empty(visibleFields[i])) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -103,10 +103,14 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
 
         var visibleFields = this.visibleFields || [];
 
-        var columns = [
-            {text: 'ID', dataIndex: 'id', width: 50, hidden: !!visibleFields.length},
-            {text: t("reference"), dataIndex: 'fullpath', flex: 200, renderer:this.fullPathRenderCheck.bind(this), hidden: !!visibleFields.length}
-        ];
+        var columns = [];
+
+        if(visibleFields.length === 0) {
+            columns.push(
+                {text: 'ID', dataIndex: 'id', width: 50},
+                {text: t("reference"), dataIndex: 'fullpath', flex: 200, renderer:this.fullPathRenderCheck.bind(this)}
+            );
+        }
 
         for (i = 0; i < visibleFields.length; i++) {
             if (!empty(this.fieldConfig.visibleFieldDefinitions) && !empty(visibleFields[i])) {
@@ -242,6 +246,7 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
                 xtype: 'actioncolumn',
                 menuText: t('up'),
                 width: 40,
+                hideable: false,
                 items: [
                     {
                         tooltip: t('up'),
@@ -260,6 +265,7 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
                 xtype: 'actioncolumn',
                 menuText: t('down'),
                 width: 40,
+                hideable: false,
                 items: [
                     {
                         tooltip: t('down'),
@@ -280,6 +286,7 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
             xtype: 'actioncolumn',
             menuText: t('open'),
             width: 40,
+            hideable: false,
             items: [
                 {
                     tooltip: t('open'),
@@ -297,6 +304,7 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
                 xtype: 'actioncolumn',
                 menuText: t('remove'),
                 width: 40,
+                hideable: false,
                 items: [
                     {
                         tooltip: t('remove'),

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -233,6 +233,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
                 xtype: 'actioncolumn',
                 menuText: t('up'),
                 width: 40,
+                hideable: false,
                 items: [
                     {
                         tooltip: t('up'),
@@ -251,6 +252,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
                 xtype: 'actioncolumn',
                 menuText: t('down'),
                 width: 40,
+                hideable: false,
                 items: [
                     {
                         tooltip: t('down'),
@@ -271,6 +273,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
             xtype: 'actioncolumn',
             menuText: t('open'),
             width: 40,
+            hideable: false,
             items: [
                 {
                     tooltip: t('open'),
@@ -293,6 +296,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
                 xtype: 'actioncolumn',
                 menuText: t('remove'),
                 width: 40,
+                hideable: false,
                 items: [
                     {
                         tooltip: t('remove'),

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -294,11 +294,15 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
     getVisibleColumns: function () {
         var visibleFields = this.visibleFields || [];
 
-        var columns = [
-            {text: 'ID', dataIndex: 'id', width: 50, hidden: !!visibleFields.length},
-            {text: t("reference"), dataIndex: 'fullpath', flex: 200, renderer:this.fullPathRenderCheck.bind(this), hidden: !!visibleFields.length},
-            {text: t("class"), dataIndex: 'classname', width: 100, hidden: !!visibleFields.length}
-        ];
+        var columns = [];
+
+        if(visibleFields.length === 0) {
+            columns.push(
+                {text: 'ID', dataIndex: 'id', width: 50},
+                {text: t("reference"), dataIndex: 'fullpath', flex: 200, renderer:this.fullPathRenderCheck.bind(this)},
+                {text: t("class"), dataIndex: 'classname', width: 100}
+            );
+        }
 
         for (i = 0; i < visibleFields.length; i++) {
             if (!empty(this.fieldConfig.visibleFieldDefinitions) && !empty(visibleFields[i])) {
@@ -345,6 +349,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
             xtype: 'actioncolumn',
             menuText: t('up'),
             width: 40,
+            hideable: false,
             items: [
                 {
                     tooltip: t('up'),
@@ -361,57 +366,57 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
         });
 
         columns.push({
-                xtype: 'actioncolumn',
-                menuText: t('down'),
-                width: 40,
-                items: [
-                    {
-                        tooltip: t('down'),
-                        icon: "/bundles/pimcoreadmin/img/flat-color-icons/down.svg",
-                        handler: function (grid, rowIndex) {
-                            if (rowIndex < (grid.getStore().getCount() - 1)) {
-                                var rec = grid.getStore().getAt(rowIndex);
-                                grid.getStore().removeAt(rowIndex);
-                                grid.getStore().insert(rowIndex + 1, [rec]);
-                            }
-                        }.bind(this)
-                    }
-                ]
-            });
-
-        columns.push(
-            {
-                xtype: 'actioncolumn',
-                menuText: t('open'),
-                width: 40,
-                items: [
-                    {
-                        tooltip: t('open'),
-                        icon: "/bundles/pimcoreadmin/img/flat-color-icons/open_file.svg",
-                        handler: function (grid, rowIndex) {
-                            var data = grid.getStore().getAt(rowIndex);
-                            pimcore.helpers.openObject(data.data.id, "object");
-                        }.bind(this)
-                    }
-                ]
-            });
-
-        columns.push(
-            {
-                xtype: 'actioncolumn',
-                menuText: t('remove'),
-                width: 40,
-                items: [
-                    {
-                        tooltip: t('remove'),
-                        icon: "/bundles/pimcoreadmin/img/flat-color-icons/delete.svg",
-                        handler: function (grid, rowIndex) {
+            xtype: 'actioncolumn',
+            menuText: t('down'),
+            width: 40,
+            hideable: false,
+            items: [
+                {
+                    tooltip: t('down'),
+                    icon: "/bundles/pimcoreadmin/img/flat-color-icons/down.svg",
+                    handler: function (grid, rowIndex) {
+                        if (rowIndex < (grid.getStore().getCount() - 1)) {
+                            var rec = grid.getStore().getAt(rowIndex);
                             grid.getStore().removeAt(rowIndex);
-                        }.bind(this)
-                    }
-                ]
-            }
-        );
+                            grid.getStore().insert(rowIndex + 1, [rec]);
+                        }
+                    }.bind(this)
+                }
+            ]
+        });
+
+        columns.push({
+            xtype: 'actioncolumn',
+            menuText: t('open'),
+            width: 40,
+            hideable: false,
+            items: [
+                {
+                    tooltip: t('open'),
+                    icon: "/bundles/pimcoreadmin/img/flat-color-icons/open_file.svg",
+                    handler: function (grid, rowIndex) {
+                        var data = grid.getStore().getAt(rowIndex);
+                        pimcore.helpers.openObject(data.data.id, "object");
+                    }.bind(this)
+                }
+            ]
+        });
+
+        columns.push({
+            xtype: 'actioncolumn',
+            menuText: t('remove'),
+            width: 40,
+            hideable: false,
+            items: [
+                {
+                    tooltip: t('remove'),
+                    icon: "/bundles/pimcoreadmin/img/flat-color-icons/delete.svg",
+                    handler: function (grid, rowIndex) {
+                        grid.getStore().removeAt(rowIndex);
+                    }.bind(this)
+                }
+            ]
+        });
 
         this.component = Ext.create('Ext.grid.Panel', {
             store: this.store,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -114,6 +114,7 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
         columns.push({
             xtype: 'actioncolumn',
             menuText: t('up'),
+            hideable: false,
             width: 40,
             items: [
                 {
@@ -133,6 +134,7 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
             xtype: 'actioncolumn',
             menuText: t('down'),
             width: 40,
+            hideable: false,
             items: [
                 {
                     tooltip: t('down'),
@@ -151,6 +153,7 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
             xtype: 'actioncolumn',
             menuText: t('open'),
             width: 40,
+            hideable: false,
             items: [{
                 tooltip: t('open'),
                 icon: "/bundles/pimcoreadmin/img/flat-color-icons/open_file.svg",
@@ -168,6 +171,7 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
             xtype: 'actioncolumn',
             menuText: t('remove'),
             width: 40,
+            hideable: false,
             items: [{
                 tooltip: t('remove'),
                 icon: "/bundles/pimcoreadmin/img/flat-color-icons/delete.svg",


### PR DESCRIPTION
Currently the column `ID` always appears in an advanced many-to-many object relation - ignoring if this has been set as visible field. 
If you have set `ID` as visible field it appears twice in the object edit panel.