### PR TITLE
[Events] Symfony version agnostic EventDispatcher

### DIFF
--- a/bundles/CoreBundle/Resources/config/services.yml
+++ b/bundles/CoreBundle/Resources/config/services.yml
@@ -202,3 +202,7 @@ services:
     Pimcore\Bundle\CoreBundle\Request\ParamConverter\DataObjectParamConverter:
         tags:
             - { name: request.param_converter, priority: -2, converter: data_object_converter }
+
+    Pimcore\Event\EventDispatcher:
+        decorates: event_dispatcher
+        arguments: ['@Pimcore\Event\EventDispatcher.inner']

--- a/lib/Event/EventDispatcher.php
+++ b/lib/Event/EventDispatcher.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Pimcore\Event;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class EventDispatcher implements EventDispatcherInterface
+{
+    /** @var EventDispatcherInterface */
+    private $eventDispatcher;
+
+    public function __construct($eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function dispatch($event/*, $eventName = null*/) {
+        $eventName = 1 < \func_num_args() ? func_get_arg(1) : null;
+        if(\version_compare(Kernel::VERSION, '4') >= 0) {
+            if(is_string($event) && is_object($eventName)) {
+                $tmp = $eventName;
+                $eventName = $event;
+                $event = $tmp;
+            }
+            $this->eventDispatcher->dispatch($event, $eventName);
+        } else {
+            if(is_string($eventName) && is_object($event)) {
+                $tmp = $eventName;
+                $eventName = $event;
+                $event = $tmp;
+            }
+            $this->eventDispatcher->dispatch($eventName, $event);
+        }
+    }
+
+    public function addListener($eventName, $listener, $priority = 0)
+    {
+        return $this->eventDispatcher->addListener($eventName, $listener, $priority);
+    }
+
+    public function addSubscriber(EventSubscriberInterface $subscriber)
+    {
+        return $this->eventDispatcher->addSubscriber($subscriber);
+    }
+
+    public function removeListener($eventName, $listener)
+    {
+        return $this->eventDispatcher->removeListener($eventName, $listener);
+    }
+
+    public function removeSubscriber(EventSubscriberInterface $subscriber)
+    {
+        return $this->eventDispatcher->removeSubscriber($subscriber);
+    }
+
+    public function getListeners($eventName = null)
+    {
+        return $this->eventDispatcher->getListeners($eventName);
+    }
+
+    public function getListenerPriority($eventName, $listener)
+    {
+        return $this->eventDispatcher->getListenerPriority($eventName, $listener);
+    }
+
+    public function hasListeners($eventName = null)
+    {
+        return $this->eventDispatcher->hasListeners($eventName);
+    }
+
+    public function __call($method, $args)
+    {
+        if (is_callable([$this->eventDispatcher, $method])) {
+            return call_user_func_array(array($this->eventDispatcher, $method), $args);
+        }
+        throw new \Exception(
+            'Undefined method - ' . get_class($this->eventDispatcher) . '::' . $method
+        );
+    }
+
+    public function __get($property)
+    {
+        if (property_exists($this->eventDispatcher, $property)) {
+            return $this->eventDispatcher->$property;
+        }
+        return null;
+    }
+
+    public function __isset($property)
+    {
+        return isset($this->eventDispatcher->$property);
+    }
+
+    public function __set($property, $value)
+    {
+        $this->eventDispatcher->$property = $value;
+        return $this;
+    }
+}

--- a/lib/Event/EventDispatcher.php
+++ b/lib/Event/EventDispatcher.php
@@ -18,7 +18,7 @@ class EventDispatcher implements EventDispatcherInterface
 
     public function dispatch($event/*, $eventName = null*/) {
         $eventName = 1 < \func_num_args() ? func_get_arg(1) : null;
-        if(\version_compare(Kernel::VERSION, '4') >= 0) {
+        if(\version_compare(Kernel::VERSION, '4.3') >= 0) {
             if(is_string($event) && is_object($eventName)) {
                 $tmp = $eventName;
                 $eventName = $event;

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -387,7 +387,7 @@ abstract class PageSnippet extends Model\Document
      */
     public function removeElement($name)
     {
-        if (isset($this->elements[$name])) {
+        if ($this->hasElement($name)) {
             unset($this->elements[$name]);
         }
 

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -404,7 +404,7 @@ abstract class PageSnippet extends Model\Document
     public function getElement($name)
     {
         $elements = $this->getElements();
-        if ($this->hasElement($name)) {
+        if (isset($this->elements[$name]) ){
             return $elements[$name];
         }
 
@@ -504,9 +504,7 @@ abstract class PageSnippet extends Model\Document
      */
     public function hasElement($name)
     {
-        $elements = $this->getElements();
-
-        return array_key_exists($name, $elements);
+        return $this->getElement($name) !== null;
     }
 
     /**

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -387,7 +387,7 @@ abstract class PageSnippet extends Model\Document
      */
     public function removeElement($name)
     {
-        if ($this->hasElement($name)) {
+        if (isset($this->elements[$name])) {
             unset($this->elements[$name]);
         }
 

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -404,7 +404,7 @@ abstract class PageSnippet extends Model\Document
     public function getElement($name)
     {
         $elements = $this->getElements();
-        if (isset($this->elements[$name]) ){
+        if ($this->hasElement($name)) {
             return $elements[$name];
         }
 
@@ -504,7 +504,9 @@ abstract class PageSnippet extends Model\Document
      */
     public function hasElement($name)
     {
-        return $this->getElement($name) !== null;
+        $elements = $this->getElements();
+
+        return array_key_exists($name, $elements);
     }
 
     /**


### PR DESCRIPTION
As I was annoyed by all the deprecation notices like `Calling the "EventDispatcher::dispatch()" method with the event name as the first argument is deprecated since Symfony 4.3, pass it as the second argument and provide the event object as the first argument instead.` which come from the Pimcore core, I created this decorator. The reason for the dispatch calls to have wrong order (in the sense of Symfony 4) is that in Pimcore 6.* we want to support Symfony 3 where the order of arguments of `EventDispatcher::dispatch()` was switched compared to now.
With this decorator we can switch to the new `dispatch()` syntax step by step without BC breaks.

A disadvantage is that developers would not get deprecation notices about application-specific events. But perhaps we find a way to also solve that until we can throw away this decorator when Pimcore will not support Symfony 3 anymore.