### PR TITLE
Fix column label loss for the 'Operator Merge' type in object grids

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Merge.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Merge.js
@@ -124,6 +124,7 @@ pimcore.object.gridcolumn.operator.merge = Class.create(pimcore.object.gridcolum
 
     commitData: function(params) {
         this.node.set('isOperator', true);
+        this.node.data.configAttributes.label = this.textField.getValue();
         this.node.data.configAttributes.flatten = this.flattenField.getValue();
         this.node.data.configAttributes.unique = this.uniqueField.getValue();
         this.node.set('text', this.textField.getValue());


### PR DESCRIPTION
This fix solves the issue when you try to add or edit an 'Operator Merge' column with a custom label (other than 'Operator Merge').

The column label was uncorrectly reported in the grid display and in the related CSV export. It displayed 'Operator Merge' whatever you edited for this label in the 'Grid Options' window.
