### PR TITLE
Update Pimcore DB master/slave to primary/replica

### DIFF
--- a/doc/Development_Documentation/26_Best_Practice/55_Primary-Replica_Database_Connection.md
+++ b/doc/Development_Documentation/26_Best_Practice/55_Primary-Replica_Database_Connection.md
@@ -5,6 +5,8 @@ for a primary/replica server setup! Due to the extensive multi-layered, consiste
 it is necessary that Pimcore always has access to the latest data in the database. Due to the asynchronous nature 
 of the primary/replica setup, this isn't ensured for that.
 
+Note: Doctrine\DBAL versions older than 2.11 uses master/slave terminology.
+
 ### Create a Project specific Database Connection Class 
 
 Create a new class at `src\AppBundle\Db\Connection.php`, with the following content: 

--- a/doc/Development_Documentation/26_Best_Practice/55_Primary-Replica_Database_Connection.md
+++ b/doc/Development_Documentation/26_Best_Practice/55_Primary-Replica_Database_Connection.md
@@ -1,9 +1,9 @@
 
-# How to configure Pimcore to use a Master/Slave Database Connection 
-**IMPORTANT**: Please be aware that the master/slave connection can only be used for a clustered MariaDB/MySQL environment, **NOT** 
-for a master/slave replication server setup! Due to the extensive multi-layered, consistent and tagged caching of Pimcore
+# How to configure Pimcore to use a Primary/Replica Database Connection 
+**IMPORTANT**: Please be aware that the primary/replica connection can only be used for a clustered MariaDB/MySQL environment, **NOT** 
+for a primary/replica server setup! Due to the extensive multi-layered, consistent and tagged caching of Pimcore
 it is necessary that Pimcore always has access to the latest data in the database. Due to the asynchronous nature 
-of the master/slave replication, this isn't ensured for that. 
+of the primary/replica setup, this isn't ensured for that.
 
 ### Create a Project specific Database Connection Class 
 
@@ -17,7 +17,7 @@ namespace AppBundle\Db;
 use Pimcore\Db\PimcoreExtensionsTrait;
 use Pimcore\Db\ConnectionInterface;
 
-class Connection extends \Doctrine\DBAL\Connections\MasterSlaveConnection implements ConnectionInterface
+class Connection extends \Doctrine\DBAL\Connections\PrimaryReadReplicaConnection implements ConnectionInterface
 {
     use PimcoreExtensionsTrait;
 
@@ -36,11 +36,11 @@ class Connection extends \Doctrine\DBAL\Connections\MasterSlaveConnection implem
 ```
 
 
-### Configure the Master/Slave Connection
+### Configure the Primary/Replica Connection
 
-The main database connection which you have configured for Pimcore is always the master connection. 
-Then you can add as many slave hosts as you like, in the following example there's just one slave host, 
-where only the host is different (in our case `slave1`), all other options are reused from the master connection. 
+The main database connection which you have configured for Pimcore is always the primary connection. 
+Then you can add as many replica hosts as you like, in the following example there's just one replica host, 
+where only the host is different (in our case `replica1`), all other options are reused from the primary connection. 
 
 ```yml 
 doctrine:
@@ -48,9 +48,9 @@ doctrine:
         connections:
             default:
                 wrapper_class: '\AppBundle\Db\Connection'
-                slaves:
-                    slave1:
-                          host: 'slave1'
+                replicas:
+                    replica1:
+                          host: 'replica1'
                           port: 3306
                           dbname: dbname
                           user: username


### PR DESCRIPTION
Following [Doctrine/DBAL's recent deprecation](/doctrine/dbal/commit/7047798fbb5484703e2f628ab6110b08f887d550) of master/slave in favour of primary/replica Pimcore should do the same
