### PR TITLE
Trigger useSession before executing HtmlToImage Command

### DIFF
--- a/lib/Image/HtmlToImage.php
+++ b/lib/Image/HtmlToImage.php
@@ -16,6 +16,7 @@ namespace Pimcore\Image;
 
 use Pimcore\Tool\Console;
 use Pimcore\Tool\Session;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 
 class HtmlToImage
 {
@@ -61,8 +62,13 @@ class HtmlToImage
             '--format ' . $format
         ];
 
-        if (php_sapi_name() != 'cli') {
-            $options[] = '--cookie ' .  Session::getSessionName() . ' ' . Session::getSessionId();
+        if (php_sapi_name() !== 'cli') {
+
+            $sessionData = Session::useSession(function (AttributeBagInterface $session) {
+                return ['name' => Session::getSessionName(), 'id' => Session::getSessionId()];
+            });
+
+            $options[] = sprintf('--cookie %s %s', $sessionData['name'], $sessionData['id']);
         }
 
         $arguments = ' ' . implode(' ', $options) . ' "' . $url . '" ' . $outputFile;


### PR DESCRIPTION
On most server, the document version compare does not work (It works on your demo instance though). Most of the time, this process will run for 60sec before a timeout kicks in. After that, no image has been generated.

After some research, I found a similar issue: https://github.com/KnpLabs/KnpSnappyBundle/issues/42

This PR will fix this issue.