### PR TITLE
Omit mandatory check when copying objects

### DIFF
--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -149,6 +149,7 @@ class Service extends Model\Element\Service
             foreach ($new->getClass()->getFieldDefinitions() as $fieldDefinition) {
                 if ($fieldDefinition->getUnique()) {
                     $new->set($fieldDefinition->getName(), null);
+                    $new->setOmitMandatoryCheck(true);
                     $new->setPublished(false);
                 }
             }
@@ -213,6 +214,7 @@ class Service extends Model\Element\Service
             foreach ($new->getClass()->getFieldDefinitions() as $fieldDefinition) {
                 if ($fieldDefinition->getUnique()) {
                     $new->set($fieldDefinition->getName(), null);
+                    $new->setOmitMandatoryCheck(true);
                     $new->setPublished(false);
                 }
             }


### PR DESCRIPTION
When using a field which is both unique and mandatory copy action will fail.
This is caused by the copy routine setting all the values of "unique" fields to null, but the object is saved with `omitMandatoryCheck` on `false`, which causes a validation exception.

Reproduce:
- Create a field and check both `Mandatory field` and `Unique`
- Now create an object and give the field a value. 
- Save the object
- Copy the object and past as child.
- Now you'll get an exception "Validation failed: Empty mandatory field [ fieldname ]"
