### PR TITLE
[Image / Video thumbnails] Make thumbnail deletion compatible with stream wrappers

### DIFF
--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -317,7 +317,7 @@ EOT;
      */
     public function clearThumbnails($force = false)
     {
-        if ($this->getDataChanged() || $force) {
+        if (($this->getDataChanged() || $force) && is_dir($this->getImageThumbnailSavePath())) {
             $directoryIterator = new \DirectoryIterator($this->getImageThumbnailSavePath());
             $filterIterator = new \CallbackFilterIterator($directoryIterator, function(\SplFileInfo $fileInfo) {
                 return strpos($fileInfo->getFilename(), 'image-thumb__' . $this->getId()) === 0;

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -165,7 +165,7 @@ class Image extends Model\Asset
                         'x' => $Px,
                         'y' => $Py,
                         'width' => $Pw,
-                        'height' => $Ph
+                        'height' => $Ph,
                     ];
                 }
 
@@ -270,7 +270,7 @@ EOT;
 
         $event = new GenericEvent($this, [
             'filesystemPath' => $fsPath,
-            'frontendPath' => $path
+            'frontendPath' => $path,
         ]);
         \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::ASSET_IMAGE_THUMBNAIL, $event);
         $path = $event->getArgument('frontendPath');
@@ -318,9 +318,13 @@ EOT;
     public function clearThumbnails($force = false)
     {
         if ($this->getDataChanged() || $force) {
-            $files = glob($this->getImageThumbnailSavePath() . '/image-thumb__' . $this->getId() . '__*');
-            foreach ($files as $file) {
-                recursiveDelete($file);
+            $directoryIterator = new \DirectoryIterator($this->getImageThumbnailSavePath());
+            $filterIterator = new \CallbackFilterIterator($directoryIterator, function(\SplFileInfo $fileInfo) {
+                return strpos($fileInfo->getFilename(), 'image-thumb__' . $this->getId()) === 0;
+            });
+            /** @var \SplFileInfo $fileInfo */
+            foreach($filterIterator as $fileInfo) {
+                recursiveDelete($fileInfo->getPathname());
             }
         }
     }
@@ -426,7 +430,7 @@ EOT;
             if ($width && $height) {
                 return [
                     'width' => $width,
-                    'height' => $height
+                    'height' => $height,
                 ];
             }
         }
@@ -443,7 +447,7 @@ EOT;
             if ($imageSize && $imageSize[0] && $imageSize[1]) {
                 $dimensions = [
                     'width' => $imageSize[0],
-                    'height' => $imageSize[1]
+                    'height' => $imageSize[1],
                 ];
             }
         }
@@ -458,7 +462,7 @@ EOT;
 
             $dimensions = [
                 'width' => $image->getWidth(),
-                'height' => $image->getHeight()
+                'height' => $image->getHeight(),
             ];
         }
 
@@ -472,7 +476,7 @@ EOT;
                         // flip height & width
                         $dimensions = [
                             'width' => $dimensions['height'],
-                            'height' => $dimensions['width']
+                            'height' => $dimensions['width'],
                         ];
                     }
                 }

--- a/models/Asset/Thumbnail/ClearTempFilesTrait.php
+++ b/models/Asset/Thumbnail/ClearTempFilesTrait.php
@@ -26,17 +26,17 @@ trait ClearTempFilesTrait
 
     protected function recursiveDelete($dir, $thumbnail, &$matches = [])
     {
-        $dirs = glob($dir . '/*', GLOB_ONLYDIR);
-        foreach ($dirs as $dir) {
-            if (
-                preg_match('@/(image|video)\-thumb__[\d]+__' . $thumbnail . '$@', $dir) ||
-                preg_match('@/(image|video)\-thumb__[\d]+__' . $thumbnail . '_auto_@', $dir)
-            ) {
-                recursiveDelete($dir);
-            }
-            $this->recursiveDelete($dir, $thumbnail, $matches);
-        }
+        $directoryIterator = new \DirectoryIterator($dir);
+        $filterIterator = new \CallbackFilterIterator($directoryIterator, function(\SplFileInfo $fileInfo) use ($thumbnail) {
+            return $fileInfo->isDir() && (
+                preg_match('@/(image|video)\-thumb__[\d]+__' . $thumbnail . '$@', $fileInfo->getFilename()) ||
+                preg_match('@/(image|video)\-thumb__[\d]+__' . $thumbnail . '_auto_@', $fileInfo->getFilename())
+            );
+        });
 
-        return $matches;
+        /** @var \SplFileInfo $fileInfo */
+        foreach($filterIterator as $fileInfo) {
+            recursiveDelete($fileInfo->getPathname());
+        }
     }
 }

--- a/models/Asset/Thumbnail/ClearTempFilesTrait.php
+++ b/models/Asset/Thumbnail/ClearTempFilesTrait.php
@@ -26,17 +26,20 @@ trait ClearTempFilesTrait
 
     protected function recursiveDelete($dir, $thumbnail, &$matches = [])
     {
-        $directoryIterator = new \DirectoryIterator($dir);
-        $filterIterator = new \CallbackFilterIterator($directoryIterator, function(\SplFileInfo $fileInfo) use ($thumbnail) {
-            return $fileInfo->isDir() && (
-                preg_match('@/(image|video)\-thumb__[\d]+__' . $thumbnail . '$@', $fileInfo->getFilename()) ||
-                preg_match('@/(image|video)\-thumb__[\d]+__' . $thumbnail . '_auto_@', $fileInfo->getFilename())
-            );
-        });
+        $directoryIterator = new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS);
 
         /** @var \SplFileInfo $fileInfo */
-        foreach($filterIterator as $fileInfo) {
-            recursiveDelete($fileInfo->getPathname());
+        foreach(new \RecursiveIteratorIterator($directoryIterator, \RecursiveIteratorIterator::SELF_FIRST, \RecursiveIteratorIterator::CATCH_GET_CHILD) as $fileInfo) {
+            if($fileInfo->isDir()) {
+                if (
+                    preg_match('@/(image|video)\-thumb__[\d]+__' . $thumbnail . '$@', $fileInfo->getPathname(), $matches) ||
+                    preg_match('@/(image|video)\-thumb__[\d]+__' . $thumbnail . '_auto_@', $fileInfo->getPathname(), $matches)
+                ) {
+                    recursiveDelete($fileInfo->getPathname());
+                }
+            }
         }
+
+        return $matches;
     }
 }

--- a/models/Asset/Video.php
+++ b/models/Asset/Video.php
@@ -96,7 +96,7 @@ class Video extends Model\Asset
 
             $directoryIterator = new \DirectoryIterator($this->getImageThumbnailSavePath());
             $filterIterator = new \CallbackFilterIterator($directoryIterator, function(\SplFileInfo $fileInfo) {
-                return strpos($fileInfo->getFilename(), 'image-thumb__' . $this->getId()) === 0 || strpos($fileInfo->getFilename(), 'video-image-cache__' . $this->getId() . '__thumbnail_');
+                return strpos($fileInfo->getFilename(), 'image-thumb__' . $this->getId()) === 0 || strpos($fileInfo->getFilename(), 'video-image-cache__' . $this->getId() . '__thumbnail_') === 0;
             });
             /** @var \SplFileInfo $fileInfo */
             foreach($filterIterator as $fileInfo) {

--- a/models/Asset/Video.php
+++ b/models/Asset/Video.php
@@ -94,13 +94,22 @@ class Video extends Model\Asset
             // clear the thumbnail custom settings
             $this->setCustomSetting('thumbnails', null);
 
-            $imageFiles = glob($this->getImageThumbnailSavePath() . '/image-thumb__' . $this->getId() . '__*');
-            $videoFiles = glob($this->getVideoThumbnailSavePath() . '/video-thumb__' . $this->getId() . '__*');
-            $imageCacheFiles = glob($this->getImageThumbnailSavePath() . '/video-image-cache__' . $this->getId() . '__thumbnail_*');
+            $directoryIterator = new \DirectoryIterator($this->getImageThumbnailSavePath());
+            $filterIterator = new \CallbackFilterIterator($directoryIterator, function(\SplFileInfo $fileInfo) {
+                return strpos($fileInfo->getFilename(), 'image-thumb__' . $this->getId()) === 0 || strpos($fileInfo->getFilename(), 'video-image-cache__' . $this->getId() . '__thumbnail_');
+            });
+            /** @var \SplFileInfo $fileInfo */
+            foreach($filterIterator as $fileInfo) {
+                recursiveDelete($fileInfo->getPathname());
+            }
 
-            $files = array_merge($imageFiles, $videoFiles, $imageCacheFiles);
-            foreach ($files as $file) {
-                recursiveDelete($file);
+            $directoryIterator = new \DirectoryIterator($this->getVideoThumbnailSavePath());
+            $filterIterator = new \CallbackFilterIterator($directoryIterator, function(\SplFileInfo $fileInfo) {
+                return strpos($fileInfo->getFilename(), 'video-thumb__' . $this->getId()) === 0;
+            });
+            /** @var \SplFileInfo $fileInfo */
+            foreach($filterIterator as $fileInfo) {
+                recursiveDelete($fileInfo->getPathname());
             }
         }
     }


### PR DESCRIPTION
Currently when a thumbnail definition gets saved or when thumbnails get deleted with the "Clear thumbnails" button at an asset, PHP's glob() function gets used to find the thumbnail files to be deleted.
But glob() does not work with stream wrappers (when thumbnails get stored on AWS S3 or Google Cloud Storage like described in https://pimcore.com/docs/6.x/Development_Documentation/Installation_and_Upgrade/System_Setup_and_Hosting/Amazon_AWS_Setup/Amazon_AWS_S3_Setup.html). For this reason thumbnail deletion does not work at all when thumbnails are not stored locally: once a thumbnail for an image has been created there is no way to update it.