### PR TITLE
fix seo panel tree route

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/seopanel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/seopanel.js
@@ -100,7 +100,7 @@ pimcore.document.seopanel = Class.create({
         var store = Ext.create('Ext.data.TreeStore', {
             proxy: {
                 type: 'ajax',
-                url: Routing.generate('pimcore_admin_document_document_seopaneltreeroot')
+                url: Routing.generate('pimcore_admin_document_document_seopaneltree')
             }
         });
 


### PR DESCRIPTION
SEO Document editor does not work because of wrong route definition. Regression of https://github.com/pimcore/pimcore/pull/6146.
