### PR TITLE
Batch processes performance

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1795,7 +1795,7 @@ class DataObjectHelperController extends AdminController
 
         $ids = $list->loadIdList();
 
-        $jobs = array_chunk($ids, 100);
+        $jobs = array_chunk($ids, 20);
 
         $fileHandle = uniqid('export-');
         file_put_contents($this->getCsvFile($fileHandle), '');

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1795,7 +1795,7 @@ class DataObjectHelperController extends AdminController
 
         $ids = $list->loadIdList();
 
-        $jobs = array_chunk($ids, 20);
+        $jobs = array_chunk($ids, 100);
 
         $fileHandle = uniqid('export-');
         file_put_contents($this->getCsvFile($fileHandle), '');

--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -15,6 +15,8 @@
 pimcore.registerNS("pimcore.element.helpers.gridColumnConfig");
 pimcore.element.helpers.gridColumnConfig = {
 
+    batchJobDelay: 50,
+
     getSaveAsDialog: function () {
         var defaultName = new Date();
 
@@ -576,7 +578,7 @@ pimcore.element.helpers.gridColumnConfig = {
                 window.setTimeout(function () {
                     this.batchJobCurrent++;
                     this.batchProcess(jobs, append, remove);
-                }.bind(this), 400);
+                }.bind(this), this.batchJobDelay);
             }.bind(this, jobs, this.batchParameters.job)
         });
     },
@@ -681,7 +683,7 @@ pimcore.element.helpers.gridColumnConfig = {
                 window.setTimeout(function () {
                     this.exportJobCurrent++;
                     this.exportProcess(jobs, fileHandle, fields, false, settings, exportType);
-                }.bind(this), 400);
+                }.bind(this), this.batchJobDelay);
             }.bind(this, jobs, jobs[this.exportJobCurrent])
         });
     },


### PR DESCRIPTION
Hi, I would like to discuss and improve the performance of batch processes and exports. I think it would be best if we discuss this using examples, that's why it is a PR not an issue.

In this PR I found two places that influence performance:
- size of the chunks that are being exported in a single request - currently set to 20, I've raised it to 100, gaining great general performance boost with the cost of longer requests
- the delay between requests - I reduced it from 400 to 50ms. I guess its purpose is to not overload backend or frontend of the application but in most cases, it is the main factor of the processing time.

## Changes in this pull request  
Bigger chunks in export.
Lower the delay between batch processes.

## Possible further improvements
- implement working in chunks in batch processing, similar to the export
- work on the list of ids in the backend, so the list of ids wouldn't have to be sent between frontend and the backend; this would have additional pros: possibility to resume job, the backend could decide dynamically how many jobs it should handle (e.g. 5 seconds instead of 20 jobs), jobs could be processed in the background