### PR TITLE
Fix uncorrect CSV/XLS export for 'Operator Merge' values

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -2075,7 +2075,7 @@ class DataObjectHelperController extends AdminController
                     if ($helperDefinitions[$field]) {
                         $cellValue = DataObject\Service::calculateCellValue($object, $helperDefinitions, $field, ['language' => $requestedLanguage]);
 
-                        //'Operator Merge' management
+                        // Mimic grid concatenation behavior
                         if (is_array($cellValue)) {
                             $cellValue = implode(',', $cellValue);
                         }

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -2073,7 +2073,13 @@ class DataObjectHelperController extends AdminController
                 // check for objects bricks and localized fields
                 if (DataObject\Service::isHelperGridColumnConfig($field)) {
                     if ($helperDefinitions[$field]) {
-                        return DataObject\Service::calculateCellValue($object, $helperDefinitions, $field, ['language' => $requestedLanguage]);
+                        $cellValue = DataObject\Service::calculateCellValue($object, $helperDefinitions, $field, ['language' => $requestedLanguage]);
+
+                        //'Operator Merge' management
+                        if (is_array($cellValue)) {
+                            $cellValue = implode(',', $cellValue);
+                        }
+                        return $cellValue;
                     }
                 } elseif (substr($field, 0, 1) == '~') {
                     $type = $fieldParts[1];


### PR DESCRIPTION
This fix is intented to correct CSV/XLS data export for merged values via the 'Operator Merge' formatter for object grids.

Before:

| Operator Merge   |
|----------|
| Array |
| Array |
| Array |

Now:

| Operator Merge   |
|----------|
| value1,value2 |
| value1,value3 |
| value4 |
