### PR TITLE
[CS-Fixer] Add trailing comma in multiline array rule

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -65,6 +65,7 @@ return PhpCsFixer\Config::create()
         'space_after_semicolon'               => true,
         'standardize_not_equals'              => true,
         'ternary_operator_spaces'             => true,
+        'trailing_comma_in_multiline_array'   => true,
         'whitespace_after_comma_in_array'     => true,
     ])
     ->setFinder($finder);


### PR DESCRIPTION
Also Symfony do this:
https://symfony.com/doc/current/contributing/code/standards.html#structure
`Add a comma after each array item in a multi-line array, even after the last one`
