### PR TITLE
Allow usage of `Pimcore\Navigation\Builder` without request

### DIFF
--- a/lib/Navigation/Builder.php
+++ b/lib/Navigation/Builder.php
@@ -119,14 +119,18 @@ class Builder
         }
 
         // set active path
-        $request = $this->requestHelper->getMasterRequest();
+        $activePages = [];
 
-        // try to find a page matching exactly the request uri
-        $activePages = $navigation->findAllBy('uri', $request->getRequestUri());
+        if ($this->requestHelper->hasMasterRequest()) {
+            $request = $this->requestHelper->getMasterRequest();
 
-        if (empty($activePages)) {
-            // try to find a page matching the path info
-            $activePages = $navigation->findAllBy('uri', $request->getPathInfo());
+            // try to find a page matching exactly the request uri
+            $activePages = $navigation->findAllBy('uri', $request->getRequestUri());
+
+            if (empty($activePages)) {
+                // try to find a page matching the path info
+                $activePages = $navigation->findAllBy('uri', $request->getPathInfo());
+            }
         }
 
         if ($activeDocument instanceof Document) {


### PR DESCRIPTION
I want to use the navigation builder inside a console command but it fails because obviously there's no request available which results in a `There is no master request available.` exception.

The builder actually doesn't need a request if the first parameter (`$activeDocument`) is not `null` because it uses that document to determine which pages are active if it could not be determined from the request.