### PR TITLE
Report niceName/group not translateable in Panel Title and Menu

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/report.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/report.js
@@ -496,7 +496,7 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
 
         if(!this.panel) {
             this.panel = new Ext.Panel({
-                title: this.config["niceName"],
+                title: t(this.config["niceName"]),
                 layout: "fit",
                 border: false,
                 items: []

--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/toolbarenricher.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/toolbarenricher.js
@@ -64,7 +64,7 @@ pimcore.report.custom.toolbarenricher = Class.create(pimcore.plugin.admin, {
 
                                             if(!groupToolbarMenuEntries[report["group"]]) {
                                                 groupToolbarMenuEntries[report["group"]] = new Ext.menu.Item({
-                                                    text: report["group"],
+                                                    text: t(report["group"]),
                                                     iconCls: report["groupIconClass"],
                                                     menu: []
                                                 });
@@ -75,12 +75,12 @@ pimcore.report.custom.toolbarenricher = Class.create(pimcore.plugin.admin, {
                                         }
 
                                         parentMenuEntry.add({
-                                            text: report["niceName"],
+                                            text: t(report["niceName"]),
                                             iconCls: report["iconClass"],
                                             handler: function (report, reportClass) {
                                                 toolbar.showReports(reportClass, {
                                                     name: report["name"],
-                                                    text: report["niceName"],
+                                                    text: t(report["niceName"]),
                                                     niceName: report["niceName"],
                                                     iconCls: report["iconClass"]
                                                 });


### PR DESCRIPTION
The report name and group only translated in the left menu of the report page.