### PR TITLE
[Ecommerce][Indexservice] Fix timeout for transactional queries

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
@@ -553,7 +553,7 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
                 if ($i === $maxTries) {
                     throw $e;
                 }
-                sleep($sleep);
+                usleep($sleep * 1000000);
             }
         }
 


### PR DESCRIPTION
Calling `sleep` will cast the given value to `int` so a default value auf `0.5` would be treated as `sleep(0)`. This PR utilizes `usleep` to be able to use float values.