### PR TITLE
[Document] "Create Page" dialog: title should be the first field, the rest should be pre-filled

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
@@ -23,10 +23,6 @@ Ext.define('documentreemodel', {
     }]
 });
 
-const a = 'àáâäæãåāăąçćčđďèéêëēėęěğǵḧîïíīįìłḿñńǹňôöòóœøōõőṕŕřßśšşșťțûüùúūǘůűųẃẍÿýžźż·/_,:;';
-const b = 'aaaaaaaaaacccddeeeeeeeegghiiiiiilmnnnnoooooooooprrsssssttuuuuuuuuuwxyyzzz------';
-const p = new RegExp(a.split('').join('|'), 'g');
-
 pimcore.registerNS("pimcore.document.tree");
 pimcore.document.tree = Class.create({
 
@@ -1341,7 +1337,8 @@ pimcore.document.tree = Class.create({
                             }.bind(this), 100);
                         },
                         keyup: function (el) {
-                            this.setKeyAndNavigation(el.getValue(), pageForm);
+                            pageForm.getComponent("name").setValue(el.getValue());
+                            pageForm.getComponent("key").setValue(el.getValue());
                         }.bind(this),
                     }
                 },{
@@ -1419,18 +1416,6 @@ pimcore.document.tree = Class.create({
                 }
             }.bind(this, tree, record, type, docTypeId));
         }
-    },
-    
-    setKeyAndNavigation: function(title, pageForm) {
-        var urlFriendlyTitle = title.toLowerCase()
-            .replace(/\s+/g, '-')
-            .replace(p, c => b.charAt(a.indexOf(c)))
-            .replace(/[^\w-]+/g, '')
-            .replace(/[-]{2,}/g, '-')
-            .replace(/^-+/, '')
-            .replace(/-+$/, '');
-        pageForm.getComponent("name").setValue(urlFriendlyTitle);
-        pageForm.getComponent("key").setValue(urlFriendlyTitle);
     },
 
     publishDocument: function (tree, record, task) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
@@ -23,6 +23,9 @@ Ext.define('documentreemodel', {
     }]
 });
 
+const a = 'àáâäæãåāăąçćčđďèéêëēėęěğǵḧîïíīįìłḿñńǹňôöòóœøōõőṕŕřßśšşșťțûüùúūǘůűųẃẍÿýžźż·/_,:;';
+const b = 'aaaaaaaaaacccddeeeeeeeegghiiiiiilmnnnnoooooooooprrsssssttuuuuuuuuuwxyyzzz------';
+const p = new RegExp(a.split('').join('|'), 'g');
 
 pimcore.registerNS("pimcore.document.tree");
 pimcore.document.tree = Class.create({
@@ -1326,10 +1329,10 @@ pimcore.document.tree = Class.create({
                 bodyStyle: "padding: 10px;",
                 items: [{
                     xtype: "textfield",
+                    itemId: "title",
+                    fieldLabel: t('title'),
+                    name: 'title',
                     width: "100%",
-                    fieldLabel: t('key'),
-                    itemId: "key",
-                    name: 'key',
                     enableKeyEvents: true,
                     listeners: {
                         afterrender: function () {
@@ -1338,21 +1341,21 @@ pimcore.document.tree = Class.create({
                             }.bind(this), 100);
                         },
                         keyup: function (el) {
-                            pageForm.getComponent("name").setValue(el.getValue());
-                        }
+                            this.setKeyAndNavigation(el.getValue(), pageForm);
+                        }.bind(this),
                     }
                 },{
                     xtype: "textfield",
                     itemId: "name",
                     fieldLabel: t('navigation'),
                     name: 'name',
-                    width: "100%"
+                    width: "100%",
                 },{
                     xtype: "textfield",
-                    itemId: "title",
-                    fieldLabel: t('title'),
-                    name: 'title',
-                    width: "100%"
+                    width: "100%",
+                    fieldLabel: t('key'),
+                    itemId: "key",
+                    name: 'key',
                 }]
             });
 
@@ -1416,6 +1419,18 @@ pimcore.document.tree = Class.create({
                 }
             }.bind(this, tree, record, type, docTypeId));
         }
+    },
+    
+    setKeyAndNavigation: function(title, pageForm) {
+        var urlFriendlyTitle = title.toLowerCase()
+            .replace(/\s+/g, '-')
+            .replace(p, c => b.charAt(a.indexOf(c)))
+            .replace(/[^\w-]+/g, '')
+            .replace(/[-]{2,}/g, '-')
+            .replace(/^-+/, '')
+            .replace(/-+$/, '');
+        pageForm.getComponent("name").setValue(urlFriendlyTitle);
+        pageForm.getComponent("key").setValue(urlFriendlyTitle);
     },
 
     publishDocument: function (tree, record, task) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
@@ -1339,20 +1339,20 @@ pimcore.document.tree = Class.create({
                         keyup: function (el) {
                             pageForm.getComponent("name").setValue(el.getValue());
                             pageForm.getComponent("key").setValue(el.getValue());
-                        }.bind(this),
+                        }.bind(this)
                     }
                 },{
                     xtype: "textfield",
                     itemId: "name",
                     fieldLabel: t('navigation'),
                     name: 'name',
-                    width: "100%",
+                    width: "100%"
                 },{
                     xtype: "textfield",
                     width: "100%",
                     fieldLabel: t('key'),
                     itemId: "key",
-                    name: 'key',
+                    name: 'key'
                 }]
             });
 


### PR DESCRIPTION
## Changes in this pull request  

Altered the way how pages (here: key, navigation) are created:
Key and navigation follow the entered title

Why? Since key is representing the navigation-url of the node in the backend tree those 2 values should match by default (but can still be altered) and the navigation entry will by default be a valid url with replacing invalid chars

Even if you think the replacement won't be sufficient, this might serve as a starting point to enhance it further