### PR TITLE
Remove unnecessary `@throws` annotation

### DIFF
--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -469,8 +469,6 @@ abstract class PageSnippet extends Model\Document
 
     /**
      * @return Document|null
-     *
-     * @throws \Exception
      */
     public function getContentMasterDocument()
     {


### PR DESCRIPTION
This was introduced in #3908.

The ones on `Element::getById()` were deleted in 8fffea84 right after merge, but this one was forgotten.