### PR TITLE
Correction in applySpecialData fuction for different data types

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/advancedManyToManyObjectRelation.js
@@ -379,7 +379,8 @@ pimcore.object.classes.data.advancedManyToManyObjectRelation = Class.create(pimc
                     classes: source.datax.classes,
                     enableBatchEdit: source.datax.enableBatchEdit,
                     allowMultipleAssignments: source.datax.allowMultipleAssignments,
-                    optimizedAdminLoading: source.datax.optimizedAdminLoading
+                    optimizedAdminLoading: source.datax.optimizedAdminLoading,
+                    pathFormatterClass: source.datax.pathFormatterClass
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/advancedManyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/advancedManyToManyRelation.js
@@ -575,7 +575,11 @@ pimcore.object.classes.data.advancedManyToManyRelation = Class.create(pimcore.ob
                     assetsAllowed: source.datax.assetsAllowed,
                     assetTypes: source.datax.assetTypes,
                     documentsAllowed: source.datax.documentsAllowed,
-                    documentTypes: source.datax.documentTypes
+                    documentTypes: source.datax.documentTypes,
+                    pathFormatterClass: source.datax.pathFormatterClass,
+                    enableBatchEdit: source.datax.enableBatchEdit,
+                    allowMultipleAssignments: source.datax.allowMultipleAssignments,
+                    optimizedAdminLoading: source.datax.optimizedAdminLoading
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/block.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/block.js
@@ -133,7 +133,10 @@ pimcore.object.classes.data.block = Class.create(pimcore.object.classes.data.dat
                     disallowAddRemove: source.datax.disallowAddRemove,
                     disallowReorder: source.datax.disallowReorder,
                     collapsible: source.datax.collapsible,
-                    collapsed: source.datax.collapsed
+                    collapsed: source.datax.collapsed,
+                    lazyLoading: source.datax.lazyLoading,
+                    styleElement: source.datax.styleElement
+                    
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/classificationstore.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/classificationstore.js
@@ -142,7 +142,12 @@ pimcore.object.classes.data.classificationstore = Class.create(pimcore.object.cl
                     width: source.datax.width,
                     height: source.datax.height,
                     maxTabs: source.datax.maxTabs,
-                    labelWidth: source.datax.labelWidth
+                    labelWidth: source.datax.labelWidth,
+                    localized: source.datax.localized,
+                    allowedGroupIds: source.datax.allowedGroupIds,
+                    hideEmptyData: source.datax.hideEmptyData,
+                    disallowAddRemove: source.datax.disallowAddRemove,
+                    storeId: source.datax.storeId 
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/countrymultiselect.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/countrymultiselect.js
@@ -150,7 +150,11 @@ pimcore.object.classes.data.countrymultiselect = Class.create(pimcore.object.cla
             }
             Ext.apply(this.datax,
                 {
-                    restrictTo: source.datax.restrictTo
+                    restrictTo: source.datax.restrictTo,
+                    width: source.datax.width,
+                    height: source.datax.height,
+                    renderType : source.datax.renderType
+                    
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/date.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/date.js
@@ -162,7 +162,8 @@ pimcore.object.classes.data.date = Class.create(pimcore.object.classes.data.data
                 {
                     defaultValue: source.datax.defaultValue,
                     useCurrentDate: source.datax.useCurrentDate,
-                    defaultValueGenerator: source.datax.defaultValueGenerator
+                    defaultValueGenerator: source.datax.defaultValueGenerator,
+                    columnType: source.datax.columnType
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/datetime.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/datetime.js
@@ -219,7 +219,8 @@ pimcore.object.classes.data.datetime = Class.create(pimcore.object.classes.data.
                 {
                     defaultValue: source.datax.defaultValue,
                     useCurrentDate: source.datax.useCurrentDate,
-                    defaultValueGenerator: source.datax.defaultValueGenerator
+                    defaultValueGenerator: source.datax.defaultValueGenerator,
+                    columnType: source.datax.columnType
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/email.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/email.js
@@ -96,5 +96,18 @@ pimcore.object.classes.data.email = Class.create(pimcore.object.classes.data.dat
         }
 
         return specificItems;
+    },
+    
+    applySpecialData: function (source) {
+        if (source.datax) {
+            if (!this.datax) {
+                this.datax = {};
+            }
+            Ext.apply(this.datax,
+                {
+                    width: source.datax.width,
+                    columnLength: source.datax.columnLength
+                });
+        }
     }
 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/externalImage.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/externalImage.js
@@ -90,8 +90,9 @@ pimcore.object.classes.data.externalImage = Class.create(pimcore.object.classes.
             }
             Ext.apply(this.datax,
                 {
-                    width: source.datax.width,
-                    height: source.datax.height
+                    previewWidth: source.datax.previewWidth,
+                    previewHeight: source.datax.previewHeight,
+                    inputWidth: source.datax.inputWidth
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/fieldcollections.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/fieldcollections.js
@@ -158,7 +158,10 @@ pimcore.object.classes.data.fieldcollections = Class.create(pimcore.object.class
                     lazyLoading: source.datax.lazyLoading,
                     maxItems: source.datax.maxItems,
                     disallowAddRemove: source.datax.disallowAddRemove,
-                    disallowReorder: source.datax.disallowReorder
+                    disallowReorder: source.datax.disallowReorder,
+                    collapsible: source.datax.collapsible,
+                    collapsed: source.datax.collapsed,
+                    border: source.datax.border
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/geo/abstract.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/geo/abstract.js
@@ -80,5 +80,22 @@ pimcore.object.classes.data.geo.abstract = Class.create(pimcore.object.classes.d
                 value: this.datax.height
             }
         ];
+    },
+    
+    applySpecialData: function (source) {
+        if (source.datax) {
+            if (!this.datax) {
+                this.datax = {};
+            }
+            Ext.apply(this.datax,
+                {
+                    lat: source.datax.lat,
+                    lng: source.datax.lat,
+                    zoom: source.datax.zoom,
+                    width: source.datax.width,
+                    height: source.datax.height
+                });
+        }
     }
+    
 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/hotspotimage.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/hotspotimage.js
@@ -105,7 +105,8 @@ pimcore.object.classes.data.hotspotimage = Class.create(pimcore.object.classes.d
                     height: source.datax.height,
                     uploadPath: source.datax.uploadPath,
                     ratioX: source.datax.ratioX,
-                    ratioY: source.datax.ratioY
+                    ratioY: source.datax.ratioY,
+                    predefinedDataTemplates: source.datax.predefinedDataTemplates
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/input.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/input.js
@@ -62,10 +62,11 @@ pimcore.object.classes.data.input = Class.create(pimcore.object.classes.data.dat
     getSpecificPanelItems: function (datax, inEncryptedField) {
         var specificItems = [
             {
-                xtype: "numberfield",
+                xtype: "textfield",
                 fieldLabel: t("default_value"),
                 name: "defaultValue",
-                value: datax.defaultValue
+                value: datax.defaultValue,
+                width: 600
             },{
                 xtype: 'textfield',
                 width: 600,
@@ -168,7 +169,8 @@ pimcore.object.classes.data.input = Class.create(pimcore.object.classes.data.dat
                     regex: source.datax.regex,
                     unique: source.datax.unique,
                     defaultValue: source.datax.defaultValue,
-                    defaultValueGenerator: source.datax.defaultValueGenerator
+                    defaultValueGenerator: source.datax.defaultValueGenerator,
+                    showCharCount : source.datax.showCharCount
                 });
         }
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/inputQuantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/inputQuantityValue.js
@@ -90,5 +90,20 @@ pimcore.object.classes.data.inputQuantityValue = Class.create(pimcore.object.cla
         ]);
 
         return this.layout;
-    }
+    },
+    
+    applySpecialData: function(source) {
+        if (source.datax) {
+            if (!this.datax) {
+                this.datax =  {};
+            }
+            Ext.apply(this.datax,
+                {
+                    width: source.datax.width,
+                    defaultValue: source.datax.defaultValue,
+                    defaultUnit: source.datax.defaultUnit,
+                    validUnits : source.datax.validUnits
+                });
+        }
+    },
 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/languagemultiselect.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/languagemultiselect.js
@@ -101,7 +101,10 @@ pimcore.object.classes.data.languagemultiselect = Class.create(pimcore.object.cl
             }
             Ext.apply(this.datax,
                 {
-                    onlySystemLanguages: source.datax.onlySystemLanguages
+                    onlySystemLanguages: source.datax.onlySystemLanguages,
+                    width: source.datax.width,
+                    height: source.datax.height,
+                    renderType : source.datax.renderType
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/localizedfields.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/localizedfields.js
@@ -193,7 +193,11 @@ pimcore.object.classes.data.localizedfields = Class.create(pimcore.object.classe
                     width: source.datax.width,
                     height: source.datax.height,
                     maxTabs: source.datax.maxTabs,
-                    labelWidth: source.datax.labelWidth
+                    labelWidth: source.datax.labelWidth,
+                    border: source.datax.border,
+                    tabPosition: source.datax.tabPosition,
+                    hideLabelsWhenTabsReached: source.datax.hideLabelsWhenTabsReached,
+                    provideSplitView: source.datax.provideSplitView
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/manyToManyObjectRelation.js
@@ -217,7 +217,9 @@ pimcore.object.classes.data.manyToManyObjectRelation = Class.create(pimcore.obje
                     remoteOwner: source.datax.remoteOwner,
                     classes: source.datax.classes,
                     visibleFields: source.datax.visibleFields,
-                    optimizedAdminLoading: source.datax.optimizedAdminLoading
+                    optimizedAdminLoading: source.datax.optimizedAdminLoading,
+                    pathFormatterClass: source.datax.pathFormatterClass,
+                    allowToCreateNewObject: source.datax.allowToCreateNewObject
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/manyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/manyToManyRelation.js
@@ -362,7 +362,8 @@ pimcore.object.classes.data.manyToManyRelation = Class.create(pimcore.object.cla
                     documentsAllowed: source.datax.documentsAllowed,
                     documentTypes: source.datax.documentTypes,
                     remoteOwner: source.datax.remoteOwner,
-                    classes: source.datax.classes
+                    classes: source.datax.classes,
+                    pathFormatterClass: source.datax.pathFormatterClass
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/manyToOneRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/manyToOneRelation.js
@@ -347,7 +347,8 @@ pimcore.object.classes.data.manyToOneRelation = Class.create(pimcore.object.clas
                     assetsAllowed: source.datax.assetsAllowed,
                     assetTypes: source.datax.assetTypes,
                     documentsAllowed: source.datax.documentsAllowed,
-                    documentTypes: source.datax.documentTypes
+                    documentTypes: source.datax.documentTypes,
+                    pathFormatterClass: source.datax.pathFormatterClass
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/numeric.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/numeric.js
@@ -155,7 +155,8 @@ pimcore.object.classes.data.numeric = Class.create(pimcore.object.classes.data.d
                     maxValue: source.datax.maxValue,
                     decimalSize: source.datax.decimalSize,
                     decimalPrecision: source.datax.decimalPrecision,
-                    defaultValueGenerator: source.datax.defaultValueGenerator
+                    defaultValueGenerator: source.datax.defaultValueGenerator,
+                    unique: source.datax.unique
                 });
         }
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/objectbricks.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/objectbricks.js
@@ -96,8 +96,8 @@ pimcore.object.classes.data.objectbricks = Class.create(pimcore.object.classes.d
             }
             Ext.apply(this.datax,
                 {
-                    allowedTypes: source.datax.allowedTypes,
-                    maxItems: source.datax.maxItems
+                    maxItems: source.datax.maxItems,
+                    border: source.datax.border
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/reverseManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/reverseManyToManyObjectRelation.js
@@ -164,7 +164,12 @@ pimcore.object.classes.data.reverseManyToManyObjectRelation = Class.create(pimco
             }
             Ext.apply(this.datax,
                 {
-                    remoteOwner: source.datax.remoteOwner
+                    remoteOwner: source.datax.remoteOwner,
+                    width: source.datax.width,
+                    height: source.datax.height,
+                    pathFormatterClass: source.datax.pathFormatterClass,
+                    ownerClassName: source.datax.ownerClassName,
+                    ownerFieldName: source.datax.ownerFieldName
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/table.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/table.js
@@ -286,7 +286,8 @@ pimcore.object.classes.data.table = Class.create(pimcore.object.classes.data.dat
                     rows: source.datax.rows,
                     rowsFixed: source.datax.rowsFixed,
                     data: source.datax.data,
-                    columnConfig: source.datax.columnConfig
+                    columnConfig: source.datax.columnConfig,
+                    columnConfigActivated: source.datax.columnConfigActivated,
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/textarea.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/textarea.js
@@ -106,7 +106,10 @@ pimcore.object.classes.data.textarea = Class.create(pimcore.object.classes.data.
             Ext.apply(this.datax,
                 {
                     width: source.datax.width,
-                    height: source.datax.height
+                    height: source.datax.height,
+                    maxLength: source.datax.maxLength,
+                    showCharCount: source.datax.showCharCount,
+                    excludeFromSearchIndex: source.datax.excludeFromSearchIndex
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/time.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/time.js
@@ -113,6 +113,7 @@ pimcore.object.classes.data.time = Class.create(pimcore.object.classes.data.data
                     xtype: 'button',
                     text: t('reset'),
                     handler: function() {
+                        minmaxSet.getComponent('increment').reset();
                         minmaxSet.getComponent('minTime').reset();
                         minmaxSet.getComponent('maxTime').reset();
                     }
@@ -137,7 +138,8 @@ pimcore.object.classes.data.time = Class.create(pimcore.object.classes.data.data
             Ext.apply(this.datax,
                 {
                     minValue: source.datax.minValue,
-                    maxValue: source.datax.maxValue
+                    maxValue: source.datax.maxValue,
+                    increment: source.datax.increment
                 });
         }
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/urlSlug.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/urlSlug.js
@@ -142,7 +142,8 @@ pimcore.object.classes.data.urlSlug = Class.create(pimcore.object.classes.data.d
                     width: source.datax.width,
                     action: source.datax.action,
                     availableSites: source.datax.availableSites,
-                    domainLabelWidth: source.datax.domainLabelWidth
+                    domainLabelWidth: source.datax.domainLabelWidth,
+                    defaultValueGenerator: source.datax.defaultValueGenerator
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/user.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/user.js
@@ -55,6 +55,18 @@ pimcore.object.classes.data.user = Class.create(pimcore.object.classes.data.data
         this.specificPanel.removeAll();
         return this.layout;
     },
+    
+    applySpecialData: function(source) {
+        if (source.datax) {
+            if (!this.datax) {
+                this.datax =  {};
+            }
+            Ext.apply(this.datax,
+                {
+                    unique: source.datax.unique
+                });
+        }
+    },
 
     supportsUnique: function() {
         return true;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/wysiwyg.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/wysiwyg.js
@@ -102,7 +102,8 @@ pimcore.object.classes.data.wysiwyg = Class.create(pimcore.object.classes.data.d
                 {
                     width: source.datax.width,
                     height: source.datax.height,
-                    toolbarConfig: source.datax.toolbarConfig
+                    toolbarConfig: source.datax.toolbarConfig,
+                    excludeFromSearchIndex : source.datax.excludeFromSearchIndex
                 });
         }
     }


### PR DESCRIPTION
While cloning or copying data fields in class settings, all the specific settings of the field are not copied to the destination field.
applySpecialData function is modified or added to resolve the same for following data fields:

- Input  - Default value was number field, changed to text field
	    - Increased the default value width to 600.
- Textarea 
- Wysiwyg 
- Iinput qualtity 
- Numeric
- Date
- Date & Time
- Time  - reset button also corrected
- User  
- Country Multiselect
- Language Multiselect
- External Image 
- Advanced Image
- Many-to-one- Relation
- Many-to-many Object Relation
- Advanced many-to-many Relation
- Reverse Many-To-Many Object Relation
- Many-to-many Relation
- Advanced many-to-many Object Relation
- All geographic points
- Block
- Classification Store
- Table
- Field Collection
- Object Bricks - allowed types removed and border added.
- Localised Fields 
- Url Slugs
- Email

