### PR TITLE
[Element] Remove multiple triggers of POST_DELETE_FAILURE event

### DIFF
--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -249,7 +249,6 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
             $this->commit();
         } catch (\Exception $e) {
             $this->rollBack();
-            \Pimcore::getEventDispatcher()->dispatch(DataObjectEvents::POST_DELETE_FAILURE, new DataObjectEvent($this));
             Logger::crit($e);
             throw $e;
         }

--- a/models/Document/Hardlink.php
+++ b/models/Document/Hardlink.php
@@ -259,7 +259,6 @@ class Hardlink extends Document
             $this->commit();
         } catch (\Exception $e) {
             $this->rollBack();
-            \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_DELETE_FAILURE, new DocumentEvent($this));
             Logger::error($e);
             throw $e;
         }

--- a/models/Document/Page.php
+++ b/models/Document/Page.php
@@ -97,7 +97,6 @@ class Page extends TargetingDocument
             $this->commit();
         } catch (\Exception $e) {
             $this->rollBack();
-            \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_DELETE_FAILURE, new DocumentEvent($this));
             Logger::error($e);
             throw $e;
         }

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -199,7 +199,6 @@ abstract class PageSnippet extends Model\Document
             $this->commit();
         } catch (\Exception $e) {
             $this->rollBack();
-            \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::POST_DELETE_FAILURE, new DocumentEvent($this));
             Logger::error($e);
             throw $e;
         }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #6821

## Additional info  
As `PRE_DELETE` & `POST_DELETE` events are triggered only on abstract classes so `POST_DELETE_FAILURE` should only be triggered from there.
https://github.com/pimcore/pimcore/blob/2662d44a8828ad8fc7c8d878020b115f8ba61d69/models/Document.php#L791


Reason for `master` base https://github.com/pimcore/pimcore/issues/6821#issuecomment-662882535