### PR TITLE
[Feature] Allow PHP CS Fixer to run directly on Definition save

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
@@ -1435,6 +1435,7 @@ pimcore.object.classes.klass = Class.create({
                         values: n,
                         id: this.data.id
                     },
+                    timeout: 120000, // Longer than usual timout due to complex classes taking a long time if PHP CS Fixer runs
                     success: this.saveOnComplete.bind(this),
                     failure: this.saveOnError.bind(this)
                 });

--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,7 @@
     "ext-curl": "*",
     "ext-imagick": "*",
     "ext-redis": "*",
+    "friendsofphp/php-cs-fixer": "Suggested for automatically formatted PHP files (Classes, Fielddefinitions, etc.)",
     "heidelpay/heidelpay-php": "Required for Heidelpay payment",
     "klarna/checkout": "Required for Klarna payment",
     "elasticsearch/elasticsearch": "Required for Elastic Search service",

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -503,7 +503,7 @@ class ClassDefinition extends Model\AbstractModel
         if (!is_writable(dirname($classFile)) || (is_file($classFile) && !is_writable($classFile))) {
             throw new \Exception('Cannot write class file in '.$classFile.' please check the rights on this directory');
         }
-        File::put($classFile, $cd);
+        File::putPhpFile($classFile, $cd);
 
         // create class for object list
         $extendListingClass = 'DataObject\\Listing\\Concrete';
@@ -558,7 +558,7 @@ class ClassDefinition extends Model\AbstractModel
                 'Cannot write class file in '.$classListFile.' please check the rights on this directory'
             );
         }
-        File::put($classListFile, $cd);
+        File::putPhpFile($classListFile, $cd);
 
         // save definition as a php file
         $definitionFile = $this->getDefinitionFile();
@@ -584,7 +584,7 @@ class ClassDefinition extends Model\AbstractModel
 
             $data .= "\nreturn ".$exportedClass.";\n";
 
-            \Pimcore\File::putPhpFile($definitionFile, $data);
+            File::putPhpFile($definitionFile, $data);
         }
     }
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -62,6 +62,9 @@ parameters:
         - '~^Unsafe usage of new static\(\)~'
         - '~^Method Psr\\Cache\\CacheItemPoolInterface::clear\(\) invoked with 1 parameter, 0 required\.\z~'
         - '~^Method Symfony\\Component\\Cache\\Adapter\\AdapterInterface::clear\(\) invoked with 1 parameter, 0 required\.\z~'
+        -
+            message: '/^(PHPDoc tag .*|Instantiated|Call to method \w*\(\) on an unknown) class PhpCsFixer\\\w*/'
+            path: lib/File.php
 
     # see https://github.com/phpstan/phpstan#universal-object-crates
     universalObjectCratesClasses:


### PR DESCRIPTION
Once `friendsofphp/php-cs-fixer` is installed, this PR will automatically apply the `.php_cs.dist` rules on any file in `var/classes` whenever they are updated.

Because this is a potentially very computationally heavy process (I counted up to 48 seconds with debugger running in a VM) on a rather big class the request timeout was increased.

I did this primarily to better be able to diff class definition files when checking them into our repository, but it was also nice to apply these to `var/classes/DataObject/*` files as well, they look much nicer now.