### PR TITLE
Renderlet: frontend method should not catch errors

### DIFF
--- a/models/Document/Tag/Renderlet.php
+++ b/models/Document/Tag/Renderlet.php
@@ -160,15 +160,13 @@ class Renderlet extends Model\Document\Tag
                 $moduleOrBundle = $this->options['module'];
             }
 
-            $content = $tagHandler->renderAction(
+            return $tagHandler->renderAction(
                 $this->view,
                 $this->options['controller'],
                 $this->options['action'],
                 $moduleOrBundle,
                 $params
             );
-
-            return $content;
         }
 
         return '';

--- a/models/Document/Tag/Renderlet.php
+++ b/models/Document/Tag/Renderlet.php
@@ -152,30 +152,23 @@ class Renderlet extends Model\Document\Tag
                 }
             }
 
-            try {
-                $moduleOrBundle = null;
+            $moduleOrBundle = null;
 
-                if (isset($this->options['bundle'])) {
-                    $moduleOrBundle = $this->options['bundle'];
-                } elseif (isset($this->options['module'])) {
-                    $moduleOrBundle = $this->options['module'];
-                }
-
-                $content = $tagHandler->renderAction(
-                    $this->view,
-                    $this->options['controller'],
-                    $this->options['action'],
-                    $moduleOrBundle,
-                    $params
-                );
-
-                return $content;
-            } catch (\Exception $e) {
-                if (\Pimcore::inDebugMode()) {
-                    return 'ERROR: ' . $e->getMessage() . ' (for details see log files in /var/logs)';
-                }
-                Logger::error($e);
+            if (isset($this->options['bundle'])) {
+                $moduleOrBundle = $this->options['bundle'];
+            } elseif (isset($this->options['module'])) {
+                $moduleOrBundle = $this->options['module'];
             }
+
+            $content = $tagHandler->renderAction(
+                $this->view,
+                $this->options['controller'],
+                $this->options['action'],
+                $moduleOrBundle,
+                $params
+            );
+
+            return $content;
         }
 
         return '';


### PR DESCRIPTION
If I have a error in a renderlet template I get following error:

`An exception has been thrown during the rendering of a template ("There are no indexes to pop from as index list is empty").`

```
UnderflowException:
There are no indexes to pop from as index list is empty

  at vendor/pimcore/pimcore/lib/Document/Tag/Block/BlockState.php:92
  at Pimcore\Document\Tag\Block\BlockState->popIndex()
     (vendor/pimcore/pimcore/models/Document/Tag/Areablock.php:263)
  at Pimcore\Model\Document\Tag\Areablock->blockDestruct()
     (vendor/pimcore/pimcore/models/Document/Tag/Areablock.php:128)
  at Pimcore\Model\Document\Tag\Areablock->loop()
     (vendor/pimcore/pimcore/models/Document/Tag/Areablock.php:94)
  at Pimcore\Model\Document\Tag\Areablock->frontend()
     (vendor/pimcore/pimcore/models/Document/Tag.php:521)
  at Pimcore\Model\Document\Tag->render()
     (vendor/twig/twig/src/Extension/CoreExtension.php:1499)
```

I use the `Tag::render()` method in the template. So I want get the correct error.

The `Tag::__toString()` method should catch this errors
