### PR TITLE
[System-Config]: fix email settings detection

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/IndexController.php
+++ b/bundles/AdminBundle/Controller/Admin/IndexController.php
@@ -394,13 +394,13 @@ class IndexController extends AdminController implements EventedControllerInterf
         //mail settings
         $mailIncomplete = false;
         if (isset($config['email'])) {
-            if (!empty($config['email']['debug']['email_addresses'])) {
+            if (empty($config['email']['debug']['email_addresses'])) {
                 $mailIncomplete = true;
             }
-            if (!empty($config['email']['sender']['email'])) {
+            if (empty($config['email']['sender']['email'])) {
                 $mailIncomplete = true;
             }
-            if (($config['email']['method'] ?? '') == 'smtp' && !empty($config['email']['smtp']['host'])) {
+            if (($config['email']['method'] ?? '') == 'smtp' && empty($config['email']['smtp']['host'])) {
                 $mailIncomplete = true;
             }
         }


### PR DESCRIPTION
still one regression left from https://github.com/pimcore/pimcore/pull/5745

email settings detection was false positiv


How to reproduce:

Frontend still has notification that email settings are not completed although completed (and other way round). False positive detection


