### PR TITLE
[Data objects] Add "open" button for non-editable image fields

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/image.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/image.js
@@ -166,7 +166,6 @@ pimcore.object.tags.image = Class.create(pimcore.object.tags.abstract, {
     },
 
     getLayoutShow: function () {
-
         if (intval(this.fieldConfig.width) < 1) {
             this.fieldConfig.width = 300;
         }
@@ -177,9 +176,21 @@ pimcore.object.tags.image = Class.create(pimcore.object.tags.abstract, {
         var conf = {
             width: this.fieldConfig.width,
             height: this.fieldConfig.height,
-            title: this.fieldConfig.title,
             border: true,
             style: "padding-bottom: 10px",
+            tbar: {
+                overflowHandler: 'menu',
+                items:
+                    [{
+                        xtype: "tbtext",
+                        text: "<b>" + this.fieldConfig.title + "</b>"
+                    }, "->",{
+                        xtype: "button",
+                        iconCls: "pimcore_icon_open",
+                        overflowText: t("open"),
+                        handler: this.openImage.bind(this)
+                    }]
+            },
             cls: "object_field",
             bodyCls: "pimcore_droptarget_image pimcore_image_container"
         };
@@ -187,6 +198,7 @@ pimcore.object.tags.image = Class.create(pimcore.object.tags.abstract, {
         this.component = new Ext.Panel(conf);
 
         this.component.on("afterrender", function (el) {
+            el.getEl().on("contextmenu", this.onContextMenu.bind(this));
             this.updateImage();
         }.bind(this));
 
@@ -308,15 +320,17 @@ pimcore.object.tags.image = Class.create(pimcore.object.tags.abstract, {
         var menu = new Ext.menu.Menu();
 
         if (this.data) {
-            menu.add(new Ext.menu.Item({
-                text: t('empty'),
-                iconCls: "pimcore_icon_delete",
-                handler: function (item) {
-                    item.parentMenu.destroy();
+            if(!this.fieldConfig.noteditable) {
+                menu.add(new Ext.menu.Item({
+                    text: t('empty'),
+                    iconCls: "pimcore_icon_delete",
+                    handler: function (item) {
+                        item.parentMenu.destroy();
 
-                    this.empty();
-                }.bind(this)
-            }));
+                        this.empty();
+                    }.bind(this)
+                }));
+            }
 
             menu.add(new Ext.menu.Item({
                 text: t('open'),
@@ -328,8 +342,7 @@ pimcore.object.tags.image = Class.create(pimcore.object.tags.abstract, {
                 }.bind(this)
             }));
 
-            if (this instanceof pimcore.object.tags.hotspotimage) {
-
+            if (!this.fieldConfig.noteditable && this instanceof pimcore.object.tags.hotspotimage) {
                 menu.add(new Ext.menu.Item({
                     text: t('select_specific_area_of_image'),
                     iconCls: "pimcore_icon_image_region",
@@ -352,24 +365,26 @@ pimcore.object.tags.image = Class.create(pimcore.object.tags.abstract, {
             }
         }
 
-        menu.add(new Ext.menu.Item({
-            text: t('search'),
-            iconCls: "pimcore_icon_search",
-            handler: function (item) {
-                item.parentMenu.destroy();
-                this.openSearchEditor();
-            }.bind(this)
-        }));
+        if(!this.fieldConfig.noteditable) {
+            menu.add(new Ext.menu.Item({
+                text: t('search'),
+                iconCls: "pimcore_icon_search",
+                handler: function (item) {
+                    item.parentMenu.destroy();
+                    this.openSearchEditor();
+                }.bind(this)
+            }));
 
-        menu.add(new Ext.menu.Item({
-            text: t('upload'),
-            cls: "pimcore_inline_upload",
-            iconCls: "pimcore_icon_upload",
-            handler: function (item) {
-                item.parentMenu.destroy();
-                this.uploadDialog();
-            }.bind(this)
-        }));
+            menu.add(new Ext.menu.Item({
+                text: t('upload'),
+                cls: "pimcore_inline_upload",
+                iconCls: "pimcore_icon_upload",
+                handler: function (item) {
+                    item.parentMenu.destroy();
+                    this.uploadDialog();
+                }.bind(this)
+            }));
+        }
 
         menu.showAt(e.getXY());
 


### PR DESCRIPTION
Currently when an image field is set to `not editable` for a data object class, one cannot open the assigned image from the edit panel on an object. This PR adds the "Open" button in the tag's toolbar as well as in the context menu.