### PR TITLE
Update Concrete.php

### DIFF
--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -582,7 +582,7 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
 
             if ($parent && in_array($parent->getType(), [self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_VARIANT], true)) {
                 /** @var Concrete $parent */
-                if ($parent->getClassId() === $this->getClassId()) {
+                if ($parent->getClassId() === $this->getClassId() || $parent->getClassId() === $classId) {
                     return $parent;
                 }
             }


### PR DESCRIPTION
Allow returning parent of calling class type or specified class type.  This seems to be the intended behavior and purpose of the function and the option to pass in $classId.  Current code only returns $parent if it is of the same class as calling class.

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

