### PR TITLE
[Data Object] Add current layout id to context

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/edit.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/edit.js
@@ -31,6 +31,10 @@ pimcore.object.helpers.edit = {
 
         context.objectId = this.object.id;
 
+        if (this.object.data.currentLayoutId) {
+            context.layoutId = this.object.data.currentLayoutId;
+        }
+
         var panelListenerConfig = {};
 
         var tabpanelCorrection = function (panel) {


### PR DESCRIPTION
This allows you to fetch the current layout id in a custom path formatter. Makes it much easier for example to output a localized based custom path. Editors can switch to a custom layout and see immediately where content is still missing.