### PR TITLE
[Document] Fix missing info for only save new version

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -95,6 +95,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
 
         $document = clone $document;
         $data = $document->getObjectVars();
+        $data['versionDate'] = $document->getModificationDate();
 
         $data['php'] = [
             'classes' => array_merge([get_class($document)], array_values(class_parents($document))),

--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -88,6 +88,7 @@ class DocumentController extends ElementControllerBase implements EventedControl
     public function getDataByIdAction(Request $request, EventDispatcherInterface $eventDispatcher)
     {
         $document = Document::getById($request->get('id'));
+        $documentFromDatabase = Document::getById($document->getId(), true);
 
         if (!$document) {
             throw $this->createNotFoundException('Document not found');
@@ -95,7 +96,9 @@ class DocumentController extends ElementControllerBase implements EventedControl
 
         $document = clone $document;
         $data = $document->getObjectVars();
-        $data['versionDate'] = $document->getModificationDate();
+        $data['versionDate'] = $documentFromDatabase->getModificationDate();
+        // this used for the "this is not a published version" hint
+        $data['documentFromVersion'] = $document !== $documentFromDatabase;
 
         $data['php'] = [
             'classes' => array_merge([get_class($document)], array_values(class_parents($document))),

--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -88,7 +88,6 @@ class DocumentController extends ElementControllerBase implements EventedControl
     public function getDataByIdAction(Request $request, EventDispatcherInterface $eventDispatcher)
     {
         $document = Document::getById($request->get('id'));
-        $documentFromDatabase = Document::getById($document->getId(), true);
 
         if (!$document) {
             throw $this->createNotFoundException('Document not found');
@@ -96,9 +95,6 @@ class DocumentController extends ElementControllerBase implements EventedControl
 
         $document = clone $document;
         $data = $document->getObjectVars();
-        $data['versionDate'] = $documentFromDatabase->getModificationDate();
-        // this used for the "this is not a published version" hint
-        $data['documentFromVersion'] = $document !== $documentFromDatabase;
 
         $data['php'] = [
             'classes' => array_merge([get_class($document)], array_values(class_parents($document))),

--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentControllerBase.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentControllerBase.php
@@ -269,9 +269,9 @@ abstract class DocumentControllerBase extends AdminController implements Evented
     {
         $latestVersion = $document->getLatestVersion();
         if ($latestVersion) {
-            $isLatestVersion = false;
             $latestDoc = $latestVersion->loadData();
             if ($latestDoc instanceof Model\Document\PageSnippet) {
+                $isLatestVersion = false;
                 return $latestDoc;
             }
         }

--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentControllerBase.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentControllerBase.php
@@ -38,7 +38,9 @@ abstract class DocumentControllerBase extends AdminController implements Evented
 
     protected function preSendDataActions(&$data, Model\Document $document)
     {
-        $data['versionDate'] = $document->getModificationDate();
+        $documentFromDatabase = Model\Document::getById($document->getId(), true);
+
+        $data['versionDate'] = $documentFromDatabase->getModificationDate();
         $data['userPermissions'] = $document->getUserPermissions();
         $data['idPath'] = Element\Service::getIdPath($document);
 

--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentControllerBase.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentControllerBase.php
@@ -261,13 +261,15 @@ abstract class DocumentControllerBase extends AdminController implements Evented
 
     /**
      * @param Model\Document\PageSnippet $document
+     * @param bool $isLatestVersion
      *
      * @return Model\Document\PageSnippet
      */
-    protected function getLatestVersion(Model\Document\PageSnippet $document)
+    protected function getLatestVersion(Model\Document\PageSnippet $document, &$isLatestVersion = true)
     {
         $latestVersion = $document->getLatestVersion();
         if ($latestVersion) {
+            $isLatestVersion = false;
             $latestDoc = $latestVersion->loadData();
             if ($latestDoc instanceof Model\Document\PageSnippet) {
                 return $latestDoc;

--- a/bundles/AdminBundle/Controller/Admin/Document/EmailController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/EmailController.php
@@ -74,14 +74,15 @@ class EmailController extends DocumentControllerBase
         }
         Element\Editlock::lock($request->get('id'), 'document');
 
-        $emailFromDatabase = Document\Email::getById($request->get('id'));
+        $email = Document\Email::getById($request->get('id'));
 
-        if (!$emailFromDatabase) {
+        if (!$email) {
             throw $this->createNotFoundException('Email not found');
         }
 
-        $emailFromDatabase = clone $emailFromDatabase;
-        $email = $this->getLatestVersion($emailFromDatabase);
+        $email = clone $email;
+        $isLatestVersion = true;
+        $email = $this->getLatestVersion($email, $isLatestVersion);
 
         $versions = Element\Service::getSafeVersionInfo($email->getVersions());
         $email->setVersions(array_splice($versions, -1, 1));
@@ -99,7 +100,7 @@ class EmailController extends DocumentControllerBase
 
         $data['url'] = $email->getUrl();
         // this used for the "this is not a published version" hint
-        $data['documentFromVersion'] = $email !== $emailFromDatabase;
+        $data['documentFromVersion'] = !$isLatestVersion;
 
         $this->preSendDataActions($data, $email);
 

--- a/bundles/AdminBundle/Controller/Admin/Document/EmailController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/EmailController.php
@@ -74,14 +74,14 @@ class EmailController extends DocumentControllerBase
         }
         Element\Editlock::lock($request->get('id'), 'document');
 
-        $email = Document\Email::getById($request->get('id'));
+        $emailFromDatabase = Document\Email::getById($request->get('id'));
 
-        if (!$email) {
+        if (!$emailFromDatabase) {
             throw $this->createNotFoundException('Email not found');
         }
 
-        $email = clone $email;
-        $email = $this->getLatestVersion($email);
+        $emailFromDatabase = clone $emailFromDatabase;
+        $email = $this->getLatestVersion($emailFromDatabase);
 
         $versions = Element\Service::getSafeVersionInfo($email->getVersions());
         $email->setVersions(array_splice($versions, -1, 1));
@@ -98,6 +98,8 @@ class EmailController extends DocumentControllerBase
         $this->minimizeProperties($email, $data);
 
         $data['url'] = $email->getUrl();
+        // this used for the "this is not a published version" hint
+        $data['documentFromVersion'] = $email !== $emailFromDatabase;
 
         $this->preSendDataActions($data, $email);
 

--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -71,22 +71,22 @@ class PageController extends DocumentControllerBase
      */
     public function getDataByIdAction(Request $request)
     {
-        $page = Document\Page::getById($request->get('id'));
+        $pageFromDatabase = Document\Page::getById($request->get('id'));
 
-        if (!$page) {
+        if (!$pageFromDatabase) {
             throw $this->createNotFoundException('Page not found');
         }
 
         // check for lock
-        if ($page->isAllowed('save') || $page->isAllowed('publish') || $page->isAllowed('unpublish') || $page->isAllowed('delete')) {
+        if ($pageFromDatabase->isAllowed('save') || $pageFromDatabase->isAllowed('publish') || $pageFromDatabase->isAllowed('unpublish') || $pageFromDatabase->isAllowed('delete')) {
             if (Element\Editlock::isLocked($request->get('id'), 'document')) {
                 return $this->getEditLockResponse($request->get('id'), 'document');
             }
             Element\Editlock::lock($request->get('id'), 'document');
         }
 
-        $page = clone $page;
-        $page = $this->getLatestVersion($page);
+        $pageFromDatabase = clone $pageFromDatabase;
+        $page = $this->getLatestVersion($pageFromDatabase);
 
         $pageVersions = Element\Service::getSafeVersionInfo($page->getVersions());
         $page->setVersions(array_splice($pageVersions, -1, 1));
@@ -108,6 +108,8 @@ class PageController extends DocumentControllerBase
         }
 
         $data['url'] = $page->getUrl();
+        // this used for the "this is not a published version" hint
+        $data['documentFromVersion'] = $page !== $pageFromDatabase;
 
         $this->preSendDataActions($data, $page);
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/page_snippet.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/page_snippet.js
@@ -304,7 +304,7 @@ pimcore.document.page_snippet = Class.create(pimcore.document.document, {
 
             // check for newer version than the published
             if (this.data.versions.length > 0) {
-                if (this.data.modificationDate < this.data.versions[0].date) {
+                if (this.data.documentFromVersion) {
                     this.newerVersionNotification.show();
                 }
             }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #6951

## Additional info  

Fixes 2 issues:
- Publish icon on Version Tab list
- "This is a newer not published version" Notification on documents.
