### PR TITLE
Update Important Notice Text of XLIFF Export

### DIFF
--- a/bundles/CoreBundle/Resources/translations/en.extended.json
+++ b/bundles/CoreBundle/Resources/translations/en.extended.json
@@ -84,7 +84,7 @@
   "turn_off_usage_statistics": "Turn off usage statistics",
   "children": "Children",
   "elements_to_export": "Elements to Export",
-  "xliff_export_documents": "If you want to translate eg. the whole \/en tree to a different language, first create a copy of \/en, eg. \/de then export \/de for translation. When importing the translated XLIFF the English contents in \/de will be overwritten by the German translation in the XLIFF file.",
+  "xliff_export_documents": "If you want to translate eg. the whole \/en tree to a different language, first create a copy of the \/en tree. Afterwards use the copied tree in the export and select the source language 'en' and the target language 'de'. When importing the translated XLIFF file, the contents of the exported documents (in this case the copied tree documents) will be overwritten by the German translations in the XLIFF file.",
   "xliff_export_objects": "Only fields inside a Localized Fields container are recognized. When importing the translated XLIFF the source language will be untouched, only the target language fields will be overwritten. Use Relations checkbox to include Objects & Documents from Dependencies e.g. Relation fields, Properties etc.",
   "xliff_export_notice": "Here you can select the documents and objects you want to export for external translation.",
   "important_notice": "Important Notice",


### PR DESCRIPTION
The current translation was confusing and did not indicate, whether the copied tree, or the original tree should be used for the export.
I believe the new translation would give clearer instructions to the user.