### PR TITLE
Feature: Change getSaveCopyName() to behave more like Operating Systems

### DIFF
--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -401,6 +401,16 @@ class Service extends Model\AbstractModel
             // only for assets: add the prefix _copy before the file extension (if exist) not after to that source.jpg will be source_copy.jpg and not source.jpg_copy
             if ($type == 'asset' && $fileExtension = File::getFileExtension($sourceKey)) {
                 $sourceKey = preg_replace('/\.' . $fileExtension . '$/i', '_copy.' . $fileExtension, $sourceKey);
+            } elseif (preg_match("/_copy(|_\d*)$/", $sourceKey) === 1) {
+                // If key already ends with _copy or copy_N, append a digit to avoid _copy_copy_copy naming
+                $keyParts = explode('_', $sourceKey);
+                $counterKey = array_key_last($keyParts);
+                if (intval($keyParts[$counterKey]) > 0) {
+                    $keyParts[$counterKey] = intval($keyParts[$counterKey]) + 1;
+                } else {
+                    $keyParts[] = 1;
+                }
+                $sourceKey = implode('_', $keyParts);
             } else {
                 $sourceKey .= '_copy';
             }


### PR DESCRIPTION
Just a nice thing to have: If an element key already ends with _copy or copy_N, append/increment a digit to avoid _copy_copy_copy chains if pasting the same object multiple times.

For example, in Windows, pasting a file multiple times will result in: *filename - copy* and then *filename - copy (2)*, in Ubuntu it becomes *filename (copy 1)* and *filename (copy 2)* and similarly will MacOS.

Edit: By the way, I'm using `array_key_last` here, it's a PHP 7.3 requirement, but I'm assuming symfony/polyfill-php73 is loaded if anyone is using PHP 7.2.