### PR TITLE
Change admin UI state only when (un)publishing documents succeeds

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/document.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/document.js
@@ -91,17 +91,6 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
                 saveData.missingRequiredEditable = this.data.missingRequiredEditable;
             }
 
-            // check for version notification
-            if (this.newerVersionNotification) {
-                var newerVersionNotificationBackup = this.newerVersionNotification.isVisible()
-
-                if (task == "publish" || task == "unpublish") {
-                    this.newerVersionNotification.hide();
-                } else {
-                    this.newerVersionNotification.show();
-                }
-            }
-
             try {
                 pimcore.plugin.broker.fireEvent("preSaveDocument", this, this.getType(), task, only);
             } catch (e) {
@@ -126,10 +115,19 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
                     try {
                         var rdata = Ext.decode(response.responseText);
                         if (typeof successCallback == 'function') {
-                            //the successCallback function retrieves response data information
+                            // the successCallback function retrieves response data information
                             successCallback(rdata);
                         }
                         if (rdata && rdata.success) {
+                            // check for version notification
+                            if (this.newerVersionNotification) {
+                                if (task == "publish" || task == "unpublish") {
+                                    this.newerVersionNotification.hide();
+                                } else {
+                                    this.newerVersionNotification.show();
+                                }
+                            }
+
                             pimcore.helpers.showNotification(t("success"), t("saved_successfully"), "success");
                             this.resetChanges();
                             Ext.apply(this.data, rdata.data);
@@ -159,11 +157,6 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
                 }.bind(this),
                 failure: function () {
                     this.tab.unmask();
-
-                    // reset version notification
-                    if (this.newerVersionNotification) {
-                        this.newerVersionNotification.setVisible(newerVersionNotificationBackup);
-                    }
                 }.bind(this),
             });
         } else {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/document.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/document.js
@@ -176,17 +176,20 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
         pimcore.elementservice.deleteElement(options);
     },
 
+    close: function() {
+        var tabPanel = Ext.getCmp("pimcore_panel_tabs");
+        tabPanel.remove(this.tab);
+    },
+
     saveClose: function (only) {
         this.save(null, only, function () {
-            var tabPanel = Ext.getCmp("pimcore_panel_tabs");
-            tabPanel.remove(this.tab);
+            this.close();
         }.bind(this));
     },
 
     publishClose: function () {
         this.publish(null, function () {
-            var tabPanel = Ext.getCmp("pimcore_panel_tabs");
-            tabPanel.remove(this.tab);
+            this.close();
         }.bind(this));
     },
 
@@ -234,9 +237,8 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
 
     unpublishClose: function () {
         this.unpublish(null, function () {
-            var tabPanel = Ext.getCmp("pimcore_panel_tabs");
-            tabPanel.remove(this.tab);
-        });
+            this.close();
+        }.bind(this));
     },
 
     reload: function () {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/page_snippet.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/page_snippet.js
@@ -457,12 +457,12 @@ pimcore.document.page_snippet = Class.create(pimcore.document.document, {
         $super(only, callback);
     },
 
-    save: function ($super, task, only, callback) {
-        if(task !== "publish") {
+    save: function ($super, task, only, callback, successCallback) {
+        if (task !== "publish") {
             this.validateRequiredEditables(true);
         }
 
-        $super(task, only, callback);
+        $super(task, only, callback, successCallback);
     },
 
     validateRequiredEditables: function (dismissAlert) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/page_snippet.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/page_snippet.js
@@ -457,12 +457,12 @@ pimcore.document.page_snippet = Class.create(pimcore.document.document, {
         $super(only, callback);
     },
 
-    save: function ($super, task, only, callback, failureCallback) {
+    save: function ($super, task, only, callback) {
         if(task !== "publish") {
             this.validateRequiredEditables(true);
         }
 
-        $super(task, only, callback, failureCallback);
+        $super(task, only, callback);
     },
 
     validateRequiredEditables: function (dismissAlert) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/page_snippet.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/page_snippet.js
@@ -457,11 +457,12 @@ pimcore.document.page_snippet = Class.create(pimcore.document.document, {
         $super(only, callback);
     },
 
-    save : function ($super, task, only, callback) {
+    save: function ($super, task, only, callback, failureCallback) {
         if(task !== "publish") {
             this.validateRequiredEditables(true);
         }
-        $super(task, only, callback);
+
+        $super(task, only, callback, failureCallback);
     },
 
     validateRequiredEditables: function (dismissAlert) {
@@ -498,6 +499,5 @@ pimcore.document.page_snippet = Class.create(pimcore.document.document, {
             }
         } catch(e) {
         }
-
     }
 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
@@ -746,16 +746,6 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
         var saveData = this.getSaveData(only, omitMandatoryCheck);
 
         if (saveData && saveData.data != false && saveData.data != "false") {
-
-            // check for version notification
-            if (this.newerVersionNotification) {
-                if (task == "publish" || task == "unpublish") {
-                    this.newerVersionNotification.hide();
-                } else if (task != "session") {
-                    this.newerVersionNotification.show();
-                }
-            }
-
             try {
                 pimcore.plugin.broker.fireEvent('preSaveObject', this, 'object');
             } catch (e) {
@@ -785,8 +775,16 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                                 successCallback(rdata);
                             }
                             if (rdata && rdata.success) {
-                                pimcore.helpers.showNotification(t("success"), t("saved_successfully"),
-                                    "success");
+                                // check for version notification
+                                if (this.newerVersionNotification) {
+                                    if (task == "publish" || task == "unpublish") {
+                                        this.newerVersionNotification.hide();
+                                    } else {
+                                        this.newerVersionNotification.show();
+                                    }
+                                }
+
+                                pimcore.helpers.showNotification(t("success"), t("saved_successfully"), "success");
                                 this.resetChanges();
                                 Ext.apply(this.data.general, rdata.general);
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
@@ -673,9 +673,9 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
     },
 
     saveClose: function (only) {
-        if (this.save()) {
+        this.save(null, only, function () {
             this.close();
-        }
+        }.bind(this))
     },
 
     publishClose: function () {
@@ -683,7 +683,6 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
             this.close();
         }.bind(this))
     },
-
 
     publish: function (only, callback) {
         return this.save("publish", only, callback, function (rdata) {
@@ -703,25 +702,28 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
         }.bind(this));
     },
 
-    unpublish: function () {
-        this.data.general.o_published = false;
+    unpublish: function (only, callback) {
+        this.save("unpublish", only, callback, function (rdata) {
+            if (rdata && rdata.success) {
+                this.data.general.o_published = false;
 
-        if (this.save("unpublish")) {
-            // toggle buttons
-            this.toolbarButtons.unpublish.hide();
-            this.toolbarButtons.save.show();
+                // toggle buttons
+                this.toolbarButtons.unpublish.hide();
+                this.toolbarButtons.save.show();
 
-            pimcore.elementservice.setElementPublishedState({
-                elementType: "object",
-                id: this.id,
-                published: false
-            });
-        }
+                pimcore.elementservice.setElementPublishedState({
+                    elementType: "object",
+                    id: this.id,
+                    published: false
+                });
+            }
+        }.bind(this))
     },
 
     unpublishClose: function () {
-        this.unpublish();
-        this.close();
+        this.unpublish(null, function () {
+            this.close();
+        }.bind(this));
     },
 
     saveToSession: function (callback) {
@@ -771,7 +773,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                         try {
                             var rdata = Ext.decode(response.responseText);
                             if (typeof successCallback == 'function') {
-                                //the successCallback function retrieves response data information
+                                // the successCallback function retrieves response data information
                                 successCallback(rdata);
                             }
                             if (rdata && rdata.success) {
@@ -810,14 +812,12 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                         }
                     }
 
-
                     this.tab.unmask();
 
                     if (typeof callback == "function") {
                         callback();
                     }
-
-                }.bind(this).bind(successCallback),
+                }.bind(this),
                 failure: function (response) {
                     this.tab.unmask();
                 }.bind(this)
@@ -829,7 +829,6 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
         }
         return false;
     },
-
 
     remove: function () {
         var options = {


### PR DESCRIPTION
We're validating documents (and their editables) on the server-side when publishing them and throw a `ValidationException` when they're not in a valid state.

The moment I click on the "Save & Publish" button, the buttons in the admin UI changes: the "Save" button disappears and the "Unpublish" button appears, etc.

But if now the exception is thrown, the document is not saved and the buttons display a wrong state. 

This PR tries to fix this.