### PR TITLE
Add Permissions-Policy alongside Feature-Policy for nginx configuration

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
@@ -292,13 +292,15 @@ server {
     # Referrer Policy
     add_header Referrer-Policy same-origin;
 
-    # Feature Policy
-    # Browsers feature a set of functionality that could be used
+    # Feature Policy && Permissions Policy
+    # Note that Feature Policy is to be replaced with Permissions Policy
+    # See W3C Document regarding setup: https://github.com/w3c/webappsec-permissions-policy/blob/master/permissions-policy-explainer.md
+    # 
     # Please check how to properly evaluate, define and include to your needs
     # Thanks to: https://fearby.com/article/set-up-feature-policy-referrer-policy-and-content-security-policy-headers-in-nginx/
     # For pre-writing these.
-    # Note: Mobile functionalities were explicitly not included.gi
     add_header Feature-Policy "geolocation 'none';midi 'none';sync-xhr 'none';microphone 'none';camera 'none';magnetometer 'none';gyroscope 'none';fullscreen 'self';payment 'none';";
+    add_header Permissions-Policy "geolocation=(), midi=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), fullscreen=(self), payment=()";
 
     # set X-Frame-Options
     add_header X-Frame-Options "SAMEORIGIN" always;


### PR DESCRIPTION
Changes:
Add "Permissions-Policy" alongside "Feature-Policy" to http headers.
Fixed a small typo in documentation.

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
--

## Additional info  
Roundabout 2 weeks ago the W3C formally acknowledged the shift from Feature-Policy to Permissions-Policy. 
They are, metaphorically speaking, the same shoe from a different manufacture. However, eventually they will entirely replace them.

To ensure we have similar (same) configuration here, we basically copied the settings we already have to the new standard.
