### PR TITLE
[Docs] Wrong document resolving (BC break in 6.6.9)

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -5,6 +5,9 @@
 - Rules regarding default values in combination with inheritance enabled have been clarified. Read [this](../../05_Objects/01_Object_Classes/01_Data_Types/README.md) for details.
 - [Ecommerce] Deprecated FactFinder integration and will be removed in Pimcore 7.
 
+## 6.6.9
+- If you access `$this->view` in your controller before Symfony's `kernel.controller` event (e.g. with `onKernelController()` with higher priority than 3 or by overriding `Pimcore\Controller\setContainer()`), document routing may not work correctly. Please use `onKernelController()` with lower priority than 3 or `onKernelResponse()`.
+
 ## 6.6.4
 - If you are using the specific settings 'max. items' option for ObjectBricks & Fieldcollections on your class definition, then API will validate the max limit on save() calls from now on.
 

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -8,7 +8,7 @@
 - `\Pimcore\DataObject\GridColumnConfig\Operator\ObjectBrickGetter` operator is deprecated and will be removed in 7.0.0
 
 ## 6.6.9
-- If you access `$this->view` in your controller before Symfony's `kernel.controller` event (e.g. with `onKernelController()` with higher priority than 3 or by overriding `Pimcore\Controller\setContainer()`), document routing may not work correctly. Please use `onKernelController()` with lower priority than 3 or `onKernelResponse()`.
+- If you access `$this->view` in your controller before Symfony's `kernel.controller` event (e.g. with `onKernelController()` with higher priority than 3 or by overriding `Pimcore\Controller\FrontendController::setContainer()`), document routing may not work correctly. Please use `onKernelController()` with lower priority than 3 or `onKernelResponse()`.
 
 ## 6.6.4
 - If you are using the specific settings 'max. items' option for ObjectBricks & Fieldcollections on your class definition, then API will validate the max limit on save() calls from now on.

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -23,6 +23,7 @@ use Pimcore\Event\Model\DocumentEvent;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Document;
+use Pimcore\Model\Document\Tag\Loader\TagLoaderInterface;
 
 /**
  * @method \Pimcore\Model\Document\PageSnippet\Dao getDao()
@@ -349,6 +350,7 @@ abstract class PageSnippet extends Model\Document
     {
         try {
             if ($type) {
+                /** @var TagLoaderInterface $loader */
                 $loader = \Pimcore::getContainer()->get('pimcore.implementation_loader.document.tag');
                 $element = $loader->build($type);
 

--- a/models/Document/Tag.php
+++ b/models/Document/Tag.php
@@ -111,7 +111,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
      * @param ViewModel|null $view
      * @param bool|null $editmode
      *
-     * @return mixed
+     * @return Tag
      */
     public static function factory($type, $name, $documentId, $config = null, $controller = null, $view = null, $editmode = null)
     {

--- a/models/Webservice/Data.php
+++ b/models/Webservice/Data.php
@@ -129,12 +129,6 @@ abstract class Data
      */
     public function reverseMap($object, $disableMappingExceptions = false, $idMapper = null)
     {
-        $fallbackProperties = [];
-        $existingObject = Element\Service::getElementByPath('document', $this->path.$this->key);
-        if($existingObject) {
-            $fallbackProperties = $existingObject->getProperties();
-        }
-
         $keys = get_object_vars($this);
         foreach ($keys as $key => $value) {
             $method = 'set' . ucfirst($key);
@@ -165,10 +159,7 @@ abstract class Data
                     }
 
                     if ($id) {
-                        try {
                             $dat = Element\Service::getElementById($type, $id);
-                        } catch(\Exception $e) {
-                        }
                     }
 
                     if (is_numeric($propertyWs['data']) and !$dat) {
@@ -176,12 +167,6 @@ abstract class Data
                             throw new \Exception('cannot import property [ ' . $type . ' ] because it references unknown ' . $propertyWs['data']);
                         } else {
                             $idMapper->recordMappingFailure('object', $object->getId(), $type, $propertyWs['data']);
-                        }
-
-                        foreach($fallbackProperties as $fallbackProperty) {
-                            if($fallbackProperty->getName() == $propertyWs['name'] && $fallbackProperty->getType() == $propertyWs['type']) {
-                                $dat = $fallbackProperty->getData();
-                            }
                         }
                     }
                 } elseif ($type == 'date') {


### PR DESCRIPTION
I wondered why in one project Pimcore documents did not resolve correctly after updating to 6.6.9. The reason was that the controller overrode `Pimcore\Controller\setContainer()` and set some default variables via `$this->view->variableName = 123;`. The problem with this is that this sets the view model in the request via https://github.com/pimcore/pimcore/blob/24a5ff9eca55b0a14b310ccaee3213df76fb4fad/lib/Controller/FrontendController.php#L47 -> https://github.com/pimcore/pimcore/blob/24a5ff9eca55b0a14b310ccaee3213df76fb4fad/lib/Http/Request/Resolver/ViewModelResolver.php#L56-L65 -> https://github.com/pimcore/pimcore/blob/24a5ff9eca55b0a14b310ccaee3213df76fb4fad/lib/Http/Request/Resolver/ViewModelResolver.php#L97

In https://github.com/pimcore/pimcore/commit/7a99c74104749e761c2bd2ffbdf84c03bc902964#diff-cafe6135bd57517b8d11e7e4edf3cb0cR93 document resolving was moved to `kernel.controller` event. The found document gets written to `Request::attributes[DynamicRouter::CONTENT_KEY]` in https://github.com/pimcore/pimcore/blob/24a5ff9eca55b0a14b310ccaee3213df76fb4fad/bundles/CoreBundle/EventListener/Frontend/ElementListener.php#L136 and https://github.com/pimcore/pimcore/blob/24a5ff9eca55b0a14b310ccaee3213df76fb4fad/lib/Http/Request/Resolver/DocumentResolver.php#L47-L53 
But the Request's view model does not get updated here. Beside documenting this BC break (what this PR does), I wonder if we should update the view model's document here.

When you then later on call `$this->view->document` the previously generated, cached view model gets returned:
https://github.com/pimcore/pimcore/blob/24a5ff9eca55b0a14b310ccaee3213df76fb4fad/lib/Http/Request/Resolver/ViewModelResolver.php#L56-L58
This might contain the wrong document - it will for example when in edit mode and the document gets loaded from session. 
https://github.com/pimcore/pimcore/blob/24a5ff9eca55b0a14b310ccaee3213df76fb4fad/models/Document/Tag/Area/Info.php#L220

This prevents the user from editing any area brick in the documents because as soon as you add or remove a brick or just change its data, the document gets saved to session and then reloaded. But as the view model gets fixed too early due to our access to `$this->view` in the overridden `FrontendController::setContainer()`, the wrong document gets used to fetch the elements to be rendered (the document from the database gets used, not the one from the session - so you can never change anything which automatically saves the document to session). 