### PR TITLE
[Tracking] fix quantity for trackCartProductActionAdd

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Tracking/Tracker/GoogleTagManager.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/Tracker/GoogleTagManager.php
@@ -96,7 +96,7 @@ class GoogleTagManager extends Tracker implements
 
     public function trackCartProductActionAdd(CartInterface $cart, ProductInterface $product, $quantity = 1)
     {
-        $item = $this->trackingItemBuilder->buildProductActionItem($product, $quantity = 1);
+        $item = $this->trackingItemBuilder->buildProductActionItem($product, $quantity);
 
         $productArray = $this->transformProductAction($item);
 


### PR DESCRIPTION
# Bugfix

Currently the `GoogleTagManager` will always track quantity 1, this PR considers the passed quantity in the method signature.