### PR TITLE
Use constant instead of its value

### DIFF
--- a/bundles/CoreBundle/Resources/config/pimcore/default.yml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yml
@@ -47,9 +47,8 @@ doctrine:
                 logging: false
                 profiling: false
                 options:
-                    # 20 is the value of PDO::ATTR_EMULATE_PREPARES => FALSE
                     # this stops Doctrine to return strings for integer values
-                    20: false
+                    !php/const PDO::ATTR_EMULATE_PREPARES: false
                 default_table_options:
                     charset: UTF8MB4
                     collate: utf8mb4_general_ci


### PR DESCRIPTION
The values of those PDO constants tend to change between PHP versions (see: https://stackoverflow.com/a/20990359) so it's better to not rely on them and use the real constant instead of its "magic number" value.

Follow-up to #5727 