### PR TITLE
[Webservice] Quantity Value: Only use mapped unit id if a mapping exists

### DIFF
--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -537,7 +537,10 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
             if (array_key_exists('value', $value) && array_key_exists('unit', $value) && array_key_exists('unitAbbreviation', $value)) {
                 $unitId = $value['unit'];
                 if ($idMapper) {
-                    $unitId = $idMapper->getMappedId('unit', $unitId);
+                    $mappedId = $idMapper->getMappedId('unit', $unitId);
+                    if($mappedId) {
+                        $unitId = $mappedId;
+                    }
                 }
 
                 $unit = Model\DataObject\QuantityValue\Unit::getById($unitId);


### PR DESCRIPTION
Currently when the id mapper does not return an id the unit id gets set to `false` - at least in case of https://github.com/pimcore/RestImporter/blob/deb8daaa4136aa2ba7d10e154b6f918d6a4d5a3b/src/Elements/Bundle/RestImporterBundle/IdMapper.php#L49-L71). This PR keeps the transfered unit id if there isn't any id mapping.