### PR TITLE
[Data objects] Set default value for database column

### DIFF
--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -168,7 +168,7 @@ class Dao extends Model\Dao\AbstractDao
                         } elseif ($value->getColumnType()) {
                             $defaultValue = '';
                             if(method_exists($value, 'getDefaultValue') && $value->getDefaultValue() !== '') {
-                                $defaultValue = 'DEFAULT '.$this->db->quote($value->getDefaultValue());
+                                $defaultValue = ' DEFAULT '.$this->db->quote($value->getDefaultValue());
                             }
                             $this->addModifyColumn($objectDatastoreTable, $key, $value->getColumnType(), $defaultValue, 'NULL');
                             $protectedDatastoreColumns[] = $key;

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -167,7 +167,7 @@ class Dao extends Model\Dao\AbstractDao
                             }
                         } elseif ($value->getColumnType()) {
                             $defaultValue = '';
-                            if(method_exists($value, 'getDefaultValue') && $value->getDefaultValue() !== '') {
+                            if(method_exists($value, 'getDefaultValue') && $value->getDefaultValue() !== null && $value->getDefaultValue() !== '') {
                                 $defaultValue = ' DEFAULT '.$this->db->quote($value->getDefaultValue());
                             }
                             $this->addModifyColumn($objectDatastoreTable, $key, $value->getColumnType(), $defaultValue, 'NULL');

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -166,7 +166,11 @@ class Dao extends Model\Dao\AbstractDao
                                 $protectedDatastoreColumns[] = $key . '__' . $fkey;
                             }
                         } elseif ($value->getColumnType()) {
-                            $this->addModifyColumn($objectDatastoreTable, $key, $value->getColumnType(), '', 'NULL');
+                            $defaultValue = '';
+                            if(method_exists($value, 'getDefaultValue') && $value->getDefaultValue() !== '') {
+                                $defaultValue = 'DEFAULT '.$this->db->quote($value->getDefaultValue());
+                            }
+                            $this->addModifyColumn($objectDatastoreTable, $key, $value->getColumnType(), $defaultValue, 'NULL');
                             $protectedDatastoreColumns[] = $key;
                         }
                     }


### PR DESCRIPTION
Currently data object tables get `NULL` as default value (or more exactly, no default value is specified while the columns allow `NULL` values).
This leads to the problem that when you add a new field with a default value this field is set to `NULL` for all existing objects. #5594 changed this behaviour for newly created objects but for already existing ones the problem still exists. 
Quoted from #4600: 
> By not saving default values to the database a lot of problems arise, e.g. the value does not appear in exports. When you then open the object to check if the value really has not been set, it gets even more confusing because there the default value gets displayed.

This PR is far from being finished, I only want to check other opinions to determine if it is worth to continue.