### PR TITLE
Pass params from link editable to link generator

### DIFF
--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -296,12 +296,17 @@ class Link extends Model\Document\Editable
                                 if ($realPath) {
                                     $this->data['path'] = $object->getFullPath();
                                 } else {
+                                    $parameters = [];
+                                    parse_str($this->getParameters(), $parameters);
                                     $this->data['path'] = $linkGenerator->generate(
                                         $object,
-                                        [
-                                            'document' => $this->getDocument(),
-                                            'context' => $this,
-                                        ]
+                                        array_merge(
+                                            $parameters,
+                                            [
+                                                'document' => $this->getDocument(),
+                                                'context' => $this,
+                                            ]
+                                        )
                                     );
                                 }
                             }


### PR DESCRIPTION
With this PR the defined params in the link editable now get passed to the link generator service. 

![image](https://user-images.githubusercontent.com/9052094/93451675-c7163580-f8d7-11ea-8ef9-63f15aa6594c.png)
