### PR TITLE
Fix collecting condition parameters

### DIFF
--- a/lib/Model/Listing/AbstractListing.php
+++ b/lib/Model/Listing/AbstractListing.php
@@ -310,8 +310,12 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
                 // If there is not a placeholder, ignore value!
                 if (!$value['ignore-value']) {
                     if (is_array($value['value'])) {
-                        foreach ($value['value'] as $v) {
-                            $params[] = $v;
+                        foreach ($value['value'] as $k => $v) {
+                            if (is_int($k)) {
+                                $params[] = $v;
+                            } else {
+                                $params[$k] = $v;
+                            }
                         }
                     } else {
                         $params[] = $value['value'];

--- a/lib/Model/Listing/AbstractListing.php
+++ b/lib/Model/Listing/AbstractListing.php
@@ -310,8 +310,8 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
                 // If there is not a placeholder, ignore value!
                 if (!$value['ignore-value']) {
                     if (is_array($value['value'])) {
-                        foreach ($value['value'] as $k => $v) {
-                            $params[$k] = $v;
+                        foreach ($value['value'] as $v) {
+                            $params[] = $v;
                         }
                     } else {
                         $params[] = $value['value'];


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
* Fix collecting parameters which were added to DataObject listing via `$listing->addConditionParam($key, $value, $concatenator)`

## Additional info

Example listing that fails:

```
$listing = new \Pimcore\Model\DataObject\Product\Listing();
$listing->setObjectTypes(['object', 'folder', 'variant']);
$listing->setOrderKey('o_id');
$listing->setOrder('ASC');
$listing->setOffset(0);
$listing->setLimit(25);
$listing->setUnpublished(true);
$listing->addConditionParam('3256 = 3256 AND suppliers LIKE ?', '%,15793,%', 'AND');
$listing->addConditionParam('8665 = 8665 AND manufacturer__id = ? AND manufacturer__type = ?', ['7', 'object'], 'AND');
$listing->load();  // Throws exception
```

```
An exception occurred while executing 'SELECT object_localized_6_en.o_id as o_id, `object_localized_6_en`.`o_type` FROM `object_localized_6_en` WHERE ((3256 = 3256 AND suppliers LIKE ?) AND (8665 = 8665 AND manufacturer__id = ? AND manufacturer__type = ?) AND object_localized_6_en.o_type IN ('object','folder','variant')) ORDER BY `o_id` ASC LIMIT 25' with params ["7", "object"]: SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens
```

There should be 3 parameters but only 2 are passed.
