### PR TITLE
[CSV Import] No error if header and data rows have different number of columns

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1559,8 +1559,15 @@ class DataObjectHelperController extends AdminController
             if (0 === $rows) {
                 $nbFields = count($fields);
                 $rows++;
-            } elseif ($nbFields == count($fields)) {
+            } elseif ($nbFields === count($fields)) {
                 $rows++;
+            } else {
+                $translator = $this->get('translator');
+
+                return $this->adminJson([
+                    'success' => false,
+                    'message' => $translator->trans('different_number_of_columns', [], 'admin'),
+                ]);
             }
         }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/import/configDialog.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/import/configDialog.js
@@ -132,7 +132,7 @@ pimcore.object.helpers.import.configDialog = Class.create({
                 pimcore.helpers.download(this.getExportConfigUrl());
             }.bind(this)
         });
-        
+
         this.loadButton = new Ext.button.Split({
 
                 text: t("load"),
@@ -255,9 +255,12 @@ pimcore.object.helpers.import.configDialog = Class.create({
             } else {
                 this.showWindow(data);
             }
-        }
-        else {
-            Ext.MessageBox.alert(t("error"), t("unsupported_filetype"));
+        } else {
+            if (data.message) {
+                Ext.MessageBox.alert(t('error'), t('unsupported_filetype') + ':<br>' + data.message);
+            } else {
+                Ext.MessageBox.alert(t('error'), t('unsupported_filetype'));
+            }
         }
     },
 
@@ -796,15 +799,15 @@ pimcore.object.helpers.import.configDialog = Class.create({
             }.bind(this)
         });
     },
-    
+
     getExportConfigUrl: function(){
         this.commitEverything();
         var config = this.prepareSaveData();
         config = Ext.encode(config);
-        
+
         return "/admin/object-helper/export-csv-import-config-as-json?classId="+this.classId+"&config="+config;
     },
-    
+
     getImportConfigUrl: function(){
         return '/admin/object-helper/import-csv-import-config-from-json?importId=' + this.uniqueImportId + "&importConfigId="+this.importConfigId + "&classId=" + this.classId;
     }

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -248,6 +248,7 @@
   "main_site": "Main Site",
   "filename": "Filename",
   "unsupported_filetype": "Unsupported Filetype",
+  "different_number_of_columns": "Different number of columns",
   "email_log_resend_window_success_message": "The email has been sent successfully to all recipients.",
   "email_log_resend_window_error_message": "An error occurred. The email has not been resent.",
   "error_jobs": "The following jobs failed",


### PR DESCRIPTION
## Changes in this pull request  

If you have a csv file with empty columns only on the end of the data rows, all seems okay in the admin interface. It shows the data in preview. Only the import is immediately successful without importing anything.

I think pimcore should immediately display an error message and not mislead the user.