### PR TITLE
show items count in many-to-many data components

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/document.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/document.js
@@ -103,7 +103,21 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
 
             }
 
-            pimcore.plugin.broker.fireEvent("preSaveDocument", this, this.getType(), task, only);
+            try {
+                pimcore.plugin.broker.fireEvent("preSaveDocument", this, this.getType(), task, only);
+            } catch (e) {
+                if (e instanceof pimcore.error.ValidationException) {
+                        this.tab.unmask();
+                        pimcore.helpers.showPrettyError('document', t("error"), e.message);
+                        return false;
+                    }
+
+                    if (e instanceof pimcore.error.ActionCancelledException) {
+                        this.tab.unmask();
+                        pimcore.helpers.showNotification(t("Info"), 'Document not saved: ' + e.message, 'info');
+                        return false;
+                    }
+            }
 
             Ext.Ajax.request({
                 url: this.urlprefix + this.getType() + '/save?task=' + task,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -567,7 +567,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
             },
             {
                 xtype: "tbtext",
-                text: "<b>" + this.fieldConfig.title + "</b>"
+                text: "<b>" + this.fieldConfig.title +  " (" + this.store.data.items.length + ")</b>"
             },
             "->"
         ];

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -551,7 +551,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
             },
             {
                 xtype: "tbtext",
-                text: "<b>" + this.fieldConfig.title + "</b>"
+                text: "<b>" + this.fieldConfig.title + " (" + this.store.data.items.length + ")</b>"
             },
             "->"
         ];

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -328,7 +328,7 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
             },
             {
                 xtype: "tbtext",
-                text: "<b>" + this.fieldConfig.title + "</b>"
+                text: "<b>" + this.fieldConfig.title +  " (" + this.store.data.items.length + ")</b>"
             },
             "->"
         ];


### PR DESCRIPTION
## Changes in this pull request  
To have a quick overview about the amount of items in a many-to-many field, we implemented an items count next to the title.

