### PR TITLE
Add missing getter for PaymentNotSuccessFullException

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Exception/PaymentNotSuccessfulException.php
+++ b/bundles/EcommerceFrameworkBundle/Exception/PaymentNotSuccessfulException.php
@@ -42,4 +42,20 @@ class PaymentNotSuccessfulException extends AbstractEcommerceException
         $this->order = $order;
         $this->status = $status;
     }
+    
+        /**
+     * @return AbstractOrder
+     */
+    public function getOrder(): AbstractOrder
+    {
+        return $this->order;
+    }
+
+    /**
+     * @return StatusInterface
+     */
+    public function getStatus(): StatusInterface
+    {
+        return $this->status;
+    }
 }

--- a/bundles/EcommerceFrameworkBundle/Exception/PaymentNotSuccessfulException.php
+++ b/bundles/EcommerceFrameworkBundle/Exception/PaymentNotSuccessfulException.php
@@ -43,7 +43,7 @@ class PaymentNotSuccessfulException extends AbstractEcommerceException
         $this->status = $status;
     }
     
-        /**
+    /**
      * @return AbstractOrder
      */
     public function getOrder(): AbstractOrder


### PR DESCRIPTION
PaymentNotSuccessFullException misses Getters for protected properties `order` and `status`.