### PR TITLE
Fix xliff import overriding source values

### DIFF
--- a/lib/Translation/ImporterService/Importer/DataObjectImporter.php
+++ b/lib/Translation/ImporterService/Importer/DataObjectImporter.php
@@ -19,6 +19,8 @@ use Pimcore\Model\Element;
 use Pimcore\Translation\AttributeSet\Attribute;
 use Pimcore\Translation\ExportDataExtractorService\DataExtractor\DataObjectDataExtractor;
 
+use function explode;
+
 class DataObjectImporter extends AbstractElementImporter
 {
     /**
@@ -70,12 +72,10 @@ class DataObjectImporter extends AbstractElementImporter
             $blockData = $element->{'get' . $blockName}($targetLanguage);
             $blockItem = !empty($blockData) && $blockData[$blockIndex] ? $blockData[$blockIndex] : $originalBlockItem;
 
-            // ensure correct target language
-            /* @var $blockItemField DataObject\Data\BlockElement */
-            $blockItemField = $blockItem[$fieldname];
-            $blockItemField->setValue('_language', $targetLanguage);
-
             $blockItemData = !empty($blockData) ? $blockItem[$fieldname] : clone $originalBlockItemData;
+
+            /* @var $blockItemData DataObject\Data\BlockElement */
+            $blockItemData->setLanguage($targetLanguage);
 
             $blockItemData->setData($attribute->getContent());
             $blockItem[$fieldname] = $blockItemData;

--- a/lib/Translation/ImporterService/Importer/DataObjectImporter.php
+++ b/lib/Translation/ImporterService/Importer/DataObjectImporter.php
@@ -19,8 +19,6 @@ use Pimcore\Model\Element;
 use Pimcore\Translation\AttributeSet\Attribute;
 use Pimcore\Translation\ExportDataExtractorService\DataExtractor\DataObjectDataExtractor;
 
-use function explode;
-
 class DataObjectImporter extends AbstractElementImporter
 {
     /**

--- a/models/DataObject/Data/BlockElement.php
+++ b/models/DataObject/Data/BlockElement.php
@@ -212,4 +212,12 @@ class BlockElement extends AbstractModel implements OwnerAwareFieldInterface
     {
         $this->needsRenewReferences = (bool) $needsRenewReferences;
     }
+
+    /**
+     * @param string $language
+     */
+    public function setLanguage(string $language)
+    {
+        $this->_language = $language;
+    }
 }


### PR DESCRIPTION
Followup to: https://github.com/pimcore/pimcore/pull/6549

@brusch I guess I changed the setValues method and forgot about it, using the original pimcore sources my patch didn't solve the problem. I extended the OwnerAwareInterface and trait to allow updating the language, we are not aware of the owning container at the import so it's the best I came up with. I hope the tests will still work, and sorry - was my mistake.