### PR TITLE
[DataObject][QuantityValue] Fixes for zero value, default unit (and inheritance)

### DIFF
--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -257,7 +257,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
      */
     public function getDataFromResource($data, $object = null, $params = [])
     {
-        if ($data[$this->getName() . '__value'] || $data[$this->getName() . '__unit']) {
+        if (strlen($data[$this->getName() . '__value']) > 0 || $data[$this->getName() . '__unit']) {
             $quantityValue = new Model\DataObject\Data\QuantityValue((float)$data[$this->getName() . '__value'], $data[$this->getName() . '__unit']);
 
             if (isset($params['owner'])) {
@@ -328,7 +328,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
      */
     public function getDataFromEditmode($data, $object = null, $params = [])
     {
-        if ($data['value'] || $data['unit']) {
+        if (strlen($data['value']) > 0 || $data['unit']) {
             if (is_numeric($data['unit'])) {
                 if ($data['unit'] == -1 || $data['unit'] == null || empty($data['unit'])) {
                     return new Model\DataObject\Data\QuantityValue($data['value'], null);

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -258,7 +258,8 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
     public function getDataFromResource($data, $object = null, $params = [])
     {
         if (strlen($data[$this->getName() . '__value']) > 0 || $data[$this->getName() . '__unit']) {
-            $quantityValue = new Model\DataObject\Data\QuantityValue((float)$data[$this->getName() . '__value'], $data[$this->getName() . '__unit']);
+            $value = $data[$this->getName() . '__value'];
+            $quantityValue = new Model\DataObject\Data\QuantityValue($value !== null ? (float)$value : null, $data[$this->getName() . '__unit']);
 
             if (isset($params['owner'])) {
                 $quantityValue->setOwner($params['owner'], $params['fieldname'], $params['language'] ?? null);

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -257,7 +257,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
      */
     public function getDataFromResource($data, $object = null, $params = [])
     {
-        if (strlen($data[$this->getName() . '__value']) > 0 || $data[$this->getName() . '__unit']) {
+        if ($data[$this->getName() . '__value'] !== null || $data[$this->getName() . '__unit']) {
             $value = $data[$this->getName() . '__value'];
             $quantityValue = new Model\DataObject\Data\QuantityValue($value !== null ? (float)$value : null, $data[$this->getName() . '__unit']);
 


### PR DESCRIPTION
This PR fixes two things:

1. Make zero (0) a legitimate value.
2. Doesn't enforce value zero (0) when a default unit is configured for the QuantityValue field.
