### PR TITLE
[Users] Allow users to have children (not biologically ;-) )

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -71,7 +71,6 @@ class UserController extends AdminController implements EventedControllerInterfa
         $tmpUser = [
             'id' => $user->getId(),
             'text' => $user->getName(),
-            'elementType' => 'user',
             'type' => $user->getType(),
             'qtipCfg' => [
                 'title' => 'ID: ' . $user->getId()
@@ -80,6 +79,7 @@ class UserController extends AdminController implements EventedControllerInterfa
 
         // set type specific settings
         if ($user instanceof User\Folder) {
+            $tmpUser['elementType'] = 'userfolder';
             $tmpUser['leaf'] = false;
             $tmpUser['iconCls'] = 'pimcore_icon_folder';
             $tmpUser['expanded'] = true;
@@ -91,12 +91,21 @@ class UserController extends AdminController implements EventedControllerInterfa
                 $tmpUser['loaded'] = true;
             }
         } else {
+            $tmpUser['elementType'] = 'user';
             $tmpUser['leaf'] = true;
             $tmpUser['iconCls'] = 'pimcore_icon_user';
             if (!$user->getActive()) {
                 $tmpUser['cls'] = ' pimcore_unpublished';
             }
-            $tmpUser['allowChildren'] = false;
+            $tmpUser['allowChildren'] = true;
+            $tmpUser['expanded'] = true;
+
+            if ($user->hasChildren()) {
+                $tmpUser['expanded'] = false;
+                $tmpUser['leaf'] = false;
+            } else {
+                $tmpUser['loaded'] = true;
+            }
             $tmpUser['admin'] = $user->isAdmin();
         }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/panel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/panel.js
@@ -189,7 +189,7 @@ pimcore.settings.user.panel = Class.create(pimcore.settings.user.panels.abstract
             return;
         }
 
-        if(!record.data.allowChildren && record.data.id > 0) {
+        if(record.get("elementType") === "user" && record.get("id") > 0) {
             this.openUser(record.data.id);
         }
     },
@@ -206,6 +206,7 @@ pimcore.settings.user.panel = Class.create(pimcore.settings.user.panels.abstract
 
         var menu = new Ext.menu.Menu();
 
+
         if (record.data.allowChildren) {
             menu.add(new Ext.menu.Item({
                 text: t('create_folder'),
@@ -221,7 +222,9 @@ pimcore.settings.user.panel = Class.create(pimcore.settings.user.panels.abstract
                     "click": this.add.bind(this, "user", null, record)
                 }
             }));
-        } else if (record.data.elementType == "user") {
+        }
+
+        if (record.data.elementType === "user") {
             menu.add(new Ext.menu.Item({
                 text: t('clone'),
                 iconCls: "pimcore_icon_user pimcore_icon_overlay_add",
@@ -231,7 +234,7 @@ pimcore.settings.user.panel = Class.create(pimcore.settings.user.panels.abstract
             }));
         }
 
-        if (record.data.id > 0 && record.data.id != user.id && (record.data.type != "userfolder" || user.admin)) {
+        if (record.data.id > 0 && record.data.id != user.id && (record.data.type !== "userfolder" || user.admin)) {
             menu.add(new Ext.menu.Item({
                 text: t('delete'),
                 iconCls: "pimcore_icon_delete",

--- a/models/User.php
+++ b/models/User.php
@@ -140,6 +140,11 @@ class User extends User\UserRole
     public $twoFactorAuthentication;
 
     /**
+     * @var bool
+     */
+    public $hasChilds;
+
+    /**
      * @return string
      */
     public function getPassword()
@@ -1050,5 +1055,31 @@ class User extends User\UserRole
 
             $this->twoFactorAuthentication[$key] = $value;
         }
+    }
+
+    /**
+     * @param bool $state
+     *
+     * @return $this
+     */
+    public function setHasChilds($state)
+    {
+        $this->hasChilds = $state;
+
+        return $this;
+    }
+
+    /**
+     * Returns true if the document has at least one child
+     *
+     * @return bool
+     */
+    public function hasChildren()
+    {
+        if ($this->hasChilds !== null) {
+            return $this->hasChilds;
+        }
+
+        return $this->getDao()->hasChildren();
     }
 }


### PR DESCRIPTION
Currently Pimcore users can only be created within folders. This PR makes the user structure more flexible by allowing users to have children - other users as well as folders.

This can for example be useful in an application where one business department admin is responsible for its users. With this PR you could create the department employees directly under the department admin user.

Example:
We have department admins, e.g. user marketing-admin. This user is responsible for all employees in the marketing department, e.g. marketing-employee-1 and marketing-employee-2.
To structure this responsibility, I would like to add marketing-employee-1 and marketing-employee-2 directly under marketing-admin:
- marketing-admin
  - marketing-employee-1
  - marketing-employee-2

With folders we would need an additional folder marketing-users beside marketing-admin and put marketing-employee-1 and marketing-employee-2 to this folder, so we would have
- marketing-admin
- marketing-users
  - marketing-employee-1
  - marketing-employee-2

Additionally this PR makes the GUI compatible to what is possible via PHP since forever: With PHP you can set the `parentId` of a user object to the ID of another user. Currently everything works fine for this sub-user (login, permissions etc.) except that this sub-user does not get shown in the user settings tree. With this PR it does.