### PR TITLE
[Targeting] Check for Internet Explorer uses wrong value

### DIFF
--- a/lib/Targeting/Condition/Browser.php
+++ b/lib/Targeting/Condition/Browser.php
@@ -76,6 +76,10 @@ class Browser extends AbstractVariableCondition implements DataProviderDependent
         $type = $client['type'] ?? null;
         $name = $client['name'] ?? null;
 
+        if ($this->browser === 'ie') {
+            $this->browser = 'Internet Explorer';
+        }
+
         if ('browser' === $type && strtolower($name ?? '') === strtolower($this->browser)) {
             $this->setMatchedVariables([
                 'type' => $type,


### PR DESCRIPTION
## Changes in this pull request  

When defining a global targeting rule, you can choose to target Internet Explorer using the "Browser" condition. The corresponding rule is defined in `lib/Targeting/Debug/Form/DeviceType.php` as follows:

```php
$builder->add('browser', ChoiceType::class, [
    'label' => 'Browser',
    'required' => false,
    'choices' => [
        'Internet Explorer' => 'ie',
        'Firefox' => 'firefox',
        'Google Chrome' => 'chrome',
        'Safari' => 'safari',
        'Opera' => 'opera',
    ],
]);
```

Thus when you choose "Internet Explorer" the value `ie` is persisted into the database.

However, when device detection happens in `lib/Targeting/DataProvider/Device.php`, any Internet Explorer user agent is resolved to `Internet Explorer`. When the condition is checked in `lib/Targeting/Condition/Browser.php`, the string `ie` (stored in `$this->browser`) is compared against `Internet Explorer` (in `$name`) on line 79, which is of course not true even though it should be.

The attached fix is, while crude and simple, entirely backwards compatible.

## Additional info  

I've tested the Browser condition using Safari instead of IE, both locally and on demo.pimcore.fun and it worked fine while when targeting IE it didn't.

---

Please let me know if you'd like me to make any changes or if I missed anything!