### PR TITLE
[Data object grid] Prevent error "Call to a member function getPermissions() on null"

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1274,7 +1274,7 @@ class DataObjectHelperController extends AdminController
                 $object = DataObject\AbstractObject::getById($objectId);
                 $context['object'] = $object;
             }
-            DataObject\Service::enrichLayoutDefinition($field, null, $context);
+            DataObject\Service::enrichLayoutDefinition($field, $context['object'] ?? null, $context);
 
             $result = [
                 'key' => $key,


### PR DESCRIPTION
In https://github.com/pimcore/pimcore/blob/735282d92b7097ca2687f8881ed06075fbe116a5/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php#L1277 `DataObject\Service::enrichLayoutDefinition()` gets called with second parameter `null`.

In https://github.com/pimcore/pimcore/blob/735282d92b7097ca2687f8881ed06075fbe116a5/models/DataObject/Service.php#L1408 the method `self::getLanguagePermissions($object)` gets then called with `$object` being `null`.

And then in In https://github.com/pimcore/pimcore/blob/735282d92b7097ca2687f8881ed06075fbe116a5/models/DataObject/Service.php#L573 there is a null pointer exception `Call to a member function getPermissions() on null`.