### PR TITLE
[DataObject] Fix deleting folders with class override

### DIFF
--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -358,7 +358,9 @@ class AbstractObject extends Model\Element\AbstractElement
         if (!in_array(static::class, [__CLASS__, Concrete::class, Folder::class], true)) {
             /** @var Concrete $tmpObject */
             $tmpObject = new static();
-            $className = 'Pimcore\\Model\\DataObject\\' . ucfirst($tmpObject->getClassName());
+            if ($tmpObject instanceof Concrete) {
+                $className = 'Pimcore\\Model\\DataObject\\' . ucfirst($tmpObject->getClassName());
+            }
         }
 
         if (is_array($config)) {


### PR DESCRIPTION
Regression from #6947 and #6945

as discussed external bundles with class override on DataObject\Folder class will still break.

Fix it with explicity checking if class is instanceof Concrete before constructing DataObject class and listing
