### PR TITLE
[Asset] JPEG Thumbnails should only use .jpg as file extension, not pjpeg or .jpeg

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -5,6 +5,10 @@
 - `app` migration set is now located in `app/Migrations` instead of `app/Resources/migrations` - Pimcore will automatically move existing migration scripts for you (update your VCS!)
 - Replaced `html2text` from [Martin Bayer] with `Html2Text\Html2Text` library. `Pimcore\Mail::determineHtml2TextIsInstalled`, `Pimcore\Mail::getHtml2TextBinaryEnabled`, `Pimcore\Mail::enableHtml2textBinary`, are deprecated in favour of new library and will be removed in Pimcore 7. Also, `Pimcore\Mail::setHtml2TextOptions` now accepts array options instead of string.
 - Dirty detection `\Pimcore\Model\DataObject\DirtyIndicatorInterface` & `\Pimcore\Model\DataObject\Traits\DirtyIndicatorTrait` is deprecated and will be removed in Pimcore 7. Please use new interface `\Pimcore\Model\Element\DirtyIndicatorInterface` and trait `\Pimcore\Model\Element\Traits\DirtyIndicatorTrait` instead.
+- Image thumbnails using any (P)JPEG/AUTO format will now all use `.jpg` as file extension (used to be `.jpeg` or `.pjpeg`). 
+You can delete all existing `.pjpeg` and `.jpeg` thumbnails as they are not getting used anymore (`.jpg` files will be newly generated). 
+You can use the following command to delete the obsolete files: `find web/var/tmp/image-thumbnails/ -type f \( -iname \*.jpeg -o -iname \*.pjpeg \) -delete`   
+If you're using pre-generation for your thumbnails, don't forget to run the command (e.g. `./bin/console pimcore:thumbnails:image ...`). 
 
 ## 6.5.2
 - Passing multiple relations(w/o multiple assignments check) in data objects is deprecated and will throw exception in Pimcore 7.

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -381,7 +381,7 @@ class Thumbnail
 
                     $sourceHtml = '<source ' . array_to_html_attribute_string($sourceTagAttributes) . ' />';
                     if ($isAutoFormat) {
-                        $sourceHtmlWebP = preg_replace(['@(\.)(jpg|png)@', '@(/)(jpeg|png)@'], '$1webp', $sourceHtml);
+                        $sourceHtmlWebP = preg_replace(['@(\.)(jpg|png)( \dx)@', '@(/)(jpeg|png)(")@'], '$1webp$3', $sourceHtml);
                         $html .= "\t" . $sourceHtmlWebP . "\n";
                     }
 

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -381,7 +381,7 @@ class Thumbnail
 
                     $sourceHtml = '<source ' . array_to_html_attribute_string($sourceTagAttributes) . ' />';
                     if ($isAutoFormat) {
-                        $sourceHtmlWebP = preg_replace(['@(\.)(pjpeg|png)@', '@(/)(jpeg|png)@'], '$1webp', $sourceHtml);
+                        $sourceHtmlWebP = preg_replace(['@(\.)(jpg|png)@', '@(/)(jpeg|png)@'], '$1webp', $sourceHtml);
                         $html .= "\t" . $sourceHtmlWebP . "\n";
                     }
 

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -167,7 +167,10 @@ class Processor
         $fileExtension = $format;
         if ($format == 'original') {
             $fileExtension = \Pimcore\File::getFileExtension($fileSystemPath);
+        } elseif ($format === 'pjpeg' || $format === 'jpeg') {
+            $fileExtension = 'jpg';
         }
+
         $filename .= '.' . $fileExtension;
 
         $fsPath = $thumbDir . '/' . $filename;


### PR DESCRIPTION
This solves issues e.g. with mime detections by object storages like S3 and probably also für CDNs and other services. 
There is also no reason to not use the standard file extension at all. 