### PR TITLE
Update presta/sitemap-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
     "pear/net_url2": "^2.2",
     "phive/twig-extensions-deferred": "^2.0",
     "piwik/device-detector": "^3.9",
-    "presta/sitemap-bundle": "^2.1",
+    "presta/sitemap-bundle": "^1.5 || ^2.1",
     "ramsey/uuid": "^3.8",
     "sabre/dav": "^3.2",
     "sensio/framework-extra-bundle": "^5.4",

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
     "pear/net_url2": "^2.2",
     "phive/twig-extensions-deferred": "^2.0",
     "piwik/device-detector": "^3.9",
-    "presta/sitemap-bundle": "^1.5",
+    "presta/sitemap-bundle": "^2.1",
     "ramsey/uuid": "^3.8",
     "sabre/dav": "^3.2",
     "sensio/framework-extra-bundle": "^5.4",


### PR DESCRIPTION
## Changes in this pull request
This PR changes the version constraint of presta/sitemap-bundle to version 2.1 and above.
Resolves #6340 

## Additional info
Also removes the ugly deprecation messages when running `composer update`. ;)