### PR TITLE
[Data objects] Generate default values on update

### DIFF
--- a/models/DataObject/Traits/DefaultValueTrait.php
+++ b/models/DataObject/Traits/DefaultValueTrait.php
@@ -47,7 +47,6 @@ trait DefaultValueTrait
     protected function handleDefaultValue($data, $object = null, $params = [])
     {
         $context = isset($params['context']) ? $params['context'] : [];
-        $isUpdate = isset($params['isUpdate']) ? $params['isUpdate'] : true;
 
         /**
          * if inheritance is enabled and there is no parent value then take the default value.

--- a/models/DataObject/Traits/DefaultValueTrait.php
+++ b/models/DataObject/Traits/DefaultValueTrait.php
@@ -50,15 +50,8 @@ trait DefaultValueTrait
         $isUpdate = isset($params['isUpdate']) ? $params['isUpdate'] : true;
 
         /**
-         * 1. only for create, not on update. otherwise there is no way to null it out anymore.
-         */
-        if ($isUpdate) {
-            return $data;
-        }
-
-        /**
-         * 2. if inheritance is enabled and there is no parent value then take the default value.
-         * 3. if inheritance is disabled, take the default value.
+         * if inheritance is enabled and there is no parent value then take the default value.
+         * if inheritance is disabled, take the default value.
          */
         if ($this->isEmpty($data)) {
             $class = null;

--- a/models/DataObject/Traits/DefaultValueTrait.php
+++ b/models/DataObject/Traits/DefaultValueTrait.php
@@ -57,16 +57,8 @@ trait DefaultValueTrait
             $class = null;
             $owner = isset($params['owner']) ? $params['owner'] : null;
             if ($owner instanceof Concrete) {
-                if ($isUpdate) {
-                    // only consider default value for new objects
-                    return $data;
-                }
                 $class = $owner->getClass();
             } elseif ($owner instanceof AbstractData) {
-                if ($isUpdate) {
-                    // only consider default value for new bricks
-                    return $data;
-                }
                 $class = $owner->getObject()->getClass();
             }
 


### PR DESCRIPTION
Currently default values are only applied on object creation. This makes default value generators completely useless for manually created objects because in the moment of creation all fields are empty. So when you want to create a value based on other fields - e.g. a URL slug based on a product's name - this becomes impossible because on object creation the product has no name and on first saving it is an update operation and thus default values are not applied.
This PR changes this behaviour so default values are also applied for updates.

Of course then there is the problem that you will not be able to nullify this field (except if your default value generator supports a special value for this). But this is also the case for inheritance (it is not possible to override an inherited field with an empty string / array / null or whatever. So why would one want to set a field with a default value to `null`? And why do we need to allow it for default values but not for inheritance? The only clean solution I can think of would be a "nullify-button" - be it as a button beside the field or via context menu on right-clicking the field. Any other suggestions?