### PR TITLE
[Web2Print] Remove unnecessary displayfield settings in web2print.php

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/web2print.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/web2print.js
@@ -320,8 +320,18 @@ pimcore.settings.web2print = Class.create({
         tabPanel.setActiveItem("pimcore_settings_web2print");
     },
 
-    save: function () {
+    getValues: function () {
         var values = this.layout.getForm().getFieldValues();
+        Object.keys(values).forEach(function (key) {
+            if (key.includes('displayfield')) {
+                delete values[key];
+            }
+        });
+        return values;
+    },
+
+    save: function () {
+        var values = this.getValues();
 
         Ext.Ajax.request({
             url: Routing.generate('pimcore_admin_settings_setweb2print'),


### PR DESCRIPTION
**Before**
```
<?php

return [
    "enableInDefaultView" => TRUE,
    "displayfield-1581-inputEl" => "Enables Web2Print documents in default documents view in default perspective. Either activate this or create custom views and perspectives for managing Web2Print documents.",
    "generalTool" => "pdfreactor",
    "generalDocumentSaveMode" => "default",
    "displayfield-1584-inputEl" => "Document Save Mode = cleanup deletes all not used document elements for current document. This might be necessary for useage reports in print documents.",
    "pdfreactorVersion" => "9.0",
    "pdfreactorProtocol" => "https",
    "pdfreactorServer" => "cloud.pdfreactor.com",
    "pdfreactorServerPort" => "443",
    "pdfreactorBaseUrl" => "https://demo.pimcore.fun",
    "displayfield-1568-inputEl" => "BaseURL for PDFreactor. This is prefixed to each relative url in print templates when creating PDFs.",
    "pdfreactorApiKey" => "",
    "displayfield-1570-inputEl" => "If the PDFreactor instance is set up to require API keys, you can enter it here.",
    "pdfreactorLicence" => "",
    "pdfreactorEnableDebugMode" => FALSE,
    "wkhtmltopdfBin" => "wkhtmltopdf",
    "wkhtml2pdfOptions" => [
        "print-media-type" => "",
        "page-size" => "A4"
    ],
    "displayfield-1576-inputEl" => "One per line with '--' and whitespace between key and value (e.g. --key value)",
    "wkhtml2pdfHostname" => "http://demo.pimcore.org"
];

```

**After**
```
<?php

return [
    "enableInDefaultView" => TRUE,
    "generalTool" => "pdfreactor",
    "generalDocumentSaveMode" => "default",
    "pdfreactorVersion" => "9.0",
    "pdfreactorProtocol" => "https",
    "pdfreactorServer" => "cloud.pdfreactor.com",
    "pdfreactorServerPort" => "443",
    "pdfreactorBaseUrl" => "https://demo.pimcore.fun",
    "pdfreactorApiKey" => "",
    "pdfreactorLicence" => "",
    "pdfreactorEnableDebugMode" => FALSE,
    "wkhtmltopdfBin" => "wkhtmltopdf",
    "wkhtml2pdfOptions" => [
        "print-media-type" => "",
        "page-size" => "A4"
    ],
    "wkhtml2pdfHostname" => "http://demo.pimcore.org"
];

```