### PR TITLE
Add kernel bootstrap to codeception boostrap file example in documentation

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/01_Application_Testing.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/01_Application_Testing.md
@@ -338,7 +338,7 @@ require_once PIMCORE_PROJECT_ROOT . '/vendor/autoload.php';
 
 \Pimcore\Bootstrap::setProjectRoot();
 \Pimcore\Bootstrap::bootstrap();
-
+\Pimcore\Bootstrap::kernel();
 
 // add the core pimcore test library to the autoloader - this could also be done in composer.json's autoload-dev section
 // but is done here for demonstration purpose


### PR DESCRIPTION
Hello,

This pull request add a missing kernel bootstrap in documentation for codeception.
I was working with codeception 4 and Pimcore 6.6.0, and without this, it was not possible to use Pimcore API on unit tests.

Same for any custom php file needing Pimcore API (php my-script.php), kernel must be run (I think on older Pimcore kernel was bootstraped in `\Pimcore\Bootstrap::bootstrap();` before). I don't know if there is some other places in documentation which need to be updated about this.

Thanks.