### PR TITLE
[DataObject] Fix inconsistent version diffs

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.php
@@ -227,7 +227,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
                                     <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                                         <td><?= $v1 ?></td>
                                     <?php } ?>
-                                    <td<?php if ($v1 != $v2) { ?> class="modified"<?php } ?>><?= $v2 ?></td>
+                                    <td<?php if ($v1 !== $v2) { ?> class="modified"<?php } ?>><?= $v2 ?></td>
 
                                 </tr>
                                 <?php
@@ -259,7 +259,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
                             <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                                 <td><?= $v1 ?></td>
                             <?php } ?>
-                            <td<?php if ($v1 != $v2) { ?> class="modified"<?php } ?>><?= $v2 ?></td>
+                            <td<?php if ($v1 !== $v2) { ?> class="modified"<?php } ?>><?= $v2 ?></td>
                         </tr>
 
                         <?php
@@ -310,7 +310,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
                             <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                                 <td><?= $v1 ?></td>
                             <?php } ?>
-                            <td<?php if ($v1 != $v2 || !isset($v2)) { ?> class="modified"<?php } ?>><?= $v2 ?></td>
+                            <td<?php if ($v1 !== $v2 || !isset($v2)) { ?> class="modified"<?php } ?>><?= $v2 ?></td>
                         </tr>
                         <?php
                         $c++;
@@ -333,7 +333,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
                             <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                                 <td><?= $v1 ?></td>
                             <?php } ?>
-                            <td<?php if ($v1 != $v2) { ?> class="modified"<?php } ?>><?= $v2 ?></td>
+                            <td<?php if ($v1 !== $v2) { ?> class="modified"<?php } ?>><?= $v2 ?></td>
                         </tr>
                         <?php
                         $c++;
@@ -351,7 +351,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
                 <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                     <td><?= $v1 ?></td>
                 <?php } ?>
-                <td<?php if ($v1 != $v2) { ?> class="modified"<?php } ?>><?= $v2 ?></td>
+                <td<?php if ($v1 !== $v2) { ?> class="modified"<?php } ?>><?= $v2 ?></td>
             </tr>
 
         <?php } ?>


### PR DESCRIPTION
Alternative approach to #5991 

In the long term diffVersions should use the data object's isEqual method instead of comparing the version preview.

This however requires that every data type properly implements this method. Currently only done for 
relational data types and url slug (needed for dirty detection).
Default implementation in Data returns false not really useable currently.