### PR TITLE
[Data Object] Numeric Data-Type: fix schema if 'decimalPrecision' => ''

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Numeric.php
+++ b/models/DataObject/ClassDefinition/Data/Numeric.php
@@ -261,6 +261,10 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
      */
     public function setDecimalPrecision($decimalPrecision)
     {
+        if(!is_numeric($decimalPrecision)) {
+            $decimalPrecision = null;
+        }
+
         $this->decimalPrecision = $decimalPrecision;
     }
 

--- a/models/DataObject/ClassDefinition/Data/Numeric.php
+++ b/models/DataObject/ClassDefinition/Data/Numeric.php
@@ -102,7 +102,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
      * but as decimalPrecision already existed to denote the amount of digits after the point (as it is called on the ExtJS
      * number field), decimalSize was chosen instead.
      *
-     * @var int
+     * @var int|null
      */
     public $decimalSize;
 
@@ -110,7 +110,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
      * This is the y part in DECIMAL(x, y) and denotes amount of digits after a comma. In MySQL this is called scale. See
      * commend on decimalSize.
      *
-     * @var int
+     * @var int|null
      */
     public $decimalPrecision;
 
@@ -241,7 +241,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getDecimalSize()
     {
@@ -249,15 +249,19 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     }
 
     /**
-     * @param int $decimalSize
+     * @param int|null $decimalSize
      */
     public function setDecimalSize($decimalSize)
     {
+        if(!is_numeric($decimalSize)) {
+            $decimalSize = null;
+        }
+
         $this->decimalSize = $decimalSize;
     }
 
     /**
-     * @param int $decimalPrecision
+     * @param int|null $decimalPrecision
      */
     public function setDecimalPrecision($decimalPrecision)
     {
@@ -269,7 +273,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getDecimalPrecision()
     {


### PR DESCRIPTION
If `'decimalPrecision' => ''` and `'decimalSize' = NULL` the resulting column type is `decimal(64,0)` which is wrong, correct would be the default type which is `double`. 