### PR TITLE
[Bundles] Use bundle's description from composer.json for extension list

### DIFF
--- a/lib/Extension/Bundle/Traits/PackageVersionTrait.php
+++ b/lib/Extension/Bundle/Traits/PackageVersionTrait.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Pimcore\Extension\Bundle\Traits;
 
 use PackageVersions\Versions;
+use Pimcore\Composer\PackageInfo;
 
 /**
  * Exposes a simple getVersion() implementation by looking up the installed versions via ocramius/package-versions
@@ -42,5 +43,17 @@ trait PackageVersionTrait
         $version = preg_replace('/@(.+)$/', '', $version);
 
         return $version;
+    }
+
+    public function getDescription() {
+        $packageInfo = new PackageInfo();
+
+        foreach($packageInfo->getInstalledPackages('pimcore-bundle') as $bundle) {
+            if($bundle['name'] === $this->getComposerPackageName()) {
+                return $bundle['description'];
+            }
+        }
+
+        return '';
     }
 }


### PR DESCRIPTION
The bundle description in the extension list in the Pimcore backend gets fetched from the Bundle classes' `getDescription()` method. This PR uses the description from a bundle's composer.json when its bundle class uses the `PackageVersionTrait`. If someone wants to provide an alternative description in the Pimcore backend compared to the one in the composer.json he can of course override the `getDescription()` method in the bundle class (as before).