### PR TITLE
Assert PDO Variable Type Casting

### DIFF
--- a/lib/Model/Listing/AbstractListing.php
+++ b/lib/Model/Listing/AbstractListing.php
@@ -336,7 +336,18 @@ abstract class AbstractListing extends AbstractModel implements \Iterator
                     $conditionVariableTypes[$pkey] = \Doctrine\DBAL\Connection::PARAM_INT_ARRAY;
                 }
             } else {
-                $conditionVariableTypes[$pkey] = \PDO::PARAM_STR;
+
+                if (is_bool($param)) {
+                    $type = \PDO::PARAM_BOOL;
+                } elseif (is_int($param)) {
+                    $type = \PDO::PARAM_INT;
+                } elseif (is_null($param)) {
+                    $type = \PDO::PARAM_NULL;
+                } else {
+                    $type = \PDO::PARAM_STR;
+                }
+
+                $conditionVariableTypes[$pkey] = $type;
             }
         }
 


### PR DESCRIPTION
This PR introduces a deeper variable type casting to prevent sloppy data comparing.
E.g. `value (int)  >= var_char_column (pimcore dropdown data)`.