### PR TITLE
[Documents] Fix get poster thumbnail

### DIFF
--- a/models/Document/Tag/Video.php
+++ b/models/Document/Tag/Video.php
@@ -411,7 +411,7 @@ class Video extends Model\Document\Tag
     {
         $options = $this->getOptions();
         if (!array_key_exists('imagethumbnail', $options) || empty($options['imagethumbnail'])) {
-            $thumbnailConfig = $asset->getThumbnailConfig($options['thumbnail'] ?? null);
+            $thumbnailConfig = $asset->getThumbnailConfig($options['thumbnail'] ?: null);
 
             if ($thumbnailConfig instanceof Asset\Video\Thumbnail\Config) {
                 // try to get the dimensions out ouf the video thumbnail


### PR DESCRIPTION
Follow-up of 810af43a772a96918f62ee2577220ab8bd84dcf1
When using a video area brick with a `imagethumbnail` but without `thumbnail` then currently the thumbnail definition dies not get used.