### PR TITLE
Areabrick rendering via twig template

### DIFF
--- a/bundles/CoreBundle/Resources/views/Areabrick/wrapper.html.twig
+++ b/bundles/CoreBundle/Resources/views/Areabrick/wrapper.html.twig
@@ -1,0 +1,39 @@
+{# @var brick \Pimcore\Extension\Document\Areabrick\AreabrickInterface #}
+{# @var info \Pimcore\Model\Document\Tag\Area\Info #}
+{# @var templating \Symfony\Component\Templating\EngineInterface #}
+
+{# @var editmode bool #}
+
+{# @var viewTemplate string #}
+{# @var viewParameters array #}
+
+{# @var editTemplate string #}
+{# @var editParameters array #}
+
+{% block areabrickWrapper %}
+    {% block areabrickOpenTag %}
+        {{ brick.htmlTagOpen(info) | raw }}
+    {% endblock %}
+
+        {% if brick.hasEditTemplate() and editmode %}
+
+            <div class="pimcore_area_edit_button" data-name="{{ info.tag.name }}" data-real-name="{{ info.tag.realName }}"></div>
+
+        {% endif %}
+
+        {% block areabrickFrontend %}
+            {{ templating.render(viewTemplate, viewParameters) | raw }}
+        {% endblock %}
+
+        {% if brick.hasEditTemplate() and editmode and editTemplate %}
+
+            <div class="pimcore_area_editmode pimcore_area_editmode_hidden" data-name="{{ info.tag.name }}" data-real-name="{{ info.tag.realName }}">
+                {{ templating.render(editTemplate, editParameters) | raw }}
+            </div>
+
+        {% endif %}
+
+    {% block areabrickCloseTag %}
+        {{ brick.htmlTagClose(info) | raw }}
+    {% endblock %}
+{% endblock %}

--- a/lib/Extension/Document/Areabrick/AbstractAreabrick.php
+++ b/lib/Extension/Document/Areabrick/AbstractAreabrick.php
@@ -134,7 +134,17 @@ abstract class AbstractAreabrick implements AreabrickInterface, TemplateAreabric
      */
     public function getHtmlTagOpen(Info $info)
     {
-        return '<div class="pimcore_area_' . $info->getId() . ' pimcore_area_content">';
+        return '<div class="pimcore_area_' . $info->getId() . ' pimcore_area_content '. $this->getOpenTagCssClass($info) .'">';
+    }
+
+    /**
+     * @param Info $info
+     *
+     * @return string|null
+     */
+    protected function getOpenTagCssClass(Info $info)
+    {
+        return null;
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  

### Method getOpenTagCssClass
Added a "getOpenTagCssClass" method to the AbstractAreabrick class that can be used to add additional css classes to the basic wrapper div around every areabrick "pimcore_area_content".

### Areabrick Rendering TagHandler
The rendering mechanism for areabricks in the TagHandler has been extracted and moved to a twig template with various blocks in it. This way its easy to alter the way an areabrick is rendered (surrounding divs, wrapper classes, ...) by extending the twig template via symfonys template inheritance.

```twig
{# /app/Resources/PimcoreCoreBundle/views/Areabrick/wrapper.html.twig #}
{% extends "@!PimcoreCoreBundle/Areabrick/wrapper.html.twig %}

{% block areabrickWrapper %}
   <div class="my-custom-wrapper">
      {{ parent() }}
   </div>
{% endblock
```