### PR TITLE
Removes limitation on password length

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/password.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/password.js
@@ -32,7 +32,6 @@ pimcore.object.tags.password = Class.create(pimcore.object.tags.abstract, {
             name: this.fieldConfig.name,
             componentCls: "object_field",
             inputType: "password",
-            maxLength: 30,
             listeners: {
                 afterrender: function (cmp) {
                     cmp.inputEl.set({
@@ -49,9 +48,6 @@ pimcore.object.tags.password = Class.create(pimcore.object.tags.abstract, {
         } else {
             input.width = 350;
         }
-
-        input.maxLength = 30;
-        input.inputType = "password";
 
         this.component = new Ext.form.TextField(input);
 

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/95_Text_Types.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/95_Text_Types.md
@@ -26,8 +26,7 @@ $object->save();
 The password field is basically the same as the input field with hidden input characters. It's column length can not be 
 changed, since passwords are always hashed using the selected algorithm.  
 
-If a string appears to already be hashed, either by detection by [password_get_info()](https://www.php.net/manual/en/function.password-get-info.php) 
-or if it matches any common hash patterns:
+If a string appears to already be hashed, either by detection by [password_get_info()](https://www.php.net/manual/en/function.password-get-info.php) or if it matches any common hash patterns below, then it will not be hashed again.
 
  - Hexadecimal string
  - with legth of 32, 40, 48, 56, 64, 96, or 128 characters

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/95_Text_Types.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/95_Text_Types.md
@@ -26,15 +26,21 @@ $object->save();
 The password field is basically the same as the input field with hidden input characters. It's column length can not be 
 changed, since passwords are always hashed using the selected algorithm.  
 
-If a string shorter than 32 characters is passed to the setter, it is assumed that it is a plain text password, so 
-Pimcore creates a Hash of that password and stores it in the database.
+If a string appears to already be hashed, either by detection by [password_get_info()](https://www.php.net/manual/en/function.password-get-info.php) 
+or if it matches any common hash patterns:
 
-If a string with 32 characters is passed to the setter, Pimcore assumes that a hash was given and stores the string 
-without further hashing in the database. 
-The maximum length of a plain text password is 30 characters.
+ - Hexadecimal string
+ - with legth of 32, 40, 48, 56, 64, 96, or 128 characters
 
-If `password_hash` is selected as algorithm, Pimcore checks with `password_get_info()` if given string is already 
-hashed - and does so if not. 
+These rules will detect the following hashes:
+ - MD2, MD4, MD5, RIPEMD-128, Snefru 128, Tiger/128, HAVAL128
+ - SHA-1, HAS-160, RIPEMD-160, Tiger/160, HAVAL160
+ - Tiger/192, HAVAL192
+ - SHA-224, HAVAL224
+ - SHA-256, BLAKE-256, GOST, GOST CryptoPro, HAVAL256, RIPEMD-256, Snefru 256
+ - SHA-384
+ - SHA-512, BLAKE-512, SWIFFT
+
 
 We recommend using `password_hash` as algorithm.
  

--- a/models/DataObject/ClassDefinition/Data/Password.php
+++ b/models/DataObject/ClassDefinition/Data/Password.php
@@ -166,11 +166,11 @@ class Password extends Data implements ResourcePersistenceAwareInterface, QueryR
 
         // password_get_info() will not detect older, less secure, hashing algos
         $maybeMD5 = preg_match('/^[a-f0-9]{32}$/', $data);
-        $maybeSHA1 = preg_match("/^([a-f0-9]{40})$/", $data);
-        $maybeSHA224 = preg_match("/^([a-f0-9]{56})$/", $data);
-        $maybeSHA256 = preg_match("/^([a-f0-9]{64})$/", $data);
-        $maybeSHA384 = preg_match("/^([a-f0-9]{96})$/", $data);
-        $maybeSHA512 = preg_match("/^([a-f0-9]{128})$/", $data);
+        $maybeSHA1 = preg_match("/^[a-f0-9]{40}$/", $data);
+        $maybeSHA224 = preg_match("/^[a-f0-9]{56}$/", $data);
+        $maybeSHA256 = preg_match("/^[a-f0-9]{64}$/", $data);
+        $maybeSHA384 = preg_match("/^[a-f0-9]{96}$/", $data);
+        $maybeSHA512 = preg_match("/^[a-f0-9]{128}$/", $data);
 
         // Probably already a hashed string
         if ($maybeMD5 || $maybeSHA1 || $maybeSHA224 || $maybeSHA256 || $maybeSHA384 || $maybeSHA512) {

--- a/models/DataObject/ClassDefinition/Data/Password.php
+++ b/models/DataObject/ClassDefinition/Data/Password.php
@@ -44,14 +44,14 @@ class Password extends Data implements ResourcePersistenceAwareInterface, QueryR
      *
      * @var string
      */
-    public $queryColumnType = 'varchar(190)';
+    public $queryColumnType = 'varchar(255)';
 
     /**
      * Type for the column
      *
      * @var string
      */
-    public $columnType = 'varchar(190)';
+    public $columnType = 'varchar(255)';
 
     /**
      * Type for the generated phpdoc

--- a/models/DataObject/ClassDefinition/Data/Password.php
+++ b/models/DataObject/ClassDefinition/Data/Password.php
@@ -164,16 +164,21 @@ class Password extends Data implements ResourcePersistenceAwareInterface, QueryR
             return $data;
         }
 
-        // password_get_info() will not detect older, less secure, hashing algos
-        $maybeMD5 = preg_match('/^[a-f0-9]{32}$/', $data);
-        $maybeSHA1 = preg_match("/^[a-f0-9]{40}$/", $data);
-        $maybeSHA224 = preg_match("/^[a-f0-9]{56}$/", $data);
-        $maybeSHA256 = preg_match("/^[a-f0-9]{64}$/", $data);
-        $maybeSHA384 = preg_match("/^[a-f0-9]{96}$/", $data);
-        $maybeSHA512 = preg_match("/^[a-f0-9]{128}$/", $data);
+        // password_get_info() will not detect older, less secure, hashing algos.
+        // It might not detect some less common ones as well.
+        $maybeHash = preg_match('/^[a-f0-9]{32,}$/i', $data);
+        $hashLenghts = [
+            32,  // MD2, MD4, MD5, RIPEMD-128, Snefru 128, Tiger/128, HAVAL128
+            40,  // SHA-1, HAS-160, RIPEMD-160, Tiger/160, HAVAL160
+            48,  // Tiger/192, HAVAL192
+            56,  // SHA-224, HAVAL224
+            64,  // SHA-256, BLAKE-256, GOST, GOST CryptoPro, HAVAL256, RIPEMD-256, Snefru 256
+            96,  // SHA-384
+            128, // SHA-512, BLAKE-512, SWIFFT
+        ];
 
-        // Probably already a hashed string
-        if ($maybeMD5 || $maybeSHA1 || $maybeSHA224 || $maybeSHA256 || $maybeSHA384 || $maybeSHA512) {
+        if ($maybeHash && in_array(strlen($data), $hashLenghts, true)) {
+            // Probably already a hashed string
             return $data;
         }
 


### PR DESCRIPTION
It makes no sense to have an upper limit* on password length. Anyway, it was never enforced in the backend if you did a `$account->setPasswordField('somestring');`, only in the UI, and even then it never actually prevented submitting the data.

This PR also removes an unneccesary duplicate declaration of inputType = password.

Hashes which are harder to detect are generally always in the HEX 00 to FF `a-f0-9` character range and of a set length (4 bits per char, e.g. SHA512 = 512/4=128), only checking for >= 32 is too weak and makes very little sense in the world of password managers and diceware passwords.

\* Well, technically maybe a password in the kilobyte range or larger would be uneccesarily large and a [problem in itself](https://arstechnica.com/information-technology/2013/09/long-passwords-are-good-but-too-much-length-can-be-bad-for-security/), but only 32 non-multibyte chars is way too low.