### PR TITLE
[Document] Deprecate legacy naming scheme of editables as well as the migration tool

### DIFF
--- a/bundles/CoreBundle/Command/Document/MigrateTagNamingStrategyCommand.php
+++ b/bundles/CoreBundle/Command/Document/MigrateTagNamingStrategyCommand.php
@@ -35,6 +35,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @deprecated
+ */
 class MigrateTagNamingStrategyCommand extends AbstractCommand
 {
     use DryRun;

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -654,6 +654,7 @@ class Configuration implements ConfigurationInterface
                             ->info('Sets naming strategy used to build editable names')
                             ->values(['legacy', 'nested'])
                             ->defaultValue('nested')
+                            ->setDeprecated('The "%node%" option is deprecated. Migrate to the new editable naming scheme!')
                         ->end()
                     ->end()
                 ->end()

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -7,6 +7,9 @@
 - Saving unpublished data objects via API will not throw Validation exceptions anymore (just like Admin UI). Please set `omitMandatoryCheck` explicitly to `false` to force mandatory checks.
 - `\Pimcore\DataObject\GridColumnConfig\Operator\ObjectBrickGetter` operator is deprecated and will be removed in 7.0.0
 - Calling `Pimcore\Model\DataObject\ClassDefinition\Data::isEqual()` is deprecated since version 6.7.0 and will be removed in version 7 . Implement `\Pimcore\Model\DataObject\ClassDefinition\Data\EqualComparisonInterface` instead.
+- The legacy editable naming scheme has been deprecated and will be removed in Pimcore 7. Please [migrate to the new naming scheme](../../03_Documents/13_Editable_Naming_Strategies.md). 
+- All classes in namespace `Pimcore\Document\Tag\NamingStrategy` are marked as deprecated and will be removed in v7. 
+- `TagHandlerInterface` and `DelegatingTagHandler` are marked as deprecated and will be removed in v7.
 
 ## 6.6.4
 - If you are using the specific settings 'max. items' option for ObjectBricks & Fieldcollections on your class definition, then API will validate the max limit on save() calls from now on.

--- a/lib/Document/Tag/DelegatingTagHandler.php
+++ b/lib/Document/Tag/DelegatingTagHandler.php
@@ -19,6 +19,9 @@ use Pimcore\Model\Document\Tag;
 use Pimcore\Model\Document\Tag\Area\Info;
 use Pimcore\Templating\Model\ViewModelInterface;
 
+/**
+ * @deprecated
+ */
 class DelegatingTagHandler implements TagHandlerInterface
 {
     /**

--- a/lib/Document/Tag/NamingStrategy/AbstractNamingStrategy.php
+++ b/lib/Document/Tag/NamingStrategy/AbstractNamingStrategy.php
@@ -20,6 +20,9 @@ namespace Pimcore\Document\Tag\NamingStrategy;
 use Pimcore\Document\Tag\Block\BlockName;
 use Pimcore\Document\Tag\Block\BlockState;
 
+/**
+ * @deprecated
+ */
 abstract class AbstractNamingStrategy implements NamingStrategyInterface
 {
     /**

--- a/lib/Document/Tag/NamingStrategy/Exception/TagNameException.php
+++ b/lib/Document/Tag/NamingStrategy/Exception/TagNameException.php
@@ -17,6 +17,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Document\Tag\NamingStrategy\Exception;
 
+/**
+ * @deprecated
+ */
 class TagNameException extends \RuntimeException
 {
 }

--- a/lib/Document/Tag/NamingStrategy/LegacyNamingStrategy.php
+++ b/lib/Document/Tag/NamingStrategy/LegacyNamingStrategy.php
@@ -20,6 +20,9 @@ namespace Pimcore\Document\Tag\NamingStrategy;
 use Pimcore\Document\Tag\Block\BlockName;
 use Pimcore\Document\Tag\NamingStrategy\Exception\TagNameException;
 
+/**
+ * @deprecated
+ */
 final class LegacyNamingStrategy extends AbstractNamingStrategy
 {
     const STRATEGY_NAME = 'legacy';

--- a/lib/Document/Tag/NamingStrategy/Migration/AbstractMigrationStrategy.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/AbstractMigrationStrategy.php
@@ -23,6 +23,9 @@ use Pimcore\Document\Tag\NamingStrategy\NamingStrategyInterface;
 use Pimcore\Model\Document;
 use Psr\SimpleCache\CacheInterface;
 
+/**
+ * @deprecated
+ */
 abstract class AbstractMigrationStrategy
 {
     /**

--- a/lib/Document/Tag/NamingStrategy/Migration/Analyze/ConflictResolver.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/Analyze/ConflictResolver.php
@@ -28,6 +28,9 @@ use Pimcore\Model\Document;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 
+/**
+ * @deprecated
+ */
 class ConflictResolver implements ConflictResolverInterface
 {
     /**

--- a/lib/Document/Tag/NamingStrategy/Migration/Analyze/ConflictResolverInterface.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/Analyze/ConflictResolverInterface.php
@@ -22,6 +22,9 @@ use Pimcore\Document\Tag\NamingStrategy\Migration\Analyze\Element\Editable;
 use Pimcore\Document\Tag\NamingStrategy\Migration\Analyze\Exception\BuildEditableException;
 use Pimcore\Model\Document;
 
+/**
+ * @deprecated
+ */
 interface ConflictResolverInterface
 {
     /**

--- a/lib/Document/Tag/NamingStrategy/Migration/Analyze/Element/AbstractBlock.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/Analyze/Element/AbstractBlock.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Pimcore\Document\Tag\NamingStrategy\Migration\Analyze\Element;
 
 /**
+ * @deprecated
  * Represents a block element (block, areablock)
  */
 abstract class AbstractBlock extends AbstractElement

--- a/lib/Document/Tag/NamingStrategy/Migration/Analyze/Element/AbstractElement.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/Analyze/Element/AbstractElement.php
@@ -24,6 +24,7 @@ use Pimcore\Document\Tag\NamingStrategy\Migration\Analyze\Exception\LogicExcepti
 use Pimcore\Document\Tag\NamingStrategy\NamingStrategyInterface;
 
 /**
+ * @deprecated
  * Represents all document editables (blocks + other editables)
  */
 abstract class AbstractElement

--- a/lib/Document/Tag/NamingStrategy/Migration/Analyze/Element/Areablock.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/Analyze/Element/Areablock.php
@@ -17,6 +17,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Document\Tag\NamingStrategy\Migration\Analyze\Element;
 
+/**
+ * @deprecated
+ */
 final class Areablock extends AbstractBlock
 {
     /**

--- a/lib/Document/Tag/NamingStrategy/Migration/Analyze/Element/Block.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/Analyze/Element/Block.php
@@ -17,6 +17,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Document\Tag\NamingStrategy\Migration\Analyze\Element;
 
+/**
+ * @deprecated
+ */
 final class Block extends AbstractBlock
 {
     /**

--- a/lib/Document/Tag/NamingStrategy/Migration/Analyze/Element/Editable.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/Analyze/Element/Editable.php
@@ -17,6 +17,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Document\Tag\NamingStrategy\Migration\Analyze\Element;
 
+/**
+ * @deprecated
+ */
 final class Editable extends AbstractElement
 {
 }

--- a/lib/Document/Tag/NamingStrategy/Migration/Analyze/ElementTree.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/Analyze/ElementTree.php
@@ -26,6 +26,9 @@ use Pimcore\Document\Tag\NamingStrategy\Migration\Analyze\Exception\BuildEditabl
 use Pimcore\Document\Tag\NamingStrategy\Migration\Analyze\Exception\LogicException;
 use Pimcore\Model\Document;
 
+/**
+ * @deprecated
+ */
 final class ElementTree
 {
     /**

--- a/lib/Document/Tag/NamingStrategy/Migration/Analyze/Exception/BuildEditableException.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/Analyze/Exception/BuildEditableException.php
@@ -17,6 +17,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Document\Tag\NamingStrategy\Migration\Analyze\Exception;
 
+/**
+ * @deprecated
+ */
 class BuildEditableException extends \RuntimeException
 {
     /**

--- a/lib/Document/Tag/NamingStrategy/Migration/Analyze/Exception/LogicException.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/Analyze/Exception/LogicException.php
@@ -17,6 +17,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Document\Tag\NamingStrategy\Migration\Analyze\Exception;
 
+/**
+ * @deprecated
+ */
 class LogicException extends \LogicException
 {
 }

--- a/lib/Document/Tag/NamingStrategy/Migration/AnalyzeMigrationStrategy.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/AnalyzeMigrationStrategy.php
@@ -27,6 +27,9 @@ use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableCell;
 
+/**
+ * @deprecated
+ */
 class AnalyzeMigrationStrategy extends AbstractMigrationStrategy
 {
     /**

--- a/lib/Document/Tag/NamingStrategy/Migration/Exception/NameMappingException.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/Exception/NameMappingException.php
@@ -17,6 +17,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Document\Tag\NamingStrategy\Migration\Exception;
 
+/**
+ * @deprecated
+ */
 class NameMappingException extends \RuntimeException
 {
     /**

--- a/lib/Document/Tag/NamingStrategy/Migration/MappingError.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/MappingError.php
@@ -19,6 +19,9 @@ namespace Pimcore\Document\Tag\NamingStrategy\Migration;
 
 use Pimcore\Model\Document;
 
+/**
+ * @deprecated
+ */
 final class MappingError
 {
     /**

--- a/lib/Document/Tag/NamingStrategy/Migration/Render/MigrationSubscriber.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/Render/MigrationSubscriber.php
@@ -25,6 +25,7 @@ use Pimcore\Event\Model\Document\TagNameEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
+ * @deprecated
  * This listener is not intended to be always registered on the dispatcher, but instead
  * is added manually when needed in the MigrateTagNamingStrategy CLI command. The listener
  * collects all rendered tag names and creates a matching new tag name mapping which can

--- a/lib/Document/Tag/NamingStrategy/Migration/RenderMigrationStrategy.php
+++ b/lib/Document/Tag/NamingStrategy/Migration/RenderMigrationStrategy.php
@@ -38,6 +38,9 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\Stopwatch\Stopwatch;
 
+/**
+ * @deprecated
+ */
 class RenderMigrationStrategy extends AbstractMigrationStrategy
 {
     /**

--- a/lib/Document/Tag/NamingStrategy/NamingStrategyInterface.php
+++ b/lib/Document/Tag/NamingStrategy/NamingStrategyInterface.php
@@ -19,6 +19,9 @@ namespace Pimcore\Document\Tag\NamingStrategy;
 
 use Pimcore\Document\Tag\Block\BlockState;
 
+/**
+ * @deprecated
+ */
 interface NamingStrategyInterface
 {
     /**

--- a/lib/Document/Tag/NamingStrategy/NestedNamingStrategy.php
+++ b/lib/Document/Tag/NamingStrategy/NestedNamingStrategy.php
@@ -20,6 +20,9 @@ namespace Pimcore\Document\Tag\NamingStrategy;
 use Pimcore\Document\Tag\Block\BlockName;
 use Pimcore\Document\Tag\NamingStrategy\Exception\TagNameException;
 
+/**
+ * @deprecated
+ */
 final class NestedNamingStrategy extends AbstractNamingStrategy
 {
     const STRATEGY_NAME = 'nested';

--- a/lib/Document/Tag/TagHandler.php
+++ b/lib/Document/Tag/TagHandler.php
@@ -116,6 +116,7 @@ class TagHandler implements TagHandlerInterface, LoggerAwareInterface
     }
 
     /**
+     * @deprecated
      * {@inheritdoc}
      */
     public function supports($view)

--- a/lib/Document/Tag/TagHandlerInterface.php
+++ b/lib/Document/Tag/TagHandlerInterface.php
@@ -18,6 +18,9 @@ use Pimcore\Model\Document\Tag;
 use Pimcore\Model\Document\Tag\Area\Info;
 use Pimcore\Templating\Model\ViewModelInterface;
 
+/**
+ * @deprecated
+ */
 interface TagHandlerInterface
 {
     /**


### PR DESCRIPTION
Fixes #6912