### PR TITLE
Support stream wrappers in LowQualityImagePreviewTask

### DIFF
--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -224,6 +224,13 @@ class Image extends Model\Asset
         if (class_exists('Imagick')) {
             // Imagick fallback
             $path = $this->getThumbnail(Image\Thumbnail\Config::getPreviewConfig())->getFileSystemPath();
+
+            if (!stream_is_local($path)) {
+                // imagick is only able to deal with local files
+                // if your're using custom stream wrappers this wouldn't work, so we create a temp. local copy
+                $path = $this->getTemporaryFile();
+            }
+
             $imagick = new \Imagick($path);
             $imagick->setImageFormat('jpg');
             $imagick->setOption('jpeg:extent', '1kb');


### PR DESCRIPTION
As https://github.com/pimcore/pimcore/blob/5dba19710d71e7843d19d2fed8e82feec022c348/lib/Image/Adapter/Imagick.php#L71-L76 correctly says Imagick does not support stream wrappers. The `LowQualityImagePreviewTask` does currently not handle this. 
This is especially necessary when `PIMCORE_TEMPORARY_DIRECTORY` uses a stream wrapper.