### PR TITLE
[Staticroute] respect base url

### DIFF
--- a/lib/Routing/Staticroute/Router.php
+++ b/lib/Routing/Staticroute/Router.php
@@ -198,6 +198,9 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
                 if (self::RELATIVE_PATH === $referenceType) {
                     $url = UrlGenerator::getRelativePath($this->context->getPathInfo(), $url);
                 }
+                else {
+                    $url = $this->context->getBaseUrl().$url;
+                }
             }
 
             return $url;

--- a/lib/Routing/Staticroute/Router.php
+++ b/lib/Routing/Staticroute/Router.php
@@ -187,19 +187,26 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
             unset($parameters['encode']);
             // assemble the route / url in Staticroute::assemble()
             $url = $route->assemble($parameters, $reset, $encode);
+            $port = '';
+            $scheme = $this->context->getScheme() ;
+
+            if ('http' === $scheme && 80 !== $this->context->getHttpPort()) {
+                $port = ':'.$this->context->getHttpPort();
+            } elseif ('https' === $scheme && 443 !== $this->context->getHttpsPort()) {
+                $port = ':'.$this->context->getHttpsPort();
+            }
+
+            $schemeAuthority = self::NETWORK_PATH === $referenceType || '' === $scheme ? '//' : "$scheme://";
+            $schemeAuthority .= $hostname.$port;
 
             if ($needsHostname) {
-                if (self::ABSOLUTE_URL === $referenceType) {
-                    $url = $this->context->getScheme() . '://' . $hostname . $url;
-                } else {
-                    $url = '//' . $hostname . $url;
-                }
+                $url = $schemeAuthority.$this->context->getBaseUrl().$url;
             } else {
                 if (self::RELATIVE_PATH === $referenceType) {
                     $url = UrlGenerator::getRelativePath($this->context->getPathInfo(), $url);
                 }
                 else {
-                    $url = $this->context->getBaseUrl().$url;
+                    $url = $schemeAuthority.$this->context->getBaseUrl().$url;
                 }
             }
 
@@ -214,7 +221,7 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
      */
     public function matchRequest(Request $request)
     {
-        return $this->doMatch($request->getPathInfo(), $request);
+        return $this->doMatch($request->getPathInfo());
     }
 
     /**
@@ -227,11 +234,10 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
 
     /**
      * @param string $pathinfo
-     * @param Request $request
      *
      * @return array
      */
-    protected function doMatch($pathinfo, Request $request = null)
+    protected function doMatch($pathinfo)
     {
         $pathinfo = urldecode($pathinfo);
 
@@ -239,14 +245,6 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
         $params = array_merge(Tool::getRoutingDefaults(), $params);
 
         foreach ($this->getStaticRoutes() as $route) {
-            if (null !== $request && null !== $route->getMethods() && 0 !== count($route->getMethods())) {
-                $method = $request->getMethod();
-
-                if (!in_array($method, $route->getMethods(), true)) {
-                    continue;
-                }
-            }
-
             if ($routeParams = $route->match($pathinfo, $params)) {
                 Staticroute::setCurrentRoute($route);
 

--- a/lib/Routing/Staticroute/Router.php
+++ b/lib/Routing/Staticroute/Router.php
@@ -206,7 +206,7 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
                     $url = UrlGenerator::getRelativePath($this->context->getPathInfo(), $url);
                 }
                 else {
-                    $url = $schemeAuthority.$this->context->getBaseUrl().$url;
+                    $url = $this->context->getBaseUrl().$url;
                 }
             }
 


### PR DESCRIPTION
Respect base-url in static-routes. Use case:

I started developing Frontend Tests for CoreShop, since I need a fixed environment, I created `web/app_test.php` where I force an ENV. Since that is now my base-path for all generated Routes, Pimcore Static Routes should respect that as well.