### PR TITLE
Document should first update data and then process page count

### DIFF
--- a/models/Asset/Document.php
+++ b/models/Asset/Document.php
@@ -39,6 +39,7 @@ class Document extends Model\Asset
      */
     protected function update($params = [])
     {
+        parent::update($params);
         $this->clearThumbnails();
 
         if ($this->getDataChanged() && \Pimcore\Document::isAvailable()) {
@@ -50,8 +51,6 @@ class Document extends Model\Asset
                 TmpStore::add(sprintf('asset_document_conversion_%d', $this->getId()), $this->getId(), 'asset-document-conversion');
             }
         }
-
-        parent::update($params);
     }
 
     /**

--- a/tests/_support/Util/TestHelper.php
+++ b/tests/_support/Util/TestHelper.php
@@ -575,16 +575,13 @@ class TestHelper
 
     /**
      * @param string $keyPrefix
+     * @param string|null $data
      * @param bool $save
      *
      * @return Asset\Image
      */
-    public static function createImageAsset($keyPrefix = '', $data, $save = true)
+    public static function createImageAsset($keyPrefix = '', $data = null, $save = true)
     {
-        if (null === $keyPrefix) {
-            $keyPrefix = '';
-        }
-
         if (!$data) {
             $path = static::resolveFilePath('assets/images/image5.jpg');
             if (!file_exists($path)) {
@@ -611,6 +608,49 @@ class TestHelper
         $asset->setProperties($properties);
 
         $asset->setFilename($keyPrefix . uniqid() . rand(10, 99) . '.jpg');
+
+        if ($save) {
+            $asset->save();
+        }
+
+        return $asset;
+    }
+
+    /**
+     * @param string $keyPrefix
+     * @param string|null $data
+     * @param bool $save
+     *
+     * @return Asset\Document
+     */
+    public static function createDocumentAsset($keyPrefix = '', $data = null, $save = true)
+    {
+        if (!$data) {
+            $path = static::resolveFilePath('assets/document/sonnenblume.pdf');
+            if (!file_exists($path)) {
+                throw new \RuntimeException(sprintf('Path %s was not found', $path));
+            }
+
+            $data = file_get_contents($path);
+        }
+
+        $asset = new Asset\Document();
+        $asset->setParentId(1);
+        $asset->setUserOwner(1);
+        $asset->setUserModification(1);
+        $asset->setCreationDate(time());
+        $asset->setData($data);
+        $asset->setType('document');
+
+        $property = new Property();
+        $property->setName('propname');
+        $property->setType('text');
+        $property->setData('bla');
+
+        $properties = [$property];
+        $asset->setProperties($properties);
+
+        $asset->setFilename($keyPrefix . uniqid() . rand(10, 99) . '.pdf');
 
         if ($save) {
             $asset->save();

--- a/tests/_support/Util/TestHelper.php
+++ b/tests/_support/Util/TestHelper.php
@@ -661,6 +661,49 @@ class TestHelper
 
     /**
      * @param string $keyPrefix
+     * @param string|null $data
+     * @param bool $save
+     *
+     * @return Asset\Video
+     */
+    public static function createVideoAsset($keyPrefix = '', $data = null, $save = true)
+    {
+        if (!$data) {
+            $path = static::resolveFilePath('assets/video/example.mp4');
+            if (!file_exists($path)) {
+                throw new \RuntimeException(sprintf('Path %s was not found', $path));
+            }
+
+            $data = file_get_contents($path);
+        }
+
+        $asset = new Asset\Video();
+        $asset->setParentId(1);
+        $asset->setUserOwner(1);
+        $asset->setUserModification(1);
+        $asset->setCreationDate(time());
+        $asset->setData($data);
+        $asset->setType('video');
+
+        $property = new Property();
+        $property->setName('propname');
+        $property->setType('text');
+        $property->setData('bla');
+
+        $properties = [$property];
+        $asset->setProperties($properties);
+
+        $asset->setFilename($keyPrefix . uniqid() . rand(10, 99) . '.mp4');
+
+        if ($save) {
+            $asset->save();
+        }
+
+        return $asset;
+    }
+
+    /**
+     * @param string $keyPrefix
      * @param bool   $save
      *
      * @return Asset\Folder

--- a/tests/model/Asset/AssetTest.php
+++ b/tests/model/Asset/AssetTest.php
@@ -21,7 +21,7 @@ class AssetTest extends ModelTestCase
     public function testCustomUserModification()
     {
         $userId = 101;
-        $asset = TestHelper::createImageAsset('', null);
+        $asset = TestHelper::createImageAsset();
 
         //custom user modification
         $asset->setUserModification($userId);
@@ -43,7 +43,7 @@ class AssetTest extends ModelTestCase
         $customDateTime = new \Carbon\Carbon();
         $customDateTime = $customDateTime->subHour();
 
-        $asset = TestHelper::createImageAsset('', null);
+        $asset = TestHelper::createDocumentAsset();
 
         //custom modification date
         $asset->setModificationDate($customDateTime->getTimestamp());

--- a/tests/model/Asset/ListingTest.php
+++ b/tests/model/Asset/ListingTest.php
@@ -22,8 +22,12 @@ class ListingTest extends ModelTestCase
         $count = $db->fetchOne('SELECT count(*) from assets');
         $this->assertEquals(1, $count, 'expected 1 asset');
 
-        for ($i = 0; $i < 5; $i++) {
-            TestHelper::createImageAsset('', null, true);
+        for ($i = 0; $i < 3; $i++) {
+            TestHelper::createImageAsset();
+        }
+
+        for ($i = 0; $i < 2; $i++) {
+            TestHelper::createDocumentAsset();
         }
 
         $count = $db->fetchOne('SELECT count(*) from assets');

--- a/tests/model/Asset/ListingTest.php
+++ b/tests/model/Asset/ListingTest.php
@@ -26,9 +26,8 @@ class ListingTest extends ModelTestCase
             TestHelper::createImageAsset();
         }
 
-        for ($i = 0; $i < 2; $i++) {
-            TestHelper::createDocumentAsset();
-        }
+        TestHelper::createDocumentAsset();
+        TestHelper::createVideoAsset();
 
         $count = $db->fetchOne('SELECT count(*) from assets');
         $this->assertEquals(6, $count, 'expected 6 assets');


### PR DESCRIPTION
When you create new documents via symfony command you get following exception:
```
12:14:00 ERROR     [pimcore] Exception: Unable to get page-count of /var/www/pimcore/web/var/assets/test.pdf in /var/www/pimcore/vendor/pimcore/pimcore/lib/Document/Adapter/Ghostscript.php:148
```

Because the file doesn't yet exist in this moment.