### PR TITLE
Refactors login/lost-pw/2-factor form autocomplete functionality

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/profile/panel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/profile/panel.js
@@ -135,7 +135,12 @@ pimcore.settings.profile.panel = Class.create({
             width: 400,
             enableKeyEvents: true,
             listeners: {
-                keyup: passwordCheck
+                keyup: passwordCheck,
+                afterrender: function (cmp) {
+                    cmp.inputEl.set({
+                        autocomplete: 'new-password'
+                    });
+                }
             }
         });
 
@@ -148,7 +153,12 @@ pimcore.settings.profile.panel = Class.create({
             style: "margin-bottom: 20px;",
             enableKeyEvents: true,
             listeners: {
-                keyup: passwordCheck
+                keyup: passwordCheck,
+                afterrender: function (cmp) {
+                    cmp.inputEl.set({
+                        autocomplete: 'new-password'
+                    });
+                }
             }
         });
 
@@ -161,7 +171,14 @@ pimcore.settings.profile.panel = Class.create({
                 name: "old_password",
                 inputType: "password",
                 width: 400,
-                hidden: this.currentUser.isPasswordReset
+                hidden: this.currentUser.isPasswordReset,
+                listeners: {
+                    afterrender: function (cmp) {
+                        cmp.inputEl.set({
+                            autocomplete: 'current-password'
+                        });
+                    }
+                }
             }, {
                 xtype: "fieldcontainer",
                 layout: 'hbox',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
@@ -75,7 +75,12 @@ pimcore.settings.user.user.settings = Class.create({
             listeners: {
                 keyup: function (el) {
                     this.validatePassword(el);
-                }.bind(this)
+                }.bind(this),
+                afterrender: function (cmp) {
+                    cmp.inputEl.set({
+                        autocomplete: 'new-password'
+                    });
+                }
             }
         });
 

--- a/bundles/AdminBundle/Resources/views/Admin/Login/login.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/Login/login.html.php
@@ -27,7 +27,7 @@ if ($browser->getBrowser() == \Pimcore\Browser::BROWSER_OPERA && $browserVersion
 
 
 <div id="loginform">
-    <form method="post" action="<?= $view->router()->path('pimcore_admin_login_check', ['perspective' => strip_tags($view->request()->getParameter('perspective'))]) ?>" autocomplete="off">
+    <form method="post" action="<?= $view->router()->path('pimcore_admin_login_check', ['perspective' => strip_tags($view->request()->getParameter('perspective'))]) ?>">
 
         <?php if ($this->error) { ?>
             <div class="text error">
@@ -35,8 +35,8 @@ if ($browser->getBrowser() == \Pimcore\Browser::BROWSER_OPERA && $browserVersion
             </div>
         <?php } ?>
 
-        <input type="text" name="username" placeholder="<?= $this->translate("Username"); ?>" required autofocus/>
-        <input type="password" name="password" placeholder="<?= $this->translate("Password"); ?>" required/>
+        <input type="text" name="username" autocomplete="username" placeholder="<?= $this->translate("Username"); ?>" required autofocus>
+        <input type="password" name="password" placeholder="<?= $this->translate("Password"); ?>" required>
         <input type="hidden" name="csrfToken" value="<?= $this->csrfToken ?>">
 
         <button type="submit"><?= $this->translate("Login"); ?></button>

--- a/bundles/AdminBundle/Resources/views/Admin/Login/login.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/Login/login.html.php
@@ -36,7 +36,7 @@ if ($browser->getBrowser() == \Pimcore\Browser::BROWSER_OPERA && $browserVersion
         <?php } ?>
 
         <input type="text" name="username" autocomplete="username" placeholder="<?= $this->translate("Username"); ?>" required autofocus>
-        <input type="password" name="password" placeholder="<?= $this->translate("Password"); ?>" required>
+        <input type="password" name="password" autocomplete="current-password" placeholder="<?= $this->translate("Password"); ?>" required>
         <input type="hidden" name="csrfToken" value="<?= $this->csrfToken ?>">
 
         <button type="submit"><?= $this->translate("Login"); ?></button>
@@ -93,4 +93,3 @@ if ($browser->getBrowser() == \Pimcore\Browser::BROWSER_OPERA && $browserVersion
 <?php $view->slots()->stop() ?>
 
 <?= $this->breachAttackRandomContent(); ?>
-

--- a/bundles/AdminBundle/Resources/views/Admin/Login/lostpassword.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/Login/lostpassword.html.php
@@ -20,7 +20,7 @@ $this->get("translate")->setDomain("admin");
     </div>
 
     <form method="post" action="<?= $view->router()->path('pimcore_admin_login_lostpassword') ?>">
-        <input type="text" name="username" placeholder="<?= $this->translate("Username"); ?>" required autofocus>
+        <input type="text" name="username" autocomplete="username" placeholder="<?= $this->translate("Username"); ?>" required autofocus>
         <input type="hidden" name="csrfToken" value="<?= $this->csrfToken ?>">
 
         <button type="submit" name="submit"><?= $this->translate("Submit"); ?></button>

--- a/bundles/AdminBundle/Resources/views/Admin/Login/twoFactorAuthentication.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/Login/twoFactorAuthentication.html.php
@@ -21,8 +21,8 @@ $this->get("translate")->setDomain("admin");
     </div>
 <?php } ?>
 
-<form method="post" action="<?=$this->url('pimcore_admin_2fa-verify')?>" autocomplete="off">
-    <input name="_auth_code" id="_auth_code" type="password" placeholder="<?= $this->translate("2fa_code"); ?>" required autofocus>
+<form method="post" action="<?=$this->url('pimcore_admin_2fa-verify')?>">
+    <input name="_auth_code" id="_auth_code" autocomplete="one-time-code" type="password" placeholder="<?= $this->translate("2fa_code"); ?>" required autofocus>
     <input type="hidden" name="csrfToken" value="<?= $this->csrfToken ?>">
 
     <button type="submit"><?= $this->translate("Login"); ?></button>


### PR DESCRIPTION
Autocomplete=off on login forms is [not really a thing any more](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields).

Also, added autocomplete hints to improve compatibility with password managers.