### PR TITLE
fixing matchRequest resolving for dataobjects with urlslug

### DIFF
--- a/lib/Routing/Dynamic/DataObjectRouteHandler.php
+++ b/lib/Routing/Dynamic/DataObjectRouteHandler.php
@@ -91,12 +91,8 @@ class DataObjectRouteHandler implements DynamicRouteHandlerInterface
     public function matchRequest(RouteCollection $collection, DynamicRequestContext $context)
     {
         $slug = null;
-        if ($site = $this->siteResolver->getSite($context->getRequest())) {
-            $slug = DataObject\Data\UrlSlug::resolveSlug($context->getOriginalPath(), $site->getId());
-        }
-        if (!$slug) {
-            $slug = DataObject\Data\UrlSlug::resolveSlug($context->getOriginalPath(), 0);
-        }
+        $site = $this->siteResolver->getSite($context->getRequest());
+        $slug = DataObject\Data\UrlSlug::resolveSlug($context->getOriginalPath(), $site ? $site->getId() : 0);
         if ($slug) {
             $object = DataObject::getById($slug->getObjectId());
             if ($object instanceof DataObject\Concrete && $object->isPublished()) {

--- a/models/DataObject/Data/UrlSlug.php
+++ b/models/DataObject/Data/UrlSlug.php
@@ -330,7 +330,7 @@ class UrlSlug implements OwnerAwareFieldInterface
      *
      * @return UrlSlug|null
      */
-    public static function resolveSlug($path, $siteId = 0)
+    public static function resolveSlug($path, int $siteId = 0)
     {
         $cacheKey = $path . '~~' . $siteId;
         if (isset(self::$cache[$cacheKey])) {
@@ -340,12 +340,11 @@ class UrlSlug implements OwnerAwareFieldInterface
         $slug = null;
         $db = Db::get();
         try {
-            $query = 'SELECT * FROM object_url_slugs WHERE slug = ' . $db->quote($path)
-                . ' AND siteId = ' . $db->quote($siteId);
-
-            if ($siteId > 0) {
-                $query .= ' OR siteId = 0 ORDER BY siteId DESC LIMIT 1';
-            }
+            $query = sprintf(
+                'SELECT * FROM object_url_slugs WHERE slug = %s AND (siteId = %d OR siteId = 0) ORDER BY siteId DESC LIMIT 1',
+                $db->quote($path),
+                $siteId
+            );
 
             $rawItem = $db->fetchRow($query);
 

--- a/models/DataObject/Data/UrlSlug.php
+++ b/models/DataObject/Data/UrlSlug.php
@@ -330,7 +330,7 @@ class UrlSlug implements OwnerAwareFieldInterface
      *
      * @return UrlSlug|null
      */
-    public static function resolveSlug($path, int $siteId = 0)
+    public static function resolveSlug($path, $siteId = 0)
     {
         $cacheKey = $path . '~~' . $siteId;
         if (isset(self::$cache[$cacheKey])) {


### PR DESCRIPTION
# Issue
Call: \Pimcore\Model\DataObject\Data\UrlSlug::resolveSlug("/my/path", 1)
SELECT * FROM object_url_slugs WHERE slug = "/my/path" AND siteId = 1 OR siteId = 0 ORDER BY siteId DESC LIMIT 1

# Solution
SELECT * FROM object_url_slugs WHERE slug = "/my/path" AND (siteId = 1 OR siteId = 0) ORDER BY siteId DESC LIMIT 1