### PR TITLE
[DataObjects] Relations - fix getClasses() return value

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -75,7 +75,7 @@ trait Relation
      */
     public function getClasses()
     {
-        return [];
+        return $this->classes ?: [];
     }
 
     /**


### PR DESCRIPTION
##Changes in this pull request  
Resolves #6122 

## Additional info  
regression caused by https://github.com/pimcore/pimcore/pull/6032/commits/e402dce9643389b926efe809db1c9ca4be271037
