### PR TITLE
operator fix

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -2011,7 +2011,7 @@ class DataObjectHelperController extends AdminController
                         if (!isset($mappedFieldnames[$field])) {
                             $mappedFieldnames[$field] = $this->mapFieldname($field, $helperDefinitions);
                         }
-                        $objectData[$field] = $fieldData;
+                        $objectData[$field] = is_array($fieldData) ? $fieldData[0] : $fieldData;
                     }
                 }
                 $objects[] = $objectData;

--- a/lib/DataObject/GridColumnConfig/Value/DefaultValue.php
+++ b/lib/DataObject/GridColumnConfig/Value/DefaultValue.php
@@ -138,12 +138,10 @@ class DefaultValue extends AbstractValue
                 $getter = 'get' . ucfirst($attributeParts[2]);
                 $details = explode('-', $attributeParts[3]);
 
-                $groupId = $this->getGroupByKey($details[1], $element);
-
-                if ($element->$getter()->getLocalizedKeyValue($groupId, $details[1], $this->context['language'], true, true)) {
-                    $result = $this->getDefaultValue($element->$getter()->getLocalizedKeyValue($groupId, $details[1], $this->context['language'], true, true)->__toString());
-                } elseif(empty($result) && $element->$getter()->getLocalizedKeyValue($groupId, $details[1], null, true, true)) {
-                    $result = $this->getDefaultValue($element->$getter()->getLocalizedKeyValue($groupId, $details[1], null, true, true)->__toString());
+                if ($element->$getter()->getLocalizedKeyValue($details[0], $details[1], $this->context['language'], true, true)) {
+                    $result = $this->getDefaultValue($element->$getter()->getLocalizedKeyValue($details[0], $details[1], $this->context['language'], true, true)->__toString());
+                } elseif(empty($result) && $element->$getter()->getLocalizedKeyValue($details[0], $details[1], null, true, true)) {
+                    $result = $this->getDefaultValue($element->$getter()->getLocalizedKeyValue($details[0], $details[1], null, true, true)->__toString());
                 } else {
                     $getter = null;
                 }
@@ -167,17 +165,5 @@ class DefaultValue extends AbstractValue
         }
 
         return $result;
-    }
-
-    private function getGroupByKey(int $keyId, AbstractObject $element): int
-    {
-        $group = reset(Db::get()->query('SELECT groupId' .
-            ' FROM object_classificationstore_data_' . $element->getClassId() .
-            ' classificationData INNER JOIN classificationstore_keys classificationKeys ON (classificationData.keyId = classificationKeys.id)' .
-            ' INNER JOIN classificationstore_groups classificationGroups ON (classificationData.groupId = classificationGroups.id)' .
-            ' WHERE o_id =' . $element->getId() . ' AND classificationData.keyId = ' . $keyId . ' LIMIT 1')
-            ->fetchAll(FetchMode::COLUMN));
-
-        return $group;
     }
 }


### PR DESCRIPTION
When using operators in the grid options and the fieldData is an array the export file only displayed "Array" in the column.