### PR TITLE
Correct ACL for overlapping roles

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -257,10 +257,8 @@ class AssetController extends ElementControllerBase implements EventedController
 
                 $condition = 'parentId = ' . $db->quote($asset->getId()) . ' and
                 (
-                (select list from users_workspaces_asset where userId in (' . implode(',', $userIds) . ') and LOCATE(CONCAT(path,filename),cpath)=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
-                or
-                (select list from users_workspaces_asset where userId in (' . implode(',', $userIds) . ') and LOCATE(cpath,CONCAT(path,filename))=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
-                    )';
+                    (select list from users_workspaces_asset where userId in (' . implode(',', $userIds) . ') and (LOCATE(CONCAT(path,filename),cpath)=1 or LOCATE(cpath,CONCAT(path,filename))=1) ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $this->getAdminUser()->getId() . ') DESC, list DESC LIMIT 1)=1
+                )';
             }
 
             if (! is_null($filter)) {

--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -255,9 +255,11 @@ class AssetController extends ElementControllerBase implements EventedController
                 $userIds = $this->getAdminUser()->getRoles();
                 $userIds[] = $this->getAdminUser()->getId();
 
-                $condition = 'parentId = ' . $db->quote($asset->getId()) . ' and
+                $condition = 'parentId = ' . $db->quote($asset->getId()) . ' AND
                 (
-                    (SELECT list FROM users_workspaces_asset WHERE userId IN (' . implode(',', $userIds) . ') AND (LOCATE(CONCAT(path,filename),cpath)=1 OR LOCATE(cpath,CONCAT(path,filename))=1) ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $this->getAdminUser()->getId() . ') DESC, list DESC LIMIT 1)=1
+                    (SELECT list FROM users_workspaces_asset WHERE userId IN (' . implode(',', $userIds) . ') AND LOCATE(CONCAT(path,filename),cpath)=1 ORDER BY LENGTH(cpath) DESC, FIELD(userId, '. $this->getAdminUser()->getId() .') DESC, list DESC LIMIT 1)=1
+                    or
+                    (SELECT list FROM users_workspaces_asset WHERE userId IN (' . implode(',', $userIds) . ') AND LOCATE(cpath,CONCAT(path,filename))=1 ORDER BY LENGTH(cpath) DESC, FIELD(userId, '. $this->getAdminUser()->getId() .') DESC, list DESC LIMIT 1)=1
                 )';
             }
 

--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -257,7 +257,7 @@ class AssetController extends ElementControllerBase implements EventedController
 
                 $condition = 'parentId = ' . $db->quote($asset->getId()) . ' and
                 (
-                    (select list from users_workspaces_asset where userId in (' . implode(',', $userIds) . ') and (LOCATE(CONCAT(path,filename),cpath)=1 or LOCATE(cpath,CONCAT(path,filename))=1) ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $this->getAdminUser()->getId() . ') DESC, list DESC LIMIT 1)=1
+                    (SELECT list FROM users_workspaces_asset WHERE userId IN (' . implode(',', $userIds) . ') AND (LOCATE(CONCAT(path,filename),cpath)=1 OR LOCATE(cpath,CONCAT(path,filename))=1) ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $this->getAdminUser()->getId() . ') DESC, list DESC LIMIT 1)=1
                 )';
             }
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -168,7 +168,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
                 $userIds[] = $this->getAdminUser()->getId();
                 $condition .= '
                     AND (
-                        (SELECT list FROM users_workspaces_object WHERE userId IN (' . implode(',', $userIds) . ') AND (LOCATE(CONCAT(objects.o_path,objects.o_key),cpath)=1 or LOCATE(cpath,CONCAT(objects.o_path,objects.o_key))=1) ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $this->getAdminUser()->getId() . ') DESC, list DESC LIMIT 1)=1
+                        (SELECT list FROM users_workspaces_object WHERE userId IN (' . implode(',', $userIds) . ') AND (LOCATE(CONCAT(objects.o_path,objects.o_key),cpath)=1 OR LOCATE(cpath,CONCAT(objects.o_path,objects.o_key))=1) ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $this->getAdminUser()->getId() . ') DESC, list DESC LIMIT 1)=1
                     )'
                 ;
             }

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -166,11 +166,12 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             if (!$this->getAdminUser()->isAdmin()) {
                 $userIds = $this->getAdminUser()->getRoles();
                 $userIds[] = $this->getAdminUser()->getId();
-                $condition .= '
-                    AND (
-                        (SELECT list FROM users_workspaces_object WHERE userId IN (' . implode(',', $userIds) . ') AND (LOCATE(CONCAT(objects.o_path,objects.o_key),cpath)=1 OR LOCATE(cpath,CONCAT(objects.o_path,objects.o_key))=1) ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $this->getAdminUser()->getId() . ') DESC, list DESC LIMIT 1)=1
-                    )'
-                ;
+                $condition .= ' AND
+                (
+                    (SELECT list FROM users_workspaces_object WHERE userId IN (' . implode(',', $userIds) . ') AND LOCATE(CONCAT(objects.o_path,objects.o_key),cpath)=1 ORDER BY LENGTH(cpath) DESC, FIELD(userId, '. $this->getAdminUser()->getId() .') DESC, list DESC LIMIT 1)=1
+                    OR
+                    (SELECT list FROM users_workspaces_object WHERE userId IN (' . implode(',', $userIds) . ') AND LOCATE(cpath,CONCAT(objects.o_path,objects.o_key))=1 ORDER BY LENGTH(cpath) DESC, FIELD(userId, '. $this->getAdminUser()->getId() .') DESC, list DESC LIMIT 1)=1
+                )';
             }
 
             if (!is_null($filter)) {

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -166,11 +166,11 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             if (!$this->getAdminUser()->isAdmin()) {
                 $userIds = $this->getAdminUser()->getRoles();
                 $userIds[] = $this->getAdminUser()->getId();
-                $condition .= ' AND (
-                    (SELECT list FROM users_workspaces_object WHERE userId IN (' . implode(',', $userIds) . ') AND LOCATE(CONCAT(objects.o_path,objects.o_key),cpath)=1 ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
-                    OR
-                    (SELECT list FROM users_workspaces_object WHERE userId IN (' . implode(',', $userIds) . ') AND LOCATE(cpath,CONCAT(objects.o_path,objects.o_key))=1 ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
-                )';
+                $condition .= '
+                    AND (
+                        (SELECT list FROM users_workspaces_object WHERE userId IN (' . implode(',', $userIds) . ') AND (LOCATE(CONCAT(objects.o_path,objects.o_key),cpath)=1 or LOCATE(cpath,CONCAT(objects.o_path,objects.o_key))=1) ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $this->getAdminUser()->getId() . ') DESC, list DESC LIMIT 1)=1
+                    )'
+                ;
             }
 
             if (!is_null($filter)) {

--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -164,7 +164,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
                 $userIds[] = $this->getAdminUser()->getId();
                 $condition =
                     'parentId = ' . $db->quote($document->getId()) . ' and (
-                        (select list from users_workspaces_document where userId in (' . implode(',', $userIds) . ') and (LOCATE(CONCAT(path,`key`),cpath)=1 or LOCATE(cpath,CONCAT(path,`key`))=1) ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $this->getAdminUser()->getId() . ') DESC, list DESC LIMIT 1)=1
+                        (SELECT list FROM users_workspaces_document WHERE userId IN (' . implode(',', $userIds) . ') AND (LOCATE(CONCAT(path,`key`),cpath)=1 OR LOCATE(cpath,CONCAT(path,`key`))=1) ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $this->getAdminUser()->getId() . ') DESC, list DESC LIMIT 1)=1
                     )'
                 ;
             }

--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -162,12 +162,11 @@ class DocumentController extends ElementControllerBase implements EventedControl
             } else {
                 $userIds = $this->getAdminUser()->getRoles();
                 $userIds[] = $this->getAdminUser()->getId();
-                $condition = 'parentId = ' . $db->quote($document->getId()) . ' and
-                                        (
-                                        (select list from users_workspaces_document where userId in (' . implode(',', $userIds) . ') and LOCATE(CONCAT(path,`key`),cpath)=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
-                                        or
-                                        (select list from users_workspaces_document where userId in (' . implode(',', $userIds) . ') and LOCATE(cpath,CONCAT(path,`key`))=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1
-                                        )';
+                $condition =
+                    'parentId = ' . $db->quote($document->getId()) . ' and (
+                        (select list from users_workspaces_document where userId in (' . implode(',', $userIds) . ') and (LOCATE(CONCAT(path,`key`),cpath)=1 or LOCATE(cpath,CONCAT(path,`key`))=1) ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $this->getAdminUser()->getId() . ') DESC, list DESC LIMIT 1)=1
+                    )'
+                ;
             }
 
             if ($filter) {

--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -162,11 +162,12 @@ class DocumentController extends ElementControllerBase implements EventedControl
             } else {
                 $userIds = $this->getAdminUser()->getRoles();
                 $userIds[] = $this->getAdminUser()->getId();
-                $condition =
-                    'parentId = ' . $db->quote($document->getId()) . ' and (
-                        (SELECT list FROM users_workspaces_document WHERE userId IN (' . implode(',', $userIds) . ') AND (LOCATE(CONCAT(path,`key`),cpath)=1 OR LOCATE(cpath,CONCAT(path,`key`))=1) ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $this->getAdminUser()->getId() . ') DESC, list DESC LIMIT 1)=1
-                    )'
-                ;
+                $condition = 'parentId = ' . $db->quote($document->getId()) . ' AND
+                (
+                    (SELECT list FROM users_workspaces_document WHERE userId IN (' . implode(',', $userIds) . ') AND LOCATE(CONCAT(path,`key`),cpath)=1  ORDER BY LENGTH(cpath) DESC, FIELD(userId, '. $this->getAdminUser()->getId() .') DESC, list DESC LIMIT 1)=1
+                    or
+                    (SELECT list FROM users_workspaces_document WHERE userId IN (' . implode(',', $userIds) . ') AND LOCATE(cpath,CONCAT(path,`key`))=1  ORDER BY LENGTH(cpath) DESC, FIELD(userId, '. $this->getAdminUser()->getId() .') DESC, list DESC LIMIT 1)=1
+                )';
             }
 
             if ($filter) {

--- a/models/Asset/Dao.php
+++ b/models/Asset/Dao.php
@@ -439,7 +439,7 @@ class Dao extends Model\Element\Dao
         $userIds[] = $user->getId();
 
         try {
-            $permissionsParent = $this->db->fetchOne('SELECT `' . $type . '` FROM users_workspaces_asset WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, ABS(userId-' . $user->getId() . ') ASC LIMIT 1');
+            $permissionsParent = $this->db->fetchOne('SELECT `' . $type . '` FROM users_workspaces_asset WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $user->getId() . ') DESC, `' . $type . '` DESC  LIMIT 1');
 
             if ($permissionsParent) {
                 return true;

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -504,7 +504,7 @@ class Dao extends Model\Element\Dao
             $commaSeparated = in_array($type, ['lView', 'lEdit', 'layouts']);
 
             if ($commaSeparated) {
-                $allPermissions = $this->db->fetchAll('SELECT ' . $queryType . ',cid,cpath FROM users_workspaces_object WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESCFIELD(userId, ' . $user->getId() . ') DESC, `' . $type . '` DESC');
+                $allPermissions = $this->db->fetchAll('SELECT ' . $queryType . ',cid,cpath FROM users_workspaces_object WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $user->getId() . ') DESC, `' . $type . '` DESC');
                 if (!$allPermissions) {
                     return null;
                 }

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -504,7 +504,7 @@ class Dao extends Model\Element\Dao
             $commaSeparated = in_array($type, ['lView', 'lEdit', 'layouts']);
 
             if ($commaSeparated) {
-                $allPermissions = $this->db->fetchAll('SELECT ' . $queryType . ',cid,cpath FROM users_workspaces_object WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC');
+                $allPermissions = $this->db->fetchAll('SELECT ' . $queryType . ',cid,cpath FROM users_workspaces_object WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESCFIELD(userId, ' . $user->getId() . ') DESC, `' . $type . '` DESC');
                 if (!$allPermissions) {
                     return null;
                 }
@@ -541,7 +541,7 @@ class Dao extends Model\Element\Dao
                 return $firstPermission;
             }
 
-            $permissions = $this->db->fetchRow('SELECT ' . $queryType . ' FROM users_workspaces_object WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC LIMIT 1');
+            $permissions = $this->db->fetchRow('SELECT ' . $queryType . ' FROM users_workspaces_object WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $user->getId() . ') DESC, `' . $type . '` DESC  LIMIT 1');
 
             return $permissions;
         } catch (\Exception $e) {

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -454,7 +454,7 @@ class Dao extends Model\Element\Dao
         $userIds[] = $user->getId();
 
         try {
-            $permissionsParent = $this->db->fetchOne('SELECT `' . $type . '` FROM users_workspaces_object WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, ABS(userId-' . $user->getId() . ') ASC LIMIT 1');
+            $permissionsParent = $this->db->fetchOne('SELECT `' . $type . '` FROM users_workspaces_object WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $user->getId() . ') DESC, `' . $type . '` DESC LIMIT 1');
 
             if ($permissionsParent) {
                 return true;

--- a/models/Document/Dao.php
+++ b/models/Document/Dao.php
@@ -480,7 +480,7 @@ class Dao extends Model\Element\Dao
         $userIds[] = $user->getId();
 
         try {
-            $permissionsParent = $this->db->fetchOne('SELECT `' . $type . '` FROM users_workspaces_document WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, ABS(userId-' . $user->getId() . ') ASC LIMIT 1');
+            $permissionsParent = $this->db->fetchOne('SELECT `' . $type . '` FROM users_workspaces_document WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $user->getId() . ') DESC, `' . $type . '` DESC  LIMIT 1');
 
             if ($permissionsParent) {
                 return true;


### PR DESCRIPTION
Sort rows correctly to ensure that access rights for specific document are fully taken into account

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves issue #6654 with overlapping roles for the same tree element

## Additional info  

With the old select statement and the following setup, this will get false values for checking if a right has to be given or not

2 Roles:

GiveRight  
| cid  | cpath  | userId  | list  | view  | ... |
|---|---|---|---|---|---|
| 2 | /tree-element  | 100  | 1  | 1  | ...  |

DeclineRight  
| cid  | cpath  | userId  | list  | view  | ... |
|---|---|---|---|---|---|
| 2 | /tree-element  | 100  | 0  | 0  | ...  |

=> expected result: the user should be able to list and view the element _/tree-element_, but he won't since:
```
$permissionsParent = $this->db->fetchOne('SELECT `' . $type . '` FROM users_workspaces_document WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, ABS(userId-' . $user->getId() . ') ASC LIMIT 1');
```
**can** (the sorting might be random when none of the given parameters for sort makes a different, eg. no user specific workspace is set for this element) result (without the limit 1) in something like this:

| type (eg list) |
|---|
| 0 |
| 1 |

and the *Limit 1* will then ommit the second result row which has the correct right for this case.  
I therefore changed the ordering to first check for user specific rights on the element
```
FIELD(userId, ' . $user->getId() . ') DESC
```
and then check (if no user specific right is set) for the rights delivered from the results by sorting DESC (to see if there is a 1 in the resultset)
```
`' . $type . '` DESC 
```

It's tricky to get a setup which reproduces the error, but it does exist.