### PR TITLE
Fixes settings_abstract.js to align inputs & elements

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/settings_abstract.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/settings_abstract.js
@@ -241,10 +241,6 @@ pimcore.document.settings_abstract = Class.create({
             collapsible: true,
             collapsed: collapsed,
             autoHeight:true,
-            defaults: {
-                labelWidth: 320,
-                width: 700
-            },
             defaultType: 'textfield',
             items :[
                 {
@@ -385,6 +381,8 @@ pimcore.document.settings_abstract = Class.create({
                 }
             ],
             defaults: {
+                labelWidth: 300,
+                width: 700,
                 listeners: {
                     "change": function (field, checked) {
                         Ext.getCmp("pimcore_document_settings_" + this.document.id).dirty = true;


### PR DESCRIPTION
There was a duplicate declaration of `defaults` which overrode the width/labelWidth settings inside the Controller, Action & Template fieldset.

Now it looks like this:

![Skärmbild (315)](https://user-images.githubusercontent.com/279826/76738914-c3a8c280-676b-11ea-9a5f-a6210b3b21c1.png)
