### PR TITLE
Add client_max_body_size directive to nginx config

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
@@ -31,6 +31,9 @@ server {
     server_name pimcore.loc;
     root /var/www/pimcore/web;
     index index.php;
+    
+    # Filesize depending on your data
+    client_max_body_size 100m;
 
     access_log  /var/log/access.log;
     error_log   /var/log/error.log error;


### PR DESCRIPTION
The default nginx client_max_body_size is set to 1m (http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size). On default nginx config the directive is not set in the highest level in "http". Based on the Pimcore Documentation client_max_body_size is set to 100m to prevent the "413 Request Entity Too Large" error.

<!--
## Please make sure your PR complies with all of the following points: 
- [] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

"413 Request Entity Too Large" error using nginx while upload in frontend and backend files larger then 1m.

## Additional info  

