### PR TITLE
Escape fullpath to get valid path for keys with quotes

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/treenodelocator.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/treenodelocator.js
@@ -287,7 +287,7 @@ pimcore.treenodelocator = function()
                         let sortIndexPath = sortIndexParts[pos];
                         var elementKey = sortIndexPath;
                     } else {
-                        var pathKeys = globalState.fullPath.replace(/^\//, "").split("/");
+                        var pathKeys = escape(globalState.fullPath).replace(/^\//, "").split("/");
                         var elementKey = pathKeys[pos-1];
                     }
                 }


### PR DESCRIPTION
I put the fix in once and checked. But the problem still seems to occur.
I saw that our customer used quotation marks for some keys in his object hierarchy. So I took a look at the code myself and found the following fix, which also works. I ask you to check my suggested solution.