### PR TITLE
Pimcore | Bootstrap | Initialize .env variables before constants init

### DIFF
--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -209,13 +209,13 @@ class Bootstrap
 
     public static function defineConstants()
     {
+        self::prepareEnvVariables();
+        
         // load custom constants
         $customConstantsFile = PIMCORE_PROJECT_ROOT . '/app/constants.php';
         if (file_exists($customConstantsFile)) {
             include_once $customConstantsFile;
-        }
-
-        self::prepareEnvVariables();
+        }     
 
         $resolveConstant = function (string $name, $default, bool $define = true) {
             // return constant if defined


### PR DESCRIPTION
When implementing app/constants.php access to environment variables may be required, for instance when setting up a connection to S3 based on a docker environment.

This PR recommends to initialize the .env variables before the initialization of the constants take place.