### PR TITLE
[Bundles] Add install migration to available migrations

### DIFF
--- a/lib/Migrations/Configuration/Configuration.php
+++ b/lib/Migrations/Configuration/Configuration.php
@@ -383,6 +383,16 @@ class Configuration extends \Doctrine\DBAL\Migrations\Configuration\Configuratio
         return $newMigrations;
     }
 
+    public function getAvailableVersions()
+    {
+        $migrations = parent::getAvailableVersions();
+        if ($this->installer !== null) {
+            $migrations[] = $this->installer->getMigrationVersion();
+        }
+        return $migrations;
+    }
+
+
     /**
      * Handles simple placeholder handling in query. Makes queries more readable as we need to replace the configurable
      * columns in every query.


### PR DESCRIPTION
Currently the install migration gets added to `pimcore_migrations` table but in https://github.com/pimcore/pimcore/blob/65720840f7219cb0d061c818eff5cfc0499b3d5c/lib/Migrations/Configuration/Configuration.php#L373-L383 only migrations in the migration folder get used to determine available migrations. This leads to the following error when trying to execute migrations after the inital installation:
```
WARNING! You have 1 previously executed migrations in the database that are not registered migrations.
    >>  (00000001)
```

This PR adds the installer migration to the list of available migrations.

To reproduce bug:
1. Install bundle with installer which extends `Pimcore\Extension\Bundle\Installer\MigrationInstaller`
1. Execute `bin/console pimcore:migration:status -b <Bundle name>`
`Executed Unavailable Migrations` should be `0`.
1. Alternatively execute `bin/console pimcore:migration:migrate -b <Bundle name>`
Above error should not appear.

Resolves #5098