### PR TITLE
[Admin] DataObjects Grid - Fix grid config error when object brick is deleted

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -552,8 +552,8 @@ class DataObjectHelperController extends AdminController
                                 /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedFields */
                                 $localizedFields = $brickClass->getFieldDefinition($innerContainer);
                                 $fd = $localizedFields->getFieldDefinition($brickDescriptor['brickfield']);
-                            } else {
-                                $fd = $brickClass->getFieldDefinition($fieldname);
+                            } elseif ($brickClass instanceof DataObject\Objectbrick\Definition) {
+                                    $fd = $brickClass->getFieldDefinition($fieldname);
                             }
 
                             if (!empty($fd)) {

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -547,13 +547,15 @@ class DataObjectHelperController extends AdminController
 
                             $brickClass = DataObject\Objectbrick\Definition::getByKey($brick);
 
-                            if ($brickDescriptor) {
-                                $innerContainer = $brickDescriptor['innerContainer'] ?? 'localizedfields';
-                                /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedFields */
-                                $localizedFields = $brickClass->getFieldDefinition($innerContainer);
-                                $fd = $localizedFields->getFieldDefinition($brickDescriptor['brickfield']);
-                            } elseif ($brickClass instanceof DataObject\Objectbrick\Definition) {
+                            if ($brickClass instanceof DataObject\Objectbrick\Definition) {
+                                if ($brickDescriptor) {
+                                    $innerContainer = $brickDescriptor['innerContainer'] ?? 'localizedfields';
+                                    /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedFields */
+                                    $localizedFields = $brickClass->getFieldDefinition($innerContainer);
+                                    $fd = $localizedFields->getFieldDefinition($brickDescriptor['brickfield']);
+                                } else {
                                     $fd = $brickClass->getFieldDefinition($fieldname);
+                                }
                             }
 
                             if (!empty($fd)) {


### PR DESCRIPTION
## Bugfix
### Steps to reproduce
- Add obejctbrick fields to folder grid and save it.
- Delete objectbrick
- Load folder grid with saved config => error
![image](https://user-images.githubusercontent.com/5137917/78017414-8ab44480-734c-11ea-8de7-83ec16b8227e.png)

