### PR TITLE
[Workflow] fix #6013 initial place empty on add with `single_state` store

### DIFF
--- a/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
+++ b/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
@@ -169,7 +169,7 @@ class WorkflowManagementListener implements EventSubscriberInterface
             $data['workflowManagement']['workflows'] = $data['workflowManagement']['workflows'] ?? [];
 
             // Fix: places stored as empty string ("") considered uninitialized prior to Symfony 4.4.8
-            $this->workflowManager->ensureBackwardCompatibleInitialPlace($workflowName, $element);
+            $this->workflowManager->ensureInitialPlace($workflowName, $element);
 
             $allowedTransitions = $this->actionsButtonService->getAllowedTransitions($workflow, $element);
             $globalActions = $this->actionsButtonService->getGlobalActions($workflow, $element);

--- a/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
+++ b/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
@@ -82,6 +82,9 @@ class WorkflowManagementListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
+            DataObjectEvents::PRE_ADD => 'onElementPreAdd',
+            DocumentEvents::PRE_ADD => 'onElementPreAdd',
+            AssetEvents::PRE_ADD => 'onElementPreAdd',
 
             DataObjectEvents::POST_DELETE => 'onElementPostDelete',
             DocumentEvents::POST_DELETE => 'onElementPostDelete',
@@ -91,6 +94,29 @@ class WorkflowManagementListener implements EventSubscriberInterface
             AdminEvents::ASSET_GET_PRE_SEND_DATA => 'onAdminElementGetPreSendData',
             AdminEvents::DOCUMENT_GET_PRE_SEND_DATA => 'onAdminElementGetPreSendData',
         ];
+    }
+
+    /**
+     * Set initial place if defined on element create.
+     */
+    public function onElementPreAdd(ElementEventInterface $e): void
+    {
+        /** @var Asset|Document|ConcreteObject $element */
+        $element = $e->getElement();
+
+        foreach ($this->workflowManager->getAllWorkflows() as $workflowName) {
+            $workflow = $this->workflowManager->getWorkflowIfExists($element, $workflowName);
+            if (!$workflow) {
+                continue;
+            }
+
+            $hasInitialPlaceConfig = count($this->workflowManager->getInitialPlacesForWorkflow($workflow)) > 0;
+
+            // calling getMarking will ensure the initial place is set
+            if ($hasInitialPlaceConfig) {
+                $workflow->getMarking($element);
+            }
+        }
     }
 
     /**
@@ -141,6 +167,9 @@ class WorkflowManagementListener implements EventSubscriberInterface
 
             $data['workflowManagement']['hasWorkflowManagement'] = true;
             $data['workflowManagement']['workflows'] = $data['workflowManagement']['workflows'] ?? [];
+
+            // Fix: places stored as empty string ("") considered uninitialized prior to Symfony 4.4.8
+            $this->workflowManager->ensureBackwardCompatibleInitialPlace($workflowName, $element);
 
             $allowedTransitions = $this->actionsButtonService->getAllowedTransitions($workflow, $element);
             $globalActions = $this->actionsButtonService->getGlobalActions($workflow, $element);

--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -336,12 +336,11 @@ class Manager
     }
 
     /**
-     * Compatibility Fix: forces an initial place being set (and stored) if the current place is empty.
+     * Forces an initial place being set (and stored) if the current place is empty.
      * We cannot apply a regular transition b/c it would be considered invalid by the state machine.
      *
      * As of Symfony 4.4.8 built-in implementations of @see \Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface
-     * use strict `null` comparison when retrieving the current marking. This will throw exceptions for elements
-     * stored with empty marking despite an initial state was configured in prior versions of Pimcore.
+     * use strict `null` comparison when retrieving the current marking and throw an exception otherwise.
      *
      * @param Asset|Concrete|PageSnippet $subject
      *
@@ -349,7 +348,7 @@ class Manager
      *
      * @throws \Exception
      */
-    public function ensureBackwardCompatibleInitialPlace(string $workflowName, $subject): bool
+    public function ensureInitialPlace(string $workflowName, $subject): bool
     {
         if (!$workflow = $this->getWorkflowIfExists($subject, $workflowName)) {
             return false;

--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -23,6 +23,7 @@ use Pimcore\Model\Element\AbstractElement;
 use Pimcore\Model\Element\ValidationException;
 use Pimcore\Workflow\EventSubscriber\ChangePublishedStateSubscriber;
 use Pimcore\Workflow\EventSubscriber\NotesSubscriber;
+use Pimcore\Workflow\MarkingStore\StateTableMarkingStore;
 use Pimcore\Workflow\Place\PlaceConfig;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Workflow\Exception\InvalidArgumentException;
@@ -332,5 +333,75 @@ class Manager
         }
 
         return null;
+    }
+
+    /**
+     * Compatibility Fix: forces an initial place being set (and stored) if the current place is empty.
+     * We cannot apply a regular transition b/c it would be considered invalid by the state machine.
+     *
+     * As of Symfony 4.4.8 built-in implementations of @see \Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface
+     * use strict `null` comparison when retrieving the current marking. This will throw exceptions for elements
+     * stored with empty marking despite an initial state was configured in prior versions of Pimcore.
+     *
+     * @param Asset|Concrete|PageSnippet $subject
+     *
+     * @return bool true if initial state was applied
+     *
+     * @throws \Exception
+     */
+    public function ensureBackwardCompatibleInitialPlace(string $workflowName, $subject): bool
+    {
+        if (!$workflow = $this->getWorkflowIfExists($subject, $workflowName)) {
+            return false;
+        }
+
+        if (!$markingStore = $workflow->getMarkingStore()) {
+            return false;
+        }
+
+        // check that the subject has a non-empty place
+        $initialPlaces = $this->getInitialPlacesForWorkflow($workflow);
+        $markingObject = $markingStore->getMarking($subject);
+        foreach ($markingObject->getPlaces() as $placeName => $nbToken) {
+            if ('' !== $placeName) {
+                continue;
+            }
+
+            // fill empty place with initial place, if any
+            $markingObject->unmark($placeName);
+            foreach ($initialPlaces as $initialPlace) {
+                $markingObject->mark($initialPlace);
+            }
+
+            $markingStore->setMarking($subject, $markingObject);
+
+            // StateTableMarkingStore handles persistence of it's own
+            if ($markingStore instanceof StateTableMarkingStore === false) {
+                $wasOmitMandatoryCheck = $subject->getOmitMandatoryCheck();
+                $subject->setOmitMandatoryCheck(true);
+                $subject->save();
+                $subject->setOmitMandatoryCheck($wasOmitMandatoryCheck);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getInitialPlacesForWorkflow(Workflow $workflow): array
+    {
+        $initialPlaces = [];
+        $definition = $workflow->getDefinition();
+
+        if(method_exists($definition, 'getInitialPlaces')) {
+            // Symfony >= 4.3
+            $initialPlaces = $definition->getInitialPlaces();
+        } elseif (method_exists($definition, 'getInitialPlace')) {
+            // Symfony < 4.3
+            $initialPlaces = [$definition->getInitialPlace()];
+        }
+
+        return $initialPlaces;
     }
 }


### PR DESCRIPTION
- fixes invalid place "" exception as of Symfony >= 4.4.8
- set place on load for compat with objects created prior to fix

## Changes in this pull request  
Resolves #6013 

## Additional info  

Tested mainly with marking store of type `single_state` where on adding objects the initial place was not saved. The custom [StateTableMarkingStore](https://github.com/pimcore/pimcore/blob/master/lib/Workflow/MarkingStore/StateTableMarkingStore.php) seems not to be affected by the bug b/c loose checking is still applied (also, on object add the initial place get's stored to the `element_workflow_state` table).

Setting the initial place programmatically in [onAdminElementGetPreSendData](https://github.com/macghriogair/pimcore/blob/bugfix/issue-6013-initial-workflow-place-on-add/bundles/CoreBundle/EventListener/WorkflowManagementListener.php#L167) seems necessary to me as there might be (as in our case) objects persisted with empty string in the db. Feel free to suggest any alternatives. (The method could be run by a batch job as well or via maintenance, but this is maybe too case specific).