### PR TITLE
[Documents] Fix Can't change to a template with a required editable

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -162,6 +162,9 @@ class PageController extends DocumentControllerBase
         $settings = [];
         if ($request->get('settings')) {
             $settings = $this->decodeJson($request->get('settings'));
+            if ($settings["published"] ?? false) {
+                $page->setMissingRequiredEditable(null);
+            }
         }
 
         // check if settings exist, before saving meta data

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/page_snippet.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/page_snippet.js
@@ -473,6 +473,7 @@ pimcore.document.page_snippet = Class.create(pimcore.document.document, {
              */
             var settingsForm = Ext.getCmp("pimcore_document_settings_" + this.id);
             if(settingsForm.dirty) {
+                this.data.missingRequiredEditable = null;
                 return;
             }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #6673

## Additional info  
- Client side: Resets the required editable prompt for a document, if settings are changed.
- Server side: Document is rechecked for missing required editables, if settings are changed.
