### PR TITLE
Notification events for add/delete

### DIFF
--- a/doc/Development_Documentation/20_Extending_Pimcore/11_Event_API_and_Event_Manager.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/11_Event_API_and_Event_Manager.md
@@ -30,6 +30,7 @@ All Pimcore events are defined and documented as a constant on component specifi
 - [Workflows](https://github.com/pimcore/pimcore/blob/master/lib/Event/WorkflowEvents.php)
 - [Elements](https://github.com/pimcore/pimcore/blob/master/lib/Event/ElementEvents.php)
 - [Mail](https://github.com/pimcore/pimcore/blob/master/lib/Event/MailEvents.php)
+- [Notifications](https://github.com/pimcore/pimcore/blob/master/lib/Event/NotificationEvents.php)
 - [Redirect](https://github.com/pimcore/pimcore/blob/master/lib/Event/RedirectEvents.php)
 - [Admin](https://github.com/pimcore/pimcore/blob/master/lib/Event/AdminEvents.php)
 - [Frontend](https://github.com/pimcore/pimcore/blob/master/lib/Event/FrontendEvents.php)

--- a/lib/Event/Model/NotificationEvent.php
+++ b/lib/Event/Model/NotificationEvent.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Event\Model;
+
+use Pimcore\Event\Traits\ArgumentsAwareTrait;
+use Pimcore\Model\Notification;
+use Symfony\Component\EventDispatcher\Event;
+
+class NotificationEvent extends Event implements ElementEventInterface
+{
+    use ArgumentsAwareTrait;
+
+    /**
+     * @var Notification
+     */
+    protected $notification;
+
+    /**
+     * DataObjectEvent constructor.
+     *
+     * @param Notification $notification
+     * @param array $arguments
+     */
+    public function __construct(Notification $notification, array $arguments = [])
+    {
+        $this->notification = $notification;
+        $this->arguments = $arguments;
+    }
+
+    /**
+     * @return Notification
+     */
+    public function getNotification()
+    {
+        return $this->notification;
+    }
+
+    /**
+     * @param Notification $notification
+     */
+    public function setObject($notification)
+    {
+        $this->notification = $notification;
+    }
+
+    /**
+     * @return Notification
+     */
+    public function getElement()
+    {
+        return $this->getNotification();
+    }
+}

--- a/lib/Event/Model/NotificationEvent.php
+++ b/lib/Event/Model/NotificationEvent.php
@@ -50,7 +50,7 @@ class NotificationEvent extends Event implements ElementEventInterface
     /**
      * @param Notification $notification
      */
-    public function setObject($notification)
+    public function setNotification($notification)
     {
         $this->notification = $notification;
     }

--- a/lib/Event/NotificationEvents.php
+++ b/lib/Event/NotificationEvents.php
@@ -21,14 +21,14 @@ final class NotificationEvents
      *
      * @var string
      */
-    const PRE_ADD = 'pimcore.notification.preAdd';
+    const PRE_SAVE = 'pimcore.notification.preSave';
 
     /**
      * @Event("Pimcore\Event\Model\NotificationEvent")
      *
      * @var string
      */
-    const POST_ADD = 'pimcore.notification.postAdd';
+    const POST_SAVE = 'pimcore.notification.postSave';
 
     /**
      * @Event("Pimcore\Event\Model\NotificationEvent")

--- a/lib/Event/NotificationEvents.php
+++ b/lib/Event/NotificationEvents.php
@@ -35,20 +35,6 @@ final class NotificationEvents
      *
      * @var string
      */
-    const PRE_UPDATE = 'pimcore.notification.preUpdate';
-
-    /**
-     * @Event("Pimcore\Event\Model\NotificationEvent")
-     *
-     * @var string
-     */
-    const POST_UPDATE = 'pimcore.notification.postUpdate';
-
-    /**
-     * @Event("Pimcore\Event\Model\NotificationEvent")
-     *
-     * @var string
-     */
     const PRE_DELETE = 'pimcore.notification.preDelete';
 
     /**

--- a/lib/Event/NotificationEvents.php
+++ b/lib/Event/NotificationEvents.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Event;
+
+final class NotificationEvents
+{
+    /**
+     * @Event("Pimcore\Event\Model\NotificationEvent")
+     *
+     * @var string
+     */
+    const PRE_ADD = 'pimcore.notification.preAdd';
+
+    /**
+     * @Event("Pimcore\Event\Model\NotificationEvent")
+     *
+     * @var string
+     */
+    const POST_ADD = 'pimcore.notification.postAdd';
+
+    /**
+     * @Event("Pimcore\Event\Model\NotificationEvent")
+     *
+     * @var string
+     */
+    const PRE_UPDATE = 'pimcore.notification.preUpdate';
+
+    /**
+     * @Event("Pimcore\Event\Model\NotificationEvent")
+     *
+     * @var string
+     */
+    const POST_UPDATE = 'pimcore.notification.postUpdate';
+
+    /**
+     * @Event("Pimcore\Event\Model\NotificationEvent")
+     *
+     * @var string
+     */
+    const PRE_DELETE = 'pimcore.notification.preDelete';
+
+    /**
+     * @Event("Pimcore\Event\Model\NotificationEvent")
+     *
+     * @var string
+     */
+    const POST_DELETE = 'pimcore.notification.postDelete';
+}

--- a/models/Notification.php
+++ b/models/Notification.php
@@ -321,21 +321,9 @@ class Notification extends AbstractModel
      */
     public function save(): void
     {
-        if ($this->getId()) {
-            \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::PRE_UPDATE, new NotificationEvent($this));
-        }
-        else {
-            \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::PRE_ADD, new NotificationEvent($this));
-        }
-
+        \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::PRE_ADD, new NotificationEvent($this));
         $this->getDao()->save();
-
-        if ($this->getId()) {
-            \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::POST_UPDATE, new NotificationEvent($this));
-        }
-        else {
-            \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::POST_ADD, new NotificationEvent($this));
-        }
+        \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::POST_ADD, new NotificationEvent($this));
     }
 
     /**

--- a/models/Notification.php
+++ b/models/Notification.php
@@ -321,9 +321,9 @@ class Notification extends AbstractModel
      */
     public function save(): void
     {
-        \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::PRE_ADD, new NotificationEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::PRE_SAVE, new NotificationEvent($this));
         $this->getDao()->save();
-        \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::POST_ADD, new NotificationEvent($this));
+        \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::POST_SAVE, new NotificationEvent($this));
     }
 
     /**

--- a/models/Notification.php
+++ b/models/Notification.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 namespace Pimcore\Model;
 
 use Pimcore\Cache;
+use Pimcore\Event\Model\NotificationEvent;
+use Pimcore\Event\NotificationEvents;
 
 /**
  * @method Notification\Dao getDao()
@@ -319,7 +321,21 @@ class Notification extends AbstractModel
      */
     public function save(): void
     {
+        if ($this->getId()) {
+            \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::PRE_UPDATE, new NotificationEvent($this));
+        }
+        else {
+            \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::PRE_ADD, new NotificationEvent($this));
+        }
+
         $this->getDao()->save();
+
+        if ($this->getId()) {
+            \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::POST_UPDATE, new NotificationEvent($this));
+        }
+        else {
+            \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::POST_ADD, new NotificationEvent($this));
+        }
     }
 
     /**
@@ -327,6 +343,8 @@ class Notification extends AbstractModel
      */
     public function delete(): void
     {
+        \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::PRE_DELETE, new NotificationEvent($this));
         $this->getDao()->delete();
+        \Pimcore::getEventDispatcher()->dispatch(NotificationEvents::POST_DELETE, new NotificationEvent($this));
     }
 }


### PR DESCRIPTION
Hi,

This PR is intented to bring new events regarding the notification feature.
This adds the pre/post add/update/delete events.
For example, this could be useful to send an email for a new notification.