### PR TITLE
change[Thumbnails]: make auto clipping configurable

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -457,6 +457,15 @@ class Configuration implements ConfigurationInterface
                                         ->end()
                                         ->defaultTrue()
                                     ->end()
+                                    ->booleanNode('clip_auto_support')
+                                        ->beforeNormalization()
+                                            ->ifString()
+                                            ->then(function ($v) {
+                                                return (bool)$v;
+                                            })
+                                        ->end()
+                                        ->defaultTrue()
+                                    ->end()
                                     ->booleanNode('auto_clear_temp_files')
                                         ->beforeNormalization()
                                             ->ifString()

--- a/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
+++ b/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
@@ -327,7 +327,7 @@ If you prefer not using WebP, you can disable the support by adding the followin
 ```
 
 ## Clipping Support 
-Automatically clip images with embedded clipping path (8BIM / Adobe profile meta data) to generate thumbnails. 
+Images with an embedded clipping path (8BIM / Adobe profile meta data) are automatically clipped when generating thumbnails of them. 
     
 If you do not want to use thumbnail auto clipping, you can disable the support by adding the following config option: 
 ```yml

--- a/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
+++ b/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
@@ -326,6 +326,17 @@ If you prefer not using WebP, you can disable the support by adding the followin
                 webp_auto_support: false
 ```
 
+## Clipping Support 
+Automatically clip images with embedded clipping path (8BIM / Adobe profile meta data) to generate thumbnails. 
+    
+If you do not want to use thumbnail auto clipping, you can disable the support by adding the following config option: 
+```yml
+    assets:
+        image:
+            thumbnails:
+                clip_auto_support: false
+```
+
 #### Note on using WebP with Imagick using delegates
 Please ensure that your delegate definition for WebP encoding includes the `-q` flag, otherwise the quality 
 setting on thumbnails will not be considered and the default value of `75` is being used by `cwebp`.

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -144,27 +144,30 @@ class Imagick extends Adapter
                 $this->setColorspaceToRGB();
             }
 
-            // check for the existence of an embedded clipping path (8BIM / Adobe profile meta data)
-            $identifyRaw = $i->identifyImage(true)['rawOutput'];
-            if (strpos($identifyRaw, 'Clipping path') && strpos($identifyRaw, '<svg')) {
-                // if there's a clipping path embedded, apply the first one
+            $isClipAutoSupport = \Pimcore::getContainer()->getParameter('pimcore.config')['assets']['image']['thumbnails']['clip_auto_support'];
+            if ($isClipAutoSupport) {
+                // check for the existence of an embedded clipping path (8BIM / Adobe profile meta data)
+                $identifyRaw = $i->identifyImage(true)['rawOutput'];
+                if (strpos($identifyRaw, 'Clipping path') && strpos($identifyRaw, '<svg')) {
+                    // if there's a clipping path embedded, apply the first one
 
-                // known issues:
-                // - it seems that -clip doesnt work with the ImageMagick version
-                //   ImageMagick 6.9.7-4 Q16 x86_64 20170114 (which is used in Debian 9)
-                // - Imagick 3.4.4 with ImageMagick 7 on OSX is horrible broken clipping support
-                $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_TRANSPARENT);
-                $i->clipImage();
+                    // known issues:
+                    // - it seems that -clip doesnt work with the ImageMagick version
+                    //   ImageMagick 6.9.7-4 Q16 x86_64 20170114 (which is used in Debian 9)
+                    // - Imagick 3.4.4 with ImageMagick 7 on OSX has horrible broken clipping support
+                    $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_TRANSPARENT);
+                    $i->clipImage();
 
-                // Imagick version compatibility
-                // Since Imagick 3.4.4 compiled against ImageMagick 7 ALPHACHANNEL_OPAQUE was removed for whatever reason
-                // ImageMagick is still defining and using OpaqueAlphaChannel in ImageMagick 7 releases
-                // Let's hardcode the current ImageMagick 7 enum number to workaround this issue
-                $alphaChannel = 11;
-                if (defined('Imagick::ALPHACHANNEL_OPAQUE')) {
-                    $alphaChannel = \Imagick::ALPHACHANNEL_OPAQUE;
+                    // Imagick version compatibility
+                    // Since Imagick 3.4.4 compiled against ImageMagick 7 ALPHACHANNEL_OPAQUE was removed for whatever reason
+                    // ImageMagick is still defining and using OpaqueAlphaChannel in ImageMagick 7 releases
+                    // Let's hardcode the current ImageMagick 7 enum number to workaround this issue
+                    $alphaChannel = 11;
+                    if (defined('Imagick::ALPHACHANNEL_OPAQUE')) {
+                        $alphaChannel = \Imagick::ALPHACHANNEL_OPAQUE;
+                    }
+                    $i->setImageAlphaChannel($alphaChannel);
                 }
-                $i->setImageAlphaChannel($alphaChannel);
             }
         } catch (\Exception $e) {
             Logger::error('Unable to load image: ' . $imagePath);


### PR DESCRIPTION
https://github.com/pimcore/pimcore/issues/5505 introduced auto clipping for images
with embedded clipping path.

This is a pretty wonky feature and often broken through several ImageMagick releases. As well
this is a high cpu intensive task. People should be carful to use it.

hence we make it globaly configurable

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

follow up on discussion:

https://github.com/pimcore/pimcore/issues/5505

and regression fix

https://github.com/pimcore/pimcore/pull/6949

## Additional info  

As mentioned a pretty wonky ImageMagick feature especially if used with Imagick. Several stable ImageMagick releases are broken (again current 7.0.10 release since 8 minor releases) as well some popular 6.9 releases.

The most reliably implementation would be to call convert / imagick over cli. We are doing this over enqueue queues in background if new images are uploaded (see Screenshot). This works on most imagemagick releases and workaround the shity Imagick ImageMagick MagickWall alpha implementation.

![image](https://user-images.githubusercontent.com/38670469/90188424-bac02980-ddbb-11ea-97e8-0857ff884186.png)

But........TBH I do not see a direct cli call in pimcore imagick core adapter. This way we would need to add server platform dependent calls....this should never be in pimcore core.

hence just let the admin decide to enable/disable clipping and check beforehand all requirements