### PR TITLE
fix: csv dataobject import reload column configuration

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/import/configDialog.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/import/configDialog.js
@@ -75,7 +75,7 @@ pimcore.object.helpers.import.configDialog = Class.create({
         this.csvPreviewPanel = new pimcore.object.helpers.import.csvPreviewTab(this.config, this);
         this.columnConfigPanel = new pimcore.object.helpers.import.columnConfigurationTab(this.config, this);
         this.resolverSettingsPanel = new pimcore.object.helpers.import.resolverSettingsTab(this.config, this);
-        this.csvSettingsPanel = new pimcore.object.helpers.import.csvSettingsTab(this.config, this);
+        this.csvSettingsPanel = new pimcore.object.helpers.import.csvSettingsTab(this.config, true, this);
         this.saveAndSharePanel = new pimcore.object.helpers.import.saveAndShareTab(this.config, this);
         this.reportPanel = new pimcore.object.helpers.import.reportTab(this.config, this);
 


### PR DESCRIPTION
Error: CSV DataObject import, tab panel "CSV Settings", button "Reload column configuration" triggered error "Uncaught TypeError: this.callback is undefined" in updateColumnConfig
Caused by: Argument "showReload" was missing in constructor call
Introduced by: 62202949a129c806754f57c15498a60bf753943b
Relates to: Issue #6462

Steps to reproduce:
- Create a CSV file
- Start a CSV DataObject import with any random class
- Go to the CSV Settings tab
- Change settings and hit "Reload column configuration"

- Nothing happens, browser console displays: Uncaught TypeError: this.callback is undefined in updateColumnConfig
