### PR TITLE
[Asset] Image previews with duplicate id params

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tags/image.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tags/image.js
@@ -337,24 +337,18 @@ pimcore.document.tags.image = Class.create(pimcore.document.tag, {
 
         if (!this.options["thumbnail"]) {
             if(!this.originalDimensions["width"] && !this.originalDimensions["height"]) {
-                path = "/admin/asset/get-image-thumbnail?id=" + this.datax.id + "&width=" + this.element.getWidth()
+                path = "/admin/asset/get-image-thumbnail?width=" + this.element.getWidth()
                     + "&aspectratio=true&" + Ext.urlEncode(this.datax);
             } else if (this.originalDimensions["width"]) {
-                path = "/admin/asset/get-image-thumbnail?id=" + this.datax.id + "&width=" + this.originalDimensions["width"]
+                path = "/admin/asset/get-image-thumbnail?width=" + this.originalDimensions["width"]
                     + "&aspectratio=true&" + Ext.urlEncode(this.datax);
             } else if (this.originalDimensions["height"]) {
-                path = "/admin/asset/get-image-thumbnail?id=" + this.datax.id + "&height="
+                path = "/admin/asset/get-image-thumbnail?height="
                 + this.originalDimensions["height"] + "&aspectratio=true&" + Ext.urlEncode(this.datax);
             }
-        } else {
-            if (typeof this.options.thumbnail == "string") {
-                path = "/admin/asset/get-image-thumbnail?id=" + this.datax.id + "&thumbnail=" + this.options.thumbnail
+        } else if (typeof this.options.thumbnail == "string" || typeof this.options.thumbnail == "object") {
+                path = "/admin/asset/get-image-thumbnail?thumbnail=" + this.options.thumbnail
                     + "&" + Ext.urlEncode(this.datax) + "&pimcore_editmode=1";
-            } else if (typeof this.options.thumbnail === 'object') {
-                path = "/admin/asset/get-image-thumbnail?id=" + this.datax.id + "&"
-                    + Ext.urlEncode(this.options.thumbnail) + "&"
-                    + Ext.urlEncode(this.datax);
-            }
         }
 
         var image = document.createElement("img");


### PR DESCRIPTION
## Changes in this pull request  
Reported in #6279

## Additional info  

> I would like to report just something strange too, id seems duplicated when i inspected the link generated in BO:
https://demo.pimcore.fun/admin/asset/get-image-thumbnail?id=410&thumbnail=standardTeaser&id=410&pimcore_editmode=1
You will notice the id parameter is defined twice.
