### PR TITLE
Fix on object variant grid: batch edit for 'select' fields + batch edit all with selected items

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -375,17 +375,17 @@ pimcore.element.helpers.gridColumnConfig = {
             for (var i = 0; i < selectedRows.length; i++) {
                 jobs.push(selectedRows[i].get("id"));
             }
-            this.batchOpen(columnIndex, jobs, append, remove, true);
+            this.batchOpen(columnIndex, jobs, append, remove, onlySelected);
 
         } else {
-            let params = this.getGridParams();
+            let params = this.getGridParams(onlySelected);
             Ext.Ajax.request({
                 url: this.batchPrepareUrl,
                 params: params,
                 success: function (columnIndex, response) {
                     var rdata = Ext.decode(response.responseText);
                     if (rdata.success && rdata.jobs) {
-                        this.batchOpen(columnIndex, rdata.jobs, append, remove, false);
+                        this.batchOpen(columnIndex, rdata.jobs, append, remove, onlySelected);
                     }
 
                 }.bind(this, columnIndex)
@@ -414,7 +414,7 @@ pimcore.element.helpers.gridColumnConfig = {
         }
         // HACK END
 
-        if(this.objecttype == "object") {
+        if((this.objecttype === "object") || (this.objecttype === "variant")) {
             if (!fieldInfo.layout || !fieldInfo.layout.layout) {
                 return;
             }
@@ -692,7 +692,7 @@ pimcore.element.helpers.gridColumnConfig = {
         this.buildColumnConfigMenu();
     },
 
-    getGridParams: function () {
+    getGridParams: function (onlySelected) {
         var filters = "";
         var condition = "";
         var searchQuery = this.searchField ? this.searchField.getValue() : "";
@@ -720,15 +720,17 @@ pimcore.element.helpers.gridColumnConfig = {
             params["query"] = searchQuery;
         }
 
-        //create the ids array which contains chosen rows to export
-        ids = [];
-        var selectedRows = this.grid.getSelectionModel().getSelection();
-        for (var i = 0; i < selectedRows.length; i++) {
-            ids.push(selectedRows[i].data.id);
-        }
+        if (onlySelected !== false) {
+            //create the ids array which contains chosen rows to export
+            ids = [];
+            var selectedRows = this.grid.getSelectionModel().getSelection();
+            for (var i = 0; i < selectedRows.length; i++) {
+                ids.push(selectedRows[i].data.id);
+            }
 
-        if (ids.length > 0) {
-            params["ids[]"] = ids;
+            if (ids.length > 0) {
+                params["ids[]"] = ids;
+            }
         }
 
         //tags filter


### PR DESCRIPTION
This PR fixes two issues in the object variant grid:

1/ broken batch edit for 'select' fields: the code worked for the object type 'object', not 'variant', so the select options were not populated in the batch edit popup,
2/ broken 'batch edit all' when some lines were selected in the grid.
