### PR TITLE
[Admin] Asset Custom Metadata grid - fix data for rows with same name

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/metadata/grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/metadata/grid.js
@@ -286,10 +286,7 @@ pimcore.asset.metadata.grid = Class.create({
         for (var i = 0; i < rows.length; i++) {
 
             try {
-                var propertyName = Ext.get(rows[i]).query(".x-grid-cell-first div div")[0].getAttribute("name");
-                var storeIndex = this.grid.getStore().findExact("name", propertyName);
-
-                var data = this.grid.getStore().getAt(storeIndex).data;
+                var data = this.grid.getStore().getAt(i).data;
 
                 if(in_array(data.name, this.disallowedKeys)) {
                     Ext.get(rows[i]).addCls("pimcore_properties_hidden_row");


### PR DESCRIPTION
## Changes in this pull request  
Resolves #
Bug fix: If there are metadata rows with same name and different language then onDrop always take the first occurrence in grid.
![divesh pim zone __ Pimcore (1)](https://user-images.githubusercontent.com/5137917/80968339-158ad200-8e18-11ea-94a9-d3a6348d7f03.gif)

## Additional info  

