### PR TITLE
Remove docblock data which changes everytime

### DIFF
--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -600,10 +600,6 @@ class ClassDefinition extends Model\AbstractModel
         $cd .= '* Inheritance: '.($this->getAllowInherit() ? 'yes' : 'no')."\n";
         $cd .= '* Variants: '.($this->getAllowVariants() ? 'yes' : 'no')."\n";
 
-        if (isset($_SERVER['REMOTE_ADDR'])) {
-            $cd .= '* IP: '.$_SERVER['REMOTE_ADDR']."\n";
-        }
-
         if ($this->getDescription()) {
             $description = str_replace(['/**', '*/', '//'], '', $this->getDescription());
             $description = str_replace("\n", "\n* ", $description);

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -597,14 +597,8 @@ class ClassDefinition extends Model\AbstractModel
 
         $cd .= '/** ';
         $cd .= "\n";
-        $cd .= '* Generated at: '.date('c')."\n";
         $cd .= '* Inheritance: '.($this->getAllowInherit() ? 'yes' : 'no')."\n";
         $cd .= '* Variants: '.($this->getAllowVariants() ? 'yes' : 'no')."\n";
-
-        $user = Model\User::getById($this->getUserModification());
-        if ($user) {
-            $cd .= '* Changed by: '.$user->getName().' ('.$user->getId().')'."\n";
-        }
 
         if (isset($_SERVER['REMOTE_ADDR'])) {
             $cd .= '* IP: '.$_SERVER['REMOTE_ADDR']."\n";

--- a/models/DataObject/ClassDefinition/CustomLayout.php
+++ b/models/DataObject/ClassDefinition/CustomLayout.php
@@ -291,7 +291,6 @@ class CustomLayout extends Model\AbstractModel
 
         $cd .= '/** ';
         $cd .= "\n";
-        $cd .= '* Generated at: '.date('c')."\n";
 
         if ($this->getDescription()) {
             $description = str_replace(['/**', '*/', '//'], '', $this->getDescription());

--- a/models/DataObject/ClassDefinition/CustomLayout.php
+++ b/models/DataObject/ClassDefinition/CustomLayout.php
@@ -293,15 +293,6 @@ class CustomLayout extends Model\AbstractModel
         $cd .= "\n";
         $cd .= '* Generated at: '.date('c')."\n";
 
-        $user = Model\User::getById($this->getUserModification());
-        if ($user) {
-            $cd .= '* Changed by: '.$user->getName().' ('.$user->getId().')'."\n";
-        }
-
-        if (isset($_SERVER['REMOTE_ADDR'])) {
-            $cd .= '* IP: '.$_SERVER['REMOTE_ADDR']."\n";
-        }
-
         if ($this->getDescription()) {
             $description = str_replace(['/**', '*/', '//'], '', $this->getDescription());
             $description = str_replace("\n", "\n* ", $description);

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -285,7 +285,6 @@ class Definition extends Model\AbstractModel
 
         $cd .= '/** ';
         $cd .= "\n";
-        $cd .= '* Generated at: ' . date('c') . "\n";
 
         if (isset($_SERVER['REMOTE_ADDR'])) {
             $cd .= '* IP: ' . $_SERVER['REMOTE_ADDR'] . "\n";

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -285,12 +285,6 @@ class Definition extends Model\AbstractModel
 
         $cd .= '/** ';
         $cd .= "\n";
-
-        if (isset($_SERVER['REMOTE_ADDR'])) {
-            $cd .= '* IP: ' . $_SERVER['REMOTE_ADDR'] . "\n";
-        }
-
-        $cd .= "\n\n";
         $cd .= "Fields Summary: \n";
 
         $cd = $this->getInfoDocBlockForFields($this, $cd, 1);


### PR DESCRIPTION
Resolves #6211

As discussed there's not much added value in having this data in the docblocks. The disadvantages (merge conflicts when working with several feature branches) outweigh the advantages, so we remove this.