### PR TITLE
Backend Search CleanupData: Replace strip_tags function by regex

### DIFF
--- a/models/Search/Backend/Data.php
+++ b/models/Search/Backend/Data.php
@@ -507,7 +507,7 @@ class Data extends \Pimcore\Model\AbstractModel
      */
     protected function cleanupData($data)
     {
-        $data = preg_replace('/(<\?.*?(\?>|$)|<.*?>)/', '', $data);
+        $data = preg_replace('/(<\?.*?(\?>|$)|<.*?>)/s', '', $data);
 
         $data = html_entity_decode($data, ENT_QUOTES, 'UTF-8');
 

--- a/models/Search/Backend/Data.php
+++ b/models/Search/Backend/Data.php
@@ -507,7 +507,7 @@ class Data extends \Pimcore\Model\AbstractModel
      */
     protected function cleanupData($data)
     {
-        $data = strip_tags($data);
+        $data = preg_replace('/(<\?.*?(\?>|$)|<.*?>)/', '', $data);
 
         $data = html_entity_decode($data, ENT_QUOTES, 'UTF-8');
 


### PR DESCRIPTION
# Bug Report
This pull request resolves a search backend indexing issue where greater than and/or less than characters are used.

### Expected behavior
If a DataObject with the following text in one of the textarea-fields is indexed, we expect all words, including the values of all other defined fields, are stored in the search backend index.
`In compliance with UNE 0064-1:2020 . Bacterial filtration efficiency (BFE) ≥ 95%. Breathability (differential pressure) <60 Pa/cm2. Non-reusable.`

### Actual behavior
The text that is stored in the search backend index does not contain any word, text, character or value that comes after `<60 Pa...`

### Steps to reproduce
1. Create a DataObject class with two textarea fields, `field1` and `field2`.
2. Create an object of this class, with value for `field1` the above mentioned value, and `field2` any other text.
3. Execute the CLI command `bin/console pimcore:search-backend-reindex`.
4. The texts `Pa/cm2 Non reusable` as well as the value of `field2` are not stored in the search backend index.

### Suggested bugfix
The reason why the text is not indexed, is the `strip_tags()` function in `Pimcore\Model\Search\Backend::cleanupData()`. This function strips all text after the `<60 Pa/cm2` in the `$data` variable that eventually will be stored in the search index, since the `<60` is considered a opening tag without closing tag. 
The proposed bugfix replaces the `strip_tags()` function by a regular expression, which still removes all tags that are closed, as well as any PHP opening/closing tag. 
The following lines of text have been tested:
```
this <b>is</b> a <i>test</i>
this is <b><i>second </b></i> test
this is <img src="test" /> a third test
this is <br> a test too
this is not a test, this <60 should just work.
<p>Test paragraph.</p><!-- Comment --> <a href="#fragment">Other text</a>
<strong style="font: 72pt Times New Roman">THIS BUG SUCKS!</strong>
test <?php echo 'hi'; ?> end.
test <?php echo '<hi>'; ?> end.
test <?php echo 'hi';
test <? echo '<hi>'; ?> end
test <script type="javascript">div.Value('<input type="text" />');</script> end.
```
outcomes:
```
this is a test
this is second  test
this is  a third test
this is  a test too
this is not a test, this <60 should just work.
Test paragraph. Other text
THIS BUG SUCKS!
test  end.
test  end.
test 
test  end
test div.Value(''); end.
```