### PR TITLE
[Ghostscript] Use version_compare to compare ghostscript versions

### DIFF
--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -166,7 +166,7 @@ class Ghostscript extends Adapter
         $command = self::getGhostscriptCli() . ' -dNODISPLAY -q';
 
         // Adding permit-file-read flag to prevent issue with Ghostscript's SAFER mode which is enabled by default as of version 9.50.
-        if ($this->getVersion() >= 9.50) {
+        if (version_compare($this->getVersion(), '9.50') >= 0) {
             $command .= " --permit-file-read='" . $this->path . "'";
         }
 
@@ -185,7 +185,7 @@ class Ghostscript extends Adapter
     protected function getVersion()
     {
         if (is_null($this->version)) {
-            $this->version = (float) Console::exec(self::getGhostscriptCli() . ' --version');
+            $this->version = Console::exec(self::getGhostscriptCli() . ' --version');
         }
 
         return $this->version;

--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -178,7 +178,7 @@ class Ghostscript extends Adapter
     /**
      * Get the version of the installed Ghostscript CLI.
      *
-     * @return float
+     * @return string
      *
      * @throws \Exception
      */

--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -166,7 +166,7 @@ class Ghostscript extends Adapter
         $command = self::getGhostscriptCli() . ' -dNODISPLAY -q';
 
         // Adding permit-file-read flag to prevent issue with Ghostscript's SAFER mode which is enabled by default as of version 9.50.
-        if (version_compare($this->getVersion(), '9.50') >= 0) {
+        if (version_compare($this->getVersion(), '9.50', '>=')) {
             $command .= " --permit-file-read='" . $this->path . "'";
         }
 

--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -27,7 +27,7 @@ class Ghostscript extends Adapter
     protected $path;
 
     /**
-     * @var float|null
+     * @var string|null
      */
     private $version = null;
 


### PR DESCRIPTION
Currently the code compares versions with floats:
```php
if ($this->getVersion() >= 9.50) {
```

This works as long as there won't be a version 9.100 - for sure this is more of a hypothetical case but in my experience comparing versions is not as trivial as a numerical comparison.