### PR TITLE
Gridconfig dialog: renderer should not be mandatory

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/gridConfigDialog.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/gridConfigDialog.js
@@ -305,7 +305,9 @@ pimcore.object.helpers.gridConfigDialog = Class.create(pimcore.element.helpers.g
                                             layout: layout
                                         }, true);
 
-                                        value = fc.renderer(value, null, record);
+                                        if (fc.renderer) {
+                                            value = fc.renderer(value, null, record);
+                                        }
                                     }
                                 } catch (e) {
                                     console.log(e);


### PR DESCRIPTION
Preview fails for datatypes that don't provide a grid config renderer