### PR TITLE
Add example of pimcore.cnf for MySQL

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
@@ -25,7 +25,7 @@ GRANT ALL ON `project_database`.* TO 'project_user'@'localhost';
 
 While setting up the MySQL Server you can enforce `utf8mb4` character set and [lower case table names](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_lower_case_table_names) by placing a `pimcore.cnf` file with the following contents into the server config directory (e.g. `/etc/mysql/conf.d/`). Refer to the server configuration manual applicable to your environment to determine the location of the server config directory.
 
-```cnf
+```ini
 # MySQL Server configuration for Pimcore.
 # @See https://dev.mysql.com/doc/refman/8.0/en/option-files.html
 # @See https://pimcore.com/docs/6.x/Development_Documentation/Installation_and_Upgrade/System_Setup_and_Hosting/DB_Setup.html

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
@@ -9,7 +9,7 @@ their class names contain capital letters.
 > Note: You have to create the database manually before you can continue with the web-based installer, 
 > which automatically creates the underlying database schema for Pimcore.
 
-### Dabase server configuration
+### Database Server Configuration
 
 While setting up the MySQL Server you can enforce `utf8mb4` character set and [lover case table names](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_lower_case_table_names) by placing a pimcore.cnf file with the following contents into the server config directory (e.g. `/etc/mysql/conf.d/`). Refer to server configuration manual applicable to your environment to determine the location of server config directory.
 

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
@@ -3,10 +3,34 @@
 Pimcore requires a standard MySQL database, the only thing you should assure is that the database uses `utf8mb4` as character set.  
 If you create a new database just set the character set to `utf8mb4`.
 
-> Note: You have to create the database manually before you can continue with the web-based installer, 
-> which automatically creates the underlying database schema for Pimcore. 
+You also might want to set `lower_case_table_names=1` to make sure that tables for pimcore classes are created in lover case even though
+their class names contain capital letters.
 
-### Command to Create a new Database 
+> Note: You have to create the database manually before you can continue with the web-based installer, 
+> which automatically creates the underlying database schema for Pimcore.
+
+### Dabase server configuration
+
+While setting up the MySQL Server you can enforce `utf8mb4` character set and [lover case table names](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_lower_case_table_names) by placing a pimcore.cnf file with the following contents into the server config directory (e.g. `/etc/mysql/conf.d/`). Refer to server configuration manual applicable to your environment to determine the location of server config directory.
+
+```cnf
+# Applies to any client connecting to this sever
+[client]
+default-character-set=utf8mb4
+
+# Applies to mysql cli client application
+[mysql]
+default-character-set=utf8mb4
+
+# Applies to mysql server
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+init-connect='SET NAMES utf8mb4'
+lower_case_table_names=1
+```
+
+### Command to Create a new Database
 
 ```bash
 mysql -u root -p -e "CREATE DATABASE project_database charset=utf8mb4;"

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
@@ -3,13 +3,25 @@
 Pimcore requires a standard MySQL database, the only thing you should assure is that the database uses `utf8mb4` as character set.  
 If you create a new database just set the character set to `utf8mb4`.
 
-You also might want to set `lower_case_table_names=1` to make sure that tables for Pimcore classes are created in lower case even though
-their class names contain capital letters.
-
 > Note: You have to create the database manually before you can continue with the web-based installer, 
 > which automatically creates the underlying database schema for Pimcore.
 
-### Database Server Configuration
+### Command to Create a new Database
+
+```bash
+mysql -u root -p -e "CREATE DATABASE project_database charset=utf8mb4;"
+```
+
+### Permissions needed for Pimcore
+
+Pimcore requires all permissions on database level. You can create a user with the necessary
+rights with the following commands:
+
+```sql
+CREATE USER 'project_user'@'localhost' IDENTIFIED BY 'PASSWORD';
+GRANT ALL ON `project_database`.* TO 'project_user'@'localhost';
+```
+### Database Server Configuration (Optional)
 
 While setting up the MySQL Server you can enforce `utf8mb4` character set and [lower case table names](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_lower_case_table_names) by placing a `pimcore.cnf` file with the following contents into the server config directory (e.g. `/etc/mysql/conf.d/`). Refer to the server configuration manual applicable to your environment to determine the location of the server config directory.
 
@@ -34,18 +46,4 @@ init-connect='SET NAMES utf8mb4'
 lower_case_table_names=1
 ```
 
-### Command to Create a new Database
-
-```bash
-mysql -u root -p -e "CREATE DATABASE project_database charset=utf8mb4;"
-```
-
-### Permissions needed for Pimcore
-
-Pimcore requires all permissions on database level. You can create a user with the necessary
-rights with the following commands:
-
-```sql
-CREATE USER 'project_user'@'localhost' IDENTIFIED BY 'PASSWORD';
-GRANT ALL ON `project_database`.* TO 'project_user'@'localhost';
-```
+Setting `lower_case_table_names=1` makes sure that tables for Pimcore classes are created in lower case even though their class names contain capital letters.

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
@@ -14,7 +14,7 @@ their class names contain capital letters.
 While setting up the MySQL Server you can enforce `utf8mb4` character set and [lower case table names](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_lower_case_table_names) by placing a `pimcore.cnf` file with the following contents into the server config directory (e.g. `/etc/mysql/conf.d/`). Refer to the server configuration manual applicable to your environment to determine the location of the server config directory.
 
 ```cnf
-# MySQL Server configuration for pimcore.
+# MySQL Server configuration for Pimcore.
 # @See https://dev.mysql.com/doc/refman/8.0/en/option-files.html
 # @See https://pimcore.com/docs/6.x/Development_Documentation/Installation_and_Upgrade/System_Setup_and_Hosting/DB_Setup.html
 

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
@@ -3,7 +3,7 @@
 Pimcore requires a standard MySQL database, the only thing you should assure is that the database uses `utf8mb4` as character set.  
 If you create a new database just set the character set to `utf8mb4`.
 
-You also might want to set `lower_case_table_names=1` to make sure that tables for pimcore classes are created in lower case even though
+You also might want to set `lower_case_table_names=1` to make sure that tables for Pimcore classes are created in lower case even though
 their class names contain capital letters.
 
 > Note: You have to create the database manually before you can continue with the web-based installer, 

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
@@ -11,7 +11,7 @@ their class names contain capital letters.
 
 ### Database Server Configuration
 
-While setting up the MySQL Server you can enforce `utf8mb4` character set and [lover case table names](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_lower_case_table_names) by placing a pimcore.cnf file with the following contents into the server config directory (e.g. `/etc/mysql/conf.d/`). Refer to server configuration manual applicable to your environment to determine the location of server config directory.
+While setting up the MySQL Server you can enforce `utf8mb4` character set and [lower case table names](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_lower_case_table_names) by placing a `pimcore.cnf` file with the following contents into the server config directory (e.g. `/etc/mysql/conf.d/`). Refer to the server configuration manual applicable to your environment to determine the location of the server config directory.
 
 ```cnf
 # MySQL Server configuration for pimcore.

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
@@ -14,6 +14,10 @@ their class names contain capital letters.
 While setting up the MySQL Server you can enforce `utf8mb4` character set and [lover case table names](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_lower_case_table_names) by placing a pimcore.cnf file with the following contents into the server config directory (e.g. `/etc/mysql/conf.d/`). Refer to server configuration manual applicable to your environment to determine the location of server config directory.
 
 ```cnf
+# MySQL Server configuration for pimcore.
+# @See https://dev.mysql.com/doc/refman/8.0/en/option-files.html
+# @See https://pimcore.com/docs/6.x/Development_Documentation/Installation_and_Upgrade/System_Setup_and_Hosting/DB_Setup.html
+
 # Applies to any client connecting to this sever
 [client]
 default-character-set=utf8mb4

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
@@ -3,7 +3,7 @@
 Pimcore requires a standard MySQL database, the only thing you should assure is that the database uses `utf8mb4` as character set.  
 If you create a new database just set the character set to `utf8mb4`.
 
-You also might want to set `lower_case_table_names=1` to make sure that tables for pimcore classes are created in lover case even though
+You also might want to set `lower_case_table_names=1` to make sure that tables for pimcore classes are created in lower case even though
 their class names contain capital letters.
 
 > Note: You have to create the database manually before you can continue with the web-based installer, 


### PR DESCRIPTION
This MR adds some documentation on how to configure MySQL Server for pimcore using a .cnf file. Options listet in the file can also be helpful while setting up a managed mysql service such as AWS RDS.