### PR TITLE
CKE and editmode adjustments/fixes

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/editmode.css
+++ b/bundles/AdminBundle/Resources/public/css/editmode.css
@@ -28,7 +28,7 @@
     -webkit-box-sizing: content-box !important;
 }
 
-.cke_dialog {
+.cke_dialog_container {
     z-index: 100300 !important;
 }
 

--- a/bundles/AdminBundle/Resources/public/js/lib/ckeditor/plugins/dialog/styles/dialog.css
+++ b/bundles/AdminBundle/Resources/public/js/lib/ckeditor/plugins/dialog/styles/dialog.css
@@ -1,7 +1,3 @@
-.cke_dialog_open {
-	overflow: hidden;
-}
-
 .cke_dialog_container {
 	position: fixed;
 	overflow-y: auto;


### PR DESCRIPTION
This PR has two changes:

1. In editmode, the CKE modal dialogues did not properly position themselves above the WYSIWYG button panel, using `.cke_dialog_container` resolved that.
2. Any time a CKE modal dialogue were opened the background document jumped sideways due to the disappearing scroll bar, this keeps the scrollbar. The modal will still be centred in the viewport if the user scrolls and scrolling scrollable fields in the modal works as expected.