### PR TITLE
Implement Countable interface for all Listings

### DIFF
--- a/bundles/EcommerceFrameworkBundle/CartManager/Cart/Listing/Dao.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/Cart/Listing/Dao.php
@@ -38,9 +38,11 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
 
     public function getTotalCount()
     {
-        $amount = $this->db->fetchRow('SELECT COUNT(*) as amount FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME . '`' . $this->getCondition());
-
-        return $amount['amount'];
+        try {
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME . '`' . $this->getCondition());
+        } catch (\Exception $e) {
+            return 0;
+        }
     }
 
     public function setCartClass($cartClass)

--- a/bundles/EcommerceFrameworkBundle/CartManager/CartCheckoutData/Listing/Dao.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/CartCheckoutData/Listing/Dao.php
@@ -36,8 +36,10 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
 
     public function getTotalCount()
     {
-        $amount = $this->db->fetchRow('SELECT COUNT(*) as amount FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . '`' . $this->getCondition());
-
-        return $amount['amount'];
+        try {
+            return $this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . '`' . $this->getCondition());
+        } catch(\Exception $e) {
+            return 0;
+        }
     }
 }

--- a/bundles/EcommerceFrameworkBundle/CartManager/CartCheckoutData/Listing/Dao.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/CartCheckoutData/Listing/Dao.php
@@ -37,7 +37,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     public function getTotalCount()
     {
         try {
-            return $this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . '`' . $this->getCondition());
+            return (int)$this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . '`' . $this->getCondition());
         } catch(\Exception $e) {
             return 0;
         }

--- a/bundles/EcommerceFrameworkBundle/CartManager/CartItem/Listing/Dao.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/CartItem/Listing/Dao.php
@@ -41,7 +41,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     public function getTotalCount()
     {
         try {
-            return $this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition());
+            return (int)$this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition());
         } catch(\Exception $e) {
             return 0;
         }

--- a/bundles/EcommerceFrameworkBundle/CartManager/CartItem/Listing/Dao.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/CartItem/Listing/Dao.php
@@ -40,9 +40,11 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
 
     public function getTotalCount()
     {
-        $amount = $this->db->fetchRow('SELECT COUNT(*) as amount FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition());
-
-        return $amount['amount'];
+        try {
+            return $this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition());
+        } catch(\Exception $e) {
+            return 0;
+        }
     }
 
     public function getTotalAmount()

--- a/bundles/EcommerceFrameworkBundle/PricingManager/Rule/Listing/Dao.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Rule/Listing/Dao.php
@@ -55,4 +55,13 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         return $this->ruleClass;
     }
+
+    public function getTotalCount()
+    {
+        try {
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME . '`' . $this->getCondition());
+        } catch (\Exception $e) {
+            return 0;
+        }
+    }
 }

--- a/bundles/EcommerceFrameworkBundle/VoucherService/Token/Listing/Dao.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/Token/Listing/Dao.php
@@ -42,19 +42,20 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
         return $tokens;
     }
 
+    /**
+     * @return int
+     */
     public function getTotalCount()
     {
         try {
-            $amount = (int)$this->db->fetchOne(
+            return (int)$this->db->fetchOne(
                 'SELECT COUNT(*) as amount FROM ' .
                 \Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\Token\Dao::TABLE_NAME .
                 $this->getCondition(),
                 $this->model->getConditionVariables()
             );
         } catch (\Exception $e) {
-            return false;
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/lib/Model/Listing/AbstractListing.php
+++ b/lib/Model/Listing/AbstractListing.php
@@ -24,7 +24,7 @@ use Pimcore\Model\AbstractModel;
  *
  * @method \Pimcore\Db\ZendCompatibility\QueryBuilder getQuery()
  */
-abstract class AbstractListing extends AbstractModel implements \Iterator
+abstract class AbstractListing extends AbstractModel implements \Iterator, \Countable
 {
     /**
      * @var array
@@ -570,5 +570,15 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
     {
         $this->getData();
         reset($this->data);
+    }
+
+    public function count()
+    {
+        $dao = $this->getDao();
+        if(!\method_exists($dao, 'getTotalCount')) {
+            @trigger_error('Listings should implement Countable interface', E_USER_DEPRECATED);
+            return 0;
+        }
+        return $this->getDao()->getTotalCount();
     }
 }

--- a/lib/Model/Listing/AbstractListing.php
+++ b/lib/Model/Listing/AbstractListing.php
@@ -579,6 +579,6 @@ abstract class AbstractListing extends AbstractModel implements \Iterator, \Coun
             @trigger_error('Listings should implement Countable interface', E_USER_DEPRECATED);
             return 0;
         }
-        return $this->getDao()->getTotalCount();
+        return $dao->getTotalCount();
     }
 }

--- a/lib/Model/Listing/AbstractListing.php
+++ b/lib/Model/Listing/AbstractListing.php
@@ -572,6 +572,9 @@ abstract class AbstractListing extends AbstractModel implements \Iterator, \Coun
         reset($this->data);
     }
 
+    /**
+     * @return int
+     */
     public function count()
     {
         $dao = $this->getDao();

--- a/models/DataObject/ClassDefinition/CustomLayout/Listing/Dao.php
+++ b/models/DataObject/ClassDefinition/CustomLayout/Listing/Dao.php
@@ -45,18 +45,13 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
     /**
      * @return int
-     *
-     * @todo: $amount could not be defined, so this could cause an issue
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM custom_layouts ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM custom_layouts ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/DataObject/ClassDefinition/Listing/Dao.php
+++ b/models/DataObject/ClassDefinition/Listing/Dao.php
@@ -51,13 +51,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM classes ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM classes ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/DataObject/Classificationstore/CollectionConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/CollectionConfig/Listing/Dao.php
@@ -60,13 +60,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM ' . DataObject\Classificationstore\CollectionConfig\Dao::TABLE_NAME_COLLECTIONS . ' '. $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\CollectionConfig\Dao::TABLE_NAME_COLLECTIONS . ' '. $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/DataObject/Classificationstore/CollectionGroupRelation/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/CollectionGroupRelation/Listing/Dao.php
@@ -76,13 +76,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM ' . DataObject\Classificationstore\CollectionGroupRelation\Dao::TABLE_NAME_RELATIONS . ' '. $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\CollectionGroupRelation\Dao::TABLE_NAME_RELATIONS . ' '. $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/DataObject/Classificationstore/GroupConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/GroupConfig/Listing/Dao.php
@@ -62,13 +62,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM ' . DataObject\Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS . ' '. $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS . ' '. $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/DataObject/Classificationstore/KeyConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/KeyConfig/Listing/Dao.php
@@ -62,14 +62,11 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM ' . DataObject\Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS . ' '. $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS . ' '. $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 
     /**

--- a/models/DataObject/Classificationstore/KeyGroupRelation/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/KeyGroupRelation/Listing/Dao.php
@@ -95,13 +95,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM ' . DataObject\Classificationstore\KeyGroupRelation\Dao::TABLE_NAME_RELATIONS . ' '. $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\KeyGroupRelation\Dao::TABLE_NAME_RELATIONS . ' '. $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/DataObject/Classificationstore/StoreConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/StoreConfig/Listing/Dao.php
@@ -60,13 +60,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM ' . DataObject\Classificationstore\StoreConfig\Dao::TABLE_NAME_STORES . ' '. $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . DataObject\Classificationstore\StoreConfig\Dao::TABLE_NAME_STORES . ' '. $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/DataObject/QuantityValue/Unit/Listing/Dao.php
+++ b/models/DataObject/QuantityValue/Unit/Listing/Dao.php
@@ -47,12 +47,14 @@ class Dao extends Model\Listing\Dao\AbstractDao
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getTotalCount()
     {
-        $amount = $this->db->fetchRow('SELECT COUNT(*) as amount FROM `' . DataObject\QuantityValue\Unit\Dao::TABLE_NAME . '`' . $this->getCondition());
-
-        return $amount['amount'];
+        try {
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM '.DataObject\QuantityValue\Unit\Dao::TABLE_NAME.' ' . $this->getCondition(), $this->model->getConditionVariables());
+        } catch (\Exception $e) {
+            return 0;
+        }
     }
 }

--- a/models/Dependency.php
+++ b/models/Dependency.php
@@ -118,7 +118,7 @@ class Dependency extends AbstractModel
      * @param int|null $offset
      * @param int|null $limit
      *
-     * @return array{type: string, id: int}
+     * @return array
      */
     public function getRequiredBy($offset = null, $limit = null)
     {

--- a/models/Dependency.php
+++ b/models/Dependency.php
@@ -118,7 +118,7 @@ class Dependency extends AbstractModel
      * @param int|null $offset
      * @param int|null $limit
      *
-     * @return array
+     * @return array{type: string, id: int}
      */
     public function getRequiredBy($offset = null, $limit = null)
     {

--- a/models/Element/Note/Listing/Dao.php
+++ b/models/Element/Note/Listing/Dao.php
@@ -61,7 +61,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount()
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM notes ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM notes ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
             return 0;
         }

--- a/models/Element/Note/Listing/Dao.php
+++ b/models/Element/Note/Listing/Dao.php
@@ -57,18 +57,13 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
     /**
      * @return int
-     *
-     * @todo: $amount could not be defined, so this could cause an issue
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM notes ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM notes ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/Element/Recyclebin/Item/Listing/Dao.php
+++ b/models/Element/Recyclebin/Item/Listing/Dao.php
@@ -50,13 +50,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM recyclebin ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM recyclebin ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/Element/Recyclebin/Item/Listing/Dao.php
+++ b/models/Element/Recyclebin/Item/Listing/Dao.php
@@ -51,7 +51,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount()
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM recyclebin ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM recyclebin ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
             return 0;
         }

--- a/models/Element/Tag/Listing/Dao.php
+++ b/models/Element/Tag/Listing/Dao.php
@@ -57,18 +57,12 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
     /**
      * @return int
-     *
-     * @todo: $amount could not be defined, so this could cause an issue
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM tags ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM tags ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
         }
-
-        return $amount;
     }
 }

--- a/models/Element/Tag/Listing/Dao.php
+++ b/models/Element/Tag/Listing/Dao.php
@@ -63,6 +63,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
         try {
             return (int) $this->db->fetchOne('SELECT COUNT(*) FROM tags ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
     }
 }

--- a/models/Element/WorkflowState/Listing/Dao.php
+++ b/models/Element/WorkflowState/Listing/Dao.php
@@ -50,13 +50,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM element_workflow_state ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM element_workflow_state ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/Element/WorkflowState/Listing/Dao.php
+++ b/models/Element/WorkflowState/Listing/Dao.php
@@ -51,7 +51,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount()
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM element_workflow_state ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM element_workflow_state ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
             return 0;
         }

--- a/models/Glossary/Listing/Dao.php
+++ b/models/Glossary/Listing/Dao.php
@@ -61,7 +61,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount()
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM glossary ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM glossary ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
             return 0;
         }

--- a/models/Glossary/Listing/Dao.php
+++ b/models/Glossary/Listing/Dao.php
@@ -60,13 +60,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM glossary ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM glossary ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/GridConfig/Listing/Dao.php
+++ b/models/GridConfig/Listing/Dao.php
@@ -50,13 +50,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM gridconfigs ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM gridconfigs ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/GridConfigFavourite/Listing/Dao.php
+++ b/models/GridConfigFavourite/Listing/Dao.php
@@ -51,13 +51,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM gridconfig_favourites ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM gridconfig_favourites ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/GridConfigShare/Listing/Dao.php
+++ b/models/GridConfigShare/Listing/Dao.php
@@ -50,13 +50,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) FROM gridconfig_shares ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM gridconfig_shares ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/GridConfigShare/Listing/Dao.php
+++ b/models/GridConfigShare/Listing/Dao.php
@@ -53,7 +53,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
         $amount = 0;
 
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM gridconfig_shares ' . $this->getCondition(), $this->model->getConditionVariables());
+            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) FROM gridconfig_shares ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
         }
 

--- a/models/ImportConfig/Listing/Dao.php
+++ b/models/ImportConfig/Listing/Dao.php
@@ -50,13 +50,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM importconfigs ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM importconfigs ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/ImportConfigShare/Listing/Dao.php
+++ b/models/ImportConfigShare/Listing/Dao.php
@@ -50,13 +50,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) FROM importconfig_shares ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM importconfig_shares ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/ImportConfigShare/Listing/Dao.php
+++ b/models/ImportConfigShare/Listing/Dao.php
@@ -53,7 +53,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
         $amount = 0;
 
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM importconfig_shares ' . $this->getCondition(), $this->model->getConditionVariables());
+            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) FROM importconfig_shares ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
         }
 

--- a/models/Notification/Listing/Dao.php
+++ b/models/Notification/Listing/Dao.php
@@ -42,6 +42,11 @@ class Dao extends AbstractDao
         return $count;
     }
 
+    public function getTotalCount()
+    {
+        return $this->count();
+    }
+
     /**
      * @return array
      *

--- a/models/Redirect/Listing/Dao.php
+++ b/models/Redirect/Listing/Dao.php
@@ -48,13 +48,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM redirects ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM redirects ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/Redirect/Listing/Dao.php
+++ b/models/Redirect/Listing/Dao.php
@@ -49,7 +49,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount()
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM redirects ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM redirects ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
             return 0;
         }

--- a/models/Schedule/Task/Listing/Dao.php
+++ b/models/Schedule/Task/Listing/Dao.php
@@ -42,4 +42,13 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
         return $tasks;
     }
+
+    public function getTotalCount()
+    {
+        try {
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM schedule_tasks ' . $this->getCondition(), $this->model->getConditionVariables());
+        } catch (\Exception $e) {
+            return 0;
+        }
+    }
 }

--- a/models/Search/Backend/Data/Listing/Dao.php
+++ b/models/Search/Backend/Data/Listing/Dao.php
@@ -64,9 +64,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = (int)$this->db->fetchOne('SELECT COUNT(*) as amount FROM search_backend_data' . $this->getCondition() . $this->getGroupBy(), $this->model->getConditionVariables());
-
-        return $amount;
+        return (int)$this->db->fetchOne('SELECT COUNT(*) as amount FROM search_backend_data' . $this->getCondition() . $this->getGroupBy(), $this->model->getConditionVariables());
     }
 
     /**

--- a/models/Search/Backend/Data/Listing/Dao.php
+++ b/models/Search/Backend/Data/Listing/Dao.php
@@ -64,7 +64,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        return (int)$this->db->fetchOne('SELECT COUNT(*) as amount FROM search_backend_data' . $this->getCondition() . $this->getGroupBy(), $this->model->getConditionVariables());
+        return (int)$this->db->fetchOne('SELECT COUNT(*) FROM search_backend_data' . $this->getCondition() . $this->getGroupBy(), $this->model->getConditionVariables());
     }
 
     /**

--- a/models/Site/Listing/Dao.php
+++ b/models/Site/Listing/Dao.php
@@ -42,4 +42,16 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
         return $sites;
     }
+
+    /**
+     * @return int
+     */
+    public function getTotalCount()
+    {
+        try {
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM sites ' . $this->getCondition(), $this->model->getConditionVariables());
+        } catch (\Exception $e) {
+            return 0;
+        }
+    }
 }

--- a/models/Tool/Email/Blacklist/Listing/Dao.php
+++ b/models/Tool/Email/Blacklist/Listing/Dao.php
@@ -52,13 +52,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM email_blacklist ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM email_blacklist ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/Tool/Email/Blacklist/Listing/Dao.php
+++ b/models/Tool/Email/Blacklist/Listing/Dao.php
@@ -47,13 +47,11 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
     /**
      * @return int
-     *
-     * @todo: $amount could not be defined, so this could cause an issue
      */
     public function getTotalCount()
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM email_blacklist ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM email_blacklist ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
             return 0;
         }

--- a/models/Tool/Email/Log/Listing/Dao.php
+++ b/models/Tool/Email/Log/Listing/Dao.php
@@ -62,7 +62,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount()
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM email_log ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM email_log ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
             return 0;
         }

--- a/models/Tool/Email/Log/Listing/Dao.php
+++ b/models/Tool/Email/Log/Listing/Dao.php
@@ -61,13 +61,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM email_log ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM email_log ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/Tool/Targeting/Rule/Listing/Dao.php
+++ b/models/Tool/Targeting/Rule/Listing/Dao.php
@@ -41,4 +41,13 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
         return $targets;
     }
+
+    public function getTotalCount()
+    {
+        try {
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM targeting_rules ' . $this->getCondition(), $this->model->getConditionVariables());
+        } catch (\Exception $e) {
+            return 0;
+        }
+    }
 }

--- a/models/Tool/Targeting/TargetGroup/Listing/Dao.php
+++ b/models/Tool/Targeting/TargetGroup/Listing/Dao.php
@@ -41,4 +41,16 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
         return $targetGroups;
     }
+
+    /**
+     * @return int
+     */
+    public function getTotalCount()
+    {
+        try {
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM targeting_target_groups ' . $this->getCondition(), $this->model->getConditionVariables());
+        } catch (\Exception $e) {
+            return 0;
+        }
+    }
 }

--- a/models/Tool/UUID/Listing/Dao.php
+++ b/models/Tool/UUID/Listing/Dao.php
@@ -49,7 +49,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount()
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM ' . UUID\Dao::TABLE_NAME .' ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM ' . UUID\Dao::TABLE_NAME .' ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
             return 0;
         }

--- a/models/Tool/UUID/Listing/Dao.php
+++ b/models/Tool/UUID/Listing/Dao.php
@@ -48,13 +48,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM ' . UUID\Dao::TABLE_NAME .' ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM ' . UUID\Dao::TABLE_NAME .' ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }

--- a/models/User/Listing/AbstractListing/Dao.php
+++ b/models/User/Listing/AbstractListing/Dao.php
@@ -64,4 +64,16 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
         return $condition;
     }
+
+    /**
+     * @return int
+     */
+    public function getTotalCount()
+    {
+        try {
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM users ' . $this->getCondition(), $this->model->getConditionVariables());
+        } catch (\Exception $e) {
+            return 0;
+        }
+    }
 }

--- a/models/User/Permission/Definition/Listing/Dao.php
+++ b/models/User/Permission/Definition/Listing/Dao.php
@@ -43,4 +43,16 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
         return $definitions;
     }
+
+    /**
+     * @return int
+     */
+    public function getTotalCount()
+    {
+        try {
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM users_permission_definitions ' . $this->getCondition(), $this->model->getConditionVariables());
+        } catch (\Exception $e) {
+            return 0;
+        }
+    }
 }

--- a/models/Version/Listing/Dao.php
+++ b/models/Version/Listing/Dao.php
@@ -49,7 +49,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount()
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM versions ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM versions ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
             return 0;
         }

--- a/models/Version/Listing/Dao.php
+++ b/models/Version/Listing/Dao.php
@@ -48,13 +48,10 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function getTotalCount()
     {
-        $amount = 0;
-
         try {
-            $amount = (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM versions ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) as amount FROM versions ' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
+            return 0;
         }
-
-        return $amount;
     }
 }


### PR DESCRIPTION
This PR implements PHP's Countable interface for all Listings, so you can do something like this:
```php
$listing = new Listing();
$listing->addConditionParam('column = ?', 123);
if(count($listing) === 0) {
  echo "No entries found";
}
```
Internally the `getTotalCount()` method of the Listing DAO gets called. Most of them already had this method - where it was missing this PR adds it.