### PR TITLE
Localized classification store tab label translations

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/classificationstore.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/classificationstore.js
@@ -189,7 +189,7 @@ pimcore.object.tags.classificationstore = Class.create(pimcore.object.tags.abstr
                 }
                 var title = this.frontendLanguages[i];
                 if (title != "default") {
-                    var title = pimcore.available_languages[title];
+                    var title = t(pimcore.available_languages[title]);
                     var icon = "pimcore_icon_language_" + this.frontendLanguages[i].toLowerCase();
                 } else {
                     var title = t(title);


### PR DESCRIPTION
Admin translations are not applied to localized classification store tab labels. Also see https://github.com/pimcore/pimcore/pull/6022