### PR TITLE
[Logging] Do not use fingers_crossed as default in prod environment

### DIFF
--- a/bundles/CoreBundle/Resources/config/pimcore/prod.yml
+++ b/bundles/CoreBundle/Resources/config/pimcore/prod.yml
@@ -1,14 +1,9 @@
 monolog:
     handlers:
         main:
-            type:         fingers_crossed
-            action_level: error
-            buffer_size:  2000
-            handler:      nested
-        nested:
             type:  stream
             path:  "%kernel.logs_dir%/%kernel.environment%.log"
-            level: debug
+            level: error
         console:
             type: console
             process_psr_3_messages: false

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## 6.6.0
+- Default config for monolog handler `main` in prod environment is now `stream` instead of `fingers_crossed`. If you still want to use `fingers_crossed` please update your project config accordingly. 
+
 ## 6.5.2
 - Passing multiple relations(w/o multiple assignments check) in data objects is deprecated and will throw exception in Pimcore 7.
 


### PR DESCRIPTION

Reasons: 
- is triggered by `HttpNotFoundException` as well, so fills up the logs with useless info
- higher memory usage due to buffering
