### PR TITLE
fixed [Ecommerce][Productindex] elasticsearch preparation queue children do not update if parent is not in index

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -360,8 +360,9 @@ abstract class AbstractElasticSearch extends Worker\ProductCentricBatchProcessin
 
         if (count($subObjectIds) > 0) {
             $this->commitBatchToIndex();
-            $this->fillupPreparationQueue($object);
         }
+        
+        $this->fillupPreparationQueue($object);
     }
 
     protected function doUpdateIndex($objectId, $data = null, $metadata = null)


### PR DESCRIPTION
fixes #7168  

`fillupPreparationQueue` got moved, so that children are updated nevertheless if parent is in index or not