### PR TITLE
[Object bricks] More specific return type for object brick container getter

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Objectbricks.php
+++ b/models/DataObject/ClassDefinition/Data/Objectbricks.php
@@ -701,15 +701,15 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface
         $key = $this->getName();
         $code = '';
 
+        $classname = '\\Pimcore\\Model\\DataObject\\' . ucfirst($class->getName()) . '\\' . ucfirst($this->getName());
+
         $code .= '/**' . "\n";
-        $code .= '* @return ' . $this->getPhpdocType() . "\n";
+        $code .= '* @return ' . $classname . "\n";
         $code .= '*/' . "\n";
         $code .= 'public function get' . ucfirst($key) . " () {\n";
 
         $code .= "\t" . '$data = $this->' . $key . ";\n";
         $code .= "\t" . 'if(!$data) { ' . "\n";
-
-        $classname = '\\Pimcore\\Model\\DataObject\\' . ucfirst($class->getName()) . '\\' . ucfirst($this->getName());
 
         $code .= "\t\t" . 'if(\Pimcore\Tool::classExists("' . str_replace('\\', '\\\\', $classname) . '")) { ' . "\n";
         $code .= "\t\t\t" . '$data = new ' . $classname . '($this, "' . $key . '");' . "\n";


### PR DESCRIPTION
Currently for object brick fields in a data object class its getter only says `@return \Pimcore\Model\DataObject\Objectbrick`. While this is correct it could be more specific by documenting the brick container class as return type, for example `@return \Pimcore\Model\DataObject\DataObjectClassName\ObjectBrickContainerFieldName`.