### PR TITLE
Add additional Twig functions for Site model

### DIFF
--- a/lib/Twig/Extension/PimcoreObjectExtension.php
+++ b/lib/Twig/Extension/PimcoreObjectExtension.php
@@ -32,6 +32,10 @@ class PimcoreObjectExtension extends AbstractExtension
         return [
             new TwigFunction('pimcore_document', [Document::class, 'getById']),
             new TwigFunction('pimcore_site', [Site::class, 'getById']),
+            new TwigFunction('pimcore_site_by_root_id', [Site::class, 'getByRootId']),
+            new TwigFunction('pimcore_site_by_domain', [Site::class, 'getByDomain']),
+            new TwigFunction('pimcore_site_is_request', [Site::class, 'isSiteRequest']),
+            new TwigFunction('pimcore_site_current', [Site::class, 'getCurrentSite']),
             new TwigFunction('pimcore_asset', [Asset::class, 'getById']),
             new TwigFunction('pimcore_object', [DataObject\AbstractObject::class, 'getById']),
             new TwigFunction('pimcore_document_wrap_hardlink', [Document\Hardlink\Service::class, 'wrap']),


### PR DESCRIPTION
Needed to retrieve the current site in a Twig template not related to a document and figured it would be useful to add this to the core.