### PR TITLE
[DataObjects] Respect params passed to Fieldcollections save

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -315,11 +315,9 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
         }
 
         if ($container instanceof DataObject\Fieldcollection) {
-            $params = [
-                'context' => [
-                    'containerType' => 'fieldcollection',
-                    'fieldname' => $this->getName()
-                ]
+            $params['context'] = [
+                'containerType' => 'fieldcollection',
+                'fieldname' => $this->getName()
             ];
 
             $container->save($object, $params);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #

## Additional info  
params info(other than context) should not be overwritten in fieldcollections save 
