### PR TITLE
[Users] Type-cast parent id to int

### DIFF
--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -141,7 +141,7 @@ class AbstractUser extends Model\AbstractModel
      */
     public function setParentId($parentId)
     {
-        $this->parentId = $parentId;
+        $this->parentId = (int)$parentId;
 
         return $this;
     }


### PR DESCRIPTION
I just stumbled about this when trying to get all users below a certain role folder via 
```php
$roleListing = new Listing();
$roleFolder = Role\Folder::getByName('abc');
$roles = array_filter($roleListing->load(), static function(AbstractUser $role) use ($roleFolder) {
    return $role->getParentId() === $roleFolder->getId();
});
```