### PR TITLE
[Search] Allow duplicate words in search_backend_data

### DIFF
--- a/models/Search/Backend/Data.php
+++ b/models/Search/Backend/Data.php
@@ -507,11 +507,6 @@ class Data extends \Pimcore\Model\AbstractModel
         $data = str_replace("\t", '', $data);
         $data = preg_replace('#[ ]+#', ' ', $data);
 
-        // deduplication
-        $arr = explode(' ', $data);
-        $arr = array_unique($arr);
-        $data = implode(' ', $arr);
-
         return $data;
     }
 

--- a/models/Search/Backend/Data.php
+++ b/models/Search/Backend/Data.php
@@ -29,6 +29,9 @@ use Pimcore\Model\Search\Backend\Data\Dao;
  */
 class Data extends \Pimcore\Model\AbstractModel
 {
+    // if a word occures more often than this number it will get stripped to keep the search_backend_data table from getting too big
+    const MAX_WORD_OCCURENCES = 3;
+
     /**
      * @var Data\Id
      */
@@ -506,6 +509,28 @@ class Data extends \Pimcore\Model\AbstractModel
         $data = str_replace("\r", ' ', $data);
         $data = str_replace("\t", '', $data);
         $data = preg_replace('#[ ]+#', ' ', $data);
+
+        $minWordLength = $this->getDao()->getMinWordLengthForFulltextIndex();
+        $maxWordLength = $this->getDao()->getMaxWordLengthForFulltextIndex();
+
+        $words = explode(' ', $data);
+
+        $wordOccurrences = [];
+        foreach($words as $key => &$word) {
+            $wordLength = \mb_strlen($word);
+            if($wordLength < $minWordLength || $wordLength > $maxWordLength) {
+                unset($words[$key]);
+                continue;
+            }
+
+            $wordOccurrences[$word] = ($wordOccurrences[$word] ?? 0) + 1;
+            if($wordOccurrences[$word] > self::MAX_WORD_OCCURENCES) {
+                unset($words[$key]);
+            }
+        }
+        unset($word);
+
+        $data = implode(' ', $words);
 
         return $data;
     }

--- a/models/Search/Backend/Data.php
+++ b/models/Search/Backend/Data.php
@@ -516,7 +516,7 @@ class Data extends \Pimcore\Model\AbstractModel
         $words = explode(' ', $data);
 
         $wordOccurrences = [];
-        foreach($words as $key => &$word) {
+        foreach($words as $key => $word) {
             $wordLength = \mb_strlen($word);
             if($wordLength < $minWordLength || $wordLength > $maxWordLength) {
                 unset($words[$key]);
@@ -528,7 +528,6 @@ class Data extends \Pimcore\Model\AbstractModel
                 unset($words[$key]);
             }
         }
-        unset($word);
 
         $data = implode(' ', $words);
 

--- a/models/Search/Backend/Data/Dao.php
+++ b/models/Search/Backend/Data/Dao.php
@@ -85,4 +85,20 @@ class Dao extends \Pimcore\Model\Dao\AbstractDao
             Logger::alert('Cannot delete Search\\Backend\\Data, ID is empty');
         }
     }
+
+    public function getMinWordLengthForFulltextIndex() {
+        try {
+            return $this->db->fetchOne('SELECT @@innodb_ft_min_token_size');
+        } catch(\Exception $e) {
+            return 3;
+        }
+    }
+
+    public function getMaxWordLengthForFulltextIndex() {
+        try {
+            return $this->db->fetchOne('SELECT @@innodb_ft_max_token_size');
+        } catch(\Exception $e) {
+            return 84;
+        }
+    }
 }


### PR DESCRIPTION
Currently duplicate words are removed in `search_backend_data` datasets. But as search results are ordered by relevance (by default) an object with multiple occurences of the search term should be ranked higher than an object where the search term only occurs once. 