### PR TITLE
[Admin] DataObjects - Improve Fieldcollections controls visibility

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
@@ -165,6 +165,10 @@ pimcore.object.tags.fieldcollections = Class.create(pimcore.object.tags.abstract
 
     getControls: function (blockElement, title) {
 
+        if(this.fieldConfig.noteditable) {
+            return new Ext.Toolbar();
+        }
+
         var menuData = this.fieldcollections;
         var collectionMenuBefore = this.buildMenu(menuData, blockElement, 'before');
         var collectionMenuAfter = this.buildMenu(menuData, blockElement, 'after');

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
@@ -165,8 +165,13 @@ pimcore.object.tags.fieldcollections = Class.create(pimcore.object.tags.abstract
 
     getControls: function (blockElement, title) {
 
-        if(this.fieldConfig.noteditable) {
-            return new Ext.Toolbar();
+        if (this.fieldConfig.noteditable) {
+            return new Ext.Toolbar({
+                items: {
+                    xtype: "tbtext",
+                    text: t(title)
+                }
+            });
         }
 
         var menuData = this.fieldcollections;


### PR DESCRIPTION
## Changes in this pull request  
Follow up of #6276 

## Additional info  
Fieldcollections controls should be hidden for read-only fields

Before change:
![image](https://user-images.githubusercontent.com/5137917/80492576-7e7bd100-8964-11ea-9a9d-4968a0bc286e.png)

After change:
![image](https://user-images.githubusercontent.com/5137917/80493883-44abca00-8966-11ea-9120-de64e39034eb.png)


