### PR TITLE
Fixed: programmatically setting children of type "variant" will not be loaded when calling getChildren([AbstractObject::OBJECT_TYPE_VARIANT])

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -7,6 +7,7 @@ If you have custom editables or wysiwyg global config then please change namespa
 - Javascript - Class `pimcore.document.tag` is deprecated as well and will be removed in 7. Use new class `pimcore.document.editable` instead.
 - All classes in namespace `Pimcore\Document\Tag` moved to new namespace `Pimcore\Document\Editable` (including their services) for better readability and marked as deprecated. Please update custom document editable classes and mappings. [#6921](https://github.com/pimcore/pimcore/pull/6921)
 - All `document_tag_` css classes are deprecated and will be removed in Pimcore 7. Use new classes `document_editable_` for custom styling of document editables.
+- If `AbstractObject` was extended and `setChildren()` overridden, you'll run into a **BC**.
 
 ## 6.7.0
 - [Ecommerce][IndexService] Elastic Search worker does not use mockup cache anymore. Now mockup objects are build directly based on information in response of ES response (_source flag). Therefore `AbstractElasticSearch` Worker does not extend `AbstractMockupCacheWorker` anymore. 

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -7,7 +7,7 @@ If you have custom editables or wysiwyg global config then please change namespa
 - Javascript - Class `pimcore.document.tag` is deprecated as well and will be removed in 7. Use new class `pimcore.document.editable` instead.
 - All classes in namespace `Pimcore\Document\Tag` moved to new namespace `Pimcore\Document\Editable` (including their services) for better readability and marked as deprecated. Please update custom document editable classes and mappings. [#6921](https://github.com/pimcore/pimcore/pull/6921)
 - All `document_tag_` css classes are deprecated and will be removed in Pimcore 7. Use new classes `document_editable_` for custom styling of document editables.
-- If `AbstractObject` was extended and `setChildren()` overridden, you'll run into a **BC**.
+- Method signature `AbstractObject::setChildren($children)` has been updated to `AbstractObject::setChildren($children, array $objectTypes = [self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_FOLDER], $includingUnpublished = false)`.
 
 ## 6.7.0
 - [Ecommerce][IndexService] Elastic Search worker does not use mockup cache anymore. Now mockup objects are build directly based on information in response of ES response (_source flag). Therefore `AbstractElasticSearch` Worker does not extend `AbstractMockupCacheWorker` anymore. 

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1118,10 +1118,12 @@ class AbstractObject extends Model\Element\AbstractElement
 
     /**
      * @param array|null $children
+     * @param array $objectTypes
+     * @param bool $includingUnpublished
      *
      * @return $this
      */
-    public function setChildren($children)
+    public function setChildren($children, array $objectTypes = [self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_FOLDER], $includingUnpublished = false)
     {
         if ($children === null) {
             // unset all cached children
@@ -1129,7 +1131,7 @@ class AbstractObject extends Model\Element\AbstractElement
             $this->o_hasChildren = [];
         } elseif (is_array($children)) {
             //default cache key
-            $cacheKey = $this->getListingCacheKey();
+            $cacheKey = $this->getListingCacheKey([$objectTypes, $includingUnpublished]);
             $this->o_children[$cacheKey] = $children;
             $this->o_hasChildren[$cacheKey] = (bool) count($children);
         }


### PR DESCRIPTION
## Description
When programmatically creating an object and its variants then setting the variants via `setChildren($variants)` will result in unexpected behaviour when trying to call `getChildren([AbstractObject::OBJECT_TYPE_VARIANT])`, if the object/variants is/are never saved.

## Expected Behaviour
Whenever the method `setChildren` is called, I'd expect it to return the same children when calling `getChildren`.

## Actual Behaviour
When calling `getChildren([AbstractObject::OBJECT_TYPE_VARIANT])`, the returned array is empty.

## Example Code
```php
$product = new Product();
$product->setChildren($variants);
p_r($product->getChildren([AbstractObject::OBJECT_TYPE_VARIANT]));
```

## The Problem
Setting the children works differently than getting the children when it comes to building the cache key.
In the method `getChildren` one automatically defines the cache key with the passed arguments:

```php
$cacheKey = $this->getListingCacheKey(func_get_args());
```
However, in the method `setChildren`, the cache key is always the same:

```php
$cacheKey = $this->getListingCacheKey();
```

## The Solution
Building the cache key the same way as `getChildren` does, will resolve this issue:
```php
public function setChildren($children, array $objectTypes = [self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_FOLDER], $includingUnpublished = false)
    {
        if ($children === null) {
            // unset all cached children
            $this->o_children = [];
            $this->o_hasChildren = [];
        } elseif (is_array($children)) {
            //default cache key
            $cacheKey = $this->getListingCacheKey([$objectTypes, $includingUnpublished]);
            $this->o_children[$cacheKey] = $children;
            $this->o_hasChildren[$cacheKey] = (bool) count($children);
        }

        return $this;
    }
```

Now, when setting variants using `setChildren($variants, [AbstractObject::OBJECT_TYPE_VARIANT])` it is possible to retrieve the same variants using `getChildren([AbstractObject::OBJECT_TYPE_VARIANT])`.