### PR TITLE
[Reverse object relation] More defensive check if item is allowed

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ReverseManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseManyToManyObjectRelation.php
@@ -142,7 +142,7 @@ class ReverseManyToManyObjectRelation extends ManyToManyObjectRelation
     {
         //only relations of owner type are allowed
         $ownerClass = DataObject\ClassDefinition::getByName($this->getOwnerClassName());
-        if ($ownerClass->getId() > 0 and $ownerClass->getId() == $object->getClassId()) {
+        if ($ownerClass instanceof DataObject\ClassDefinition && $object instanceof DataObject\Concrete && $ownerClass->getId() == $object->getClassId()) {
             $fd = $ownerClass->getFieldDefinition($this->getOwnerFieldName());
             if ($fd instanceof DataObject\ClassDefinition\Data\ManyToManyObjectRelation) {
                 return $fd->allowObjectRelation($object);


### PR DESCRIPTION
On the current implementation calling `allowObjectRelation(null)` would throw `Fatal error: Uncaught Error: Call to a member function getClassId() on null`.