### PR TITLE
[Admin] Users - Fix user type for Analyze Permissions

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/ElementController.php
+++ b/bundles/AdminBundle/Controller/Admin/ElementController.php
@@ -774,6 +774,7 @@ class ElementController extends AdminController
             $userList = [$user];
         } else {
             $userList = new Model\User\Listing();
+            $userList->setCondition('type = ?', ['user']);
             $userList = $userList->load();
         }
 

--- a/models/Element/PermissionChecker.php
+++ b/models/Element/PermissionChecker.php
@@ -65,6 +65,10 @@ class PermissionChecker
 
         /** @var User $user */
         foreach ($users as $user) {
+            if (!$user instanceof User) {
+                continue;
+            }
+
             $userPermission = [];
             $userPermission['userId'] = $user->getId();
             $userPermission['userName'] = $user->getName();


### PR DESCRIPTION
## Changes in this pull request  
Resolves #
when there's a user folder then Permission Analyzer throws exception

![image](https://user-images.githubusercontent.com/5137917/83239487-3edd1a80-a198-11ea-8863-b474101dc99a.png)

![image](https://user-images.githubusercontent.com/5137917/83239448-2c62e100-a198-11ea-8529-1499e1d882c2.png)

## Additional info  

