### PR TITLE
Performance enhancements when deleting elements

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/ElementControllerBase.php
+++ b/bundles/AdminBundle/Controller/Admin/ElementControllerBase.php
@@ -157,7 +157,7 @@ class ElementControllerBase extends AdminController
 
                 if ($hasChilds) {
                     // get amount of childs
-                    $list = $element->getList(['unpublished' => true]);
+                    $list = $element::getList(['unpublished' => true]);
                     $pathColumn = ($type === 'object') ? 'o_path' : 'path';
                     $list->setCondition($pathColumn . ' LIKE ?', [$element->getRealFullPath() . '/%']);
                     $childs = $list->getTotalCount();

--- a/bundles/AdminBundle/Controller/Admin/ElementControllerBase.php
+++ b/bundles/AdminBundle/Controller/Admin/ElementControllerBase.php
@@ -157,16 +157,15 @@ class ElementControllerBase extends AdminController
 
                 if ($hasChilds) {
                     // get amount of childs
-                    $listClass = '\Pimcore\Model\\' . Service::getBaseClassNameForElement($element) . '\Listing';
-                    $list = new $listClass();
-                    $pathColumn = ($type == 'object') ? 'o_path' : 'path';
+                    $list = $element->getList(['unpublished' => true]);
+                    $pathColumn = ($type === 'object') ? 'o_path' : 'path';
                     $list->setCondition($pathColumn . ' LIKE ?', [$element->getRealFullPath() . '/%']);
                     $childs = $list->getTotalCount();
                     $totalChilds += $childs;
 
                     if ($childs > 0) {
                         $deleteObjectsPerRequest = 5;
-                        for ($i = 0; $i < ceil($childs / $deleteObjectsPerRequest); $i++) {
+                        for ($i = 0, $iMax = ceil($childs / $deleteObjectsPerRequest); $i < $iMax; $i++) {
                             $deleteJobs[] = [[
                                 'url' => $this->get('router')->getContext()->getBaseUrl() . '/admin/' . $type . '/delete',
                                 'method' => 'DELETE',
@@ -181,7 +180,7 @@ class ElementControllerBase extends AdminController
                     }
                 }
 
-                // the asset itself is the last one
+                // the element itself is the last one
                 $deleteJobs[] = [[
                     'url' => $this->get('router')->getContext()->getBaseUrl() . '/admin/' . $type . '/delete',
                     'method' => 'DELETE',

--- a/bundles/AdminBundle/Controller/Admin/RecyclebinController.php
+++ b/bundles/AdminBundle/Controller/Admin/RecyclebinController.php
@@ -170,7 +170,7 @@ class RecyclebinController extends AdminController implements EventedControllerI
             $element = Element\Service::getElementById($request->get('type'), $request->get('id'));
 
             if ($element) {
-                $list = $element->getList(['unpublished' => true]);
+                $list = $element::getList(['unpublished' => true]);
                 $list->setCondition((($request->get('type') === 'object') ? 'o_' : '') . 'path LIKE ' . $list->quote($element->getRealFullPath() . '/%'));
                 $children = $list->getTotalCount();
 

--- a/bundles/AdminBundle/Controller/Admin/RecyclebinController.php
+++ b/bundles/AdminBundle/Controller/Admin/RecyclebinController.php
@@ -170,11 +170,8 @@ class RecyclebinController extends AdminController implements EventedControllerI
             $element = Element\Service::getElementById($request->get('type'), $request->get('id'));
 
             if ($element) {
-                $type = Element\Service::getElementType($element);
-                $baseClass = Element\Service::getBaseClassNameForElement($type);
-                $listClass = '\\Pimcore\\Model\\' . $baseClass . '\\Listing';
-                $list = new $listClass();
-                $list->setCondition((($type == 'object') ? 'o_' : '') . 'path LIKE ' . $list->quote($element->getRealFullPath() . '/%'));
+                $list = $element->getList(['unpublished' => true]);
+                $list->setCondition((($request->get('type') === 'object') ? 'o_' : '') . 'path LIKE ' . $list->quote($element->getRealFullPath() . '/%'));
                 $children = $list->getTotalCount();
 
                 if ($children <= 100) {

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -529,18 +529,15 @@ class AbstractObject extends Model\Element\AbstractElement
 
         try {
             // delete children
-            if ($this->hasChildren([self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_FOLDER, self::OBJECT_TYPE_VARIANT])) {
-                // delete also unpublished children
-                $unpublishedStatus = self::doHideUnpublished();
-                self::setHideUnpublished(false);
-                foreach ($this->getChildren([self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_FOLDER, self::OBJECT_TYPE_VARIANT], true) as $child) {
+            $children = $this->getChildren([self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_FOLDER, self::OBJECT_TYPE_VARIANT], true);
+            if (count($children) > 0) {
+                foreach ($children as $child) {
                     $child->delete(true);
                 }
-                self::setHideUnpublished($unpublishedStatus);
             }
 
             // remove dependencies
-            $d = $this->getDependencies();
+            $d = new Model\Dependency;
             $d->cleanAllForElement($this);
 
             // remove all properties


### PR DESCRIPTION
This PR consists of 2 changes:
1. Slight modification of `RecycleBinController::addAction()`: 
Refactored to use `getList()` method which all deletable elements have. And it now also checks for unpublished child elements (in the check if there are more than 100 children).
1. Change of `AbstractObject::delete()`: 
    - It first checked for `hasChildren()` and if this was `true` called `getChildren()` - this is redundant because `hasChildren()` does a database query and afterwards we fetch the children via `getChildren()` which needs an additional database query. Currently only `hasChildren()` can reuse the results of `getChildren()` but not vice-versa.
    - Currently the dependencies of the deleted element get fetched. This is not necessary as in the next line they get cleared by `cleanAllForElement()`.