### PR TITLE
Get Versions by UserId

### DIFF
--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -431,6 +431,26 @@ class Dao extends Model\DataObject\AbstractObject\Dao
 
         return $versions;
     }
+    
+    
+     /**
+     * get versions by userId from database, and assign it to object
+     *
+     * @return Model\Version[]
+     */
+    public function getVersionsByUserId($userId = 0)
+    {
+        $versionIds = $this->db->fetchCol("SELECT id FROM versions WHERE cid = ? AND ctype='object' AND userId = ? ORDER BY `id` ASC", [$this->model->getId(), $userId]);
+
+        $versions = [];
+        foreach ($versionIds as $versionId) {
+            $versions[] = Model\Version::getById($versionId);
+        }
+
+        $this->model->setVersions($versions);
+
+        return $versions;
+    }
 
     /**
      * Get latest available version, using $force always returns a version no matter if it is the same as the published one


### PR DESCRIPTION
there is no way to get version by userid without going to use direct query. we can add this function for filter versions by user-specific.

<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

