### PR TITLE
Javascript: Replace ts function to t in js files

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/tags/select.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/tags/select.js
@@ -119,7 +119,7 @@ pimcore.asset.tags.select = Class.create(pimcore.asset.tags.abstract, {
             options = options.split(',');
             for (var i = 0; i < options.length; i++) {
 
-                var key = ts(options[i]);
+                var key = t(options[i]);
                 if(key.indexOf('<') >= 0) {
                     key = replace_html_event_attributes(strip_tags(key, "div,span,b,strong,em,i,small,sup,sub"));
                 }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/tags/textarea.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/tags/textarea.js
@@ -24,7 +24,7 @@ pimcore.asset.tags.textarea = Class.create(pimcore.asset.tags.abstract, {
 
     getGridColumnConfig:function (field) {
         return {
-            text:ts(field.label),
+            text: t(field.label),
             width: this.getColumnWidth(field, 200),
             sortable:false,
             dataIndex:field.key,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/properties.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/properties.js
@@ -34,7 +34,7 @@ pimcore.element.properties = Class.create({
                     {
                         name:"translatedName",
                         convert: function(v, rec){
-                            return ts(rec.data.name);
+                            return t(rec.data.name);
                         },
                         depends : ['name']
                     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/object.js
@@ -122,7 +122,7 @@ pimcore.element.selector.object = Class.create(pimcore.element.selector.abstract
         var selectedClassStore = [];
         for (i=0; i<possibleClassRestrictions.length; i++) {
             if(in_array(possibleClassRestrictions[i], this.parent.restrictions.specific.classes )) {
-                filterClassStore.push([possibleClassRestrictions[i], ts(possibleClassRestrictions[i])]);
+                filterClassStore.push([possibleClassRestrictions[i], t(possibleClassRestrictions[i])]);
                 selectedClassStore.push(possibleClassRestrictions[i]);
             }
         }
@@ -214,7 +214,7 @@ pimcore.element.selector.object = Class.create(pimcore.element.selector.abstract
             this.selectionStore = new Ext.data.JsonStore({
                 data: [],
                 fields: ["id", "type", "filename", "fullpath", "subtype", {name:"classname",renderer: function(v){
-                    return ts(v);
+                    return t(v);
                 }}]
             });
 
@@ -372,7 +372,7 @@ pimcore.element.selector.object = Class.create(pimcore.element.selector.abstract
                 }
             },
             fields: ["id","fullpath","type","subtype","filename",{name:"classname",convert: function(v, rec){
-                return ts(rec.data.classname);
+                return t(rec.data.classname);
             }},"published"]
         });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/tag/imagehotspotmarkereditor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/tag/imagehotspotmarkereditor.js
@@ -693,7 +693,7 @@ pimcore.element.tag.imagehotspotmarkereditor = Class.create({
                 }
                 menu.push(
                     {
-                        text: ts(templateMenuName),
+                        text: t(templateMenuName),
                         iconCls: "pimcore_icon_hotspotmarker_template",
                         handler: function (templateConfig) {
                             var elId = callbackFunction(templateConfig);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -2891,7 +2891,7 @@ pimcore.helpers.keyBindingMapping = {
 };
 
 pimcore.helpers.showPermissionError = function(permission) {
-    Ext.MessageBox.alert(t("error"), sprintf(t('permission_missing'), ts(permission)));
+    Ext.MessageBox.alert(t("error"), sprintf(t('permission_missing'), t(permission)));
 };
 
 pimcore.helpers.registerAssetDnDSingleUpload = function (element, parent, parentType, success, failure, context) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/layout/portlets/customreports.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/layout/portlets/customreports.js
@@ -184,7 +184,7 @@ pimcore.layout.portlets.customreports = Class.create(pimcore.layout.portlets.abs
 
         for(var f=0; f<data.columnConfiguration.length; f++) {
             colConfig = data.columnConfiguration[f];
-            this.columnLabels[colConfig["name"]] = colConfig["label"] ? ts(colConfig["label"]) : ts(colConfig["name"]);
+            this.columnLabels[colConfig["name"]] = colConfig["label"] ? t(colConfig["label"]) : t(colConfig["name"]);
         }
 
 
@@ -401,10 +401,10 @@ pimcore.layout.portlets.customreports = Class.create(pimcore.layout.portlets.abs
                 continue;
             }
 
-            this.columnLabels[colConfig["name"]] = colConfig["label"] ? ts(colConfig["label"]) : ts(colConfig["name"]);
+            this.columnLabels[colConfig["name"]] = colConfig["label"] ? t(colConfig["label"]) : t(colConfig["name"]);
 
             gridColConfig = {
-                header: colConfig["label"] ? ts(colConfig["label"]) : ts(colConfig["name"]),
+                header: colConfig["label"] ? t(colConfig["label"]) : t(colConfig["name"]),
                 hidden: !colConfig["display"],
                 sortable: colConfig["order"],
                 dataIndex: colConfig["name"]
@@ -447,7 +447,7 @@ pimcore.layout.portlets.customreports = Class.create(pimcore.layout.portlets.abs
                     width: 40,
                     items: [
                         {
-                            tooltip: t("open") + " " + (colConfig["label"] ? ts(colConfig["label"]) : ts(colConfig["name"])),
+                            tooltip: t("open") + " " + (colConfig["label"] ? t(colConfig["label"]) : t(colConfig["name"])),
                             icon: "/bundles/pimcoreadmin/img/flat-color-icons/open_file.svg",
                             handler: function (colConfig, grid, rowIndex) {
                                 var data = grid.getStore().getAt(rowIndex).getData();

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/bulk-import.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/bulk-import.js
@@ -203,7 +203,7 @@ pimcore.object.bulkimport = Class.create(pimcore.object.bulkbase, {
                 });
             }
 
-            this.batchProgressBar.updateText(t('saving') + ' ' + t(this.values[idx].type) + " " + t("definition") + " " + ts(this.values[idx].displayName) + " (" + (idx + 1) + "/" + this.values.length + ")");
+            this.batchProgressBar.updateText(t('saving') + ' ' + t(this.values[idx].type) + " " + t("definition") + " " + t(this.values[idx].displayName) + " (" + (idx + 1) + "/" + this.values.length + ")");
 
             Ext.Ajax.request({
                 url: "/admin/class/bulk-commit",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/folder/search.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/folder/search.js
@@ -47,7 +47,7 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
                 var data = [];
                 for (i = 0; i < this.object.data.classes.length; i++) {
                     var klass = this.object.data.classes[i];
-                    data.push([klass.id, klass.name, ts(klass.name), klass.inheritance]);
+                    data.push([klass.id, klass.name, t(klass.name), klass.inheritance]);
 
                 }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/AssetMetadataGetter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/AssetMetadataGetter.js
@@ -89,7 +89,7 @@ pimcore.object.gridcolumn.operator.assetmetadatagetter = Class.create(pimcore.ob
         var data = [];
         for (var i = 0; i < pimcore.settings.websiteLanguages.length; i++) {
             var language = pimcore.settings.websiteLanguages[i];
-            data.push([language, ts(pimcore.available_languages[language])]);
+            data.push([language, t(pimcore.available_languages[language])]);
         }
 
         var store = new Ext.data.ArrayStore({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/LFExpander.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/LFExpander.js
@@ -92,7 +92,7 @@ pimcore.object.gridcolumn.operator.lfexpander = Class.create(pimcore.object.grid
         var data = [];
         for (var i = 0; i < pimcore.settings.websiteLanguages.length; i++) {
             var language = pimcore.settings.websiteLanguages[i];
-            data.push([language, ts(pimcore.available_languages[language])]);
+            data.push([language, t(pimcore.available_languages[language])]);
         }
 
         var localeStore = new Ext.data.ArrayStore({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/LocaleSwitcher.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/LocaleSwitcher.js
@@ -91,7 +91,7 @@ pimcore.object.gridcolumn.operator.localeswitcher = Class.create(pimcore.object.
         var data = [];
         for (var i = 0; i < pimcore.settings.websiteLanguages.length; i++) {
             var language = pimcore.settings.websiteLanguages[i];
-            data.push([language, ts(pimcore.available_languages[language])]);
+            data.push([language, t(pimcore.available_languages[language])]);
         }
 
         var store = new Ext.data.ArrayStore({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/classTree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/classTree.js
@@ -143,7 +143,7 @@ pimcore.object.helpers.classTree = Class.create({
                             brickField: data[keys[i]].brickField
                         };
 
-                        text = ts(data[keys[i]].nodeLabel) + " " + t("columns");
+                        text = t(data[keys[i]].nodeLabel) + " " + t("columns");
 
                     }
                     var baseNode = {
@@ -253,7 +253,7 @@ pimcore.object.helpers.classTree = Class.create({
                 }
             }
 
-            var text = ts(initData.title);
+            var text = t(initData.title);
             if (showFieldname) {
                 if (brickDescriptor && brickDescriptor.insideBrick && brickDescriptor.insideLocalizedFields) {
                     text = text + "(" + brickDescriptor.brickType + "." + initData.name + ")";

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
@@ -590,7 +590,7 @@ pimcore.object.helpers.customLayoutEditor = Class.create({
 
                     var text = t(child.name);
                     if(child.nodeType == "objectbricks") {
-                        text = ts(child.title) + " " + t("columns");
+                        text = t(child.title) + " " + t("columns");
                         attributePrefix = child.title;
                     }
 
@@ -698,7 +698,7 @@ pimcore.object.helpers.customLayoutEditor = Class.create({
             key = attributePrefix + "~" + key;
         }
 
-        var text = ts(initData.title);
+        var text = t(initData.title);
         if(showFieldname) {
             text = text + " (" + key.replace("~", ".") + ")";
         }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/edit.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/edit.js
@@ -406,7 +406,7 @@ pimcore.object.helpers.edit = {
                                 try {
                                     new Ext.ToolTip({
                                         target: el,
-                                        html: nl2br(ts(field.tooltip)),
+                                        html: nl2br(t(field.tooltip)),
                                         trackMouse:true,
                                         showDelay: 200,
                                         dismissDelay: 0

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/edit.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/edit.js
@@ -133,7 +133,7 @@ pimcore.object.helpers.edit = {
 
         // translate title
         if(typeof l.title != "undefined") {
-            l.title = ts(l.title);
+            l.title = t(l.title);
         }
 
         if (l.datatype == "layout") {
@@ -215,7 +215,7 @@ pimcore.object.helpers.edit = {
                     if(l[configKeys[u]]) {
                         //if (typeof l[configKeys[u]] != "undefined") {
                         if(configKeys[u] == "html"){
-                            newConfig[configKeys[u]] = l["renderingClass"] ? l[configKeys[u]] : ts(l[configKeys[u]]);
+                            newConfig[configKeys[u]] = l["renderingClass"] ? l[configKeys[u]] : t(l[configKeys[u]]);
                         } else {
                             newConfig[configKeys[u]] = l[configKeys[u]];
                         }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
@@ -243,7 +243,7 @@ pimcore.object.helpers.grid = Class.create({
                     dataIndex: 'key', hidden: !showKey, filter: 'string'});
             } else if(field.key == "classname") {
                 gridColumns.push({text: t("class"), width: this.getColumnWidth(field, 200), sortable: true,
-                    dataIndex: 'classname',renderer: function(v){return ts(v);}/*, hidden: true*/});
+                    dataIndex: 'classname',renderer: function(v){return t(v);}/*, hidden: true*/});
             } else if(field.key == "creationDate") {
                 gridColumns.push({text: t("creationdate") + " (System)", width: this.getColumnWidth(field, 200), sortable: true,
                     dataIndex: "creationDate", filter: 'date', editable: false, renderer: function(d) {
@@ -411,7 +411,7 @@ pimcore.object.helpers.grid = Class.create({
 
                 result += '<tr><td>&nbsp;</td>';
                 for (let i = 0; i < columnKeys.length; i++) {
-                    result += '<td style="padding: 0 5px 0 5px; font-size:11px; border-bottom: 1px solid #d0d0d0; border-top: 1px solid #d0d0d0; border-left: 1px solid #d0d0d0; border-right: 1px solid #d0d0d0;">' + ts(columnKeys[i]) + '</td>';
+                    result += '<td style="padding: 0 5px 0 5px; font-size:11px; border-bottom: 1px solid #d0d0d0; border-top: 1px solid #d0d0d0; border-left: 1px solid #d0d0d0; border-right: 1px solid #d0d0d0;">' + t(columnKeys[i]) + '</td>';
                 }
                 result += '</tr>';
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/gridConfigDialog.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/gridConfigDialog.js
@@ -202,7 +202,7 @@ pimcore.object.helpers.gridConfigDialog = Class.create(pimcore.element.helpers.g
                     }
                     child = child[0];
                 } else {
-                    var text = ts(nodeConf.label);
+                    var text = t(nodeConf.label);
 
                     if (nodeConf.dataType !== "system" && this.showFieldname && nodeConf.key) {
                         text = text + " (" + nodeConf.key.replace("~", ".") + ")";

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/metadataMultiselectEditor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/metadataMultiselectEditor.js
@@ -44,7 +44,7 @@ Ext.define('pimcore.object.helpers.metadataMultiselectEditor', {
         if (fieldConfig.value) {
             var selectDataRaw = fieldConfig.value.split(";");
             for (var j = 0; j < selectDataRaw.length; j++) {
-                selectData.push([selectDataRaw[j], ts(selectDataRaw[j])]);
+                selectData.push([selectDataRaw[j], t(selectDataRaw[j])]);
             }
         }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/LocaleSwitcher.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/importcolumn/operator/LocaleSwitcher.js
@@ -90,7 +90,7 @@ pimcore.object.importcolumn.operator.localeswitcher = Class.create(pimcore.objec
         var data = [];
         for (var i = 0; i < pimcore.settings.websiteLanguages.length; i++) {
             var language = pimcore.settings.websiteLanguages[i];
-            data.push([language, ts(pimcore.available_languages[language])]);
+            data.push([language, t(pimcore.available_languages[language])]);
         }
 
         var store = new Ext.data.ArrayStore({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
@@ -464,7 +464,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
 
                 var menu = [];
                 for (var i = 0; i < this.data.validLayouts.length; i++) {
-                    var menuLabel = ts(this.data.validLayouts[i].name);
+                    var menuLabel = t(this.data.validLayouts[i].name);
                     if (this.data.currentLayoutId == this.data.validLayouts[i].id) {
                         menuLabel = "<b>" + menuLabel + "</b>";
                     }
@@ -539,7 +539,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
             buttons.push("-");
             buttons.push({
                 xtype: 'tbtext',
-                text: ts(this.data.general.o_className),
+                text: t(this.data.general.o_className),
                 scale: "medium"
             });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbricks/field.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbricks/field.js
@@ -134,7 +134,7 @@ pimcore.object.objectbricks.field = Class.create(pimcore.object.classes.klass, {
 
             if (rec) {
                 classMenu.push({
-                    text: ts(rec.data.translatedText),
+                    text: t(rec.data.translatedText),
                     handler: this.addClassDefinition.bind(this, null, rec.data.text),
                     iconCls: "pimcore_icon_class"
                 });
@@ -146,7 +146,7 @@ pimcore.object.objectbricks.field = Class.create(pimcore.object.classes.klass, {
         if (classMenu.length === 1) {
             items.push({
                 cls: "pimcore_block_button_plus",
-                text: ts(classMenu[0].text),
+                text: t(classMenu[0].text),
                 iconCls: "pimcore_icon_plus",
                 handler: classMenu[0].handler
             });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/abstract.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/abstract.js
@@ -89,7 +89,7 @@ pimcore.object.tags.abstract = Class.create({
 
         }.bind(this, field.key);
 
-        return {text:ts(field.label), sortable:true, dataIndex:field.key, renderer:renderer,
+        return {text: t(field.label), sortable:true, dataIndex:field.key, renderer:renderer,
             editor:this.getGridColumnEditor(field)};
     },
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/abstractRelations.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/abstractRelations.js
@@ -107,7 +107,7 @@ pimcore.object.tags.abstractRelations = Class.create(pimcore.object.tags.abstrac
             if (columnConfig.value) {
                 var selectDataRaw = columnConfig.value.split(";");
                 for (var j = 0; j < selectDataRaw.length; j++) {
-                    selectData.push([selectDataRaw[j], ts(selectDataRaw[j])]);
+                    selectData.push([selectDataRaw[j], t(selectDataRaw[j])]);
                 }
             }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -163,7 +163,7 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
                     var selectDataRaw = this.fieldConfig.columns[i].value.split(";");
 
                     for (var j = 0; j < selectDataRaw.length; j++) {
-                        selectData.push([selectDataRaw[j], ts(selectDataRaw[j])]);
+                        selectData.push([selectDataRaw[j], t(selectDataRaw[j])]);
                     }
                 }
 
@@ -209,7 +209,7 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
 
                 if (readOnly) {
                     columns.push(Ext.create('Ext.grid.column.Check', {
-                        text: ts(this.fieldConfig.columns[i].label),
+                        text: t(this.fieldConfig.columns[i].label),
                         dataIndex: this.fieldConfig.columns[i].key,
                         width: width,
                         renderer: renderer
@@ -221,12 +221,12 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
 
             if(this.fieldConfig.columns[i].type == "select") {
                 renderer = function (value, metaData, record, rowIndex, colIndex, store) {
-                    return ts(value);
+                    return t(value);
                 }
             }
 
             var columnConfig = {
-                text: ts(this.fieldConfig.columns[i].label),
+                text: t(this.fieldConfig.columns[i].label),
                 dataIndex: this.fieldConfig.columns[i].key,
                 renderer: renderer,
                 listeners: listeners,
@@ -576,7 +576,7 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
 
     getGridColumnConfig: function (field) {
         return {
-            text: ts(field.label), width: 150, sortable: false, dataIndex: field.key,
+            text: t(field.label), width: 150, sortable: false, dataIndex: field.key,
             getEditor: this.getWindowCellEditor.bind(this, field),
             renderer: pimcore.object.helpers.grid.prototype.advancedRelationGridRenderer.bind(this, field, "fullpath")
         };

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -127,7 +127,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
                 if (this.fieldConfig.columns[i].value) {
                     var selectDataRaw = this.fieldConfig.columns[i].value.split(";");
                     for (var j = 0; j < selectDataRaw.length; j++) {
-                        selectData.push([selectDataRaw[j], ts(selectDataRaw[j])]);
+                        selectData.push([selectDataRaw[j], t(selectDataRaw[j])]);
                     }
                 }
 
@@ -169,7 +169,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
 
                 if (readOnly) {
                     columns.push(Ext.create('Ext.grid.column.Check', {
-                        text: ts(this.fieldConfig.columns[i].label),
+                        text: t(this.fieldConfig.columns[i].label),
                         dataIndex: this.fieldConfig.columns[i].key,
                         width: width,
                         renderer: renderer
@@ -204,12 +204,12 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
 
             if (this.fieldConfig.columns[i].type == "select") {
                 renderer = function (value, metaData, record, rowIndex, colIndex, store) {
-                    return ts(value);
+                    return t(value);
                 }
             }
 
             var columnConfig = {
-                text: ts(this.fieldConfig.columns[i].label),
+                text: t(this.fieldConfig.columns[i].label),
                 dataIndex: this.fieldConfig.columns[i].key,
                 renderer: renderer,
                 listeners: listeners,
@@ -907,7 +907,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
 
     getGridColumnConfig: function (field) {
         return {
-            text: ts(field.label), width: 150, sortable: false, dataIndex: field.key,
+            text: t(field.label), width: 150, sortable: false, dataIndex: field.key,
             getEditor: this.getWindowCellEditor.bind(this, field),
             renderer: pimcore.object.helpers.grid.prototype.advancedRelationGridRenderer.bind(this, field, "path")
         };

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/block.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/block.js
@@ -33,7 +33,7 @@ pimcore.object.tags.block = Class.create(pimcore.object.tags.abstract, {
     },
 
     getGridColumnConfig: function(field) {
-        return {text: ts(field.label), width: 150, sortable: false, dataIndex: field.key,
+        return {text: t(field.label), width: 150, sortable: false, dataIndex: field.key,
             renderer: function (key, value, metaData, record) {
                 this.applyPermissionStyle(key, value, metaData, record);
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/booleanSelect.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/booleanSelect.js
@@ -45,7 +45,7 @@ pimcore.object.tags.booleanSelect = Class.create(pimcore.object.tags.abstract, {
         }.bind(this, field.key);
 
         return {
-            text: ts(field.label), sortable: true, dataIndex: field.key, renderer: renderer,
+            text: t(field.label), sortable: true, dataIndex: field.key, renderer: renderer,
             editor: this.getGridColumnEditor(field)
         };
 
@@ -159,7 +159,7 @@ pimcore.object.tags.booleanSelect = Class.create(pimcore.object.tags.abstract, {
         if (this.fieldConfig.options) {
             for (var i = 0; i < this.fieldConfig.options.length; i++) {
                 var value = this.fieldConfig.options[i].value;
-                store.push([value, ts(this.fieldConfig.options[i].key)]);
+                store.push([value, t(this.fieldConfig.options[i].key)]);
                 validValues.push(value);
             }
         }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
@@ -98,7 +98,7 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
             return value;
         }.bind(this, field.key);
 
-        return {text:ts(field.label), sortable:true, dataIndex:field.key, renderer:renderer,
+        return {text: t(field.label), sortable:true, dataIndex:field.key, renderer:renderer,
             editor:this.getGridColumnEditor(field)};
     }
 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/checkbox.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/checkbox.js
@@ -35,7 +35,7 @@ pimcore.object.tags.checkbox = Class.create(pimcore.object.tags.abstract, {
 
     getGridColumnConfig:function (field) {
         var columnConfig = {
-            text:ts(field.label),
+            text: t(field.label),
             dataIndex:field.key,
             renderer:function (key, value, metaData, record, rowIndex, colIndex, store) {
                 var key = field.key;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/classificationstore.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/classificationstore.js
@@ -421,7 +421,7 @@ pimcore.object.tags.classificationstore = Class.create(pimcore.object.tags.abstr
 
 
         var config = {
-            title: ts(groupTitle),
+            title: t(groupTitle),
             items: groupedChildItems,
             collapsible: true
         };

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/consent.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/consent.js
@@ -32,7 +32,7 @@ pimcore.object.tags.consent = Class.create(pimcore.object.tags.abstract, {
 
     getGridColumnConfig:function (field) {
         var columnConfig = {
-            text: ts(field.label),
+            text: t(field.label),
             dataIndex: field.key,
             renderer:function (key, value, metaData, record, rowIndex, colIndex, store) {
                 var key = field.key;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/date.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/date.js
@@ -36,7 +36,7 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
     },
 
     getGridColumnConfig:function (field) {
-        return {text:ts(field.label), width:150, sortable:true, dataIndex:field.key,
+        return {text: t(field.label), width:150, sortable:true, dataIndex:field.key,
             getEditor:this.getWindowCellEditor.bind(this, field),
             renderer:function (key, value, metaData, record) {
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/datetime.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/datetime.js
@@ -35,7 +35,7 @@ pimcore.object.tags.datetime = Class.create(pimcore.object.tags.abstract, {
 
     getGridColumnConfig:function (field) {
         return {
-            text:ts(field.label),
+            text: t(field.label),
             width:150,
             sortable:true,
             dataIndex:field.key,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/encryptedField.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/encryptedField.js
@@ -30,7 +30,7 @@ pimcore.object.tags.encryptedField = Class.create(pimcore.object.tags.abstract, 
         if (typeof pimcore.object.tags[field.layout.delegateDatatype] !== "undefined") {
             return pimcore.object.tags[field.layout.delegateDatatype].prototype.getGridColumnConfig(this.getDelegateGridConfig(field));
         } else {
-            return {text: ts(field.label), width: 150, sortable: false};
+            return {text: t(field.label), width: 150, sortable: false};
         }
     },
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/externalImage.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/externalImage.js
@@ -28,7 +28,7 @@ pimcore.object.tags.externalImage = Class.create(pimcore.object.tags.abstract, {
 
     getGridColumnConfig: function(field) {
 
-        return {text: ts(field.label), width: 100, sortable: false, dataIndex: field.key,
+        return {text: t(field.label), width: 100, sortable: false, dataIndex: field.key,
             getEditor:this.getWindowCellEditor.bind(this, field),
             renderer: function (key, value, metaData, record) {
                                     this.applyPermissionStyle(key, value, metaData, record);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
@@ -39,7 +39,7 @@ pimcore.object.tags.fieldcollections = Class.create(pimcore.object.tags.abstract
 
 
     getGridColumnConfig: function(field) {
-        return {text: ts(field.label), width: 150, sortable: false, dataIndex: field.key,
+        return {text: t(field.label), width: 150, sortable: false, dataIndex: field.key,
                 renderer: function (key, value, metaData, record) {
                     this.applyPermissionStyle(key, value, metaData, record);
 
@@ -144,7 +144,7 @@ pimcore.object.tags.fieldcollections = Class.create(pimcore.object.tags.abstract
                 var elementData = data[i];
 
                 var menuItem = {
-                    text: elementData.title ? ts(elementData.title) : ts(elementData.text),
+                    text: elementData.title ? t(elementData.title) : t(elementData.text),
                     iconCls: elementData.iconCls
                 };
                 if (elementData.group) {
@@ -254,7 +254,7 @@ pimcore.object.tags.fieldcollections = Class.create(pimcore.object.tags.abstract
             if (title) {
                 items.push({
                     xtype: "tbtext",
-                    text: ts(title)
+                    text: t(title)
                 });
             }
         }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geo/abstract.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geo/abstract.js
@@ -21,7 +21,7 @@ pimcore.object.tags.geo.abstract = Class.create(pimcore.object.tags.abstract, {
 
     getGridColumnConfig: function(field) {
         return {
-            text: ts(field.label),
+            text: t(field.label),
             width: 150,
             sortable: false,
             dataIndex: field.key,
@@ -32,7 +32,7 @@ pimcore.object.tags.geo.abstract = Class.create(pimcore.object.tags.abstract, {
                     metaData.tdCls += ' grid_value_inherited';
                 }
                 if (value) {
-                    return ts('preview_not_available');
+                    return t('preview_not_available');
                 }
             }.bind(this, field.key)
         };

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geopoint.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geopoint.js
@@ -251,7 +251,7 @@ pimcore.object.tags.geopoint = Class.create(pimcore.object.tags.geo.abstract, {
 
     getGridColumnConfig: function (field) {
         return {
-            text: ts(field.label),
+            text: t(field.label),
             width: 150,
             sortable: false,
             dataIndex: field.key,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
@@ -52,7 +52,7 @@ pimcore.object.tags.hotspotimage = Class.create(pimcore.object.tags.image, {
 
     getGridColumnConfig: function (field, forGridConfigPreview) {
         return {
-            text: ts(field.label), width: 100, sortable: false, dataIndex: field.key,
+            text: t(field.label), width: 100, sortable: false, dataIndex: field.key,
             getEditor: this.getWindowCellEditor.bind(this, field),
             renderer: function (key, value, metaData, record, rowIndex, colIndex, store, view) {
                 this.applyPermissionStyle(key, value, metaData, record);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/image.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/image.js
@@ -30,7 +30,7 @@ pimcore.object.tags.image = Class.create(pimcore.object.tags.abstract, {
     getGridColumnConfig: function (field, forGridConfigPreview) {
 
         return {
-            text: ts(field.label), width: 100, sortable: false, dataIndex: field.key,
+            text: t(field.label), width: 100, sortable: false, dataIndex: field.key,
             getEditor: this.getWindowCellEditor.bind(this, field),
             renderer: function (key, value, metaData, record, rowIndex, colIndex, store, view) {
                 this.applyPermissionStyle(key, value, metaData, record);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/imagegallery.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/imagegallery.js
@@ -35,7 +35,7 @@ pimcore.object.tags.imageGallery = Class.create(pimcore.object.tags.abstract, {
     getGridColumnConfig: function (field) {
 
         return {
-            text: ts(field.label), width: 100, sortable: false, dataIndex: field.key,
+            text: t(field.label), width: 100, sortable: false, dataIndex: field.key,
             getEditor: this.getWindowCellEditor.bind(this, field),
             renderer: function (key, value, metaData, record) {
                 this.applyPermissionStyle(key, value, metaData, record);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/inputQuantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/inputQuantityValue.js
@@ -132,7 +132,7 @@ pimcore.object.tags.inputQuantityValue = Class.create(pimcore.object.tags.abstra
         }.bind(this, field.key);
 
         return {
-            text:ts(field.label),
+            text: t(field.label),
             sortable:true,
             dataIndex:field.key,
             renderer:renderer

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/link.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/link.js
@@ -56,7 +56,7 @@ pimcore.object.tags.link = Class.create(pimcore.object.tags.abstract, {
         }.bind(this, field.key);
 
         return {
-            text: ts(field.label), sortable: true, dataIndex: field.key, renderer: renderer,
+            text: t(field.label), sortable: true, dataIndex: field.key, renderer: renderer,
             getEditor: this.getWindowCellEditor.bind(this, field)
         };
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/localizedfields.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/localizedfields.js
@@ -243,7 +243,7 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
                 var data = [];
                 for (var i = 0; i < nrOfLanguages; i++) {
                     var language = this.frontendLanguages[i];
-                    data.push([language, ts(pimcore.available_languages[language])]);
+                    data.push([language, t(pimcore.available_languages[language])]);
                 }
 
                 var store = new Ext.data.ArrayStore({
@@ -788,7 +788,7 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
                     dataIndex: 'language',
                     flex: 5,
                     renderer: function (value, metaData, record, row, col, store, gridView) {
-                        return ts(pimcore.available_languages[value]);
+                        return t(pimcore.available_languages[value]);
                     }
                 }, {
                     xtype: 'checkcolumn',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -63,7 +63,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
 
     getGridColumnConfig: function (field) {
         return {
-            text: ts(field.label), width: 150, sortable: false, dataIndex: field.key, renderer:
+            text: t(field.label), width: 150, sortable: false, dataIndex: field.key, renderer:
                 function (key, value, metaData, record) {
                     this.applyPermissionStyle(key, value, metaData, record);
 
@@ -257,7 +257,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
         if (allowedClasses && allowedClasses.length > 0) {
             for (i = 0; i < allowedClasses.length; i++) {
                 collectionMenu.push({
-                    text: ts(allowedClasses[i]),
+                    text: t(allowedClasses[i]),
                     handler: this.create.bind(this, allowedClasses[i]),
                     iconCls: "pimcore_icon_fieldcollection"
                 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -74,7 +74,7 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
 
     getGridColumnConfig: function (field) {
         return {
-            text: ts(field.label), width: 150, sortable: false, dataIndex: field.key,
+            text: t(field.label), width: 150, sortable: false, dataIndex: field.key,
             getEditor: this.getWindowCellEditor.bind(this, field),
             renderer: function (key, value, metaData, record) {
                 this.applyPermissionStyle(key, value, metaData, record);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -54,7 +54,7 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
         }.bind(this, field.key);
 
         return {
-            text: ts(field.label), sortable: false, dataIndex: field.key, renderer: renderer,
+            text: t(field.label), sortable: false, dataIndex: field.key, renderer: renderer,
             getEditor: this.getWindowCellEditor.bind(this, field)
         };
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multiselect.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multiselect.js
@@ -29,11 +29,11 @@ pimcore.object.tags.multiselect = Class.create(pimcore.object.tags.abstract, {
         var displayValues = {};
         if (field.layout.options) {
             for (var i = 0; i < field.layout.options.length; i++) {
-                displayValues[field.layout.options[i].value] = ts(field.layout.options[i].key);
+                displayValues[field.layout.options[i].value] = t(field.layout.options[i].key);
             }
         }
 
-        return {text: ts(field.label), width: 150, sortable: false, dataIndex: field.key,
+        return {text: t(field.label), width: 150, sortable: false, dataIndex: field.key,
             getEditor:this.getWindowCellEditor.bind(this, field),
             renderer: function (key, displayValues, value, metaData, record) {
                 try {
@@ -105,7 +105,7 @@ pimcore.object.tags.multiselect = Class.create(pimcore.object.tags.abstract, {
                     }
                 }
 
-                var label = ts(fieldConfig.options[i].key);
+                var label = t(fieldConfig.options[i].key);
                 if(label.indexOf('<') >= 0) {
                     label = replace_html_event_attributes(strip_tags(label, "div,span,b,strong,em,i,small,sup,sub2"));
                 }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
@@ -110,7 +110,7 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
                 }
 
                 var menuItem = {
-                    text: elementData.title ? ts(elementData.title) : ts(elementData.text),
+                    text: elementData.title ? t(elementData.title) : t(elementData.text),
                     iconCls: elementData.iconCls
                 };
                 if (elementData.group) {
@@ -168,7 +168,7 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
 
             items.push({
                 xtype: "tbtext",
-                text: ts(this.fieldConfig.title)
+                text: t(this.fieldConfig.title)
             });
 
             var toolbar = new Ext.Toolbar({
@@ -270,7 +270,7 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
                 closable: !this.fieldConfig.noteditable,
                 autoHeight: true,
                 border: false,
-                title: title ? ts(title) : ts(type),
+                title: title ? t(title) : t(type),
                 // items: items
                 items: [],
                 listeners: {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
@@ -230,7 +230,7 @@ pimcore.object.tags.quantityValue = Class.create(pimcore.object.tags.abstract, {
 
         return {
             getEditor:this.getWindowCellEditor.bind(this, field),
-            text:ts(field.label),
+            text: t(field.label),
             sortable:true,
             dataIndex:field.key,
             renderer:renderer

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/reverseManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/reverseManyToManyObjectRelation.js
@@ -122,7 +122,7 @@ pimcore.object.tags.reverseManyToManyObjectRelation = Class.create(pimcore.objec
         // no class for nonowner is specified
         if(!record) {
             this.component = new Ext.Panel({
-                title: ts(this.fieldConfig.title),
+                title: t(this.fieldConfig.title),
                 cls: cls,
                 html: "There's no class specified in the field-configuration"
             });
@@ -189,8 +189,8 @@ pimcore.object.tags.reverseManyToManyObjectRelation = Class.create(pimcore.objec
                 items: [{
                     xtype: "tbtext",
                     text: ' <span class="warning">' + t('nonownerobject_warning') + " | " + t('owner_class')
-                                    + ':<b>' + ts(className) + "</b> " + t('owner_field') + ': <b>'
-                                    + ts(this.fieldConfig.ownerFieldName) + '</b></span>'
+                                    + ':<b>' + t(className) + "</b> " + t('owner_field') + ': <b>'
+                                    + t(this.fieldConfig.ownerFieldName) + '</b></span>'
                 }],
                 ctCls: "pimcore_force_auto_width",
                 cls: "pimcore_force_auto_width"

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/rgbaColor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/rgbaColor.js
@@ -30,7 +30,7 @@ pimcore.object.tags.rgbaColor = Class.create(pimcore.object.tags.abstract, {
     getGridColumnConfig: function (field) {
 
         return {
-            text: ts(field.label), width: 120, sortable: false, dataIndex: field.key, sortable: true,
+            text: t(field.label), width: 120, sortable: false, dataIndex: field.key, sortable: true,
             getEditor: this.getWindowCellEditor.bind(this, field),
             renderer: function (key, value, metaData, record) {
                 this.applyPermissionStyle(key, value, metaData, record);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/select.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/select.js
@@ -48,7 +48,7 @@ pimcore.object.tags.select = Class.create(pimcore.object.tags.abstract, {
         }.bind(this, field.key);
 
         return {
-            text:ts(field.label),
+            text: t(field.label),
             sortable:true,
             dataIndex:field.key,
             renderer: renderer,
@@ -78,7 +78,7 @@ pimcore.object.tags.select = Class.create(pimcore.object.tags.abstract, {
         }.bind(this, field.key);
 
         return {
-            text: ts(field.label),
+            text: t(field.label),
             sortable: true,
             dataIndex: field.key,
             renderer: renderer,
@@ -184,7 +184,7 @@ pimcore.object.tags.select = Class.create(pimcore.object.tags.abstract, {
         if (options) {
             for (var i = 0; i < options.length; i++) {
 
-                var label = ts(options[i].key);
+                var label = t(options[i].key);
                 if(label.indexOf('<') >= 0) {
                     label = replace_html_event_attributes(strip_tags(label, "div,span,b,strong,em,i,small,sup,sub2"));
                 }
@@ -239,7 +239,7 @@ pimcore.object.tags.select = Class.create(pimcore.object.tags.abstract, {
                     }
                 }
 
-                var label = ts(this.fieldConfig.options[i].key);
+                var label = t(this.fieldConfig.options[i].key);
                 if(label.indexOf('<') >= 0) {
                     hasHTMLContent = true;
                     label = replace_html_event_attributes(strip_tags(label, "div,span,b,strong,em,i,small,sup,sub2"));

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/slider.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/slider.js
@@ -148,7 +148,7 @@ pimcore.object.tags.slider = Class.create(pimcore.object.tags.abstract, {
         }.bind(this, field.key);
 
         return {
-            text: ts(field.label), sortable: true, dataIndex: field.key, renderer: renderer,
+            text: t(field.label), sortable: true, dataIndex: field.key, renderer: renderer,
             getEditor: this.getWindowCellEditor.bind(this, field)
         };
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/structuredTable.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/structuredTable.js
@@ -64,7 +64,7 @@ pimcore.object.tags.structuredTable = Class.create(pimcore.object.tags.abstract,
     },
 
     getGridColumnConfig: function(field) {
-        return {text: ts(field.label), width: 150, sortable: false, dataIndex: field.key,
+        return {text: t(field.label), width: 150, sortable: false, dataIndex: field.key,
             renderer: function (key, field, value, metaData, record) {
                         this.applyPermissionStyle(key, value, metaData, record);
 
@@ -81,7 +81,7 @@ pimcore.object.tags.structuredTable = Class.create(pimcore.object.tags.abstract,
                             table += '<tr>';
                             table += '<td></td>';
                             for (var c = 0; c < cols.length; c++) {
-                                table += '<td>' + ts(field.layout.cols[c].label) + '</td>';
+                                table += '<td>' + t(field.layout.cols[c].label) + '</td>';
                             }
                             table += '</tr>';
 
@@ -91,7 +91,7 @@ pimcore.object.tags.structuredTable = Class.create(pimcore.object.tags.abstract,
                                 cols = Object.keys(row);
 
                                 table += '<tr>';
-                                table += '<td>' + ts(field.layout.rows[i].label) + '</td>';
+                                table += '<td>' + t(field.layout.rows[i].label) + '</td>';
                                 for (var c = 0; c < cols.length; c++) {
                                     table += '<td>' + row[cols[c]] + '</td>';
                                 }
@@ -115,7 +115,7 @@ pimcore.object.tags.structuredTable = Class.create(pimcore.object.tags.abstract,
             {text: this.fieldConfig.labelFirstCell, width: this.fieldConfig.labelWidth, sortable: false,
                                 dataIndex: '__row_label', editor: null, renderer: function(value, metaData) {
                     metaData.tdCls = 'x-grid-hd-row';
-                    return ts(value);
+                    return t(value);
                }
             }
         ];
@@ -152,7 +152,7 @@ pimcore.object.tags.structuredTable = Class.create(pimcore.object.tags.abstract,
             }
 
             columns.push({
-                text: ts(this.fieldConfig.cols[i].label),
+                text: t(this.fieldConfig.cols[i].label),
                 width: this.fieldConfig.cols[i].width,
                 sortable: false,
                 dataIndex: this.fieldConfig.cols[i].key,
@@ -224,14 +224,14 @@ pimcore.object.tags.structuredTable = Class.create(pimcore.object.tags.abstract,
             {text: "", width: 80, sortable: false, dataIndex: '__row_label', editor: null,
                 renderer: function(value, metaData) {
                                 metaData.tdCls = 'x-grid3-hd-row';
-                                return ts(value);
+                                return t(value);
                            }
             }
         ];
 
         for(var i = 0; i < this.fieldConfig.cols.length; i++) {
 
-            var columnConfig = {text: ts(this.fieldConfig.cols[i].label), width: 120, sortable: false,
+            var columnConfig = {text: t(this.fieldConfig.cols[i].label), width: 120, sortable: false,
                 dataIndex: this.fieldConfig.cols[i].key, editor: null};
             if(this.fieldConfig.cols[i].type == "bool") {
                 columnConfig.renderer = function (value, metaData, record, rowIndex, colIndex, store) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/table.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/table.js
@@ -79,7 +79,7 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
                     if(field.layout.columnConfigActivated && field.layout.columnConfig) {
                         table += '<tr>';
                         for (var i = 0; i < value[0].length; i++) {
-                            table += '<th>' + Ext.util.Format.htmlEncode(ts(field.layout.columnConfig[i].label)) + '</th>';
+                            table += '<th>' + Ext.util.Format.htmlEncode(t(field.layout.columnConfig[i].label)) + '</th>';
                         }
                         table += '</tr>';
                     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/table.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/table.js
@@ -63,7 +63,7 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
 
     getGridColumnConfig: function (field) {
         return {
-            text: ts(field.label), width: 150, sortable: false, dataIndex: field.key,
+            text: t(field.label), width: 150, sortable: false, dataIndex: field.key,
             getEditor: this.getWindowCellEditor.bind(this, field),
             renderer: function (key, value, metaData, record) {
                 this.applyPermissionStyle(key, value, metaData, record);
@@ -146,7 +146,7 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
         if (data.items[0]) {
             for (var i = 0; i < fields.length; i++) {
                 columns.push({
-                    text: this.fieldConfig.columnConfigActivated && this.fieldConfig.columnConfig[i] ? ts(this.fieldConfig.columnConfig[i].label) : '',
+                    text: this.fieldConfig.columnConfigActivated && this.fieldConfig.columnConfig[i] ? t(this.fieldConfig.columnConfig[i].label) : '',
                     dataIndex: fields[i].name,
                     editor: new Ext.form.TextField(),
                     sortable: false,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/time.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/time.js
@@ -75,7 +75,7 @@ pimcore.object.tags.time = Class.create(pimcore.object.tags.abstract, {
         }.bind(this, field.key);
 
         return {
-            text: ts(field.label), sortable: true, dataIndex: field.key, renderer: renderer,
+            text: t(field.label), sortable: true, dataIndex: field.key, renderer: renderer,
             getEditor:this.getWindowCellEditor.bind(this, field)
         };
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
@@ -276,7 +276,7 @@ pimcore.object.tags.urlSlug = Class.create(pimcore.object.tags.abstract, {
 
     getGridColumnConfig: function (field) {
         return {
-            text: ts(field.label), sortable: false, dataIndex: field.key,
+            text: t(field.label), sortable: false, dataIndex: field.key,
             editor: this.getGridColumnEditor(field)
         };
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/video.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/video.js
@@ -30,7 +30,7 @@ pimcore.object.tags.video = Class.create(pimcore.object.tags.abstract, {
     getGridColumnConfig: function (field) {
 
         return {
-            text: ts(field.label), width: 100, sortable: false, dataIndex: field.key,
+            text: t(field.label), width: 100, sortable: false, dataIndex: field.key,
             getEditor: this.getWindowCellEditor.bind(this, field),
             renderer: function (key, value, metaData, record) {
                 this.applyPermissionStyle(key, value, metaData, record);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/wysiwyg.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/wysiwyg.js
@@ -68,7 +68,7 @@ pimcore.object.tags.wysiwyg = Class.create(pimcore.object.tags.abstract, {
         }.bind(this, field.key);
 
         return {
-            text: ts(field.label), sortable: true, dataIndex: field.key, renderer: renderer,
+            text: t(field.label), sortable: true, dataIndex: field.key, renderer: renderer,
             getEditor: this.getWindowCellEditor.bind(this, field)
         };
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
@@ -941,7 +941,7 @@ pimcore.object.tree = Class.create({
         var dialogTitle = t("object_add_dialog_custom_title" + "." + className);
 
         if (dialogTitle == "object_add_dialog_custom_title" + "." + className) {
-            dialogTitle =  sprintf(t('add_object_mbx_title'), ts(className));
+            dialogTitle =  sprintf(t('add_object_mbx_title'), t(className));
         }
 
         Ext.MessageBox.prompt(dialogTitle, dialogText,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/item.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/item.js
@@ -726,7 +726,7 @@ pimcore.report.custom.item = Class.create({
         if (classMenu.length == 1) {
             items.push({
                 cls: "pimcore_block_button_plus",
-                text: ts(classMenu[0].text),
+                text: t(classMenu[0].text),
                 iconCls: "pimcore_icon_plus",
                 handler: classMenu[0].handler
             });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/report.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/report.js
@@ -55,10 +55,10 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
                 continue;
             }
 
-            this.columnLabels[colConfig["name"]] = colConfig["label"] ? ts(colConfig["label"]) : ts(colConfig["name"]);
+            this.columnLabels[colConfig["name"]] = colConfig["label"] ? t(colConfig["label"]) : t(colConfig["name"]);
 
             gridColConfig = {
-                text: colConfig["label"] ? ts(colConfig["label"]) : ts(colConfig["name"]),
+                text: colConfig["label"] ? t(colConfig["label"]) : t(colConfig["name"]),
                 hidden: !colConfig["display"],
                 sortable: colConfig["order"],
                 dataIndex: colConfig["name"]
@@ -112,7 +112,7 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
                     width: 40,
                     items: [
                         {
-                            tooltip: t("open") + " " + (colConfig["label"] ? ts(colConfig["label"]) : ts(colConfig["name"])),
+                            tooltip: t("open") + " " + (colConfig["label"] ? t(colConfig["label"]) : t(colConfig["name"])),
                             icon: "/bundles/pimcoreadmin/img/flat-color-icons/open_file.svg",
                             handler: function (colConfig, grid, rowIndex) {
                                 var data = grid.getStore().getAt(rowIndex).getData();
@@ -252,8 +252,8 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
         for(var i = 0; i < this.drillDownFilterDefinitions.length; i++) {
             drillDownFilterComboboxes.push({
                 xtype: 'label',
-                text: this.drillDownFilterDefinitions[i]["label"] ? ts(this.drillDownFilterDefinitions[i]["label"])
-                                                    : ts(this.drillDownFilterDefinitions[i]["name"]),
+                text: this.drillDownFilterDefinitions[i]["label"] ? t(this.drillDownFilterDefinitions[i]["label"])
+                                                    : t(this.drillDownFilterDefinitions[i]["name"]),
                 style: 'padding-right: 5px'
             });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/panel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/panel.js
@@ -113,7 +113,7 @@ pimcore.report.panel = Class.create({
                                 iconCls = iconCls + ' ' + iconCls.replace(/^pimcore_nav_icon_/, 'pimcore_icon_');
 
                                 var childConfig = {
-                                    text: reportConfig["text"] ? ts(reportConfig["text"]) : t(reportClass.prototype.getName()),
+                                    text: reportConfig["text"] ? t(reportConfig["text"]) : t(reportClass.prototype.getName()),
                                     iconCls: iconCls,
                                     leaf: true,
                                     xdata: {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/gdpr/dataproviders/dataObjects.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/gdpr/dataproviders/dataObjects.js
@@ -59,7 +59,7 @@ pimcore.settings.gdpr.dataproviders.dataObjects = Class.create({
                 extraParams: this.searchParams
             },
             fields: ["id","fullpath","type","subtype","filename",{name:"classname",convert: function(v, rec){
-                return ts(rec.data.classname);
+                return t(rec.data.classname);
             }},"published"]
         });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/editorSettings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/editorSettings.js
@@ -33,7 +33,7 @@ pimcore.settings.user.editorSettings = Class.create({
         var data = [];
         for (var i = 0; i < nrOfLanguages; i++) {
             var language = this.contentLanguages[i];
-            data.push([language, ts(pimcore.available_languages[language])]);
+            data.push([language, t(pimcore.available_languages[language])]);
         }
 
         this.store = new Ext.data.ArrayStore({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/role/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/role/settings.js
@@ -36,7 +36,7 @@ pimcore.settings.user.role.settings = Class.create({
                 {
                     name:"translatedName",
                     convert: function (v, rec) {
-                        return ts(rec.data.name);
+                        return t(rec.data.name);
                     },
                     depends : ['name']
                 }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
@@ -290,7 +290,7 @@ pimcore.settings.user.user.settings = Class.create({
                 {
                     name:"translatedName",
                     convert: function (v, rec) {
-                        return ts(rec.data.name);
+                        return t(rec.data.name);
                     },
                     depends : ['name']
                 }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/websiteTranslationSettings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/websiteTranslationSettings.js
@@ -36,7 +36,7 @@ pimcore.settings.user.websiteTranslationSettings = Class.create({
             var language = this.validLanguages[i];
             data.push([
                 language,
-                ts(pimcore.available_languages[language]),
+                t(pimcore.available_languages[language]),
                 this.userRole.websiteTranslationLanguagesView.indexOf(language) >= 0,
                 this.userRole.websiteTranslationLanguagesEdit.indexOf(language) >= 0
             ]);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
@@ -289,7 +289,7 @@ Ext.onReady(function () {
             {
                 name: "translatedName",
                 convert: function (v, rec) {
-                    return ts(rec.data.name);
+                    return t(rec.data.name);
                 },
                 depends : ['name']
             },
@@ -348,7 +348,7 @@ Ext.onReady(function () {
         {name: 'text', allowBlank: false},
         {
             name: "translatedText", convert: function (v, rec) {
-                return ts(rec.data.text);
+                return t(rec.data.text);
             }
         },
         {name: 'icon'},
@@ -769,7 +769,7 @@ Ext.onReady(function () {
                                 rootVisible: treeConfig.showroot,
                                 treeId: "pimcore_panel_tree_" + treetype + "_" + treeConfig.id,
                                 treeIconCls: "pimcore_" + treetype + "_customview_icon_" + treeConfig.id + " pimcore_icon_material",
-                                treeTitle: ts(treeConfig.name),
+                                treeTitle: t(treeConfig.name),
                                 parentPanel: treepanel,
                                 loaderBaseParams: {}
                             }, treeConfig);

--- a/bundles/EcommerceFrameworkBundle/Resources/public/js/indexfieldselectionfield/tags/indexFieldSelectionField.js
+++ b/bundles/EcommerceFrameworkBundle/Resources/public/js/indexfieldselectionfield/tags/indexFieldSelectionField.js
@@ -50,7 +50,7 @@ pimcore.object.tags.indexFieldSelectionField = Class.create(pimcore.object.tags.
                             if(store.find('key', values[i]) < 0) {
                                 var defaultData = {
                                     'key': values[i],
-                                    'name': ts(values[i])
+                                    'name': t(values[i])
                                 };
                                 store.add(defaultData);
                             }

--- a/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/objects.js
+++ b/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/objects.js
@@ -73,7 +73,7 @@ pimcore.bundle.EcommerceFramework.pricing.config.objects = Class.create(pimcore.
         columns.push({header: 'ID', dataIndex: 'id', width: 50});
 
         for (i = 0; i < visibleFields.length; i++) {
-            columns.push({header: ts(visibleFields[i]), dataIndex: visibleFields[i], width: 100, editor: null,
+            columns.push({header: t(visibleFields[i]), dataIndex: visibleFields[i], width: 100, editor: null,
                                                                     renderer: renderer});
         }
 
@@ -119,7 +119,7 @@ pimcore.bundle.EcommerceFramework.pricing.config.objects = Class.create(pimcore.
             } else if(this.fieldConfig.columns[i].type == "bool") {
                 if(!readOnly) {
                     columns.push(new Ext.grid.CheckColumn({
-                        header: ts(this.fieldConfig.columns[i].label),
+                        header: t(this.fieldConfig.columns[i].label),
                         dataIndex: this.fieldConfig.columns[i].key,
                         width: width
                     }));
@@ -137,7 +137,7 @@ pimcore.bundle.EcommerceFramework.pricing.config.objects = Class.create(pimcore.
             }
 
             columns.push({
-                header: ts(this.fieldConfig.columns[i].label),
+                header: t(this.fieldConfig.columns[i].label),
                 dataIndex: this.fieldConfig.columns[i].key,
                 editor: editor,
                 renderer: renderer,


### PR DESCRIPTION
## Changes in this pull request  

Replace ts  to t function for translations, because in code it`s the same:
https://github.com/pimcore/pimcore/blob/f4062f6918c53628b495827bec1d322165e69a65/bundles/AdminBundle/Resources/public/js/pimcore/functions.js#L64-L66.

## Additional info
I suggest to mark function ts as deprecated in next release and remove in 7.0.
