### PR TITLE
[User|Role] be consistent on checkbox UI and use boxLabel

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/role/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/role/settings.js
@@ -78,7 +78,7 @@ pimcore.settings.user.role.settings = Class.create({
             }
             itemsPerSection[section].push({
                 xtype: "checkbox",
-                fieldLabel: t(this.data.availablePermissions[i].key),
+                boxLabel: t(this.data.availablePermissions[i].key),
                 name: "permission_" + this.data.availablePermissions[i].key,
                 checked: this.data.permissions[this.data.availablePermissions[i].key],
                 labelWidth: 200

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
@@ -52,7 +52,7 @@ pimcore.settings.user.user.settings = Class.create({
 
         generalItems.push({
             xtype: "checkbox",
-            fieldLabel: t("active"),
+            boxLabel: t("active"),
             name: "active",
             disabled: user.id == this.currentUser.id,
             checked: this.currentUser.active
@@ -490,7 +490,7 @@ pimcore.settings.user.user.settings = Class.create({
             }
             itemsPerSection[section].push({
                 xtype: "checkbox",
-                fieldLabel: t(this.data.availablePermissions[i].key),
+                boxLabel: t(this.data.availablePermissions[i].key),
                 name: "permission_" + this.data.availablePermissions[i].key,
                 checked: this.data.permissions[this.data.availablePermissions[i].key],
                 labelWidth: 200


### PR DESCRIPTION
most checkboxes have boxLabel in User and Role tab. Permission checkboxes should go inline.
This will allow long descriptions for custom permissions as well.

## Before
<img width="644" alt="Screenshot 2020-03-08 at 21 01 54" src="https://user-images.githubusercontent.com/38670469/76170273-b34b8300-6180-11ea-9264-b4e3e05f02ee.png">

## Changes in this pull request  
<img width="740" alt="Screenshot 2020-03-08 at 21 01 01" src="https://user-images.githubusercontent.com/38670469/76170277-b9d9fa80-6180-11ea-8eac-3bdbedcc08d3.png">

<img width="1118" alt="Screenshot 2020-03-08 at 21 07 52" src="https://user-images.githubusercontent.com/38670469/76170301-e7bf3f00-6180-11ea-9ced-0b6368d914c7.png">

