### PR TITLE
[Document] Navigation: Add missing argument to recursive method call

### DIFF
--- a/lib/Navigation/Builder.php
+++ b/lib/Navigation/Builder.php
@@ -333,7 +333,7 @@ class Builder
                 $page->setClass($page->getClass() . $classes);
 
                 if ($child->hasChildren() && (!$maxDepth || $maxDepth > $this->currentLevel)) {
-                    $childPages = $this->buildNextLevel($child, false, $pageCallback, $parents);
+                    $childPages = $this->buildNextLevel($child, false, $pageCallback, $parents, $maxDepth);
                     $page->setPages($childPages);
                 }
 


### PR DESCRIPTION
#5747 added the possibility to limit the navigation depth, but misses passing the `$maxDepth` value in the recursive call.

Thus, it only works if `$maxDepth` is `1` (when the method is called directly). After that, in the recursive calls, `$maxDepth` is always `null` which means it will never trigger.