### PR TITLE
Translate perspectives and docTypes in user/role settings

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/role/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/role/settings.js
@@ -31,6 +31,16 @@ pimcore.settings.user.role.settings = Class.create({
         });
 
         var perspectivesStore = Ext.create('Ext.data.JsonStore', {
+            fields: [
+                "name",
+                {
+                    name:"translatedName",
+                    convert: function (v, rec) {
+                        return ts(rec.data.name);
+                    },
+                    depends : ['name']
+                }
+            ],
             data: this.data.availablePerspectives
         });
 
@@ -42,7 +52,7 @@ pimcore.settings.user.role.settings = Class.create({
             width: 400,
             minHeight: 100,
             store: perspectivesStore,
-            displayField: "name",
+            displayField: "translatedName",
             valueField: "name",
             value: this.data.role.perspectives ? this.data.role.perspectives.join(",") : null
         });
@@ -102,7 +112,7 @@ pimcore.settings.user.role.settings = Class.create({
                 store: pimcore.globalmanager.get("document_types_store"),
                 value: this.data.docTypes,
                 listConfig: {
-                    itemTpl: new Ext.XTemplate('{[this.sanitize(values.name)]}',
+                    itemTpl: new Ext.XTemplate('{[this.sanitize(values.translatedName)]}',
                         {
                             sanitize: function (name) {
                                 return Ext.util.Format.htmlEncode(name);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
@@ -285,6 +285,16 @@ pimcore.settings.user.user.settings = Class.create({
         generalItems.push(this.roleField);
 
         var perspectivesStore = Ext.create('Ext.data.JsonStore', {
+            fields: [
+                "name",
+                {
+                    name:"translatedName",
+                    convert: function (v, rec) {
+                        return ts(rec.data.name);
+                    },
+                    depends : ['name']
+                }
+            ],
             data: this.data.availablePerspectives
         });
 
@@ -296,7 +306,7 @@ pimcore.settings.user.user.settings = Class.create({
             width: 400,
             minHeight: 100,
             store: perspectivesStore,
-            displayField: "name",
+            displayField: "translatedName",
             valueField: "name",
             value: this.currentUser.perspectives ? this.currentUser.perspectives.join(",") : null,
             hidden: this.currentUser.admin
@@ -519,7 +529,7 @@ pimcore.settings.user.user.settings = Class.create({
                     store: pimcore.globalmanager.get("document_types_store"),
                     value: this.currentUser.docTypes,
                     listConfig: {
-                        itemTpl: new Ext.XTemplate('{[this.sanitize(values.name)]}',
+                        itemTpl: new Ext.XTemplate('{[this.sanitize(values.translatedName)]}',
                             {
                                 sanitize: function (name) {
                                     return Ext.util.Format.htmlEncode(name);


### PR DESCRIPTION
The settings window should display the translated name of perspective and doc type