### PR TITLE
[Reports] Flex column width if width not explicitly set

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/report.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/report.js
@@ -66,6 +66,8 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
 
             if(colConfig["width"]) {
                 gridColConfig["width"] = intval(colConfig["width"]);
+            } else {
+                gridColConfig["flex"] = 1;
             }
 
             if(colConfig["filter"]) {
@@ -232,9 +234,7 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
             plugins: ['pimcore.gridfilters'],
             stripeRows: true,
             trackMouseOver: true,
-            viewConfig: {
-                forceFit: false
-            },
+            forceFit: false,
             tbar: topBar
         });
 
@@ -253,7 +253,7 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
             drillDownFilterComboboxes.push({
                 xtype: 'label',
                 text: this.drillDownFilterDefinitions[i]["label"] ? t(this.drillDownFilterDefinitions[i]["label"])
-                                                    : t(this.drillDownFilterDefinitions[i]["name"]),
+                    : t(this.drillDownFilterDefinitions[i]["name"]),
                 style: 'padding-right: 5px'
             });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/report.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/report.js
@@ -253,7 +253,7 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
             drillDownFilterComboboxes.push({
                 xtype: 'label',
                 text: this.drillDownFilterDefinitions[i]["label"] ? t(this.drillDownFilterDefinitions[i]["label"])
-                    : t(this.drillDownFilterDefinitions[i]["name"]),
+                                                    : t(this.drillDownFilterDefinitions[i]["name"]),
                 style: 'padding-right: 5px'
             });
 


### PR DESCRIPTION
Currently if column width is not explicitly set ExtJS's default column width gets used. This is not optimal as it is not responsive. This PR sets `flex: 1` attribute for all columns which have no width being set. This way the columns use the whole available panel width.