### PR TITLE
Added translation support in the version tab of the data objects

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.php
@@ -11,6 +11,7 @@
 
 use Pimcore\Model\DataObject;
 
+$this->get('translate')->setDomain('admin');
 $fields = $this->object1->getClass()->getFieldDefinitions();
 ?>
 
@@ -82,7 +83,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
                     $v2 = $v2Container ? $lfd->getVersionPreview($v2Container->getLocalizedValue($lfd->getName(), $language)) : "";
                     ?>
                     <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                        <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($lfd->getTitle(), true, true) ?> (<?= $language; ?>)</td>
+                        <td><?= $this->translate($lfd->getTitle()) ?> (<?= $language; ?>)</td>
                         <td><?= $lfd->getName() ?></td>
                         <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                             <td><?= $v1 ?></td>
@@ -162,7 +163,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
                         ?>
 
                         <tr class = "<?php if ($c % 2) { ?> odd<?php  } ?>">
-                            <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($definition->getTitle(), true, true) ?></td>
+                            <td><?= $this->translate($definition->getTitle()) ?></td>
                             <td><?= $groupDefinition->getName() ?> - <?= $keyGroupRelation->getName()?> <?= $definition->isLocalized() ? "/ " . $language : "" ?></td>
                             <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                                 <td><?= $preview1 ?></td>
@@ -197,7 +198,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
                         <?php foreach (\Pimcore\Tool::getValidLanguages() as $language) { ?>
                             <?php foreach ($lfd->getFieldDefinitions() as $localizedFieldDefinition) { ?>
                                 <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                                    <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($localizedFieldDefinition->getTitle(), true, true) ?> (<?= $language; ?>)</td>
+                                    <td><?= $this->translate($localizedFieldDefinition->getTitle()) ?> (<?= $language; ?>)</td>
                                     <td><?= $localizedFieldDefinition->getName() ?></td>
 
                                     <?php
@@ -254,7 +255,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
 
                         ?>
                         <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                            <td><?= ucfirst($asAllowedType) . " - " . \Pimcore\Model\Translation\Admin::getByKeyLocalized($lfd->getTitle(), true, true) ?></td>
+                            <td><?= ucfirst($asAllowedType) . " - " . $this->translate($lfd->getTitle()) ?></td>
                             <td><?= $lfd->getName() ?></td>
                             <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                                 <td><?= $v1 ?></td>
@@ -305,7 +306,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
 
                         ?>
                         <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                            <td><?= ucfirst($fieldItem1->getType()) . " - " . \Pimcore\Model\Translation\Admin::getByKeyLocalized($fieldKey1->title, true, true) ?></td>
+                            <td><?= ucfirst($fieldItem1->getType()) . " - " . $this->translate($fieldKey1->title) ?></td>
                             <td><?= $fieldKey1->name ?></td>
                             <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                                 <td><?= $v1 ?></td>
@@ -328,7 +329,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
 
                         ?>
                         <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                            <td><?= ucfirst($fieldItem2->getType()) . " - " . \Pimcore\Model\Translation\Admin::getByKeyLocalized($fieldKey2->title, true, true) ?></td>
+                            <td><?= ucfirst($fieldItem2->getType()) . " - " . $this->translate($fieldKey2->title) ?></td>
                             <td><?= $fieldKey2->name ?></td>
                             <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                                 <td><?= $v1 ?></td>
@@ -346,7 +347,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
             $v2 = $definition->getVersionPreview($this->object2->getValueForFieldName($fieldName));
             ?>
             <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($definition->getTitle(), true, true) ?></td>
+                <td><?= $this->translate($definition->getTitle()) ?></td>
                 <td><?= $definition->getName() ?></td>
                 <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                     <td><?= $v1 ?></td>

--- a/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.php
@@ -82,7 +82,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
                     $v2 = $v2Container ? $lfd->getVersionPreview($v2Container->getLocalizedValue($lfd->getName(), $language)) : "";
                     ?>
                     <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                        <td><?= $lfd->getTitle() ?> (<?= $language; ?>)</td>
+                        <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($lfd->getTitle(), true, true) ?> (<?= $language; ?>)</td>
                         <td><?= $lfd->getName() ?></td>
                         <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                             <td><?= $v1 ?></td>
@@ -162,7 +162,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
                         ?>
 
                         <tr class = "<?php if ($c % 2) { ?> odd<?php  } ?>">
-                            <td><?= $definition->getTitle() ?></td>
+                            <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($definition->getTitle(), true, true) ?></td>
                             <td><?= $groupDefinition->getName() ?> - <?= $keyGroupRelation->getName()?> <?= $definition->isLocalized() ? "/ " . $language : "" ?></td>
                             <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                                 <td><?= $preview1 ?></td>
@@ -197,7 +197,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
                         <?php foreach (\Pimcore\Tool::getValidLanguages() as $language) { ?>
                             <?php foreach ($lfd->getFieldDefinitions() as $localizedFieldDefinition) { ?>
                                 <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                                    <td><?= $localizedFieldDefinition->getTitle() ?> (<?= $language; ?>)</td>
+                                    <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($localizedFieldDefinition->getTitle(), true, true) ?> (<?= $language; ?>)</td>
                                     <td><?= $localizedFieldDefinition->getName() ?></td>
 
                                     <?php
@@ -254,7 +254,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
 
                         ?>
                         <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                            <td><?= ucfirst($asAllowedType) . " - " . $lfd->getTitle() ?></td>
+                            <td><?= ucfirst($asAllowedType) . " - " . \Pimcore\Model\Translation\Admin::getByKeyLocalized($lfd->getTitle(), true, true) ?></td>
                             <td><?= $lfd->getName() ?></td>
                             <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                                 <td><?= $v1 ?></td>
@@ -305,7 +305,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
 
                         ?>
                         <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                            <td><?= ucfirst($fieldItem1->getType()) . " - " . $fieldKey1->title ?></td>
+                            <td><?= ucfirst($fieldItem1->getType()) . " - " . \Pimcore\Model\Translation\Admin::getByKeyLocalized($fieldKey1->title, true, true) ?></td>
                             <td><?= $fieldKey1->name ?></td>
                             <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                                 <td><?= $v1 ?></td>
@@ -328,7 +328,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
 
                         ?>
                         <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                            <td><?= ucfirst($fieldItem2->getType()) . " - " . $fieldKey2->title ?></td>
+                            <td><?= ucfirst($fieldItem2->getType()) . " - " . \Pimcore\Model\Translation\Admin::getByKeyLocalized($fieldKey2->title, true, true) ?></td>
                             <td><?= $fieldKey2->name ?></td>
                             <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                                 <td><?= $v1 ?></td>
@@ -346,7 +346,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
             $v2 = $definition->getVersionPreview($this->object2->getValueForFieldName($fieldName));
             ?>
             <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                <td><?= $definition->getTitle() ?></td>
+                <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($definition->getTitle(), true, true) ?></td>
                 <td><?= $definition->getName() ?></td>
                 <?php if (!$this->isImportPreview || !$this->isNew) { ?>
                     <td><?= $v1 ?></td>

--- a/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/previewVersion.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/previewVersion.html.php
@@ -12,6 +12,7 @@
 
 use Pimcore\Model\DataObject;
 
+$this->get('translate')->setDomain('admin');
 $fields = $this->object->getClass()->getFieldDefinitions();
 
 ?>
@@ -48,7 +49,7 @@ $fields = $this->object->getClass()->getFieldDefinitions();
             <?php foreach (\Pimcore\Tool::getValidLanguages() as $language) { ?>
                 <?php foreach ($definition->getFieldDefinitions() as $lfd) { ?>
                     <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                        <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($lfd->getTitle(), true, true) ?> (<?= $language; ?>)</td>
+                        <td><?= $this->translate($lfd->getTitle()) ?> (<?= $language; ?>)</td>
                         <td><?= $lfd->getName() ?></td>
                         <td>
                             <?php
@@ -82,7 +83,7 @@ $fields = $this->object->getClass()->getFieldDefinitions();
                         <?php foreach (\Pimcore\Tool::getValidLanguages() as $language) { ?>
                             <?php foreach ($lfd->getFieldDefinitions() as $localizedFieldDefinition) { ?>
                                 <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                                    <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($localizedFieldDefinition->getTitle(), true, true) ?> (<?= $language; ?>)</td>
+                                    <td><?= $this->translate($localizedFieldDefinition->getTitle()) ?> (<?= $language; ?>)</td>
                                     <td><?= $localizedFieldDefinition->getName() ?></td>
                                     <td>
                                         <?php
@@ -109,7 +110,7 @@ $fields = $this->object->getClass()->getFieldDefinitions();
 
                         ?>
                         <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                            <td><?= ucfirst($asAllowedType) . " - " . \Pimcore\Model\Translation\Admin::getByKeyLocalized($lfd->getTitle(), true, true) ?></td>
+                            <td><?= ucfirst($asAllowedType) . " - " . $this->translate($lfd->getTitle()) ?></td>
                             <td><?= $lfd->getName() ?></td>
                             <td><?= $value ?></td>
                         </tr>
@@ -163,7 +164,7 @@ $fields = $this->object->getClass()->getFieldDefinitions();
                         ?>
 
                         <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                            <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($definition->getTitle(), true, true) ?></td>
+                            <td><?= $this->translate($definition->getTitle()) ?></td>
                             <td><?= $groupDefinition->getName() ?> - <?= $keyGroupRelation->getName() ?>
                                 / <?= $definition->isLocalized() ? $language : "" ?></td>
                             <td><?= $preview ?></td>
@@ -189,7 +190,7 @@ $fields = $this->object->getClass()->getFieldDefinitions();
                     foreach ($fieldKeys as $fieldKey) {
                         $value = $fieldItem->{"get" . ucfirst($fieldKey->name)}();  ?>
                         <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                            <td><?= ucfirst($fieldItem->getType()) . " - " . \Pimcore\Model\Translation\Admin::getByKeyLocalized($fieldKey->title, true, true) ?></td>
+                            <td><?= ucfirst($fieldItem->getType()) . " - " . $this->translate($fieldKey->title) ?></td>
                             <td><?= $fieldKey->name ?></td>
                             <td><?= $fieldKey->getVersionPreview($value) ?></td>
                         </tr>
@@ -201,7 +202,7 @@ $fields = $this->object->getClass()->getFieldDefinitions();
             ?>
         <?php } else { ?>
             <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($definition->getTitle(), true, true) ?></td>
+                <td><?= $this->translate($definition->getTitle()) ?></td>
                 <td><?= $definition->getName() ?></td>
                 <td><?= $definition->getVersionPreview($this->object->getValueForFieldName($fieldName)) ?></td>
             </tr>

--- a/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/previewVersion.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/previewVersion.html.php
@@ -48,7 +48,7 @@ $fields = $this->object->getClass()->getFieldDefinitions();
             <?php foreach (\Pimcore\Tool::getValidLanguages() as $language) { ?>
                 <?php foreach ($definition->getFieldDefinitions() as $lfd) { ?>
                     <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                        <td><?= $lfd->getTitle() ?> (<?= $language; ?>)</td>
+                        <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($lfd->getTitle(), true, true) ?> (<?= $language; ?>)</td>
                         <td><?= $lfd->getName() ?></td>
                         <td>
                             <?php
@@ -82,7 +82,7 @@ $fields = $this->object->getClass()->getFieldDefinitions();
                         <?php foreach (\Pimcore\Tool::getValidLanguages() as $language) { ?>
                             <?php foreach ($lfd->getFieldDefinitions() as $localizedFieldDefinition) { ?>
                                 <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                                    <td><?= $localizedFieldDefinition->getTitle() ?> (<?= $language; ?>)</td>
+                                    <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($localizedFieldDefinition->getTitle(), true, true) ?> (<?= $language; ?>)</td>
                                     <td><?= $localizedFieldDefinition->getName() ?></td>
                                     <td>
                                         <?php
@@ -109,7 +109,7 @@ $fields = $this->object->getClass()->getFieldDefinitions();
 
                         ?>
                         <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                            <td><?= ucfirst($asAllowedType) . " - " . $lfd->getTitle() ?></td>
+                            <td><?= ucfirst($asAllowedType) . " - " . \Pimcore\Model\Translation\Admin::getByKeyLocalized($lfd->getTitle(), true, true) ?></td>
                             <td><?= $lfd->getName() ?></td>
                             <td><?= $value ?></td>
                         </tr>
@@ -163,7 +163,7 @@ $fields = $this->object->getClass()->getFieldDefinitions();
                         ?>
 
                         <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                            <td><?= $definition->getTitle() ?></td>
+                            <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($definition->getTitle(), true, true) ?></td>
                             <td><?= $groupDefinition->getName() ?> - <?= $keyGroupRelation->getName() ?>
                                 / <?= $definition->isLocalized() ? $language : "" ?></td>
                             <td><?= $preview ?></td>
@@ -184,15 +184,12 @@ $fields = $this->object->getClass()->getFieldDefinitions();
             }
 
             if (!is_null($fieldItems) && count($fieldItems)) {
-
                 foreach ($fieldItems as $fkey => $fieldItem) {
                     $fieldKeys = $fieldDefinitions[$fieldItem->getType()]->getFieldDefinitions();
                     foreach ($fieldKeys as $fieldKey) {
-
-
                         $value = $fieldItem->{"get" . ucfirst($fieldKey->name)}();  ?>
                         <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                            <td><?= ucfirst($fieldItem->getType()) . " - " . $fieldKey->title ?></td>
+                            <td><?= ucfirst($fieldItem->getType()) . " - " . \Pimcore\Model\Translation\Admin::getByKeyLocalized($fieldKey->title, true, true) ?></td>
                             <td><?= $fieldKey->name ?></td>
                             <td><?= $fieldKey->getVersionPreview($value) ?></td>
                         </tr>
@@ -204,7 +201,7 @@ $fields = $this->object->getClass()->getFieldDefinitions();
             ?>
         <?php } else { ?>
             <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                <td><?= $definition->getTitle() ?></td>
+                <td><?= \Pimcore\Model\Translation\Admin::getByKeyLocalized($definition->getTitle(), true, true) ?></td>
                 <td><?= $definition->getName() ?></td>
                 <td><?= $definition->getVersionPreview($this->object->getValueForFieldName($fieldName)) ?></td>
             </tr>


### PR DESCRIPTION
Closes #7098 

Not sure if this is ok with " \Pimcore\Model\Translation\Admin::getByKeyLocalized" but " $this->translate" is only for the shared translations.