### PR TITLE
Add event to allow programmatic manipulation of element permissions

### DIFF
--- a/lib/Event/AdminEvents.php
+++ b/lib/Event/AdminEvents.php
@@ -404,4 +404,19 @@ final class AdminEvents
      * @var string
      */
     const RESOLVE_ELEMENT_ADMIN_STYLE = 'pimcore.admin.resolve.elementAdminStyle';
+
+    /**
+     * Allows you to modify whether a permission on an element is granted or not
+     *
+     * Subject: \Pimcore\Model\Element\AbstractElement
+     * Arguments:
+     *  - isAllowed | bool | the original "isAllowed" value as determined by pimcore. This can be modfied
+     *  - permissionType | string | the permission that is checked
+     *  - user | \Pimcore\Model\User | user the permission is checked for
+     *
+     * @Event("Pimcore\Event\Model\ElementEvent")
+     *
+     * @var string
+     */
+    const ELEMENT_PERMISSION_IS_ALLOWED = 'pimcore.admin.permissions.elementIsAllowed';
 }

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -17,6 +17,8 @@
 
 namespace Pimcore\Model\Element;
 
+use Pimcore\Event\AdminEvents;
+use Pimcore\Event\Model\ElementEvent;
 use Pimcore\Model;
 
 /**
@@ -229,7 +231,12 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
             return true;
         }
 
-        return $this->getDao()->isAllowed($type, $user);
+        $isAllowed = $this->getDao()->isAllowed($type, $user);
+
+        $event = new ElementEvent($this, ['isAllowed' => $isAllowed, 'permissionType' => $type, 'user' => $user]);
+        \Pimcore::getEventDispatcher()->dispatch(AdminEvents::ELEMENT_PERMISSION_IS_ALLOWED, $event);
+
+        return (bool) $event->getArgument('isAllowed');
     }
 
     public function unlockPropagate()


### PR DESCRIPTION
This event gives developers a way to add their own custom logic when determining whether a user should be granted a certain permission.

I was facing a situation where, in a multi-tenant-setup, all tenants have similar basic roles.
Say, for data objects, I have folder structure like:

```
/My Tenants
    |-- tenant 1
           |-- customers
           |-- products
           |-- orders
    |-- tenant 2
           |-- customers
           |-- products
           |-- orders
    |-- tenant 3
           |-- customers
           |-- products
           |-- orders
```

A role "Product Manager" should have access to `/My Tenants/<whatever tenant I belong to>/products`. With hundreds of tenants and half a dozen or so roles it can be
cumbersome to handle this with the default setup of workspaces. With this event, I have to possibility to fine-tune permissions in any way I like.
