### PR TITLE
[Object bricks] Prevent fatal error if unserialize for data object is not possible

### DIFF
--- a/models/DataObject/Objectbrick.php
+++ b/models/DataObject/Objectbrick.php
@@ -313,8 +313,12 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
         $brickGetter = null;
 
         // for backwards compatibility
-        if (isset($this->object) && $this->object && !$this->object instanceof  \__PHP_Incomplete_Class) {
-            $this->objectId = $this->object->getId();
+        if (isset($this->object) && $this->object) {
+            if($this->object instanceof  \__PHP_Incomplete_Class) {
+                Logger::error('Parent object of '.$brickGetter.' could not be unserialized (probably its class does not exist anymore)');
+            } else {
+                $this->objectId = $this->object->getId();
+            }
         }
 
         // sanity check, remove data requiring non-existing (deleted) brick definitions

--- a/models/DataObject/Objectbrick.php
+++ b/models/DataObject/Objectbrick.php
@@ -313,7 +313,7 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
         $brickGetter = null;
 
         // for backwards compatibility
-        if (isset($this->object) && $this->object) {
+        if (isset($this->object) && $this->object && !$this->object instanceof  \__PHP_Incomplete_Class) {
             $this->objectId = $this->object->getId();
         }
 

--- a/models/DataObject/Objectbrick/Data/AbstractData.php
+++ b/models/DataObject/Objectbrick/Data/AbstractData.php
@@ -306,7 +306,7 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
 
     public function __wakeup()
     {
-        if ($this->object) {
+        if ($this->object && !$this->object instanceof \__PHP_Incomplete_Class) {
             $this->objectId = $this->object->getId();
         }
     }


### PR DESCRIPTION
Steps to reproduce:
1. Create class named `Abc`, add object brick field `bricks`
1. Create object brick `Brick`, allow it to be assigned to `Abc::bricks`
1. Override class by adding 
```yaml
pimcore:
    models:
        class_overrides:
            'Pimcore\Model\DataObject\Abc': 'AppBundle\Model\DataObject\Abc'
```
to `app/config/config.yml`
1. Create PHP class `AppBundle\Model\DataObject\Abc` under `src/AppBundle/Model/DataObject`
1. Clear cache
2. Create object of class `Abc`, assign brick `Brick` and save object
3. Rename class `AppBundle\Model\DataObject\Abc` to `AppBundle\Model\DataObject\AbcNew`
4. Update `app/config/config.yml` to:
 ```yaml
pimcore:
    models:
        class_overrides:
            'Pimcore\Model\DataObject\Abc': 'AppBundle\Model\DataObject\AbcNew'
```
5. Open object `Abc` and open versions tab.
6. Click on latest version (this should be the one which got created while the class was still named `Abc`)

Expected behaviour:
Version cannot be opened

Actual behaviour:
Fatal error `Fatal error: Pimcore\Model\DataObject\Objectbrick\Data\AbstractData::__wakeup(): The script tried to execute a method or access a property of an incomplete object. Please ensure that the class definition "AppBundle\Model\DataObject\Abc" of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide an autoloader to load the class definition in /var/www/clients/client1/web1/web/vendor/pimcore/pimcore/models/DataObject/Objectbrick/Data/AbstractData.php on line 304`