### PR TITLE
[Ecommerce][Indexservice] Fix doPreIndexDataModification call

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -391,6 +391,8 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
             $indexAttributeData = [];
             $indexRelationData = [];
 
+            $data = $this->doPreIndexDataModification($data);
+            
             //add system and index attributes
             foreach ($data['data'] as $dataKey => $dataEntry) {
                 if (array_key_exists($dataKey, $systemAttributeKeys)) {
@@ -410,8 +412,6 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
             foreach ($data['relations'] as $relation) {
                 $indexRelationData[$relation['fieldname']][] = $relation['dest'];
             }
-
-            $data = $this->doPreIndexDataModification($data);
 
             //check if parent should exist and if so, consider parent relation at indexing
             $routingId = $indexSystemData['o_type'] == ProductListInterface::PRODUCT_TYPE_VARIANT ? $indexSystemData['o_virtualProductId'] : $indexSystemData['o_id'];


### PR DESCRIPTION
# Bugfix
If the `$data = $this->doPreIndexDataModification($data);` gets called after the categorization of 

`$indexSystemData = [];
            $indexAttributeData = [];
            $indexRelationData = [];` 

the data in the mockup cache and the data which is written to the index may get inconsistent!

- Data `$data` which considers the adjustments done in `doPreIndexDataModification` is written to the cache in line https://github.com/pimcore/pimcore/blob/master/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php#L436
- Data `$this->bulkIndexData` which does not consider the adjustments done in `doPreIndexDataModification` is collected in https://github.com/pimcore/pimcore/blob/master/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php#L425