### PR TITLE
PageSippet: set/remove editable loses existing elements on save

### DIFF
--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -420,6 +420,7 @@ abstract class PageSnippet extends Model\Document
      */
     public function setEditable(string $name, Tag $data)
     {
+        $this->getEditables();
         $this->editables[$name] = $data;
 
         return $this;
@@ -444,6 +445,7 @@ abstract class PageSnippet extends Model\Document
      */
     public function removeEditable(string $name)
     {
+        $this->getEditables();
         if (isset($this->editables[$name])) {
             unset($this->editables[$name]);
         }


### PR DESCRIPTION
Steps to reproduce:

```
$doc = Document::getById(99);
$doc->setEditable("somekey", "somedata");    // it doesn't check if existing editables are already loaded, so overwrites them ...
$doc->save();
```