### PR TITLE
[Data objects] Override inherited value with same value (break inheritance)

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20200428111313.php
+++ b/bundles/CoreBundle/Migrations/Version20200428111313.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\Objectbrick\Definition;
+
+class Version20200428111313 extends AbstractPimcoreMigration
+{
+    public function doesSqlMigrations(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $list = new ClassDefinition\Listing();
+        foreach ($list as $class) {
+            $class->save(false);
+        }
+
+        $list = new Definition\Listing();
+        foreach ($list as $brickDefinition) {
+            $brickDefinition->save(false);
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->writeMessage('Please execute bin/console pimcore:deployment:classes-rebuild afterwards.');
+    }
+}

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -840,14 +840,15 @@ abstract class Data
         }
 
         if ($this->supportsDirtyDetection()) {
-            $code .= "\t" . 'if(\Pimcore\Model\DataObject::doGetInheritedValues($this->getObject())) {' . "\n";
+            $code .= "\t" . '$class = $this->getObject() ? $this->getObject()->getClass() : null;' . "\n";
+            $code .= "\t" . 'if($class && $class->getAllowInherit()) {' . "\n";
             $code .= "\t\t" . '$inheritValues = $this->getObject()::getGetInheritedValues();'."\n";
             $code .= "\t\t" . '$this->getObject()::setGetInheritedValues(false);'."\n";
             $code .= "\t" . '}'."\n";
             $code .= "\t" . '$currentData = $this->get' . ucfirst($this->getName()) . '();' . "\n";
-            $code .= "\t" . 'if(\Pimcore\Model\DataObject::doGetInheritedValues($this->getObject())) {' . "\n";
+            $code .= "\t" . 'if($class && $class->getAllowInherit()) {' . "\n";
             $code .= "\t\t" . '$this->getObject()::setGetInheritedValues($inheritValues);'."\n";
-            $code .= "\t" . '}'."\n";
+            $code .= "\t" . '}' . "\n";
             $code .= "\t" . '$isEqual = $fd->isEqual($currentData, $' . $key . ');' . "\n";
             $code .= "\t" . 'if (!$isEqual) {' . "\n";
             $code .= "\t\t" . '$this->markFieldDirty("' . $key . '", true);' . "\n";

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -740,7 +740,13 @@ abstract class Data
         }
 
         if ($this->supportsDirtyDetection()) {
+            if($class instanceof DataObject\ClassDefinition && $class->getAllowInherit()) {
+                $code .= "\t" . "self::setGetInheritedValues(false);\n";
+            }
             $code .= "\t" . '$currentData = $this->get' . ucfirst($this->getName()) . '();' . "\n";
+            if($class instanceof DataObject\ClassDefinition && $class->getAllowInherit()) {
+                $code .= "\t" . "self::setGetInheritedValues(true);\n";
+            }
             $code .= "\t" . '$isEqual = $fd->isEqual($currentData, $' . $key . ');' . "\n";
             $code .= "\t" . 'if (!$isEqual) {' . "\n";
             $code .= "\t\t" . '$this->markFieldDirty("' . $key . '", true);' . "\n";

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -840,7 +840,14 @@ abstract class Data
         }
 
         if ($this->supportsDirtyDetection()) {
+            $code .= "\t" . 'if(\Pimcore\Model\DataObject::doGetInheritedValues($this->getObject())) {' . "\n";
+            $code .= "\t\t" . '$inheritValues = $this->getObject()::getGetInheritedValues();'."\n";
+            $code .= "\t\t" . '$this->getObject()::setGetInheritedValues(false);'."\n";
+            $code .= "\t" . '}'."\n";
             $code .= "\t" . '$currentData = $this->get' . ucfirst($this->getName()) . '();' . "\n";
+            $code .= "\t" . 'if(\Pimcore\Model\DataObject::doGetInheritedValues($this->getObject())) {' . "\n";
+            $code .= "\t\t" . '$this->getObject()::setGetInheritedValues($inheritValues);'."\n";
+            $code .= "\t" . '}'."\n";
             $code .= "\t" . '$isEqual = $fd->isEqual($currentData, $' . $key . ');' . "\n";
             $code .= "\t" . 'if (!$isEqual) {' . "\n";
             $code .= "\t\t" . '$this->markFieldDirty("' . $key . '", true);' . "\n";

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -741,11 +741,12 @@ abstract class Data
 
         if ($this->supportsDirtyDetection()) {
             if($class instanceof DataObject\ClassDefinition && $class->getAllowInherit()) {
-                $code .= "\t" . "self::setGetInheritedValues(false);\n";
+                $code .= "\t" . '$inheritValues = self::getGetInheritedValues();'."\n";
+                $code .= "\t" . 'self::setGetInheritedValues(false);'."\n";
             }
             $code .= "\t" . '$currentData = $this->get' . ucfirst($this->getName()) . '();' . "\n";
             if($class instanceof DataObject\ClassDefinition && $class->getAllowInherit()) {
-                $code .= "\t" . "self::setGetInheritedValues(true);\n";
+                $code .= "\t" . 'self::setGetInheritedValues($inheritValues);'."\n";
             }
             $code .= "\t" . '$isEqual = $fd->isEqual($currentData, $' . $key . ');' . "\n";
             $code .= "\t" . 'if (!$isEqual) {' . "\n";
@@ -1020,7 +1021,14 @@ abstract class Data
         }
 
         if ($this->supportsDirtyDetection()) {
+            if($class instanceof DataObject\ClassDefinition && $class->getAllowInherit()) {
+                $code .= "\t" . '$inheritValues = self::getGetInheritedValues();'."\n";
+                $code .= "\t" . 'self::setGetInheritedValues(false);'."\n";
+            }
             $code .= "\t" . '$currentData = $this->get' . ucfirst($this->getName()) . '($language);' . "\n";
+            if($class instanceof DataObject\ClassDefinition && $class->getAllowInherit()) {
+                $code .= "\t" . 'self::setGetInheritedValues($inheritValues);'."\n";
+            }
             $code .= "\t" . '$isEqual = $fd->isEqual($currentData, $' . $key . ');' . "\n";
         } else {
             $code .= "\t" . '$isEqual = false;' . "\n";

--- a/tests/_support/Helper/Model.php
+++ b/tests/_support/Helper/Model.php
@@ -73,7 +73,7 @@ class Model extends AbstractDefinitionHelper
 
             $panel->addChild($this->createDataChild('manyToManyObjectRelation', 'objects')
                 ->setClasses(['RelationTest'])
-                );
+            );
 
             $panel->addChild($this->createDataChild('manyToOneRelation', 'relation')
                 ->setDocumentTypes([])->setAssetTypes([])->setClasses(['RelationTest'])
@@ -490,6 +490,9 @@ class Model extends AbstractDefinitionHelper
             $otherPanel->addChild($this->createDataChild('slider'));
             $otherPanel->addChild($this->createDataChild('manyToManyObjectRelation', 'relationobjects')
                 ->setClasses([]));
+            $panel->addChild($this->createDataChild('manyToOneRelation', 'relation')
+                ->setDocumentTypes([])->setAssetTypes([])->setClasses(['RelationTest'])
+                ->setDocumentsAllowed(false)->setAssetsAllowed(false)->setObjectsAllowed(true));
 
             $panel->addChild($lFields);
             $panel->addChild($otherPanel);
@@ -886,6 +889,7 @@ class Model extends AbstractDefinitionHelper
 
         $this->setupPimcoreClass_Unittest();
         $this->setupPimcoreClass_Inheritance();
+        $this->setupPimcoreClass_RelationTest();
 
         $this->setupObjectbrick_UnittestBrick();
     }


### PR DESCRIPTION
Steps to reproduce:
1. Create class `Category`
1. Create class `Product` with inheritance enabled and add a many-to-many object relation field `categories` with allowed class `Category` and `lazy-loading` enabled
1. Create `Category` object with path `/category`
1. Run `bin/console pimcore:run-script` with the following script:
```php
<?php
$parent = new \Pimcore\Model\DataObject\Product;
$parent->setParentId(1);
$parent->setKey('parent');
$category = \Pimcore\Model\DataObject\Category::getByPath('/category');
$parent->setCategories([$category]);
$parent->save();

$child = new \Pimcore\Model\DataObject\Product;
$child->setParent($parent);
$child->setKey('child');
$child->save();
```
After this the child object with path `/parent/child` inherits the field `categories` from its parent.

Now call `bin/console pimcore:run-script` again but with the following script:
```php
<?php
$child = \Pimcore\Model\DataObject\Product::getByPath('/parent/child');
$category = \Pimcore\Model\DataObject\Category::getByPath('/category');
$child->setCategories([$category]);
$child->save();
```

Expected behaviour (at least for me) is that the categories relation gets set directly for the child object, so that the inheritance gets broken up.
Actual behaviour is that the `categories` field stays inherited because the object value did not change and so the setter does not set the value directly for the child object.

Currently I have to set the relation to `null` first and thereafter set it to the desired value to break up the inheritance.

With this PR inheritance gets disabled in the setter to get the current value. This way you can directly set the desired value, even if it is the same as the previously inherited one.