### PR TITLE
Allows PreviewRequestTrait to discover primcore_preview

### DIFF
--- a/bundles/CoreBundle/EventListener/Traits/PreviewRequestTrait.php
+++ b/bundles/CoreBundle/EventListener/Traits/PreviewRequestTrait.php
@@ -33,6 +33,10 @@ trait PreviewRequestTrait
             return true;
         }
 
+        if ($request->get('pimcore_preview') === 'true') {
+            return true;
+        }
+
         return false;
     }
 }


### PR DESCRIPTION
Not 100% sure if this is the most optimal location for this change, but I'm submitting it like this. This change resolves no issue, but it helps with previewing Snippets and such objects.