### PR TITLE
Cache definition in Classification Store Service

### DIFF
--- a/models/DataObject/Classificationstore/Service.php
+++ b/models/DataObject/Classificationstore/Service.php
@@ -22,17 +22,34 @@ use Pimcore\Model\DataObject;
 class Service
 {
     /**
+     * @var array Used for storing definitions
+     */
+    protected static $definitionsCache = [];
+
+    /**
      * @param KeyConfig $keyConfig
      *
      * @return DataObject\ClassDefinition\Data
      */
     public static function getFieldDefinitionFromKeyConfig($keyConfig)
     {
+        if ($keyConfig instanceof KeyConfig) {
+            $cacheId = $keyConfig->getId();
+        }
+
+        if ($keyConfig instanceof KeyGroupRelation) {
+            $cacheId = $keyConfig->getGroupId() . "_" . $keyConfig->getKeyId();
+        }
+
+        if (array_key_exists($keyConfigId, self::$definitionsCache)) {
+            return self::$definitionsCache[$cacheId];
+        }
+
         $definition = $keyConfig->getDefinition();
         $definition = json_decode($definition, true);
         $type = $keyConfig->getType();
         $fd = self::getFieldDefinitionFromJson($definition, $type);
-
+        self::$definitionsCache[$cacheId] = $fd;
         return $fd;
     }
 

--- a/models/DataObject/Classificationstore/Service.php
+++ b/models/DataObject/Classificationstore/Service.php
@@ -35,10 +35,10 @@ class Service
     {
         if ($keyConfig instanceof KeyConfig) {
             $cacheId = $keyConfig->getId();
-        }
-
-        if ($keyConfig instanceof KeyGroupRelation) {
+        } else if ($keyConfig instanceof KeyGroupRelation) {
             $cacheId = $keyConfig->getKeyId();
+        } else {
+            throw new \Exception('$keyConfig should be KeyConfig or KeyGroupRelation');
         }
 
         if (array_key_exists($cacheId, self::$definitionsCache)) {

--- a/models/DataObject/Classificationstore/Service.php
+++ b/models/DataObject/Classificationstore/Service.php
@@ -27,6 +27,14 @@ class Service
     protected static $definitionsCache = [];
 
     /**
+     * Clears the cache for the definitions
+     */
+    public static function clearDefinitionsCache()
+    {
+        self::$definitionsCache = [];
+    }
+    
+    /**
      * @param KeyConfig|KeyGroupRelation $keyConfig
      *
      * @return DataObject\ClassDefinition\Data

--- a/models/DataObject/Classificationstore/Service.php
+++ b/models/DataObject/Classificationstore/Service.php
@@ -41,7 +41,7 @@ class Service
             $cacheId = $keyConfig->getGroupId() . "_" . $keyConfig->getKeyId();
         }
 
-        if (array_key_exists($keyConfigId, self::$definitionsCache)) {
+        if (array_key_exists($cacheId, self::$definitionsCache)) {
             return self::$definitionsCache[$cacheId];
         }
 

--- a/models/DataObject/Classificationstore/Service.php
+++ b/models/DataObject/Classificationstore/Service.php
@@ -27,7 +27,7 @@ class Service
     protected static $definitionsCache = [];
 
     /**
-     * @param KeyConfig $keyConfig
+     * @param KeyConfig|KeyGroupRelation $keyConfig
      *
      * @return DataObject\ClassDefinition\Data
      */

--- a/models/DataObject/Classificationstore/Service.php
+++ b/models/DataObject/Classificationstore/Service.php
@@ -38,7 +38,7 @@ class Service
         }
 
         if ($keyConfig instanceof KeyGroupRelation) {
-            $cacheId = $keyConfig->getGroupId() . "_" . $keyConfig->getKeyId();
+            $cacheId = $keyConfig->getKeyId();
         }
 
         if (array_key_exists($cacheId, self::$definitionsCache)) {


### PR DESCRIPTION
During the save process, getFieldDefinitionFromJson is called multiple times. In vanilla Pimcore at least twice for each definition - during save and when pushing data to backend search. When AOS plugin is installed - that's another one.

This change caches the result of getFieldDefinitionFromJson in static array. As the gain during regular save is minimal, the real benefit can be seen when saving a lot of objects in one go.

Here's the comparision for importing data from file (~100 objects with classification store). Before:
https://blackfire.io/profiles/43a7d2bf-0adc-45e9-9bf0-530a8c3e564a/graph
After:
https://blackfire.io/profiles/0be9a7e9-162a-40fa-90f7-247605a5895f/graph