### PR TITLE
fix flatpickr compatibility

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Controller/AdminOrderController.php
+++ b/bundles/EcommerceFrameworkBundle/Controller/AdminOrderController.php
@@ -141,7 +141,7 @@ class AdminOrderController extends AdminController implements EventedControllerI
         if ($request->query->has('from') === false && $request->query->has('till') === false) {
             // als default, nehmen wir den ersten des aktuellen monats
             $from = new \DateTime('first day of this month');
-            $request->query->set('from', $from->format('d.m.Y'));
+            $request->query->set('from', $from->format('Y-m-d'));
         }
 
         $filterDate = new OrderDateTime();


### PR DESCRIPTION
Change date format to ISO to match flatpickr date format.

The Orderlist filtering tool shows a different date than what the filter uses.

Go to orderlist, check the date in UI, go to browser  inspection tools and see that the value given is correct, but in wrong form

```html
<input 
type="text" 
id="date-from" 
class="form-control date flatpickr-input active" 
name="from"
placeholder="Date from" 
value="01.05.2020"
> 
```

it should be: 

```html
<input 
type="text" 
id="date-from" 
class="form-control date flatpickr-input active" 
name="from"
placeholder="Date from" 
value="2020-05-01"
>
```


