### PR TITLE
Prevent `get_class(null)` calls

### DIFF
--- a/models/Document/Tag/Areablock/Item.php
+++ b/models/Document/Tag/Areablock/Item.php
@@ -38,7 +38,7 @@ class Item extends AbstractBlockItem
         $element = $this->getElement($args[0]);
         $class = 'Pimcore\\Model\\Document\\Tag\\' . str_replace('get', '', $func);
 
-        if (!strcasecmp(get_class($element), $class)) {
+        if ($element !== null && !strcasecmp(get_class($element), $class)) {
             return $element;
         }
 

--- a/models/Document/Tag/Areablock/Item.php
+++ b/models/Document/Tag/Areablock/Item.php
@@ -26,22 +26,4 @@ class Item extends AbstractBlockItem
     {
         return 'areablock';
     }
-
-    /**
-     * @param string $func
-     * @param array $args
-     *
-     * @return Document\Tag|null
-     */
-    public function __call($func, $args)
-    {
-        $element = $this->getElement($args[0]);
-        $class = 'Pimcore\\Model\\Document\\Tag\\' . str_replace('get', '', $func);
-
-        if ($element !== null && !strcasecmp(get_class($element), $class)) {
-            return $element;
-        }
-
-        return null;
-    }
 }

--- a/models/Document/Tag/Block/AbstractBlockItem.php
+++ b/models/Document/Tag/Block/AbstractBlockItem.php
@@ -73,7 +73,7 @@ abstract class AbstractBlockItem
         $element = $this->getElement($args[0]);
         $class = 'Pimcore\\Model\\Document\\Tag\\' . str_replace('get', '', $func);
 
-        if (!strcasecmp(get_class($element), $class)) {
+        if ($element !== null && !strcasecmp(get_class($element), $class)) {
             return $element;
         }
 

--- a/models/Document/Tag/Block/Item.php
+++ b/models/Document/Tag/Block/Item.php
@@ -37,10 +37,12 @@ class Item extends AbstractBlockItem
         $element = $this->getElement($args[0]);
         $class = 'Pimcore\\Model\\Document\\Tag\\' . str_replace('get', '', $func);
 
+        if ($element === null) {
+            return new $class;
+        }
+
         if (!strcasecmp(get_class($element), $class)) {
             return $element;
-        } elseif ($element === null) {
-            return new $class;
         }
 
         return null;


### PR DESCRIPTION
They're not allowed anymore since PHP 7.2: https://wiki.php.net/rfc/get_class_disallow_null_parameter

This also removes some duplicated code.