### PR TITLE
Fixed typo in simple example twig variant in Date Editable

### DIFF
--- a/doc/Development_Documentation/03_Documents/01_Editables/10_Date.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/10_Date.md
@@ -35,7 +35,7 @@ Please read the topic [Localization](../../06_Multi_Language_i18n/README.md).
 ```twig
 {{ pimcore_date('myDate', {
     'format': 'd.m.Y',
-    'outputFormat' => '%d.%m.%Y'
+    'outputFormat' : '%d.%m.%Y'
     })
 }}
 ```


### PR DESCRIPTION
## Changes in this pull request  
Fixed typo in simple example twig variant in [Date Editable](https://pimcore.com/docs/6.x/Development_Documentation/Documents/Editables/Date.html)