### PR TITLE
[docs] [paypal] casting object to array looses data

### DIFF
--- a/doc/Development_Documentation/10_E-Commerce_Framework/15_Payment/04_PayPal.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/15_Payment/04_PayPal.md
@@ -124,7 +124,7 @@ public function startPaymentAction() {
     ];
     
     $response = $payment->initPayment($cart->getPriceCalculator()->getGrandTotal(), $config);
-    return $this->json((array)$response);
+    return new \Symfony\Component\HttpFoundation\JsonResponse($response);
 
 } 
 


### PR DESCRIPTION
casting the object to an array will loose some nested objects that are needed.
