### PR TITLE
Fix ecommerce filter to keep original ordering

### DIFF
--- a/bundles/EcommerceFrameworkBundle/FilterService/Helper.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/Helper.php
@@ -127,8 +127,10 @@ class Helper
 
                 $viewModel->currentOrderBy = implode('#', reset($orderByList));
             }
-            $productList->setOrderKey($orderByList);
-            $productList->setOrder('ASC');
+            if ($orderByList) {
+                $productList->setOrderKey($orderByList);
+                $productList->setOrder('ASC');
+            }
         }
 
         if ($filterService) {


### PR DESCRIPTION
Hello,

We are using ecommerce ecommerce filters and current implementation break desired ordering forced in productListing, even if no order is configured in the filterDefinition.

This PR provide a fix.


Please check the comments for the dump command which explains the problem:

```
$productListing = $factory->getIndexService()->getProductListForCurrentTenant();

// Set order
$productOrderIds = MyProduct::getOrderIds();
$productListing->setOrderKey('FIELD(a.o_id, ' . $productOrderIds . ')');
$productListing->setOrder('ASC');

// dump($productListing->getProducts()); // Order is ok, as desired

// We create and init filter service
\Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\Helper::setupProductList($filterDefinition, $productListing, $params, $viewModel, $filterService, true);

// dump($productListing->getProducts()); // Order is reset ! Even if the filter definition no order is given
```

The filter definition has no order setted, so it should keep the setOrderKey  of the productListing:

![image](https://user-images.githubusercontent.com/9025839/86300002-e9b27f80-bc01-11ea-85bc-9efba4d4ceb5.png)

Thanks.