### PR TITLE
Read access for protected object properties

### DIFF
--- a/lib/Model/AbstractModel.php
+++ b/lib/Model/AbstractModel.php
@@ -284,6 +284,7 @@ abstract class AbstractModel implements ModelInterface
         if(\method_exists($this, $getter)) {
             return $this->$getter();
         }
+        return null;
     }
 
     /**

--- a/lib/Model/AbstractModel.php
+++ b/lib/Model/AbstractModel.php
@@ -273,6 +273,19 @@ abstract class AbstractModel implements ModelInterface
         return $result;
     }
 
+    public function __isset($name)
+    {
+        return isset($this->$name);
+    }
+
+    public function __get($name)
+    {
+        $getter = 'get'.ucfirst($name);
+        if(\method_exists($this, $getter)) {
+            return $this->$getter();
+        }
+    }
+
     /**
      * @return Factory
      */


### PR DESCRIPTION
More and more object properties got and will get converted from `public` to `protected` access. Of course this makes sense so nobody can inject any garbage into the objects. On the other hand it breaks a lot of legacy code. In the last time we see more and more customers upgrading to Pimcore 6 and a lot of applications use object property access instead of getters. I do not know why the original application developers decided to not use the getter methods but actually it was possible to use property access - and so they did use it.

While accessing the value of object properties result in a fatal PHP error and so are quite easy to find (at least when you have lots of tests - automatic or manual) , it cost us 5 hours to find this line:
```php
if(empty($fieldCollectionItem->name)) {
...
}
```
The problem here is that while the `name` property was `public` `empty($fieldCollectionItem->name)` returned `false` if a name had been set to the name field of the field collection. Now as it is `protected` this simply returns `true` and consequently does go into this if-block - this completely inverts the logic without any error, log or anything.

It is very difficult to find such code occurences, so I thought if there was a way to support developers during Pimcore version upgrade.
At first I thought to only implement magic `__isset()` and `__get()` methods with a deprecation notice (because `empty()` calls `__get()` when `__isset()` returns `true`). But in the end I wondered whether those deprecation notices actually get read in the logs (because there would actually be no need for developers to look at the logs while the system works as expected).
Then I went one step back and thought that the goal of setting object property access to `protected` was to prevent **setting** unexpected values to those properties. So imho there is no reason to not allow **read access** via object properties. To ensure correct data handling the magic `__get()` calls the actual getter method instead of returning the property value directly.