### PR TITLE
[Quantity values] Only save default value with value AND unit to database

### DIFF
--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -648,7 +648,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
      */
     protected function doGetDefaultValue($object, $context = [])
     {
-        if ($this->getDefaultValue() || $this->getDefaultUnit()) {
+        if ($this->getDefaultValue() && $this->getDefaultUnit()) {
             return new Model\DataObject\Data\QuantityValue($this->getDefaultValue(), $this->getDefaultUnit());
         }
 


### PR DESCRIPTION
Currently when you have set a default unit for a quantity value field but no default value and create a new object this quantity value without value gets saved to the database, even if you call `$object->setQuantityField(null)`. I wonder if this is intended.