### PR TITLE
[Workflow]fix #6468 modification date unchanged during workflow transition publish

### DIFF
--- a/lib/Workflow/EventSubscriber/ChangePublishedStateSubscriber.php
+++ b/lib/Workflow/EventSubscriber/ChangePublishedStateSubscriber.php
@@ -44,6 +44,7 @@ class ChangePublishedStateSubscriber implements EventSubscriberInterface
         if ($changePublishedState === self::FORCE_UNPUBLISHED) {
             $subject->setPublished(false);
         } elseif ($changePublishedState === self::FORCE_PUBLISHED) {
+            $subject->setModificationDate(time());
             $subject->setPublished(true);
         }
     }


### PR DESCRIPTION
Fix for issue #6468: https://github.com/pimcore/pimcore/issues/6468

Set current timestamp as modificationDate when publish a new version of an object through a workflow state transition with changePublishedState: force_published