### PR TITLE
[AreaBricks]  Add possibility to access editables from brick info

### DIFF
--- a/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/02_Bricks.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/02_Bricks.md
@@ -240,6 +240,8 @@ reasons, but a couple of methods could be useful when implementing your own bric
 | Method                  | Description                                      |
 |-------------------------|--------------------------------------------------|
 | `$info->getTag()`       | Returns the tag rendering the brick              |
+| `$info->getDocument()`  | Retrieve the document   |
+| `$info->getDocumentElement($name)` | Retrieve the editable tag from document   |
 | `$info->getRequest()`   | Returns the current request                      |
 | `$info->getView()`      | Returns the ViewModel to be rendered             |
 | `$info->getIndex()`     | Returns the current index inside the areablock   |

--- a/models/Document/Tag/Area/Info.php
+++ b/models/Document/Tag/Area/Info.php
@@ -238,7 +238,7 @@ class Info
         $element = null;
         $document = $this->getDocument();
 
-        if($document) {
+        if ($document instanceof Document\PageSnippet) {
             $name = Tag::buildTagName($type, $name, $document);
             $element = $document->getElement($name);
         }

--- a/models/Document/Tag/Area/Info.php
+++ b/models/Document/Tag/Area/Info.php
@@ -224,4 +224,25 @@ class Info
 
         return $document;
     }
+
+    /**
+     * @param $name
+     * @param string $type
+     *
+     * @return Tag|null
+     *
+     * @throws \Exception
+     */
+    public function getDocumentElement($name, $type = '')
+    {
+        $element = null;
+        $document = $this->getDocument();
+
+        if($document) {
+            $name = Tag::buildTagName($type, $name, $document);
+            $element = $document->getElement($name);
+        }
+
+        return $element;
+    }
 }

--- a/models/Document/Tag/Area/Info.php
+++ b/models/Document/Tag/Area/Info.php
@@ -226,7 +226,7 @@ class Info
     }
 
     /**
-     * @param $name
+     * @param string $name
      * @param string $type
      *
      * @return Tag|null


### PR DESCRIPTION
## Changes in this pull request  
Resolves #4057

## Additional info  
```
public function action(Info $info)
{
     $editable= $info->getDocumentElement('editableName');

     if ($editable) {
       $editable->getData();
     }
}
```

