### PR TITLE
Fixes Symfony 4.2 deprecation warnings in TreeBuilder

### DIFF
--- a/bundles/AdminBundle/DependencyInjection/Configuration.php
+++ b/bundles/AdminBundle/DependencyInjection/Configuration.php
@@ -28,8 +28,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('pimcore_admin');
+        $treeBuilder = new TreeBuilder('pimcore_admin');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode->append($this->buildGdprDataExtractorNode());
         $rootNode->append($this->buildObjectsNode());
@@ -86,12 +86,8 @@ class Configuration implements ConfigurationInterface
      */
     protected function buildGdprDataExtractorNode()
     {
-        $treeBuilder = new TreeBuilder();
-
-        $gdprDataExtractor = $treeBuilder->root('gdpr_data_extractor');
-        $gdprDataExtractor->addDefaultsIfNotSet();
-
-        $dataObjects = $treeBuilder->root('dataObjects');
+        $dataObjectsTreeBuilder = new TreeBuilder('dataObjects');
+        $dataObjects = $dataObjectsTreeBuilder->getRootNode();
         $dataObjects
             ->addDefaultsIfNotSet()
             ->info('Settings for DataObjects DataProvider');
@@ -102,7 +98,7 @@ class Configuration implements ConfigurationInterface
                     ->info('Configure which classes should be considered, array key is class name')
                     ->prototype('array')
                         ->info('
-    MY_CLASS_NAME: 
+    MY_CLASS_NAME:
 		include: true
 		allowDelete: false
 		includedRelations:
@@ -128,9 +124,13 @@ class Configuration implements ConfigurationInterface
             ->end()
         ;
 
+        $gdprTreeBuilder = new TreeBuilder('gdpr_data_extractor');
+        $gdprDataExtractor = $gdprTreeBuilder->getRootNode();
+        $gdprDataExtractor->addDefaultsIfNotSet();
         $gdprDataExtractor->append($dataObjects);
 
-        $assets = $treeBuilder->root('assets');
+        $assetsTreeBuilder = new TreeBuilder('assets');
+        $assets = $assetsTreeBuilder->getRootNode();
         $assets
             ->addDefaultsIfNotSet()
             ->info('Settings for Assets DataProvider');
@@ -154,8 +154,8 @@ class Configuration implements ConfigurationInterface
      */
     protected function buildEventsNode()
     {
-        $treeBuilder = new TreeBuilder();
-        $notesEvents = $treeBuilder->root('notes_events');
+        $treeBuilder = new TreeBuilder('notes_events');
+        $notesEvents = $treeBuilder->getRootNode();
 
         $notesEvents
             ->addDefaultsIfNotSet()
@@ -176,8 +176,8 @@ class Configuration implements ConfigurationInterface
      */
     protected function buildObjectsNode()
     {
-        $treeBuilder = new TreeBuilder();
-        $objectsNode = $treeBuilder->root('objects');
+        $treeBuilder = new TreeBuilder('objects');
+        $objectsNode = $treeBuilder->getRootNode();
 
         $objectsNode
             ->addDefaultsIfNotSet()
@@ -191,8 +191,8 @@ class Configuration implements ConfigurationInterface
      */
     protected function buildAssetsNode()
     {
-        $treeBuilder = new TreeBuilder();
-        $assetsNode = $treeBuilder->root('assets');
+        $treeBuilder = new TreeBuilder('assets');
+        $assetsNode = $treeBuilder->getRootNode();
 
         $assetsNode
             ->addDefaultsIfNotSet()
@@ -206,8 +206,8 @@ class Configuration implements ConfigurationInterface
      */
     protected function buildDocumentsNode()
     {
-        $treeBuilder = new TreeBuilder();
-        $documentsNode = $treeBuilder->root('documents');
+        $treeBuilder = new TreeBuilder('documents');
+        $documentsNode = $treeBuilder->getRootNode();
 
         $documentsNode
             ->addDefaultsIfNotSet()

--- a/bundles/AdminBundle/DependencyInjection/Configuration.php
+++ b/bundles/AdminBundle/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('pimcore_admin');
-        $rootNode = $treeBuilder->getRootNode();
+        $rootNode = $treeBuilder->root();
 
         $rootNode->append($this->buildGdprDataExtractorNode());
         $rootNode->append($this->buildObjectsNode());
@@ -87,7 +87,7 @@ class Configuration implements ConfigurationInterface
     protected function buildGdprDataExtractorNode()
     {
         $dataObjectsTreeBuilder = new TreeBuilder('dataObjects');
-        $dataObjects = $dataObjectsTreeBuilder->getRootNode();
+        $dataObjects = $dataObjectsTreeBuilder->root();
         $dataObjects
             ->addDefaultsIfNotSet()
             ->info('Settings for DataObjects DataProvider');
@@ -125,12 +125,12 @@ class Configuration implements ConfigurationInterface
         ;
 
         $gdprTreeBuilder = new TreeBuilder('gdpr_data_extractor');
-        $gdprDataExtractor = $gdprTreeBuilder->getRootNode();
+        $gdprDataExtractor = $gdprTreeBuilder->root();
         $gdprDataExtractor->addDefaultsIfNotSet();
         $gdprDataExtractor->append($dataObjects);
 
         $assetsTreeBuilder = new TreeBuilder('assets');
-        $assets = $assetsTreeBuilder->getRootNode();
+        $assets = $assetsTreeBuilder->root();
         $assets
             ->addDefaultsIfNotSet()
             ->info('Settings for Assets DataProvider');
@@ -155,7 +155,7 @@ class Configuration implements ConfigurationInterface
     protected function buildEventsNode()
     {
         $treeBuilder = new TreeBuilder('notes_events');
-        $notesEvents = $treeBuilder->getRootNode();
+        $notesEvents = $treeBuilder->root();
 
         $notesEvents
             ->addDefaultsIfNotSet()
@@ -177,7 +177,7 @@ class Configuration implements ConfigurationInterface
     protected function buildObjectsNode()
     {
         $treeBuilder = new TreeBuilder('objects');
-        $objectsNode = $treeBuilder->getRootNode();
+        $objectsNode = $treeBuilder->root();
 
         $objectsNode
             ->addDefaultsIfNotSet()
@@ -192,7 +192,7 @@ class Configuration implements ConfigurationInterface
     protected function buildAssetsNode()
     {
         $treeBuilder = new TreeBuilder('assets');
-        $assetsNode = $treeBuilder->getRootNode();
+        $assetsNode = $treeBuilder->root();
 
         $assetsNode
             ->addDefaultsIfNotSet()
@@ -207,7 +207,7 @@ class Configuration implements ConfigurationInterface
     protected function buildDocumentsNode()
     {
         $treeBuilder = new TreeBuilder('documents');
-        $documentsNode = $treeBuilder->getRootNode();
+        $documentsNode = $treeBuilder->root();
 
         $documentsNode
             ->addDefaultsIfNotSet()

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -49,9 +49,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('pimcore');
 
-        $rootNode = $treeBuilder->root('pimcore');
+        $rootNode = $treeBuilder->getRootNode();
         $rootNode->addDefaultsIfNotSet();
         $rootNode->ignoreExtraKeys();
 

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -51,7 +51,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('pimcore');
 
-        $rootNode = $treeBuilder->getRootNode();
+        $rootNode = $treeBuilder->root();
         $rootNode->addDefaultsIfNotSet();
         $rootNode->ignoreExtraKeys();
 

--- a/bundles/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
+++ b/bundles/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
@@ -88,7 +88,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('pimcore_ecommerce_framework');
 
-        $rootNode = $treeBuilder->getRootNode();
+        $rootNode = $treeBuilder->root();
         $rootNode->addDefaultsIfNotSet();
 
         $this->addRootNodeChildren($rootNode);
@@ -129,7 +129,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('pimcore');
 
-        $pimcore = $builder->getRootNode();
+        $pimcore = $builder->root();
         $pimcore
             ->addDefaultsIfNotSet()
             ->info('Configuration of Pimcore backend menu entries');
@@ -168,7 +168,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('factory');
 
-        $factory = $builder->getRootNode();
+        $factory = $builder->root();
         $factory
             ->addDefaultsIfNotSet()
             ->info('Configuration of e-commerce framework factory');
@@ -193,7 +193,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('environment');
 
-        $environment = $builder->getRootNode();
+        $environment = $builder->root();
         $environment
             ->addDefaultsIfNotSet()
             ->info('Configuration of environment');
@@ -212,7 +212,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('cart_manager');
 
-        $cartManager = $builder->getRootNode();
+        $cartManager = $builder->root();
         $cartManager
             ->addDefaultsIfNotSet()
             ->info('Settings for cart manager');
@@ -327,7 +327,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('order_manager');
 
-        $orderManager = $builder->getRootNode();
+        $orderManager = $builder->root();
         $orderManager
             ->info('Configuration of Order Manager')
             ->addDefaultsIfNotSet();
@@ -412,7 +412,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('pricing_manager');
 
-        $pricingManager = $builder->getRootNode();
+        $pricingManager = $builder->root();
         $pricingManager
             ->info('Configuration of Pricing Manager')
             ->addDefaultsIfNotSet();
@@ -556,7 +556,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('price_systems');
 
-        $priceSystems = $builder->getRootNode();
+        $priceSystems = $builder->root();
         $priceSystems
             ->info('Configuration of price systems - key is name of price system.')
             ->useAttributeAsKey('name')
@@ -582,7 +582,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('availability_systems');
 
-        $availabilitySystems = $builder->getRootNode();
+        $availabilitySystems = $builder->root();
         $availabilitySystems
             ->useAttributeAsKey('name')
             ->info('Configuration of availability systems - key is name of price system.')
@@ -608,7 +608,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('checkout_manager');
 
-        $checkoutManager = $builder->getRootNode();
+        $checkoutManager = $builder->root();
         $checkoutManager
             ->info('Configuration of checkout manager')
             ->addDefaultsIfNotSet();
@@ -685,7 +685,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('payment_manager');
 
-        $paymentManager = $builder->getRootNode();
+        $paymentManager = $builder->root();
         $paymentManager
             ->info('Configuration of payment manager and payment providers')
             ->addDefaultsIfNotSet();
@@ -739,7 +739,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('index_service');
 
-        $indexService = $builder->getRootNode();
+        $indexService = $builder->root();
         $indexService
             ->addDefaultsIfNotSet()
             ->info('Configuration of index service');
@@ -941,7 +941,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('filter_service');
 
-        $filterService = $builder->getRootNode();
+        $filterService = $builder->root();
         $filterService
             ->info('Configuration of filter service')
             ->addDefaultsIfNotSet();
@@ -1010,7 +1010,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('voucher_service');
 
-        $voucherService = $builder->getRootNode();
+        $voucherService = $builder->root();
         $voucherService
             ->info('Configuration of voucher service')
             ->addDefaultsIfNotSet();
@@ -1063,7 +1063,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('offer_tool');
 
-        $offerTool = $builder->getRootNode();
+        $offerTool = $builder->root();
         $offerTool
             ->info('Configuration of offer tool')
             ->addDefaultsIfNotSet();
@@ -1104,7 +1104,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('tracking_manager');
 
-        $trackingManager = $builder->getRootNode();
+        $trackingManager = $builder->root();
         $trackingManager
             ->info('Configuration of Tracking Manager')
             ->addDefaultsIfNotSet();

--- a/bundles/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
+++ b/bundles/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
@@ -86,9 +86,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('pimcore_ecommerce_framework');
 
-        $rootNode = $treeBuilder->root('pimcore_ecommerce_framework');
+        $rootNode = $treeBuilder->getRootNode();
         $rootNode->addDefaultsIfNotSet();
 
         $this->addRootNodeChildren($rootNode);
@@ -127,9 +127,9 @@ class Configuration implements ConfigurationInterface
 
     private function buildPimcoreNode(): NodeDefinition
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('pimcore');
 
-        $pimcore = $builder->root('pimcore');
+        $pimcore = $builder->getRootNode();
         $pimcore
             ->addDefaultsIfNotSet()
             ->info('Configuration of Pimcore backend menu entries');
@@ -166,9 +166,9 @@ class Configuration implements ConfigurationInterface
 
     private function buildFactoryNode(): NodeDefinition
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('factory');
 
-        $factory = $builder->root('factory');
+        $factory = $builder->getRootNode();
         $factory
             ->addDefaultsIfNotSet()
             ->info('Configuration of e-commerce framework factory');
@@ -191,9 +191,9 @@ class Configuration implements ConfigurationInterface
 
     private function buildEnvironmentNode(): NodeDefinition
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('environment');
 
-        $environment = $builder->root('environment');
+        $environment = $builder->getRootNode();
         $environment
             ->addDefaultsIfNotSet()
             ->info('Configuration of environment');
@@ -210,9 +210,9 @@ class Configuration implements ConfigurationInterface
 
     private function buildCartManagerNode(): NodeDefinition
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('cart_manager');
 
-        $cartManager = $builder->root('cart_manager');
+        $cartManager = $builder->getRootNode();
         $cartManager
             ->addDefaultsIfNotSet()
             ->info('Settings for cart manager');
@@ -325,9 +325,9 @@ class Configuration implements ConfigurationInterface
 
     private function buildOrderManagerNode(): NodeDefinition
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('order_manager');
 
-        $orderManager = $builder->root('order_manager');
+        $orderManager = $builder->getRootNode();
         $orderManager
             ->info('Configuration of Order Manager')
             ->addDefaultsIfNotSet();
@@ -410,9 +410,9 @@ class Configuration implements ConfigurationInterface
 
     private function buildPricingManagerNode(): NodeDefinition
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('pricing_manager');
 
-        $pricingManager = $builder->root('pricing_manager');
+        $pricingManager = $builder->getRootNode();
         $pricingManager
             ->info('Configuration of Pricing Manager')
             ->addDefaultsIfNotSet();
@@ -554,9 +554,9 @@ class Configuration implements ConfigurationInterface
 
     private function buildPriceSystemsNode(): NodeDefinition
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('price_systems');
 
-        $priceSystems = $builder->root('price_systems');
+        $priceSystems = $builder->getRootNode();
         $priceSystems
             ->info('Configuration of price systems - key is name of price system.')
             ->useAttributeAsKey('name')
@@ -580,9 +580,9 @@ class Configuration implements ConfigurationInterface
 
     private function buildAvailabilitySystemsNode(): NodeDefinition
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('availability_systems');
 
-        $availabilitySystems = $builder->root('availability_systems');
+        $availabilitySystems = $builder->getRootNode();
         $availabilitySystems
             ->useAttributeAsKey('name')
             ->info('Configuration of availability systems - key is name of price system.')
@@ -606,9 +606,9 @@ class Configuration implements ConfigurationInterface
 
     private function buildCheckoutManagerNode(): NodeDefinition
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('checkout_manager');
 
-        $checkoutManager = $builder->root('checkout_manager');
+        $checkoutManager = $builder->getRootNode();
         $checkoutManager
             ->info('Configuration of checkout manager')
             ->addDefaultsIfNotSet();
@@ -683,9 +683,9 @@ class Configuration implements ConfigurationInterface
 
     private function buildPaymentManagerNode(): NodeDefinition
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('payment_manager');
 
-        $paymentManager = $builder->root('payment_manager');
+        $paymentManager = $builder->getRootNode();
         $paymentManager
             ->info('Configuration of payment manager and payment providers')
             ->addDefaultsIfNotSet();
@@ -737,9 +737,9 @@ class Configuration implements ConfigurationInterface
 
     private function buildIndexServiceNode(): NodeDefinition
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('index_service');
 
-        $indexService = $builder->root('index_service');
+        $indexService = $builder->getRootNode();
         $indexService
             ->addDefaultsIfNotSet()
             ->info('Configuration of index service');
@@ -939,9 +939,9 @@ class Configuration implements ConfigurationInterface
 
     private function buildFilterServiceNode(): NodeDefinition
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('filter_service');
 
-        $filterService = $builder->root('filter_service');
+        $filterService = $builder->getRootNode();
         $filterService
             ->info('Configuration of filter service')
             ->addDefaultsIfNotSet();
@@ -1008,9 +1008,9 @@ class Configuration implements ConfigurationInterface
 
     private function buildVoucherServiceNode(): NodeDefinition
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('voucher_service');
 
-        $voucherService = $builder->root('voucher_service');
+        $voucherService = $builder->getRootNode();
         $voucherService
             ->info('Configuration of voucher service')
             ->addDefaultsIfNotSet();
@@ -1061,9 +1061,9 @@ class Configuration implements ConfigurationInterface
 
     private function buildOfferToolNode(): NodeDefinition
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('offer_tool');
 
-        $offerTool = $builder->root('offer_tool');
+        $offerTool = $builder->getRootNode();
         $offerTool
             ->info('Configuration of offer tool')
             ->addDefaultsIfNotSet();
@@ -1102,9 +1102,9 @@ class Configuration implements ConfigurationInterface
 
     private function buildTrackingManagerNode(): NodeDefinition
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('tracking_manager');
 
-        $trackingManager = $builder->root('tracking_manager');
+        $trackingManager = $builder->getRootNode();
         $trackingManager
             ->info('Configuration of Tracking Manager')
             ->addDefaultsIfNotSet();

--- a/bundles/GeneratorBundle/Resources/skeleton/bundle/Configuration.php.twig
+++ b/bundles/GeneratorBundle/Resources/skeleton/bundle/Configuration.php.twig
@@ -24,8 +24,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('{{ extension_alias }}');
+        $treeBuilder = new TreeBuilder('{{ extension_alias }}');
+        $rootNode = $treeBuilder->getRootNode();
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/bundles/GeneratorBundle/Resources/skeleton/bundle/Configuration.php.twig
+++ b/bundles/GeneratorBundle/Resources/skeleton/bundle/Configuration.php.twig
@@ -25,7 +25,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('{{ extension_alias }}');
-        $rootNode = $treeBuilder->getRootNode();
+        $rootNode = $treeBuilder->root();
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/bundles/InstallBundle/DependencyInjection/Configuration.php
+++ b/bundles/InstallBundle/DependencyInjection/Configuration.php
@@ -24,9 +24,9 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('pimcore_install');
 
-        $rootNode = $treeBuilder->root('pimcore_install');
+        $rootNode = $treeBuilder->getRootNode();
         $rootNode->addDefaultsIfNotSet();
 
         $rootNode

--- a/bundles/InstallBundle/DependencyInjection/Configuration.php
+++ b/bundles/InstallBundle/DependencyInjection/Configuration.php
@@ -26,7 +26,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('pimcore_install');
 
-        $rootNode = $treeBuilder->getRootNode();
+        $rootNode = $treeBuilder->root();
         $rootNode->addDefaultsIfNotSet();
 
         $rootNode


### PR DESCRIPTION
See https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-tree-builders-without-root-nodes

Might have to be tested with Symfony 3.x just to be sure nothing breaks.