### PR TITLE
Fixed wrong project root on pimcore-install command

### DIFF
--- a/bin/pimcore-install
+++ b/bin/pimcore-install
@@ -41,6 +41,8 @@ if (file_exists($a = getcwd() . '/vendor/autoload.php')) {
     exit(1);
 }
 
+define('PIMCORE_PROJECT_ROOT', $projectRoot);
+
 Bootstrap::setProjectRoot();
 Bootstrap::defineConstants();
 

--- a/bin/pimcore-install
+++ b/bin/pimcore-install
@@ -43,7 +43,6 @@ if (file_exists($a = getcwd() . '/vendor/autoload.php')) {
 
 define('PIMCORE_PROJECT_ROOT', $projectRoot);
 
-Bootstrap::setProjectRoot();
 Bootstrap::defineConstants();
 
 Debug::enable(PIMCORE_PHP_ERROR_REPORTING);


### PR DESCRIPTION
Same behaviour as in issue #5495 but this time during installation.

I think the line I added was forgotten?
Otherwise the variable `$projectRoot` makes no sense.