### PR TITLE
Possibility to override the admin locale in view templates

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -100,6 +100,12 @@ class Configuration implements ConfigurationInterface
                             ->info('Force Pimcore translations to NOT be case sensitive. This only applies to translations set via Pimcore\'s translator (e.g. website translations)')
                             ->defaultFalse()
                         ->end()
+
+                        ->arrayNode('admin_translation_mapping')
+                            ->useAttributeAsKey('locale')
+                            ->prototype('scalar')->end()
+                        ->end()
+
                         ->arrayNode('debugging')
                             ->info('If debugging is enabled, the translator will return the plain translation key instead of the translated message.')
                             ->addDefaultsIfNotSet()

--- a/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -73,6 +73,8 @@ class PimcoreCoreExtension extends ConfigurableExtension implements PrependExten
         $container->setParameter('pimcore.admin.session.attribute_bags', $config['admin']['session']['attribute_bags']);
         $container->setParameter('pimcore.admin.translations.path', $config['admin']['translations']['path']);
 
+        $container->setParameter('pimcore.translations.admin_translation_mapping', $config['translations']['admin_translation_mapping']);
+
         $container->setParameter('pimcore.web_profiler.toolbar.excluded_routes', $config['web_profiler']['toolbar']['excluded_routes']);
 
         $container->setParameter('pimcore.response_exception_listener.render_error_document', $config['error_handling']['render_error_document']);

--- a/bundles/CoreBundle/Resources/config/l10n.yml
+++ b/bundles/CoreBundle/Resources/config/l10n.yml
@@ -14,6 +14,7 @@ services:
         calls:
             - [setKernel, ['@kernel']]
             - [setAdminPath, ['%pimcore.admin.translations.path%']]
+            - [setAdminTranslationMapping, ['%pimcore.translations.admin_translation_mapping%']]
 
     #
     # LOCALE

--- a/doc/Development_Documentation/06_Multi_Language_i18n/07_Admin_Translations.md
+++ b/doc/Development_Documentation/06_Multi_Language_i18n/07_Admin_Translations.md
@@ -51,7 +51,7 @@ file for the desired language into the default path for the symfony translator
 (e.g. use `translations/admin.af.yml` for making `Afrikaans` available, the translation file can be also empty). 
 If you haven't configured anything different this is `%kernel.project_dir%/translations` for Symfony 4 projects.
 
-#### Override locale of admin translations
+#### Override language of admin translations
 In some projects you want to use a different language as admin translations, e.g. English (en) instead of Croatian (hr) or Chinese (zh_Hans) instead of Chinese (zh).
 
 ```yaml

--- a/doc/Development_Documentation/06_Multi_Language_i18n/07_Admin_Translations.md
+++ b/doc/Development_Documentation/06_Multi_Language_i18n/07_Admin_Translations.md
@@ -49,4 +49,16 @@ included in the main distribution.
 If you want make additional languages available for the admin interface, you can do so by putting a symfony translation
 file for the desired language into the default path for the symfony translator 
 (e.g. use `translations/admin.af.yml` for making `Afrikaans` available, the translation file can be also empty). 
-If you haven't configured anything different this is `%kernel.project_dir%/translations` for Symfony 4 projects. 
+If you haven't configured anything different this is `%kernel.project_dir%/translations` for Symfony 4 projects.
+
+#### Override locale of admin translations
+In some projects you want to use a different language as admin translations, e.g. English (en) instead of Croatian (hr) or Chinese (zh_Hans) instead of Chinese (zh).
+
+```yaml
+# src/AppBundle/Resources/config/pimcore/config.yml
+pimcore:
+    translations:
+        admin_translation_mapping:
+            'hr': 'en'
+            'zh': 'zh_Hans'
+```

--- a/doc/Development_Documentation/06_Multi_Language_i18n/07_Admin_Translations.md
+++ b/doc/Development_Documentation/06_Multi_Language_i18n/07_Admin_Translations.md
@@ -51,7 +51,7 @@ file for the desired language into the default path for the symfony translator
 (e.g. use `translations/admin.af.yml` for making `Afrikaans` available, the translation file can be also empty). 
 If you haven't configured anything different this is `%kernel.project_dir%/translations` for Symfony 4 projects.
 
-#### Override language of admin translations
+#### Override language of admin translations in editmode of documents
 In some projects you want to use a different language as admin translations, e.g. English (en) instead of Croatian (hr) or Chinese (zh_Hans) instead of Chinese (zh).
 
 ```yaml

--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -48,6 +48,11 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
     protected $adminPath = '';
 
     /**
+     * @var array
+     */
+    protected $adminTranslationMapping = [];
+
+    /**
      * If true, the translator will just return the translation key instead of actually translating
      * the message. Can be useful for debugging and to get an overview over used translation keys on
      * a page.
@@ -91,6 +96,17 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
         }
 
         $id = (string) $id;
+
+        if ($domain === 'admin' && !empty($this->adminTranslationMapping)) {
+            if (null === $locale) {
+                $locale = $this->getLocale();
+            }
+
+            if (array_key_exists($locale, $this->adminTranslationMapping)) {
+                $locale = $this->adminTranslationMapping[$locale];
+            }
+        }
+
         $catalogue = $this->getCatalogue($locale);
         $locale = $catalogue->getLocale();
 
@@ -389,6 +405,22 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
     public function setAdminPath($adminPath)
     {
         $this->adminPath = $adminPath;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAdminTranslationMapping(): array
+    {
+        return $this->adminTranslationMapping;
+    }
+
+    /**
+     * @param array $adminTranslationMapping
+     */
+    public function setAdminTranslationMapping(array $adminTranslationMapping): void
+    {
+        $this->adminTranslationMapping = $adminTranslationMapping;
     }
 
     /**


### PR DESCRIPTION
In some projects I had issues with the admin locale, for example: When you open a document with the locale "hr" or "zh" in Pimcore backend, it shows just the basic key without translation because "hr" is not available as an admin translation and "zh" is only available as "zh_Hans".

This PR allows you to override the admin locale with following mapping like:
```
pimcore:
    translations:
        admin_translation_mapping:
            'hr': 'en'
            'zh': 'zh_Hans'
```


