### PR TITLE
[Glossary] Deprecate Acronyms and move them to Abbr (Sucessor)

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/glossary.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/glossary.js
@@ -60,7 +60,7 @@ pimcore.settings.glossary = Class.create({
             '/admin/settings/glossary?',
             [
                 'id', {name: 'text', allowBlank: false}, 'language', 'casesensitive', 'exactmatch',
-                'site', 'link', 'acronym', 'creationDate', 'modificationDate'
+                'site', 'link', 'abbr', 'creationDate', 'modificationDate'
             ],
             itemsPerPage
         );
@@ -100,8 +100,6 @@ pimcore.settings.glossary = Class.create({
             {text: t("link"), flex: 200, sortable: true, dataIndex: 'link', editor: new Ext.form.TextField({}),
                                 tdCls: "pimcore_droptarget_input"},
             {text: t("abbr"), flex: 200, sortable: true, dataIndex: 'abbr', editor: new Ext.form.TextField({})},
-            {text: t("acronym"), flex: 200, sortable: true, dataIndex: 'acronym',
-                                editor: new Ext.form.TextField({})},
             {text: t("language"), flex: 50, sortable: true, dataIndex: 'language', editor: new Ext.form.ComboBox({
                 store: this.languages,
                 mode: "local",

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -427,7 +427,6 @@
   "link": "Link",
   "links": "Links",
   "abbr": "Abbr.",
-  "acronym": "Acronym",
   "stop": "Stop",
   "dependencies": "Dependencies",
   "requires": "Requires",

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -294,7 +294,6 @@ CREATE TABLE `glossary` (
   `text` varchar(255) DEFAULT NULL,
   `link` varchar(255) DEFAULT NULL,
   `abbr` varchar(255) DEFAULT NULL,
-  `acronym` varchar(255) DEFAULT NULL,
   `site` int(11) unsigned DEFAULT NULL,
   `creationDate` int(11) unsigned DEFAULT '0',
   `modificationDate` int(11) unsigned DEFAULT '0',

--- a/doc/Development_Documentation/18_Tools_and_Features/21_Glossary.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/21_Glossary.md
@@ -5,7 +5,7 @@
 The glossary module is a powerful tool making internal linking easy and smart.
 In a special editor you can define your terms which are replaced automatically with a link to the defined page.
 
-But the glossary is not only useful for internal linking, it's also perfect for explaining abbreviations and/or acronyms.
+But the glossary is not only useful for internal linking, it's also perfect for explaining abbreviations.
 
 ## How it Works
 

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -14,6 +14,7 @@ pimcore:
 
 - Using static methods for [dynamic text labels](../../05_Objects/01_Object_Classes/03_Layout_Elements/01_Dynamic_Text_Labels.md) is now deprecated, use services instead.
 - Removed method `\Pimcore\Model\DataObject\ClassDefinition\Data\Relations\AbstractRelations::isRemoteOwner()`, as this method was only used for `ReverseManyToManyObjectRelation` internal check are now made using `instanceof` 
+- Glossary: _Acronym_ values are migrated to _Abbr_ , methods `getAcronym()` and `setAcronym()` are marked as deprecated (they are now an alias of Abbr)
 
 ## 6.4.0
 - Deprecated the REST Webservice API. The API will be removed in Pimcore 7, use the [Pimcore Data-Hub](https://github.com/pimcore/data-hub) instead.

--- a/lib/Tool/Glossary/Processor.php
+++ b/lib/Tool/Glossary/Processor.php
@@ -220,15 +220,13 @@ class Processor
 
         // prepare data
         foreach ($data as $d) {
-            if (!($d['link'] || $d['abbr'] || $d['acronym'])) {
+            if (!($d['link'] || $d['abbr'])) {
                 continue;
             }
 
             $r = $d['text'];
             if ($d['abbr']) {
                 $r = '<abbr class="pimcore_glossary" title="' . $d['abbr'] . '">' . $r . '</abbr>';
-            } elseif ($d['acronym']) {
-                $r = '<acronym class="pimcore_glossary" title="' . $d['acronym'] . '">' . $r . '</acronym>';
             }
 
             $linkType = '';

--- a/models/Glossary.php
+++ b/models/Glossary.php
@@ -46,11 +46,6 @@ class Glossary extends AbstractModel
     /**
      * @var string
      */
-    public $acronym;
-
-    /**
-     * @var string
-     */
     public $language;
 
     /**
@@ -188,23 +183,23 @@ class Glossary extends AbstractModel
     }
 
     /**
+     * @deprecated
      * @param string $acronym
      *
      * @return $this
      */
     public function setAcronym($acronym)
     {
-        $this->acronym = $acronym;
-
-        return $this;
+        return $this->setAbbr($acronym);
     }
 
     /**
+     * @deprecated
      * @return string
      */
     public function getAcronym()
     {
-        return $this->acronym;
+        return $this->getAbbr();
     }
 
     /**


### PR DESCRIPTION
Resolves #5705