### PR TITLE
Fix xliff import overriding source values

### DIFF
--- a/lib/Translation/ImporterService/Importer/DataObjectImporter.php
+++ b/lib/Translation/ImporterService/Importer/DataObjectImporter.php
@@ -69,6 +69,12 @@ class DataObjectImporter extends AbstractElementImporter
             /** @var array $blockData */
             $blockData = $element->{'get' . $blockName}($targetLanguage);
             $blockItem = !empty($blockData) && $blockData[$blockIndex] ? $blockData[$blockIndex] : $originalBlockItem;
+
+            // ensure correct target language
+            /* @var $blockItemField DataObject\Data\BlockElement */
+            $blockItemField = $blockItem[$fieldname];
+            $blockItemField->setValue('_language', $targetLanguage);
+
             $blockItemData = !empty($blockData) ? $blockItem[$fieldname] : clone $originalBlockItemData;
 
             $blockItemData->setData($attribute->getContent());


### PR DESCRIPTION
This is a bug fix for latest release and master. The bug was introduced with https://github.com/pimcore/pimcore/pull/4529/files.

Having a translated block doesn't work properly when importing an XLIFF file.

As seen in this screenshot, the language isn't changed, but the value is, that caused Pimcore to override it's original value instead of the source value. (Which by some magic later on is set anyway. - Didn't investigate)
<img width="480" alt="Screenshot 2020-06-08 at 17 26 55" src="https://user-images.githubusercontent.com/579227/84051094-ec2d0b00-a9ae-11ea-82b8-f05e1f6b09ed.png">

I enforce the '_language' variable in the block element which is supposed to be present when in context of a translation.

I hope I didn't miss something and I'd be happy to hear some feedback!