### PR TITLE
[Data Object] \Pimcore\Model\DataObject\Listing::count() needs to return the value of getTotalCount()

### DIFF
--- a/models/DataObject/Listing.php
+++ b/models/DataObject/Listing.php
@@ -179,7 +179,7 @@ class Listing extends Model\Listing\AbstractListing implements AdapterInterface,
      */
     public function count()
     {
-        return $this->getDao()->getCount();
+        return $this->getDao()->getTotalCount();
     }
 
     /**


### PR DESCRIPTION
... (see Assets & Documents) otherwise this will break existing pagination implementations -> regression of #5837
