### PR TITLE
Fix pagination in object custom view

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -188,7 +188,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             }
             //pagination for custom view
             $total = $cv
-                ? $childsList->count()
+                ? $filteredTotalCount
                 : $object->getChildAmount(null, $this->getAdminUser());
         }
 


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

Fixes a bug which prevents pagination in object custom views.

Resolves #5944

## Additional info  

To reproduce:

1. Create object custom view
2. Create a folder in the custom view
3. Create >30 objects in that folder
4. In the custom view tree, there are only 30 objects and no pagination
