### PR TITLE
[Ecommerce][Indexservice] Utilize transactions for avoiding deadlocks

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
@@ -531,10 +531,9 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
     }
     
     /**
-     * @param string $query
-     * @param null $params
+     * @param \Closure $fn
      * @param int $maxTries
-     * @param int $waitTimeout
+     * @param float $sleep
      * @return bool
      * @throws \Exception
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
@@ -553,5 +553,6 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
                 sleep($sleep);
             }
         }
+        return false;
     }
 }

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
@@ -352,9 +352,13 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
         if (!$currentEntry) {
             $this->db->insert($this->getStoreTableName(), $data);
         } elseif ($currentEntry['crc_current'] != $data['crc_current']) {
-            $this->db->updateWhere($this->getStoreTableName(), $data, 'o_id = ' . $this->db->quote((string)$subObjectId) . ' AND tenant = ' . $this->db->quote($this->name));
+            $this->executeTransactionalQuery(function () use ($data, $subObjectId) {
+                $this->db->updateWhere($this->getStoreTableName(), $data, 'o_id = ' . $this->db->quote((string)$subObjectId) . ' AND tenant = ' . $this->db->quote($this->name));
+            });
         } elseif ($currentEntry['in_preparation_queue']) {
-            $this->db->query('UPDATE ' . $this->getStoreTableName() . ' SET in_preparation_queue = 0, preparation_worker_timestamp = 0, preparation_worker_id = null WHERE o_id = ? AND tenant = ?', [$subObjectId, $this->name]);
+            $this->executeTransactionalQuery(function () use ($subObjectId) {
+                $this->db->query('UPDATE ' . $this->getStoreTableName() . ' SET in_preparation_queue = 0, preparation_worker_timestamp = 0, preparation_worker_id = null WHERE o_id = ? AND tenant = ?', [$subObjectId, $this->name]);
+            });
         }
     }
 
@@ -522,5 +526,31 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
             sprintf('Reset indexing queue in "%s".', $className),
             $this->name
         ]);
+    }
+    
+    /**
+     * @param string $query
+     * @param null $params
+     * @param int $maxTries
+     * @param int $waitTimeout
+     * @return bool
+     * @throws \Exception
+     */
+    protected function executeTransactionalQuery(\Closure $fn, int $maxTries = 3, float $sleep = .5)
+    {
+        $this->db->beginTransaction();
+        for ($i = 1; $i <= $maxTries; $i++) {
+            try {
+                $fn();
+                return $this->db->commit();
+            } catch (\Exception $e) {
+                $this->db->rollBack();
+                Logger::warning("Executing transational query, no. {$i} of {$maxTries} tries failed. " . $e->getMessage());
+                if ($i === $maxTries) {
+                    throw $e;
+                }
+                sleep($sleep);
+            }
+        }
     }
 }

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
@@ -383,8 +383,10 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
             //need check, if there are sub objects because update on empty result set is too slow
             $objects = $this->db->fetchCol('SELECT o_id FROM objects WHERE o_path LIKE ?', [$object->getFullPath() . '/%']);
             if ($objects) {
-                $updateStatement = 'UPDATE ' . $this->getStoreTableName() . ' SET in_preparation_queue = 1 WHERE tenant = ? AND o_id IN ('.implode(',', $objects).')';
-                $this->db->query($updateStatement, [$this->name]);
+                 $this->executeTransactionalQuery(function () use ($objects) {
+                    $updateStatement = 'UPDATE ' . $this->getStoreTableName() . ' SET in_preparation_queue = 1 WHERE tenant = ? AND o_id IN ('.implode(',', $objects).')';
+                    $this->db->query($updateStatement, [$this->name]);
+                });
             }
         }
     }


### PR DESCRIPTION
# Bugfix

Tries to fix #5499 

As discribed in the issue, we experience deadlocks in the store table as well.

This PR adds a method `executeTransactionalQuery` which tries to commit a query for n times (default 3) with a given sleep timeout (default .5 seconds). 
There may be some more places in the worker class(es) where it could help to utilize this method, I added the calls to our pain points only.

The solution is inspired by `AbstractObject::save()` in https://github.com/pimcore/pimcore/blob/master/models/DataObject/AbstractObject.php#L664