### PR TITLE
Fix headline in the docs

### DIFF
--- a/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
+++ b/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
@@ -223,7 +223,7 @@ This is a special functionality to allow embedding high resolution (ppi/dpi) ima
 The following is only necessary in special use-cases like Web-to-Print, in typical web-based cases, Pimcore 
 automatically adds the `srcset` attribute to `<img>` and `<picture>` tags automatically, so no manual work is necessary. 
 
-####Use in the Thumbnail Configuration: 
+#### Use in the Thumbnail Configuration: 
 ![High Resolution](../../img/thumbnails3.png)
 The above configuration will generate a thumbnail with 500px width. 
 


### PR DESCRIPTION
Headlines need a space after the `#`'s to be rendered correctly.