### PR TITLE
Hide all unpublished elements in document relation tags

### DIFF
--- a/models/Document/Tag/Relation.php
+++ b/models/Document/Tag/Relation.php
@@ -113,7 +113,7 @@ class Relation extends Model\Document\Tag
         $this->setElement();
 
         //don't give unpublished elements in frontend
-        if (Document::doHideUnpublished() and !Element\Service::isPublished($this->element)) {
+        if (Element\Service::doHideUnpublished($this->element) && !Element\Service::isPublished($this->element)) {
             return '';
         }
 
@@ -181,14 +181,14 @@ class Relation extends Model\Document\Tag
     /**
      * Returns one of them: Document, Object, Asset
      *
-     * @return Element\ElementInterface|false
+     * @return Element\ElementInterface|false|null
      */
     public function getElement()
     {
         $this->setElement();
 
         //don't give unpublished elements in frontend
-        if (Document::doHideUnpublished() and !Element\Service::isPublished($this->element)) {
+        if (Element\Service::doHideUnpublished($this->element) && !Element\Service::isPublished($this->element)) {
             return false;
         }
 
@@ -205,7 +205,7 @@ class Relation extends Model\Document\Tag
         $this->setElement();
 
         //don't give unpublished elements in frontend
-        if (Document::doHideUnpublished() and !Element\Service::isPublished($this->element)) {
+        if (Element\Service::doHideUnpublished($this->element) && !Element\Service::isPublished($this->element)) {
             return false;
         }
         if ($this->element instanceof Element\ElementInterface) {
@@ -415,7 +415,7 @@ class Relation extends Model\Document\Tag
      */
     public function rewriteIds($idMapping)
     {
-        if (array_key_exists($this->type, $idMapping) and array_key_exists($this->getId(), $idMapping[$this->type])) {
+        if (array_key_exists($this->type, $idMapping) && array_key_exists($this->getId(), $idMapping[$this->type])) {
             $this->id = $idMapping[$this->type][$this->getId()];
         }
     }

--- a/models/Document/Tag/Relations.php
+++ b/models/Document/Tag/Relations.php
@@ -241,7 +241,7 @@ class Relations extends Model\Document\Tag implements \Iterator
             $type = $elementId['type'];
             $id = $elementId['id'];
 
-            if (array_key_exists($type, $idMapping) and array_key_exists((int) $id, $idMapping[$type])) {
+            if (array_key_exists($type, $idMapping) && array_key_exists((int) $id, $idMapping[$type])) {
                 $elementId['id'] = $idMapping[$type][$id];
             }
         }

--- a/models/Document/Tag/Relations.php
+++ b/models/Document/Tag/Relations.php
@@ -89,7 +89,7 @@ class Relations extends Model\Document\Tag implements \Iterator
     /**
      * Converts the data so it's suitable for the editmode
      *
-     * @return mixed
+     * @return array
      */
     public function getDataEditmode()
     {
@@ -172,11 +172,7 @@ class Relations extends Model\Document\Tag implements \Iterator
         $elements = [];
 
         foreach ($this->elements as $element) {
-            if (
-                ($element instanceof DataObject && DataObject::doHideUnpublished())
-                ||
-                ($element instanceof Document && Document::doHideUnpublished())
-            ) {
+            if (Element\Service::doHideUnpublished($element)) {
                 if (Element\Service::isPublished($element)) {
                     $elements[] = $element;
                 }
@@ -396,11 +392,7 @@ class Relations extends Model\Document\Tag implements \Iterator
         $this->setElements();
 
         $el = $this->current();
-        if (
-            ($el instanceof DataObject && DataObject::doHideUnpublished())
-            ||
-            ($el instanceof Document && Document::doHideUnpublished())
-        ) {
+        if (Element\Service::doHideUnpublished($el)) {
             if (!Element\Service::isPublished($el)) {
                 $this->next();
             }

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -126,7 +126,7 @@ class Service extends Model\AbstractModel
      *
      * @internal
      *
-     * @param DataObject|Document $element
+     * @param AbstractObject|Document $element
      *
      * @return string
      *
@@ -257,7 +257,7 @@ class Service extends Model\AbstractModel
     public static function getDependedElement($config)
     {
         if ($config['type'] == 'object') {
-            return DataObject::getById($config['id']);
+            return AbstractObject::getById($config['id']);
         } elseif ($config['type'] == 'asset') {
             return Asset::getById($config['id']);
         } elseif ($config['type'] == 'document') {
@@ -274,7 +274,7 @@ class Service extends Model\AbstractModel
      */
     public static function doHideUnpublished($element)
     {
-        return ($element instanceof DataObject && DataObject::doHideUnpublished())
+        return ($element instanceof AbstractObject && AbstractObject::doHideUnpublished())
             || ($element instanceof Document && Document::doHideUnpublished());
     }
 
@@ -400,7 +400,7 @@ class Service extends Model\AbstractModel
         if ($type == 'asset') {
             $element = Asset::getByPath($path);
         } elseif ($type == 'object') {
-            $element = DataObject::getByPath($path);
+            $element = AbstractObject::getByPath($path);
         } elseif ($type == 'document') {
             $element = Document::getByPath($path);
         }
@@ -498,7 +498,7 @@ class Service extends Model\AbstractModel
      * @param  int $id
      * @param  bool $force
      *
-     * @return Asset|DataObject|Document|null
+     * @return Asset|AbstractObject|Document|null
      */
     public static function getElementById($type, $id, $force = false)
     {
@@ -506,7 +506,7 @@ class Service extends Model\AbstractModel
         if ($type === 'asset') {
             $element = Asset::getById($id, $force);
         } elseif ($type === 'object') {
-            $element = DataObject::getById($id, $force);
+            $element = AbstractObject::getById($id, $force);
         } elseif ($type === 'document') {
             $element = Document::getById($id, $force);
         }

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -268,6 +268,17 @@ class Service extends Model\AbstractModel
     }
 
     /**
+     * @static
+     *
+     * @return bool
+     */
+    public static function doHideUnpublished($element)
+    {
+        return ($element instanceof DataObject && DataObject::doHideUnpublished())
+            || ($element instanceof Document && Document::doHideUnpublished());
+    }
+
+    /**
      * determines whether an element is published
      *
      * @static

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -309,7 +309,7 @@ class Service extends Model\AbstractModel
      */
     public static function filterUnpublishedAdvancedElements($data)
     {
-        if (DataObject\AbstractObject::doHideUnpublished() and is_array($data)) {
+        if (DataObject\AbstractObject::doHideUnpublished() && is_array($data)) {
             $publishedList = [];
             $mapping = [];
             foreach ($data as $advancedElement) {


### PR DESCRIPTION
While `Pimcore\Model\Document\Tag\Relations` checked for both, `DataObject`s and `Document`s whether to hide unpublished ones, `Pimcore\Model\Document\Tag\Relation` only checked this for `Document`s.