### PR TITLE
[Doc] Remove some unnecessary whitespace

### DIFF
--- a/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/00_Placeholder.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/00_Placeholder.md
@@ -12,7 +12,7 @@ echo out.
 
 <div class="code-section">
 
-```php 
+```php
 <?php $this->placeholder('foo')->set("Some text for later") ?>
 
 <?php
@@ -21,7 +21,7 @@ echo out.
 ?>
 ```
 
-```twig 
+```twig
 {% do pimcore_placeholder('foo').set("Some text for later") %}
 
 {% outputs "Some text for later" %}
@@ -48,7 +48,7 @@ determine what the current setting is.
 spaces will be used. If a string is passed, the string will be used. Use `getIndent()` at any time to determine what 
 the current setting is.
 
-```php 
+```php
 <?php
 $this->placeholder('foo')->setPrefix("<ul>\n    <li>")
                          ->setSeparator("</li><li>\n")

--- a/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/01_HeadLink.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/02_Templating_Helpers/01_HeadLink.md
@@ -35,7 +35,7 @@ You may specify a headLink at any time.
 Typically, you will specify global links in your layout script, and application specific links in your 
 application view scripts. In your layout script, in the `<head>` section, you will then echo the helper to output it.
 
-```php 
+```php
 <?php // setting links in a view script:
 $this->headLink()->appendStylesheet('/styles/basic.css'); 
 $this->headLink(['rel' => 'icon', 'href' => '/img/favicon.ico'], 'PREPEND')

--- a/doc/Development_Documentation/02_MVC/02_Template/README.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/README.md
@@ -35,7 +35,7 @@ possible and use PHP just printing out data.
 
 #### Example
 
-```php 
+```php
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/doc/Development_Documentation/02_MVC/04_Routing_and_URLs/08_Working_with_Sites.md
+++ b/doc/Development_Documentation/02_MVC/04_Routing_and_URLs/08_Working_with_Sites.md
@@ -26,7 +26,7 @@ Also, lots of other Pimcore tools and functionalities like Glossary, Tag & Snipp
 
 #### Check if Current Request is Inside a Subsite
 
-```php 
+```php
 if(\Pimcore\Model\Site::isSiteRequest()) { /* ... */ }
 ```
 
@@ -35,15 +35,15 @@ See [Navigation](../../03_Documents/03_Navigation.md) for more information.
 
 
 #### Getting the full path of a document inside a subsite-request
-```php 
+```php
 $document->getRealFullpath(); // returns the path including the site-root
 $document->getFullPath(); // returns the path relative to the site-root
 ```
 
 
 #### Getting the root-document of the current site
-```php 
-if(\Pimcore\Model\Site::isSiteRequest()) {
+```php
+if (\Pimcore\Model\Site::isSiteRequest()) {
     $site = \Pimcore\Model\Site::getCurrentSite();
     $navStartNode = $site->getRootDocument();
 } else {
@@ -53,7 +53,7 @@ if(\Pimcore\Model\Site::isSiteRequest()) {
 
 #### Some other Tools
 The functionality should be pretty self-explanatory: 
-```php 
+```php
 \Pimcore\Tool\Frontend::getSiteForDocument($document);
 \Pimcore\Tool\Frontend::isDocumentInCurrentSite($document);
 \Pimcore\Tool\Frontend::isDocumentInSite($site, $document);

--- a/doc/Development_Documentation/03_Documents/01_Editables/12_Relation_(Many-To-One).md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/12_Relation_(Many-To-One).md
@@ -33,7 +33,7 @@ You can just create the code line like, below:
 
 <div class="code-section">
 
-```php 
+```php
 <?= $this->relation("myRelation"); ?>
 ```
 

--- a/doc/Development_Documentation/04_Assets/01_Working_with_PHP_API.md
+++ b/doc/Development_Documentation/04_Assets/01_Working_with_PHP_API.md
@@ -52,7 +52,7 @@ and [document listings](../03_Documents/09_Working_with_PHP_API.md#documentsList
 Custom Settings/Properties can be added programmatically to every asset. This is mostly used for plugins or something 
 similar.
 
-```php 
+```php
 $asset = Asset::getById(2345);
 $settings = $asset->getCustomSettings();
 $settings["mySetting"] = "this is my value this can be everythin also an array or an object not only a string";

--- a/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/03_Video_Thumbnails.md
+++ b/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/03_Video_Thumbnails.md
@@ -22,7 +22,7 @@ if($asset instanceof Asset\Video) {
 ```
 
 ##### Examples - Video Transcoding
-```php 
+```php
 $asset = Asset::getById(123);
 if($asset instanceof Asset\Video) {
  

--- a/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/05_Document_Thumbnails.md
+++ b/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/05_Document_Thumbnails.md
@@ -6,7 +6,7 @@ odt, ods, odp and many others.
 You can of course use existing image-thumbnail configurations to create a thumbnail of your choice.
  
 ##### Examples
-```php 
+```php
 $asset = Asset::getById(123);
 if($asset instanceof Asset\Document) {
  

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/20_Consent.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/20_Consent.md
@@ -18,7 +18,7 @@ When setting consent in custom controllers or in other places, use the service `
 and its methods `giveConsent` and `revokeConsent`. Please make sure that your DataObject was saved before using the Consent Service. If your DataObject doesent have an Id the note cannot be saved!
 
 
-```php 
+```php
 <?php 
 
     $customer = Customer::getById(345);

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/55_Number_Types.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/55_Number_Types.md
@@ -32,7 +32,7 @@ Start off with defining a global list of known units.
 
 This can also be achieved programmatically.
 
-```php 
+```php
 $unit = new Pimcore\Model\DataObject\QuantityValue\Unit();
 $unit->setAbbreviation("km");   // mandatory
 $unit->setLongname("kilometers");

--- a/doc/Development_Documentation/05_Objects/03_Working_with_PHP_API.md
+++ b/doc/Development_Documentation/05_Objects/03_Working_with_PHP_API.md
@@ -7,7 +7,7 @@ with these objects via a comfortable PHP API and take full advantage of a IDE (e
 ## CRUD Operations
 The following code snippet indicates how to access, create and modify an object programmatically:
 
-```php 
+```php
 <?php
 
 use \Pimcore\Model\DataObject;

--- a/doc/Development_Documentation/05_Objects/05_External_System_Interaction.md
+++ b/doc/Development_Documentation/05_Objects/05_External_System_Interaction.md
@@ -98,7 +98,7 @@ prevent memory issues
 
 To avoid this, you can pass an array with keys (indexes) which should stay in the registry eg. 
 
-```php 
+```php
 \Pimcore::collectGarbage(["myImportantKey", "myConfig"]);
 
 // You can also add items to the static list of globally protected keys by passing them to

--- a/doc/Development_Documentation/06_Multi_Language_i18n/04_Shared_Translations.md
+++ b/doc/Development_Documentation/06_Multi_Language_i18n/04_Shared_Translations.md
@@ -54,8 +54,7 @@ You can also use variable interpolation in localized messages.
 </div>
 ```
 
-
-```twig 
+```twig
 <div>
     <address>&copy; {{ 'Copyright'|trans }}</address>
     <a href="/imprint">{{ 'Imprint'|trans }}</a>

--- a/doc/Development_Documentation/06_Multi_Language_i18n/09_Formatting_Service.md
+++ b/doc/Development_Documentation/06_Multi_Language_i18n/09_Formatting_Service.md
@@ -5,7 +5,7 @@ factory and wrapper of the [`IntlDateFormatter` component of php](http://php.net
   
 #### Usage Example
  
-```php 
+```php
 <?php
 $service = \Pimcore::getContainer()->get(\Pimcore\Localization\IntlFormatter::class);
 
@@ -25,7 +25,7 @@ echo $service->formatCurrency("45632325.32", "EUR", "#,##0.00 ¤¤");
 
 You can overwrite the default service definition with your own, e.g. to overwrite the default currency patterns. 
 
-```yml 
+```yml
 services:
     # Formatting service for dates, times and numbers
     Pimcore\Localization\IntlFormatter:

--- a/doc/Development_Documentation/07_Workflow_Management/05_Workflow_Tutorial.md
+++ b/doc/Development_Documentation/07_Workflow_Management/05_Workflow_Tutorial.md
@@ -189,7 +189,7 @@ At the final stage of the workflow I would like to have three choices
 We've already made the reject and start processing transition, the only thing here is to add an additional from place. 
 This can be done because we have workflow type `state_machine` activated, here our modified transition definitions.
 
-```yml 
+```yml
 
 (...)
     transitions:

--- a/doc/Development_Documentation/07_Workflow_Management/09_Working_with_PHP_API.md
+++ b/doc/Development_Documentation/07_Workflow_Management/09_Working_with_PHP_API.md
@@ -14,7 +14,7 @@ and apply global actions (`applyGlobalAction()`).
 See following example how to interact with workflows with PHP API. 
 
 
-```php 
+```php
 
 /**
  * $object ... your element, e.g. a Pimcore data object

--- a/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/07_Elastic_Search/01_Configuration_Details.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/07_Elastic_Search/01_Configuration_Details.md
@@ -24,7 +24,7 @@ Specify synonym providers for synonym filters defined in filter section of index
 For details see [Synonyms](./02_Synonyms.md).
 
 #### Sample Config
-```yml 
+```yml
 pimcore_ecommerce_framework:
     index_service:
         tenants:

--- a/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/07_Elastic_Search/02_Synonyms.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/07_Elastic_Search/02_Synonyms.md
@@ -18,7 +18,7 @@ Pimcore ships with a simple `FileSynonymProvider` that can be used right away. T
 Besides the service configuration it self, the synonym providers need to be configured in index service 
 configuration as follows. 
 
-```yml 
+```yml
 pimcore_ecommerce_framework:
     index_service:
         tenants:
@@ -47,7 +47,7 @@ The filter definition in the index settings can hold just an empty array (as som
 index building, index resetting or reloading of synonyms, the synonyms are loaded from synonyms provider and injected
 to the synonyms array of the corresponding synonyms filter. 
 
-```yml 
+```yml
 pimcore_ecommerce_framework:
     index_service:
         tenants:

--- a/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/07_Product_List.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/07_Product_List.md
@@ -7,7 +7,7 @@ Product Index implementation specific. Detailed method documentation is availabl
 For how to get a Product List instance suitable for the current Product Index implementation and filter for products see 
 following code sample: 
 
-```php 
+```php
 <?php 
 $list = \Pimcore\Bundle\EcommerceFrameworkBundle\Factory::getInstance()->getIndexService()->getProductListForCurrentTenant();
 $list->addCondition("name = 'testproduct'", 'name');

--- a/doc/Development_Documentation/10_E-Commerce_Framework/07_Filter_Service/03_Elastic_Search/01_Filter_Classification_Store.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/07_Filter_Service/03_Elastic_Search/01_Filter_Classification_Store.md
@@ -10,7 +10,7 @@ To do so, follow these steps
 Pimcore ships with a special interpreter to load all classification store attributes to the index. To use this interpreter
 add following attribute configuration into your index definition:  
 
-```yml 
+```yml
 some_field_name:
     fieldname: 'my_classification_store_field_name'
     interpreter: Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Interpreter\DefaultClassificationStore
@@ -70,7 +70,7 @@ with elastic search, it is not activated by default. Following steps are necessa
   the filter definition class.  
 - add following filter type mapping (see [here](../README.md) for details):
 
-```yml 
+```yml
 FilteSelectClsStoreAttributes:
     filter_type_id: Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\FilterType\ElasticSearch\SelectClassificationStoreAttributes
     template: 'product/filters/nested_attributes.html.twig'

--- a/doc/Development_Documentation/10_E-Commerce_Framework/09_Working_with_Prices/07_Vouchers.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/09_Working_with_Prices/07_Vouchers.md
@@ -44,6 +44,7 @@ not all other conditions of the pricing rule are met.
 
 #### Allow the User to Add a Token to his Cart
 A voucher token is always applied to a cart. To do so, use following snippet. 
+
 ```php
 <?php
 
@@ -59,8 +60,8 @@ if($token = strip_tags($request->get('voucher-code'))) {
         $this->addFlash('danger', $translator->trans('cart.error-voucher-code-' . $e->getCode()));
     }
 }
-
 ```
+
 ##### Error Codes of Exceptions thrown
 
 | Code | Description |
@@ -96,7 +97,7 @@ for each added token with following information:
 
 See an sample snippet to display the voucher information to the customer:
 
-```twig 
+```twig
 <form method="post" action="{{ path('shop-cart-apply-voucher') }}" class="card p-2 mb-4">
 
     {% if(cart.pricingManagerTokenInformationDetails | length > 0) %}
@@ -142,4 +143,3 @@ See an sample snippet to display the voucher information to the customer:
     </div>
 </form>
 ```
- 

--- a/doc/Development_Documentation/10_E-Commerce_Framework/15_Payment/01_Wirecard_QPay.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/15_Payment/01_Wirecard_QPay.md
@@ -29,7 +29,7 @@ If additional parameters should be allowed for initializing the payment,
  payment provider configuration. 
 
 *Configuration sample* 
-```yaml 
+```yaml
 pimcore_ecommerce_framework:
     payment_manager:
         providers:
@@ -51,7 +51,7 @@ pimcore_ecommerce_framework:
 ```
 
 *usage sample* 
-```php 
+```php
 <?php
 $payment->initPayment($price, [
     ...,

--- a/doc/Development_Documentation/10_E-Commerce_Framework/15_Payment/04_PayPal.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/15_Payment/04_PayPal.md
@@ -14,7 +14,7 @@ Add `paypal/paypal-checkout-sdk:^1` to your `composer.json`.
 
 Setup payment provider in e-commerce framework configuration tree and add PayPal API 
 credentials to it: 
-```yml 
+```yml
     payment_manager.
         providers: 
             paypal:
@@ -104,7 +104,7 @@ Initialize checkout manager, call `startOrderPayment` and then `initPayment` of 
 implementation. It is creating an order at PayPal and its response is the default PayPal 
 response, which need to be returned as a json response of the action.  
 
-```php 
+```php
 
 //in your payment controller, e.g. startPaymentAction
 
@@ -139,7 +139,7 @@ committing the order.
 Depending on your settings (see below), the payment is also automatically captured. If not
 you need to capture the payment manually by calling `$payment->executeDebit()`.  
 
-```php 
+```php
 
 public function handleResponseAction() {
 
@@ -172,7 +172,7 @@ If you are updating an existing Pimcore instance (with originated before 6.0.1),
 ### Configuration Options
 In payment configuration, following options are available: 
 
-```yml 
+```yml
     payment_manager.
         providers: 
             paypal:

--- a/doc/Development_Documentation/10_E-Commerce_Framework/15_Payment/08_PayU.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/15_Payment/08_PayU.md
@@ -3,7 +3,7 @@
 * [Documentation](http://developers.payu.com/en/restapi.html)
 
 *Configuration* 
-```yaml 
+```yaml
 pimcore_ecommerce_framework:
     payment_manager:
         providers:
@@ -19,7 +19,7 @@ pimcore_ecommerce_framework:
 ```
 
 *usage sample* 
-```php 
+```php
 <?php
 $config = [
     'extOrderId'  => $paymentId,

--- a/doc/Development_Documentation/10_E-Commerce_Framework/15_Payment/09_Heidelpay.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/15_Payment/09_Heidelpay.md
@@ -33,7 +33,7 @@ definition [here](https://github.com/pimcore/pimcore/blob/master/bundles/Ecommer
 Setup payment provider in e-commerce framework configuration. The access keys you find
 in heidelpay documentation (or you will get them from heidelpay for production integrations). 
 
-```yml 
+```yml
 heidelpay:
     provider_id: Pimcore\Bundle\EcommerceFrameworkBundle\PaymentManager\Payment\Heidelpay
     profile: sandbox
@@ -52,8 +52,8 @@ Create view template for payment method selection. This view template
 - has an additional form that submits successful payment information (heidelpay payment id) back to Pimcore.  
 
 **Sample template with Creditcard, Paypal and Sofort** 
-```twig 
 
+```twig
 {% do pimcore_head_link().appendStylesheet('https://static.heidelpay.com/v1/heidelpay.css') %}
 {% do pimcore_head_script().appendFile('https://static.heidelpay.com/v1/heidelpay.js') %}
 {% do pimcore_inline_script().appendFile(asset('static/js/payment.js')) %} {# custom payment js, see below #}
@@ -161,10 +161,9 @@ Create view template for payment method selection. This view template
 </form>
 ```
 
-
 **Sample Javascript (payment.js) with Creditcard, Paypal and Sofort**
-```javascript
 
+```javascript
 $(document).ready(function() {
 
     let heidelpayInstance = new heidelpay(_config.accessKey, {locale: 'en-GB'});
@@ -255,16 +254,14 @@ $(document).ready(function() {
 
 
 });
-
 ```
-
 
 5) **Create Controller Action for Payment Selection**
 
 The only special thing in this controller action is to get public access key out of
 payment provider and assign it to the template. 
 
-```php 
+```php
 /**
  * @Route("/checkout-payment", name="shop-checkout-payment")
  *
@@ -351,14 +348,13 @@ public function paymentErrorAction(Request $request, LoggerInterface $logger)
 
     return $this->redirectToRoute('shop-checkout-payment');
 }
-
 ```
 
 
 7) **Create Controller Action for Commit Order**
 Finally commit order and redirect user to order success page. 
 
-```php 
+```php
 /**
  * @Route("/payment-commit-order", name="shop-commit-order")
  *

--- a/doc/Development_Documentation/10_E-Commerce_Framework/15_Payment/10_Recurring_Payments.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/15_Payment/10_Recurring_Payments.md
@@ -75,7 +75,7 @@ public function paymentAction(Request $request)
 
 #### payment.html.php
 
-```php 
+```php
 ?>
 <form method="post" action="<?= $this->pimcoreUrl(array('action' => 'confirm'), 'checkout', true) ?>">
 

--- a/doc/Development_Documentation/10_E-Commerce_Framework/15_Payment/11_Hobex.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/15_Payment/11_Hobex.md
@@ -11,7 +11,7 @@ Hobex does not require an additional PHP-SDK. You just need to get a test accoun
 
 ## Configuration
 
-```yaml 
+```yaml
 pimcore_ecommerce_framework:
     
     # ...

--- a/doc/Development_Documentation/18_Tools_and_Features/27_Website_Settings.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/27_Website_Settings.md
@@ -26,7 +26,7 @@ Usage in a template:
 
 <div class="code-section">
 
-```php 
+```php
 <?php
 // access the whole configuration
 $this->websiteConfig();

--- a/doc/Development_Documentation/18_Tools_and_Features/35_GDPR_Data_Extractor.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/35_GDPR_Data_Extractor.md
@@ -15,7 +15,7 @@ Via the configuration, following options can be set to modify the behaviour of t
 
 For Details see configuration reference as follows: 
 
-```yml 
+```yml
 # Default configuration for "PimcoreAdminBundle"
 pimcore_admin:
     gdpr_data_extractor:

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/09_Cache/README.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/09_Cache/README.md
@@ -109,7 +109,7 @@ If you don't need the transactional tagging functionality as used in the core yo
 integrated with Pimcore's cache clearing functionality.
  
 #### Example of custom usage in an action
-```php 
+```php
 $lifetime = 99999;
 $cacheKey = md5($uri);
 if(!$data = \Pimcore\Cache::load($cacheKey)) {
@@ -123,7 +123,7 @@ if(!$data = \Pimcore\Cache::load($cacheKey)) {
 ```
 
 #### Overview of functionalities
-```php 
+```php
 // disable the cache globally
 \Pimcore\Cache::disable();
  

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/11_Console_CLI.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/11_Console_CLI.md
@@ -72,7 +72,7 @@ a command, use `bin/console <subcommand>`.
 > Be sure to run the console with the PHP user to prevent writing permissions issues later, either by calling `php bin/console` or by switching to the appropriate user, for instance on Debian system `su -l www-data -s /bin/bash`.
 
 ##### Examples:
-```php 
+```php
 # get a list of all registered commands
 $ ./bin/console list
  

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/25_Email_Framework/01_Pimcore_Mail.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/25_Email_Framework/01_Pimcore_Mail.md
@@ -38,7 +38,7 @@ for the generation of the text version by calling `enableHtml2textBinary()`. (re
 
 ## Usage Example
 
-```php 
+```php
 $params = ['firstName' => 'Pim', 'lastName' => 'Core', 'product' => 73613];
  
 //sending an email document (pimcore document)

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/35_Working_with_Sessions.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/35_Working_with_Sessions.md
@@ -34,7 +34,7 @@ class SessionCartConfigurator implements SessionConfiguratorInterface
 ```
 
 #### Session Configurator Service Definition
-```yml 
+```yml
 services:
     test.session.configurator.session_cart:
         class: TestBundle\Session\Configurator\SessionCartConfigurator

--- a/doc/Development_Documentation/20_Extending_Pimcore/03_Overriding_Models.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/03_Overriding_Models.md
@@ -21,7 +21,7 @@ But you cannot override `Pimcore\Model\Asset` (or the other abstract model class
 The configuration is a simple key / value map in your `app/config/config.yml` using the key 
 `pimcore.models.class_overrides`, for example: 
 
-```yaml 
+```yaml
 pimcore:
     models:
         class_overrides:
@@ -38,7 +38,7 @@ pimcore:
 
 In your `app/config/config.yml`: 
 
-```yaml 
+```yaml
 pimcore:
     models:
         class_overrides:

--- a/doc/Development_Documentation/20_Extending_Pimcore/23_Deeplinks_into_Admin_Interface.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/23_Deeplinks_into_Admin_Interface.md
@@ -7,7 +7,7 @@ The link always follows the schema: `https://YOUR-HOST/admin/login/deeplink?TYPE
 ## Examples 
 
 #### Documents 
-```text 
+```text
 https://acme.com/admin/login/deeplink?document_123_page 
 https://acme.com/admin/login/deeplink?document_45_snippet 
 https://acme.com/admin/login/deeplink?document_67_link 
@@ -17,7 +17,7 @@ https://acme.com/admin/login/deeplink?document_10_newsletter
 ```
 
 #### Assets 
-```text 
+```text
 https://acme.com/admin/login/deeplink?asset_23_image 
 https://acme.com/admin/login/deeplink?asset_34_document
 https://acme.com/admin/login/deeplink?asset_56_folder
@@ -25,7 +25,7 @@ https://acme.com/admin/login/deeplink?asset_78_video
 ```
 
 #### Objects 
-```text 
+```text
 https://acme.com/admin/login/deeplink?object_24_object 
 https://acme.com/admin/login/deeplink?object_98_variant 
 https://acme.com/admin/login/deeplink?object_66_folder

--- a/doc/Development_Documentation/22_Administration_of_Pimcore/01_Backups.md
+++ b/doc/Development_Documentation/22_Administration_of_Pimcore/01_Backups.md
@@ -12,7 +12,7 @@ No matter which solution your're using, it's crucial to back up the following co
 We definitely recommend to use a professional backup solution depending on your infrastructure, but sometimes a poor 
 man's backup can be quite handy :) 
 
-```bash 
+```bash
 
 # change directory to your project root 
 cd /var/www/your/project/

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/06_Additional_Tools_Installation.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/06_Additional_Tools_Installation.md
@@ -23,7 +23,7 @@ sudo apt-get install ffmpeg
 
 ## LibreOffice, pdftotext, Inkscape, ...
 
-```bash 
+```bash
 apt-get install libreoffice libreoffice-script-provider-python libreoffice-math xfonts-75dpi poppler-utils inkscape libxrender1 libfontconfig1 ghostscript
 ```
 
@@ -97,7 +97,7 @@ ln -s /usr/lib/go/bin/primitive
 
 ## Exiftool
 
-```bash 
+```bash
 apt-get install libimage-exiftool-perl
 ```
 
@@ -105,7 +105,7 @@ apt-get install libimage-exiftool-perl
 
 Install webp for [WebP-Support](../../04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md)
 
-```bash 
+```bash
 apt-get install webp
 ```
 

--- a/doc/Development_Documentation/26_Best_Practice/10_Advanced_Pricing_System.md
+++ b/doc/Development_Documentation/26_Best_Practice/10_Advanced_Pricing_System.md
@@ -98,7 +98,7 @@ productIds that apply the other filter criteria (without offset and limit) needs
  
 Following sample implementation does that by using a sql query:
  
-```php 
+```php
 <?php
     /**
      * Filters and orders given product IDs based on price information
@@ -139,7 +139,7 @@ Following sample implementation does that by using a sql query:
 
 To tell the product list that sorting should be done based on prices, use `ProductListInterface::ORDERKEY_PRICE` as order key 
 as follows: 
-```php 
+```php
 $products = $factory->getIndexService()->getProductListForCurrentTenant();
 $products->setOrderKey(ProductListInterface::ORDERKEY_PRICE);
 ```

--- a/doc/Development_Documentation/26_Best_Practice/15_Build_Role_Rights_System_for_Frontends.md
+++ b/doc/Development_Documentation/26_Best_Practice/15_Build_Role_Rights_System_for_Frontends.md
@@ -66,7 +66,7 @@ The Frontend Permission Toolkit Service provides two methods for working with pe
 There are several ways how to integrate the configured user permissions into the Frontend: 
 
 1) Use the Frontend Permission Toolkit Service in your application code to check if user is allowed for a certain resource: 
-```php 
+```php
     //get user object from Symfony
     $userObject = $this->get('security.token_storage')->getToken()->getUser();
 

--- a/doc/Development_Documentation/26_Best_Practice/20_Building_Custom_Rest_APIs.md
+++ b/doc/Development_Documentation/26_Best_Practice/20_Building_Custom_Rest_APIs.md
@@ -10,7 +10,7 @@ in the desired format.
 
 ### Example
 
-```php 
+```php
 <?php
 
 namespace AppBundle\Controller;

--- a/doc/Development_Documentation/26_Best_Practice/40_Integrating_Commerce_Data_with_Content.md
+++ b/doc/Development_Documentation/26_Best_Practice/40_Integrating_Commerce_Data_with_Content.md
@@ -33,7 +33,7 @@ class MyProductTeaser extends AbstractAreabrick
 ```
 
 **MyProductTeaser Template**
-```php 
+```php
 <?php
 /**
  * @var \Pimcore\Templating\PhpEngine $this
@@ -61,7 +61,7 @@ class MyProductTeaser extends AbstractAreabrick
 ### Create Controller and Action for Teaser Content
 
 **Controller Action** 
-```php 
+```php
     public function productCellAction(Request $request)
     {
     
@@ -81,7 +81,7 @@ class MyProductTeaser extends AbstractAreabrick
 ```
 
 **Template** 
-```php 
+```php
 <?php
 /**
  * @var \Pimcore\Templating\PhpEngine $this

--- a/doc/Development_Documentation/26_Best_Practice/55_Primary-Replica_Database_Connection.md
+++ b/doc/Development_Documentation/26_Best_Practice/55_Primary-Replica_Database_Connection.md
@@ -44,7 +44,7 @@ The main database connection which you have configured for Pimcore is always the
 Then you can add as many replica hosts as you like, in the following example there's just one replica host, 
 where only the host is different (in our case `replica1`), all other options are reused from the primary connection. 
 
-```yml 
+```yml
 doctrine:
     dbal:
         connections:

--- a/doc/Development_Documentation/26_Best_Practice/80_Setup_Multilanguage_Multishop_Product_Index.md
+++ b/doc/Development_Documentation/26_Best_Practice/80_Setup_Multilanguage_Multishop_Product_Index.md
@@ -22,7 +22,7 @@ There are two ways of setting up a multi language product index.
 This is suitable when only having a few multi language fields, e.g. just name and description, and all the other fields 
 are the same for each language. 
 
-```yml 
+```yml
 pimcore_ecommerce_framework:
     index_service:
         tenants:
@@ -58,7 +58,7 @@ This is suitable when having multiple language fields or complex applications an
 In order to reduce configuration effort (like copying all attributes for each assortment tenant), you can take advantage of
 the `_defaults` configuration feature and `placeholders`.
  
-```yml 
+```yml
 pimcore_ecommerce_framework:
     index_service:
         tenants:

--- a/doc/Development_Documentation/26_Best_Practice/85_Using_Tags_for_Filtering.md
+++ b/doc/Development_Documentation/26_Best_Practice/85_Using_Tags_for_Filtering.md
@@ -103,7 +103,7 @@ Important to know:
 - Tag assignment to elements is stored in the table `tags_assignment`.
 
 
-```php 
+```php
 <?php
     public function filterForTags(Asset\Listing $listing, Request $request)
     {

--- a/doc/Development_Documentation/26_Best_Practice/90_Web2Print_Extending_Config_for_PDFX_conformance.md
+++ b/doc/Development_Documentation/26_Best_Practice/90_Web2Print_Extending_Config_for_PDFX_conformance.md
@@ -23,7 +23,7 @@ To do so, Pimcore provides two events:
 ##### Example for adding Additional Config
 
 Services in Container:
-```yml 
+```yml
  app.event_listener.test:
         class: AppBundle\EventListener\PDFConfigListener
         tags:


### PR DESCRIPTION
Some docs had `CRLF` line endings. Those got changed to `LF` which makes them appear completely changed in the diff ;)

It's best to view the diff while [ignoring whitespace changes](https://github.com/pimcore/pimcore/pull/7069/files?w=1).