### PR TITLE
[Users] Doctype: Return type for getBy*

### DIFF
--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -49,7 +49,7 @@ class AbstractUser extends Model\AbstractModel
     /**
      * @param int $id
      *
-     * @return AbstractUser|null
+     * @return static|null
      */
     public static function getById($id)
     {
@@ -92,7 +92,7 @@ class AbstractUser extends Model\AbstractModel
     /**
      * @param string $name
      *
-     * @return self|null
+     * @return static|null
      */
     public static function getByName($name)
     {


### PR DESCRIPTION
When you call `User::getById()` you get a `User` object. When you call `Role::getById()` you get a `Role` object etc.