### PR TITLE
Check if redirect_to_maindomain is set to true

### DIFF
--- a/bundles/CoreBundle/EventListener/Frontend/FrontendRoutingListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/FrontendRoutingListener.php
@@ -244,7 +244,7 @@ class FrontendRoutingListener implements EventSubscriberInterface
         $hostRedirect = null;
 
         $gc = $this->config['general'];
-        if (isset($gc['redirect_to_maindomain']) && isset($gc['domain']) && $gc['domain'] !== $request->getHost()) {
+        if (isset($gc['redirect_to_maindomain']) && $gc['redirect_to_maindomain'] === true && isset($gc['domain']) && $gc['domain'] !== $request->getHost()) {
             $hostRedirect = $gc['domain'];
         }
 


### PR DESCRIPTION
This PR checks if `redirect_to_maindomain` is a true boolean. Otherwise, every instance will be redirected to `domain` => always!