### PR TITLE
[Grid View] Make Direct SQL Button visible through permissions

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/gridTabAbstract.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/gridTabAbstract.js
@@ -175,7 +175,7 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
             iconCls: "pimcore_icon_sql",
             enableToggle: true,
             tooltip: t("direct_sql_query"),
-            hidden: !pimcore.currentuser.admin,
+            hidden: pimcore.currentuser.permissions.indexOf("direct_sql_query") < 0,
             handler: function (button) {
 
                 this.sqlEditor.setValue("");

--- a/bundles/CoreBundle/Migrations/Version20200922140344.php
+++ b/bundles/CoreBundle/Migrations/Version20200922140344.php
@@ -6,7 +6,8 @@ use Doctrine\DBAL\Schema\Schema;
 use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
 
 /**
- * Auto-generated Migration: Please modify to your needs!
+ * Class Version20200922140344
+ * @package Pimcore\Bundle\CoreBundle\Migrations
  */
 class Version20200922140344 extends AbstractPimcoreMigration
 {

--- a/bundles/CoreBundle/Migrations/Version20200922140344.php
+++ b/bundles/CoreBundle/Migrations/Version20200922140344.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20200922140344 extends AbstractPimcoreMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("INSERT IGNORE INTO users_permission_definitions (`key`, `category`) VALUES ('direct_sql_query', '');");
+
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->addSql("DELETE FROM users_permission_definitions WHERE `key` = 'direct_sql_query';");
+    }
+}


### PR DESCRIPTION
# Feature Request
<!--
## Please make sure all the following boxes are checked before submitting your feature request - thank you!
- [X] There is no existing issue regarding the same topic
-->
Making the Direct SQL Query functionality available for non-admin users

## Feature description
As Improvement #699 has not yet received any priority, using the Direct SQL Query functionality allows users with basic SQL and data structure knowledge to filter on relations. In ancient versions (PimCore 4.5) normal users had this option as well, but nowadays the feature is only available for admin users. The proposed changes make the Direct SQL Query available for other users as well - though only if the new permission `direct_sql_query` is set. 
