### PR TITLE
[PHPStan] Fix current errors

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/ElementController.php
+++ b/bundles/AdminBundle/Controller/Admin/ElementController.php
@@ -120,7 +120,7 @@ class ElementController extends AdminController
      */
     protected function processNoteTypesFromParameters(string $parameterName)
     {
-        $config = $this->container->getParameter($parameterName);
+        $config = $this->getParameter($parameterName);
         $result = [];
         foreach ($config as $configEntry) {
             $result[] = [

--- a/bundles/AdminBundle/Controller/Admin/IndexController.php
+++ b/bundles/AdminBundle/Controller/Admin/IndexController.php
@@ -311,13 +311,11 @@ class IndexController extends AdminController implements EventedControllerInterf
     private function getInstanceId()
     {
         $instanceId = 'not-set';
-        if ($this->container->hasParameter('secret')) {
+        try {
             $instanceId = $this->getParameter('secret');
-            try {
-                $instanceId = sha1(substr($instanceId, 3, -3));
-            } catch (\Exception $e) {
-                // noting to do
-            }
+            $instanceId = sha1(substr($instanceId, 3, -3));
+        } catch (\Exception $e) {
+            // nothing to do
         }
 
         return $instanceId;


### PR DESCRIPTION
There are current 2 phpstan errors. See https://travis-ci.com/github/pimcore/pimcore/jobs/321052738
```
------ ------------------------------------------------------------ 
  Line   bundles/AdminBundle/Controller/Admin/ElementController.php  
 ------ ------------------------------------------------------------ 
  123    Call to an undefined method                                 
         Psr\Container\ContainerInterface::getParameter().           
 ------ ------------------------------------------------------------ 
 ------ ---------------------------------------------------------- 
  Line   bundles/AdminBundle/Controller/Admin/IndexController.php  
 ------ ---------------------------------------------------------- 
  314    Call to an undefined method                               
         Psr\Container\ContainerInterface::hasParameter().         
 ------ ---------------------------------------------------------- 
 [ERROR] Found 2 errors                                                      
```