### PR TITLE
Output actual name of Product class on indexing.

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Tool/IndexUpdater.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Tool/IndexUpdater.php
@@ -88,7 +88,7 @@ class IndexUpdater
             self::log($loggername, '=========================');
 
             foreach ($products as $p) {
-                self::log($loggername, 'Updating product ' . $p->getId());
+                self::log($loggername, 'Updating '.array_pop(explode('\\', get_class($p))).' '.$p->getId());
                 $updater->updateIndex($p);
             }
             $page++;

--- a/bundles/EcommerceFrameworkBundle/IndexService/Tool/IndexUpdater.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Tool/IndexUpdater.php
@@ -88,7 +88,7 @@ class IndexUpdater
             self::log($loggername, '=========================');
 
             foreach ($products as $p) {
-                self::log($loggername, 'Updating '.array_pop(explode('\\', get_class($p))).' '.$p->getId());
+                self::log($loggername, 'Updating ' . $p->getClass()->getName() . ': '.$p->getId());
                 $updater->updateIndex($p);
             }
             $page++;


### PR DESCRIPTION
## Improvement 

 Output the actual (short) name of the class instead of "product". This is useful as other entities might get indexed as well, and it that case the message "Updating product ..." might get confusing.
