### PR TITLE
Extends the configurability of custom views

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -149,9 +149,9 @@ class DataObjectController extends ElementControllerBase implements EventedContr
 
                 if ($cv['classes']) {
                     $cvConditions = [];
-                    $cvClasses = explode(',', $cv['classes']);
-                    foreach ($cvClasses as $cvClass) {
-                        $cvConditions[] = "objects.o_classId = '" . $cvClass . "'";
+                    $cvClasses = $cv['classes'];
+                    foreach ($cvClasses as $key => $cvClass) {
+                        $cvConditions[] = "objects.o_classId = '" . $key . "'";
                     }
 
                     $cvConditions[] = "objects.o_type = 'folder'";

--- a/bundles/AdminBundle/Controller/Admin/IndexController.php
+++ b/bundles/AdminBundle/Controller/Admin/IndexController.php
@@ -430,7 +430,7 @@ class IndexController extends AdminController implements EventedControllerInterf
 
                 if ($rootNode) {
                     $tmpData['rootId'] = $rootNode->getId();
-                    $tmpData['allowedClasses'] = isset($tmpData['classes']) && $tmpData['classes'] ? explode(',', $tmpData['classes']) : null;
+                    $tmpData['allowedClasses'] = isset($tmpData['classes']) && $tmpData['classes'] ? $tmpData['classes'] : null;
                     $tmpData['showroot'] = (bool)$tmpData['showroot'];
 
                     // Check if a user has privileges to that node

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
@@ -635,7 +635,7 @@ pimcore.object.tree = Class.create({
                     }
                 }
 
-                if (lockMenu.length > 0) {
+                if (lockMenu.length > 0 && perspectiveCfg.inTreeContextMenu("object.unlock")) {
                     advancedMenuItems.push({
                         text: t('lock'),
                         iconCls: "pimcore_icon_lock",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
@@ -348,9 +348,15 @@ pimcore.object.tree = Class.create({
 
             object_types.each(function (classRecord) {
 
-                if ($this.config.allowedClasses && !in_array(classRecord.get("id"), $this.config.allowedClasses)) {
+                if ($this.config.allowedClasses && !in_array(classRecord.get("id"), Object.keys($this.config.allowedClasses))) {
                     return;
                 }
+                
+                if ($this.config.allowedClasses && $this.config.allowedClasses[classRecord.get("id")] !== null) {
+                    if(record.data.depth >= $this.config.allowedClasses[classRecord.get("id")]) {
+                        return;
+                    }
+                };
 
                 tmpMenuEntry = {
                     text: classRecord.get("translatedText"),

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/20_Custom_Views.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/20_Custom_Views.md
@@ -21,6 +21,7 @@ The main idea for this configuration is to
 * not showing the parent folder as its root
 * showing it at the right side in expanded state (there can be only one expanded tree on each side)
 * do NOT show all blog articles which have the text "magnis" in their English title.
+* only the classes `Category` (class id: 5) and `Subarticle` (class id: SUBARTICLE) should be enabled to be added. `Category` is only allowed to be added on the first level of the object tree. `Subarticle` is available in the context menu of the object tree three levels deep.   
 
 ```php
 <?php
@@ -36,7 +37,10 @@ return [
             "id" => 1,
             "rootfolder" => "/blog",
             "showroot" => FALSE,
-            "classes" => "",
+            'classes' => [                                                      
+                "5" => 1,                                                                
+                "SUBARTICLE" => 3,                                      
+            ],
             "position" => "right",
             "sort" => "1",
             "expanded" => TRUE,

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/20_Custom_Views.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/20_Custom_Views.md
@@ -21,7 +21,7 @@ The main idea for this configuration is to
 * not showing the parent folder as its root
 * showing it at the right side in expanded state (there can be only one expanded tree on each side)
 * do NOT show all blog articles which have the text "magnis" in their English title.
-* only the classes `Category` (class id: 5) and `Subarticle` (class id: SUBARTICLE) should be enabled to be added. `Category` is only allowed to be added on the first level of the object tree. `Subarticle` is available in the context menu of the object tree three levels deep.   
+* only the classes `Category` (class id: 5) and `Subarticle` (class id: SUBARTICLE) should be enabled to be added. `Category` is only allowed to be added on the first level of the object tree. `Subarticle` is available in the context menu on the first three levels of the object tree.   
 
 ```php
 <?php

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -848,7 +848,7 @@ class Config implements \ArrayAccess
                 if ($rootNode) {
                     $tmpData['type'] = 'customview';
                     $tmpData['rootId'] = $rootNode->getId();
-                    $tmpData['allowedClasses'] = isset($tmpData['classes']) && $tmpData['classes'] ? explode(',', $tmpData['classes']) : null;
+                    $tmpData['allowedClasses'] = isset($tmpData['classes']) && $tmpData['classes'] ? $tmpData['classes'] : null;
                     $tmpData['showroot'] = (bool)$tmpData['showroot'];
                     $customViewId = $tmpData['id'];
                     $cfConfigMapping[$customViewId] = $tmpData;

--- a/lib/Tool.php
+++ b/lib/Tool.php
@@ -538,6 +538,16 @@ class Tool
             foreach ($confArray['views'] as $tmp) {
                 if (isset($tmp['name'])) {
                     $tmp['showroot'] = !empty($tmp['showroot']);
+                    
+                    if (!is_array($tmp['classes'])) {
+                        $flipArray = array();
+                        $tempClasses = explode(",",$tmp['classes']);
+                        
+                        foreach ($tempClasses as $tempClass) {
+                            $flipArray[$tempClass] = null;   
+                        }
+                        $tmp['classes'] = $flipArray;
+                    }
 
                     if (!empty($tmp['hidden'])) {
                         continue;


### PR DESCRIPTION
With this extension, you can define to which depth in a custom view object tree a specific object is available.
It's also backward compatible, both markups can be used:

- 'classes' => 'PRODUCT,3,CONFIGITEM'

- 'classes' => [
      "PRODUCT" => 1,  
      "3" => 3,
      "CONFIGITEM" => 4
   ],

This extension, in combination with a very limited custom view, is very helpful when working with automated hierarchy trees that depend heavily on inheritance and order levels. 
   
Plus an additional PR:
If an object, for example, has been locked by code, the unlock button in the context menu can be hidden as well.