### PR TITLE
[Followup] Fixed Monolog Bundle incompatibility caused by 3.6.0 release of symfony/monolog-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
     "sensiolabs/ansi-to-html": "^1.1",
     "symfony-cmf/routing-bundle": "^2.0",
     "symfony/contracts": "^1.1",
-    "symfony/monolog-bundle": "3.5.0",
+    "symfony/monolog-bundle": "^3.1.0",
     "symfony/swiftmailer-bundle": "^3.2.2",
     "symfony/symfony": "^3.4.26 || ^4.1.12",
     "tijsverkoyen/css-to-inline-styles": "^2.2.1",
@@ -100,7 +100,8 @@
   },
   "conflict": {
     "monolog/monolog": ">=2",
-    "symfony/symfony": "3.4.43 || 4.4.11"
+    "symfony/symfony": "3.4.43 || 4.4.11",
+    "symfony/monolog-bundle": "3.6.0"
   },
   "require-dev": {
     "cache/integration-tests": "^0.16.0",


### PR DESCRIPTION
## Changes in this pull request  
Only the `v3.6.0` is incompatible, so only this one should be prevented from being installed.

Followup of: #7255