### PR TITLE
 Depend on `StreamOutput` instead of `ConsoleOutput` in `Pimcore\Console\Dumper`

### DIFF
--- a/lib/Console/Dumper.php
+++ b/lib/Console/Dumper.php
@@ -14,7 +14,7 @@
 
 namespace Pimcore\Console;
 
-use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 
@@ -27,7 +27,7 @@ class Dumper
     const NEWLINE_AFTER = 2;
 
     /**
-     * @var ConsoleOutput
+     * @var StreamOutput
      */
     protected $output;
 
@@ -42,11 +42,11 @@ class Dumper
     protected $varCloner;
 
     /**
-     * @param ConsoleOutput $output
+     * @param StreamOutput $output
      * @param CliDumper $cliDumper
      * @param VarCloner $varCloner
      */
-    public function __construct(ConsoleOutput $output, CliDumper $cliDumper = null, VarCloner $varCloner = null)
+    public function __construct(StreamOutput $output, CliDumper $cliDumper = null, VarCloner $varCloner = null)
     {
         $this->output = $output;
         $this->setCliDumper($cliDumper);


### PR DESCRIPTION
I wanted to write a Test according to https://symfony.com/doc/4.4/console.html#testing-commands but it fails because Symfony injects a `Symfony\Component\Console\Output\StreamOutput` instance, while Pimcore expects a `Symfony\Component\Console\Output\ConsoleOutput`.

As `ConsoleOutput` is a subclass of `StreamOutput` and all methods that are used in the `Dumper` are actually defined in `StreamOutput` it should be safe to switch the dependencies.