### PR TITLE
[Adminer] Fix http headers generation when cookie expiry is present

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/External/AdminerController.php
+++ b/bundles/AdminBundle/Controller/Admin/External/AdminerController.php
@@ -157,7 +157,7 @@ namespace Pimcore\Bundle\AdminBundle\Controller\Admin\External {
                 $headersRaw = headers_list();
 
                 foreach ($headersRaw as $header) {
-                    $header = explode(':', $header);
+                    $header = explode(':', $header, 2);
                     list($headerKey, $headerValue) = $header;
 
                     if ($headerKey && $headerValue) {


### PR DESCRIPTION

## Changes in this pull request  

When cookie expiration is set in http headers e.g. "Set-Cookie: PHPSESSID=***; expires=Wed, 24-Sep-2021 08:20:14 GMT; Max-Age=31536000; path=/; HttpOnly" then it is merged here -> https://github.com/pimcore/pimcore/blob/master/bundles/AdminBundle/Controller/Admin/External/AdminerController.php#L160 but not properly because of the ":" in the time of the expire param.

![image](https://user-images.githubusercontent.com/5137917/94140368-6ce31a80-fe6b-11ea-9cbb-64d21692cd0d.png)

## Additional info  

