### PR TITLE
Avoid deadlocks caused by object_relations table

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20200408134745.php
+++ b/bundles/CoreBundle/Migrations/Version20200408134745.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Db;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+
+class Version20200408134745 extends AbstractPimcoreMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $db = Db::get();
+
+        $relationTables = $db->fetchAll("SHOW TABLES LIKE 'object\_relations\_%'");
+        foreach ($relationTables as $table) {
+            $relationTableName = current($table);
+            $table = $schema->getTable($relationTableName);
+            if ($table->getPrimaryKey()) {
+                $table->dropPrimaryKey();
+            }
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $db = Db::get();
+
+        $relationTables = $db->fetchAll("SHOW TABLES LIKE 'object\_relations\_%'");
+        foreach ($relationTables as $table) {
+            $relationTableName = current($table);
+            $table = $schema->getTable($relationTableName);
+            if (!$table->getPrimaryKey()) {
+                $table->setPrimaryKey(['`src_id`', '`dest_id`', '`type`', '`fieldname`', '`index`', '`ownertype`', '`ownername`', '`position`']);
+            }
+        }
+    }
+}


### PR DESCRIPTION
see #5761 

primary keys has already been dropped in the table's create statement but was never removed via migration script