### PR TITLE
TrackingCodeFlashMessageListener: Avoid autostart session by accessing the FlashBag

### DIFF
--- a/bundles/EcommerceFrameworkBundle/EventListener/Frontend/TrackingCodeFlashMessageListener.php
+++ b/bundles/EcommerceFrameworkBundle/EventListener/Frontend/TrackingCodeFlashMessageListener.php
@@ -65,13 +65,16 @@ class TrackingCodeFlashMessageListener implements EventSubscriberInterface
             return;
         }
 
-        $trackedCodes = $this->session->getFlashBag()->get(self::FLASH_MESSAGE_BAG_KEY);
+       // Avoid autostart session by accessing the FlashBag.
+        if ($this->session->isStarted()) {
+            $trackedCodes = $this->session->getFlashBag()->get(self::FLASH_MESSAGE_BAG_KEY);
 
-        if (is_array($trackedCodes) && sizeof($trackedCodes)) {
-            foreach ($this->trackingManger->getTrackers() as $tracker) {
-                if ($tracker instanceof TrackingCodeAwareInterface && isset($trackedCodes[get_class($tracker)])) {
-                    foreach ($trackedCodes[get_class($tracker)] as $trackedCode) {
-                        $tracker->trackCode($trackedCode);
+            if (is_array($trackedCodes) && sizeof($trackedCodes)) {
+                foreach ($this->trackingManger->getTrackers() as $tracker) {
+                    if ($tracker instanceof TrackingCodeAwareInterface && isset($trackedCodes[get_class($tracker)])) {
+                        foreach ($trackedCodes[get_class($tracker)] as $trackedCode) {
+                            $tracker->trackCode($trackedCode);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
With session autostart enabled accessing the FlashBag on the session container will create a session.
I think it would be beneficial to start sessions only if necessary.
Sessions make upstream caching e.g. with Varnish hard.
Explicitly checking if a session has been started before attempting to read if there are any data in the session shouldn't hurt the functionality in any way.