### PR TITLE
[Asset] fix not authorized view on animated images if .htaccess publi…

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -124,7 +124,7 @@ class AssetController extends ElementControllerBase implements EventedController
 
             $imageInfo['previewUrl'] = sprintf('/admin/asset/get-image-thumbnail?id=%d&treepreview=true&hdpi=true&_dc=%d', $asset->getId(), time());
             if ($asset->isAnimated()) {
-                $imageInfo['previewUrl'] = $asset->getFullPath() . '?_dc=' . time();
+                $imageInfo['previewUrl'] = sprintf('/admin/asset/get-image?id=%d&_dc=%d', $asset->getId(), time());
             }
 
             if ($asset->getWidth() && $asset->getHeight()) {
@@ -1156,6 +1156,33 @@ class AssetController extends ElementControllerBase implements EventedController
         }
 
         throw $this->createNotFoundException('Thumbnail not found');
+    }
+
+    /**
+     * @Route("/get-image", methods={"GET"})
+     *
+     * @param Request $request
+     *
+     * @return BinaryFileResponse
+     */
+    public function getImageAction(Request $request)
+    {
+        $image = Asset\Image::getById(intval($request->get('id')));
+
+        if (!$image) {
+            throw $this->createNotFoundException('Asset not found');
+        }
+
+        if (!$image->isAllowed('view')) {
+            throw $this->createAccessDeniedException('not allowed to view asset');
+        }
+
+        $response = new BinaryFileResponse($image->getFileSystemPath());
+        $response->headers->set('Content-type', $image->getMimetype());
+        $response->headers->set('Access-Control-Allow-Origin', '*');
+        $this->addThumbnailCacheHeaders($response);
+
+        return $response;
     }
 
     /**

--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -124,7 +124,7 @@ class AssetController extends ElementControllerBase implements EventedController
 
             $imageInfo['previewUrl'] = sprintf('/admin/asset/get-image-thumbnail?id=%d&treepreview=true&hdpi=true&_dc=%d', $asset->getId(), time());
             if ($asset->isAnimated()) {
-                $imageInfo['previewUrl'] = sprintf('/admin/asset/get-image?id=%d&_dc=%d', $asset->getId(), time());
+                $imageInfo['previewUrl'] = sprintf('/admin/asset/get-asset-?id=%d&_dc=%d', $asset->getId(), time());
             }
 
             if ($asset->getWidth() && $asset->getHeight()) {
@@ -1159,15 +1159,15 @@ class AssetController extends ElementControllerBase implements EventedController
     }
 
     /**
-     * @Route("/get-image", methods={"GET"})
+     * @Route("/get-asset", methods={"GET"})
      *
      * @param Request $request
      *
      * @return BinaryFileResponse
      */
-    public function getImageAction(Request $request)
+    public function getAssetAction(Request $request)
     {
-        $image = Asset\Image::getById(intval($request->get('id')));
+        $image = Asset::getById(intval($request->get('id')));
 
         if (!$image) {
             throw $this->createNotFoundException('Asset not found');

--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -124,7 +124,7 @@ class AssetController extends ElementControllerBase implements EventedController
 
             $imageInfo['previewUrl'] = sprintf('/admin/asset/get-image-thumbnail?id=%d&treepreview=true&hdpi=true&_dc=%d', $asset->getId(), time());
             if ($asset->isAnimated()) {
-                $imageInfo['previewUrl'] = sprintf('/admin/asset/get-asset-?id=%d&_dc=%d', $asset->getId(), time());
+                $imageInfo['previewUrl'] = sprintf('/admin/asset/get-asset?id=%d&_dc=%d', $asset->getId(), time());
             }
 
             if ($asset->getWidth() && $asset->getHeight()) {


### PR DESCRIPTION
…c resriction is enabled

If pimcore setup restricts public asset access (like stated in the docs) animated images
cannot be viewed anymore due of direct path access.

add new controller action and return the animated image

## How to reproduce

- Change `.htaccess`like stated here and restrict some asset area: https://pimcore.com/docs/6.x/Development_Documentation/Assets/Restricting_Public_Asset_Access.html
- Upload an animated image into the restricted asset area
- Open image in backend....it will be broken
<img width="1309" alt="Screenshot 2020-03-08 at 20 02 25" src="https://user-images.githubusercontent.com/38670469/76169373-c9a11100-6177-11ea-9e8c-7ddcd73fc6fc.png">


## How it should be
At least in admin backend all images should be shown even if all assets are restricted from outside access.
<img width="1318" alt="Screenshot 2020-03-08 at 20 01 28" src="https://user-images.githubusercontent.com/38670469/76169381-d7569680-6177-11ea-8702-72a961678b38.png">
 

## Changes in this pull request  
add new controller action and return the animated image

## Additional info  
I think for the backend ui this is still acceptable resource wise @brusch 
