### PR TITLE
[DataObject][Inheritance] Fix inheritance when using default values

### DIFF
--- a/models/DataObject/Traits/DefaultValueTrait.php
+++ b/models/DataObject/Traits/DefaultValueTrait.php
@@ -126,13 +126,20 @@ trait DefaultValueTrait
                 if ($class && $class->getAllowInherit()) {
                     $params = [];
 
+                    $inheritanceEnabled = Concrete::getGetInheritedValues();
+
                     try {
+                        // make sure we get the inherited value of the parent
+                        Concrete::setGetInheritedValues(true);
+
                         $data = $owner->getValueFromParent($this->getName(), $params);
                         if (!$this->isEmpty($data)) {
                             return null;
                         }
                     } catch (InheritanceParentNotFoundException $e) {
                         // no data from parent available, use the default value
+                    } finally {
+                        Concrete::setGetInheritedValues($inheritanceEnabled);
                     }
                 }
             }


### PR DESCRIPTION
DefaultValueTrait::handleDefaultValue() determines the parent's value
and decides whether or not to use the default value. This worked for
the first child (1st level of inheritance) but not for the next child
(2nd level), as GetInheritedValues is disabled in save() context.

The result is unwanted persisting of the default value to store table
for the 2nd child as thus effectively breaking inheritance.

```
* object
|-- variant 1: OK
    |-- variant 2: NOT OK
        |-- variant 3: OK
            |-- variant 4: NOT OK
                ...
```

This fix enables inheritance while determining the value from the parent
and thus make the right decision whether to use the default or not.


## Steps to reproduce

1) Create a data object class with fields supporting default values (e.g. input) and set a default value
2) Run this code
```php
<?php
namespace AppBundle\Command;

use Pimcore\Model\DataObject;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;

class TestCommand extends \Pimcore\Console\AbstractCommand
{
    protected static $defaultName = 'app:test';

    /**
     * @inheritDoc
     */
    protected function execute(InputInterface $input, OutputInterface $output)
    {
        $obj = new DataObject\Example();
        $obj
            ->setType(DataObject\Concrete::OBJECT_TYPE_OBJECT)
            ->setParentId(1 /* root */)
            ->setKey('example')
            ->save();

        for ($v = 1; $v <= 5; $v++) {
            // workaround for differing behavior Backend vs. API: force reload data object
            $obj = DataObject\Example::getById($obj->getId(), true);

            $variant = new DataObject\Example();
            $variant
                ->setType(DataObject\Concrete::OBJECT_TYPE_VARIANT)
                ->setParent($obj)
                ->setKey("variant_{$v}")
                ->save();

            // use this variant as next parent
            $obj = $variant;
        }
    }
}
```