### PR TITLE
[DOCS] Update 20_Building_Custom_Rest_APIs.md

### DIFF
--- a/doc/Development_Documentation/26_Best_Practice/20_Building_Custom_Rest_APIs.md
+++ b/doc/Development_Documentation/26_Best_Practice/20_Building_Custom_Rest_APIs.md
@@ -25,7 +25,7 @@ use \Pimcore\Controller\FrontendController;
 class CustomRestController extends FrontendController
 {
     /**
-     * @Route("/webservice/rest/get-products")
+     * @Route("/custom-pimcore-webservice/rest/get-products")
      */
     public function defaultAction(Request $request)
     {


### PR DESCRIPTION
 if REST API is deprecated then routes endpoint also needs to change . because using these routes "/webservice/rest/*" , it is using the deprecated api key method for authentication.

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

