### PR TITLE
fix: forbidden names can be added to class

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
@@ -21,7 +21,7 @@ pimcore.object.classes.data.data = Class.create({
                 "userpermissions","dependencies","modificationdate","usermodification","byid","bypath","data",
                 "versions","properties","permissions","permissionsforuser","childamount","apipluginbroker","resource",
                 "parentClass","definition","locked","language","omitmandatorycheck", "idpath", "object", "fieldname",
-                "property","localizedfields","parentId", "children", "scheduledTasks"
+                "property","localizedfields","parentid", "children", "scheduledtasks"
             ],
 
     /**


### PR DESCRIPTION
Caused by case sensitive check while field name is changed to lower case in the isValid() check.
Fixed by converting all forbidden names to lower case.

To reproduce: add the field 'parentid', 'parentId', 'parentID' or 'pArEnTiD' to a class (you get the idea). It's all allowed.
Relates to https://github.com/pimcore/pimcore/issues/2677