### PR TITLE
Only get DB if relation is available to save

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
@@ -104,12 +104,12 @@ abstract class AbstractRelations extends Data implements
             }
         }
 
-        $db = Db::get();
-
         $data = $this->getDataFromObjectParam($object, $params);
         $relations = $this->prepareDataForPersistence($data, $object, $params);
 
         if (is_array($relations) && !empty($relations)) {
+            $db = Db::get();
+
             foreach ($relations as $relation) {
                 $this->enrichDataRow($object, $params, $classId, $relation);
 


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [-] Features need to be proper documented in `doc/` -> target branch `master`
- [-] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [x] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [x] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
--> 
  
## Changes in this pull request  

Discovered while saving a lot of objects with no Delations, there were no need to actually load the DB connection when no Relation should be saved anyway.
