### PR TITLE
fixing matchRequest resolving for dataobjects with urlslug

### DIFF
--- a/lib/Routing/Dynamic/DataObjectRouteHandler.php
+++ b/lib/Routing/Dynamic/DataObjectRouteHandler.php
@@ -90,6 +90,7 @@ class DataObjectRouteHandler implements DynamicRouteHandlerInterface
      */
     public function matchRequest(RouteCollection $collection, DynamicRequestContext $context)
     {
+        $slug = null;
         if ($site = $this->siteResolver->getSite($context->getRequest())) {
             $slug = DataObject\Data\UrlSlug::resolveSlug($context->getOriginalPath(), $site->getId());
         }

--- a/lib/Routing/Dynamic/DataObjectRouteHandler.php
+++ b/lib/Routing/Dynamic/DataObjectRouteHandler.php
@@ -90,13 +90,12 @@ class DataObjectRouteHandler implements DynamicRouteHandlerInterface
      */
     public function matchRequest(RouteCollection $collection, DynamicRequestContext $context)
     {
-        $siteIds = [0];
-        $site = $this->siteResolver->getSite($context->getRequest());
-        if ($site) {
-            $siteIds[] = $site->getId();
+        if ($site = $this->siteResolver->getSite($context->getRequest())) {
+            $slug = DataObject\Data\UrlSlug::resolveSlug($context->getOriginalPath(), $site->getId());
         }
-
-        $slug = DataObject\Data\UrlSlug::resolveSlug($context->getPath());
+        if (!$slug) {
+            $slug = DataObject\Data\UrlSlug::resolveSlug($context->getOriginalPath(), 0);
+        }
         if ($slug) {
             $object = DataObject::getById($slug->getObjectId());
             if ($object instanceof DataObject\Concrete && $object->isPublished()) {


### PR DESCRIPTION
### Expected behavior:
If I create a DataObject with UrlSlug and enter the domain relative URL /test there, I expect that I can call this DataObject with http://127.0.0.1/test.

If I have a MultiSite (example1.local and example2.local) and give the DataObject the URL /test at page ID 0, page ID 1 the URL /test1 and page ID 2 the URL /test2. Then I should be able to call both example1.local/test and example2.local/test. /test1 and /test2 only under the respective page

### Current behavior:
I cannot call anything and the DataObject is not found, whether the data is stored correctly in the database.

### Adjustment:
Currently the matchRequest function found the page and created an array with page IDs, but it did not evaluate the page. Furthermore the URL was converted to a document page path. This must remain 1:1 and may not be adjusted. So the URL was searched for /example1.local/test and /example1.local/test1.

The change by this pull request ensures that if a site is found, the URL itself is searched for with the found site ID and if this was not found, the URL itself is searched for with the site ID 0.