### PR TITLE
[Data objects] Fulltext search for select fields

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/select.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/select.js
@@ -269,6 +269,7 @@ pimcore.object.tags.select = Class.create(pimcore.object.tags.abstract, {
             triggerAction: "all",
             editable: true,
             queryMode: 'local',
+            anyMatch: true,
             autoComplete: false,
             forceSelection: true,
             selectOnFocus: true,


### PR DESCRIPTION
Currently you can filter a select field in a data object's edit panel only be prefix. For example when you have the options `Test` and `My test` and you type `test` in the input field, you will only get `Test` suggested but not `My test`. With this PR the searched string can be anywhere in the option to get suggested.