### PR TITLE
show validationExceptions for documents correctly as well

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/asset.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/asset.js
@@ -337,7 +337,21 @@ pimcore.asset.asset = Class.create(pimcore.element.abstract, {
 
         this.tab.mask();
 
-        pimcore.plugin.broker.fireEvent("preSaveAsset", this.id);
+        try {
+            pimcore.plugin.broker.fireEvent("preSaveAsset", this.id);
+        } catch (e) {
+            if (e instanceof pimcore.error.ValidationException) {
+                this.tab.unmask();
+                pimcore.helpers.showPrettyError('asset', t("error"), t("saving_failed"), e.message);
+                return false;
+            }
+
+            if (e instanceof pimcore.error.ActionCancelledException) {
+                this.tab.unmask();
+                pimcore.helpers.showNotification(t("Info"), 'Asset not saved: ' + e.message, 'info');
+                return false;
+            }
+        }
 
         Ext.Ajax.request({
             url: '/admin/asset/save',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/document.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/document.js
@@ -108,7 +108,7 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
             } catch (e) {
                 if (e instanceof pimcore.error.ValidationException) {
                         this.tab.unmask();
-                        pimcore.helpers.showPrettyError('document', t("error"), e.message);
+                        pimcore.helpers.showPrettyError('document', t("error"), t("saving_failed"), e.message);
                         return false;
                     }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/document.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/document.js
@@ -103,7 +103,21 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
 
             }
 
-            pimcore.plugin.broker.fireEvent("preSaveDocument", this, this.getType(), task, only);
+            try {
+                pimcore.plugin.broker.fireEvent("preSaveDocument", this, this.getType(), task, only);
+            } catch (e) {
+                if (e instanceof pimcore.error.ValidationException) {
+                        this.tab.unmask();
+                        pimcore.helpers.showPrettyError('document', t("error"), e.message);
+                        return false;
+                    }
+
+                    if (e instanceof pimcore.error.ActionCancelledException) {
+                        this.tab.unmask();
+                        pimcore.helpers.showNotification(t("Info"), 'Document not saved: ' + e.message, 'info');
+                        return false;
+                    }
+            }
 
             Ext.Ajax.request({
                 url: this.urlprefix + this.getType() + '/save?task=' + task,


### PR DESCRIPTION
As it was already implemented for objects, we would like to have a proper JS validation for documents as well. Without these changes, we can't close the validation box correctly (the background is still unclickable)