### PR TITLE
Update Listing.php

### DIFF
--- a/bundles/EcommerceFrameworkBundle/OrderManager/Order/Listing.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/Order/Listing.php
@@ -226,7 +226,7 @@ class Listing extends AbstractOrderList implements OrderListInterface
     }
 
     /**
-     * @param int $classId
+     * @param string $classId
      *
      * @return $this
      */

--- a/bundles/EcommerceFrameworkBundle/OrderManager/Order/Listing.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/Order/Listing.php
@@ -236,7 +236,7 @@ class Listing extends AbstractOrderList implements OrderListInterface
 
         if (!array_key_exists('product', $joins)) {
             $this->getQuery()->join(
-                ['product' => 'object_query_' . (int)$classId],
+                ['product' => 'object_query_' . $classId],
                 'product.oo_id = orderItem.product__id',
                 ''
             );


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [ ] Bugfixes need a short guide how to reproduce them. 
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Removed typecasting to INT for the `$classId` in the joinProduct() method in the <a href="https://pimcore.com/docs/api/master/Pimcore/Bundle/EcommerceFrameworkBundle/OrderManager/IOrderList.html">Order List Interface</a>.

## Additional info  

The method classId() in AbstractProduct or any Concrete object should return an INT according to the Pimcore API, ie., for <a href="https://pimcore.com/docs/api/master/Pimcore/Bundle/EcommerceFrameworkBundle/Model/AbstractProduct.html">AbstractProduct</a>.

However, a STRING can be entered as an identifier when creating a class. In this case, a STRING is returned with classId(). And joinProduct() fails.

## To Reproduce
1. Create a class with an identifier that is not an INT, for example "CAR"
2. Call joinProduct():
`$orderManager = Factory::getInstance()->getOrderManager();`
`$orderList = $orderManager->createOrderList();`
`$orderList->joinProduct( ClassFromStep1::classId() );`

This will fail when displaying if the classId() is type casted to an INT.