### PR TITLE
[Document] Link editable - generate absolute path for sub-site links

### DIFF
--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -280,7 +280,8 @@ class Link extends Model\Document\Editable
                     if ($editmode || (!Document::doHideUnpublished() || $doc->isPublished())) {
                         //check if document exist in sub site, if so, then set absolute path
                         /** @var Model\Site|null $site */
-                        if ($site = Frontend::getSiteForDocument($doc)) {
+                        $site = Frontend::getSiteForDocument($doc);
+                        if ($site) {
                             if ($site->getMainDomain()) {
                                 $scheme = \Pimcore\Tool::getRequestScheme() . '://';
                                 $this->data['path'] = $scheme . $site->getMainDomain() .

--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -279,7 +279,7 @@ class Link extends Model\Document\Editable
                 if ($doc = Document::getById($this->data['internalId'])) {
                     if ($editmode || (!Document::doHideUnpublished() || $doc->isPublished())) {
                         //check if document exist in sub site, if so, then set absolute path
-                        /** @var Model\Site $site */
+                        /** @var Model\Site|null $site */
                         if ($site = Frontend::getSiteForDocument($doc)) {
                             if ($site->getMainDomain()) {
                                 $scheme = \Pimcore\Tool::getRequestScheme() . '://';


### PR DESCRIPTION
## Changes in this pull request  

When using sub-site path in link editable, generate absolute url based on sub-site domain.

## Additional info  
![subsite_link](https://user-images.githubusercontent.com/5137917/93604183-53525680-f9c5-11ea-80d8-513d39cbf94d.png)

![image](https://user-images.githubusercontent.com/5137917/93604383-990f1f00-f9c5-11ea-9c01-bcf104bb1f41.png)
