### PR TITLE
Increase the number of characters for workflow places

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20200902111642.php
+++ b/bundles/CoreBundle/Migrations/Version20200902111642.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+
+class Version20200902111642 extends AbstractPimcoreMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws \Exception
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE `element_workflow_state` CHANGE `place` `place` text NULL;');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE `element_workflow_state` CHANGE `place` `place` varchar(255) NULL;');
+    }
+}

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -873,7 +873,7 @@ DROP TABLE IF EXISTS `element_workflow_state`;
 CREATE TABLE `element_workflow_state` (
   `cid` int(10) NOT NULL DEFAULT '0',
   `ctype` enum('document','asset','object') NOT NULL,
-  `place` varchar(255) DEFAULT NULL,
+  `place` text DEFAULT NULL,
   `workflow` varchar(100) NOT NULL,
   PRIMARY KEY (`cid`,`ctype`,`workflow`)
 ) DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION


<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/` -> target branch `master`
- [x] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [x] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [x] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
This fixes the problem when you have complex workflows with too many parallel places.

255 characters is not enough to create complex workflows, hence the field is updated to text

When you have more then a few places in your workflow you run out of characters in the database table.
for instance 
translation_english_done,translation_spanish_done, etc. etc.
This results in the final string being cut off and breaking the workflows. You then have to enter the database and reset the field manually. Changing this to a text instead of varchar makes sure you can create much more complex workflows. 

## Additional info  

