### PR TITLE
Fix $systemConfig not initialized in Config::offsetExists()

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -54,7 +54,7 @@ class Config implements \ArrayAccess
      */
     public function offsetExists($offset)
     {
-        return isset(static::$systemConfig[$offset]);
+        return self::getSystemConfiguration($offset) !== null;
     }
 
     /**
@@ -89,11 +89,7 @@ class Config implements \ArrayAccess
      */
     public function offsetGet($offset)
     {
-        if (null === static::$systemConfig || $this->offsetExists($offset)) {
-            return self::getSystemConfiguration($offset);
-        }
-
-        return null;
+        return self::getSystemConfiguration($offset);
     }
 
     /**


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Fixes Pimcore\Config::$systemConfig being not initialized in ::offsetExists().

Resolves #5919 
