### PR TITLE
[Ecommerce][Productlist] Consider ElasticSearch reverse nested aggregations

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -1209,9 +1209,13 @@ abstract class AbstractElasticSearch implements ProductListInterface
         if (!empty($bucket)) {
             $subAggregationField = array_key_first($bucket);
             $subAggregationBuckets = $bucket[$subAggregationField];
+            $reverseAggregationField = array_key_last($bucket);
+            $reverseAggregationBucket = $bucket[$reverseAggregationField];
 
             if (array_key_exists('key_as_string', $bucket)) {          // date aggregations
                 $data['key_as_string'] = $bucket['key_as_string'];
+            } elseif (is_array($reverseAggregationBucket) && array_key_exists('doc_count', $reverseAggregationBucket)) { // reverse aggregation
+                $data['reverse_count'] = $reverseAggregationBucket['doc_count'];
             } elseif (is_array($subAggregationBuckets['buckets'])) {        // sub aggregations
                 foreach ($subAggregationBuckets['buckets'] as $bucket) {
                     $data[$subAggregationField][] = $this->convertBucketValues($bucket);


### PR DESCRIPTION
# New Feature

The product list converts the aggregation bucket values returned from elastic search to "value" and "count" pairs. If I want to use nested aggregations, but only count the source documents I have to use reverse nested aggregations. The returned values in this type of aggregation gets lost in the `convertBucketValues()` method. 

This PR considers the values and adds an additional field `reverse_count`.

![image](https://user-images.githubusercontent.com/9052094/74663752-a7c9f500-519c-11ea-9631-c62e0799220f.png)

Also see https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-aggregations-bucket-reverse-nested-aggregation.html


