### PR TITLE
AbstractUser: Fix return PHPdoc

### DIFF
--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -78,7 +78,7 @@ class AbstractUser extends Model\AbstractModel
     /**
      * @param array $values
      *
-     * @return self
+     * @return static
      */
     public static function create($values = [])
     {


### PR DESCRIPTION
PHPStan classify `$role = User\Role::create($options);` as AbstractUser now. Should be Role.