### PR TITLE
Fix to keep icon sizes regular and centered

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/Misc/admin-css.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/Misc/admin-css.html.php
@@ -23,7 +23,7 @@
             $treetype = $cv["treetype"] ? $cv["treetype"] : "object";
             ?>
     .pimcore_<?= $treetype ?>_customview_icon_<?= $cv["id"]; ?> {
-        background: url(<?= $cv["icon"]; ?>) center center no-repeat !important;
+        background: center / contain url(<?= $cv["icon"]; ?>) no-repeat !important;
     }
     <?php } ?>
 


### PR DESCRIPTION
Previously larger icons from the library would not look good, such as Twemoji and flags, because they did not properly fit into the available box.