### PR TITLE
video image-thumbnails should be delivered web-optimized

### DIFF
--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -192,14 +192,6 @@ class ImageThumbnail
      */
     protected function createConfig($selector)
     {
-        $config = Image\Thumbnail\Config::getByAutoDetect($selector);
-        if ($config) {
-            $format = strtolower($config->getFormat());
-            if ($format == 'source') {
-                $config->setFormat('PNG');
-            }
-        }
-
-        return $config;
+        return Image\Thumbnail\Config::getByAutoDetect($selector);
     }
 }


### PR DESCRIPTION
image thumbnails for videos should be created the same way ordinary image thumbnails are. 

### **Expected behavior**

Thumbnails will be generated according to the thumbnail config format 
![image](https://user-images.githubusercontent.com/14984260/91822715-71376180-ec38-11ea-8ac7-71fadc601d11.png)


### **Actual behavior**

Thumbnails are created with the png format in case of "source"-format (=Auto). See [Video-ImageThumbnail](https://github.com/pimcore/pimcore/blame/master/models/Asset/Video/ImageThumbnail.php#L199)


This PR changes the behaviour to match the image - thumbnail logic (see [Image-Thumbnail](https://github.com/pimcore/pimcore/blob/master/models/Asset/Image/Thumbnail.php#L467))