### PR TITLE
[Docs] Fix formatting in HeadStyle documentation

### DIFF
--- a/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/04_HeadStyle.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/04_HeadStyle.md
@@ -86,6 +86,6 @@ The following assumptions are made:
 The style declarations will be appended to the stack. If you wish for them to replace the stack or be added to the top, 
 you will need to pass `SET` or `PREPEND`, respectively, as the first argument to `captureStart()`.
 
-If you wish to specify any additional attributes for the <style> tag, pass them in an array as the second argument to 
+If you wish to specify any additional attributes for the `<style>` tag, pass them in an array as the second argument to 
 `captureStart()`.
 


### PR DESCRIPTION
## Changes in this pull request  

Fixes the  currently broken part of the documentation for [HeadStyle](https://pimcore.com/docs/6.x/Development_Documentation/MVC/Template/Templating_Helpers/HeadStyle.html) by quoting the `<style>` tag properly.

<img width="760" alt="Screenshot 2020-02-17 at 09 27 46" src="https://user-images.githubusercontent.com/42136707/74636272-f610d100-5167-11ea-86cc-9be2e949f9d5.png">


