### PR TITLE
adjusts portrait images in the search preview to prevent overflow

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/admin.css
+++ b/bundles/AdminBundle/Resources/public/css/admin.css
@@ -2023,6 +2023,7 @@ span.warning {
 
 #pimcore_quicksearch_preview .full-preview img {
     max-width: 100%;
+    max-height: 100%;
 }
 
 #pimcore_quicksearch_preview .data-table {
@@ -2056,6 +2057,10 @@ span.warning {
 
 #pimcore_quicksearch_preview .data-table td .limit-height {
     overflow: hidden;
+    max-height: 50px;
+}
+
+#pimcore_quicksearch_preview .data-table td .limit-height img {
     max-height: 50px;
 }
 


### PR DESCRIPTION
## Changes in this pull request  
Prevents portrait preview images in the search to overflow and keeps image within the container.
## Resolves
Overflow of image in the search preview

##Additional Info
Example Screenshots: 
Before:
<img src="https://user-images.githubusercontent.com/24474378/88641206-27021400-d0bf-11ea-97d4-b6284b48727d.jpg" width="45%" height="45%">

After:
<img src="https://user-images.githubusercontent.com/24474378/88641209-28334100-d0bf-11ea-9066-5436d867dadc.jpg" width="45%" height="45%">


