### PR TITLE
Fix PhpDoc type

### DIFF
--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -342,7 +342,7 @@ abstract class PageSnippet extends Model\Document
      *
      * @param string $name
      * @param string $type
-     * @param string $data
+     * @param mixed $data
      *
      * @return $this
      */


### PR DESCRIPTION
The type of the `$data` parameter in [`Pimcore\Model\Document\Tag\TagInterface::setDataFromEditmode($data)`](https://github.com/pimcore/pimcore/blob/master/models/Document/Tag/TagInterface.php#L53-L60) is `mixed`.