### PR TITLE
Fixed bug with sitemap generation for hardlinks

### DIFF
--- a/lib/Sitemap/Document/DocumentTreeGenerator.php
+++ b/lib/Sitemap/Document/DocumentTreeGenerator.php
@@ -154,7 +154,7 @@ class DocumentTreeGenerator extends AbstractElementGenerator
             }
         }
 
-        if ($this->handlesChildren($document, $context)) {
+        if ($document->hasChildren() && $this->handlesChildren($document, $context)) {
             foreach ($document->getChildren() as $child) {
                 yield from $this->visit($child, $context);
             }


### PR DESCRIPTION
The sitemap generation command does not work when using hardlinks. If the linked element has subpages.

In Pimcore Admin:
![grafik](https://user-images.githubusercontent.com/54348050/80632241-43a69580-8a57-11ea-99c9-31471f6992ea.png)


```
vagrant@homestead ~www/...forked/dev (git)-[fix-sitemap-generator] % php7.3 ../bin/console presta:sitemaps:dump --base-url=http://pimcore-forked.twocream.local/ -vv
Dumping all sections of sitemaps into web directory

In DocumentTreeGenerator.php line 158:

  [ErrorException]
  Warning: Invalid argument supplied for foreach()


Exception trace:
  at /var/www/...forked/dev/lib/Sitemap/Document/DocumentTreeGenerator.php:158
 Pimcore\Sitemap\Document\DocumentTreeGenerator->visit() at /var/www/...forked/dev/lib/Sitemap/Document/DocumentTreeGenerator.php:159
 Pimcore\Sitemap\Document\DocumentTreeGenerator->visit() at /var/www/...forked/dev/lib/Sitemap/Document/DocumentTreeGenerator.php:159
 Pimcore\Sitemap\Document\DocumentTreeGenerator->visit() at /var/www/...forked/dev/lib/Sitemap/Document/DocumentTreeGenerator.php:104
 Pimcore\Sitemap\Document\DocumentTreeGenerator->populateCollection() at /var/www/...forked/dev/lib/Sitemap/Document/DocumentTreeGenerator.php:83
 Pimcore\Sitemap\Document\DocumentTreeGenerator->populate() at /var/www/...forked/dev/lib/Sitemap/EventListener/SitemapGeneratorListener.php:54
 Pimcore\Sitemap\EventListener\SitemapGeneratorListener->onPopulateSitemap() at /var/www/...forked/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php:126
 Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke() at /var/www/...forked/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php:251
 Symfony\Component\EventDispatcher\EventDispatcher->callListeners() at /var/www/...forked/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php:73
 Symfony\Component\EventDispatcher\EventDispatcher->dispatch() at /var/www/...forked/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php:168
 Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch() at /var/www/...forked/vendor/presta/sitemap-bundle/Service/AbstractGenerator.php:150
 Presta\SitemapBundle\Service\AbstractGenerator->populate() at /var/www/...forked/vendor/presta/sitemap-bundle/Service/Dumper.php:81
 Presta\SitemapBundle\Service\Dumper->dump() at /var/www/...forked/vendor/presta/sitemap-bundle/Command/DumpSitemapsCommand.php:132
 Presta\SitemapBundle\Command\DumpSitemapsCommand->execute() at /var/www/...forked/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /var/www/...forked/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:1019
 Symfony\Component\Console\Application->doRunCommand() at /var/www/...forked/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:97
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /var/www/...forked/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:271
 Symfony\Component\Console\Application->doRun() at /var/www/...forked/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:83
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /var/www/...forked/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:147
 Symfony\Component\Console\Application->run() at /var/www/...forked/bin/console:28

presta:sitemaps:dump [--section SECTION] [--base-url BASE-URL] [--gzip] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [--ignore-maintenance-mode] [--maintenance-mode] [-e|--env ENV] [--no-debug] [--] <command> [<target>]
```

After my fix, that's working:
"Use children from source document:" is disabled:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <url>
        <loc>http://pimcore-forked.twocream.local/</loc>
        <lastmod>2020-04-03T14:12:21+00:00</lastmod>
    </url>
    <url>
        <loc>http://pimcore-forked.twocream.local/linked-page</loc>
        <lastmod>2020-04-29T17:58:13+00:00</lastmod>
    </url>
    <url>
        <loc>http://pimcore-forked.twocream.local/linked-page/linked-sub-page</loc>
        <lastmod>2020-04-29T17:58:24+00:00</lastmod>
    </url>
    <url>
        <loc>http://pimcore-forked.twocream.local/hardlink</loc>
        <lastmod>2020-04-29T17:58:13+00:00</lastmod>
    </url>
</urlset>
```

"Use children from source document:" is active:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <url>
        <loc>http://pimcore-forked.twocream.local/</loc>
        <lastmod>2020-04-03T14:12:21+00:00</lastmod>
    </url>
    <url>
        <loc>http://pimcore-forked.twocream.local/linked-page</loc>
        <lastmod>2020-04-29T17:58:13+00:00</lastmod>
    </url>
    <url>
        <loc>http://pimcore-forked.twocream.local/linked-page/linked-sub-page</loc>
        <lastmod>2020-04-29T17:58:24+00:00</lastmod>
    </url>
    <url>
        <loc>http://pimcore-forked.twocream.local/hardlink</loc>
        <lastmod>2020-04-29T17:58:13+00:00</lastmod>
    </url>
    <url>
        <loc>http://pimcore-forked.twocream.local/hardlink/linked-sub-page</loc>
        <lastmod>2020-04-29T17:58:24+00:00</lastmod>
    </url>
</urlset>
```