### PR TITLE
[Asset] fix download-filename when file extension of Asset is uppercased

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -1151,8 +1151,8 @@ class AssetController extends ElementControllerBase implements EventedController
         if ($thumbnail) {
             $thumbnailFile = $thumbnailFile ?: $thumbnail->getFileSystemPath();
 
-            $downloadFilename = str_replace(
-                '.' . File::getFileExtension($image->getFilename()),
+            $downloadFilename = preg_replace(
+                '/\.' . preg_quote(File::getFileExtension($image->getFilename())) . '/i',
                 '.' . $thumbnail->getFileExtension(),
                 $image->getFilename()
             );

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -148,7 +148,7 @@ class Processor
         }
 
         $thumbDir = $asset->getImageThumbnailSavePath() . '/image-thumb__' . $asset->getId() . '__' . $config->getName();
-        $filename = preg_replace("/\." . preg_quote(File::getFileExtension($asset->getFilename()), '/') . '/', '', $asset->getFilename());
+        $filename = preg_replace("/\." . preg_quote(File::getFileExtension($asset->getFilename()), '/') . '/i', '', $asset->getFilename());
 
         // add custom suffix if available
         if ($config->getFilenameSuffix()) {


### PR DESCRIPTION
## Changes in this pull request

* Modifies Admin/AssetController to replace the Assets file extension with case insensitive regexp
* Modifies Image/Thumbnail/Processer to create tmp files with correct filename by replacing the original file extension with case insensitive regexp

## Steps to reproduce

* Upload an Asset with an uppercased file-extension (e.g. `picture.TIF`)
* Download the "Web-Format" of this Asset

## Expected

* Downloaded file is named `picture.jpeg`

## Actual Behaviour

* Downloaded file is named `picture.tif` 
