### PR TITLE
Avoid function aliases

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetHelperController.php
@@ -693,7 +693,7 @@ class AssetHelperController extends AdminController
                 $line = implode($delimiter, $line) . "\r\n";
                 fwrite($fp, $line);
             } else {
-                fputs($fp, implode($delimiter, array_map([$this, 'encodeFunc'], $line)) . "\r\n");
+                fwrite($fp, implode($delimiter, array_map([$this, 'encodeFunc'], $line)) . "\r\n");
             }
         }
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1900,7 +1900,7 @@ class DataObjectHelperController extends AdminController
                 $line = implode($delimiter, $line);
                 fwrite($fp, $line);
             } else {
-                fputs($fp, implode($delimiter, array_map([$this, 'encodeFunc'], $line)));
+                fwrite($fp, implode($delimiter, array_map([$this, 'encodeFunc'], $line)));
             }
             if ($i < $lineCount - 1) {
                 fwrite($fp, "\r\n");

--- a/bundles/AdminBundle/Controller/Admin/MiscController.php
+++ b/bundles/AdminBundle/Controller/Admin/MiscController.php
@@ -362,7 +362,7 @@ class MiscController extends AdminController
             if (is_readable($file)) {
                 $content = file_get_contents($file);
                 $success = true;
-                $writeable = is_writeable($file);
+                $writeable = is_writable($file);
             }
         }
 
@@ -390,7 +390,7 @@ class MiscController extends AdminController
 
         if ($request->get('content') && $request->get('path')) {
             $file = $this->getFileexplorerPath($request, 'path');
-            if (is_file($file) && is_writeable($file)) {
+            if (is_file($file) && is_writable($file)) {
                 File::put($file, $request->get('content'));
 
                 $success = true;
@@ -426,7 +426,7 @@ class MiscController extends AdminController
                 throw new \Exception('not allowed');
             }
 
-            if (is_writeable(dirname($file))) {
+            if (is_writable(dirname($file))) {
                 File::put($file, '');
 
                 $success = true;
@@ -462,7 +462,7 @@ class MiscController extends AdminController
                 throw new \Exception('not allowed');
             }
 
-            if (is_writeable(dirname($file))) {
+            if (is_writable(dirname($file))) {
                 File::mkdir($file);
 
                 $success = true;
@@ -488,7 +488,7 @@ class MiscController extends AdminController
 
         if ($request->get('path')) {
             $file = $this->getFileexplorerPath($request, 'path');
-            if (is_writeable($file)) {
+            if (is_writable($file)) {
                 unlink($file);
                 $success = true;
             }

--- a/bundles/AdminBundle/Controller/Admin/WorkflowController.php
+++ b/bundles/AdminBundle/Controller/Admin/WorkflowController.php
@@ -119,7 +119,7 @@ class WorkflowController extends AdminController implements EventedControllerInt
                 ];
             } catch (ValidationException $e) {
                 $reason = '';
-                if (sizeof((array)$e->getSubItems()) > 0) {
+                if (count((array)$e->getSubItems()) > 0) {
                     $reason = '<ul>' . implode('', array_map(function ($item) {
                         return '<li>' . $item . '</li>';
                     }, $e->getSubItems())) . '</ul>';
@@ -170,7 +170,7 @@ class WorkflowController extends AdminController implements EventedControllerInt
             ];
         } catch (ValidationException $e) {
             $reason = '';
-            if (sizeof((array)$e->getSubItems()) > 0) {
+            if (count((array)$e->getSubItems()) > 0) {
                 $reason = '<ul>' . implode('', array_map(function ($item) {
                     return '<li>' . $item . '</li>';
                 }, $e->getSubItems())) . '</ul>';
@@ -246,7 +246,7 @@ class WorkflowController extends AdminController implements EventedControllerInt
         return $this->adminJson([
             'data' => $data,
             'success' => true,
-            'total' => sizeof($data),
+            'total' => count($data),
         ]);
     }
 

--- a/bundles/AdminBundle/Controller/Reports/CustomReportController.php
+++ b/bundles/AdminBundle/Controller/Reports/CustomReportController.php
@@ -436,7 +436,7 @@ class CustomReportController extends ReportsControllerBase
             'exportFile' => $exportFile,
             'offset' => $offset,
             'progress' => $progress,
-            'finished' => empty($result['data']) || sizeof($result['data']) < $limit,
+            'finished' => empty($result['data']) || count($result['data']) < $limit,
         ]);
     }
 

--- a/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
+++ b/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
@@ -183,7 +183,7 @@ class WorkflowManagementListener implements EventSubscriberInterface
 
             $marking = $workflow->getMarking($element);
 
-            if (!sizeof($marking->getPlaces())) {
+            if (!count($marking->getPlaces())) {
                 continue;
             }
 

--- a/bundles/EcommerceFrameworkBundle/EventListener/Frontend/TrackingCodeFlashMessageListener.php
+++ b/bundles/EcommerceFrameworkBundle/EventListener/Frontend/TrackingCodeFlashMessageListener.php
@@ -67,7 +67,7 @@ class TrackingCodeFlashMessageListener implements EventSubscriberInterface
 
         $trackedCodes = $this->session->getFlashBag()->get(self::FLASH_MESSAGE_BAG_KEY);
 
-        if (is_array($trackedCodes) && sizeof($trackedCodes)) {
+        if (is_array($trackedCodes) && count($trackedCodes)) {
             foreach ($this->trackingManger->getTrackers() as $tracker) {
                 if ($tracker instanceof TrackingCodeAwareInterface && isset($trackedCodes[get_class($tracker)])) {
                     foreach ($trackedCodes[get_class($tracker)] as $trackedCode) {

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectCategory.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectCategory.php
@@ -82,7 +82,7 @@ class MultiSelectCategory extends AbstractFilterType
             }
         }
 
-        if (sizeof($conditions)) {
+        if (count($conditions)) {
             if ($filterDefinition->getUseAndCondition()) {
                 $conditions = implode(' AND ', $conditions);
             } else {

--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -574,7 +574,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
         $params['type'] = $this->getTenantConfig()->getElasticSearchClientParams()['indexType'];
         $params['body']['_source'] = true;
 
-        if (is_integer($this->getLimit())) { // null not allowed
+        if (is_int($this->getLimit())) { // null not allowed
             $params['body']['size'] = $this->getLimit();
         }
         $params['body']['from'] = $this->getOffset();

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -455,7 +455,7 @@ abstract class AbstractElasticSearch extends Worker\ProductCentricBatchProcessin
      */
     public function commitBatchToIndex(): void
     {
-        if (sizeof($this->bulkIndexData)) {
+        if (count($this->bulkIndexData)) {
             $esClient = $this->getElasticSearchClient();
             $responses = $esClient->bulk([
                 'body' => $this->bulkIndexData,

--- a/bundles/EcommerceFrameworkBundle/Tracking/TrackingManager.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/TrackingManager.php
@@ -322,7 +322,7 @@ class TrackingManager implements TrackingManagerInterface
         $result = '';
         foreach ($this->getTrackers() as $tracker) {
             if ($tracker instanceof TrackingCodeAwareInterface) {
-                if (sizeof($tracker->getTrackedCodes())) {
+                if (count($tracker->getTrackedCodes())) {
                     $result .= implode(PHP_EOL, $tracker->getTrackedCodes()).PHP_EOL.PHP_EOL;
                 }
             }
@@ -337,7 +337,7 @@ class TrackingManager implements TrackingManagerInterface
 
         foreach ($this->getTrackers() as $tracker) {
             if ($tracker instanceof TrackingCodeAwareInterface) {
-                if (sizeof($tracker->getTrackedCodes())) {
+                if (count($tracker->getTrackedCodes())) {
                     $trackedCodes[get_class($tracker)] = $tracker->getTrackedCodes();
                 }
             }

--- a/bundles/EcommerceFrameworkBundle/VoucherService/Token/Listing.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/Token/Listing.php
@@ -66,7 +66,7 @@ class Listing extends \Pimcore\Model\Listing\AbstractListing implements AdapterI
             throw new \Exception('Unable to load series tokens: no VoucherSeriesId given.', 100);
         }
 
-        if (sizeof($filter)) {
+        if (count($filter)) {
             if (!empty($filter['token'])) {
                 $this->addConditionParam('token LIKE ?', '%' . $filter['token'] . '%');
             }
@@ -302,10 +302,10 @@ class Listing extends \Pimcore\Model\Listing\AbstractListing implements AdapterI
             $queryParts[] = 't.timestamp < STR_TO_DATE(' . $param . ",'%Y-%m-%d')";
         }
 
-        if (sizeof($queryParts) == 1) {
+        if (count($queryParts) == 1) {
             $reservationsQuery = $reservationsQuery . ' AND ' . $queryParts[0];
             $tokensQuery = $tokensQuery . ' AND ' . $queryParts[0];
-        } elseif (sizeof($queryParts) > 1) {
+        } elseif (count($queryParts) > 1) {
             $reservationsQuery = $reservationsQuery . ' AND (' . implode(' AND ', $queryParts) . ')';
             $tokensQuery = $tokensQuery . ' AND (' . implode(' AND ', $queryParts) . ')';
         }

--- a/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/AbstractTokenManager.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/AbstractTokenManager.php
@@ -133,7 +133,7 @@ abstract class AbstractTokenManager implements TokenManagerInterface
     protected function checkOnlyToken(CartInterface $cart)
     {
         $cartCodes = $cart->getVoucherTokenCodes();
-        $cartVoucherCount = sizeof($cartCodes);
+        $cartVoucherCount = count($cartCodes);
         if ($cartVoucherCount && method_exists($this->configuration, 'getOnlyTokenPerCart')) {
             if ($this->configuration->getOnlyTokenPerCart()) {
                 throw new VoucherServiceException('OnlyTokenPerCart: This token is only allowed as only token in this cart.', VoucherServiceException::ERROR_CODE_ONLY_TOKEN_PER_CART_CANNOT_BE_ADDED);

--- a/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/Pattern.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/Pattern.php
@@ -393,7 +393,7 @@ class Pattern extends AbstractTokenManager implements ExportableTokenManagerInte
         $finalLength = $this->getFinalTokenLength();
         $insertParts = [];
 
-        if (sizeof($insertTokens) > 0) {
+        if (count($insertTokens) > 0) {
             foreach ($insertTokens as $token) {
                 $insertParts[] =
                     "('" .
@@ -490,7 +490,7 @@ class Pattern extends AbstractTokenManager implements ExportableTokenManagerInte
             }
 
             // If there are tokens to insert add them to query.
-            if (sizeof($insertTokens)) {
+            if (count($insertTokens)) {
                 $resultTokenSet[] = $insertTokens;
             }
 
@@ -551,7 +551,7 @@ class Pattern extends AbstractTokenManager implements ExportableTokenManagerInte
             $paginator->setCurrentPageNumber($params['page']);
 
             $viewParamsBag['paginator'] = $paginator;
-            $viewParamsBag['count'] = sizeof($tokens);
+            $viewParamsBag['count'] = count($tokens);
         } else {
             $viewParamsBag['msg']['result'] = 'bundle_ecommerce_voucherservice_msg-error-token-noresult';
         }

--- a/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/Single.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/Single.php
@@ -77,7 +77,7 @@ class Single extends AbstractTokenManager implements ExportableTokenManagerInter
 
         if ($codes = $this->getCodes()) {
             $viewParamsBag['paginator'] = new Paginator(new ArrayAdapter($codes));
-            $viewParamsBag['count'] = sizeof($codes);
+            $viewParamsBag['count'] = count($codes);
         }
 
         $viewParamsBag['msg']['error'] = $params['error'];

--- a/lib/DataObject/GridColumnConfig/Operator/DateFormatter.php
+++ b/lib/DataObject/GridColumnConfig/Operator/DateFormatter.php
@@ -88,7 +88,7 @@ class DateFormatter extends AbstractOperator
     public function format($theValue)
     {
         if ($theValue) {
-            if (is_integer($theValue)) {
+            if (is_int($theValue)) {
                 $theValue = Carbon::createFromTimestamp($theValue);
             }
             if ($this->format) {

--- a/lib/Db/PhpArrayFileTable.php
+++ b/lib/Db/PhpArrayFileTable.php
@@ -73,10 +73,10 @@ class PhpArrayFileTable
     {
         $writeable = false;
 
-        if (file_exists($filePath) && is_writeable($filePath)) {
+        if (file_exists($filePath) && is_writable($filePath)) {
             $writeable = true;
         } elseif (!file_exists($filePath)) {
-            if (is_writeable(dirname($filePath))) {
+            if (is_writable(dirname($filePath))) {
                 $writeable = true;
             }
         }

--- a/lib/Db/ZendCompatibility/QueryBuilder/PaginationAdapter.php
+++ b/lib/Db/ZendCompatibility/QueryBuilder/PaginationAdapter.php
@@ -139,7 +139,7 @@ class PaginationAdapter implements AdapterInterface
             $result = $rowCount->query(\PDO::FETCH_ASSOC)->fetch();
 
             $this->_rowCount = count($result) > 0 ? $result[$rowCountColumn] : 0;
-        } elseif (is_integer($rowCount)) {
+        } elseif (is_int($rowCount)) {
             $this->_rowCount = $rowCount;
         } else {
             throw new \Exception('Invalid row count');

--- a/lib/DependencyInjection/ConfigMerger.php
+++ b/lib/DependencyInjection/ConfigMerger.php
@@ -38,7 +38,7 @@ class ConfigMerger
     public function merge(array $first, array $second): array
     {
         foreach ($second as $idx => $value) {
-            if (is_integer($idx)) {
+            if (is_int($idx)) {
                 $first[] = $value;
             } else {
                 if (!array_key_exists($idx, $first)) {

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -396,7 +396,7 @@ class Mail extends \Swift_Message
      */
     public function setParam($key, $value)
     {
-        if (is_string($key) || is_integer($key)) {
+        if (is_string($key) || is_int($key)) {
             $this->params[$key] = $value;
         } else {
             Logger::warn('$key has to be a string or integer - Param ignored!');
@@ -462,7 +462,7 @@ class Mail extends \Swift_Message
      */
     public function unsetParam($key)
     {
-        if (is_string($key) || is_integer($key)) {
+        if (is_string($key) || is_int($key)) {
             unset($this->params[$key]);
         } else {
             Logger::warn('$key has to be a string or integer - unsetParam ignored!');

--- a/lib/Workflow/MarkingStore/DataObjectSplittedStateMarkingStore.php
+++ b/lib/Workflow/MarkingStore/DataObjectSplittedStateMarkingStore.php
@@ -141,7 +141,7 @@ class DataObjectSplittedStateMarkingStore implements MarkingStoreInterface
         }
 
         if ($fd->getFieldtype() !== 'multiselect') {
-            if (sizeof($places) > 1) {
+            if (count($places) > 1) {
                 throw new LogicException(sprintf('field type "%s" is not able to handle multiple values - given values are [%s]', $fd->getFieldtype(), implode(', ', $places)));
             }
 
@@ -169,7 +169,7 @@ class DataObjectSplittedStateMarkingStore implements MarkingStoreInterface
     {
         $diff = array_diff($places, array_keys($stateMapping));
 
-        if (sizeof($diff) > 0) {
+        if (count($diff) > 0) {
             throw new LogicException(sprintf('State mapping and places configuration need to match each other [detected differences: %s].', implode(', ', $diff)));
         }
     }

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -350,7 +350,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
 
                 $item = $o->getRealFullPath();
 
-                if (sizeof($metaObject->getData())) {
+                if (count($metaObject->getData())) {
                     $subItems = [];
                     foreach ($metaObject->getData() as $key => $value) {
                         if (!$value) {
@@ -359,7 +359,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
                         $subItems[] = $key . ': ' . $value;
                     }
 
-                    if (sizeof($subItems)) {
+                    if (count($subItems)) {
                         $item .= ' <br/><span class="preview-metadata">[' . implode(' | ', $subItems) . ']</span>';
                     }
                 }

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -438,7 +438,7 @@ class AdvancedManyToManyRelation extends ManyToManyRelation
                 $o = $metaObject->getElement();
                 $item = Element\Service::getElementType($o) . ' ' . $o->getRealFullPath();
 
-                if (sizeof($metaObject->getData())) {
+                if (count($metaObject->getData())) {
                     $subItems = [];
                     foreach ($metaObject->getData() as $key => $value) {
                         if (!$value) {
@@ -447,7 +447,7 @@ class AdvancedManyToManyRelation extends ManyToManyRelation
                         $subItems[] = $key . ': ' . $value;
                     }
 
-                    if (sizeof($subItems)) {
+                    if (count($subItems)) {
                         $item .= ' <br/><span class="preview-metadata">[' . implode(' | ', $subItems) . ']</span>';
                     }
                 }

--- a/models/Tool/CustomReport/Adapter/Analytics.php
+++ b/models/Tool/CustomReport/Adapter/Analytics.php
@@ -78,7 +78,7 @@ class Analytics extends AbstractAdapter
     protected function setFilters($filters, $drillDownFilters = [])
     {
         $gaFilters = [ $this->config->filters ];
-        if (sizeof($filters)) {
+        if (count($filters)) {
             foreach ($filters as $filter) {
                 if ($filter['type'] == 'string') {
                     $value = str_replace(';', '', addslashes($filter['value']));
@@ -100,7 +100,7 @@ class Analytics extends AbstractAdapter
             }
         }
 
-        if (sizeof($drillDownFilters)) {
+        if (count($drillDownFilters)) {
             foreach ($drillDownFilters as $key => $value) {
                 $gaFilters[] = "{$key}=={$value}";
             }
@@ -128,7 +128,7 @@ class Analytics extends AbstractAdapter
     {
         $configuration = clone $this->config;
 
-        if (is_array($fields) && sizeof($fields)) {
+        if (is_array($fields) && count($fields)) {
             $configuration = $this->handleFields($configuration, $fields);
         }
 
@@ -243,7 +243,7 @@ class Analytics extends AbstractAdapter
     protected function handleDimensions($configuration)
     {
         $dimension = $configuration->dimension;
-        if (sizeof($dimension)) {
+        if (count($dimension)) {
             foreach ($this->fullConfig->columnConfiguration as $column) {
                 if ($column['filter_drilldown'] == 'only_filter') {
                     foreach ($dimension as $key => $dim) {
@@ -283,7 +283,7 @@ class Analytics extends AbstractAdapter
                 }
             }
 
-            if (sizeof($applyModifiers)) {
+            if (count($applyModifiers)) {
                 $date = new \DateTime();
 
                 foreach ($applyModifiers as $modifier) {


### PR DESCRIPTION
Some functions in PHP have aliases. For consistency in the codebase, these should be avoided.