### PR TITLE
[Search/Backend] Fix Notice: Array to string conversion

### DIFF
--- a/models/Search/Backend/Data.php
+++ b/models/Search/Backend/Data.php
@@ -448,7 +448,11 @@ class Data extends \Pimcore\Model\AbstractModel
                 try {
                     $metaData = array_merge($element->getEXIFData(), $element->getIPTCData());
                     foreach ($metaData as $key => $value) {
-                        $this->data .= ' ' . $key . ' : ' . $value;
+                        if (is_array($value)) {
+                            $this->data .= ' ' . $key . ' : ' . implode(' - ', $value);
+                        } else {
+                            $this->data .= ' ' . $key . ' : ' . $value;
+                        }
                     }
                 } catch (\Exception $e) {
                     Logger::error($e);


### PR DESCRIPTION
```
ErrorException: Notice: Array to string conversion in vendor/pimcore/pimcore/models/Search/Backend/Data.php:449
```

`$value` can be a array:

![array-to-string_notice](https://user-images.githubusercontent.com/998558/78639633-9a80db00-78ae-11ea-97c7-2c2583c13020.jpg)
