### PR TITLE
Exceptions did not trigger an error message box

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1385,7 +1385,11 @@ pimcore.helpers.uploadAssetFromFileObject = function (file, url, callbackSuccess
     // these wrappers simulate the jQuery behavior
     var successWrapper = function (ev) {
         var data = JSON.parse(request.responseText);
-        callbackSuccess(data, request.statusText, request);
+        if(ev.currentTarget.status < 400) {
+            callbackSuccess(data, request.statusText, request);
+        } else {
+            callbackFailure(request, request.statusText, ev);
+        }
     };
 
     var errorWrapper = function (ev) {


### PR DESCRIPTION
If you write a Asset Listener to throw an error on certain conditions the error message was not showing in the backend UI.

XMLHttpRequest error is only called if there was an error transmitting.
if the transmission was successfull "load" is called, even if the status code is 400 and up