### PR TITLE
[Maintenance] getLastExecution() should check if TmpStore item exists

### DIFF
--- a/lib/Maintenance/Executor.php
+++ b/lib/Maintenance/Executor.php
@@ -131,7 +131,7 @@ final class Executor implements ExecutorInterface
     {
         $item = TmpStore::get($this->pidFileName);
 
-        if ($date = $item->getData()) {
+        if ($item instanceof TmpStore && $date = $item->getData()) {
             return (int) $date;
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Fixes exception "getData() on null" inside getLastExecution()

## Additional info  
Regression of #7223
