### PR TITLE
ViewModel: "document" parameter doesn't get set/updated when view model was initialized before document was resolved 

### DIFF
--- a/lib/Http/Request/Resolver/DocumentResolver.php
+++ b/lib/Http/Request/Resolver/DocumentResolver.php
@@ -18,9 +18,21 @@ use Pimcore\Model\Document;
 use Pimcore\Templating\Vars\TemplateVarsProviderInterface;
 use Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class DocumentResolver extends AbstractRequestResolver implements TemplateVarsProviderInterface
 {
+    /**
+     * @var ViewModelResolver
+     */
+    protected $viewModelResolver;
+
+    public function __construct(RequestStack $requestStack, ViewModelResolver $viewModelResolver)
+    {
+        $this->viewModelResolver = $viewModelResolver;
+        parent::__construct($requestStack);
+    }
+
     /**
      * @param Request $request
      *
@@ -49,6 +61,12 @@ class DocumentResolver extends AbstractRequestResolver implements TemplateVarsPr
         $request->attributes->set(DynamicRouter::CONTENT_KEY, $document);
         if ($document->getProperty('language')) {
             $request->setLocale($document->getProperty('language'));
+        }
+
+        // update the view model on the current request if exists
+        $viewModel = $this->viewModelResolver->getViewModel($request, false);
+        if($viewModel) {
+            $viewModel->getParameters()->set('document', $document);
         }
     }
 

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -23,6 +23,7 @@ use Pimcore\Event\Model\DocumentEvent;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Document;
+use Pimcore\Model\Document\Tag\Loader\TagLoaderInterface;
 
 /**
  * @method \Pimcore\Model\Document\PageSnippet\Dao getDao()
@@ -349,6 +350,7 @@ abstract class PageSnippet extends Model\Document
     {
         try {
             if ($type) {
+                /** @var TagLoaderInterface $loader */
                 $loader = \Pimcore::getContainer()->get('pimcore.implementation_loader.document.tag');
                 $element = $loader->build($type);
 

--- a/models/Document/Tag.php
+++ b/models/Document/Tag.php
@@ -111,7 +111,7 @@ abstract class Tag extends Model\AbstractModel implements Model\Document\Tag\Tag
      * @param ViewModel|null $view
      * @param bool|null $editmode
      *
-     * @return mixed
+     * @return Tag
      */
     public static function factory($type, $name, $documentId, $config = null, $controller = null, $view = null, $editmode = null)
     {


### PR DESCRIPTION
Follow up of  #6793

Fixed regression of #6203 and #5905, regarding the document parameter on the view model, which isn't set/updated when view model was created before the document was resolved by the event listener (onKernelController)
