### PR TITLE
Don't add custom CSS classes from editable options twice in editmode

### DIFF
--- a/models/Document/Tag.php
+++ b/models/Document/Tag.php
@@ -246,8 +246,6 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
             } else {
                 $classes[] = (string)$editableOptions['class'];
             }
-
-            $classes[] = (string)$editableOptions['class'];
         }
 
         return $classes;


### PR DESCRIPTION
Custom CSS classes defined in an editable are added twice to the container HTML element:
```twig
{{ pimcore_input("title", {'class': 'my-class'}) }}
```
```html
<div 
	data-name="title" 
	data-real-name="title" 
	data-type="input" 
	data-block-names="" 
	data-block-indexes="" 
	id="pimcore_editable_title" 
	class="pimcore_editable pimcore_tag_input my-class my-class empty" 
	style="min-height: 24px;" 
	contenteditable="true"
></div>
```

When defined as an array, they are not added twice, but an "array to string cast" (`Array`) gets added.
```twig
{{ pimcore_input("title", {'class': ['first-class', 'second-class']}) }}
```
```html
<div 
	data-name="title" 
	data-real-name="title" 
	data-type="input" 
	data-block-names="" 
	data-block-indexes="" 
	id="pimcore_editable_title" 
	class="pimcore_editable pimcore_tag_input first-class second-class Array empty" 
	style="min-height: 24px;" 
	contenteditable="true"
></div>
```