### PR TITLE
[DataObject] Fix OmitMandatoryCheck for Grids

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1716,7 +1716,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                     }
 
                     $object->setValues($objectData);
-                    if (!isset($data['published']) || !$data['published']) {
+                    if ($object->getPublished() == false) {
                         $object->setOmitMandatoryCheck(true);
                     }
 


### PR DESCRIPTION
## Changes in this pull request  
Related to #6350

## Additional info  

> I have found this line that disables the validation:
https://github.com/pimcore/pimcore/blob/master/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php#L1719
I think instead of || you mean &&?
