### PR TITLE
Addition to PullRequest #6577 - Treepaging disappears after save object

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/overrides.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/overrides.js
@@ -244,7 +244,7 @@ Ext.define('pimcore.tree.View', {
             this.updatePaging();
         },
         beforeitemupdate: function(record) {
-            if(record.ptb) {
+            if(record.ptb && !record.needsPaging) {
                 record.ptb.destroy();
                 delete record.ptb;
             }


### PR DESCRIPTION
Hello, I took another look inside and saw that the "record.ptb" is destroyed and deleted in the event "beforeitemupdate". I added the exception that this only happens when no paging is needed.

Can you check again if I am on the right way? But this adjustment works fine ;-)

