### PR TITLE
Prefix GA profiles with the name of their properties

### DIFF
--- a/bundles/AdminBundle/Controller/Reports/AnalyticsController.php
+++ b/bundles/AdminBundle/Controller/Reports/AnalyticsController.php
@@ -75,13 +75,28 @@ class AnalyticsController extends ReportsControllerBase implements EventedContro
             }
 
             foreach ($accountIds as $accountId) {
+                $propertyNames = [];
+                $properties = $this->service->management_webproperties->listManagementWebproperties($accountId);
+
+                if (is_array($properties['items'])) {
+                    foreach ($properties['items'] as $property) {
+                        $propertyNames[$property['id']] = $property['name'];
+                    }
+                }
+
                 $details = $this->service->management_profiles->listManagementProfiles($accountId, '~all');
 
                 if (is_array($details['items'])) {
                     foreach ($details['items'] as $detail) {
+                        $name = $detail['name'];
+
+                        if (array_key_exists($detail['webPropertyId'], $propertyNames)) {
+                            $name = $propertyNames[$detail['webPropertyId']] . ': ' . $name;
+                        }
+
                         $data['data'][] = [
                             'id' => $detail['id'],
-                            'name' => $detail['name'],
+                            'name' => $name,
                             'trackid' => $detail['webPropertyId'],
                             'internalid' => $detail['internalWebPropertyId'],
                             'accountid' => $detail['accountId']


### PR DESCRIPTION
When you have access to multiple profiles over die analytics API, the list of available profiles can be unclear if many profiles have the same names.
![Bildschirmfoto 2020-06-16 um 09 54 03](https://user-images.githubusercontent.com/8749138/84750835-18064d00-afbc-11ea-80f6-80970ff71b64.png)

This proposed change prefixes the profile names with the names of their property, making them easier to distinguish.