### PR TITLE
[Versions] Support version-compressing for stream wrappers which do not support gzopen

### DIFF
--- a/lib/Maintenance/Tasks/VersionsCompressTask.php
+++ b/lib/Maintenance/Tasks/VersionsCompressTask.php
@@ -40,7 +40,6 @@ final class VersionsCompressTask implements TaskInterface
     {
         $perIteration = 100;
         $alreadyCompressedCounter = 0;
-        $overallCounter = 0;
 
         $list = new Version\Listing();
         $list->setCondition('date < ' . (time() - 86400 * 30));
@@ -59,8 +58,6 @@ final class VersionsCompressTask implements TaskInterface
             $versions = $list->load();
 
             foreach ($versions as $version) {
-                $overallCounter++;
-
                 if (file_exists($version->getFilePath())) {
                     gzcompressfile($version->getFilePath(), 9);
                     @unlink($version->getFilePath());

--- a/lib/helper-functions.php
+++ b/lib/helper-functions.php
@@ -45,16 +45,33 @@ function gzcompressfile($source, $level = null, $target = null)
     $mode = 'wb'.$level;
     $error = false;
 
-    $fp_out = gzopen($dest, $mode);
+    $fp_out = @gzopen($dest, $mode);
+    $resourceSupportsGz = true;
+    if(!is_resource($fp_out)) {
+        $fp_out = fopen($dest, 'wb');
+        $deflateContext = deflate_init(ZLIB_ENCODING_GZIP, ['level' => $level]);
+        $resourceSupportsGz = false;
+    }
+
     $fp_in = fopen($source, 'rb');
 
     if ($fp_out && $fp_in) {
         while (!feof($fp_in)) {
-            gzwrite($fp_out, fread($fp_in, 1024 * 512));
+            if($resourceSupportsGz) {
+                gzwrite($fp_out, fread($fp_in, 1024 * 512));
+            } else {
+                fwrite($fp_out, deflate_add($deflateContext, fread($fp_in, 1024 * 512), ZLIB_NO_FLUSH));
+            }
         }
 
         fclose($fp_in);
-        gzclose($fp_out);
+
+        if($resourceSupportsGz) {
+            gzclose($fp_out);
+        } else {
+            fwrite($fp_out, deflate_add($deflateContext, '', ZLIB_FINISH));
+            fclose($fp_out);
+        }
     } else {
         $error = true;
     }

--- a/lib/helper-functions.php
+++ b/lib/helper-functions.php
@@ -42,37 +42,22 @@ function gzcompressfile($source, $level = null, $target = null)
         $dest = $source.'.gz';
     }
 
-    $mode = 'wb'.$level;
     $error = false;
-
-    $fp_out = @gzopen($dest, $mode);
-    $resourceSupportsGz = true;
-    $deflateContext = null;
-    if(!is_resource($fp_out)) {
-        $fp_out = fopen($dest, 'wb');
-        $deflateContext = deflate_init(ZLIB_ENCODING_GZIP, ['level' => $level]);
-        $resourceSupportsGz = false;
-    }
 
     $fp_in = fopen($source, 'rb');
 
+    $fp_out = fopen($dest, 'wb');
+    $deflateContext = deflate_init(ZLIB_ENCODING_GZIP, ['level' => $level]);
+
     if ($fp_out && $fp_in) {
         while (!feof($fp_in)) {
-            if($resourceSupportsGz) {
-                gzwrite($fp_out, fread($fp_in, 1024 * 512));
-            } else {
-                fwrite($fp_out, deflate_add($deflateContext, fread($fp_in, 1024 * 512), ZLIB_NO_FLUSH));
-            }
+            fwrite($fp_out, deflate_add($deflateContext, fread($fp_in, 1024 * 512), ZLIB_NO_FLUSH));
         }
 
         fclose($fp_in);
 
-        if($resourceSupportsGz) {
-            gzclose($fp_out);
-        } else {
-            fwrite($fp_out, deflate_add($deflateContext, '', ZLIB_FINISH));
-            fclose($fp_out);
-        }
+        fwrite($fp_out, deflate_add($deflateContext, '', ZLIB_FINISH));
+        fclose($fp_out);
     } else {
         $error = true;
     }

--- a/lib/helper-functions.php
+++ b/lib/helper-functions.php
@@ -47,6 +47,7 @@ function gzcompressfile($source, $level = null, $target = null)
 
     $fp_out = @gzopen($dest, $mode);
     $resourceSupportsGz = true;
+    $deflateContext = null;
     if(!is_resource($fp_out)) {
         $fp_out = fopen($dest, 'wb');
         $deflateContext = deflate_init(ZLIB_ENCODING_GZIP, ['level' => $level]);


### PR DESCRIPTION
When stream wrappers do not support binary operations, version compression will fail. This is for example the case for Google Cloud Storage and AWS S3, see https://github.com/googleapis/google-cloud-php-storage/blob/9412bf831a3fdd895378203b7e42b782deee8795/src/StreamWrapper.php#L147-L193

To nevertheless support version compressing for such cloud storage providers this PR adopts the suggested way from https://github.com/aws/aws-sdk-php/issues/1576#issuecomment-404446446