### PR TITLE
Fix return type annotation

### DIFF
--- a/models/Document/TargetingDocument.php
+++ b/models/Document/TargetingDocument.php
@@ -119,7 +119,7 @@ abstract class TargetingDocument extends PageSnippet implements TargetingDocumen
      *
      * @param string $name
      *
-     * @return Tag
+     * @return Tag|null
      */
     public function getElement($name)
     {


### PR DESCRIPTION
`Pimcore\Model\Document\TargetingDocument::getElement()` often returns `parent::getElement()` which may return `null`:
https://github.com/pimcore/pimcore/blob/1e49e5cb106b1e701e979782fdf7cefaae96174d/models/Document/PageSnippet.php#L402-L404