### PR TITLE
[AssetController] Fix: Call to a member function getInherited() on array

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -86,8 +86,8 @@ class AssetController extends ElementControllerBase implements EventedController
         $asset->setParent(null);
 
         $asset->setStream(null);
-        $asset->setProperties(Element\Service::minimizePropertiesForEditmode($asset->getProperties()));
         $data = $asset->getObjectVars();
+        $data['properties'] = Element\Service::minimizePropertiesForEditmode($asset->getProperties());
 
         if ($asset instanceof Asset\Text) {
             if ($asset->getFileSize() < 2000000) {

--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -87,7 +87,6 @@ class AssetController extends ElementControllerBase implements EventedController
 
         $asset->setStream(null);
         $data = $asset->getObjectVars();
-        $data['properties'] = Element\Service::minimizePropertiesForEditmode($asset->getProperties());
 
         if ($asset instanceof Asset\Text) {
             if ($asset->getFileSize() < 2000000) {
@@ -142,6 +141,7 @@ class AssetController extends ElementControllerBase implements EventedController
             $data['imageInfo'] = $imageInfo;
         }
 
+        $data['properties'] = Element\Service::minimizePropertiesForEditmode($asset->getProperties());
         $data['metadata'] = Asset\Service::expandMetadataForEditmode($asset->getMetadata());
         $data['versionDate'] = $asset->getModificationDate();
         $data['filesizeFormatted'] = $asset->getFileSize(true);


### PR DESCRIPTION
If I want open a new video in the admin interface I get following exception:

```
Error: Call to a member function getInherited() on array in vendor/pimcore/pimcore/models/Asset.php:770
Stack trace:
#0 vendor/pimcore/pimcore/models/Asset/Video.php(76): Pimcore\Model\Asset->update(Array)
#1 vendor/pimcore/pimcore/models/Asset.php(519): Pimcore\Model\Asset\Video->update(Array)
#2 vendor/pimcore/pimcore/models/Asset/Video.php(262): Pimcore\Model\Asset->save()
#3 vendor/pimcore/pimcore/models/Asset/Video.php(280): Pimcore\Model\Asset\Video->getDimensions()
#4 vendor/pimcore/pimcore/bundles/AdminBundle/Controller/Admin/AssetController.php(110): Pimcore\Model\Asset\Video->getWidth()
#5 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(146): Pimcore\Bundle\AdminBundle\Controller\Admin\AssetController->getDataByIdAction(Object(Symfony\Component\HttpFoundation\Request), Object(Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher))
#6 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(68): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#7 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php(201): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#8 web/app.php(36): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#9 {main}
```

Regression from #5864