### PR TITLE
Improve the verbosity of validation messages

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -1161,6 +1161,9 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
                                     throw new $exceptionClass($e->getMessage() . ' fieldname=' . $fd->getName(), $e->getCode(), $e->getPrevious());
                                 }
                             } else {
+                                if ($e instanceof Model\Element\ValidationException) {
+                                    throw $e;
+                                }
                                 $exceptionClass = get_class($e);
                                 throw new $exceptionClass($e->getMessage() . ' fieldname=' . $fd->getName(), $e->getCode(), $e);
                             }

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -144,6 +144,9 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
                                 throw new $exceptionClass($e->getMessage() . ' fieldname=' . $fd->getName(), $e->getCode(), $e->getPrevious());
                             }
                         } else {
+                            if ($e instanceof Model\Element\ValidationException) {
+                                throw $e;
+                            }
                             $exceptionClass = get_class($e);
                             throw new $exceptionClass($e->getMessage() . ' fieldname=' . $fd->getName(), $e->getCode(), $e);
                         }
@@ -168,10 +171,14 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
                         $subItemParts = [];
                         /** @var \Exception $subItem */
                         foreach ($subItems as $subItem) {
-                            $subItemParts[] = $subItem->getMessage();
+                            $subItemMessage = $subItem->getMessage();
+                            if ($subItem instanceof Model\Element\ValidationException) {
+                                $subItemMessage .= '[ ' . $subItem->getContextStack()[0] . ' ]';
+                            }
+                            $subItemParts[] = $subItemMessage;
                         }
-                        $msg .= implode(',', $subItems);
-                        $msg .= ' (';
+                        $msg .= implode(', ', $subItemParts);
+                        $msg .= ')';
                     }
                 }
                 $errors[] = $msg;


### PR DESCRIPTION
## Changes in this pull request  
This pull request fixes and improves very incomplete display of validation messages when saving Data Objects. The fix will improve validation messages of Localized Fields and Field collections. The context is also added so it now can be recognised in which language and which Field-Collection-Entry the field is incomplete. 

Before:
<img width="700" alt="2020-09-22_00-26-22" src="https://user-images.githubusercontent.com/10233647/93833917-693c7180-fc7a-11ea-833f-59919821b757.png">

After:
<img width="700" alt="2020-09-22_00-20-45" src="https://user-images.githubusercontent.com/10233647/93833926-6e99bc00-fc7a-11ea-8d63-af1bf085b7b9.png">

Above messages are based on this empty form:
<img width="804" alt="2020-09-22_01-12-27" src="https://user-images.githubusercontent.com/10233647/93833950-7d806e80-fc7a-11ea-9f5d-bf8c2e798312.png">

The example message above might seem too complex, but this is because a huge amount of fields was on purpose left empty for demonstration purposes.

