### PR TITLE
Pass context when adding an asset via drag and drop to a document

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tags/image.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tags/image.js
@@ -119,7 +119,7 @@ pimcore.document.tags.image = Class.create(pimcore.document.tag, {
                 } else {
                     pimcore.helpers.showNotification(t("error"), t('unsupported_filetype'), "error");
                 }
-            }.bind(this));
+            }.bind(this), null, this.getContext());
         } else {
             this.element.insertHtml("beforeEnd",'<div class="pimcore_tag_droptarget"></div>');
             this.element.addCls("pimcore_tag_image_no_upload_empty");


### PR DESCRIPTION
Passing the document context will trigger the "resolve upload target" event and gives the developer an opportunity to change the target folder.
(In my specific use case, I want to choose a folder based on the sub-site the document belongs to)