### PR TITLE
[DataObjects] Multiple assignments check for Relations Types bugfix

### DIFF
--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -1208,7 +1208,7 @@ abstract class Data
      */
     protected function setDataToObject($data, $object, $params = [])
     {
-        $this->getSetDataObjectParam($object,  $params, $data, 'set');
+        $this->getSetData($object,  $params, $data, 'set');
     }
 
     /**
@@ -1221,7 +1221,7 @@ abstract class Data
      */
     protected function getDataFromObjectParam($object, $params = [])
     {
-        return $this->getSetDataObjectParam($object, $params);
+        return $this->getSetData($object, $params);
     }
 
     /**
@@ -1234,7 +1234,7 @@ abstract class Data
      *
      * @throws \Exception
      */
-    protected function getSetDataObjectParam($object,  $params = [], $setData = null, $method = 'get')
+    protected function getSetData($object,  $params = [], $setData = null, $method = 'get')
     {
         $data = null;
 

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -603,9 +603,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
 
         $objectsMetadata = $this->getDataFromObjectParam($object, $params);
         //TODO: move validation to checkValidity & throw exception in Pimcore 7
-        if (!$object instanceof DataObject\DirtyIndicatorInterface || $object->isFieldDirty($this->getName()) || $object->isFieldDirty('_self')) {
-            $objectsMetadata = $this->filterMultipleAssignments($objectsMetadata, $object, $params);
-        }
+        $objectsMetadata = $this->filterMultipleAssignments($objectsMetadata, $object, $params);
 
         $classId = null;
         $objectId = null;

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -602,6 +602,10 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
         }
 
         $objectsMetadata = $this->getDataFromObjectParam($object, $params);
+        //TODO: move validation to checkValidity & throw exception in Pimcore 7
+        if ($object->isFieldDirty($this->getName()) || $object->isFieldDirty('_self')) {
+            $objectsMetadata = $this->filterMultipleAssignments($objectsMetadata, $object, $params);
+        }
 
         $classId = null;
         $objectId = null;
@@ -711,11 +715,6 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
         } elseif ($object instanceof DataObject\Objectbrick\Data\AbstractData) {
             parent::loadLazyBrickField($object);
             $data = $object->getObjectVar($this->getName());
-        }
-
-        //TODO: move validation to checkValidity & throw exception in Pimcore 7
-        if (!$this->getAllowMultipleAssignments()) {
-            $data = Element\Service::filterMultipleElements($data, $object, $this->getName());
         }
 
         // note, in case of advanced many to many relations we don't want to force the loading of the element

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -603,7 +603,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
 
         $objectsMetadata = $this->getDataFromObjectParam($object, $params);
         //TODO: move validation to checkValidity & throw exception in Pimcore 7
-        if ($object->isFieldDirty($this->getName()) || $object->isFieldDirty('_self')) {
+        if (!$object instanceof DataObject\DirtyIndicatorInterface || $object->isFieldDirty($this->getName()) || $object->isFieldDirty('_self')) {
             $objectsMetadata = $this->filterMultipleAssignments($objectsMetadata, $object, $params);
         }
 

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -684,6 +684,10 @@ class AdvancedManyToManyRelation extends ManyToManyRelation
         }
 
         $multihrefMetadata = $this->getDataFromObjectParam($object, $params);
+        //TODO: move validation to checkValidity & throw exception in Pimcore 7
+        if ($object->isFieldDirty($this->getName()) || $object->isFieldDirty('_self')) {
+            $multihrefMetadata = $this->filterMultipleAssignments($multihrefMetadata, $object, $params);
+        }
 
         $classId = null;
         $objectId = null;
@@ -793,11 +797,6 @@ class AdvancedManyToManyRelation extends ManyToManyRelation
         } elseif ($object instanceof DataObject\Objectbrick\Data\AbstractData) {
             parent::loadLazyBrickField($object);
             $data = $object->getObjectVar($this->getName());
-        }
-
-        //TODO: move validation to checkValidity & throw exception in Pimcore 7
-        if (!$this->getAllowMultipleAssignments()) {
-            $data = Element\Service::filterMultipleElements($data, $object, $this->getName());
         }
 
         // note, in case of advanced many to many relations we don't want to force the loading of the element

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -685,7 +685,7 @@ class AdvancedManyToManyRelation extends ManyToManyRelation
 
         $multihrefMetadata = $this->getDataFromObjectParam($object, $params);
         //TODO: move validation to checkValidity & throw exception in Pimcore 7
-        if ($object->isFieldDirty($this->getName()) || $object->isFieldDirty('_self')) {
+        if (!$object instanceof DataObject\DirtyIndicatorInterface || $object->isFieldDirty($this->getName()) || $object->isFieldDirty('_self')) {
             $multihrefMetadata = $this->filterMultipleAssignments($multihrefMetadata, $object, $params);
         }
 

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -685,9 +685,7 @@ class AdvancedManyToManyRelation extends ManyToManyRelation
 
         $multihrefMetadata = $this->getDataFromObjectParam($object, $params);
         //TODO: move validation to checkValidity & throw exception in Pimcore 7
-        if (!$object instanceof DataObject\DirtyIndicatorInterface || $object->isFieldDirty($this->getName()) || $object->isFieldDirty('_self')) {
-            $multihrefMetadata = $this->filterMultipleAssignments($multihrefMetadata, $object, $params);
-        }
+        $multihrefMetadata = $this->filterMultipleAssignments($multihrefMetadata, $object, $params);
 
         $classId = null;
         $objectId = null;

--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -135,20 +135,19 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
                     }
                     $elementData = $blockElement->getData();
                     //TODO: move validation to checkValidity & throw exception in Pimcore 7
-                    if($elementData instanceof DataObject\Localizedfield) {
+                    if($elementData instanceof DataObject\Localizedfield && $fd instanceof Localizedfields) {
                         foreach ($elementData->getInternalData() as $language => $fields) {
                             foreach ($fields as $fieldName => $values) {
-                                /** @var DataObject\ClassDefinition\Data\Localizedfields $fd */
-                                $lfd = $fd->getFieldDefinition($fieldName);
-                                if ($lfd instanceof ManyToManyRelation || $lfd instanceof ManyToManyObjectRelation) {
-                                    if (!method_exists($lfd, 'getAllowMultipleAssignments') || !$lfd->getAllowMultipleAssignments()) {
-                                        $contextParams['language'] = $language;
-                                        $contextParams['context'] = ['containerType' => 'block', 'fieldname' => $fieldName];
-                                        $updateParams = array_merge($params, $contextParams);
-                                        $lfd->filterMultipleAssignments($values, $elementData, $updateParams);
-                                        $elementData = $blockElement->getData();
+                                    $lfd = $fd->getFieldDefinition($fieldName);
+                                    if ($lfd instanceof ManyToManyRelation || $lfd instanceof ManyToManyObjectRelation) {
+                                        if (!method_exists($lfd, 'getAllowMultipleAssignments') || !$lfd->getAllowMultipleAssignments()) {
+                                            $contextParams['language'] = $language;
+                                            $contextParams['context'] = ['containerType' => 'block', 'fieldname' => $fieldName];
+                                            $updateParams = array_merge($params, $contextParams);
+                                            $lfd->filterMultipleAssignments($values, $elementData, $updateParams);
+                                            $elementData = $blockElement->getData();
+                                        }
                                     }
-                                }
                             }
                         }
                     } elseif ($fd instanceof ManyToManyRelation || $fd instanceof ManyToManyObjectRelation) {

--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -134,6 +134,27 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
                         continue;
                     }
                     $elementData = $blockElement->getData();
+                    //TODO: move validation to checkValidity & throw exception in Pimcore 7
+                    if($elementData instanceof DataObject\Localizedfield) {
+                        foreach ($elementData->getInternalData() as $language => $fields) {
+                            foreach ($fields as $fieldName => $values) {
+                                $lfd = $fd->getFieldDefinition($fieldName);
+                                if ($lfd instanceof ManyToManyRelation || $lfd instanceof ManyToManyObjectRelation) {
+                                    if (!method_exists($lfd, 'getAllowMultipleAssignments') || !$lfd->getAllowMultipleAssignments()) {
+                                        $contextParams['language'] = $language;
+                                        $contextParams['context'] = ['containerType' => 'block', 'fieldname' => $fieldName];
+                                        $updateParams = array_merge($params, $contextParams);
+                                        $lfd->filterMultipleAssignments($values, $elementData, $updateParams);
+                                        $elementData = $blockElement->getData();
+                                    }
+                                }
+                            }
+                        }
+                    } elseif ($fd instanceof ManyToManyRelation || $fd instanceof ManyToManyObjectRelation) {
+                        if (!method_exists($fd, 'getAllowMultipleAssignments') || !$fd->getAllowMultipleAssignments()) {
+                            $elementData = $fd->filterMultipleAssignments($elementData, $object, $params);
+                        }
+                    }
                     $dataForResource = $fd->marshal($elementData, $object, ['raw' => true, 'blockmode' => true]);
                     //                    $blockElement->setData($fd->unmarshal($dataForResource, $object, ["raw" => true]));
 
@@ -197,11 +218,6 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
                                 'containerKey' => $this->getName(),
                                 'classId' => $object ? $object->getClassId() : null]);
                             $blockElementRaw['data'] = $data;
-                        }
-                    } elseif ($fd instanceof ManyToManyRelation || $fd instanceof ManyToManyObjectRelation && is_array($blockElementRaw['data'])) {
-                        //TODO: move validation to checkValidity & throw exception in Pimcore 7
-                        if (!method_exists($fd, 'getAllowMultipleAssignments') || !$fd->getAllowMultipleAssignments()) {
-                            $blockElementRaw['data'] = Element\Service::filterMultipleElements($blockElementRaw['data'], $object, $elementName);
                         }
                     }
                     $blockElement = new DataObject\Data\BlockElement($blockElementRaw['name'], $blockElementRaw['type'], $blockElementRaw['data']);

--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -138,6 +138,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
                     if($elementData instanceof DataObject\Localizedfield) {
                         foreach ($elementData->getInternalData() as $language => $fields) {
                             foreach ($fields as $fieldName => $values) {
+                                /** @var DataObject\ClassDefinition\Data\Localizedfields $fd */
                                 $lfd = $fd->getFieldDefinition($fieldName);
                                 if ($lfd instanceof ManyToManyRelation || $lfd instanceof ManyToManyObjectRelation) {
                                     if (!method_exists($lfd, 'getAllowMultipleAssignments') || !$lfd->getAllowMultipleAssignments()) {

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -26,6 +26,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
     use Model\DataObject\ClassDefinition\Data\Extension\Relation;
     use Extension\QueryColumnType;
     use DataObject\ClassDefinition\Data\Relations\AllowObjectRelationTrait;
+    use DataObject\ClassDefinition\Data\Relations\ManyToManyRelationTrait;
 
     /**
      * Static type of this element
@@ -518,37 +519,6 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
         }
 
         return $relatedObjects;
-    }
-
-    /**
-     * TODO: move validation to checkValidity & throw exception in Pimcore 7
-     * @param DataObject\Concrete|DataObject\Localizedfield|DataObject\Objectbrick\Data\AbstractData|\Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData $object
-     * @param array $params
-     */
-    public function save($object, $params = [])
-    {
-        if (!DataObject\AbstractObject::isDirtyDetectionDisabled() && $object instanceof DataObject\DirtyIndicatorInterface) {
-            if ($object instanceof DataObject\Localizedfield) {
-                if ($object->getObject() instanceof DataObject\DirtyIndicatorInterface) {
-                    if (!$object->hasDirtyFields()) {
-                        return;
-                    }
-                }
-            } else {
-                if ($this->supportsDirtyDetection()) {
-                    if (!$object->isFieldDirty($this->getName())) {
-                        return;
-                    }
-                }
-            }
-        }
-
-        $objectsMetadata = $this->getDataFromObjectParam($object, $params);
-        if ($object->isFieldDirty($this->getName()) || $object->isFieldDirty('_self')) {
-            $this->filterMultipleAssignments($objectsMetadata, $object, $params);
-        }
-
-        parent::save($object, $params);
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -521,6 +521,37 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
     }
 
     /**
+     * TODO: move validation to checkValidity & throw exception in Pimcore 7
+     * @param DataObject\Concrete|DataObject\Localizedfield|DataObject\Objectbrick\Data\AbstractData|\Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData $object
+     * @param array $params
+     */
+    public function save($object, $params = [])
+    {
+        if (!DataObject\AbstractObject::isDirtyDetectionDisabled() && $object instanceof DataObject\DirtyIndicatorInterface) {
+            if ($object instanceof DataObject\Localizedfield) {
+                if ($object->getObject() instanceof DataObject\DirtyIndicatorInterface) {
+                    if (!$object->hasDirtyFields()) {
+                        return;
+                    }
+                }
+            } else {
+                if ($this->supportsDirtyDetection()) {
+                    if (!$object->isFieldDirty($this->getName())) {
+                        return;
+                    }
+                }
+            }
+        }
+
+        $objectsMetadata = $this->getDataFromObjectParam($object, $params);
+        if ($object->isFieldDirty($this->getName()) || $object->isFieldDirty('_self')) {
+            $this->filterMultipleAssignments($objectsMetadata, $object, $params);
+        }
+
+        parent::save($object, $params);
+    }
+
+    /**
      * @param DataObject\Concrete|DataObject\Localizedfield|DataObject\Objectbrick\Data\AbstractData|DataObject\Fieldcollection\Data\AbstractData $object
      * @param array $params
      *
@@ -557,9 +588,6 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
 
             return $publishedList;
         }
-
-        //TODO: move validation to checkValidity & throw exception in Pimcore 7
-        $data = Element\Service::filterMultipleElements($data, $object, $this->getName());
 
         return is_array($data) ? $data : [];
     }

--- a/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
@@ -30,6 +30,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
     use DataObject\ClassDefinition\Data\Relations\AllowObjectRelationTrait;
     use DataObject\ClassDefinition\Data\Relations\AllowAssetRelationTrait;
     use DataObject\ClassDefinition\Data\Relations\AllowDocumentRelationTrait;
+    use DataObject\ClassDefinition\Data\Relations\ManyToManyRelationTrait;
 
     /**
      * Static type of this element
@@ -697,38 +698,6 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
         } else {
             throw new \Exception('cannot get values from web service import - invalid data');
         }
-    }
-
-    /**
-     * TODO: move validation to checkValidity & throw exception in Pimcore 7
-     * @param DataObject\Concrete|DataObject\Localizedfield|DataObject\Objectbrick\Data\AbstractData|\Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData $object
-     * @param array $params
-     */
-    public function save($object, $params = [])
-    {
-        if (!DataObject\AbstractObject::isDirtyDetectionDisabled() && $object instanceof DataObject\DirtyIndicatorInterface) {
-            if ($object instanceof DataObject\Localizedfield) {
-                if ($object->getObject() instanceof DataObject\DirtyIndicatorInterface) {
-                    if (!$object->hasDirtyFields()) {
-                        return;
-                    }
-                }
-            } else {
-                if ($this->supportsDirtyDetection()) {
-                    if (!$object->isFieldDirty($this->getName())) {
-                        return;
-                    }
-                }
-            }
-        }
-
-        $multihrefMetadata = $this->getDataFromObjectParam($object, $params);
-
-        if ($object->isFieldDirty($this->getName()) || $object->isFieldDirty('_self')) {
-            $this->filterMultipleAssignments($multihrefMetadata, $object, $params);
-        }
-
-        parent::save($object, $params);
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Relations/ManyToManyRelationTrait.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/ManyToManyRelationTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Pimcore\Model\DataObject\ClassDefinition\Data\Relations;
+
+use Pimcore\Model\DataObject;
+
+trait ManyToManyRelationTrait
+{
+    /**
+     * TODO: move validation to checkValidity & throw exception in Pimcore 7
+     * @param DataObject\Concrete|DataObject\Localizedfield|DataObject\Objectbrick\Data\AbstractData|\Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData $object
+     * @param array $params
+     */
+    public function save($object, $params = [])
+    {
+        if (!DataObject\AbstractObject::isDirtyDetectionDisabled() && $object instanceof DataObject\DirtyIndicatorInterface) {
+            if ($object instanceof DataObject\Localizedfield) {
+                if ($object->getObject() instanceof DataObject\DirtyIndicatorInterface) {
+                    if (!$object->hasDirtyFields()) {
+                        return;
+                    }
+                }
+            } else {
+                if ($this->supportsDirtyDetection()) {
+                    if (!$object->isFieldDirty($this->getName())) {
+                        return;
+                    }
+                }
+            }
+        }
+
+        $data = $this->getDataFromObjectParam($object, $params);
+
+        if (!$object instanceof DataObject\DirtyIndicatorInterface || $object->isFieldDirty($this->getName()) || $object->isFieldDirty('_self')) {
+            $this->filterMultipleAssignments($data, $object, $params);
+        }
+
+        parent::save($object, $params);
+    }
+}

--- a/models/DataObject/ClassDefinition/Data/Relations/ManyToManyRelationTrait.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/ManyToManyRelationTrait.php
@@ -3,38 +3,37 @@
 namespace Pimcore\Model\DataObject\ClassDefinition\Data\Relations;
 
 use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyRelation;
+use Pimcore\Model\DataObject\ClassDefinition\Data\AdvancedManyToManyObjectRelation;
 
 trait ManyToManyRelationTrait
 {
     /**
      * TODO: move validation to checkValidity & throw exception in Pimcore 7
-     * @param DataObject\Concrete|DataObject\Localizedfield|DataObject\Objectbrick\Data\AbstractData|\Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData $object
+     * @param DataObject\Concrete|DataObject\Localizedfield|DataObject\Objectbrick\Data\AbstractData|\Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData $container
      * @param array $params
      */
-    public function save($object, $params = [])
+    public function save($container, $params = [])
     {
-        if (!DataObject\AbstractObject::isDirtyDetectionDisabled() && $object instanceof DataObject\DirtyIndicatorInterface) {
-            if ($object instanceof DataObject\Localizedfield) {
-                if ($object->getObject() instanceof DataObject\DirtyIndicatorInterface) {
-                    if (!$object->hasDirtyFields()) {
+        if (!DataObject\AbstractObject::isDirtyDetectionDisabled() && $container instanceof DataObject\DirtyIndicatorInterface) {
+            if ($container instanceof DataObject\Localizedfield) {
+                if ($container->getObject() instanceof DataObject\DirtyIndicatorInterface) {
+                    if (!$container->hasDirtyFields()) {
                         return;
                     }
                 }
             } else {
                 if ($this->supportsDirtyDetection()) {
-                    if (!$object->isFieldDirty($this->getName())) {
+                    if (!$container->isFieldDirty($this->getName())) {
                         return;
                     }
                 }
             }
         }
 
-        $data = $this->getDataFromObjectParam($object, $params);
+        $data = $this->getDataFromObjectParam($container, $params);
+        $this->filterMultipleAssignments($data, $container, $params);
 
-        if (!$object instanceof DataObject\DirtyIndicatorInterface || $object->isFieldDirty($this->getName()) || $object->isFieldDirty('_self')) {
-            $this->filterMultipleAssignments($data, $object, $params);
-        }
-
-        parent::save($object, $params);
+        parent::save($container, $params);
     }
 }

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -484,7 +484,7 @@ class Service extends Model\AbstractModel
      *
      * @return string|null
      */
-    public static function getElementHash(ElementInterface $element): string
+    public static function getElementHash(ElementInterface $element): ?string
     {
         $elementType = self::getElementType($element);
         if ($element->getId() === null || $elementType === null) {

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -337,61 +337,6 @@ class Service extends Model\AbstractModel
     }
 
     /**
-     * @internal trigger deprecation error when a relation is passed multiple times, remove in Pimcore 7
-     *
-     * @param array $data
-     * @param DataObject\Concrete|DataObject\Localizedfield|DataObject\Objectbrick\Data\AbstractData|\Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData $object
-     * @param string $fieldname
-     *
-     * @return array
-     *
-     * @throws \Exception
-     */
-    public static function filterMultipleElements($data, $object, $fieldname)
-    {
-        $relationItems = [];
-        $objectId = null;
-
-        if ($object instanceof DataObject\Concrete) {
-            $objectId = $object->getId();
-        } elseif (
-            $object instanceof DataObject\Fieldcollection\Data\AbstractData ||
-            $object instanceof DataObject\Localizedfield ||
-            $object instanceof DataObject\Objectbrick\Data\AbstractData
-        ) {
-            $object = $object->getObject();
-            if ($object) {
-                $objectId = $object->getId();
-            }
-        }
-
-        if (is_array($data)) {
-            foreach ($data as $item) {
-                $elementHash = null;
-                if ($item instanceof Model\DataObject\Data\ObjectMetadata || $item instanceof Model\DataObject\Data\ElementMetadata) {
-                    if ($item->getElement() instanceof Model\Element\ElementInterface) {
-                        $elementHash = Model\Element\Service::getElementHash($item->getElement());
-                    }
-                } elseif ($item instanceof Model\Element\ElementInterface) {
-                    $elementHash = Model\Element\Service::getElementHash($item);
-                }
-
-                if ($elementHash && !isset($relationItems[$elementHash])) {
-                    $relationItems[$elementHash] = $item;
-                } elseif (isset($relationItems[$elementHash])) {
-                    @trigger_error(
-                        'Passing relations multiple times is deprecated since version 6.5.2 and will throw exception in 7.0.0, tried to assign ' . $elementHash
-                        .  ' multiple times in field' . $fieldname . ' of object id: ' . $objectId,
-                        E_USER_DEPRECATED
-                    );
-                }
-            }
-        }
-
-        return array_values($relationItems);
-    }
-
-    /**
      * @static
      *
      * @param  string $type
@@ -537,11 +482,15 @@ class Service extends Model\AbstractModel
     /**
      * @param ElementInterface $element
      *
-     * @return string
+     * @return string|null
      */
     public static function getElementHash(ElementInterface $element): string
     {
-        return self::getElementType($element) . '-' . $element->getId();
+        $elementType = self::getElementType($element);
+        if ($element->getId() === null || $elementType === null) {
+            return null;
+        }
+        return $elementType . '-' . $element->getId();
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
Resolves #5902

## Additional info  
Multiple assignments check for Relation Types moved from setter `preGetData` to `save` method so that it is still possible to assign relations without Id before persisting data.
