### PR TITLE
[REST webservice] Handle properties as stdclass object

### DIFF
--- a/models/Webservice/Data.php
+++ b/models/Webservice/Data.php
@@ -145,7 +145,7 @@ abstract class Data
             $object->setProperties(null);
         }
 
-        if (isset($this->properties) && is_array($this->properties)) {
+        if (isset($this->properties) && (is_array($this->properties) || $this->properties instanceof \stdClass)) {
             foreach ($this->properties as $propertyWs) {
                 $propertyWs = (array) $propertyWs;
 


### PR DESCRIPTION
Depending on how you convert the JSON of a Pimcore Webservice REST API call the properties can be an `array` or an instance of `stdclass`, see second parameter of `json_decode()`. 
The RestImporterBundle only calls `json_encode()` so the JSON objects get converted to `stdclass` objects:
https://github.com/pimcore/RestImporter/blob/6aea1943de0a7bbea8a134a29db88d4f7d495941/src/Elements/Bundle/RestImporterBundle/RestClient.php#L217

As an example a JSON response of https://<Pimcore-Host>/webservice/rest/document/id/<ID> might look like
```json
{
"success":true,
"data": {
  "path":"/path/to/document",
  "creationDate":1582810483,
  ...
  "properties":{
    "language":{
      "name":"language",
      "data":"de",
      "type":"text",
      "inheritable":true,
      "inherited":true
    },
    ...
  }
}
```

When the properties get decoded to a `stdclass` object the condition in https://github.com/pimcore/pimcore/blob/9e1a89e6130df335a7917f2f0b0f14526aa53f95/models/Webservice/Data.php#L148 fails as `is_array()` returns `false`.
Of course you could also change the RESTImporterBundle to decode the JSON to an associative array but I do not dare to do so as this could have much more other side effects. Especially as it worked before 3ace074f31f970a133857eef96737e28691d6ea0 (which actually should only make things compatible with PhpStan)