### PR TITLE
Fix error with Paypal Smart Button integration when using the Credit/Debit card payment option

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PayPalSmartPaymentButton.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PayPalSmartPaymentButton.php
@@ -193,7 +193,6 @@ class PayPalSmartPaymentButton extends AbstractPayment implements \Pimcore\Bundl
         $required = [
             'orderID' => null,
             'payerID' => null,
-            'paymentID' => null
         ];
 
         $authorizedData = [


### PR DESCRIPTION
The Paypal Smart Button integration allows to pay via credit card or debit card without a paypal account. The response data paypal sends in that case is slightly different from the one you get when using a paypal account.
When using a paypal account, the response contains four fields:

```
{
  "orderID": "12AB...",
  "payerID": "AJ...",
  "paymentID": null,
  "facilitatorAccessToken": "A21...LIQ"
}
```

When using the credit card option, paypal does not include the paymentID in the response. Pimcore's integration marks the field as required. The value of this field is not used or stored in the db, however, so I think its okay to remove the field from required value list.