### PR TITLE
Revert "PageSippet: set/remove editable loses existing elements on save"

### DIFF
--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -420,7 +420,6 @@ abstract class PageSnippet extends Model\Document
      */
     public function setEditable(string $name, Tag $data)
     {
-        $this->getEditables();
         $this->editables[$name] = $data;
 
         return $this;
@@ -445,7 +444,6 @@ abstract class PageSnippet extends Model\Document
      */
     public function removeEditable(string $name)
     {
-        $this->getEditables();
         if (isset($this->editables[$name])) {
             unset($this->editables[$name]);
         }


### PR DESCRIPTION
Reverts pimcore/pimcore#6982

needs to be reverted because causes endless recursion.

`getEditables` calls `setEditable` 
