### PR TITLE
[DataObject] Add css class for object field types

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/block.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/block.js
@@ -50,7 +50,7 @@ pimcore.object.tags.block = Class.create(pimcore.object.tags.abstract, {
             autoHeight: true,
             border: true,
             style: "margin-bottom: 10px",
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             collapsible: this.fieldConfig.collapsible,
             collapsed: this.fieldConfig.collapsed
         };

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/booleanSelect.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/booleanSelect.js
@@ -171,7 +171,7 @@ pimcore.object.tags.booleanSelect = Class.create(pimcore.object.tags.abstract, {
             selectOnFocus: true,
             fieldLabel: this.fieldConfig.title,
             store: store,
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             width: 250,
             labelWidth: 100
         };

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
@@ -27,7 +27,7 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
 
         var input = {
             fieldLabel: '<img src="/bundles/pimcoreadmin/img/flat-color-icons/calculator.svg" style="height: 1.8em; display: inline-block; vertical-align: middle;"/>' + this.fieldConfig.title,
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             labelWidth: 100,
             readOnly: true
         };

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/checkbox.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/checkbox.js
@@ -144,7 +144,7 @@ pimcore.object.tags.checkbox = Class.create(pimcore.object.tags.abstract, {
                 this.checkbox,
                 this.emptyButton
             ],
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             border: false,
             style: {
                 padding: 0

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/classificationstore.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/classificationstore.js
@@ -149,7 +149,7 @@ pimcore.object.tags.classificationstore = Class.create(pimcore.object.tags.abstr
         } else {
             var panelConf = {
                 autoScroll: true,
-                cls: "object_field",
+                cls: "object_field object_field_type_" + this.type,
                 activeTab: 0,
                 height: "auto",
                 items: [],

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/consent.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/consent.js
@@ -105,7 +105,7 @@ pimcore.object.tags.consent = Class.create(pimcore.object.tags.abstract, {
             combineErrors: false,
             width: width,
             items: [this.checkBox, this.textLabel],
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             isDirty: function() {
                 return this.checkBox.isDirty()
             }.bind(this)

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/date.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/date.js
@@ -65,7 +65,7 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
         var date = {
             fieldLabel:this.fieldConfig.title,
             name:this.fieldConfig.name,
-            componentCls:"object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             width:130,
             format: "Y-m-d"
         };

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/datetime.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/datetime.js
@@ -87,7 +87,7 @@ pimcore.object.tags.datetime = Class.create(pimcore.object.tags.abstract, {
             fieldLabel:this.fieldConfig.title,
             combineErrors:false,
             items:[this.datefield, this.timefield],
-            componentCls:"object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             isDirty: function() {
                 return this.datefield.isDirty() || this.timefield.isDirty()
             }.bind(this)

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/externalImage.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/externalImage.js
@@ -102,7 +102,7 @@ pimcore.object.tags.externalImage = Class.create(pimcore.object.tags.abstract, {
                 },
                 this.deleteButton
             ],
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             border: false,
             style: {
                 padding: 0

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
@@ -82,7 +82,7 @@ pimcore.object.tags.fieldcollections = Class.create(pimcore.object.tags.abstract
             border: this.fieldConfig.border,
             style: "margin-bottom: 10px",
             bodyStyle: 'padding-top: 5px',
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             collapsible: this.fieldConfig.collapsible,
             collapsed: this.fieldConfig.collapsed
         };

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geobounds.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geobounds.js
@@ -44,7 +44,7 @@ pimcore.object.tags.geobounds = Class.create(pimcore.object.tags.geo.abstract, {
             style: "margin-bottom: 10px",
             height: this.fieldConfig.height,
             width: this.fieldConfig.width,
-            componentCls: 'object_field object_geo_field',
+            componentCls: 'object_field object_geo_field object_field_type_' + this.type,
             html: '<div id="leaflet_maps_container_' + this.mapImageID + '"></div>',
             bbar: [{
                     xtype: 'button',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geopoint.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geopoint.js
@@ -63,7 +63,7 @@ pimcore.object.tags.geopoint = Class.create(pimcore.object.tags.geo.abstract, {
             style: "margin-bottom: 10px",
             height: this.fieldConfig.height,
             width: this.fieldConfig.width,
-            componentCls: "object_field object_geo_field",
+            componentCls: 'object_field object_geo_field object_field_type_' + this.type,
             html: '<div id="leaflet_maps_container_' + this.mapImageID + '"></div>',
             bbar: [
                 t('latitude'),

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geopolygon.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geopolygon.js
@@ -47,7 +47,7 @@ pimcore.object.tags.geopolygon = Class.create(pimcore.object.tags.geo.abstract, 
             width: this.fieldConfig.width,
             border: true,
             style: "margin-bottom: 10px",
-            componentCls: 'object_field object_geo_field',
+            componentCls: 'object_field object_geo_field object_field_type_' + this.type,
             html: '<div id="leaflet_maps_container_' + this.mapImageID + '"></div>',
             bbar: [{
                 xtype: 'button',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geopolyline.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/geopolyline.js
@@ -45,7 +45,7 @@ pimcore.object.tags.geopolyline = Class.create(pimcore.object.tags.geo.abstract,
             style: "margin-bottom: 10px",
             height: this.fieldConfig.height,
             width: this.fieldConfig.width,
-            componentCls: 'object_field object_geo_field',
+            componentCls: 'object_field object_geo_field object_field_type_' + this.type,
             html: '<div id="leaflet_maps_container_' + this.mapImageID + '"></div>',
             bbar: [{
                 xtype: 'button',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
@@ -236,7 +236,7 @@ pimcore.object.tags.hotspotimage = Class.create(pimcore.object.tags.image, {
             width: this.fieldConfig.width,
             height: this.fieldConfig.height,
             border: true,
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             tbar: toolbar
         };
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/image.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/image.js
@@ -117,7 +117,7 @@ pimcore.object.tags.image = Class.create(pimcore.object.tags.abstract, {
                         handler: this.openSearchEditor.bind(this)
                     }]
             },
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             bodyCls: "pimcore_droptarget_image pimcore_image_container"
         };
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/imagegallery.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/imagegallery.js
@@ -215,7 +215,7 @@ pimcore.object.tags.imageGallery = Class.create(pimcore.object.tags.abstract, {
                 respectPlaceholder: true,
                 callback: this
             },
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             style: {
                 margin: '0 0 10px 0',
             },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/input.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/input.js
@@ -52,7 +52,7 @@ pimcore.object.tags.input = Class.create(pimcore.object.tags.abstract, {
         var input = {
             fieldLabel: this.fieldConfig.title,
             name: this.fieldConfig.name,
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             labelWidth: 100
         };
 
@@ -100,7 +100,7 @@ pimcore.object.tags.input = Class.create(pimcore.object.tags.abstract, {
             this.updateCharCount(this.component, charCount);
 
             return Ext.create("Ext.Panel", {
-                cls: "object_field",
+                cls: "object_field object_field_type_" + this.type,
                 style: "margin-bottom: 10px",
                 layout: {
                     type: 'vbox',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/input.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/input.js
@@ -52,9 +52,12 @@ pimcore.object.tags.input = Class.create(pimcore.object.tags.abstract, {
         var input = {
             fieldLabel: this.fieldConfig.title,
             name: this.fieldConfig.name,
-            componentCls: "object_field object_field_type_" + this.type,
             labelWidth: 100
         };
+
+        if (!this.fieldConfig.showCharCount) {
+            input.componentCls = "object_field object_field_type_" + this.type;
+        }
 
         if (this.data) {
             input.value = this.data;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/inputQuantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/inputQuantityValue.js
@@ -102,7 +102,7 @@ pimcore.object.tags.inputQuantityValue = Class.create(pimcore.object.tags.abstra
             labelWidth: labelWidth,
             combineErrors: false,
             items: [this.inputField, this.unitField],
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             isDirty: function() {
                 return this.inputField.isDirty() || this.unitField.isDirty()
             }.bind(this)

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/link.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/link.js
@@ -101,7 +101,7 @@ pimcore.object.tags.link = Class.create(pimcore.object.tags.abstract, {
             border: false,
             combineErrors: false,
             items: [this.displayField, this.openButton, this.editButton],
-            componentCls: "object_field"
+            componentCls: "object_field object_field_type_" + this.type
         });
 
         return this.component;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/localizedfields.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/localizedfields.js
@@ -20,7 +20,7 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
 
     tabPanelDefaultConfig: {
         monitorResize: true,
-        cls: "object_field",
+        cls: "object_field object_field_type_localizedfields",
         activeTab: 0,
         height: "auto",
         items: [],

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -340,7 +340,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
             this.fieldConfig.height = null;
         }
 
-        var cls = 'object_field';
+        var cls = 'object_field object_field_type_' + this.type;
 
         var columns = this.getVisibleColumns();
         var toolbarItems = this.getEditToolbarItems();
@@ -621,7 +621,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
             height: this.fieldConfig.height,
             autoHeight: autoHeight,
             border: true,
-            cls: "object_field",
+            cls: "object_field object_field_type_" + this.type,
             autoExpandColumn: 'path',
             style: "margin-bottom: 10px",
             title: this.fieldConfig.title,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -106,7 +106,7 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
         if (intval(this.fieldConfig.height) < 15) {
             autoHeight = true;
         }
-        var cls = 'object_field';
+        var cls = 'object_field object_field_type_' + this.type;
 
         var toolbarItems = this.getEditToolbarItems();
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -156,7 +156,7 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
             labelWidth: labelWidth,
             layout: 'hbox',
             items: items,
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             border: false,
             style: {
                 padding: 0
@@ -177,7 +177,7 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
         var href = {
             fieldLabel: this.fieldConfig.title,
             name: this.fieldConfig.name,
-            cls: "object_field",
+            cls: "object_field object_field_type_" + this.type,
             labelWidth: this.fieldConfig.labelWidth ? this.fieldConfig.labelWidth : 100
         };
 
@@ -208,7 +208,7 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
                 iconCls: "pimcore_icon_open",
                 handler: this.openElement.bind(this)
             }],
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             border: false,
             style: {
                 padding: 0

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -177,7 +177,6 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
         var href = {
             fieldLabel: this.fieldConfig.title,
             name: this.fieldConfig.name,
-            cls: "object_field object_field_type_" + this.type,
             labelWidth: this.fieldConfig.labelWidth ? this.fieldConfig.labelWidth : 100
         };
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multiselect.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multiselect.js
@@ -142,7 +142,7 @@ pimcore.object.tags.multiselect = Class.create(pimcore.object.tags.abstract, {
             editable: false,
             fieldLabel: this.fieldConfig.title,
             store: store,
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             valueField: 'id',
             labelWidth: this.fieldConfig.labelWidth ? this.fieldConfig.labelWidth : 100,
             listeners: {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/numeric.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/numeric.js
@@ -83,7 +83,7 @@ pimcore.object.tags.numeric = Class.create(pimcore.object.tags.abstract, {
         var input = {
             fieldLabel: this.fieldConfig.title,
             name: this.fieldConfig.name,
-            componentCls: "object_field"
+            componentCls: "object_field object_field_type_" + this.type
         };
 
         if (!isNaN(this.data)) {
@@ -131,7 +131,7 @@ pimcore.object.tags.numeric = Class.create(pimcore.object.tags.abstract, {
         var input = {
             fieldLabel: this.fieldConfig.title,
             name: this.fieldConfig.name,
-            componentCls: "object_field"
+            componentCls: "object_field object_field_type_" + this.type,
         };
 
         if (!isNaN(this.data)) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
@@ -68,7 +68,7 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
             autoHeight: true,
             border: this.fieldConfig.border,
             style: "margin-bottom: 10px",
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             items: [this.tabpanel]
         };
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/password.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/password.js
@@ -30,7 +30,7 @@ pimcore.object.tags.password = Class.create(pimcore.object.tags.abstract, {
         var input = {
             fieldLabel: this.fieldConfig.title,
             name: this.fieldConfig.name,
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             inputType: "password",
             listeners: {
                 afterrender: function (cmp) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
@@ -203,7 +203,7 @@ pimcore.object.tags.quantityValue = Class.create(pimcore.object.tags.abstract, {
             labelWidth: labelWidth,
             combineErrors: false,
             items: [this.inputField, this.unitField, compatibleUnitsButton],
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             isDirty: function() {
                 return this.defaultValue || this.inputField.isDirty() || this.unitField.isDirty()
             }.bind(this)

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/reverseManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/reverseManyToManyObjectRelation.js
@@ -114,7 +114,7 @@ pimcore.object.tags.reverseManyToManyObjectRelation = Class.create(pimcore.objec
             autoHeight = true;
         }
 
-        var cls = 'object_field';
+        var cls = 'object_field object_field_type_' + this.type;
 
         var classStore = pimcore.globalmanager.get("object_types_store");
         var record = classStore.getAt(classStore.findExact('text', this.fieldConfig.ownerClassName));

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/rgbaColor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/rgbaColor.js
@@ -120,7 +120,7 @@ pimcore.object.tags.rgbaColor = Class.create(pimcore.object.tags.abstract, {
             },
             layout: 'hbox',
             width: width,
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             items: [this.colorField, this.selector,
                 {
                 xtype: "button",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/select.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/select.js
@@ -275,7 +275,7 @@ pimcore.object.tags.select = Class.create(pimcore.object.tags.abstract, {
             selectOnFocus: true,
             fieldLabel: this.fieldConfig.title,
             store: store,
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             width: 250,
             displayField: 'key',
             valueField: 'value',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/slider.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/slider.js
@@ -41,7 +41,7 @@ pimcore.object.tags.slider = Class.create(pimcore.object.tags.abstract, {
     getLayoutEdit: function (disabled) {
         var sliderConfig = {
             name: this.fieldConfig.name,
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             plugins: new Ext.slider.Tip()
         };
 
@@ -119,7 +119,7 @@ pimcore.object.tags.slider = Class.create(pimcore.object.tags.abstract, {
             fieldLabel: this.fieldConfig.title,
             layout: 'hbox',
             items: items,
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             border: false,
             style: {
                 padding: 0

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/structuredTable.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/structuredTable.js
@@ -177,7 +177,7 @@ pimcore.object.tags.structuredTable = Class.create(pimcore.object.tags.abstract,
             border: true,
             style: "margin-bottom: 10px",
             columns: columns,
-            componentCls: 'object_field',
+            componentCls: 'object_field object_field_type_' + this.type,
             bodyCls: "pimcore_editable_grid",
             width: this.fieldConfig.width,
             height: this.fieldConfig.height,
@@ -218,7 +218,7 @@ pimcore.object.tags.structuredTable = Class.create(pimcore.object.tags.abstract,
             autoHeight = true;
         }
 
-        var cls = 'object_field';
+        var cls = 'object_field object_field_type_' + this.type;
 
         var columns = [
             {text: "", width: 80, sortable: false, dataIndex: '__row_label', editor: null,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/table.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/table.js
@@ -107,7 +107,7 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
         options.layout = "fit";
         options.style = "margin-bottom: 10px";
         options.title = this.fieldConfig.title;
-        options.componentCls = "object_field";
+        options.componentCls = "object_field object_field_type_" + this.type;
         if (this.fieldConfig.width) {
             options.width = this.fieldConfig.width;
         }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/textarea.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/textarea.js
@@ -63,9 +63,12 @@ pimcore.object.tags.textarea = Class.create(pimcore.object.tags.abstract, {
             width: this.fieldConfig.width,
             height: this.fieldConfig.height,
             fieldLabel: this.fieldConfig.title,
-            componentCls: "object_field object_field_type_" + this.type,
             labelWidth: labelWidth
         };
+
+        if (!this.fieldConfig.showCharCount) {
+            conf.componentCls = "object_field object_field_type_" + this.type;
+        }
 
         conf.width += conf.labelWidth;
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/textarea.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/textarea.js
@@ -63,7 +63,7 @@ pimcore.object.tags.textarea = Class.create(pimcore.object.tags.abstract, {
             width: this.fieldConfig.width,
             height: this.fieldConfig.height,
             fieldLabel: this.fieldConfig.title,
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             labelWidth: labelWidth
         };
 
@@ -97,7 +97,7 @@ pimcore.object.tags.textarea = Class.create(pimcore.object.tags.abstract, {
             this.updateCharCount(this.component, charCount);
 
             return Ext.create("Ext.Panel", {
-                cls: "object_field",
+                cls: "object_field object_field_type_" + this.type,
                 style: "margin-bottom: 10px",
                 layout: {
                     type: 'vbox',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/time.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/time.js
@@ -35,7 +35,7 @@ pimcore.object.tags.time = Class.create(pimcore.object.tags.abstract, {
             allowBlank: (!this.fieldConfig.mandatory),
             minValue: (this.fieldConfig.minValue) ? this.fieldConfig.minValue : null,
             maxValue: (this.fieldConfig.maxValue) ? this.fieldConfig.maxValue : null,
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             increment: (this.fieldConfig.increment) ? this.fieldConfig.increment : 15
         });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
@@ -131,7 +131,7 @@ pimcore.object.tags.urlSlug = Class.create(pimcore.object.tags.abstract, {
             name: "slug",
             labelWidth: 100,
             value: siteData['slug'],
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             validator: function(value) {
 
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/video.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/video.js
@@ -79,7 +79,7 @@ pimcore.object.tags.video = Class.create(pimcore.object.tags.abstract, {
                 iconCls: "pimcore_icon_delete",
                 handler: this.empty.bind(this)
             }],
-            componentCls: "object_field",
+            componentCls: "object_field object_field_type_" + this.type,
             bodyCls: "pimcore_video_container"
         };
 
@@ -110,7 +110,7 @@ pimcore.object.tags.video = Class.create(pimcore.object.tags.abstract, {
             title: this.fieldConfig.title,
             border: true,
             style: "padding-bottom: 10px",
-            cls: "object_field",
+            cls: "object_field object_field_type_" + this.type,
             bodyCls: "pimcore_video_container"
         };
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/wysiwyg.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/wysiwyg.js
@@ -94,7 +94,7 @@ pimcore.object.tags.wysiwyg = Class.create(pimcore.object.tags.abstract, {
             bodyStyle: 'background: #fff',
             style: "margin-bottom: 10px",
             manageHeight: false,
-            cls: "object_field"
+            cls: "object_field object_field_type_" + this.type
         };
 
         if(this.fieldConfig.width) {

--- a/bundles/EcommerceFrameworkBundle/Resources/public/js/indexfieldselectionfield/tags/indexFieldSelectionField.js
+++ b/bundles/EcommerceFrameworkBundle/Resources/public/js/indexfieldselectionfield/tags/indexFieldSelectionField.js
@@ -160,7 +160,7 @@ pimcore.object.tags.indexFieldSelectionField = Class.create(pimcore.object.tags.
                     tenantCombobox,
                     this.fieldsCombobox
                 ],
-                cls: "object_field",
+                cls: "object_field object_field_type_" + this.type,
                 isDirty: function() {
                     return tenantCombobox.isDirty() || this.fieldsCombobox.isDirty()
                 }.bind(this)


### PR DESCRIPTION
We want add css properties to special object field types.
Can we add a css class with the type of the field?