### PR TITLE
[Data objects] unique index for field type "User"

### DIFF
--- a/models/DataObject/ClassDefinition/Data/User.php
+++ b/models/DataObject/ClassDefinition/Data/User.php
@@ -28,6 +28,11 @@ class User extends Model\DataObject\ClassDefinition\Data\Select
     public $fieldtype = 'user';
 
     /**
+     * @var bool
+     */
+    public $unique;
+
+    /**
      * @return User
      */
     protected function init()
@@ -157,5 +162,21 @@ class User extends Model\DataObject\ClassDefinition\Data\Select
         $obj->configureOptions();
 
         return $obj;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getUnique()
+    {
+        return $this->unique;
+    }
+
+    /**
+     * @param bool $unique
+     */
+    public function setUnique($unique)
+    {
+        $this->unique = $unique;
     }
 }


### PR DESCRIPTION
Currently it seems to be only possible for Input and Numeric fields to add a unique index as they are the only classes which override 
https://github.com/pimcore/pimcore/blob/453a87daed484e85ad00120e264f5a04def5492b/models/DataObject/ClassDefinition/Data.php#L1197-L1200

This PR adds the possibility to create unique indexes also for `User` datatype.

I wonder why unique index is currently only possible for Numeric and Input datatype because the unique checkbox actually is present for all datatypes.