### PR TITLE
[Redirects] Fetch target site by domain if no target site set

### DIFF
--- a/lib/Routing/RedirectHandler.php
+++ b/lib/Routing/RedirectHandler.php
@@ -190,16 +190,11 @@ class RedirectHandler implements LoggerAwareInterface
                     return null;
                 }
             } else {
-                $redirectDomain = $this->config['general']['domain'];
-                $sites = new Site\Listing();
-                foreach ($sites as $site) {
-                    $siteDomains = $site->getDomains();
-                    $siteDomains[] = $site->getMainDomain();
-                    $siteIndex = \array_searchi($request->getHost(), $siteDomains);
-                    if($siteIndex !== false) {
-                        $redirectDomain = $siteDomains[$siteIndex];
-                        break;
-                    }
+                $site = Site::getByDomain($request->getHost());
+                if($site instanceof Site) {
+                    $redirectDomain = $request->getHost();
+                } else {
+                    $redirectDomain = $this->config['general']['domain'];
                 }
 
                 if ($redirectDomain) {

--- a/lib/Routing/RedirectHandler.php
+++ b/lib/Routing/RedirectHandler.php
@@ -174,24 +174,40 @@ class RedirectHandler implements LoggerAwareInterface
             $url = replace_pcre_backreferences($url, $matches);
         }
 
-        if ($redirect->getTargetSite() && !preg_match('@http(s)?://@i', $url)) {
-            if ($targetSite = Site::getById($redirect->getTargetSite())) {
-                // if the target site is specified and and the target-path is starting at root (not absolute to site)
-                // the root-path will be replaced so that the page can be shown
-                $url = preg_replace('@^' . $targetSite->getRootPath() . '/@', '/', $url);
-                $url = $request->getScheme() . '://' . $targetSite->getMainDomain() . $url;
-            } else {
-                $this->logger->error('Site with ID {targetSite} not found', [
-                    'redirect' => $redirect->getId(),
-                    'targetSite' => $redirect->getTargetSite()
-                ]);
+        if(!preg_match('@http(s)?://@i', $url)) {
+            if ($redirect->getTargetSite()) {
+                if ($targetSite = Site::getById($redirect->getTargetSite())) {
+                    // if the target site is specified and and the target-path is starting at root (not absolute to site)
+                    // the root-path will be replaced so that the page can be shown
+                    $url = preg_replace('@^' . $targetSite->getRootPath() . '/@', '/', $url);
+                    $url = $request->getScheme() . '://' . $targetSite->getMainDomain() . $url;
+                } else {
+                    $this->logger->error('Site with ID {targetSite} not found', [
+                        'redirect' => $redirect->getId(),
+                        'targetSite' => $redirect->getTargetSite()
+                    ]);
 
-                return null;
+                    return null;
+                }
+            } else {
+                $redirectDomain = $this->config['general']['domain'];
+                $sites = new Site\Listing();
+                foreach ($sites as $site) {
+                    foreach ($site->getDomains() as $siteDomain) {
+                        if ($request->getHost() === $siteDomain) {
+                            $redirectDomain = $siteDomain;
+                            break 2;
+                        }
+                    }
+                }
+
+                if ($redirectDomain) {
+                    // prepend the host and scheme to avoid infinite loops when using "domain" redirects
+                    $url = $request->getScheme().'://'.$redirectDomain.$url;
+                }
             }
-        } elseif (!preg_match('@http(s)?://@i', $url) && $this->config['general']['domain']) {
-            // prepend the host and scheme to avoid infinite loops when using "domain" redirects
-            $url = $request->getScheme() . '://' . $this->config['general']['domain'] . $url;
         }
+
 
         // pass-through parameters if specified
         $queryString = $request->getQueryString();

--- a/lib/Routing/RedirectHandler.php
+++ b/lib/Routing/RedirectHandler.php
@@ -193,11 +193,12 @@ class RedirectHandler implements LoggerAwareInterface
                 $redirectDomain = $this->config['general']['domain'];
                 $sites = new Site\Listing();
                 foreach ($sites as $site) {
-                    foreach ($site->getDomains() as $siteDomain) {
-                        if ($request->getHost() === $siteDomain) {
-                            $redirectDomain = $siteDomain;
-                            break 2;
-                        }
+                    $siteDomains = $site->getDomains();
+                    $siteDomains[] = $site->getMainDomain();
+                    $siteIndex = \array_searchi($request->getHost(), $siteDomains);
+                    if($siteIndex !== false) {
+                        $redirectDomain = $siteDomains[$siteIndex];
+                        break;
                     }
                 }
 


### PR DESCRIPTION
When you create a redirect without target site currently the general domain from the system settings gets used. This PR extends this by trying to find the target site by the request's hostname if no target site has been specified for the redirect. If none is found, the general domain gets used (as before)