### PR TITLE
Dispatch pimcore.system.cache.clear event when calling pimcore:cache:clear command

### DIFF
--- a/bundles/CoreBundle/Command/CacheClearCommand.php
+++ b/bundles/CoreBundle/Command/CacheClearCommand.php
@@ -16,17 +16,29 @@ namespace Pimcore\Bundle\CoreBundle\Command;
 
 use Pimcore\Cache;
 use Pimcore\Console\AbstractCommand;
+use Pimcore\Event\SystemEvents;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class CacheClearCommand extends AbstractCommand
 {
+    protected static $defaultName = 'pimcore:cache:clear';
+
+    /** @var EventDispatcherInterface */
+    private $eventDispatcher;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        parent::__construct();
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
     protected function configure()
     {
         $this
-            ->setName('pimcore:cache:clear')
             ->setDescription('Clear caches')
             ->addOption(
                 'tags',
@@ -63,6 +75,9 @@ class CacheClearCommand extends AbstractCommand
             $io->success('Pimcore output cache cleared successfully');
         } else {
             Cache::clearAll();
+
+            $this->eventDispatcher->dispatch(SystemEvents::CACHE_CLEAR);
+
             $io->success('Pimcore data cache cleared successfully');
         }
 


### PR DESCRIPTION
Currently the `pimcore.system.cache.clear` event does only get dispatched when the cache gets cleared via GUI, see https://github.com/pimcore/pimcore/blob/fb4af6928847b0635b6f782b53055e7fbdff9d8b/bundles/AdminBundle/Controller/Admin/SettingsController.php#L750

With this PR the event gets also dispatched when the cache gets cleared via CLI command `bin/console pimcore:cache:clear`