### PR TITLE
Improve forbidden names checks

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
@@ -279,19 +279,19 @@ pimcore.object.klass = Class.create({
 
     addClassComplete: function (className, classIdentifier, classes) {
 
-        var classNameRegresult = className.match(/[a-zA-Z][a-zA-Z0-9_]+/);
-        var underscoresRegresult = className.match(/^(query|store|relations)_[^_]+$/);
-        var isForbiddenName = in_array(className.toLowerCase(), this.forbiddenNames)
+        var reservedNameRegex = /^(query|store|relations)_[^_]+$/;
 
-        if (className.length <= 2 || classNameRegresult != className || underscoresRegresult || isForbiddenName) {
+        var isValidClassName = /^[a-zA-Z][a-zA-Z0-9_]+$/.test(className);
+        var isForbiddenName = in_array(className.toLowerCase(), this.forbiddenNames);
+
+        if (className.length <= 2 || isValidClassName || reservedNameRegex.test(className) || isForbiddenName) {
             Ext.Msg.alert(' ', t('invalid_class_name'));
             return false;
         }
 
-        var classIdentifierRegresult = classIdentifier.match(/[a-zA-Z0-9][a-zA-Z0-9_]*/);
-        var underscoresRegresult = classIdentifier.match(/^(query|store|relations)_[^_]+$/);
+        var isValidClassIdentifier = /^[a-zA-Z0-9][a-zA-Z0-9_]*$/.test(classIdentifier);
 
-        if (classIdentifier.length < 1 || classIdentifierRegresult != classIdentifier || underscoresRegresult) {
+        if (classIdentifier.length < 1 || isValidClassIdentifier || reservedNameRegex.test(classIdentifier)) {
             Ext.Msg.alert(' ', t('invalid_identifier'));
             return false;
         }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
@@ -284,7 +284,7 @@ pimcore.object.klass = Class.create({
 
         if (className.length <= 2 ||
             isReservedName.test(className) ||
-            isValidClassName.test(className) ||
+            !isValidClassName.test(className) ||
             in_arrayi(className, this.forbiddenNames)
         ) {
             Ext.Msg.alert(' ', t('invalid_class_name'));
@@ -293,7 +293,7 @@ pimcore.object.klass = Class.create({
 
         if (classIdentifier.length < 1 ||
             isReservedName.test(classIdentifier) ||
-            isValidClassIdentifier.test(classIdentifier)
+            !isValidClassIdentifier.test(classIdentifier)
         ) {
             Ext.Msg.alert(' ', t('invalid_identifier'));
             return false;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
@@ -14,7 +14,6 @@
 pimcore.registerNS("pimcore.object.klass");
 pimcore.object.klass = Class.create({
 
-    // Forbidden names must be lowercase!
     forbiddenNames: [
         "abstract", "class", "data", "folder", "list", "permissions", "resource", "concrete", "interface",
         "service", "fieldcollection", "localizedfield", "objectbrick"
@@ -279,24 +278,28 @@ pimcore.object.klass = Class.create({
 
     addClassComplete: function (className, classIdentifier, classes) {
 
-        var reservedNameRegex = /^(query|store|relations)_[^_]+$/;
+        var isReservedName = /^(query|store|relations)_[^_]+$/;
+        var isValidClassName = /^[a-zA-Z][a-zA-Z0-9_]+$/;
+        var isValidClassIdentifier = /^[a-zA-Z0-9][a-zA-Z0-9_]*$/;
 
-        var isValidClassName = /^[a-zA-Z][a-zA-Z0-9_]+$/.test(className);
-        var isForbiddenName = in_array(className.toLowerCase(), this.forbiddenNames);
-
-        if (className.length <= 2 || isValidClassName || reservedNameRegex.test(className) || isForbiddenName) {
+        if (className.length <= 2 ||
+            isReservedName.test(className) ||
+            isValidClassName.test(className) ||
+            in_arrayi(className, this.forbiddenNames)
+        ) {
             Ext.Msg.alert(' ', t('invalid_class_name'));
             return false;
         }
 
-        var isValidClassIdentifier = /^[a-zA-Z0-9][a-zA-Z0-9_]*$/.test(classIdentifier);
-
-        if (classIdentifier.length < 1 || isValidClassIdentifier || reservedNameRegex.test(classIdentifier)) {
+        if (classIdentifier.length < 1 ||
+            isReservedName.test(classIdentifier) ||
+            isValidClassIdentifier.test(classIdentifier)
+        ) {
             Ext.Msg.alert(' ', t('invalid_identifier'));
             return false;
         }
 
-        if (in_array(classIdentifier.toLowerCase(), classes["existingIds"])) {
+        if (in_arrayi(classIdentifier, classes["existingIds"])) {
             Ext.Msg.alert(' ', t('identifier_already_exists'));
             return false;
         }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
@@ -14,9 +14,11 @@
 pimcore.registerNS("pimcore.object.klass");
 pimcore.object.klass = Class.create({
 
-    forbiddennames: ["abstract", "class", "data", "folder", "list", "permissions", "resource", "concrete", "interface",
-        "service", "fieldcollection", "localizedfield", "objectbrick"],
-
+    // Forbidden names must be lowercase!
+    forbiddenNames: [
+        "abstract", "class", "data", "folder", "list", "permissions", "resource", "concrete", "interface",
+        "service", "fieldcollection", "localizedfield", "objectbrick"
+    ],
 
     initialize: function () {
 
@@ -279,9 +281,9 @@ pimcore.object.klass = Class.create({
 
         var classNameRegresult = className.match(/[a-zA-Z][a-zA-Z0-9_]+/);
         var underscoresRegresult = className.match(/^(query|store|relations)_[^_]+$/);
+        var isForbiddenName = in_array(className.toLowerCase(), this.forbiddenNames)
 
-        if (className.length <= 2 || classNameRegresult != className ||underscoresRegresult
-            || in_array(className.toLowerCase(), this.forbiddennames)) {
+        if (className.length <= 2 || classNameRegresult != className || underscoresRegresult || isForbiddenName) {
             Ext.Msg.alert(' ', t('invalid_class_name'));
             return false;
         }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
@@ -1430,9 +1430,9 @@ pimcore.object.classes.klass = Class.create({
         this.saveCurrentNode();
 
         var regresult = this.data["name"].match(/[a-zA-Z][a-zA-Z0-9]+/);
+        var isForbiddenName = in_array(this.data["name"].toLowerCase(), this.parentPanel.forbiddenNames);
 
-        if (this.data["name"].length > 2 && regresult == this.data["name"] && !in_array(this.data["name"].toLowerCase(),
-            this.parentPanel.forbiddennames)) {
+        if (this.data["name"].length > 2 && regresult == this.data["name"] && !isForbiddenName) {
             delete this.data.layoutDefinitions;
 
             var m = Ext.encode(this.getData());

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
@@ -1429,10 +1429,12 @@ pimcore.object.classes.klass = Class.create({
 
         this.saveCurrentNode();
 
-        var isValidName = /^[a-zA-Z][a-zA-Z0-9]+$/.test(this.data["name"]);
-        var isForbiddenName = in_array(this.data["name"].toLowerCase(), this.parentPanel.forbiddenNames);
+        var isValidName = /^[a-zA-Z][a-zA-Z0-9]+$/;
 
-        if (this.data["name"].length > 2 && isValidName && !isForbiddenName) {
+        if (this.data["name"].length > 2 &&
+            isValidName.test(this.data["name"]) &&
+            !in_arrayi(this.data["name"], this.parentPanel.forbiddenNames)
+        ) {
             delete this.data.layoutDefinitions;
 
             var m = Ext.encode(this.getData());

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
@@ -1429,10 +1429,10 @@ pimcore.object.classes.klass = Class.create({
 
         this.saveCurrentNode();
 
-        var regresult = this.data["name"].match(/[a-zA-Z][a-zA-Z0-9]+/);
+        var isValidName = /^[a-zA-Z][a-zA-Z0-9]+$/.test(this.data["name"]);
         var isForbiddenName = in_array(this.data["name"].toLowerCase(), this.parentPanel.forbiddenNames);
 
-        if (this.data["name"].length > 2 && regresult == this.data["name"] && !isForbiddenName) {
+        if (this.data["name"].length > 2 && isValidName && !isForbiddenName) {
             delete this.data.layoutDefinitions;
 
             var m = Ext.encode(this.getData());

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
@@ -15,8 +15,6 @@ pimcore.registerNS("pimcore.object.classes.data.data");
 pimcore.object.classes.data.data = Class.create({
 
     invalidFieldNames: false,
-
-    // Forbidden names must be lowercase!
     forbiddenNames: [
         "id", "key", "path", "type", "index", "classname", "creationdate", "userowner", "value", "class", "list",
         "fullpath", "childs", "values", "cachetag", "cachetags", "parent", "published", "valuefromparent",
@@ -300,10 +298,10 @@ pimcore.object.classes.data.data = Class.create({
         var data = this.getData();
         data.name = trim(data.name);
 
-        var isValidName = /^[a-zA-Z][a-zA-Z0-9_]*$/.test(data.name);
-        var isForbiddenName = in_array(data.name.toLowerCase(), this.forbiddenNames);
+        var isValidName = /^[a-zA-Z][a-zA-Z0-9_]*$/;
+        var isForbiddenName = in_arrayi(data.name, this.forbiddenNames);
 
-        if (data.name.length > 1 && isValidName && !isForbiddenName) {
+        if (data.name.length > 1 && isValidName.test(data.name) && !isForbiddenName) {
             return true;
         }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
@@ -15,14 +15,16 @@ pimcore.registerNS("pimcore.object.classes.data.data");
 pimcore.object.classes.data.data = Class.create({
 
     invalidFieldNames: false,
+
+    // Forbidden names must be lowercase!
     forbiddenNames: [
-                "id","key","path","type","index","classname","creationdate","userowner","value","class","list",
-                "fullpath","childs","values","cachetag","cachetags","parent","published","valuefromparent",
-                "userpermissions","dependencies","modificationdate","usermodification","byid","bypath","data",
-                "versions","properties","permissions","permissionsforuser","childamount","apipluginbroker","resource",
-                "parentClass","definition","locked","language","omitmandatorycheck", "idpath", "object", "fieldname",
-                "property","localizedfields","parentId", "children", "scheduledTasks"
-            ],
+        "id", "key", "path", "type", "index", "classname", "creationdate", "userowner", "value", "class", "list",
+        "fullpath", "childs", "values", "cachetag", "cachetags", "parent", "published", "valuefromparent",
+        "userpermissions", "dependencies", "modificationdate", "usermodification", "byid", "bypath", "data",
+        "versions", "properties", "permissions", "permissionsforuser", "childamount", "apipluginbroker", "resource",
+        "parentClass", "definition", "locked", "language", "omitmandatorycheck", "idpath", "object", "fieldname",
+        "property", "localizedfields", "parentid", "children", "scheduledtasks"
+    ],
 
     /**
      * define where this datatype is allowed
@@ -295,19 +297,20 @@ pimcore.object.classes.data.data = Class.create({
 
     isValid: function () {
 
-
         var data = this.getData();
         data.name = trim(data.name);
-        var regresult = data.name.match(/[a-zA-Z][a-zA-Z0-9_]*/);
 
-        if (data.name.length > 1 && regresult == data.name
-                            && in_array(data.name.toLowerCase(), this.forbiddenNames) == false) {
+        var regresult = data.name.match(/[a-zA-Z][a-zA-Z0-9_]*/);
+        var isForbiddenName = in_array(data.name.toLowerCase(), this.forbiddenNames);
+
+        if (data.name.length > 1 && regresult == data.name && !isForbiddenName) {
             return true;
         }
 
-        if(in_array(data.name.toLowerCase(), this.forbiddenNames)==true){
+        if (isForbiddenName) {
             this.invalidFieldNames = true;
         }
+
         return false;
     },
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
@@ -300,10 +300,10 @@ pimcore.object.classes.data.data = Class.create({
         var data = this.getData();
         data.name = trim(data.name);
 
-        var regresult = data.name.match(/[a-zA-Z][a-zA-Z0-9_]*/);
+        var isValidName = /^[a-zA-Z][a-zA-Z0-9_]*$/.test(data.name);
         var isForbiddenName = in_array(data.name.toLowerCase(), this.forbiddenNames);
 
-        if (data.name.length > 1 && regresult == data.name && !isForbiddenName) {
+        if (data.name.length > 1 && isValidName && !isForbiddenName) {
             return true;
         }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/fieldcollection.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/fieldcollection.js
@@ -14,7 +14,6 @@
 pimcore.registerNS("pimcore.object.fieldcollection");
 pimcore.object.fieldcollection = Class.create({
 
-    // Forbidden names must be lowercase!
     forbiddenNames: [
         "abstract", "class", "data", "folder", "list", "permissions", "resource", "concrete", "interface"
     ],
@@ -190,10 +189,9 @@ pimcore.object.fieldcollection = Class.create({
 
     addFieldComplete: function (button, value, object) {
 
-        var isValidName = /^[a-zA-Z]+$/.test(value);
-        var isForbiddenName = in_array(value.toLowerCase(), this.forbiddenNames);
+        var isValidName = /^[a-zA-Z]+$/;
 
-        if (button == "ok" && value.length > 2 && isValidName && !isForbiddenName) {
+        if (button == "ok" && value.length > 2 && isValidName.test(value) && !in_arrayi(value, this.forbiddenNames)) {
             Ext.Ajax.request({
                 url: Routing.generate('pimcore_admin_dataobject_class_fieldcollectionupdate'),
                 method: 'POST',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/fieldcollection.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/fieldcollection.js
@@ -190,10 +190,10 @@ pimcore.object.fieldcollection = Class.create({
 
     addFieldComplete: function (button, value, object) {
 
-        var regresult = value.match(/[a-zA-Z]+/);
+        var isValidName = /^[a-zA-Z]+$/.test(value);
         var isForbiddenName = in_array(value, this.forbiddenNames);
 
-        if (button == "ok" && value.length > 2 && regresult == value && !isForbiddenName) {
+        if (button == "ok" && value.length > 2 && isValidName && !isForbiddenName) {
             Ext.Ajax.request({
                 url: Routing.generate('pimcore_admin_dataobject_class_fieldcollectionupdate'),
                 method: 'POST',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/fieldcollection.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/fieldcollection.js
@@ -14,6 +14,11 @@
 pimcore.registerNS("pimcore.object.fieldcollection");
 pimcore.object.fieldcollection = Class.create({
 
+    // Forbidden names must be lowercase!
+    forbiddenNames: [
+        "abstract", "class", "data", "folder", "list", "permissions", "resource", "concrete", "interface"
+    ],
+
     initialize: function () {
 
         this.getTabPanel();
@@ -186,10 +191,9 @@ pimcore.object.fieldcollection = Class.create({
     addFieldComplete: function (button, value, object) {
 
         var regresult = value.match(/[a-zA-Z]+/);
-        var forbiddennames = ["abstract","class","data","folder","list","permissions","resource",
-                                                        "concrete","interface"];
+        var isForbiddenName = in_array(value, this.forbiddenNames);
 
-        if (button == "ok" && value.length > 2 && regresult == value && !in_array(value, forbiddennames)) {
+        if (button == "ok" && value.length > 2 && regresult == value && !isForbiddenName) {
             Ext.Ajax.request({
                 url: Routing.generate('pimcore_admin_dataobject_class_fieldcollectionupdate'),
                 method: 'POST',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/fieldcollection.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/fieldcollection.js
@@ -191,7 +191,7 @@ pimcore.object.fieldcollection = Class.create({
     addFieldComplete: function (button, value, object) {
 
         var isValidName = /^[a-zA-Z]+$/.test(value);
-        var isForbiddenName = in_array(value, this.forbiddenNames);
+        var isForbiddenName = in_array(value.toLowerCase(), this.forbiddenNames);
 
         if (button == "ok" && value.length > 2 && isValidName && !isForbiddenName) {
             Ext.Ajax.request({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbrick.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbrick.js
@@ -14,7 +14,6 @@
 pimcore.registerNS("pimcore.object.objectbrick");
 pimcore.object.objectbrick = Class.create(pimcore.object.fieldcollection, {
 
-    // Forbidden names must be lowercase!
     forbiddenNames: [
         "abstract", "class", "data", "folder", "list", "permissions", "resource", "dao", "concrete", "items",
         "object", "interface"
@@ -146,10 +145,9 @@ pimcore.object.objectbrick = Class.create(pimcore.object.fieldcollection, {
 
     addFieldComplete: function (button, value, object) {
 
-        var isValidName = /^[a-zA-Z][a-zA-Z0-9]*$/.test(value);
-        var isForbiddenName = in_array(value.toLowerCase(), this.forbiddenNames);
+        var isValidName = /^[a-zA-Z][a-zA-Z0-9]*$/;
 
-        if (button == "ok" && value.length > 2 && isValidName && !isForbiddenName) {
+        if (button == "ok" && value.length > 2 && isValidName.test(value) && !in_arrayi(value, this.forbiddenNames)) {
             Ext.Ajax.request({
                 url: Routing.generate('pimcore_admin_dataobject_class_objectbrickupdate'),
                 method: 'POST',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbrick.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbrick.js
@@ -14,6 +14,12 @@
 pimcore.registerNS("pimcore.object.objectbrick");
 pimcore.object.objectbrick = Class.create(pimcore.object.fieldcollection, {
 
+    // Forbidden names must be lowercase!
+    forbiddenNames: [
+        "abstract", "class", "data", "folder", "list", "permissions", "resource", "dao", "concrete", "items",
+        "object", "interface"
+    ],
+
     getTabPanel: function () {
 
         if (!this.panel) {
@@ -141,10 +147,9 @@ pimcore.object.objectbrick = Class.create(pimcore.object.fieldcollection, {
     addFieldComplete: function (button, value, object) {
 
         var regresult = value.match(/[a-zA-Z]+[a-zA-Z0-9]*/);
-        var forbiddennames = ["abstract","class","data","folder","list","permissions","resource","dao", "concrete",
-            "items", "object", "interface"];
+        var isForbiddenName = in_arrayi(value, this.forbiddenNames);
 
-        if (button == "ok" && value.length > 2 && regresult == value && !in_arrayi(value, forbiddennames)) {
+        if (button == "ok" && value.length > 2 && regresult == value && !isForbiddenName) {
             Ext.Ajax.request({
                 url: Routing.generate('pimcore_admin_dataobject_class_objectbrickupdate'),
                 method: 'POST',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbrick.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbrick.js
@@ -147,7 +147,7 @@ pimcore.object.objectbrick = Class.create(pimcore.object.fieldcollection, {
     addFieldComplete: function (button, value, object) {
 
         var isValidName = /^[a-zA-Z][a-zA-Z0-9]*$/.test(value);
-        var isForbiddenName = in_arrayi(value, this.forbiddenNames);
+        var isForbiddenName = in_array(value.toLowerCase(), this.forbiddenNames);
 
         if (button == "ok" && value.length > 2 && isValidName && !isForbiddenName) {
             Ext.Ajax.request({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbrick.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbrick.js
@@ -146,10 +146,10 @@ pimcore.object.objectbrick = Class.create(pimcore.object.fieldcollection, {
 
     addFieldComplete: function (button, value, object) {
 
-        var regresult = value.match(/[a-zA-Z]+[a-zA-Z0-9]*/);
+        var isValidName = /^[a-zA-Z][a-zA-Z0-9]*$/.test(value);
         var isForbiddenName = in_arrayi(value, this.forbiddenNames);
 
-        if (button == "ok" && value.length > 2 && regresult == value && !isForbiddenName) {
+        if (button == "ok" && value.length > 2 && isValidName && !isForbiddenName) {
             Ext.Ajax.request({
                 url: Routing.generate('pimcore_admin_dataobject_class_objectbrickupdate'),
                 method: 'POST',


### PR DESCRIPTION
Because of #7082 I took a deeper look at the forbidden names checks in the admin backend. 

Here are some fixes/improvements:
- consistent naming: forbiddennames → forbiddenNames
- consistent definition as class fields instead of locale variables in functions
- consistently check via `in_arrayi` instead of `in_array` (so it doesn't matter if someone adds them in mixed case again)
- use `regex.test(string)` instead of `string.match(regex) == string`