### PR TITLE
Depend on `OutputInterface` instead of `StreamOutput` in `Pimcore\Console\Dumper`

### DIFF
--- a/lib/Console/Dumper.php
+++ b/lib/Console/Dumper.php
@@ -14,6 +14,7 @@
 
 namespace Pimcore\Console;
 
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
@@ -27,7 +28,7 @@ class Dumper
     const NEWLINE_AFTER = 2;
 
     /**
-     * @var StreamOutput
+     * @var OutputInterface
      */
     protected $output;
 
@@ -42,11 +43,11 @@ class Dumper
     protected $varCloner;
 
     /**
-     * @param StreamOutput $output
+     * @param OutputInterface $output
      * @param CliDumper $cliDumper
      * @param VarCloner $varCloner
      */
-    public function __construct(StreamOutput $output, CliDumper $cliDumper = null, VarCloner $varCloner = null)
+    public function __construct(OutputInterface $output, CliDumper $cliDumper = null, VarCloner $varCloner = null)
     {
         $this->output = $output;
         $this->setCliDumper($cliDumper);
@@ -62,7 +63,13 @@ class Dumper
             $this->cliDumper = new CliDumper();
         }
 
-        $this->cliDumper->setOutput($this->output->getStream());
+        $output = $this->output instanceof StreamOutput ? $this->output->getStream() : function ($line, $depth, $indentPad) {
+            if (-1 !== $depth) {
+                $this->output->writeln(str_repeat($indentPad, $depth) . $line);
+            }
+        };
+
+        $this->cliDumper->setOutput($output);
     }
 
     /**


### PR DESCRIPTION
In #6839 I already changed the output dependecy from `ConsoleOutput` to `StreamOutput`, but this is not sufficient in all cases, so it should depend on `OutputInterface` instead.

A use case is when running commands programmatically, like this:
```php
function runCommand(Application $application, string $command, array $parameters = []): void
{
    $input = new ArrayInput(array_merge(['command' => $command], $parameters));
    $output = new BufferedOutput();

    if (0 !== $application->run($input, $output)) {
        throw new \RuntimeException(sprintf('Error running "%s": %s', $command, $output->fetch()));
    }
}

$kernel = ...
$application = new Application($kernel);
$application->setAutoExit(false);

runCommand($application, 'awesome:command', ['-v' => true]);
```

The `BufferedOutput` implements `OutputInterface` but does not extend `StreamOutput`.