### PR TITLE
Migrates tables from tinyint(4) to tinyint(1) for boolean-type content

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20200828091305.php
+++ b/bundles/CoreBundle/Migrations/Version20200828091305.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Migrations;
+namespace Pimcore\Bundle\CoreBundle\Migrations;
 
 use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\DBALException;

--- a/bundles/CoreBundle/Migrations/Version20200828091305.php
+++ b/bundles/CoreBundle/Migrations/Version20200828091305.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\ConnectionException;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Log\Handler\ApplicationLoggerDb;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+
+/**
+ * Class Version20200828091305
+ *
+ * Migrates tables from tinyint(4) to tinyint(1) for boolean-type content
+ *
+ * @package App\Migrations
+ */
+class Version20200828091305 extends AbstractPimcoreMigration
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function doesSqlMigrations(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param Schema $schema
+     * @throws ConnectionException|DBALException
+     */
+    public function up(Schema $schema)
+    {
+        $tinyint = "tinyint(1)";
+        $db = \Pimcore\Db::get();
+
+        $this->writeMessage("Migrating tables to {$tinyint}");
+        $this->addSql("ALTER TABLE `custom_layouts` CHANGE `default` `default` {$tinyint} NOT NULL default '0';");
+        $this->addSql("ALTER TABLE `" . ApplicationLoggerDb::TABLE_NAME . "` CHANGE `maintenanceChecked` `maintenanceChecked` {$tinyint} DEFAULT NULL;");
+
+        $archiveTables = $db->query("SHOW TABLES LIKE '" . ApplicationLoggerDb::TABLE_NAME . "_%'")->fetchAll(\Doctrine\DBAL\FetchMode::COLUMN);
+        if (!empty($archiveTables)) {
+            foreach ($archiveTables as $at) {
+                $this->addSql("ALTER TABLE " . $db->quoteTableAs($at) . " MODIFY `maintenanceChecked` {$tinyint};");
+            }
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     * @throws ConnectionException|DBALException
+     */
+    public function down(Schema $schema)
+    {
+        $tinyint = "tinyint(4)";
+        $db = \Pimcore\Db::get();
+
+        $this->writeMessage("Restoring tables to {$tinyint}");
+        $this->addSql("ALTER TABLE `custom_layouts` CHANGE `default` `default` {$tinyint} NOT NULL default '0';");
+        $this->addSql("ALTER TABLE `" . ApplicationLoggerDb::TABLE_NAME . "` CHANGE `maintenanceChecked` `maintenanceChecked` {$tinyint} DEFAULT NULL;");
+
+        $archiveTables = $db->query("SHOW TABLES LIKE '" . ApplicationLoggerDb::TABLE_NAME . "_%'")->fetchAll(\Doctrine\DBAL\FetchMode::COLUMN);
+        if (!empty($archiveTables)) {
+            foreach ($archiveTables as $at) {
+                $this->addSql("ALTER TABLE " . $db->quoteTableAs($at) . " MODIFY `maintenanceChecked` {$tinyint};");
+            }
+        }
+    }
+}

--- a/bundles/CoreBundle/Migrations/Version20200828091305.php
+++ b/bundles/CoreBundle/Migrations/Version20200828091305.php
@@ -12,8 +12,6 @@ use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
  * Class Version20200828091305
  *
  * Migrates tables from tinyint(4) to tinyint(1) for boolean-type content
- *
- * @package App\Migrations
  */
 class Version20200828091305 extends AbstractPimcoreMigration
 {

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -14,7 +14,7 @@ CREATE TABLE `application_logs` (
   `source` varchar(190) DEFAULT NULL,
   `relatedobject` int(11) unsigned DEFAULT NULL,
   `relatedobjecttype` enum('object','document','asset') DEFAULT NULL,
-  `maintenanceChecked` tinyint(4) DEFAULT NULL,
+  `maintenanceChecked` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `component` (`component`),
   KEY `timestamp` (`timestamp`),
@@ -90,7 +90,7 @@ CREATE TABLE `custom_layouts` (
 	`modificationDate` INT(11) UNSIGNED NULL DEFAULT NULL,
 	`userOwner` INT(11) UNSIGNED NULL DEFAULT NULL,
 	`userModification` INT(11) UNSIGNED NULL DEFAULT NULL,
-	`default` tinyint(4) NOT NULL DEFAULT '0',
+	`default` tinyint(1) NOT NULL DEFAULT '0',
 	PRIMARY KEY (`id`),
 	UNIQUE INDEX `name` (`name`, `classId`)
 ) DEFAULT CHARSET=utf8mb4;

--- a/lib/Maintenance/Tasks/LogArchiveTask.php
+++ b/lib/Maintenance/Tasks/LogArchiveTask.php
@@ -73,7 +73,7 @@ final class LogArchiveTask implements TaskInterface
                        source VARCHAR(255) NULL DEFAULT NULL,
                        relatedobject BIGINT(20),
                        relatedobjecttype ENUM('object', 'document', 'asset'),
-                       maintenanceChecked TINYINT(4)
+                       maintenanceChecked TINYINT(1)
                     ) ENGINE = ARCHIVE ROW_FORMAT = DEFAULT;");
 
             $db->query('INSERT INTO '.$tablename.' '.sprintf($sql, '*'));


### PR DESCRIPTION
## Additional info  

I prepared this PR, and then I remembered that it had [no effect on storage](https://dev.mysql.com/doc/refman/5.7/en/integer-types.html)/memory or anything like that, it's just a display value as long as it is a `tinyint`, oh well, do what you like with it, at least now it's consistent for all boolean-type columns :)