### PR TITLE
Sitemap - Empty Hardlinks causing error

### DIFF
--- a/lib/Sitemap/Document/DocumentTreeGenerator.php
+++ b/lib/Sitemap/Document/DocumentTreeGenerator.php
@@ -143,9 +143,12 @@ class DocumentTreeGenerator extends AbstractElementGenerator
     {
         if ($document instanceof Document\Hardlink) {
             $document = Document\Hardlink\Service::wrap($document);
+            if (empty($document)) {
+                return;
+            }
         }
 
-        if (!empty($document) && $this->canBeAdded($document, $context)) {
+        if ($this->canBeAdded($document, $context)) {
             yield $document;
 
             if (++$this->currentBatchCount >= $this->options['garbageCollectThreshold']) {
@@ -154,7 +157,7 @@ class DocumentTreeGenerator extends AbstractElementGenerator
             }
         }
 
-        if (!empty($document) && $document->hasChildren() && $this->handlesChildren($document, $context)) {
+        if ($document->hasChildren() && $this->handlesChildren($document, $context)) {
             foreach ($document->getChildren() as $child) {
                 yield from $this->visit($child, $context);
             }

--- a/lib/Sitemap/Document/DocumentTreeGenerator.php
+++ b/lib/Sitemap/Document/DocumentTreeGenerator.php
@@ -145,7 +145,7 @@ class DocumentTreeGenerator extends AbstractElementGenerator
             $document = Document\Hardlink\Service::wrap($document);
         }
 
-        if ($this->canBeAdded($document, $context)) {
+        if (!empty($document) && $this->canBeAdded($document, $context)) {
             yield $document;
 
             if (++$this->currentBatchCount >= $this->options['garbageCollectThreshold']) {
@@ -154,7 +154,7 @@ class DocumentTreeGenerator extends AbstractElementGenerator
             }
         }
 
-        if ($document->hasChildren() && $this->handlesChildren($document, $context)) {
+        if (!empty($document) && $document->hasChildren() && $this->handlesChildren($document, $context)) {
             foreach ($document->getChildren() as $child) {
                 yield from $this->visit($child, $context);
             }


### PR DESCRIPTION
If an empty hardlink is present, the DocumentTreeGenerator will throw an Exception "canBeAdded on null" / "hashChildren on null"


