### PR TITLE
[Application Logger] Write log also to file object (if set)

### DIFF
--- a/lib/Log/ApplicationLogger.php
+++ b/lib/Log/ApplicationLogger.php
@@ -158,7 +158,7 @@ class ApplicationLogger implements LoggerInterface
                 $context['fileObject'] = str_replace(PIMCORE_PROJECT_ROOT, '', $context['fileObject']->getFilename());
             }
 
-            file_put_contents(PHP_EOL.$context['fileObject'], $message, FILE_APPEND);
+            file_put_contents(PHP_EOL.$context['fileObject'], PHP_EOL.'['.$level.'] '.$message, FILE_APPEND);
         }
 
         $relatedObject = null;

--- a/lib/Log/ApplicationLogger.php
+++ b/lib/Log/ApplicationLogger.php
@@ -157,6 +157,8 @@ class ApplicationLogger implements LoggerInterface
             } else {
                 $context['fileObject'] = str_replace(PIMCORE_PROJECT_ROOT, '', $context['fileObject']->getFilename());
             }
+
+            file_put_contents($context['fileObject'].PHP_EOL, $message, FILE_APPEND);
         }
 
         $relatedObject = null;

--- a/lib/Log/ApplicationLogger.php
+++ b/lib/Log/ApplicationLogger.php
@@ -158,7 +158,7 @@ class ApplicationLogger implements LoggerInterface
                 $context['fileObject'] = str_replace(PIMCORE_PROJECT_ROOT, '', $context['fileObject']->getFilename());
             }
 
-            file_put_contents(PHP_EOL.$context['fileObject'], PHP_EOL.'['.$level.'] '.$message, FILE_APPEND);
+            file_put_contents($context['fileObject'], PHP_EOL.'['.$level.'] '.$message, FILE_APPEND);
         }
 
         $relatedObject = null;

--- a/lib/Log/ApplicationLogger.php
+++ b/lib/Log/ApplicationLogger.php
@@ -158,7 +158,7 @@ class ApplicationLogger implements LoggerInterface
                 $context['fileObject'] = str_replace(PIMCORE_PROJECT_ROOT, '', $context['fileObject']->getFilename());
             }
 
-            file_put_contents($context['fileObject'].PHP_EOL, $message, FILE_APPEND);
+            file_put_contents(PHP_EOL.$context['fileObject'], $message, FILE_APPEND);
         }
 
         $relatedObject = null;


### PR DESCRIPTION
Currently you can provide a file object when logging a message with the `ApplicationLogger`, see https://pimcore.com/docs/6.x/Development_Documentation/Tools_and_Features/Application_Logger.html#page_Special-context-variables.

The goal of this should be to provide some more insights on the error in a separate file (as far as I understood). But currently the data for the `FileObject` can only be set when creating the `FileObject` object. When later on you call `$logger->alert('Something bad happened', ['fileObject' => $fileObject]);` the file object does only get used for linking the application log entry to the `FileObject` file. This PR changes this behaviour as it also adds the log message to the `FileObject` file. This way it is possible to create a `FileObject` for a bulk operation and then log all messages which happen during this operation to the `FileObject` file. When then there is an error, the user sees that in the Application Logger and can directly jump to the logs for this bulk operation and also sees some other logs which happened before the error but were not critical (e.g. in an import an error happens during saving of a data object - in this moment it may help to know which data got written to the object).
```php
$logFileObject = new FileObject('My bulk operation');

$dataObject = new Product;
$dataObject->setKey($key);
$logger->info('Key='.$key,  ['fileObject' => $logFileObject]);
$dataObject->setSKU($sku);
$logger->info('SKU='.$sku,  ['fileObject' => $logFileObject]);
try {
  $dataObject->save();
  $logger->info('Object '.$dataObject->getId().' successfully saved',  ['fileObject' => $logFileObject]);
catch(\Throwable $e) {
  $logger->alert('Object could not be saved: '.$e,  ['fileObject' => $logFileObject]);
}
```

Whenever you see `Object could not be saved` in your application logs you can open the linked file object and then you see the other fields' values:
```
My bulk operation
[info] Key=
[info] SKU=1234
[alert] Object could not be saved: Key is empty
```
This way it becomes easy to analyse the cause of the error. Without the info log with the SKU it would be much harder to analyse which object had en empty key.

Without this PR you have to collect all the logs in a variable and then create a `FileObject` with the collected messages and thereafter log a dummy log so that the linked file object appears in the Application Logger.