### PR TITLE
Symfony templates location

### DIFF
--- a/doc/Development_Documentation/02_MVC/02_Template/README.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/README.md
@@ -2,8 +2,7 @@
 
 ## Introduction
 
-In general the templates are located in: `/app/Resources/views/[Controller]/[action].html.(php|twig)` 
-(both controller as well as action without their suffix).  
+In general the templates are located in: `/app/Resources/views/[Controller]/[action].html.(php|twig)` but [Symfony-style locations](https://symfony.com/doc/4.4/best_practices.html#use-the-default-directory-structure) also work (both controller as well as action without their suffix).  
 
 Pimcore uses an enhanced version of [Symfony's PHP templating engine](http://symfony.com/doc/3.4/templating/PHP.html).
 For historical reasons, Pimcore defaults to PHP as template language, but can easily reconfigured to use [Twig](./00_Twig.md)

--- a/lib/Controller/Config/ControllerDataProvider.php
+++ b/lib/Controller/Config/ControllerDataProvider.php
@@ -233,7 +233,7 @@ class ControllerDataProvider
         }
 
         $symfonyPath = realpath(implode(DIRECTORY_SEPARATOR, [PIMCORE_PROJECT_ROOT, 'templates']));
-        if ($symfonyPath && file_exists($symfonyPath) && is_dir($symfonyPath)) {
+        if ($symfonyPath && is_dir($symfonyPath)) {
             $templates = array_merge($templates, $this->findTemplates($symfonyPath));
         }
 

--- a/lib/Controller/Config/ControllerDataProvider.php
+++ b/lib/Controller/Config/ControllerDataProvider.php
@@ -215,7 +215,7 @@ class ControllerDataProvider
     }
 
     /**
-     * Builds a list of all available templates in bundles and in app/Resources/views
+     * Builds a list of all available templates in bundles, in app/Resources/views, and Symfony locations
      *
      * @return array
      */
@@ -228,7 +228,7 @@ class ControllerDataProvider
         $templates = [];
 
         $appPath = realpath(implode(DIRECTORY_SEPARATOR, [PIMCORE_APP_ROOT, 'Resources', 'views']));
-        if ($appPath && file_exists($appPath) && is_dir($appPath)) {
+        if ($appPath && is_dir($appPath)) {
             $templates = array_merge($templates, $this->findTemplates($appPath));
         }
 
@@ -239,7 +239,7 @@ class ControllerDataProvider
 
         foreach ($this->getBundles() as $bundle) {
             $bundlePath = realpath(implode(DIRECTORY_SEPARATOR, [$bundle->getPath(), 'Resources', 'views']));
-            if ($bundlePath && file_exists($bundlePath) && is_dir($bundlePath)) {
+            if ($bundlePath && is_dir($bundlePath)) {
                 $templates = array_merge($templates, $this->findTemplates($bundlePath, $bundle->getName()));
             }
         }

--- a/lib/Controller/Config/ControllerDataProvider.php
+++ b/lib/Controller/Config/ControllerDataProvider.php
@@ -232,6 +232,11 @@ class ControllerDataProvider
             $templates = array_merge($templates, $this->findTemplates($appPath));
         }
 
+        $symfonyPath = realpath(implode(DIRECTORY_SEPARATOR, [PIMCORE_PROJECT_ROOT, 'templates']));
+        if ($symfonyPath && file_exists($symfonyPath) && is_dir($symfonyPath)) {
+            $templates = array_merge($templates, $this->findTemplates($symfonyPath));
+        }
+
         foreach ($this->getBundles() as $bundle) {
             $bundlePath = realpath(implode(DIRECTORY_SEPARATOR, [$bundle->getPath(), 'Resources', 'views']));
             if ($bundlePath && file_exists($bundlePath) && is_dir($bundlePath)) {


### PR DESCRIPTION
## Additional info  

[Using Symfony's location](https://symfony.com/doc/current/templates.html#template-location) `templates` for templates already work fine, but they never show up when selecting a template for a document, this resolves that problem.