### PR TITLE
Remove unused `$isNested` parameter in `delete()` methods of `DataObject`'s and `Document`'s

### DIFF
--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -517,11 +517,9 @@ class AbstractObject extends Model\Element\AbstractElement
     }
 
     /**
-     * @param bool $isNested
-     *
      * @throws \Exception
      */
-    public function delete(bool $isNested = false)
+    public function delete()
     {
         \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::PRE_DELETE, new DataObjectEvent($this));
 

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -530,7 +530,7 @@ class AbstractObject extends Model\Element\AbstractElement
             $children = $this->getChildren([self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_FOLDER, self::OBJECT_TYPE_VARIANT], true);
             if (count($children) > 0) {
                 foreach ($children as $child) {
-                    $child->delete(true);
+                    $child->delete();
                 }
             }
 

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -232,7 +232,7 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
     /**
      * @inheritdoc
      */
-    public function delete(bool $isNested = false)
+    public function delete()
     {
         $this->beginTransaction();
 
@@ -244,7 +244,7 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
 
             $this->getDao()->deleteAllTasks();
 
-            parent::delete($isNested);
+            parent::delete();
 
             $this->commit();
         } catch (\Exception $e) {

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -244,7 +244,7 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
 
             $this->getDao()->deleteAllTasks();
 
-            parent::delete(true);
+            parent::delete($isNested);
 
             $this->commit();
         } catch (\Exception $e) {

--- a/models/DataObject/Folder.php
+++ b/models/DataObject/Folder.php
@@ -57,12 +57,12 @@ class Folder extends AbstractObject
     /**
      * @inheritdoc
      */
-    public function delete(bool $isNested = false)
+    public function delete()
     {
         if ($this->getId() == 1) {
             throw new \Exception('root-node cannot be deleted');
         }
 
-        parent::delete($isNested);
+        parent::delete();
     }
 }

--- a/models/Document.php
+++ b/models/Document.php
@@ -782,11 +782,9 @@ class Document extends Element\AbstractElement
     }
 
     /**
-     * @param bool $isNested
-     *
      * @throws \Exception
      */
-    public function delete(bool $isNested = false)
+    public function delete()
     {
         \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::PRE_DELETE, new DocumentEvent($this));
 

--- a/models/Document.php
+++ b/models/Document.php
@@ -798,7 +798,7 @@ class Document extends Element\AbstractElement
                 self::setHideUnpublished(false);
                 foreach ($this->getChildren(true) as $child) {
                     if (!$child instanceof WrapperInterface) {
-                        $child->delete(true);
+                        $child->delete();
                     }
                 }
                 self::setHideUnpublished($unpublishedStatus);

--- a/models/Document/Hardlink.php
+++ b/models/Document/Hardlink.php
@@ -240,7 +240,7 @@ class Hardlink extends Document
     /**
      * @inheritdoc
      */
-    public function delete(bool $isNested = false)
+    public function delete()
     {
         $this->beginTransaction();
 
@@ -254,7 +254,7 @@ class Hardlink extends Document
                 $redirect->delete();
             }
 
-            parent::delete($isNested);
+            parent::delete();
 
             $this->commit();
         } catch (\Exception $e) {

--- a/models/Document/Hardlink/Wrapper.php
+++ b/models/Document/Hardlink/Wrapper.php
@@ -55,11 +55,9 @@ trait Wrapper
     }
 
     /**
-     * @param bool $isNested
-     *
      * @throws \Exception
      */
-    public function delete(bool $isNested = false)
+    public function delete()
     {
         throw $this->getHardlinkError();
     }

--- a/models/Document/Page.php
+++ b/models/Document/Page.php
@@ -70,7 +70,7 @@ class Page extends TargetingDocument
     /**
      * @inheritdoc
      */
-    public function delete(bool $isNested = false)
+    public function delete()
     {
         if ($this->getId() == 1) {
             throw new \Exception('root-node cannot be deleted');
@@ -92,7 +92,7 @@ class Page extends TargetingDocument
                 $site->delete();
             }
 
-            parent::delete($isNested);
+            parent::delete();
 
             $this->commit();
         } catch (\Exception $e) {

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -181,7 +181,7 @@ abstract class PageSnippet extends Model\Document
     /**
      * @inheritdoc
      */
-    public function delete(bool $isNested = false)
+    public function delete()
     {
         $this->beginTransaction();
 
@@ -194,7 +194,7 @@ abstract class PageSnippet extends Model\Document
             // remove all tasks
             $this->getDao()->deleteAllTasks();
 
-            parent::delete($isNested);
+            parent::delete();
 
             $this->commit();
         } catch (\Exception $e) {

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -194,7 +194,7 @@ abstract class PageSnippet extends Model\Document
             // remove all tasks
             $this->getDao()->deleteAllTasks();
 
-            parent::delete(true);
+            parent::delete($isNested);
 
             $this->commit();
         } catch (\Exception $e) {


### PR DESCRIPTION
Not sure if this is desired or an oversight (actually, I don't understand the necessity of this parameter at all) but I've noticed that the method's argument is ignored when calling `parent` and instead the value is hardcoded to `true`.

Maybe someone of the core-developers can validate if this behavior is correct (in that cast I think it should be documented!) or if it should be patched by this PR.