### PR TITLE
Corrects doctype for Table ClassDefinition inputs

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -99,7 +99,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
      *
      * @var string
      */
-    public $phpdocType = 'array';
+    public $phpdocType = 'array|string';
 
     /**
      * @return int


### PR DESCRIPTION
I'm not 100% sure if this is the best solution, but the fact that an empty table will return a string should be accounted for. Personally I would prefer that it always returned an array, but since that might be a (minor) BC break I want to avoid doing that change for now.