### PR TITLE
Fix reference to where the constants are generated now

### DIFF
--- a/stubs/dynamic-constants.php
+++ b/stubs/dynamic-constants.php
@@ -1,9 +1,6 @@
 <?php
 
-// just to have a link to the real constants :)
-require_once '../config/constants.php';
-
-// constants generated in pimcore/config/constants.php
+// constants generated in lib/Bootstrap.php
 define('PIMCORE_COMPOSER_PATH', '');
 define('PIMCORE_COMPOSER_FILE_PATH', '');
 define('PIMCORE_PATH', '');


### PR DESCRIPTION
`pimcore/config/constants.php` doesn't exist anymore, they're generated in `lib/Bootstrap.php` nowadays.