### PR TITLE
[Twig] Add template helpers to get elements by path

### DIFF
--- a/doc/Development_Documentation/02_MVC/02_Template/00_Twig.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/00_Twig.md
@@ -128,16 +128,24 @@ generates HTML as otherwise the HTML will be escaped by twig.
 
 #### Loading Objects
 
-The following functions can be used to load Pimcore objects in a template (use `<type>`::getById()`):
+The following functions can be used to load Pimcore elements from within a template:
 
 * `pimcore_document`
+* `pimcore_document_by_path`
 * `pimcore_site`
 * `pimcore_asset`
+* `pimcore_asset_by_path`
 * `pimcore_object`
+* `pimcore_object_by_path`
 
 ```twig
 {% set myObject = pimcore_object(123) %}
 {{ myObject.getTitle() }}
+```
+or
+```twig
+{% set myObject = pimcore_object_by_path("/path/to/my/object") %}
+{{ myObject.title }}
 ```
 
 For documents, Pimcore also provides a function to handle hardlinks through the `pimcore_document_wrap_hardlink` method.

--- a/lib/Twig/Extension/PimcoreObjectExtension.php
+++ b/lib/Twig/Extension/PimcoreObjectExtension.php
@@ -31,13 +31,16 @@ class PimcoreObjectExtension extends AbstractExtension
         // simple object access functions in case documents/assets/objects need to be loaded directly in the template
         return [
             new TwigFunction('pimcore_document', [Document::class, 'getById']),
+            new TwigFunction('pimcore_document_by_path', [Document::class, 'getByPath']),
             new TwigFunction('pimcore_site', [Site::class, 'getById']),
             new TwigFunction('pimcore_site_by_root_id', [Site::class, 'getByRootId']),
             new TwigFunction('pimcore_site_by_domain', [Site::class, 'getByDomain']),
             new TwigFunction('pimcore_site_is_request', [Site::class, 'isSiteRequest']),
             new TwigFunction('pimcore_site_current', [Site::class, 'getCurrentSite']),
             new TwigFunction('pimcore_asset', [Asset::class, 'getById']),
+            new TwigFunction('pimcore_asset_by_path', [Asset::class, 'getByPath']),
             new TwigFunction('pimcore_object', [DataObject\AbstractObject::class, 'getById']),
+            new TwigFunction('pimcore_object_by_path', [DataObject\AbstractObject::class, 'getByPath']),
             new TwigFunction('pimcore_document_wrap_hardlink', [Document\Hardlink\Service::class, 'wrap']),
         ];
     }


### PR DESCRIPTION
Currently there are only twig helpers to get elements by id: pimcore_document, pimcore_asset, pimcore_object. This can be a problem when you transmit data between Pimcore systems because then Ids may change. For this use case this PR introduces helpers to get elements by path: pimcore_document_by_path, pimcore_asset_by_path, pimcore_object_by_path

Also they are better understandable as `pimcore_object_by_path("/path/to/special/category")` is more expressive than `pimcore_object(123)`.