### PR TITLE
[Refactoring] Extract getDependencies method to AbstractElement

### DIFF
--- a/lib/Model/AbstractModel.php
+++ b/lib/Model/AbstractModel.php
@@ -213,16 +213,11 @@ abstract class AbstractModel implements ModelInterface
      */
     public function __sleep()
     {
-        $finalVars = [];
         $blockedVars = ['dao', 'o_dirtyFields'];
-        $vars = get_object_vars($this);
-        foreach ($vars as $key => $value) {
-            if (!in_array($key, $blockedVars)) {
-                $finalVars[] = $key;
-            }
-        }
 
-        return $finalVars;
+        $vars = get_object_vars($this);
+
+        return array_diff(array_keys($vars), $blockedVars);
     }
 
     /**

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -28,7 +28,6 @@ use Pimcore\Model\Asset\Listing;
 use Pimcore\Model\Asset\MetaData\ClassDefinition\Data\Data;
 use Pimcore\Model\Asset\MetaData\ClassDefinition\Data\DataDefinitionInterface;
 use Pimcore\Model\Element\ElementInterface;
-use Pimcore\Model\Element\Service;
 use Pimcore\Tool\Mime;
 use Symfony\Component\EventDispatcher\GenericEvent;
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1935,7 +1935,6 @@ class Asset extends Element\AbstractElement
 
     public function __sleep()
     {
-        $finalVars = [];
         $parentVars = parent::__sleep();
         $blockedVars = ['_temporaryFiles', 'scheduledTasks', 'hasChildren', 'versions', 'parent', 'stream'];
 
@@ -1947,13 +1946,7 @@ class Asset extends Element\AbstractElement
             $blockedVars = array_merge($blockedVars, ['children', 'properties']);
         }
 
-        foreach ($parentVars as $key) {
-            if (!in_array($key, $blockedVars)) {
-                $finalVars[] = $key;
-            }
-        }
-
-        return $finalVars;
+        return array_diff($parentVars, $blockedVars);
     }
 
     public function __wakeup()

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -166,13 +166,6 @@ class Asset extends Element\AbstractElement
     protected $hasMetaData = false;
 
     /**
-     * Dependencies of this asset
-     *
-     * @var Dependency|null
-     */
-    protected $dependencies;
-
-    /**
      * Contains a list of sibling documents
      *
      * @var array|null

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -28,6 +28,7 @@ use Pimcore\Model\Asset\Listing;
 use Pimcore\Model\Asset\MetaData\ClassDefinition\Data\Data;
 use Pimcore\Model\Asset\MetaData\ClassDefinition\Data\DataDefinitionInterface;
 use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\Element\Service;
 use Pimcore\Tool\Mime;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -1104,18 +1105,6 @@ class Asset extends Element\AbstractElement
     }
 
     /**
-     * @return Dependency
-     */
-    public function getDependencies()
-    {
-        if (!$this->dependencies) {
-            $this->dependencies = Dependency::getBySourceId($this->getId(), 'asset');
-        }
-
-        return $this->dependencies;
-    }
-
-    /**
      * @return int
      */
     public function getCreationDate()
@@ -1955,7 +1944,7 @@ class Asset extends Element\AbstractElement
     {
         $finalVars = [];
         $parentVars = parent::__sleep();
-        $blockedVars = ['_temporaryFiles', 'scheduledTasks', 'dependencies', 'hasChildren', 'versions', 'parent', 'stream'];
+        $blockedVars = ['_temporaryFiles', 'scheduledTasks', 'hasChildren', 'versions', 'parent', 'stream'];
 
         if ($this->isInDumpState()) {
             // this is if we want to make a full dump of the asset (eg. for a new version), including children for recyclebin
@@ -2091,7 +2080,6 @@ class Asset extends Element\AbstractElement
         $this->versions = null;
         $this->hasSiblings = null;
         $this->siblings = null;
-        $this->dependencies = null;
         $this->scheduledTasks = null;
         $this->closeStream();
     }

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1246,7 +1246,6 @@ class AbstractObject extends Model\Element\AbstractElement
 
     public function __sleep()
     {
-        $finalVars = [];
         $parentVars = parent::__sleep();
 
         $blockedVars = ['o_hasChildren', 'o_versions', 'o_class', 'scheduledTasks', 'o_parent', 'omitMandatoryCheck'];
@@ -1260,13 +1259,7 @@ class AbstractObject extends Model\Element\AbstractElement
             $blockedVars = array_merge($blockedVars, ['o_children', 'o_properties']);
         }
 
-        foreach ($parentVars as $key) {
-            if (!in_array($key, $blockedVars)) {
-                $finalVars[] = $key;
-            }
-        }
-
-        return $finalVars;
+        return array_diff($parentVars, $blockedVars);
     }
 
     public function __wakeup()

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -27,7 +27,6 @@ use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Element;
-use Pimcore\Model\Element\Service;
 
 /**
  * @method AbstractObject\Dao getDao()

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -27,6 +27,7 @@ use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Element;
+use Pimcore\Model\Element\Service;
 
 /**
  * @method AbstractObject\Dao getDao()
@@ -150,11 +151,6 @@ class AbstractObject extends Model\Element\AbstractElement
      * @var bool[]
      */
     protected $o_hasSiblings = [];
-
-    /**
-     * @var Model\Dependency|null
-     */
-    protected $o_dependencies;
 
     /**
      * @var array
@@ -858,18 +854,6 @@ class AbstractObject extends Model\Element\AbstractElement
     }
 
     /**
-     * @return Model\Dependency
-     */
-    public function getDependencies()
-    {
-        if (!$this->o_dependencies) {
-            $this->o_dependencies = Model\Dependency::getBySourceId($this->getId(), 'object');
-        }
-
-        return $this->o_dependencies;
-    }
-
-    /**
      * @return string
      */
     public function getFullPath()
@@ -1258,7 +1242,7 @@ class AbstractObject extends Model\Element\AbstractElement
         $finalVars = [];
         $parentVars = parent::__sleep();
 
-        $blockedVars = ['o_dependencies', 'o_hasChildren', 'o_versions', 'o_class', 'scheduledTasks', 'o_parent', 'omitMandatoryCheck'];
+        $blockedVars = ['o_hasChildren', 'o_versions', 'o_class', 'scheduledTasks', 'o_parent', 'omitMandatoryCheck'];
 
         if ($this->isInDumpState()) {
             // this is if we want to make a full dump of the object (eg. for a new version), including children for recyclebin
@@ -1477,7 +1461,6 @@ class AbstractObject extends Model\Element\AbstractElement
         // note that o_children is currently needed for the recycle bin
         $this->o_hasSiblings = [];
         $this->o_siblings = [];
-        $this->o_dependencies = null;
     }
 }
 

--- a/models/Document.php
+++ b/models/Document.php
@@ -1376,7 +1376,6 @@ class Document extends Element\AbstractElement
 
     public function __sleep()
     {
-        $finalVars = [];
         $parentVars = parent::__sleep();
         $blockedVars = ['hasChildren', 'versions', 'scheduledTasks', 'parent', 'fullPathCache'];
 
@@ -1388,13 +1387,7 @@ class Document extends Element\AbstractElement
             $blockedVars = array_merge($blockedVars, ['children', 'properties']);
         }
 
-        foreach ($parentVars as $key) {
-            if (!in_array($key, $blockedVars)) {
-                $finalVars[] = $key;
-            }
-        }
-
-        return $finalVars;
+        return array_diff($parentVars, $blockedVars);
     }
 
     public function __wakeup()

--- a/models/Document.php
+++ b/models/Document.php
@@ -27,7 +27,6 @@ use Pimcore\Model\Document\Hardlink;
 use Pimcore\Model\Document\Hardlink\Wrapper\WrapperInterface;
 use Pimcore\Model\Document\Listing;
 use Pimcore\Model\Element\ElementInterface;
-use Pimcore\Model\Element\Service;
 use Pimcore\Tool;
 use Pimcore\Tool\Frontend as FrontendTool;
 use Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter;

--- a/models/Document.php
+++ b/models/Document.php
@@ -27,6 +27,7 @@ use Pimcore\Model\Document\Hardlink;
 use Pimcore\Model\Document\Hardlink\Wrapper\WrapperInterface;
 use Pimcore\Model\Document\Listing;
 use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\Element\Service;
 use Pimcore\Tool;
 use Pimcore\Tool\Frontend as FrontendTool;
 use Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter;
@@ -141,13 +142,6 @@ class Document extends Element\AbstractElement
      * @var int
      */
     protected $userModification;
-
-    /**
-     * Dependencies for this document
-     *
-     * @var Dependency|null
-     */
-    protected $dependencies;
 
     /**
      * List of Property, concerning the folder
@@ -629,20 +623,6 @@ class Document extends Element\AbstractElement
         } catch (\Exception $e) {
             Logger::crit($e);
         }
-    }
-
-    /**
-     * Returns the dependencies of the document
-     *
-     * @return Dependency
-     */
-    public function getDependencies()
-    {
-        if (!$this->dependencies) {
-            $this->dependencies = Dependency::getBySourceId($this->getId(), 'document');
-        }
-
-        return $this->dependencies;
     }
 
     /**
@@ -1399,7 +1379,7 @@ class Document extends Element\AbstractElement
     {
         $finalVars = [];
         $parentVars = parent::__sleep();
-        $blockedVars = ['dependencies', 'hasChildren', 'versions', 'scheduledTasks', 'parent', 'fullPathCache'];
+        $blockedVars = ['hasChildren', 'versions', 'scheduledTasks', 'parent', 'fullPathCache'];
 
         if ($this->isInDumpState()) {
             // this is if we want to make a full dump of the object (eg. for a new version), including children for recyclebin
@@ -1537,7 +1517,6 @@ class Document extends Element\AbstractElement
         $this->parent = null;
         $this->hasSiblings = [];
         $this->siblings = [];
-        $this->dependencies = null;
         $this->fullPathCache = null;
     }
 }

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -383,10 +383,11 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
      */
     public function __sleep()
     {
+        $parentVars = parent::__sleep();
         $finalVars = [];
         $blockedVars = ['dependencies'];
-        $vars = get_object_vars($this);
-        foreach ($vars as $key => $value) {
+
+        foreach ($parentVars as $key => $value) {
             if (!in_array($key, $blockedVars)) {
                 $finalVars[] = $key;
             }

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -384,16 +384,9 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
     public function __sleep()
     {
         $parentVars = parent::__sleep();
-        $finalVars = [];
         $blockedVars = ['dependencies'];
 
-        foreach ($parentVars as $key => $value) {
-            if (!in_array($key, $blockedVars)) {
-                $finalVars[] = $key;
-            }
-        }
-
-        return $finalVars;
+        return array_diff($parentVars, $blockedVars);
     }
 
     public function __clone()

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -32,6 +32,11 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
     use DirtyIndicatorTrait;
 
     /**
+     * @var Model\Dependency|null
+     */
+    protected $dependencies;
+
+    /**
      * @var int
      */
     protected $__dataVersionTimestamp = null;
@@ -346,7 +351,14 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
     /**
      * @return Model\Dependency
      */
-    abstract public function getDependencies();
+    public function getDependencies()
+    {
+        if (!$this->dependencies) {
+            $this->dependencies = Model\Dependency::getBySourceId($this->getId(), Service::getElementType($this));
+        }
+
+        return $this->dependencies;
+    }
 
     /**
      * @return Model\Schedule\Task[]
@@ -362,5 +374,28 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
     public function getVersions()
     {
         return [];
+    }
+
+    /**
+     * @return array
+     */
+    public function __sleep()
+    {
+        $finalVars = [];
+        $blockedVars = ['dependencies'];
+        $vars = get_object_vars($this);
+        foreach ($vars as $key => $value) {
+            if (!in_array($key, $blockedVars)) {
+                $finalVars[] = $key;
+            }
+        }
+
+        return $finalVars;
+    }
+
+    public function __clone()
+    {
+        parent::__clone();
+        $this->dependencies = null;
     }
 }


### PR DESCRIPTION
Just to not repeat `getDependencies()` in Asset, Document and AbstractObject class.