### PR TITLE
[PHPStan] Use new generate baseline option

### DIFF
--- a/.travis/run-stan.sh
+++ b/.travis/run-stan.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-if [ $PHPSTAN_BASELINE == 0 ]; then sed -e "s?- phpstan-baseline.neon?#- phpstan-baseline.neon?g" -i phpstan.neon; fi
-
 if [ $SYMFONY_VERSION = "^3.4" ]
 then
     config=".travis/phpstan.travis.neon"
@@ -13,7 +11,7 @@ fi
 
 cmd="vendor/bin/phpstan analyse -c $config bundles/ lib/ models/ -l $PHPSTAN_LEVEL --memory-limit=-1"
 
-if [ $PHPSTAN_BASELINE_GENERATE == 1 ]; then cmd+=" --error-format baselineNeon > phpstan-baseline.neon"; fi
+if [ $PHPSTAN_BASELINE_GENERATE == 1 ]; then cmd+=" --generate-baseline"; fi
 
 echo $cmd
 eval $cmd

--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
   "require-dev": {
     "cache/integration-tests": "^0.16.0",
     "codeception/codeception": "~2.4.5",
-    "phpstan/phpstan": "^0.12",
+    "phpstan/phpstan": "^0.12.18",
     "phpstan/phpstan-symfony": "^0.12",
     "heidelpay/heidelpay-php": "^1.2.5.1",
     "klarna/checkout": "^3.0.0",

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md
@@ -204,20 +204,10 @@ Open the build log and check for problems.
 
 PHPStan can create a baseline file, which contain all current errors. See this [blog](https://medium.com/@ondrejmirtes/phpstans-baseline-feature-lets-you-hold-new-code-to-a-higher-standard-e77d815a5dff) entry.
  
-To generate a new baseline file you have to do following steps:
-
-1. Deactivate baseline file include (comment out) in phpstan.neon
-    ```sh
-    sed -e "s?- phpstan-baseline.neon?#- phpstan-baseline.neon?g" -i phpstan.neon
-    ```
-2. Generate new baseline file
-    ```sh
-    vendor/bin/phpstan analyse -c .travis/phpstan.s4.travis.neon bundles/ lib/ models/ -l 3 --memory-limit=-1 --error-format baselineNeon > phpstan-baseline.neon
-    ```
-3. Activate baseline file include in phpstan.neon
-    ```sh
-    sed -e "s?#- phpstan-baseline.neon?- phpstan-baseline.neon?g" -i phpstan.neon
-    ```
+To generate a new baseline file you have to execute following command:
+```sh
+vendor/bin/phpstan analyse -c .travis/phpstan.s4.travis.neon bundles/ lib/ models/ -l 3 --memory-limit=-1 --generate-baseline
+```
 
 With this baseline file include, Travis can detect new errors without having to fix all errors first.
 


### PR DESCRIPTION
With the new version 0.12.18 its easier to generate a new baseline file:
https://github.com/phpstan/phpstan/releases/tag/0.12.18