### PR TITLE
Update deprecation message for `Pimcore\Tool::getMinimizedScriptPath($asUrl=true)`

### DIFF
--- a/lib/Tool/Admin.php
+++ b/lib/Tool/Admin.php
@@ -106,7 +106,7 @@ class Admin
 
         if ($asUrl) {
             @trigger_error(
-                'Calling Pimcore\Tool::getMinimizedScriptPath with $asUrl true is deprecated and will be removed with Pimcore 7.1.0',
+                'Calling Pimcore\Tool::getMinimizedScriptPath with $asUrl true is deprecated and will be removed with Pimcore 7.0',
                 E_USER_DEPRECATED
             );
             return '/admin/misc/script-proxy?'.array_toquerystring($params);


### PR DESCRIPTION
As this was deprecated in `v6.7` it can be already removed in `v7.0`.