### PR TITLE
Allow the user to be null in create function, save already allows this

### DIFF
--- a/models/Element/Recyclebin/Item.php
+++ b/models/Element/Recyclebin/Item.php
@@ -85,7 +85,7 @@ class Item extends Model\AbstractModel
      * @param Element\ElementInterface $element
      * @param Model\User $user
      */
-    public static function create(Element\ElementInterface $element, Model\User $user)
+    public static function create(Element\ElementInterface $element, Model\User $user = null)
     {
         $item = new self();
         $item->setElement($element);


### PR DESCRIPTION
If you want to use the Recyclebin functionality in custom code, the Item::create function needs a user. However the save() function which is called inside the create function allows the user to be null.

This changes makes it possible to have the user parameter omitted in the create call.
