### PR TITLE
[Docs] Display all code examples with two languages (php & twig) in tabs

### DIFF
--- a/doc/Development_Documentation/02_MVC/02_Template/01_Layouts.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/01_Layouts.md
@@ -21,6 +21,8 @@ For more details about template inheritance and layouts, please have a look at t
 
 ###### A Simple Sample Layout Looks Like the Following:  
 
+<div class="code-section">
+
 ```php
 <?php
 /**
@@ -61,6 +63,8 @@ For more details about template inheritance and layouts, please have a look at t
 </html>
 ```
 
+</div>
+
 Of course, PHP, editables and template helpers can be used within the layout file and therefore layouts can become much 
 more complicated. The most important line though is `<?php $this->slots()->output('_content') ?>`. 
 It includes the actual rendered content of the view. 
@@ -70,6 +74,8 @@ It includes the actual rendered content of the view.
 
 Layouts are simply used by declaring a parent template with the following code. 
 
+<div class="code-section">
+
 ```php
 $this->extend('layout.html.php');
 ```
@@ -78,11 +84,14 @@ $this->extend('layout.html.php');
 {% extends 'layout.html.twig' %}
 ```
 
+</div>
+
 In this example we extend from the template `layout.html.php`, but we can use any other and as many as needed 
 scripts instead.  
   
 A complete example of a document page would look like the following: 
 
+<div class="code-section">
 
 ```php
 <?php
@@ -108,3 +117,5 @@ $this->extend('layout.html.php');
     {{ pimcore_input('headline', {'width': 540}) }}
 </h1>
 ```
+
+</div>

--- a/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/02_HeadMeta.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/02_HeadMeta.md
@@ -43,6 +43,8 @@ You may specify a new meta tag at any time. Typically, you will specify client-s
 For instance, if you wish to specify SEO description, you'd be creating a meta name tag with the name 
 'keywords' and the content the keywords you wish to associate with your page:
 
+<div class="code-section">
+
 ```php
 // setting meta description
 $this->headMeta()->appendName('description', 'My SEO description for my awesome page');
@@ -68,7 +70,11 @@ $this->headMeta()->appendHttpEquiv('Content-Type', 'text/html; charset=UTF-8')
 {% do pimcore_head_meta().appendHttpEquiv('Content-Type', 'text/html; charset=UTF-8').appendHttpEquiv('Content-Language', 'en-US') %}
 ```
 
+</div>
+
 When you're ready to place your meta tags in the layout, simply echo the helper:
+
+<div class="code-section">
 
 ```php
 <?= $this->headMeta() ?>
@@ -77,3 +83,5 @@ When you're ready to place your meta tags in the layout, simply echo the helper:
 ```twig
 {{ pimcore_head_meta() }}
 ```
+
+</div>

--- a/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/04_HeadStyle.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/04_HeadStyle.md
@@ -21,6 +21,9 @@ HeadStyle allows you to wrap the style tag in conditional comments, which allows
 To add the conditional tags, pass the conditional value as part of the $attributes parameter in the method calls. 
 
 ### Headstyle With Conditional Comments
+
+<div class="code-section">
+
 ```php
 // adding scripts
 $this->headStyle()->appendStyle($styles, array('conditional' => 'lt IE 11'));
@@ -30,6 +33,8 @@ $this->headStyle()->appendStyle($styles, array('conditional' => 'lt IE 11'));
 {# adding scripts #}
 {% do pimcore_head_style().appendStyle(styles, {'conditional': 'lt IE 11'}) %}
 ```
+
+</div>
 
 HeadStyle also allows capturing style declarations; this can be useful if you want to create the declarations 
 programmatically, and then place them elsewhere. The usage for this will be showed in an example below.
@@ -47,6 +52,8 @@ items by simply modifying the object returned.
 
 You may specify a new style tag at any time:
 
+<div class="code-section">
+
 ```php
 // adding styles
 $this->headStyle()->appendStyle($styles);
@@ -57,8 +64,12 @@ $this->headStyle()->appendStyle($styles);
 {% do pimcore_head_style().appendStyle(styles) %}
 ```
 
+</div>
+
 Order is very important with CSS; you may need to ensure that declarations are loaded in a specific order due to the 
 order of the cascade; use the various append, prepend, and offsetSet directives to aid in this task:
+
+<div class="code-section">
 
 ```php
 // Putting styles in order
@@ -84,7 +95,11 @@ $this->headStyle()->prependStyle($firstStyles);
 {% do pimcore_head_style().prependStyle(firstStyles) %}
 ```
 
+</div>
+
 When you're finally ready to output all style declarations in your layout script, simply echo the helper:
+
+<div class="code-section">
 
 ```php
 <?= $this->headStyle() ?>
@@ -94,11 +109,15 @@ When you're finally ready to output all style declarations in your layout script
 {{ pimcore_head_style() }}
 ```
 
+</div>
+
 ### Capturing Style Declarations
 
 Sometimes you need to generate CSS style declarations programmatically. While you could use string concatenation, 
 heredocs, and the like, often it's easier just to do so by creating the styles and sprinkling in PHP tags. 
 HeadStyle lets you do just that, capturing it to the stack:
+
+<div class="code-section">
 
 ```php
 <?php $this->headStyle()->captureStart() ?>
@@ -115,6 +134,8 @@ body {
     }
 {% do pimcore_head_style().captureEnd() %}
 ```
+
+</div>
 
 The following assumptions are made:
 

--- a/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/05_HeadTitle.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/05_HeadTitle.md
@@ -11,6 +11,8 @@ You may specify a title tag at any time.
 A typical usage would have you setting title segments for each level of depth in your application: site, 
 controller, action, and potentially resource.
 
+<div class="code-section">
+
 ```php
 $this->headTitle("My first part")
      ->headTitle("The 2nd part");
@@ -33,7 +35,11 @@ $this->headTitle()->setSeparator(' / ');
 {% do pimcore_head_title().setSeparator(' / ') %}
 ```
 
+</div>
+
 When you're finally ready to render the title in your layout script, simply echo the helper:
+
+<div class="code-section">
 
 ```php
 <?= $this->headTitle() ?>
@@ -45,3 +51,4 @@ When you're finally ready to render the title in your layout script, simply echo
 {# renders My first part / The 2nd part / My Pimcore Website #}
 ```
 
+</div>

--- a/doc/Development_Documentation/02_MVC/02_Template/04_Thumbnails.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/04_Thumbnails.md
@@ -10,6 +10,8 @@ please have a look at [Working with Thumbnails](../../04_Assets/03_Working_with_
 
 ## Use Thumbnails in Templates
 
+<div class="code-section">
+
 ```php
 <?php 
     use Pimcore\Model\Asset;
@@ -54,7 +56,6 @@ please have a look at [Working with Thumbnails](../../04_Assets/03_Working_with_
 <?php if ($this->myObject->getMyImage() instanceof Asset\Image) { ?>
     <img src="<?= $this->myObject->getMyImage()->getThumbnail(["width" => 220, "format" => "jpeg"]); ?>" />
 <?php } ?>
-
 ```
 
 ```twig
@@ -101,3 +102,5 @@ please have a look at [Working with Thumbnails](../../04_Assets/03_Working_with_
     <img src="{{ myObject.myImage.getThumbnail({width: 220, format: 'jpeg'}).getHref() }}" />
 {% endif %}
 ```
+
+</div>

--- a/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/README.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/README.md
@@ -12,7 +12,7 @@ The areablock is the content construction kit for documents offered by Pimcore.
 Similar to the other document editables, an areablock can be integrated in any document view template as follows:
 
 <div class="code-section">
-    
+
 ```php
 <?= $this->areablock('myAreablock'); ?>
 ```
@@ -20,12 +20,13 @@ Similar to the other document editables, an areablock can be integrated in any d
 ```twig
 {{ pimcore_areablock("myAreablock") }}
 ```
+
 </div>
 
 Advanced usage with allowed areas, below:
 
 <div class="code-section">
-    
+
 ```php
 <?= $this->areablock("myAreablock", [
     "allowed" => ["iframe","googletagcloud","spacer","rssreader"],
@@ -70,6 +71,7 @@ Advanced usage with allowed areas, below:
         })
     }}
 ```
+
 </div>
 
 ##### Accessing Parameters from the Brick File
@@ -131,6 +133,7 @@ Brick-specific configurations are passed using the `params` or `globalParams` co
     ]
 ]); ?>
 ```
+
 ## Methods
 
 | Name                | Return    | Description                                                                            |
@@ -151,7 +154,7 @@ You can limit certain bricks for the Areablock by using `limits` configurations.
 ##### Example
 
 <div class="code-section">
-    
+
 ```php
 <?= $this->areablock("myAreablock", [
         "allowed" => ["iframe","teasers","wysiwyg"],
@@ -174,6 +177,7 @@ You can limit certain bricks for the Areablock by using `limits` configurations.
     })
 }}
 ```
+
 </div>
 
 ## Using Manual Mode

--- a/doc/Development_Documentation/03_Documents/01_Editables/04_Area.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/04_Area.md
@@ -46,6 +46,8 @@ Brick-specific configurations are passed using the `params` configuration (see a
 
 ## Example with Parameters
 
+<div class="code-section">
+
 ```php
 <div>
     <?= $this->area('myArea', [
@@ -61,6 +63,7 @@ Brick-specific configurations are passed using the `params` configuration (see a
     ]); ?>
 </div>
 ```
+
 ```twig
 <div>
     {{ pimcore_area('myArea', {
@@ -75,6 +78,8 @@ Brick-specific configurations are passed using the `params` configuration (see a
 </div>
 ```
 
+</div>
+
 Get the params in your brick:
 
 ```php
@@ -82,7 +87,6 @@ Get the params in your brick:
     <?= $this->param1; ?>
 </div>
 ```
-
 
 ### Accessing Data Within an Area Element
 

--- a/doc/Development_Documentation/03_Documents/01_Editables/12_Relation_(Many-To-One).md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/12_Relation_(Many-To-One).md
@@ -76,10 +76,8 @@ options in the editable configuration.
     "classes": ["person"]
 }) }}
 ```
+
 </div>
-
-
-
 
 
 We restricted the `myRelation` editable to the following entities: 
@@ -115,4 +113,5 @@ Another useful use-case for the relation editable is a download link.
     {% endif %}
 {% endif %}
 ```
+
 </div>

--- a/doc/Development_Documentation/03_Documents/01_Editables/13_Relations_(Many-To-Many).md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/13_Relations_(Many-To-Many).md
@@ -63,6 +63,7 @@ The code below is responsible for showing a list of elements types related to th
 </ul>
 {% endif %}
 ```
+
 </div>
 
 Picture below, presents the editmode preview:
@@ -86,11 +87,10 @@ array(6) {
 }
 ```
 
-
-
 ### Example with allowed types and subtypes
 Similar to the single relation editable, this editable also could specify allowed `types`, `subtypes` and `classes`. 
 For example:
+
 <div class="code-section">
 
 ```php
@@ -103,6 +103,7 @@ For example:
     "classes" => ["person"]
 ]); ?>
 ```
+
 ```twig
 {{ pimcore_relations("objectPaths", {
     "types": ["asset","object"],
@@ -113,6 +114,8 @@ For example:
     "classes": ["person"]
 }) }}
 ```
+
 </div>
+
 Now, a user is not able to add other elements than specified in the types configuration part.
 

--- a/doc/Development_Documentation/03_Documents/01_Editables/14_Image.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/14_Image.md
@@ -69,8 +69,8 @@ You can also pass every valid `<img>` tag attribute ([w3.org Image](http://www.w
 ```twig
 {{ pimcore_image("myImage") }}
 ```
-</div>
 
+</div>
 
 The code above generates an image area in the backend and displays the image at the frontend.
 
@@ -106,6 +106,7 @@ Learn more about thumbnails here: [Image Thumbnails](../../04_Assets/03_Working_
     "thumbnail": "contentimages"
 }) }}
 ```
+
 </div>
 
 ###### Backend Preview
@@ -145,6 +146,7 @@ You can also change the thumbnail configuration:
     }
 }) }}
 ```
+
 </div>
 
 ### An Example Using Custom Attributes
@@ -170,11 +172,13 @@ You can also change the thumbnail configuration:
     }
 }) }}
 ```
+
 </div>
 
 And this is how the rendered html looks: `<img custom-attr="value" data-role="image" src="/var/tmp/image-thumbnails/0/56/thumb__content/dsc03807.jpeg" />`
 
 ### Other Advanced Examples
+
 <div class="code-section">
 
 ```php
@@ -251,8 +255,8 @@ And this is how the rendered html looks: `<img custom-attr="value" data-role="im
     "dropClass": "myCustomImageDropTarget"
 }) }}
 <div class="myCustomImageDropTarget someClass">My second alternative drop target</div>
-
 ```
+
 </div>
 
 ## Field-specific Image Cropping for Documents
@@ -282,6 +286,7 @@ You can get the data with the methods `getMarker()` and `getHotspots()`.
 All dimensions are in percent and therefore independent from the image size, you have to change them back to pixels according to your image size.
  
 ### Code Usage Example
+
 <div class="code-section">
  
 ```php
@@ -369,6 +374,7 @@ All dimensions are in percent and therefore independent from the image size, you
     </p>
 </div>
 ```
+
 </div>
 
 `getHotspots` output:

--- a/doc/Development_Documentation/03_Documents/01_Editables/16_Input.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/16_Input.md
@@ -40,6 +40,7 @@ For a multi-line alternative have a look at the [textarea editable](./36_Textare
  {{ pimcore_input("myHeadline") }}
 </h2>
 ```
+
 </div>
 
 The above code generates an editable area which you can fill with the text, see:
@@ -62,4 +63,5 @@ You could also specify other parameters, like the size:
     {{ pimcore_input("headerLine", {'width': 540}) }}
 </h2>
 ```
+
 </div>

--- a/doc/Development_Documentation/03_Documents/01_Editables/18_Link.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/18_Link.md
@@ -43,12 +43,14 @@ such as: `class`, `target`, `id`, `style`, `accesskey`, `name`, `title`, `data-*
     <?= $this->link("blogLink"); ?>
 </p>
 ```
+
 ```twig
 <p>
     {{ "Visit our" | trans }}
     {{ pimcore_link('blogLink') }}
 </p>
 ```
+
 </div>
 You could see the backend preview in the picture, below.
 
@@ -76,6 +78,7 @@ Let's see how to make a list of links with [Block](./06_Block.md).
     <?php endwhile; ?>
 </ul>
 ```
+
 ```twig
 <h3>{{ "Useful links" | trans }}</h3>
 <ul>
@@ -84,6 +87,7 @@ Let's see how to make a list of links with [Block](./06_Block.md).
     {% endfor %}
 </ul>
 ```
+
 </div>
 
 The above example renders a list of links: 

--- a/doc/Development_Documentation/03_Documents/01_Editables/22_Multiselect.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/22_Multiselect.md
@@ -72,6 +72,7 @@ Also, it shows the list of chosen elements in the frontend.
     </p>
 {% endif %}
 ```
+
 </div>
 
 The editmode preview:

--- a/doc/Development_Documentation/03_Documents/01_Editables/24_Numeric.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/24_Numeric.md
@@ -24,12 +24,17 @@ The numeric editable is very similar to the [input editable](./16_Input.md), but
 
 ### Basic Usage
 
+<div class="code-section">
+
 ```php
 <?= $this->numeric("myNumber"); ?>
 ```
+
 ```twig
 {{ pimcore_numeric('myNumber') }}
 ```
+
+</div>
 
 Now you can see the **numeric** value in the editmode view 
 ![Numeric input - editmode](../../img/editables_numeric_simple_editmode.png)
@@ -37,6 +42,8 @@ Now you can see the **numeric** value in the editmode view
 ### Advanced Usage
 
 In the following example we're going to use a minimal and maximum value as well as a decimal precision. 
+
+<div class="code-section">
 
 ```php
 <?= $this->numeric("myNumber", [
@@ -46,6 +53,7 @@ In the following example we're going to use a minimal and maximum value as well 
     "decimalPrecision" => 0
 ]); ?>
 ```
+
 ```twig
 {{ pimcore_numeric('myNumber',{
 		"width" : 300,
@@ -56,14 +64,22 @@ In the following example we're going to use a minimal and maximum value as well 
 }}
 ```
 
+</div>
+
 To display the number also in editmode, you can use the method `getData()`
+
+<div class="code-section">
+
 ```php
 <p>
     <?= $this->numeric("myNumber")->getData(); ?>
 </p>
 ```
+
 ```twig
 <p>
     {{ pimcore_numeric('myNumber').getData() }}
 </p>
 ```
+
+</div>

--- a/doc/Development_Documentation/03_Documents/01_Editables/25_Embed.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/25_Embed.md
@@ -36,4 +36,5 @@ Additionally you can use any configuration option of [Embera](https://github.com
 {# Advanced usage #}
 {{ pimcore_embed("socialWidgets", { "width": 540 }) }}
 ```
+
 </div>

--- a/doc/Development_Documentation/03_Documents/01_Editables/26_PDF.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/26_PDF.md
@@ -26,6 +26,7 @@ The PDF editable allows you to embed asset documents (pdf, doc, xls, ...) into d
 
 ### Basic usage
 
+<div class="code-section">
 
 PHP:
 ```php
@@ -45,6 +46,7 @@ Twig:
 </div>    
 ```
 
+</div>
 
 This looks like the following in editmode: 
 

--- a/doc/Development_Documentation/03_Documents/01_Editables/28_Renderlet.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/28_Renderlet.md
@@ -51,7 +51,7 @@ The code below shows how to use renderlet to create gallery based on it.
 ### Specify the Renderlet Editable in a Template
 
 <div class="code-section">
-    
+
 ```php
 <section id="renderlet-gallery">
     <?= $this->renderlet("myGallery", [
@@ -62,8 +62,8 @@ The code below shows how to use renderlet to create gallery based on it.
     ]); ?>
 </section>
 ```
-    
-```twig    
+
+```twig
 <section id="renderlet-gallery">
     {{
         pimcore_renderlet('myGallery', {
@@ -74,7 +74,8 @@ The code below shows how to use renderlet to create gallery based on it.
         })
     }}
 </section>
-``` 
+```
+
 </div>
 
 Now editors are able to put elements onto the renderlet in the editmode.

--- a/doc/Development_Documentation/03_Documents/01_Editables/30_Select.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/30_Select.md
@@ -29,7 +29,6 @@ in the frontend preview you will see simply the value of the chosen option.
 
 <div class="code-section">
 
-
 ```php
 <?php
 if($this->editmode):
@@ -67,6 +66,7 @@ else:
     </p>
 {% endif %}
 ```
+
 </div>
 
 Editmode:
@@ -74,10 +74,11 @@ Editmode:
 
 Frontend:
 ![Select editable in frontend](../../img/editables_select_frontend_preview.png)
-</div>
 
 ### Preselect the option
 You can *_preselect_* an option in your select editable by using `setDataFromResource()`
+
+<div class="code-section">
 
 ```php
 if($this->editmode):
@@ -89,6 +90,7 @@ if($this->editmode):
     
 endif;
 ```
+
 ```twig
 {% if editmode %}
     {% if pimcore_select('valid_for').isEmpty() %}
@@ -99,3 +101,5 @@ endif;
     
 {% endif %}
 ```
+
+</div>

--- a/doc/Development_Documentation/03_Documents/01_Editables/32_Snippet.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/32_Snippet.md
@@ -29,9 +29,10 @@ You have to create them the same way as other documents (pages).
 
 ## Examples
 ### Basic Usage
+
 <div class="code-section">
 
-```php  
+```php
  // Define a place for a snippet to be dragged onto, advanced usage
  <?= $this->snippet("mySnippet", ["width" => 250, "height" => 100]) ?>
 ```
@@ -39,6 +40,7 @@ You have to create them the same way as other documents (pages).
 ```twig
 {{ pimcore_snippet("mySnippet", {"width": 250, "height": 100}) }}
 ```
+
 </div>
 
 ### Caching 
@@ -50,11 +52,14 @@ Regardless if you're using the full page cache or not it's a good practice to
 enable the cache directly on the editable if the snippet result should be cached. 
 
 <div class="code-section">
-```php  
+
+```php
  // Define a place for a snippet to be dragged onto, advanced usage
  <?= $this->snippet("mySnippet", ["cache" => true]) ?>
 ```
+
 ```twig
 {{ pimcore_snippet("mySnippet", {cache: true}) }}
 ```
+
 </div>

--- a/doc/Development_Documentation/03_Documents/01_Editables/34_Table.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/34_Table.md
@@ -60,6 +60,7 @@ The table editable provides the ability to edit a table structure.
     })
 }}
 ```
+
 </div>
 
 You're now able to change columns and the predefined data in the editmode.
@@ -70,6 +71,8 @@ You're now able to change columns and the predefined data in the editmode.
 
 Sometimes you need use only the data from a filled table. 
 You would just use the `getData()` method instead of rendering the entire HTML of the table.
+
+<div class="code-section">
 
 ```php
 <?php if($this->editmode):
@@ -94,6 +97,7 @@ else:
 endif;
 ?>
 ```
+
 ```twig
 {% if editmode %}
     pimcore_table("productProperties", {
@@ -117,6 +121,8 @@ endif;
     {# do something with it ;-) #}
 {% endif %}
 ```
+
+</div>
 
 The output from `getData()`:
 

--- a/doc/Development_Documentation/03_Documents/01_Editables/36_Textarea.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/36_Textarea.md
@@ -47,6 +47,7 @@ The textarea editable is very similar to the [Input](./16_Input.md) editable, th
     }) }}
 </p>
 ```
+
 </div>
 
 In the editmode, you can see the textarea and the predefined `placeholder`.

--- a/doc/Development_Documentation/03_Documents/01_Editables/38_Video.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/38_Video.md
@@ -50,6 +50,8 @@ Output returned by `getPosterAsset`:
 
 To create a container for local video files you can just use the `$this->video` helperwithout any options.
 
+<div class="code-section">
+
 ```php
 <section id="campaign_video">
     <?= $this->video("campaignVideo", [
@@ -67,6 +69,8 @@ To create a container for local video files you can just use the `$this->video` 
     }) }}
 </section>
 ```
+
+</div>
 
 In the editmode, there is now a container available where you can assign an asset path and a video poster. 
 
@@ -86,6 +90,8 @@ Have a look at the frontend preview:
 ![Video editable - YouTube configuration - frontend](../../img/editables_video_youtube_frontend.png)
 
 In the configuration, you could also specify additional options for external services.
+
+<div class="code-section">
 
 ```php
 <section id="campaign_video">
@@ -122,7 +128,12 @@ In the configuration, you could also specify additional options for external ser
 </section>
 ```
 
+</div>
+
 ### HTML5 with Automatic Video Transcoding (using video.js)
+
+<div class="code-section">
+
 ```php
 <!DOCTYPE HTML>
 <html>
@@ -167,6 +178,8 @@ In the configuration, you could also specify additional options for external ser
 </body>
 </html>
 ```
+
+</div>
 
 Read more about [Video Thumbnails](../../04_Assets/03_Working_with_Thumbnails/03_Video_Thumbnails.md).
 

--- a/doc/Development_Documentation/03_Documents/01_Editables/40_WYSIWYG.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/40_WYSIWYG.md
@@ -49,6 +49,7 @@ The following code specifies the height for the rendered WYSIWYG editable (has n
     }}
 </section>
 ```
+
 </div>
 
 If you have a look at the editmode, you will see that our WYSIWYG is rendered with the full toolbar.
@@ -64,6 +65,7 @@ The WYSIWYG editable allows us to specify the toolbar.
 If you have to limit styling options (for example only basic styles like `<b>` tag and lists would be allowed), just use `toolbarGroups` option.  
 There is also the option to disable the pimcore generated default toolbar by setting the option `toolbarGroups` explicitly to `false`. In this case,
 either the configuration from the customConfig-file or if absent the ckeditor default will be loaded.
+
 <div class="code-section">
 
 ```php
@@ -93,6 +95,7 @@ either the configuration from the customConfig-file or if absent the ckeditor de
     }}
 </section>
 ```
+
 </div>
 
 Now the user can use only the limited toolbar.
@@ -102,6 +105,8 @@ Now the user can use only the limited toolbar.
 
 There is also an additional way to specify the configuration by adding `customConfig`. 
 
+<div class="code-section">
+
 ```php
 <section id="marked-content">
     <?= $this->wysiwyg("specialContent", [
@@ -110,6 +115,7 @@ There is also an additional way to specify the configuration by adding `customCo
     ]); ?>
 </section>
 ```
+
 ```twig
 <section id="marked-content">
     {{  pimcore_wysiwyg('specialContent', {
@@ -119,6 +125,8 @@ There is also an additional way to specify the configuration by adding `customCo
     }}
 </section>
 ```
+
+</div>
 
 The `custom_config.js` file could look like the following (please refer to the [CKEditor documentation](https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_configuration-section-using-a-custom-configuration-file) for further details):
 
@@ -202,6 +210,8 @@ class EditmodeListener implements EventSubscriberInterface
 
 With the following code you can get the text even in editmode:
 
+<div class="code-section">
+
 ```php
 <?= $this->wysiwyg("specialContent"); ?>
 <?php if($this->editmode): ?>
@@ -220,5 +230,7 @@ With the following code you can get the text even in editmode:
     {{ pimcore_wysiwyg('specialContent').getData() }}
 </div>
 ```
+
+</div>
 
 ![WYSIWYG with preview - editmode](../../img/editables_wysiwyg_with_preview_editmode.png)

--- a/doc/Development_Documentation/03_Documents/01_Editables/README.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/README.md
@@ -8,24 +8,28 @@ The following code makes the `<h1>` headline editable in a document:
 
 <div class="code-section">
 
-```php 
+```php
 <h1><?= $this->input("headline") ?></h1>
 ```
 
-```twig 
+```twig
 <h1>{{ pimcore_input("headline") }}</h1>
 ```
+
+</div>
 
 In some cases, especially with areablocks, editables could throw exceptions. Since Pimcore internally uses the `__toString` method to render
 the editables, Pimcore can't throw exceptions there. Therefore Pimcore catches the exception, and puts it out as string if DEBUG Mode is enabled.
 
 To prevent that and to have Pimcore throw the Exception, you can call editables like:
 
-```php 
+<div class="code-section">
+
+```php
 <h1><?= $this->input("headline")->render() ?></h1>
 ```
 
-```twig 
+```twig
 <h1>{{ pimcore_input("headline").render() }}</h1>
 ```
 

--- a/doc/Development_Documentation/03_Documents/03_Navigation.md
+++ b/doc/Development_Documentation/03_Documents/03_Navigation.md
@@ -148,6 +148,7 @@ Having set up the navigation container as shown above, you can easily use it to 
         }) }}
 </div>
 ```
+
 </div>
 
 ### Breadcrumbs

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/45_Image_Types.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/45_Image_Types.md
@@ -56,6 +56,7 @@ This one allows you to enter an external image URL which is then shown as a prev
     <img src="{{ object.getExternalImage().getUrl() }}" />
 {% endif %}
 ```
+
 </div>
 
 ## Image Gallery

--- a/doc/Development_Documentation/06_Multi_Language_i18n/07_Admin_Translations.md
+++ b/doc/Development_Documentation/06_Multi_Language_i18n/07_Admin_Translations.md
@@ -23,6 +23,9 @@ Admin translations use the same translator component (Symfony) but on a differen
 Admin translations underly the same case sensitivity logic as [shared translations](./04_Shared_Translations.md#page_Translations_case_sensitivity).
 
 #### Example: Translate Options of a Select Editable
+
+<div class="code-section">
+
 ```php
  <?= $this->select("select", [
      "store" => [
@@ -41,7 +44,9 @@ Admin translations underly the same case sensitivity logic as [shared translatio
 	]
 }) }}
  ```
- 
+
+</div>
+
 #### Adding your own admin languages (since v6.3.6)
 Pimcore comes with a set of translations which are managed by [POEditor](https://poeditor.com/join/project/VWmZyvFVMH). 
 However, the amount of available languages is limited, because only languages with certain translation progress are


### PR DESCRIPTION
In some places, the code examples, when given in Twig & PHP, are already displayed in tabs, like here: 
https://pimcore.com/docs/6.x/Development_Documentation/Documents/Editables/Block.html#page_Using-Manual-Mode

But in other places, they're just displayed below each other, like here: 
https://pimcore.com/docs/6.x/Development_Documentation/Documents/Editables/Video.html#page_Basic-Usage-a-Local-Asset

This PR tries to align it, so that all examples existing in both languages are displayed in tabs. 