### PR TITLE
Fix: Navigation Excludes of Links are not shown in tree

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -1190,10 +1190,10 @@ class DocumentController extends ElementControllerBase implements EventedControl
             if ($site instanceof Site) {
                 $tmpDocument['url'] = 'http://' . $site->getMainDomain() . preg_replace('@^' . $site->getRootPath() . '/?@', '/', $childDocument->getRealFullPath());
             }
+        }
 
-            if ($childDocument->getProperty('navigation_exclude')) {
-                $tmpDocument['cls'] .= 'pimcore_navigation_exclude ';
-            }
+        if ($childDocument->getProperty('navigation_exclude')) {
+            $tmpDocument['cls'] .= 'pimcore_navigation_exclude ';
         }
 
         if (!$childDocument->isPublished()) {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/998558/78015101-2e9bf100-7349-11ea-91df-5ae31442ff5d.png)

After:
![image](https://user-images.githubusercontent.com/998558/78015122-365b9580-7349-11ea-8483-0e0650dedd40.png)
