### PR TITLE
Fix: Copying an object with mandatory and unique field is not possible.

### DIFF
--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -148,6 +148,7 @@ class Service extends Model\Element\Service
                 if ($fieldDefinition->getUnique()) {
                     $new->set($fieldDefinition->getName(), null);
                     $new->setPublished(false);
+                    $new->setOmitMandatoryCheck(true);
                 }
             }
         }
@@ -212,6 +213,7 @@ class Service extends Model\Element\Service
                 if ($fieldDefinition->getUnique()) {
                     $new->set($fieldDefinition->getName(), null);
                     $new->setPublished(false);
+                    $new->setOmitMandatoryCheck(true);
                 }
             }
         }


### PR DESCRIPTION
See #5243

Steps to reproduce:
- Create a Class in the pimcore demo with only 1 input field (mandatory, unique)
- Create a object
- Copy this object
- Error when paste:
![image](https://user-images.githubusercontent.com/998558/89621754-2b35ea80-d892-11ea-9e15-0ab0728f15d1.png)