### PR TITLE
Block fields have no spacing to next field

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/block.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/block.js
@@ -49,7 +49,7 @@ pimcore.object.tags.block = Class.create(pimcore.object.tags.abstract, {
         var panelConf = {
             autoHeight: true,
             border: true,
-            // style: "margin-bottom: 10px",
+            style: "margin-bottom: 10px",
             componentCls: "object_field",
             collapsible: this.fieldConfig.collapsible,
             collapsed: this.fieldConfig.collapsed


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/998558/83532705-e935a480-a4ee-11ea-9f29-e684e9bcd015.png)
