### PR TITLE
[Ecommerce][IndexService] add pre-send-data event in FilterDefinition Object

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Controller/IndexController.php
+++ b/bundles/EcommerceFrameworkBundle/Controller/IndexController.php
@@ -14,8 +14,9 @@
 
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\Controller;
 
-use Pimcore\Event\Ecommerce\IndexServiceEvents;
+use Pimcore\Event\Ecommerce\AdminEvents;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Pimcore\Bundle\AdminBundle\Controller\AdminController;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Factory;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\ProductList\ProductListInterface;
@@ -62,7 +63,7 @@ class IndexController extends AdminController
      *
      * @return \Pimcore\Bundle\AdminBundle\HttpFoundation\JsonResponse
      */
-    public function getValuesForFilterFieldAction(Request $request)
+    public function getValuesForFilterFieldAction(Request $request, EventDispatcherInterface $eventDispatcher)
     {
         try {
             $data = [];
@@ -95,7 +96,7 @@ class IndexController extends AdminController
             }
 
             $event = new GenericEvent(null, ["data" => $data, "field" => $request->get('field')]);
-            \Pimcore::getEventDispatcher()->dispatch($event, IndexServiceEvents::GET_VALUES_FOR_FILTER_FIELD_PRE_SEND_DATA);
+            $eventDispatcher->dispatch($event, AdminEvents::GET_VALUES_FOR_FILTER_FIELD_PRE_SEND_DATA);
             $data = $event->getArgument("data");
             
             return $this->adminJson(['data' => array_values($data)]);

--- a/bundles/EcommerceFrameworkBundle/Controller/IndexController.php
+++ b/bundles/EcommerceFrameworkBundle/Controller/IndexController.php
@@ -14,6 +14,8 @@
 
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\Controller;
 
+use Pimcore\Event\Ecommerce\IndexServiceEvents;
+use Symfony\Component\EventDispatcher\GenericEvent;
 use Pimcore\Bundle\AdminBundle\Controller\AdminController;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Factory;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\ProductList\ProductListInterface;
@@ -92,6 +94,10 @@ class IndexController extends AdminController
                 $data = $helper->getGroupByValuesForFilterGroup($columnGroup, $productList, $request->get('field'));
             }
 
+            $event = new GenericEvent(null, ["data" => $data, "field" => $request->get('field')]);
+            \Pimcore::getEventDispatcher()->dispatch($event, IndexServiceEvents::GET_VALUES_FOR_FILTER_FIELD_PRE_SEND_DATA);
+            $data = $event->getArgument("data");
+            
             return $this->adminJson(['data' => array_values($data)]);
         } catch (\Exception $e) {
             return $this->adminJson(['message' => $e->getMessage()]);

--- a/lib/Event/Ecommerce/AdminEvents.php
+++ b/lib/Event/Ecommerce/AdminEvents.php
@@ -12,15 +12,9 @@
  * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
-
 namespace Pimcore\Event\Ecommerce;
 
-
-/**
- * Class AdminEvents
- * @package Pimcore\Event\Ecommerce
- */
-class AdminEvents
+final class AdminEvents
 {
     /**
      * Fired when values in filter definition get fetched
@@ -29,5 +23,5 @@ class AdminEvents
      *
      * @var string
      */
-    const GET_VALUES_FOR_FILTER_FIELD_PRE_SEND_DATA = 'pimcore.ecommerce.indexservice.getValuesForFilterFieldPreSendData';
+    const GET_VALUES_FOR_FILTER_FIELD_PRE_SEND_DATA = 'pimcore.admin.ecommerce.getValuesForFilterFieldPreSendData';
 }

--- a/lib/Event/Ecommerce/AdminEvents.php
+++ b/lib/Event/Ecommerce/AdminEvents.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+
+namespace Pimcore\Event\Ecommerce;
+
+
+/**
+ * Class AdminEvents
+ * @package Pimcore\Event\Ecommerce
+ */
+class AdminEvents
+{
+    /**
+     * Fired when values in filter definition get fetched
+     *
+     * @Event("Symfony\Component\EventDispatcher\GenericEvent")
+     *
+     * @var string
+     */
+    const GET_VALUES_FOR_FILTER_FIELD_PRE_SEND_DATA = 'pimcore.ecommerce.indexservice.getValuesForFilterFieldPreSendData';
+}

--- a/lib/Event/Ecommerce/IndexServiceEvents.php
+++ b/lib/Event/Ecommerce/IndexServiceEvents.php
@@ -33,13 +33,4 @@ final class IndexServiceEvents
      * @var string
      */
     const GENERAL_PREPROCESSING_ERROR = 'pimcore.ecommerce.indexservice.generalPreProcessingError';
-    
-       /**
-     * Fired when values in filter definition get fetched
-     *
-     * @Event("Symfony\Component\EventDispatcher\GenericEvent")
-     *
-     * @var string
-     */
-    const GET_VALUES_FOR_FILTER_FIELD_PRE_SEND_DATA = 'pimcore.ecommerce.indexservice.getValuesForFilterFieldPreSendData';
 }

--- a/lib/Event/Ecommerce/IndexServiceEvents.php
+++ b/lib/Event/Ecommerce/IndexServiceEvents.php
@@ -33,4 +33,13 @@ final class IndexServiceEvents
      * @var string
      */
     const GENERAL_PREPROCESSING_ERROR = 'pimcore.ecommerce.indexservice.generalPreProcessingError';
+    
+       /**
+     * Fired when values in filter definition get fetched
+     *
+     * @Event("Symfony\Component\EventDispatcher\GenericEvent")
+     *
+     * @var string
+     */
+    const GET_VALUES_FOR_FILTER_FIELD_PRE_SEND_DATA = 'pimcore.ecommerce.indexservice.getValuesForFilterFieldPreSendData';
 }


### PR DESCRIPTION
This PR makes it possible to adjust the displayed value in the FilterDefiniton object.

In the screenshot the actual value is in brackets.

![image](https://user-images.githubusercontent.com/9052094/73766772-cf6d9600-4776-11ea-9be8-5da19e547d0a.png)
