### PR TITLE
[Ecommerce][FilterService] Fix default order by

### DIFF
--- a/bundles/EcommerceFrameworkBundle/FilterService/Helper.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/Helper.php
@@ -125,7 +125,7 @@ class Helper
                     }
                 }
 
-                $viewModel->currentOrderBy = implode('#', reset($orderByList));
+                $viewModel->currentOrderBy = implode('#', reset($orderByList) ?: []);
             }
             if ($orderByList) {
                 $productList->setOrderKey($orderByList);


### PR DESCRIPTION
# Fix default order by with empty order by options

`Warning: implode(): Invalid arguments passed`