### PR TITLE
[Asset] Thumbnails: fallback image of <picture> element should be always the default configuration

### DIFF
--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -320,8 +320,6 @@ class Thumbnail
         // $this->getConfig() can be empty, the original image is returned
         if ($this->getConfig() && ($this->getConfig()->hasMedias() || $this->getConfig()->getForcePictureTag())) {
             // output the <picture> - element
-            // mobile first => fallback image is the smallest possible image
-            $fallBackImageThumb = null;
             $isWebPAutoSupport = \Pimcore::getContainer()->getParameter('pimcore.config')['assets']['image']['thumbnails']['webp_auto_support'];
             $isAutoFormat = (strtolower($this->getConfig()->getFormat()) === 'source' && $isWebPAutoSupport) ? true : false;
             $webpSupportBackup = null;
@@ -351,10 +349,6 @@ class Thumbnail
                     $thumbConfigRes->setHighResolution($highRes);
                     $thumb = $image->getThumbnail($thumbConfigRes, true);
                     $srcSetValues[] = $this->addCacheBuster($thumb . ' ' . $highRes . 'x', $options, $image);
-
-                    if (!$fallBackImageThumb) {
-                        $fallBackImageThumb = $thumb;
-                    }
 
                     if ($isAutoFormat) {
                         $thumbConfigWebP = clone $thumbConfigRes;
@@ -396,7 +390,7 @@ class Thumbnail
             }
 
             $attrCleanedForPicture = $attributes;
-            $attrCleanedForPicture['src'] = $this->addCacheBuster((string) $fallBackImageThumb, $options, $image);
+            $attrCleanedForPicture['src'] = $this->addCacheBuster($path, $options, $image);
             unset($attrCleanedForPicture['width']);
             unset($attrCleanedForPicture['height']);
 


### PR DESCRIPTION
Currently there's an inconsistency since between the fallback image used in the data-attribute and the one used for the <img> Tag. 

This PR fixes this inconsistency and uses always the default configuration as the fallback. 