### PR TITLE
[DataObject] Fix Localizedfield lazyloading for fallback

### DIFF
--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -484,7 +484,8 @@ class Localizedfield extends Model\AbstractModel implements DirtyIndicatorInterf
         // check for fallback value
         if ($fieldDefinition->isEmpty($data) && !$ignoreFallbackLanguage && self::doGetFallbackValues()) {
             foreach (Tool::getFallbackLanguagesFor($language) as $l) {
-                if ($this->languageExists($l)) {
+                // fallback-language may not exist yet for lazy-loaded field (relation)
+                if ($this->languageExists($l) || ($fieldDefinition instanceof LazyLoadingSupportInterface && $fieldDefinition->getLazyLoading())) {
                     if ($data = $this->getLocalizedValue($name, $l)) {
                         break;
                     }


### PR DESCRIPTION
Check if localized-field should be lazy-loaded during fallback-language handling, otherwise existence check will always fail and fallback will never be loaded.

## Bug
In case a localized-field is marked as lazy-loaded (default for all relations now?) and no data exists for the required locale, fallback handling should be applied. 
But this is not possible because **_languageExists( $l )_** will most likely always return false as the fallback-language itself has never been loaded in the first place.

### Example with relations
**Locale**: de_DE
**Fallback**: de

_Localized Data for Relation:_
- **_de_DE_**: EMPTY
- **_de_**: Any valid Element (Object, Asset, Document)

Recursive call to _**getLocalizedValue**_ will never happen, as data for **_de_** has not been loaded yet.

### Class-structure
Any class with relations inside localized-fields should be affected.

#### Confirmed Case
- Create a field-collection with localized-field containing (only?) relations
![image](https://user-images.githubusercontent.com/3636662/83023263-f35a2d80-a02c-11ea-8b00-14510dec4fc8.png)

- Add the field-collection to a Class an activate lazy-loading
![image](https://user-images.githubusercontent.com/3636662/83023597-6499e080-a02d-11ea-9b6d-ae4cfd956294.png)

- Set data accordingly 


