### PR TITLE
[DataObject] Class Export: Remove Dynamic Options from Select data types

### DIFF
--- a/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionCombo.php
+++ b/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionCombo.php
@@ -19,6 +19,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Factory;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\ProductList\ProductListInterface;
 use Pimcore\Logger;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Select;
+use Pimcore\Model\DataObject\ClassDefinition\Service;
 
 class IndexFieldSelectionCombo extends Select
 {
@@ -96,5 +97,17 @@ class IndexFieldSelectionCombo extends Select
     public function getConsiderTenants()
     {
         return $this->considerTenants;
+    }
+
+    /**
+     * @return $this
+     */
+    public function jsonSerialize()
+    {
+        if (Service::doRemoveDynamicOptions()) {
+            $this->options = null;
+        }
+
+        return $this;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "ext-gd": "*",
     "ext-intl": "*",
     "ext-iconv": "*",
+    "ext-json": "*",
     "ext-mbstring": "*",
     "ext-mysqli": "*",
     "ext-pdo_mysql": "*",

--- a/models/DataObject/ClassDefinition/Data/Country.php
+++ b/models/DataObject/ClassDefinition/Data/Country.php
@@ -17,6 +17,7 @@
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
 use Pimcore\Model;
+use Pimcore\Model\DataObject\ClassDefinition\Service;
 
 class Country extends Model\DataObject\ClassDefinition\Data\Select
 {
@@ -92,5 +93,17 @@ class Country extends Model\DataObject\ClassDefinition\Data\Select
     public function isFilterable(): bool
     {
         return true;
+    }
+
+    /**
+     * @return $this
+     */
+    public function jsonSerialize()
+    {
+        if (Service::doRemoveDynamicOptions()) {
+            $this->options = null;
+        }
+
+        return $this;
     }
 }

--- a/models/DataObject/ClassDefinition/Data/Countrymultiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Countrymultiselect.php
@@ -17,6 +17,7 @@
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
 use Pimcore\Model;
+use Pimcore\Model\DataObject\ClassDefinition\Service;
 
 class Countrymultiselect extends Model\DataObject\ClassDefinition\Data\Multiselect
 {
@@ -79,5 +80,17 @@ class Countrymultiselect extends Model\DataObject\ClassDefinition\Data\Multisele
     public function getOptions()
     {
         return $this->options;
+    }
+
+    /**
+     * @return $this
+     */
+    public function jsonSerialize()
+    {
+        if (Service::doRemoveDynamicOptions()) {
+            $this->options = null;
+        }
+
+        return $this;
     }
 }

--- a/models/DataObject/ClassDefinition/Data/Gender.php
+++ b/models/DataObject/ClassDefinition/Data/Gender.php
@@ -17,6 +17,7 @@
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
 use Pimcore\Model;
+use Pimcore\Model\DataObject\ClassDefinition\Service;
 
 class Gender extends Model\DataObject\ClassDefinition\Data\Select
 {
@@ -40,5 +41,17 @@ class Gender extends Model\DataObject\ClassDefinition\Data\Select
         ];
 
         $this->setOptions($options);
+    }
+
+    /**
+     * @return $this
+     */
+    public function jsonSerialize()
+    {
+        if (Service::doRemoveDynamicOptions()) {
+            $this->options = null;
+        }
+
+        return $this;
     }
 }

--- a/models/DataObject/ClassDefinition/Data/Language.php
+++ b/models/DataObject/ClassDefinition/Data/Language.php
@@ -17,6 +17,7 @@
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
 use Pimcore\Model;
+use Pimcore\Model\DataObject\ClassDefinition\Service;
 use Pimcore\Tool;
 
 class Language extends Model\DataObject\ClassDefinition\Data\Select
@@ -86,6 +87,18 @@ class Language extends Model\DataObject\ClassDefinition\Data\Select
         $obj->configureOptions();
 
         return $obj;
+    }
+
+    /**
+     * @return $this
+     */
+    public function jsonSerialize()
+    {
+        if (Service::doRemoveDynamicOptions()) {
+            $this->options = null;
+        }
+
+        return $this;
     }
 
     public function isFilterable(): bool

--- a/models/DataObject/ClassDefinition/Data/Languagemultiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Languagemultiselect.php
@@ -17,6 +17,7 @@
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
 use Pimcore\Model;
+use Pimcore\Model\DataObject\ClassDefinition\Service;
 use Pimcore\Tool;
 
 class Languagemultiselect extends Model\DataObject\ClassDefinition\Data\Multiselect
@@ -86,5 +87,17 @@ class Languagemultiselect extends Model\DataObject\ClassDefinition\Data\Multisel
         $obj->configureOptions();
 
         return $obj;
+    }
+
+    /**
+     * @return $this
+     */
+    public function jsonSerialize()
+    {
+        if (Service::doRemoveDynamicOptions()) {
+            $this->options = null;
+        }
+
+        return $this;
     }
 }

--- a/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -19,8 +19,9 @@ namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
+use Pimcore\Model\DataObject\ClassDefinition\Service;
 
-class Multiselect extends Data implements ResourcePersistenceAwareInterface, QueryResourcePersistenceAwareInterface, TypeDeclarationSupportInterface, EqualComparisonInterface
+class Multiselect extends Data implements ResourcePersistenceAwareInterface, QueryResourcePersistenceAwareInterface, TypeDeclarationSupportInterface, EqualComparisonInterface, \JsonSerializable
 {
     use DataObject\Traits\SimpleComparisonTrait;
     use Extension\ColumnType;
@@ -37,7 +38,7 @@ class Multiselect extends Data implements ResourcePersistenceAwareInterface, Que
     /**
      * Available options to select
      *
-     * @var array
+     * @var array|null
      */
     public $options;
 
@@ -610,5 +611,17 @@ class Multiselect extends Data implements ResourcePersistenceAwareInterface, Que
     public function isEqual($value1, $value2): bool
     {
         return $this->isEqualArray($value1, $value2);
+    }
+
+    /**
+     * @return $this
+     */
+    public function jsonSerialize()
+    {
+        if ($this->getOptionsProviderClass() && Service::doRemoveDynamicOptions()) {
+            $this->options = null;
+        }
+
+        return $this;
     }
 }

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -19,8 +19,9 @@ namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
+use Pimcore\Model\DataObject\ClassDefinition\Service;
 
-class Select extends Data implements ResourcePersistenceAwareInterface, QueryResourcePersistenceAwareInterface, TypeDeclarationSupportInterface, EqualComparisonInterface
+class Select extends Data implements ResourcePersistenceAwareInterface, QueryResourcePersistenceAwareInterface, TypeDeclarationSupportInterface, EqualComparisonInterface, \JsonSerializable
 {
     use Model\DataObject\Traits\SimpleComparisonTrait;
     use Extension\ColumnType;
@@ -560,5 +561,17 @@ class Select extends Data implements ResourcePersistenceAwareInterface, QueryRes
         }
 
         return $this->getDefaultValue();
+    }
+
+    /**
+     * @return $this
+     */
+    public function jsonSerialize()
+    {
+        if ($this->getOptionsProviderClass() && Service::doRemoveDynamicOptions()) {
+            $this->options = null;
+        }
+
+        return $this;
     }
 }

--- a/models/DataObject/ClassDefinition/Data/TargetGroup.php
+++ b/models/DataObject/ClassDefinition/Data/TargetGroup.php
@@ -17,6 +17,7 @@
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
 use Pimcore\Model;
+use Pimcore\Model\DataObject\ClassDefinition\Service;
 use Pimcore\Model\Tool;
 
 class TargetGroup extends Model\DataObject\ClassDefinition\Data\Select
@@ -129,5 +130,17 @@ class TargetGroup extends Model\DataObject\ClassDefinition\Data\Select
         }
 
         return $obj;
+    }
+
+    /**
+     * @return $this
+     */
+    public function jsonSerialize()
+    {
+        if (Service::doRemoveDynamicOptions()) {
+            $this->options = null;
+        }
+
+        return $this;
     }
 }

--- a/models/DataObject/ClassDefinition/Data/TargetGroupMultiselect.php
+++ b/models/DataObject/ClassDefinition/Data/TargetGroupMultiselect.php
@@ -17,6 +17,7 @@
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
 use Pimcore\Model;
+use Pimcore\Model\DataObject\ClassDefinition\Service;
 use Pimcore\Model\Tool;
 
 class TargetGroupMultiselect extends Model\DataObject\ClassDefinition\Data\Multiselect
@@ -62,5 +63,17 @@ class TargetGroupMultiselect extends Model\DataObject\ClassDefinition\Data\Multi
         }
 
         return $obj;
+    }
+
+    /**
+     * @return $this
+     */
+    public function jsonSerialize()
+    {
+        if (Service::doRemoveDynamicOptions()) {
+            $this->options = null;
+        }
+
+        return $this;
     }
 }

--- a/models/DataObject/ClassDefinition/Data/User.php
+++ b/models/DataObject/ClassDefinition/Data/User.php
@@ -17,6 +17,7 @@
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
 use Pimcore\Model;
+use Pimcore\Model\DataObject\ClassDefinition\Service;
 
 class User extends Model\DataObject\ClassDefinition\Data\Select
 {
@@ -162,6 +163,18 @@ class User extends Model\DataObject\ClassDefinition\Data\Select
         $obj->configureOptions();
 
         return $obj;
+    }
+
+    /**
+     * @return $this
+     */
+    public function jsonSerialize()
+    {
+        if (Service::doRemoveDynamicOptions()) {
+            $this->options = null;
+        }
+
+        return $this;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -29,6 +29,27 @@ use Pimcore\Tool;
 class Service
 {
     /**
+     * @var bool
+     */
+    public static $doRemoveDynamicOptions = false;
+
+    /**
+     * @return bool
+     */
+    public static function doRemoveDynamicOptions(): bool
+    {
+        return self::$doRemoveDynamicOptions;
+    }
+
+    /**
+     * @param bool $doRemoveDynamicOptions
+     */
+    public static function setDoRemoveDynamicOptions(bool $doRemoveDynamicOptions): void
+    {
+        self::$doRemoveDynamicOptions = $doRemoveDynamicOptions;
+    }
+
+    /**
      * @static
      *
      * @param  DataObject\ClassDefinition $class
@@ -38,33 +59,16 @@ class Service
     public static function generateClassDefinitionJson($class)
     {
         $class = clone $class;
+        self::setDoRemoveDynamicOptions(true);
         $data = json_decode(json_encode($class));
+        self::setDoRemoveDynamicOptions(false);
         unset($data->name);
         unset($data->creationDate);
         unset($data->userOwner);
         unset($data->userModification);
         unset($data->fieldDefinitions);
 
-        self::removeDynamicOptionsFromLayoutDefinition($data->layoutDefinitions);
-
         return json_encode($data, JSON_PRETTY_PRINT);
-    }
-
-    public static function removeDynamicOptionsFromLayoutDefinition(&$layout)
-    {
-        if (method_exists($layout, 'getChildren')) {
-            $children = $layout->getChildren();
-            if (is_array($children)) {
-                foreach ($children as $child) {
-                    if ($child instanceof DataObject\ClassDefinition\Data\Select) {
-                        if ($child->getOptionsProviderClass()) {
-                            $child->options = null;
-                        }
-                    }
-                    self::removeDynamicOptionsFromLayoutDefinition($child);
-                }
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
When you use option provider for selects or the User/Language select data type you have all options in the export.

But these a unnecessary and can create git diffs/conflicts.