### PR TITLE
Import reporting is currently not scrollable.

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/import/reportTab.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/import/reportTab.js
@@ -155,7 +155,8 @@ pimcore.object.helpers.import.reportTab = Class.create({
                 autoScroll: true,
                 title: t("import_report"),
                 iconCls: 'pimcore_icon_import_report',
-                items: [this.statusBar, dataGrid]
+                items: [this.statusBar, dataGrid],
+                overflowY: 'scroll'
             });
         }
 


### PR DESCRIPTION
So if you import many items, you are not able to see the whole result set.
This PR adds possibility to scroll in reporting tab