### PR TITLE
[Document|Data Object] consider latest version for copying elements

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1974,6 +1974,11 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         if ($target->isAllowed('create')) {
             $source = DataObject::getById($sourceId);
             if ($source != null) {
+                if ($latestVersion = $source->getLatestVersion()) {
+                    $source = $latestVersion->loadData();
+                    $source->setPublished(false); //as latest version is used which is not published
+                }
+
                 if ($request->get('type') == 'child') {
                     $newObject = $this->_objectService->copyAsChild($target, $source);
 

--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -906,6 +906,11 @@ class DocumentController extends ElementControllerBase implements EventedControl
         if ($target instanceof Document) {
             if ($target->isAllowed('create')) {
                 if ($source != null) {
+                    if ($latestVersion = $source->getLatestVersion()) {
+                        $source = $latestVersion->loadData();
+                        $source->setPublished(false); //as latest version is used which is not published
+                    }
+
                     if ($request->get('type') == 'child') {
                         $enableInheritance = ($request->get('enableInheritance') == 'true') ? true : false;
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #5721

## Additional info  
Pasted element published status set to false, in case of "There is a newer not published version"
![image](https://user-images.githubusercontent.com/5137917/73932155-060ff180-48da-11ea-8a70-2758981b8541.png)
