### PR TITLE
[Feature] Element Router

### DIFF
--- a/bundles/CoreBundle/Resources/config/services_routing.yml
+++ b/bundles/CoreBundle/Resources/config/services_routing.yml
@@ -25,6 +25,13 @@ services:
         alias: router.request_context
         public: true
 
+    # dedicated router for elements
+    Pimcore\Routing\Element\Router:
+        arguments:
+            $context: '@router.request_context'
+        tags:
+            - { name: router, priority: 110 }
+
     # dedicated router for static routes
     Pimcore\Routing\Staticroute\Router:
         arguments:

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/30_Link_Generator.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/30_Link_Generator.md
@@ -125,6 +125,30 @@ would produce the following output
  
 ### Use in Views
 
+#### path() / url()
+
+<div class="code-section">
+
+```php
+<ul class="foo">
+    <?php foreach($this->carList as $car) { ?>
+        <li><a href="<?= $this->path($car); ?>"><?= $car->getName() ?></a></li>
+    <?php } ?>
+</ul>
+```
+
+```twig
+<ul class="foo">
+    {% for car in carList %}
+        <li><a href="{{ path(car) }}">{{ car.getName() }}</a></li>
+    {% endfor %}
+</ul>
+```
+
+</div>
+
+#### pimcoreUrl
+
 <div class="code-section">
 
 ```php
@@ -138,7 +162,7 @@ would produce the following output
 ```twig
 <ul class="foo">
     {% for car in carList %}
-        <li><a href="{{ path(car) }}">{{ car.getName() }}</a></li>
+        <li><a href="{{ pimcore_url({object: car}) }}">{{ car.getName() }}</a></li>
     {% endfor %}
 </ul>
 ```

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/30_Link_Generator.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/30_Link_Generator.md
@@ -125,12 +125,22 @@ would produce the following output
  
 ### Use in Views
 
+<div class="code-section">
+
 ```php
 <ul class="foo">
     <?php foreach($this->carList as $car) { ?>
-        <a href="<?= $this->pimcoreUrl(['object' => $car]); ?>"><?= $car->getName() ?></a>
+        <li><a href="<?= $this->pimcoreUrl(['object' => $car]); ?>"><?= $car->getName() ?></a></li>
     <?php } ?>
 </ul>
- ``` 
- 
- 
+```
+
+```twig
+<ul class="foo">
+    {% for car in carList %}
+        <li><a href="{{ path(car) }}">{{ car.getName() }}</a></li>
+    {% endfor %}
+</ul>
+```
+
+</div>

--- a/lib/Routing/Element/Router.php
+++ b/lib/Routing/Element/Router.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Routing\Element;
+
+use Pimcore\Http\RequestHelper;
+use Pimcore\Model\Asset;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\Document;
+use Pimcore\Model\Element\ElementInterface;
+use Symfony\Cmf\Component\Routing\VersatileGeneratorInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * A custom router implementation handling pimcore elements.
+ */
+class Router implements RequestMatcherInterface, VersatileGeneratorInterface
+{
+    /**
+     * @var RequestContext
+     */
+    protected $context;
+
+    /**
+     * @var RequestHelper
+     */
+    protected $requestHelper;
+
+    public function __construct(RequestContext $context, RequestHelper $requestHelper)
+    {
+        $this->context = $context;
+        $this->requestHelper = $requestHelper;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setContext(RequestContext $context)
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function supports($name)
+    {
+        return $name instanceof ElementInterface;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getRouteDebugMessage($name, array $parameters = [])
+    {
+        return sprintf('Element (Type: %s, ID: %d)', $name->getType(), $name->getId());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH)
+    {
+        if ($name instanceof Document) {
+            return $name->getFullPath();
+        }
+        if ($name instanceof Asset) {
+            return $name->getFullPath();
+        }
+        if ($name instanceof Concrete) {
+            $linkGenerator = $name->getClass()->getLinkGenerator();
+            if ($linkGenerator) {
+                return $linkGenerator->generate($name, [
+                    'route' => $this->getCurrentRoute(),
+                    'parameters' => $parameters,
+                    'context' => $this,
+                    'referenceType' => $referenceType,
+                ]);
+            }
+        }
+
+        throw new RouteNotFoundException(sprintf('Could not generate URL for element (Type: %s, ID: %d)', $name->getType(), $name->getId()));
+    }
+
+    /**
+     * Tries to get the current route name from current or master request
+     *
+     * @return string|null
+     */
+    protected function getCurrentRoute()
+    {
+        $route = null;
+
+        if ($this->requestHelper->hasCurrentRequest()) {
+            $route = $this->requestHelper->getCurrentRequest()->attributes->get('_route');
+        }
+
+        if (!$route && $this->requestHelper->hasMasterRequest()) {
+            $route = $this->requestHelper->getMasterRequest()->attributes->get('_route');
+        }
+
+        return $route;
+    }
+
+    public function matchRequest(Request $request)
+    {
+        throw new ResourceNotFoundException(sprintf('No routes found for "%s".', $request->getPathInfo()));
+    }
+}

--- a/lib/Routing/Element/Router.php
+++ b/lib/Routing/Element/Router.php
@@ -76,7 +76,11 @@ class Router implements RequestMatcherInterface, VersatileGeneratorInterface
      */
     public function getRouteDebugMessage($name, array $parameters = [])
     {
-        return sprintf('Element (Type: %s, ID: %d)', $name->getType(), $name->getId());
+        if ($name instanceof ElementInterface) {
+            return sprintf('Element (Type: %s, ID: %d)', $name->getType(), $name->getId());
+        }
+
+        return 'No element';
     }
 
     /**
@@ -84,10 +88,7 @@ class Router implements RequestMatcherInterface, VersatileGeneratorInterface
      */
     public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH)
     {
-        if ($name instanceof Document) {
-            return $name->getFullPath();
-        }
-        if ($name instanceof Asset) {
+        if ($name instanceof Document || $name instanceof Asset) {
             return $name->getFullPath();
         }
         if ($name instanceof Concrete) {
@@ -102,7 +103,17 @@ class Router implements RequestMatcherInterface, VersatileGeneratorInterface
             }
         }
 
-        throw new RouteNotFoundException(sprintf('Could not generate URL for element (Type: %s, ID: %d)', $name->getType(), $name->getId()));
+        if ($name instanceof ElementInterface) {
+            throw new RouteNotFoundException(
+                sprintf(
+                    'Could not generate URL for element (Type: %s, ID: %d)',
+                    $name->getType(),
+                    $name->getId()
+                )
+            );
+        }
+
+        throw new RouteNotFoundException('Could not generate URL for non elements');
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  

It would be nice to can use the symfony/twig functions path/url to generate urls for elements.
I know it from other systems to use this functions also for objects.

It is also supported from symfony with the `VersatileGeneratorInterface` interface.