### PR TITLE
Remove erroneous line-break from the docs

### DIFF
--- a/doc/Development_Documentation/06_Multi_Language_i18n/README.md
+++ b/doc/Development_Documentation/06_Multi_Language_i18n/README.md
@@ -15,8 +15,7 @@ website triggers a save action.
 ## Content Localization 
 
 ### Language Configuration
-The available languages for content are configured centrally in system settings (*Settings* > *System Settings*
-> *Localization & Internationalization (i18n/l10n)*). 
+The available languages for content are configured centrally in system settings (*Settings* > *System Settings* > *Localization & Internationalization (i18n/l10n)*). 
 
 ![Localization Settings](../img/localization-settings.png)
 


### PR DESCRIPTION
There should be no line break here, because otherwise it results in being rendered as follows:
![image](https://user-images.githubusercontent.com/424602/84032796-250db580-a998-11ea-8f64-7dca800aab53.png)
