### PR TITLE
Bottom margin added for  advanced image container

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
@@ -235,8 +235,8 @@ pimcore.object.tags.hotspotimage = Class.create(pimcore.object.tags.image, {
             tbar: toolbar
         };
 
-        if (!this.additionalConfig.condensed) {
-            // conf.style = "padding-bottom: 10px;";
+        if (!(this.additionalConfig.gallery)) {
+             conf.style = "padding-bottom: 10px;";
         }
 
         this.component = new Ext.Panel(conf);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
@@ -235,7 +235,7 @@ pimcore.object.tags.hotspotimage = Class.create(pimcore.object.tags.image, {
             tbar: toolbar
         };
 
-        if (!(this.additionalConfig.gallery)) {
+        if (!this.additionalConfig.gallery) {
              conf.style = "padding-bottom: 10px;";
         }
 


### PR DESCRIPTION
Margin bottom added for Advanced Image so that it doesn't sticks to the elements added after it.
Resolves #6316 