### PR TITLE
Allow LIKE operator on Select data type filter condition

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -514,11 +514,13 @@ class Select extends Data implements ResourcePersistenceAwareInterface, QueryRes
      */
     public function getFilterConditionExt($value, $operator, $params = [])
     {
+        $value = is_array($value) ? current($value) : $value;
+        $name = $params['name'] ?: $this->name;
+        
         if ($operator === '=') {
-            $value = is_array($value) ? current($value) : $value;
-            $name = $params['name'] ?: $this->name;
-
-            return '`'.$name.'` LIKE '."'$value'".' ';
+            return '`'.$name.'` = '."'$value'".' ';
+        } else if ($operator === 'LIKE') {
+            return '`'.$name.'` LIKE '."'%$value%'".' ';
         }
 
         return null;


### PR DESCRIPTION
## Changes in this pull request  
In admin object grid, filtering on select fields that use an option provider does not work. Select fields that use option providers use a free text search instead of letting you pick from a list of options. Filter type is 'string' and not 'list' and operator is 'like' instead of 'in'. 

In getFilterConditionExt method of the Select class only the '=' operator is allowed. It needs to allow 'LIKE' operator as well for filtering to work when using option provider.

Additionally for filters using the = operator, the produced query was using LIKE operator. This is not needed. Using = as operator in query should be slightly better performance wise.
