### PR TITLE
[Asset] Support for all/custom media-queries in thumbnails

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/thumbnail/item.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/thumbnail/item.js
@@ -58,12 +58,11 @@ pimcore.settings.thumbnail.item = Class.create({
                 text: t("add_media_query"),
                 iconCls: "pimcore_icon_add",
                 handler: function () {
-                    Ext.MessageBox.prompt("", t("please_enter_the_maximum_viewport_width_in_pixels_allowed_for_this_thumbnail"), function (button, value) {
-                        if (button == "ok" && is_numeric(value)) {
-                            value = value + "w"; // add the width indicator here, to be future-proof
+                    Ext.MessageBox.prompt("", t("enter_media_query"), function (button, value) {
+                        if (button == "ok") {
                             this.addMediaPanel(value, null, true, true);
                         }
-                    }.bind(this));
+                    }.bind(this), null, false, '(min-width: 576px)');
                 }.bind(this)
             }]
         };
@@ -194,6 +193,11 @@ pimcore.settings.thumbnail.item = Class.create({
 
     addMediaPanel: function (name, items, closable, activate) {
 
+        if(name.match(/^\d+w$/)) {
+            // convert legacy syntax to new syntax/name
+            name = '(max-width: ' + name.replace("w", "") + 'px)';
+        }
+
         if (this.medias[name]) {
             return;
         }
@@ -214,9 +218,7 @@ pimcore.settings.thumbnail.item = Class.create({
         if (name == "default") {
             title = t("default");
         } else {
-            // remove the width indicator (maybe there will be more complex syntax in the future)
-            var tmpName = name.replace("w", "");
-            title = "max. width: " + tmpName + "px";
+            title = name;
         }
 
         var itemContainer = new Ext.Panel({

--- a/bundles/CoreBundle/Migrations/Version20200324141723.php
+++ b/bundles/CoreBundle/Migrations/Version20200324141723.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Model\Asset;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+
+class Version20200324141723 extends AbstractPimcoreMigration
+{
+    public function doesSqlMigrations(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $listing = new Asset\Image\Thumbnail\Config\Listing;
+        $thumbnails = $listing->load();
+
+        foreach($thumbnails as $thumbnail) {
+            if($thumbnail->hasMedias()) {
+                $medias = [];
+                foreach($thumbnail->getMedias() as $key => $config) {
+                    if(preg_match('/^[\d]+w$/', $key)) {
+                        // old style key (e.g. 500w)
+                        $maxWidth = str_replace('w', '', $key);
+                        $key = '(max-width: ' . $maxWidth . 'px)';
+                    }
+
+                    $medias[$key] = $config;
+                }
+
+                $thumbnail->setMedias($medias);
+                $thumbnail->save();
+            }
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $listing = new Asset\Image\Thumbnail\Config\Listing;
+        $thumbnails = $listing->load();
+
+        foreach($thumbnails as $thumbnail) {
+            if($thumbnail->hasMedias()) {
+                $medias = [];
+                foreach($thumbnail->getMedias() as $key => $config) {
+                    if(preg_match('/max-width:[ ]+([\d]+)px/', $key, $matches)) {
+                        // old style key (e.g. 500w)
+                        $key = $matches[1] . 'w';
+                        $medias[$key] = $config;
+                    } else {
+                        $this->writeMessage(sprintf('Unable to fully downgrade thumbnail configuration for `%s` because media query `%s` is not supported in versions prior 6.6.0. Ignoring this media query.', $thumbnail->getName(), $key));
+                    }
+                }
+
+                $thumbnail->setMedias($medias);
+                $thumbnail->save();
+            }
+        }
+    }
+}

--- a/bundles/CoreBundle/Resources/translations/en.extended.json
+++ b/bundles/CoreBundle/Resources/translations/en.extended.json
@@ -50,7 +50,7 @@
   "good": "Good",
   "best": "Best",
   "average": "Average",
-  "please_enter_the_maximum_viewport_width_in_pixels_allowed_for_this_thumbnail": "Please enter the maximum viewport width (in pixels) allowed for this thumbnail",
+  "enter_media_query": "Please enter a valid CSS media query",
   "add_media_query": "Add Media Query",
   "specific_settings": "Specific Settings",
   "login_as_this_user_description": "The following link is a temporary link that allows you to login as this user in a different browser:",

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -366,9 +366,15 @@ class Thumbnail
                 if ($thumb) {
                     $sourceTagAttributes['srcset'] = implode(', ', $srcSetValues);
                     if ($mediaQuery) {
-                        // currently only max-width is supported, so we replace the width indicator (400w) out of the name
-                        $maxWidth = str_replace('w', '', $mediaQuery);
-                        $sourceTagAttributes['media'] = '(max-width: ' . $maxWidth . 'px)';
+                        if(preg_match('/^[\d]+w$/', $mediaQuery)) {
+                            // we replace the width indicator (400w) out of the name and build a proper media query for max width
+                            $maxWidth = str_replace('w', '', $mediaQuery);
+                            $sourceTagAttributes['media'] = '(max-width: ' . $maxWidth . 'px)';
+                        } else {
+                            // new style custom media queries
+                            $sourceTagAttributes['media'] = $mediaQuery;
+                        }
+
                         $thumb->reset();
                     }
 


### PR DESCRIPTION
Resolves #5201

In the past only `max-width` media queries were supported, now any media query can be defined. 

![image](https://user-images.githubusercontent.com/142037/77438167-c8ade780-6de5-11ea-8f1d-b709a8c65582.png)
