### PR TITLE
Only go to current working directory if it is accessible

### DIFF
--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -73,7 +73,9 @@ class Bootstrap
         /** @var \Pimcore\Kernel $kernel */
         $kernel = self::kernel();
 
-        chdir($workingDirectory);
+        if(is_readable($workingDirectory)) {
+            chdir($workingDirectory);
+        }
 
         // activate inheritance for cli-scripts
         \Pimcore::unsetAdminMode();


### PR DESCRIPTION
In https://github.com/pimcore/pimcore/blob/1430b30519dd28af41c938944eb431ae2593e01c/lib/Bootstrap.php#L76 it is tried to change directory to current working directory. This can be a problem when user `abc` calls a command with `sudo -u xyz bin/console command:name` when user `xyz` does not have access to the directory from which the script was called (e.g. user `abc`'s home folder).