### PR TITLE
Parallelization of thumbnail commands

### DIFF
--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -16,15 +16,24 @@ namespace Pimcore\Bundle\CoreBundle\Command;
 
 use Pimcore\Console\AbstractCommand;
 use Pimcore\Model\Asset;
-use Symfony\Component\Console\Helper\ProgressBar;
+use Pimcore\Model\Asset\Image;
+use Symfony\Component\Console\Command\LockableTrait;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Webmozarts\Console\Parallelization\Parallelization;
+
 
 class ThumbnailsImageCommand extends AbstractCommand
 {
+    use Parallelization;
+    use LockableTrait;
+
     protected function configure()
     {
+        parent::configure();
+        self::configureParallelization($this);
+
         $this
             ->setName('pimcore:thumbnails:image')
             ->setAliases(['thumbnails:image'])
@@ -74,10 +83,100 @@ class ThumbnailsImageCommand extends AbstractCommand
             );
     }
 
+    protected function runBeforeFirstCommand(InputInterface $input, OutputInterface $output): void
+    {
+        if (!$this->lock()) {
+            $this->writeError('The command is already running.');
+            exit(1);
+        }
+    }
+
+    protected function fetchItems(InputInterface $input): array
+    {
+        // get only images
+        $conditions = ["type = 'image'"];
+
+        if ($input->getOption('parent')) {
+            $parent = Asset::getById($input->getOption('parent'));
+            if ($parent instanceof Asset\Folder) {
+                $conditions[] = "path LIKE '".$parent->getRealFullPath()."/%'";
+            } else {
+                $this->writeError($input->getOption('parent').' is not a valid asset folder ID!');
+                exit(1);
+            }
+        }
+
+        if ($ids = $input->getOption('id')) {
+            $conditions[] = sprintf('id in (%s)', implode(',', $ids));
+        }
+
+        $list = new Asset\Listing();
+        $list->setCondition(implode(' AND ', $conditions));
+
+        return $list->loadIdList();
+    }
+
+    protected function runSingleCommand(string $assetId, InputInterface $input, OutputInterface $output): void
+    {
+        $image = Image::getById($assetId);
+        if (!$image) {
+            $this->writeError('No image with ID=' . $assetId . ' found. Has the image been deleted or is the asset of another type?</error>');
+            return;
+        }
+
+        $thumbnailsToGenerate = $this->fetchThumbnailConfigs($input);
+
+        if ($input->getOption('force')) {
+
+            $thumbnailConfigNames = array_unique(
+                array_map(function($thumbnailConfig) {
+                    return $thumbnailConfig->getName();
+                }, $thumbnailsToGenerate)
+            );
+
+            foreach ($thumbnailConfigNames as $thumbnailConfigName) {
+                $image->clearThumbnail($thumbnailConfigName);
+            }
+        }
+
+        foreach ($thumbnailsToGenerate as $thumbnailConfig) {
+            $thumbnail = $image->getThumbnail($thumbnailConfig);
+            $path = $thumbnail->getPath(false);
+
+            if ($output->isVeryVerbose()) {
+                $output->writeln(
+                    sprintf(
+                        'generated thumbnail for image [%d] | file: %s',
+                        $image->getId(),
+                        $path
+                    )
+                );
+            }
+        }
+
+    }
+
+    protected function runAfterBatch(InputInterface $input, OutputInterface $output, array $items): void
+    {
+        if ($this->input->getOption('processes') <= 1) {
+            if ($output->isVeryVerbose()) {
+                $output->writeln('Collect garbage.');
+            }
+            \Pimcore::collectGarbage();
+        }
+    }
+
+    protected function runAfterLastCommand(InputInterface $input, OutputInterface $output): void
+    {
+        $this->release(); //release the lock
+    }
+
     /**
-     * @inheritDoc
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return Asset\Image\Thumbnail\Config[]
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function fetchThumbnailConfigs(InputInterface $input, OutputInterface $output) : array
     {
         $list = new Asset\Image\Thumbnail\Config\Listing();
         $thumbnailConfigList = $list->getThumbnails();
@@ -134,79 +233,16 @@ class ThumbnailsImageCommand extends AbstractCommand
             $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig();
         }
 
-        $thumbnailConfigNames = [];
-        foreach ($thumbnailsToGenerate as $thumbnailConfig) {
-            $thumbnailConfigNames[] = $thumbnailConfig->getName();
-        }
-        $thumbnailConfigNames = array_unique($thumbnailConfigNames);
+        return $thumbnailsToGenerate;
+    }
 
-        // get only images
-        $conditions = ["type = 'image'"];
+    protected function getItemName(int $count): string
+    {
+        return $count <= 1 ? 'Image' : 'Images';
+    }
 
-        if ($input->getOption('parent')) {
-            $parent = Asset::getById($input->getOption('parent'));
-            if ($parent instanceof Asset\Folder) {
-                $conditions[] = "path LIKE '".$parent->getRealFullPath()."/%'";
-            } else {
-                $this->writeError($input->getOption('parent').' is not a valid asset folder ID!');
-                exit;
-            }
-        }
-
-        if ($ids = $input->getOption('id')) {
-            $conditions[] = sprintf('id in (%s)', implode(',', $ids));
-        }
-
-        $list = new Asset\Listing();
-        $list->setCondition(implode(' AND ', $conditions));
-        $total = $list->getTotalCount();
-        $perLoop = 10;
-
-        $totalToGenerate = $total * count($thumbnailsToGenerate);
-
-        $progress = new ProgressBar($output, $totalToGenerate);
-        $progress->setFormat(
-            ' %current%/%max% [%bar%] %percent:3s%% (%elapsed:6s%/%estimated:-6s%) %memory:6s%: %message%'
-        );
-        $progress->start();
-
-        for ($i = 0; $i < (ceil($total / $perLoop)); $i++) {
-            $list->setLimit($perLoop);
-            $list->setOffset($i * $perLoop);
-            $images = $list->load();
-
-            foreach ($images as $image) {
-                if (!$image instanceof Asset\Image) {
-                    continue;
-                }
-
-                if ($input->getOption('force')) {
-                    foreach ($thumbnailConfigNames as $thumbnailConfigName) {
-                        $image->clearThumbnail($thumbnailConfigName);
-                    }
-                }
-
-                foreach ($thumbnailsToGenerate as $thumbnailConfig) {
-                    $thumbnail = $image->getThumbnail($thumbnailConfig);
-
-                    $progress->setMessage(
-                        sprintf(
-                            'generated thumbnail for image [%d] | file: %s',
-                            $image->getId(),
-                            $thumbnail->getPath(false)
-                        )
-                    );
-
-                    $progress->advance(1);
-                }
-            }
-            \Pimcore::collectGarbage();
-        }
-
-        $progress->finish();
-
-        $output->writeln('');
-
-        return 0;
+    protected function getContainer()
+    {
+        return \Pimcore::getKernel()->getContainer();
     }
 }

--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -132,7 +132,7 @@ class ThumbnailsImageCommand extends AbstractCommand
             $thumbnail = $image->getThumbnail($thumbnailConfig);
             $path = $thumbnail->getPath(false);
 
-            if ($output->isVeryVerbose()) {
+            if ($output->isVerbose()) {
                 $output->writeln(
                     sprintf(
                         'generated thumbnail for image [%d] | file: %s',

--- a/bundles/CoreBundle/Command/ThumbnailsVideoCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsVideoCommand.php
@@ -92,7 +92,7 @@ class ThumbnailsVideoCommand extends AbstractCommand
         $thumbnails = [];
 
         $list = new Asset\Video\Thumbnail\Config\Listing();
-        $items = $list->load();
+        $items = $list->getThumbnails();
 
         foreach ($items as $item) {
             $thumbnails[] = $item->getName();
@@ -121,8 +121,8 @@ class ThumbnailsVideoCommand extends AbstractCommand
     }
 
     /**
-     * @param $videoId
-     * @param $thumbnail
+     * @param int $videoId
+     * @param string $thumbnail
      */
     protected function waitTillFinished($videoId, $thumbnail)
     {

--- a/bundles/CoreBundle/Command/ThumbnailsVideoCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsVideoCommand.php
@@ -15,6 +15,7 @@
 namespace Pimcore\Bundle\CoreBundle\Command;
 
 use Pimcore\Console\AbstractCommand;
+use Pimcore\Console\Traits\Parallelization;
 use Pimcore\Logger;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Version;
@@ -24,8 +25,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ThumbnailsVideoCommand extends AbstractCommand
 {
+    use Parallelization;
+
     protected function configure()
     {
+        parent::configure();
+        self::configureParallelization($this);
+
         $this
             ->setName('pimcore:thumbnails:video')
             ->setAliases(['thumbnails:video'])
@@ -49,19 +55,44 @@ class ThumbnailsVideoCommand extends AbstractCommand
             );
     }
 
-    /**
-     * @inheritDoc
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function fetchItems(InputInterface $input): array
+    {
+        // get only videos
+        $conditions = ["type = 'video'"];
+
+        if ($input->getOption('parent')) {
+            $parent = Asset::getById($input->getOption('parent'));
+            if ($parent instanceof Asset\Folder) {
+                $conditions[] = "path LIKE '" . $parent->getRealFullPath() . "/%'";
+            } else {
+                $this->writeError($input->getOption('parent') . ' is not a valid asset folder ID!');
+                exit(1);
+            }
+        }
+
+        $list = new Asset\Listing();
+        $list->setCondition(implode(' AND ', $conditions));
+        $total = $list->getTotalCount();
+
+        return $list->loadIdList();
+    }
+
+    protected function runSingleCommand(string $assetId, InputInterface $input, OutputInterface $output): void
     {
         // disable versioning
         Version::disable();
+
+        $video = Asset\Video::getById($assetId);
+        if (!$video) {
+            $this->writeError('No video with ID=' . $assetId . ' found. Has the video been deleted or is the asset of another type?</error>');
+            return;
+        }
 
         // get all thumbnails
         $thumbnails = [];
 
         $list = new Asset\Video\Thumbnail\Config\Listing();
-        $items = $list->getThumbnails();
+        $items = $list->load();
 
         foreach ($items as $item) {
             $thumbnails[] = $item->getName();
@@ -72,53 +103,26 @@ class ThumbnailsVideoCommand extends AbstractCommand
             $allowedThumbs = explode(',', $input->getOption('thumbnails'));
         }
 
-        // get only images
-        $conditions = ["type = 'video'"];
-
-        if ($input->getOption('parent')) {
-            $parent = Asset::getById($input->getOption('parent'));
-            if ($parent instanceof Asset\Folder) {
-                $conditions[] = "path LIKE '" . $parent->getRealFullPath() . "/%'";
-            } else {
-                $this->writeError($input->getOption('parent') . ' is not a valid asset folder ID!');
-                exit;
+        foreach ($thumbnails as $thumbnail) {
+            if ((empty($allowedThumbs) && !$input->getOption('system')) || in_array($thumbnail, $allowedThumbs)) {
+                $this->output->writeln('generating thumbnail for video: ' . $video->getRealFullPath() . ' | ' . $video->getId() . ' | Thumbnail: ' . $thumbnail . ' : ' . formatBytes(memory_get_usage()));
+                $video->getThumbnail($thumbnail);
+                $this->waitTillFinished($video->getId(), $thumbnail);
             }
         }
 
-        $list = new Asset\Listing();
-        $list->setCondition(implode(' AND ', $conditions));
-        $total = $list->getTotalCount();
-        $perLoop = 10;
-
-        for ($i = 0; $i < (ceil($total / $perLoop)); $i++) {
-            $list->setLimit($perLoop);
-            $list->setOffset($i * $perLoop);
-            $videos = $list->load();
-
-            foreach ($videos as $video) {
-                foreach ($thumbnails as $thumbnail) {
-                    if ((empty($allowedThumbs) && !$input->getOption('system')) || in_array($thumbnail, $allowedThumbs)) {
-                        $this->output->writeln('generating thumbnail for video: ' . $video->getRealFullPath() . ' | ' . $video->getId() . ' | Thumbnail: ' . $thumbnail . ' : ' . formatBytes(memory_get_usage()));
-                        $video->getThumbnail($thumbnail);
-                        $this->waitTillFinished($video->getId(), $thumbnail);
-                    }
-                }
-
-                if ($input->getOption('system')) {
-                    $this->output->writeln('generating thumbnail for video: ' . $video->getRealFullPath() . ' | ' . $video->getId() . ' | Thumbnail: System Preview : ' . formatBytes(memory_get_usage()));
-                    $thumbnail = Asset\Video\Thumbnail\Config::getPreviewConfig();
-                    $video->getThumbnail($thumbnail);
-                    $this->waitTillFinished($video->getId(), $thumbnail);
-                }
-            }
+        if ($input->getOption('system')) {
+            $this->output->writeln('generating thumbnail for video: ' . $video->getRealFullPath() . ' | ' . $video->getId() . ' | Thumbnail: System Preview : ' . formatBytes(memory_get_usage()));
+            $thumbnail = Asset\Video\Thumbnail\Config::getPreviewConfig();
+            $video->getThumbnail($thumbnail);
+            $this->waitTillFinished($video->getId(), $thumbnail);
         }
 
-        return 0;
     }
 
     /**
-     * @param int $videoId
-     * @param string $thumbnail
+     * @param $videoId
+     * @param $thumbnail
      */
     protected function waitTillFinished($videoId, $thumbnail)
     {
@@ -148,5 +152,10 @@ class ThumbnailsVideoCommand extends AbstractCommand
                 break;
             }
         }
+    }
+
+    protected function getItemName(int $count): string
+    {
+        return $count == 1 ? 'video' : 'videos';
     }
 }

--- a/bundles/CoreBundle/Command/ThumbnailsVideoCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsVideoCommand.php
@@ -105,7 +105,7 @@ class ThumbnailsVideoCommand extends AbstractCommand
 
         foreach ($thumbnails as $thumbnail) {
             if ((empty($allowedThumbs) && !$input->getOption('system')) || in_array($thumbnail, $allowedThumbs)) {
-                if ($output->isVeryVerbose()) {
+                if ($output->isVerbose()) {
                     $this->output->writeln('generating thumbnail for video: ' . $video->getRealFullPath() . ' | ' . $video->getId() . ' | Thumbnail: ' . $thumbnail . ' : ' . formatBytes(memory_get_usage()));
                 }
                 $video->getThumbnail($thumbnail);

--- a/bundles/CoreBundle/Command/ThumbnailsVideoCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsVideoCommand.php
@@ -114,7 +114,9 @@ class ThumbnailsVideoCommand extends AbstractCommand
         }
 
         if ($input->getOption('system')) {
-            $this->output->writeln('generating thumbnail for video: ' . $video->getRealFullPath() . ' | ' . $video->getId() . ' | Thumbnail: System Preview : ' . formatBytes(memory_get_usage()));
+            if ($output->isVerbose()) {
+                $this->output->writeln('generating thumbnail for video: ' . $video->getRealFullPath() . ' | ' . $video->getId() . ' | Thumbnail: System Preview : ' . formatBytes(memory_get_usage()));
+            }
             $thumbnail = Asset\Video\Thumbnail\Config::getPreviewConfig();
             $video->getThumbnail($thumbnail);
             $this->waitTillFinished($video->getId(), $thumbnail);

--- a/bundles/CoreBundle/Command/ThumbnailsVideoCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsVideoCommand.php
@@ -105,7 +105,9 @@ class ThumbnailsVideoCommand extends AbstractCommand
 
         foreach ($thumbnails as $thumbnail) {
             if ((empty($allowedThumbs) && !$input->getOption('system')) || in_array($thumbnail, $allowedThumbs)) {
-                $this->output->writeln('generating thumbnail for video: ' . $video->getRealFullPath() . ' | ' . $video->getId() . ' | Thumbnail: ' . $thumbnail . ' : ' . formatBytes(memory_get_usage()));
+                if ($output->isVeryVerbose()) {
+                    $this->output->writeln('generating thumbnail for video: ' . $video->getRealFullPath() . ' | ' . $video->getId() . ' | Thumbnail: ' . $thumbnail . ' : ' . formatBytes(memory_get_usage()));
+                }
                 $video->getThumbnail($thumbnail);
                 $this->waitTillFinished($video->getId(), $thumbnail);
             }

--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,8 @@
     "zendframework/zend-servicemanager": "^3.2",
     "scheb/two-factor-bundle": "^3.26",
     "phpoffice/phpspreadsheet": "^1.9",
-    "html2text/html2text": "^4.2.1"
+    "html2text/html2text": "^4.2.1",
+    "webmozarts/console-parallelization": "1.0.0-RC7"
   },
   "conflict": {
     "monolog/monolog": ">=2"

--- a/doc/Development_Documentation/21_Deployment/05_Deployment_Tools.md
+++ b/doc/Development_Documentation/21_Deployment/05_Deployment_Tools.md
@@ -65,9 +65,9 @@ To get a list of all available commands use `./bin/console list`.
 | pimcore:definition:import:fieldcollection            | Import FieldCollection definition from a JSON export                                            |
 | pimcore:definition:import:objectbrick                | Import ObjectBrick definition from a JSON export                                                |
 | pimcore:deployment:classes-rebuild                   | Rebuilds classes and db structure based on updated `var/classes/definition_*.php` files |
-| pimcore:thumbnails:image                             | Generate image thumbnails, useful to pre-generate thumbnails in the background                  |
+| pimcore:thumbnails:image                             | Generate image thumbnails, useful to pre-generate thumbnails in the background. Use `--processes` option for parallel processing.                   |
 | pimcore:thumbnails:optimize-images                   | Optimize file size of all images in `web/var/tmp`                       |
-| pimcore:thumbnails:video                             | Generate video thumbnails, useful to pre-generate thumbnails in the background                  |
+| pimcore:thumbnails:video                             | Generate video thumbnails, useful to pre-generate thumbnails in the background. Use `--processes` option for parallel processing.                   |
 
 Find more about the Pimcore Console on the [dedicated page](../19_Development_Tools_and_Details/11_Console_CLI.md).
 

--- a/lib/Console/Traits/Parallelization.php
+++ b/lib/Console/Traits/Parallelization.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Console\Traits;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Input\Input;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Webmozarts\Console\Parallelization\Parallelization as WebmozartParallelization;
+
+trait Parallelization
+{
+    use LockableTrait;
+    
+    use WebmozartParallelization
+    {
+        WebmozartParallelization::configureParallelization as parentConfigureParallelization;
+    }
+
+    protected static function configureParallelization(Command $command): void
+    {
+        $command
+            ->addArgument(
+                'item',
+                InputArgument::OPTIONAL,
+                'The item to process'
+            )
+            ->addOption(
+                'processes',
+                null,
+                //'p', avoid collisions with already existing Pimcore command options
+                InputOption::VALUE_OPTIONAL,
+                'The number of parallel processes to run',
+                1
+            )
+            ->addOption(
+                'child',
+                null,
+                InputOption::VALUE_NONE,
+                'Set on child processes'
+            )
+        ;
+    }
+
+    /**
+     * Default behavior in commands: only allow one command of a type at the same time.
+     */
+    protected function runBeforeFirstCommand(InputInterface $input, OutputInterface $output): void
+    {
+        if (!$this->lock()) {
+            $this->writeError('The command is already running.');
+            exit(1);
+        }
+    }
+
+    /**
+     * Default behavior in commands: clean up garbage after each batch run, if there is only
+     * one master process in place.
+     * @param array $items
+     */
+    protected function runAfterBatch(InputInterface $input, OutputInterface $output, array $items): void
+    {
+        if ($this->input->getOption('processes') <= 1) {
+            if ($output->isVeryVerbose()) {
+                $output->writeln('Collect garbage.');
+            }
+            \Pimcore::collectGarbage();
+        }
+    }
+
+    /**
+     * Default behavior in commands: release lock on termination.
+     */
+    protected function runAfterLastCommand(InputInterface $input, OutputInterface $output): void
+    {
+        $this->release(); //release the lock
+    }
+
+    protected function getItemName(int $count): string
+    {
+        return $count <= 1 ? 'item' : 'items';
+    }
+
+    /**
+     * @return \Symfony\Component\DependencyInjection\ContainerInterface|null
+     */
+    protected function getContainer()
+    {
+        return \Pimcore::getKernel()->getContainer();
+    }
+
+}

--- a/lib/Console/Traits/Parallelization.php
+++ b/lib/Console/Traits/Parallelization.php
@@ -75,7 +75,7 @@ trait Parallelization
      */
     protected function runAfterBatch(InputInterface $input, OutputInterface $output, array $items): void
     {
-        if ($this->input->getOption('processes') <= 1) {
+        if ((int)$this->input->getOption('processes') <= 1) {
             if ($output->isVeryVerbose()) {
                 $output->writeln('Collect garbage.');
             }

--- a/lib/Console/Traits/Parallelization.php
+++ b/lib/Console/Traits/Parallelization.php
@@ -16,7 +16,6 @@ namespace Pimcore\Console\Traits;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LockableTrait;
-use Symfony\Component\Console\Input\Input;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -38,7 +37,7 @@ trait Parallelization
             ->addArgument(
                 'item',
                 InputArgument::OPTIONAL,
-                'The item to process'
+                'The item to process. Can be used in commands where simple IDs are processed. Otherwise it is for internal use.'
             )
             ->addOption(
                 'processes',
@@ -52,7 +51,7 @@ trait Parallelization
                 'child',
                 null,
                 InputOption::VALUE_NONE,
-                'Set on child processes'
+                'Set on child processes. For internal use only.'
             )
         ;
     }


### PR DESCRIPTION
This PR enables the parallel generation of thumbnails based on their generator commands.

It includes a demonstration of the auspicious [ParallelizationTrait](https://github.com/webmozarts/console-parallelization) which has been extended to fit into Pimcore.

**Parallelization usage in general:**
```php
 # example 1: start the generation command in the same way as before:
bin/console pimcore:thumbnails:image

 # example 2: start the generation command with one child (=equivalent to example 1)
bin/console pimcore:thumbnails:image --processes 1

# example 3: start a master process with 5 concurrent child processes:
bin/console pimcore:thumbnails:image --processes 5
```

**Usage image generation command:**
```php
bin/console pimcore:thumbnails:image
bin/console pimcore:thumbnails:image --processes 1
bin/console pimcore:thumbnails:image --processes 5
bin/console pimcore:thumbnails:image --processes 20
```

**Usage video generation command:**
```php
bin/console pimcore:thumbnails:video
bin/console pimcore:thumbnails:video --processes 1
bin/console pimcore:thumbnails:video --processes 5
bin/console pimcore:thumbnails:video --processes 20
```

**Advantages of the approach**
1. The time for the generation of thumbnails is significantly recduced. Thumbnail generation processes sometimes run for several days. By executing several parallel children processes the execution time may be reduced to less than 20%.
2. No need for the developer to handle the execution of multiple parallel commands: the solution handles locking and child process termination by itself.
3. Multiple commands become a bit more structured and can be unified.

**Notes**
 - https://github.com/webmozarts/console-parallelization is still a release candidate. Befor merging the PR, we should ask for an official release.
 - This is meant to be a blueprint. Many other Pimcore commands could be parallelized in the same way.