### PR TITLE
Add doc code example for tenant ecommerce

### DIFF
--- a/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/03_Assortment_Tenant_Configuration.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/03_Assortment_Tenant_Configuration.md
@@ -36,9 +36,18 @@ and may be extended:
   - `Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\DefaultFindologic`: Provides a default [findologic](https://www.findologic.com/) 
   implementation of the product index.
 
-- **Configuring Assortment Tenants within configuration:** 
+- **Configuring Assortment Tenants within configuration:**
 Each tenant has to be configured within the `index_service` configuration by defining the tenant config class and index 
 attributes. Depending on the *Product Index* implementation, additional configuration may be necessary. 
+
+- **Declare the service:**
+You need to declare the service as well so the class can be used. On your service configuration or for instance at the top of the ecommerce configuration file:
+```
+services:
+    MyBundle\Service\MySubtenantConfig:
+        calls:
+            - [setAttributeFactory, ['@Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\AttributeFactory']]
+```
 
 
 ### Setting current Assortment Tenant for Frontend


### PR DESCRIPTION
Hello,

We get some struggle to implement tenant and subtenant for ecommerce.
This pull request update the doc to give the major hint to help.

The exemple given don't work as it for subtenant (see the example code below we needed to use):
https://github.com/pimcore/pimcore/blob/master/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultMysqlSubTenantConfig.php

There is the need to redefine the constructor in the custom tenant class for tenant:
```
class MyTenantConfig extends OptimizedMysql
{
	public function __construct(
		string $tenantName,
		array $attributes,
		array $searchAttributes,
		array $filterTypes,
		array $options = []
	) {
		parent::__construct($tenantName, $attributes, $searchAttributes, $filterTypes, $options);
	}
```

And for subtenant it was more complexe because we need to retrieve environment and db connection:
```
class MySubtenantConfig extends OptimizedMysql
{
	/**
	 * @var ConnectionInterface
	 */
	protected $db;
	/**
	 * @var EnvironmentInterface
	 */
	protected $environment;

	public function __construct(
		string $tenantName,
		array $attributes,
		array $searchAttributes,
		array $filterTypes,
		array $options = []
	) {
		$this->db = Db::getConnection();
		$this->environment = \Pimcore\Bundle\EcommerceFrameworkBundle\Factory::getInstance()->getEnvironment();
		parent::__construct($tenantName, $attributes, $searchAttributes, $filterTypes, $options);
	}
```

Without those constructors, there is php error during indexing.

I didn't add those two to the documentation as I am not sure if this is the good way to proceed.
I think maybe there are some other parameters to inject to the service declaration. I found adding `setAttributeFactory` helper (and using those constructor) works fine, so the purpose of this PR, but even digging into the code i didn't found a proper way to inject connection and environment.
If there is a proper way, please feel free to change this PR to add necessary information.


Thanks.