### PR TITLE
Follow-up for #5439: OrderManager\V7 - Save applied pricing Rule ID in the order / OrderPriceModification Fieldcollection

### DIFF
--- a/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderManager.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderManager.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\OrderUpdateNotPossibleExce
 use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\UnsupportedException;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractOrder;
 use Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\OrderAgentFactoryInterface;
+use Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\ModificatedPrice;
 use Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\VoucherServiceInterface;
 use Pimcore\Event\Ecommerce\OrderManagerEvents;
 use Pimcore\Event\Model\Ecommerce\OrderManagerEvent;

--- a/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderManager.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderManager.php
@@ -132,7 +132,7 @@ class OrderManager extends \Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager
             $modificationItem->setAmount($modification->getGrossAmount()->asString());
             $modificationItem->setNetAmount($modification->getNetAmount()->asString());
 
-            if ($rule = $modification->getRule()) {
+            if ($modification instanceof ModificatedPrice && $rule = $modification->getRule()) {
                 $modificationItem->setPricingRuleId($rule->getId());
             } else {
                 $modificationItem->setPricingRuleId(null);

--- a/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderManager.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderManager.php
@@ -131,6 +131,13 @@ class OrderManager extends \Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager
             $modificationItem->setName($modification->getDescription() ? $modification->getDescription() : $name);
             $modificationItem->setAmount($modification->getGrossAmount()->asString());
             $modificationItem->setNetAmount($modification->getNetAmount()->asString());
+
+            if ($rule = $modification->getRule()) {
+                $modificationItem->setPricingRuleId($rule->getId());
+            } else {
+                $modificationItem->setPricingRuleId(null);
+            }
+
             $modificationItems->add($modificationItem);
         }
 


### PR DESCRIPTION
Looks like the pull request #5439 didn't adjust the V7 OrderManager.

## Changes in this pull request
Copy / paste 
```
            if ($rule = $modification->getRule()) {
                $modificationItem->setPricingRuleId($rule->getId());
            } else {
                $modificationItem->setPricingRuleId(null);
            }
```
from `EcommerceFrameworkBundle/OrderManager/OrderManager.php`  to `EcommerceFrameworkBundle/OrderManager/V7/OrderManager.php `

