### PR TITLE
[docs] \Pimcore\Tool::getHttpClient() has been removed

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/09_Cache/README.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/09_Cache/README.md
@@ -115,7 +115,7 @@ $uri = "http://www.pimcore.org/...";
 $cacheKey = md5($uri);
 if(!$data = \Pimcore\Cache::load($cacheKey)) {
  
-    $httpClient = \Pimcore\Tool::getHttpClient();
+    $httpClient = \Pimcore::getContainer()->get('pimcore.http_client');
     $httpClient->setUri($uri);
  
     try {


### PR DESCRIPTION
since Pimcore 5