### PR TITLE
Improve `Element::resolveDependencies()` implementations

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -2035,28 +2035,28 @@ class Asset extends Element\AbstractElement
      */
     public function resolveDependencies()
     {
-        $dependencies = parent::resolveDependencies();
+        $dependencies = [parent::resolveDependencies()];
 
         if ($this->hasMetaData) {
-            $metaData = $this->getMetadata();
+            $loader = \Pimcore::getContainer()->get('pimcore.implementation_loader.asset.metadata.data');
 
-            foreach ($metaData as $md) {
-                if (isset($md['data']) && $md['data']) {
+            foreach ($this->getMetadata() as $metaData) {
+                if (!empty($metaData['data'])) {
                     /** @var ElementInterface $elementData */
-                    $elementData = $md['data'];
-                    $elementType = $md['type'];
-                    $loader = \Pimcore::getContainer()->get('pimcore.implementation_loader.asset.metadata.data');
-                    /** @var DataDefinitionInterface $implementation */
+                    $elementData = $metaData['data'];
+                    $elementType = $metaData['type'];
+
                     try {
+                        /** @var DataDefinitionInterface $implementation */
                         $implementation = $loader->build($elementType);
-                        $dependencies = array_merge($dependencies, $implementation->resolveDependencies($elementData, $md));
+                        $dependencies[] = $implementation->resolveDependencies($elementData, $metaData);
                     } catch (UnsupportedException $e) {
                     }
                 }
             }
         }
 
-        return $dependencies;
+        return array_merge(...$dependencies);
     }
 
     public function __clone()

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -379,15 +379,11 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
         if ($this->getClass() instanceof ClassDefinition) {
             foreach ($this->getClass()->getFieldDefinitions() as $field) {
                 $key = $field->getName();
-                $dependencies[] = $field->resolveDependencies(
-                    isset($this->$key) ? $this->$key : null
-                );
+                $dependencies[] = $field->resolveDependencies($this->$key ?? null);
             }
         }
 
-        $dependencies = array_merge(...$dependencies);
-
-        return $dependencies;
+        return array_merge(...$dependencies);
     }
 
     /**

--- a/models/Document/Hardlink.php
+++ b/models/Document/Hardlink.php
@@ -70,12 +70,13 @@ class Hardlink extends Document
     public function resolveDependencies()
     {
         $dependencies = parent::resolveDependencies();
+        $sourceDocument = $this->getSourceDocument();
 
-        if ($this->getSourceDocument() instanceof Document) {
-            $key = 'document_' . $this->getSourceDocument()->getId();
+        if ($sourceDocument instanceof Document) {
+            $key = 'document_' . $sourceDocument->getId();
 
             $dependencies[$key] = [
-                'id' => $this->getSourceDocument()->getId(),
+                'id' => $sourceDocument->getId(),
                 'type' => 'document',
             ];
         }

--- a/models/Document/Link.php
+++ b/models/Document/Link.php
@@ -78,8 +78,6 @@ class Link extends Model\Document
     protected $href = '';
 
     /**
-     * @see Document::resolveDependencies
-     *
      * @return array
      */
     public function resolveDependencies()
@@ -87,11 +85,13 @@ class Link extends Model\Document
         $dependencies = parent::resolveDependencies();
 
         if ($this->getLinktype() == 'internal') {
-            if ($this->getObject() instanceof Document || $this->getObject() instanceof Asset) {
-                $key = $this->getInternalType() . '_' . $this->getObject()->getId();
+            $element = $this->getObject();
+
+            if ($element instanceof Document || $element instanceof Asset) {
+                $key = $this->getInternalType() . '_' . $element->getId();
 
                 $dependencies[$key] = [
-                    'id' => $this->getObject()->getId(),
+                    'id' => $element->getId(),
                     'type' => $this->getInternalType(),
                 ];
             }

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -239,27 +239,27 @@ abstract class PageSnippet extends Model\Document
     }
 
     /**
-     * @see Document::resolveDependencies
-     *
      * @return array
      */
     public function resolveDependencies()
     {
-        $dependencies = parent::resolveDependencies();
+        $dependencies = [parent::resolveDependencies()];
 
         foreach ($this->getEditables() as $editable) {
-            $dependencies = array_merge($dependencies, $editable->resolveDependencies());
+            $dependencies[] = $editable->resolveDependencies();
         }
 
         if ($this->getContentMasterDocument() instanceof Document) {
-            $key = 'document_' . $this->getContentMasterDocument()->getId();
-            $dependencies[$key] = [
-                'id' => $this->getContentMasterDocument()->getId(),
-                'type' => 'document',
+            $masterDocumentId = $this->getContentMasterDocument()->getId();
+            $dependencies[] = [
+                'document_' . $masterDocumentId => [
+                    'id' => $masterDocumentId,
+                    'type' => 'document',
+                ],
             ];
         }
 
-        return $dependencies;
+        return array_merge(...$dependencies);
     }
 
     /**

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -180,15 +180,12 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
 
         // check for properties
         if (method_exists($this, 'getProperties')) {
-            $properties = $this->getProperties();
-            foreach ($properties as $property) {
+            foreach ($this->getProperties() as $property) {
                 $dependencies[] = $property->resolveDependencies();
             }
         }
 
-        $dependencies = array_merge(...$dependencies);
-
-        return $dependencies;
+        return array_merge(...$dependencies);
     }
 
     /**


### PR DESCRIPTION
This improves performance a bit by not calling `array_merge` inside loops (which was already done in `Pimcore\Model\Element\AbstractElement` and `Pimcore\Model\DataObject\Concrete'`) and pulling a container fetch outside a loop. Also, there's some general code cleanup.