### PR TITLE
[xliff import] fix XML special characters for input fields

### DIFF
--- a/lib/Translation/Escaper/Xliff12Escaper.php
+++ b/lib/Translation/Escaper/Xliff12Escaper.php
@@ -89,9 +89,7 @@ class Xliff12Escaper
      */
     public function unescapeXliff(string $content): string
     {
-        $content = preg_replace("/<\/?(target|mrk)([^>.]+)?>/i", '', $content);
-        // we have to do this again but with html entities because of CDATA content
-        $content = preg_replace("/&lt;\/?(target|mrk)((?!&gt;).)*&gt;/i", '', $content);
+        $content = $this->parseInnerXml($content);
 
         if (preg_match("/<\/?(bpt|ept)/", $content)) {
             $xml = str_get_html($content);
@@ -104,6 +102,24 @@ class Xliff12Escaper
             }
             $content = $xml->save();
         }
+
+        return $content;
+    }
+
+    private function parseInnerXml(string $content)
+    {
+        $node = simplexml_load_string($content, null, LIBXML_NOCDATA);
+
+        if(empty($node->children())) {
+            return (string) $node;
+        }
+
+
+        $content = $node->asXml();
+
+        $content = preg_replace("/<\/?(target|mrk)([^>.]+)?>/i", '', $content);
+        // we have to do this again but with html entities because of CDATA content
+        $content = preg_replace("/&lt;\/?(target|mrk)((?!&gt;).)*&gt;/i", '', $content);
 
         return $content;
     }


### PR DESCRIPTION
## Steps to reproduce
- Export a localized data object input field with content "A & B"
- Export it via XLIFF
- Translate and reimport it with the same content

=> The target input field will contain `"A &amp; B"`

This PR fixes this problem by implementing an improved version for parsing the inner XML of the target nodes.