### PR TITLE
Add --permit-file-read flag to ghostscript command.

### DIFF
--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -164,6 +164,7 @@ class Ghostscript extends Adapter
     {
         $command = self::getGhostscriptCli() . " -dNODISPLAY -q";
 
+        // Adding permit-file-read flag to prevent issue with Ghostscript's SAFER mode which is enabled by default as of version 9.50.
         if ($this->getVersion() >= 9.50) {
             $command .= " --permit-file-read='" . $this->path . "'";
         }
@@ -174,9 +175,9 @@ class Ghostscript extends Adapter
     }
 
     /**
-     * Get the version of the installed CLI.
+     * Get the version of the installed Ghostscript CLI.
      *
-     * @return float|null
+     * @return float
      * @throws \Exception
      */
     protected function getVersion()

--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -141,7 +141,7 @@ class Ghostscript extends Adapter
      */
     public function getPageCount()
     {
-        $pages = Console::exec(self::getGhostscriptCli() . " -dNODISPLAY -q -c '(" . $this->path . ") (r) file runpdfbegin pdfpagecount = quit'", null, 120);
+        $pages = Console::exec(self::getGhostscriptCli() . " -dNODISPLAY -q --permit-file-read='" . $this->path . "' -c '(" . $this->path . ") (r) file runpdfbegin pdfpagecount = quit'", null, 120);
         $pages = trim($pages);
 
         if (!is_numeric($pages)) {

--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -27,6 +27,11 @@ class Ghostscript extends Adapter
     protected $path;
 
     /**
+     * @var float|null
+     */
+    private $version = null;
+
+    /**
      * @return bool
      */
     public function isAvailable()
@@ -176,11 +181,11 @@ class Ghostscript extends Adapter
      */
     protected function getVersion()
     {
-        if (! $this->isAvailable()) {
-            return null;
+        if (is_null($this->version)) {
+            $this->version = (float) Console::exec(self::getGhostscriptCli() . ' --version');
         }
 
-        return (float) Console::exec(self::getGhostscriptCli() . ' --version');
+        return $this->version;
     }
 
     /**

--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -141,14 +141,46 @@ class Ghostscript extends Adapter
      */
     public function getPageCount()
     {
-        $pages = Console::exec(self::getGhostscriptCli() . " -dNODISPLAY -q --permit-file-read='" . $this->path . "' -c '(" . $this->path . ") (r) file runpdfbegin pdfpagecount = quit'", null, 120);
+        $pages = Console::exec($this->buildPageCountCommand(), null, 120);
         $pages = trim($pages);
 
-        if (!is_numeric($pages)) {
+        if (! is_numeric($pages)) {
             throw new \Exception('Unable to get page-count of ' . $this->path);
         }
 
-        return (int)$pages;
+        return (int) $pages;
+    }
+
+    /**
+     * @return string
+     * @throws \Exception
+     */
+    protected function buildPageCountCommand()
+    {
+        $command = self::getGhostscriptCli() . " -dNODISPLAY -q";
+
+        if ($this->getVersion() >= 9.50) {
+            $command .= " --permit-file-read='" . $this->path . "'";
+        }
+
+        $command .= " -c '(" . $this->path . ") (r) file runpdfbegin pdfpagecount = quit'";
+
+        return $command;
+    }
+
+    /**
+     * Get the version of the installed CLI.
+     *
+     * @return float|null
+     * @throws \Exception
+     */
+    protected function getVersion()
+    {
+        if (! $this->isAvailable()) {
+            return null;
+        }
+
+        return (float) Console::exec(self::getGhostscriptCli() . ' --version');
     }
 
     /**


### PR DESCRIPTION
This PR resolves #6911 

It adds the `--permit-file-read` flag with the file's path so that ghostscript is allowed to read the file.

**Note:** I am not sure, if this still works with older Ghostscript versions. I used Ghostscript version 9.52 to test it.