### PR TITLE
[Ecommerce][Elastic Search] Replace reindexing-mode with ES Native Reindexing

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Command/IndexService/EsSyncCommand.php
+++ b/bundles/EcommerceFrameworkBundle/Command/IndexService/EsSyncCommand.php
@@ -71,7 +71,7 @@ class EsSyncCommand extends AbstractIndexServiceCommand
             $output->writeln("<info>Process tenant \"{$tenantName}\" (mode \"{$mode}\")...</info>");
 
             if ('reindex' == $mode) {
-                $elasticWorker->performNativeReindexing();
+                $elasticWorker->startReindexMode();
             }
 
             $bar->advance(1);

--- a/bundles/EcommerceFrameworkBundle/Command/IndexService/EsSyncCommand.php
+++ b/bundles/EcommerceFrameworkBundle/Command/IndexService/EsSyncCommand.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\EcommerceFrameworkBundle\Command\IndexService;
+
+use Pimcore\Bundle\EcommerceFrameworkBundle\Factory;
+use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Worker\ElasticSearch\AbstractElasticSearch;
+use Pimcore\Model\Asset;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\ProgressBar;
+
+class EsSyncCommand extends AbstractIndexServiceCommand
+{
+    /**
+     * @inheritDoc
+     */
+    protected function configure()
+    {
+        parent::configure();
+        $this
+            ->setName('ecommerce:indexservice:elasticsearch-sync')
+            ->setDescription(
+                'Refresh elastic search (ES) index settings, mappings via native ES-API.'
+            )
+            ->addArgument('mode', InputArgument::REQUIRED,
+                'reindex: Reindexes ES indices based on the their native reindexing API. Might be necessary when mapping has changed.'
+            )
+            ->addOption('tenant', null, InputOption::VALUE_OPTIONAL,
+                'If a tenant name is provided (e.g. assortment_de), then only that specific tenant will be synced. '.
+                'Otherwise all tenants will be synced.'
+            )
+        ;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $mode = $input->getArgument('mode');
+        $tenantName = $input->getOption('tenant');
+
+        $indexService = Factory::getInstance()->getIndexService();
+        $tenantList = $tenantName ? [$tenantName] : $indexService->getTenants();
+
+        $bar = new ProgressBar($output, count($tenantList));
+
+        foreach ($tenantList as $tenantName) {
+
+            $elasticWorker = $indexService->getTenantWorker($tenantName); //e.g., 'AT_de_elastic'
+
+            if (!$elasticWorker instanceof AbstractElasticSearch) {
+                $output->writeln("<info>Skipping tenant \"{$tenantName}\" as it's not an elasticsearch tenant.</info>");
+                continue;
+            }
+
+            $output->writeln("<info>Process tenant \"{$tenantName}\" (mode \"{$mode}\")...</info>");
+
+            if ('reindex' == $mode) {
+                $elasticWorker->performNativeReindexing();
+            }
+
+            $bar->advance(1);
+        }
+
+        $bar->finish();
+        return 0;
+    }
+}

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -881,7 +881,7 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
                 throw new \Exception($errorMessage);
             } else {
                 //only write log message once a minute to not spam up log file when running update index
-                if($this->lastLockLogTimestamp > time() + 60) {
+                if($this->lastLockLogTimestamp < time() + 60) {
                     $this->lastLockLogTimestamp = time();
                     Logger::warning($errorMessage . ' (will suppress subsequent log messages of same type for next 60 seconds)');
                 }

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -615,7 +615,7 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
         }
     }
 
-    protected function doCreateOrUpdateIndexStructures($exceptionOnFailure = false)
+    protected function doCreateOrUpdateIndexStructures()
     {
         $this->checkIndexLock(true);
 

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -550,7 +550,7 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
             if (is_array($matches) && count($matches) > 1) {
                 $version = (int)$matches[1];
                 if ($version != $this->indexVersion) {
-                    $indexNameVersion = $this->getIndexNameVersion();
+                    $indexNameVersion = $this->getIndexNameVersion($version);
                     Logger::info('Index-Actions - Delete old Index ' . $indexNameVersion);
                     $this->deleteEsIndexIfExisting($indexNameVersion);
                 }

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -881,7 +881,7 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
                 throw new \Exception($errorMessage);
             } else {
                 //only write log message once a minute to not spam up log file when running update index
-                if($this->lastLockLogTimestamp < time() + 60) {
+                if($this->lastLockLogTimestamp < time() - 60) {
                     $this->lastLockLogTimestamp = time();
                     Logger::warning($errorMessage . ' (will suppress subsequent log messages of same type for next 60 seconds)');
                 }

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -130,9 +130,13 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
             $this->indexVersion = 0;
             $esClient = $this->getElasticSearchClient();
 
-            $stats = $esClient->indices()->stats();
-            foreach ($stats['indices'] as $key => $data) {
-                preg_match('/'.$this->indexName.'-(\d+)/', $key, $matches);
+            $result = $esClient->indices()->getAlias([
+                'name' => $this->indexName
+            ]);
+
+            if(is_array($result)) {
+                $aliasIndexName = array_key_first($result);
+                preg_match('/'.$this->indexName.'-(\d+)/', $aliasIndexName, $matches);
                 if (is_array($matches) && count($matches) > 1) {
                     $version = (int)$matches[1];
                     if ($version > $this->indexVersion) {

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -550,8 +550,9 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
             if (is_array($matches) && count($matches) > 1) {
                 $version = (int)$matches[1];
                 if ($version != $this->indexVersion) {
-                    Logger::info('Index-Actions - Delete old Index ' . $this->indexName.'-'.$version);
-                    $this->deleteEsIndexIfExisting($this->indexName.'-'.$version);
+                    $indexNameVersion = $this->getIndexNameVersion();
+                    Logger::info('Index-Actions - Delete old Index ' . $indexNameVersion);
+                    $this->deleteEsIndexIfExisting($indexNameVersion);
                 }
             }
         }

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -864,7 +864,7 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
     /**
      * @var int
      */
-    protected $lastLockLogTimestamp = null;
+    protected $lastLockLogTimestamp = 0;
 
     /**
      * Verify if the index is currently locked.
@@ -898,6 +898,6 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
 
     protected function releaseIndexLock() {
         Lock::release(self::REINDEXING_LOCK_KEY);
-        $this->lastLockLogTimestamp = null;
+        $this->lastLockLogTimestamp = 0;
     }
 }

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -855,7 +855,7 @@ abstract class AbstractElasticSearch extends Worker\AbstractMockupCacheWorker im
             $this->updateVersionFile();
 
         } finally {
-//            $this->releaseIndexLock();
+            $this->releaseIndexLock();
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,7 @@
     "phpstan/phpstan-symfony": "^0.12",
     "heidelpay/heidelpay-php": "^1.2.5.1",
     "klarna/checkout": "^3.0.0",
-    "elasticsearch/elasticsearch": "2.0.0",
+    "elasticsearch/elasticsearch": "^6",
     "paypal/paypal-checkout-sdk": "^1",
     "mpay24/mpay24-php": "^4.2",
     "composer/composer": "*"

--- a/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/07_Elastic_Search/README.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/07_Elastic_Search/README.md
@@ -11,13 +11,17 @@ See [Configuration Details](01_Configuration_Details.md) for more information.
 
 ## Reindexing Mode
 It is possible that Elastic Search cannot update the mapping, e.g. if data types of attributes change on the fly. 
-For this case, a reindex is necessary. If it is necessary, the E-Commerce Framework automatically switches into a 
-reindex mode. When in reindex mode, all queries go to the current index but in parallel a new index is created based 
-on the data in the store table. The current index is read only and all data changes that take place go directly into 
-the new index. As a result, during reindex the results delivered by Product Lists can contain old data. 
- 
-As soon the reindex is finished, the current index is switched to the newly created index and the old index is deleted.  
+For this case, a reindex is necessary. If it is necessary, a native ES reindex is executed automatically during
+`bin/console ecommerce:indexservice:bootstrap --create-or-update-index-structure`.
 
+While reindex is executed, no updates are written to the ES index. The changes remain in store table and are transferred
+to index during next execution of `bin/console ecommerce:indexservice:process-queue update-index` after reindex is finished. 
+
+All queries that take place during reindex go to the old index. As soon the reindex is finished, the current index is switched 
+to the newly created index and the old index is deleted.  
+As a result, during reindex the results delivered by Product Lists can contain old data. 
+
+To manually start a reindex, following command can be used: `bin/console ecommerce:indexservice:elasticsearch-sync reindex`. 
 
 ## Indexing of Classification Store Attributes
 


### PR DESCRIPTION
this is an alternative implementation to #5744 for the reindexing part. 

Removes ecommerce framework reindexing mode completely and forces user to start ES native reindex when mapping update is not possible. 

During ES native reindex
- any other mapping updates are not possible
- data updates are only updated in store table and updated via process update queue to ES index after reindex is finished 

Thus it would reduce complexity. 

Open question: 
- does ES serve requests from old index while building the new one? 
- what to do with delete operations when reindex is running? 
