### PR TITLE
<fix> Set default value for "handle_pending_payment_strategy"

### DIFF
--- a/bundles/EcommerceFrameworkBundle/DependencyInjection/PimcoreEcommerceFrameworkExtension.php
+++ b/bundles/EcommerceFrameworkBundle/DependencyInjection/PimcoreEcommerceFrameworkExtension.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\CheckoutManager\CheckoutManagerFacto
 use Pimcore\Bundle\EcommerceFrameworkBundle\CheckoutManager\CheckoutManagerFactoryLocatorInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\CheckoutManager\CommitOrderProcessorLocator;
 use Pimcore\Bundle\EcommerceFrameworkBundle\CheckoutManager\CommitOrderProcessorLocatorInterface;
+use Pimcore\Bundle\EcommerceFrameworkBundle\CheckoutManager\V7\HandlePendingPayments\ThrowExceptionStrategy;
 use Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\FilterServiceLocator;
 use Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\FilterServiceLocatorInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Legacy\InterfaceLoader;
@@ -312,6 +313,8 @@ class PimcoreEcommerceFrameworkExtension extends ConfigurableExtension
                 $locatorMapping = [];
                 if ($factoryConfig['handle_pending_payments_strategy']) {
                     $locatorMapping[$factoryConfig['handle_pending_payments_strategy']] = $factoryConfig['handle_pending_payments_strategy'];
+                } else {
+                    $locatorMapping[ThrowExceptionStrategy::class] = ThrowExceptionStrategy::class;
                 }
 
                 $checkoutManagerFactory->setArgument('$options', $factoryConfig);


### PR DESCRIPTION
## Changes in this pull request  
Fixes CheckoutManager bug when using EcommerceFramework V6

## Additional info  
If V6 is still used, and no 'handle_pending_payment_strategy' is set, the
payment strategy Service Locator gets initialised without any locators set.
This causes an exception whenever the CheckoutManager gets initialised, thus
this commit sets a default locator.

