### PR TITLE
XLIFF Import - DataExtractor returns null

### DIFF
--- a/lib/Translation/ImportDataExtractor/ImportDataExtractorInterface.php
+++ b/lib/Translation/ImportDataExtractor/ImportDataExtractorInterface.php
@@ -26,7 +26,7 @@ interface ImportDataExtractorInterface
      *
      * @throws \Exception
      */
-    public function extractElement(string $importId, int $stepId): AttributeSet;
+    public function extractElement(string $importId, int $stepId): ?AttributeSet;
 
     /**
      * @param string $importId

--- a/lib/Translation/ImportDataExtractor/Xliff12DataExtractor.php
+++ b/lib/Translation/ImportDataExtractor/Xliff12DataExtractor.php
@@ -41,7 +41,7 @@ class Xliff12DataExtractor implements ImportDataExtractorInterface
     /**
      * @inheritdoc
      */
-    public function extractElement(string $importId, int $stepId): AttributeSet
+    public function extractElement(string $importId, int $stepId): ?AttributeSet
     {
         $xliff = $this->loadFile($importId);
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #5768

## Additional info  
The fix in the pull request above resolves the issue #5764 
The extractElement function of the DataExtractor now returns null instead of an exception, but its not defined as return value, so the import throws exception 
```Return value of Pimcore\Translation\ImportDataExtractor\Xliff12DataExtractor::extractElement() must be an instance of Pimcore\Translation\AttributeSet\AttributeSet, null returned```