### PR TITLE
Fix doc block return types for relations

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -31,7 +31,6 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
     use DataObject\ClassDefinition\Data\Relations\AllowObjectRelationTrait;
     use DataObject\ClassDefinition\Data\Relations\AllowAssetRelationTrait;
     use DataObject\ClassDefinition\Data\Relations\AllowDocumentRelationTrait;
-    use DataObject\ClassDefinition\NullablePhpdocReturnTypeTrait;
 
     /**
      * Static type of this element
@@ -773,6 +772,18 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
             return $listing;
         }
         throw new \InvalidArgumentException('Filtering '.__CLASS__.' does only support "=" operator');
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPhpdocReturnType(): ?string
+    {
+        if ($this->getPhpdocType()) {
+            return $this->getPhpdocType() . '|null';
+        }
+
+        return null;
     }
 }
 


### PR DESCRIPTION
By changing Data::getPhpdocType() to Data::getPhpdocReturnType() the call to Relation::getPhpDocClassString() for relationship data types was lost. For example in ManyToOneRelation::getPhpdocType()

This in turn causes the IDE's to break and is causing issues with symfony serializer which uses doc block for typehinting.