### PR TITLE
[Ecommerce]IndexService] ElasticSearch Worker only filter null values

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -422,7 +422,7 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
             }
 
             $this->bulkIndexData[] = ['index' => ['_index' => $this->getIndexNameVersion(), '_type' => $this->getTenantConfig()->getElasticSearchClientParams()['indexType'], '_id' => $objectId, '_routing' => $routingId]];
-            $bulkIndexData = array_filter(['system' => array_filter($indexSystemData), 'type' => $indexSystemData['o_type'], 'attributes' => array_filter($indexAttributeData), 'relations' => $indexRelationData, 'subtenants' => $data['subtenants']]);
+            $bulkIndexData = array_filter(['system' => array_filter($indexSystemData), 'type' => $indexSystemData['o_type'], 'attributes' => array_filter($indexAttributeData, function($value){return $value !== null;}), 'relations' => $indexRelationData, 'subtenants' => $data['subtenants']]);
 
             if ($indexSystemData['o_type'] == ProductListInterface::PRODUCT_TYPE_VARIANT) {
                 $bulkIndexData[self::RELATION_FIELD] = ['name' => $indexSystemData['o_type'], 'parent' => $indexSystemData['o_virtualProductId']];


### PR DESCRIPTION
# Bugfix

Resolves #5874 

May be a bc-breaking, if there are interpreters getters in the application which do not return the correct type: a string or integer field may receive "false" - if `false` was returned which should actually be `null`. 

This may result in a filter like so:
![image](https://user-images.githubusercontent.com/9052094/75013427-90348a00-5484-11ea-8aac-e2ae6e8b9c1f.png)
