### PR TITLE
[Installer] Added option to skip database connection setup (database.yml)

### DIFF
--- a/bundles/InstallBundle/Command/InstallCommand.php
+++ b/bundles/InstallBundle/Command/InstallCommand.php
@@ -177,6 +177,11 @@ class InstallCommand extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Do not abort if a <comment>system.yml</comment> file already exists'
+            )->addOption(
+                'skip-database-config',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not write a database config file: <comment>database.yml</comment>'
             );
 
         foreach ($this->getOptions() as $name => $config) {
@@ -198,6 +203,10 @@ class InstallCommand extends Command
         $configFile = Config::locateConfigFile('system.yml');
         if ($configFile && is_file($configFile) && !$input->getOption('ignore-existing-config')) {
             throw new \RuntimeException(sprintf('The system.yml config file already exists in "%s". You can run this command with the --ignore-existing-config flag to ignore this error.', $configFile));
+        }
+
+        if ($input->getOption('skip-database-config')) {
+            $this->installer->setSkipDatabaseConfig(true);
         }
 
         $this->io = new PimcoreStyle($input, $output);

--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -88,6 +88,21 @@ class Installer
     private $importDatabaseDataDump = true;
 
     /**
+     * skip writing database.yml file
+     *
+     * @var bool
+     */
+    private $skipDatabaseConfig = false;
+
+    /**
+     * @param bool $skipDatabaseConfig
+     */
+    public function setSkipDatabaseConfig(bool $skipDatabaseConfig): void
+    {
+        $this->skipDatabaseConfig = $skipDatabaseConfig;
+    }
+
+    /**
      * @var array
      */
     private $stepEvents = [
@@ -542,7 +557,11 @@ class Installer
     private function createConfigFiles(array $config)
     {
         $writer = new ConfigWriter();
-        $writer->writeDbConfig($config);
+
+        if (!$this->skipDatabaseConfig) {
+            $writer->writeDbConfig($config);
+        }
+
         $writer->writeSystemConfig();
         $writer->writeDebugModeConfig();
         $writer->generateParametersFile();


### PR DESCRIPTION
## Changes in this pull request  
Resolves #6638

## Additional info  
`./vendor/bin/pimcore-install  --skip-database-config` use this option to skip writing database config (database.yml)