### PR TITLE
Image Optimization "dead lock"

### DIFF
--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -168,6 +168,10 @@ class Processor
         $fileExtension = $format;
         if ($format == 'original') {
             $fileExtension = \Pimcore\File::getFileExtension($fileSystemPath);
+            // If we can optimize we need to set the concrete format to do so.
+            if ($contentOptimized = in_array($fileExtension, ['jpg', 'jpeg', 'png', 'pjpeg'])) {
+                $format = $fileExtension;
+            }
         } elseif ($format === 'pjpeg' || $format === 'jpeg') {
             $fileExtension = 'jpg';
         }

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -359,6 +359,11 @@ class Processor
             }
         }
 
+        // @TODO: Should this somehow check if a format switch is acutally allowed?
+        if ($contentOptimized && !self::hasWebpSupport()) {
+            $format = $image->getContentOptimizedFormat();
+        }
+
         $tmpFsPath = preg_replace('@\.([\w]+)$@', uniqid('.tmp-', true) . '.$1', $fsPath);
         $image->save($tmpFsPath, $format, $config->getQuality());
         @rename($tmpFsPath, $fsPath); // atomic rename to avoid race conditions

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -152,7 +152,6 @@ class Processor
         if (self::hasWebpSupport() && $image->supportsFormat('webp')) {
             // We can use wepb - no need to optimize.
             // @TODO Why can we just adjust the format here without checking if
-            // the format  is source / original and / or if any preserving
             // option is active?
             $optimizedFormat = $optimizedContent = false;
             $format = 'webp';

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -151,7 +151,6 @@ class Processor
 
         if (self::hasWebpSupport() && $image->supportsFormat('webp')) {
             // @TODO Why can we just adjust the format here without checking if
-            // option is active?
             $optimizedFormat = $optimizedContent = false;
             $format = 'webp';
         }

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -100,8 +100,8 @@ class Processor
         $generated = false;
         $errorImage = PIMCORE_WEB_ROOT . '/bundles/pimcoreadmin/img/filetype-not-supported.svg';
         $format = strtolower($config->getFormat());
-        // Optimize by default.
-        $contentOptimized = true;
+        // Optimize if allowed to strip info.
+        $contentOptimized = (!$config->isPreserveColor() && !$config->isPreserveMetaData());
 
         if (self::containsTransformationType($config, '1x1_pixel')) {
             return 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
@@ -168,8 +168,9 @@ class Processor
         $fileExtension = $format;
         if ($format == 'original') {
             $fileExtension = \Pimcore\File::getFileExtension($fileSystemPath);
-            // If we can optimize we need to set the concrete format to do so.
-            if ($contentOptimized = in_array($fileExtension, ['jpg', 'jpeg', 'png', 'pjpeg'])) {
+            // If we can optimize we check if the original is compatible and
+            // set the concrete target format to do so.
+            if ($contentOptimized && $contentOptimized = in_array($fileExtension, ['jpg', 'jpeg', 'png', 'pjpeg'])) {
                 $format = $fileExtension;
             }
         } elseif ($format === 'pjpeg' || $format === 'jpeg') {

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -149,7 +149,7 @@ class Processor
 
         $image = Asset\Image::getImageTransformInstance();
 
-        if (self::hasWebpSupport() && $image->supportsFormat('webp')) {
+        if ($optimizedFormat && self::hasWebpSupport() && $image->supportsFormat('webp')) {
             // @TODO Why can we just adjust the format here without checking if
             $optimizedFormat = $optimizedContent = false;
             $format = 'webp';

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -150,7 +150,6 @@ class Processor
         $image = Asset\Image::getImageTransformInstance();
 
         if (self::hasWebpSupport() && $image->supportsFormat('webp')) {
-            // We can use wepb - no need to optimize.
             // @TODO Why can we just adjust the format here without checking if
             // option is active?
             $optimizedFormat = $optimizedContent = false;

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -149,6 +149,9 @@ class Processor
 
         if (self::hasWebpSupport() && $image->supportsFormat('webp')) {
             // We can use wepb - no need to optimize.
+            // @TODO Why can we just adjust the format here without checking if
+            // the format  is source / original and / or if any preserving
+            // option is active?
             $contentOptimized = false;
             $format = 'webp';
         }
@@ -168,11 +171,6 @@ class Processor
         $fileExtension = $format;
         if ($format == 'original') {
             $fileExtension = \Pimcore\File::getFileExtension($fileSystemPath);
-            // If we can optimize we check if the original is compatible and
-            // set the concrete target format to do so.
-            if ($contentOptimized && $contentOptimized = in_array($fileExtension, ['jpg', 'jpeg', 'png', 'pjpeg'])) {
-                $format = $fileExtension;
-            }
         } elseif ($format === 'pjpeg' || $format === 'jpeg') {
             $fileExtension = 'jpg';
         }
@@ -359,11 +357,6 @@ class Processor
                     }
                 }
             }
-        }
-
-        // Ensure the image optimization is only called with a compatible format.
-        if ($contentOptimized && !self::hasWebpSupport() && !in_array($format, ['jpeg', 'png', 'pjpeg'])) {
-            $format = $image->getContentOptimizedFormat();
         }
 
         $tmpFsPath = preg_replace('@\.([\w]+)$@', uniqid('.tmp-', true) . '.$1', $fsPath);

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -151,7 +151,7 @@ class Processor
 
         if ($optimizedFormat && self::hasWebpSupport() && $image->supportsFormat('webp')) {
             // @TODO Why can we just adjust the format here without checking if
-            $optimizedFormat = $optimizedContent = false;
+            $optimizedFormat = $optimizeContent = false;
             $format = 'webp';
         }
 

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -371,7 +371,7 @@ class Processor
 
         $generated = true;
 
-        if ($optimizedContent) {
+        if ($optimizeContent) {
             $filePath = str_replace(PIMCORE_TEMPORARY_DIRECTORY . '/', '', $fsPath);
             $tmpStoreKey = 'thumb_' . $asset->getId() . '__' . md5($filePath);
             TmpStore::add($tmpStoreKey, $filePath, 'image-optimize-queue');

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -126,7 +126,7 @@ class Processor
         if ($format == 'print') {
             // Don't optimize images for print as we assume we want images as
             // untouched as possible.
-            $optimizedFormat = $optimizedContent = false;
+            $optimizedFormat = $optimizeContent = false;
             $format = self::getAllowedFormat($fileExt, ['svg', 'jpeg', 'png', 'tiff'], 'png');
 
             if (($format == 'tiff') && \Pimcore\Tool::isFrontendRequestByAdmin()) {

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -150,7 +150,6 @@ class Processor
         $image = Asset\Image::getImageTransformInstance();
 
         if ($optimizedFormat && self::hasWebpSupport() && $image->supportsFormat('webp')) {
-            // @TODO Why can we just adjust the format here without checking if
             $optimizedFormat = $optimizeContent = false;
             $format = 'webp';
         }

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -101,7 +101,7 @@ class Processor
         $errorImage = PIMCORE_WEB_ROOT . '/bundles/pimcoreadmin/img/filetype-not-supported.svg';
         $format = strtolower($config->getFormat());
         // Optimize if allowed to strip info.
-        $optimizedContent = (!$config->isPreserveColor() && !$config->isPreserveMetaData());
+        $optimizeContent = (!$config->isPreserveColor() && !$config->isPreserveMetaData());
         $optimizedFormat = false;
 
         if (self::containsTransformationType($config, '1x1_pixel')) {

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -139,7 +139,7 @@ class Processor
                 return $asset->getFullPath();
             }
         } elseif ($format == 'tiff') {
-            $optimizedFormat = $optimizedContent = false;
+            $optimizedFormat = $optimizeContent = false;
             if (\Pimcore\Tool::isFrontendRequestByAdmin()) {
                 // return a webformat in admin -> tiff cannot be displayed in browser
                 $format = 'png';


### PR DESCRIPTION
The image optimize pipeline only works if format is set to "source".
I don't understand why that is.
However, even with format set as "source" the image optimization is _not_ triggered if an image url is directly requested for the first time.
E.g. requesting `/content/hero-slider/2020/09/image-thumb__52057__hero-slider-image/hero-slider-image-1.png` will pass through `Pimcore\Bundle\CoreBundle\Controller\PublicServicesController::thumbnailAction()`.
Now if the format is set to "source" this action will adjust the thumbnail config to set the format to the file extension.
Which then leads `\Pimcore\Model\Asset\Image\Thumbnail\Processor::process()` to never enable `$contentOptimizedFormat`  because of this condition `if ($format == 'source' || empty($format)) {`.
Format is never empty or "source" in that case - as such once the thumbnail is generated it wont be optimized ever again.

I do not know why calling the image optimization has anything to do with the 'source' format - and besides that why "original" wouldn't be considered for optimization either.
As far as I see it the optimization should happen for all _supported_ formats (keep excluding webp) and output channels where it is beneficial (exclude print / tiff).

I've made an attempt to change the approach.