### PR TITLE
Error when sorting product list with sub tenants

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultMysql.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultMysql.php
@@ -656,7 +656,7 @@ class DefaultMysql implements ProductListInterface
             }
 
             // add sorting for primary id to prevent mysql paging problem...
-            $orderKeys[] = 'o_id';
+            $orderKeys[] = 'a.o_id';
 
             $directionOrderKeys = [];
             foreach ($orderKeys as $key) {


### PR DESCRIPTION
## Changes in this pull request  
When joining the mysql productindex with a sub tenant an error is thrown on ordering since the o_id column is ambiguous. The default order key should be a.o_id instead of just o_id.

