### PR TITLE
Deprecated getElement() method on NotificationEvent and TranslationEvent

### DIFF
--- a/lib/Event/Model/NotificationEvent.php
+++ b/lib/Event/Model/NotificationEvent.php
@@ -56,6 +56,7 @@ class NotificationEvent extends Event implements ElementEventInterface
     }
 
     /**
+     * @deprecated use getNotification() instead - will be removed in Pimcore v7
      * @return Notification
      */
     public function getElement()

--- a/lib/Event/Model/TranslationEvent.php
+++ b/lib/Event/Model/TranslationEvent.php
@@ -56,6 +56,7 @@ class TranslationEvent extends Event implements ElementEventInterface
     }
 
     /**
+     * @deprecated use getTranslation() instead - will be removed in Pimcore v7
      * @return AbstractTranslation
      */
     public function getElement()


### PR DESCRIPTION
Actually `ElementEventInterface` is designed to be used by Element events, must be a copy & paste leftover I guess. 