### PR TITLE
Check for customConfig passed to ckeditor

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tags/wysiwyg.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tags/wysiwyg.js
@@ -82,7 +82,7 @@ pimcore.document.tags.wysiwyg = Class.create(pimcore.document.tag, {
 
             // if there is no toolbar defined use Full which is defined in CKEDITOR.config.toolbar_Full, possible
             // is also Basic
-            if (!this.options["toolbarGroups"] && !this.options.customConfig) {
+            if (!this.options["toolbarGroups"]) {
                 eConfig.toolbarGroups = [
                     { name: 'basicstyles', groups: [ 'undo', "find", 'basicstyles', 'list'] },
                     '/',
@@ -96,6 +96,10 @@ pimcore.document.tags.wysiwyg = Class.create(pimcore.document.tag, {
                 ];
             }
 
+            if(this.options.toolbarGroups === false){
+                delete eConfig.toolbarGroups;
+            }
+            
             delete specificConfig.width;
 
             eConfig.language = pimcore.settings["language"];

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tags/wysiwyg.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tags/wysiwyg.js
@@ -82,7 +82,7 @@ pimcore.document.tags.wysiwyg = Class.create(pimcore.document.tag, {
 
             // if there is no toolbar defined use Full which is defined in CKEDITOR.config.toolbar_Full, possible
             // is also Basic
-            if (!this.options["toolbarGroups"]) {
+            if(!this.options["toolbarGroups"] && this.options['toolbarGroups'] !== false){
                 eConfig.toolbarGroups = [
                     { name: 'basicstyles', groups: [ 'undo', "find", 'basicstyles', 'list'] },
                     '/',
@@ -94,10 +94,6 @@ pimcore.document.tags.wysiwyg = Class.create(pimcore.document.tag, {
                     { name: 'styles' },
                     { name: 'tools', groups: ['colors', "tools", 'cleanup', 'mode', "others"] }
                 ];
-            }
-
-            if(this.options.toolbarGroups === false){
-                delete eConfig.toolbarGroups;
             }
             
             delete specificConfig.width;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tags/wysiwyg.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tags/wysiwyg.js
@@ -82,7 +82,7 @@ pimcore.document.tags.wysiwyg = Class.create(pimcore.document.tag, {
 
             // if there is no toolbar defined use Full which is defined in CKEDITOR.config.toolbar_Full, possible
             // is also Basic
-            if (!this.options["toolbarGroups"]) {
+            if (!this.options["toolbarGroups"] && !this.options.customConfig) {
                 eConfig.toolbarGroups = [
                     { name: 'basicstyles', groups: [ 'undo', "find", 'basicstyles', 'list'] },
                     '/',

--- a/doc/Development_Documentation/03_Documents/01_Editables/40_WYSIWYG.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/40_WYSIWYG.md
@@ -11,7 +11,7 @@ Similar to Textarea and Input you can use the WYSIWYG editable in the templates 
 | `customConfig`  | string  | Path to JavaScript file with configuration for CKEditor                            |
 | `enterMode`     | integer | Set it to `CKEDITOR.CKEDITOR.ENTER_BR` if you don't want to add a `<p>`-tag on pressing enter key  |
 | `height`        | integer | Minimum height of the field in pixels                                              |
-| `toolbarGroups` | string  | A toolbar config array (see below)                                                 |
+| `toolbarGroups` | mixed   | A toolbar config array or false for customConfig/CKEditor default (see below)                                                 |
 | `width`         | integer | Width of the field in pixels                                                       |
 | `class`         | string  | A CSS class that is added to the surrounding container of this element in editmode |
 | `required`      | boolean | set to true to make field value required for publish                               |
@@ -29,7 +29,7 @@ Similar to Textarea and Input you can use the WYSIWYG editable in the templates 
 ### Basic usage
 
 `wysiwyg` helper doesn't require any additional configuration options.
-The following code specifies tje height for the rendered WYSIWYG editable (has no effect in frontend).
+The following code specifies the height for the rendered WYSIWYG editable (has no effect in frontend).
 
 <div class="code-section">
 
@@ -62,7 +62,8 @@ The complete list of configuration options you can find in the [CKEditor toolbar
 
 The WYSIWYG editable allows us to specify the toolbar. 
 If you have to limit styling options (for example only basic styles like `<b>` tag and lists would be allowed), just use `toolbarGroups` option.
-
+There is also the option to disable the pimcore generated default toolbar by setting the option `toolbarGroups` explicitly to `false`. In this case,
+either the configuration from the customConfig-file or if absent the ckeditor default will be loaded.
 <div class="code-section">
 
 ```php

--- a/doc/Development_Documentation/03_Documents/01_Editables/40_WYSIWYG.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/40_WYSIWYG.md
@@ -61,7 +61,7 @@ If you have a look at the editmode, you will see that our WYSIWYG is rendered wi
 The complete list of configuration options you can find in the [CKEditor toolbar documentation](http://docs.ckeditor.com/#!/guide/dev_toolbar).
 
 The WYSIWYG editable allows us to specify the toolbar. 
-If you have to limit styling options (for example only basic styles like `<b>` tag and lists would be allowed), just use `toolbarGroups` option.
+If you have to limit styling options (for example only basic styles like `<b>` tag and lists would be allowed), just use `toolbarGroups` option.  
 There is also the option to disable the pimcore generated default toolbar by setting the option `toolbarGroups` explicitly to `false`. In this case,
 either the configuration from the customConfig-file or if absent the ckeditor default will be loaded.
 <div class="code-section">


### PR DESCRIPTION
Checking only for custom set toolbarGroups and (in case none is found) passing a default for toolbarGroups won't allow to overwrite the settings given in the customConfig file passed via options.

One could argue, that the customFile is not passing a toolbarGroup config, but the user could at least then overwrite the default settings from line 86 - 97 or accept the default given in ckeditor settings.

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

