### PR TITLE
[Advanced relations] Lowercase metadata columns

### DIFF
--- a/models/DataObject/Data/ElementMetadata.php
+++ b/models/DataObject/Data/ElementMetadata.php
@@ -62,7 +62,7 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
     public function __construct($fieldname, $columns = [], $element = null)
     {
         $this->fieldname = $fieldname;
-        $this->columns = $columns;
+        $this->columns = array_map('strtolower', $columns);
         $this->setElement($element);
     }
 
@@ -221,7 +221,7 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
      */
     public function setColumns($columns)
     {
-        $this->columns = $columns;
+        $this->columns = array_map('strtolower', $columns);;
         $this->markMeDirty();
 
         return $this;

--- a/models/DataObject/Data/ObjectMetadata.php
+++ b/models/DataObject/Data/ObjectMetadata.php
@@ -59,7 +59,7 @@ class ObjectMetadata extends Model\AbstractModel implements DataObject\OwnerAwar
     public function __construct($fieldname, $columns = [], $object = null)
     {
         $this->fieldname = $fieldname;
-        $this->columns = $columns;
+        $this->columns = array_map('strtolower', $columns);
         $this->setObject($object);
     }
 
@@ -207,7 +207,7 @@ class ObjectMetadata extends Model\AbstractModel implements DataObject\OwnerAwar
      */
     public function setColumns($columns)
     {
-        $this->columns = $columns;
+        $this->columns = array_map('strtolower', $columns);;
         $this->markMeDirty();
 
         return $this;


### PR DESCRIPTION
Metadata field names are converted to lower case in https://github.com/pimcore/pimcore/blob/a393da91d63e5819bcd5eb776780414aa8fdae99/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php#L838-L854

And also the getter / setter access converts field names to lowercase in https://github.com/pimcore/pimcore/blob/a393da91d63e5819bcd5eb776780414aa8fdae99/models/DataObject/Data/ObjectMetadata.php#L94-L115

But with the following script you get an error:
```php
$meta = new \Pimcore\Model\DataObject\Data\ObjectMetadata('test', ['camelCase']);
$meta->setCamelCase('abc'); // error "Requested data camelcase not available"
```

This PR fixes that.