### PR TITLE
[Data Objects] Fix API-saving unpublished with empty mandatory field throws exception

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -4,6 +4,7 @@
 - [Ecommerce][IndexService] Elastic Search worker does not use mockup cache anymore. Now mockup objects are build directly based on information in response of ES response (_source flag). Therefore `AbstractElasticSearch` Worker does not extend `AbstractMockupCacheWorker` anymore. 
 - Rules regarding default values in combination with inheritance enabled have been clarified. Read [this](../../05_Objects/01_Object_Classes/01_Data_Types/README.md) for details.
 - [Ecommerce] Deprecated FactFinder integration and will be removed in Pimcore 7.
+- Saving unpublished data objects via API will not throw Validation exceptions anymore (just like Admin UI). Please set `omitMandatoryCheck` explicitly to `false` to force mandatory checks.
 
 ## 6.6.4
 - If you are using the specific settings 'max. items' option for ObjectBricks & Fieldcollections on your class definition, then API will validate the max limit on save() calls from now on.

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -76,7 +76,7 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
     protected $scheduledTasks = null;
 
     /**
-     * @var bool
+     * @var bool|null
      */
     protected $omitMandatoryCheck;
 

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -78,7 +78,7 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
     /**
      * @var bool
      */
-    protected $omitMandatoryCheck = false;
+    protected $omitMandatoryCheck;
 
     /**
      * @var bool
@@ -509,6 +509,10 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
      */
     public function getOmitMandatoryCheck()
     {
+        if($this->omitMandatoryCheck === null) {
+            return !$this->isPublished();
+        }
+
         return $this->omitMandatoryCheck;
     }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #6587

## Additional info  

