### PR TITLE
Check if symlink already exists before creating it, if the symlink al…

### DIFF
--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -132,7 +132,7 @@ class PublicServicesController extends Controller
                         // this can be e.g. the case when the thumbnail is called as foo.png but the thumbnail config
                         // is set to auto-optimized format so the resulting thumbnail can be jpeg
                         $requestedFile = preg_replace('/\.' . $actualFileExtension . '$/', '.' . $requestedFileExtension, $thumbnailFile);
-                        $linked = symlink($thumbnailFile, $requestedFile);
+                        $linked = is_link($requestedFile) || symlink($thumbnailFile, $requestedFile);
                         if (false === $linked) {
                             // create a hard copy
                             copy($thumbnailFile, $requestedFile);


### PR DESCRIPTION
Symlink generates a warning when the link already exists. As far as I can see it is never checked if the link already exists.

How to reproduce. To be honest i am not entirely sure. In our case it has to do with our deploy process. The issue lies somewhere in the various realpath calls when constructing thumbnail filepaths. Our deploy tracks several releases as follows 
release/X <--- this is the current release
release/X-1
release/X-2
...
current <-- this is a symlink pointing to the current release in this case release/X .

In the release/X folder the normal application structure is present with a few exceptions
the web/var/tmp and web/var/assets folders are symlinks to folders outside the release path as we do not want to copy assets etc between releases (they are "shared" among releases). Some other files are also shared among releases .env files etc. Old releases get removed from the server. Whenever a new deploy is triggered folder release/X+1 is build with a fresh git clone and composer install and the appropriate symlinks (web/var/assets and web/var/tmp, .env database config etc) are constructed, the current symlink is then pointed at release/X+1. 

In the construction of thumbnail file path various realpath calls and env configuration is involved (with env configuration I mean app/env.php where you can define 'PIMCORE_{FOLDER}_ROOT' options). In our case there is a mismatch though I am not entirely sure where this happens and why nginx cannot just serve the thumbnail. For your info I do have the PIMCORE_PROJECT_ROOT configuration in app/env.php pointing at the "fixed" symlink current (as described above) which always points at the current release precisely because of the realpath calls. And I also have the correct nginx configuration for assets.

Although I cannot specify exactly where this goes wrong I see no harm in checking if the link already exists before trying to create it. The proposed change should not affect current installations.

I admit this is an edge case but it might save someone some debug work in the future.