### PR TITLE
[Documents] add option to hide "add blank document" in documents menu

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
@@ -364,6 +364,7 @@ pimcore.document.tree = Class.create({
 
 
                 var addDocuments = perspectiveCfg.inTreeContextMenu("document.add");
+                var addBlankDocument = perspectiveCfg.inTreeContextMenu("document.addBlankDocument");
                 var addPrintDocuments = perspectiveCfg.inTreeContextMenu("document.addPrintPage");
                 var addEmail = perspectiveCfg.inTreeContextMenu("document.addEmail");
                 var addSnippet = perspectiveCfg.inTreeContextMenu("document.addSnippet");
@@ -384,12 +385,14 @@ pimcore.document.tree = Class.create({
 
                     documentMenu = this.populatePredefinedDocumentTypes(documentMenu, tree, record);
 
-                    // empty page
-                    documentMenu.page.push({
-                        text: "&gt; " + t("blank"),
-                        iconCls: "pimcore_icon_page pimcore_icon_overlay_add",
-                        handler: this.addDocument.bind(this, tree, record, "page")
-                    });
+                    if (addBlankDocument) {
+                        // empty page
+                        documentMenu.page.push({
+                            text: "&gt; " + t("blank"),
+                            iconCls: "pimcore_icon_page pimcore_icon_overlay_add",
+                            handler: this.addDocument.bind(this, tree, record, "page")
+                        });
+                    }
 
                     if (addSnippet) {
                         // empty snippet


### PR DESCRIPTION
## Changes in this pull request  
With this change you can control "add blank document" in document menu to hide it for users. 

## Additional info  
You can add `['treeContextMenu']['document']['items']['addBlankDocument'] => 0` in customviews to hide it for users.