### PR TITLE
Fix return types for Relation::getClasses

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Controller/AdminOrderController.php
+++ b/bundles/EcommerceFrameworkBundle/Controller/AdminOrderController.php
@@ -278,7 +278,7 @@ class AdminOrderController extends AdminController implements EventedControllerI
                 $field = $order->getClass()->getFieldDefinition('customer');
                 if ($field instanceof ManyToOneRelation) {
                     $classes = $field->getClasses();
-                    if (count($classes) == 1) {
+                    if (count($classes) === 1) {
                         $class = 'Pimcore\Model\DataObject\\' . reset($classes)['classes'];
                         /* @var \Pimcore\Model\DataObject\Concrete $class */
 

--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -78,4 +78,11 @@ trait Relation
 
         return $class;
     }
+
+    /**
+     * @return array[
+     *  'classes' => string,
+     * ]
+     */
+    abstract public function getClasses();
 }

--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -28,7 +28,7 @@ trait Relation
         $strArray = $asArray ? '[]' : '';
 
         // add documents
-        if (method_exists($this, 'getDocumentsAllowed') && $this->getDocumentsAllowed()) {
+        if ($this->getDocumentsAllowed()) {
             $documentTypes = $this->getDocumentTypes();
             if (count($documentTypes) == 0) {
                 $class[] = '\Pimcore\Model\Document\Page' . $strArray;
@@ -42,7 +42,7 @@ trait Relation
         }
 
         // add asset
-        if (method_exists($this, 'getAssetsAllowed') && $this->getAssetsAllowed()) {
+        if ($this->getAssetsAllowed()) {
             $assetTypes = $this->getAssetTypes();
             if (count($assetTypes) == 0) {
                 $class[] = '\Pimcore\Model\Asset' . $strArray;

--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -14,17 +14,6 @@
 
 namespace Pimcore\Model\DataObject\ClassDefinition\Data\Extension;
 
-/**
- * Class Relation
- *
- * @package Pimcore\Model\DataObject\ClassDefinition\Data\Extension
- *
- * @method bool getDocumentsAllowed()
- * @method bool getAssetsAllowed()
- * @method bool getObjectsAllowed()
- * @method string[] getDocumentTypes()
- * @method string[] getAssetTypes()
- */
 trait Relation
 {
     /**
@@ -84,5 +73,46 @@ trait Relation
      *  'classes' => string,
      * ]
      */
-    abstract public function getClasses();
+    public function getClasses() {
+        return [];
+    }
+
+    /**
+     * @return array[
+     *  'assetTypes' => string,
+     * ]
+     */
+    public function getAssetTypes() {
+        return [];
+    }
+
+    /**
+     * @return array[
+     *  'documentTypes' => string,
+     * ]
+     */
+    public function getDocumentTypes() {
+        return [];
+    }
+
+    /**
+     * @return bool
+     */
+    public function getDocumentsAllowed() {
+        return false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAssetsAllowed() {
+        return false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getObjectsAllowed() {
+        return false;
+    }
 }

--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -24,7 +24,6 @@ namespace Pimcore\Model\DataObject\ClassDefinition\Data\Extension;
  * @method bool getObjectsAllowed()
  * @method string[] getDocumentTypes()
  * @method string[] getAssetTypes()
- * @method string[] getClasses()
  */
 trait Relation
 {
@@ -67,11 +66,11 @@ trait Relation
 
         // add objects
         if ($this->getObjectsAllowed()) {
-            $classes = $this->getClasses() ? $this->getClasses() : [];
-            if (count($classes) == 0) {
+            $classes = $this->getClasses();
+            if (count($classes) === 0) {
                 $class[] = '\Pimcore\Model\DataObject\AbstractObject' . $strArray;
             } elseif (is_array($classes)) {
-                foreach ($this->getClasses() as $item) {
+                foreach ($classes as $item) {
                     $class[] = sprintf('\Pimcore\Model\DataObject\%s', ucfirst($item['classes']) . $strArray);
                 }
             }

--- a/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
@@ -90,27 +90,27 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
      *
      * @var bool
      */
-    public $assetsAllowed;
+    public $assetsAllowed = false;
 
     /**
      * Allowed asset types
      *
      * @var array
      */
-    public $assetTypes;
+    public $assetTypes = [];
 
     /**
      *
      * @var bool
      */
-    public $documentsAllowed;
+    public $documentsAllowed = false;
 
     /**
      * Allowed document types
      *
      * @var array
      */
-    public $documentTypes;
+    public $documentTypes = [];
 
     /**
      * @return bool
@@ -157,7 +157,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
      */
     public function getDocumentTypes()
     {
-        return $this->documentTypes;
+        return $this->documentTypes ?: [];
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
@@ -84,7 +84,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
      *
      * @var bool
      */
-    public $objectsAllowed;
+    public $objectsAllowed = false;
 
     /**
      *

--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -75,33 +75,33 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      *
      * @var bool
      */
-    public $objectsAllowed;
+    public $objectsAllowed = false;
 
     /**
      *
      * @var bool
      */
-    public $assetsAllowed;
+    public $assetsAllowed = false;
 
     /**
      * Allowed asset types
      *
      * @var array
      */
-    public $assetTypes;
+    public $assetTypes = [];
 
     /**
      *
      * @var bool
      */
-    public $documentsAllowed;
+    public $documentsAllowed = false;
 
     /**
      * Allowed document types
      *
      * @var array
      */
-    public $documentTypes;
+    public $documentTypes = [];
 
     /**
      * @return bool
@@ -148,7 +148,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      */
     public function getDocumentTypes()
     {
-        return $this->documentTypes;
+        return $this->documentTypes ?: [];
     }
 
     /**
@@ -190,7 +190,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      */
     public function getAssetTypes()
     {
-        return $this->assetTypes;
+        return $this->assetTypes ?: [];
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
@@ -37,7 +37,7 @@ abstract class AbstractRelations extends Data implements
      *
      * @var array
      */
-    public $classes;
+    public $classes = [];
 
     /** Optional path formatter class
      * @var null|string

--- a/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
@@ -45,11 +45,13 @@ abstract class AbstractRelations extends Data implements
     public $pathFormatterClass;
 
     /**
-     * @return array
+     * @return array[
+     *  'classes' => string,
+     * ]
      */
     public function getClasses()
     {
-        return $this->classes;
+        return $this->classes ?: [];
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Relations/AllowObjectRelationTrait.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AllowObjectRelationTrait.php
@@ -20,7 +20,7 @@ trait AllowObjectRelationTrait
         $allowed = true;
         if (!$this->getObjectsAllowed()) {
             $allowed = false;
-        } elseif ($this->getObjectsAllowed() and is_array($allowedClasses) and count($allowedClasses) > 0) {
+        } elseif ($this->getObjectsAllowed() and count($allowedClasses) > 0) {
             $allowedClassnames = [];
             foreach ($allowedClasses as $c) {
                 $allowedClassnames[] = $c['classes'];


### PR DESCRIPTION
As `AbstractRelations::getClasses()` really exists we do not need the `@method string[] getClasses()` in the `Relation` trait - this only confuses the IDE.

I actually wonder why all the other methods do not exist or what the `@method` documentations are for - because there is neither a `__call()` function nor do the methods `getAssetTypes()`, `getDocumentTypes()` etc. exist.
They actually only confuse the IDE and if you use those functions you will get errors depending on the actual relation `Data` class.