### PR TITLE
[Data Objects] Support selecting multiple items for relational fields

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -366,6 +366,7 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
             selModel: {
                 selType: (this.fieldConfig.enableBatchEdit ? 'checkboxmodel': 'rowmodel')
             },
+            multiSelect: true,
             columnLines: true,
             stripeRows: true,
             columns: {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -359,6 +359,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
             selModel: {
                 selType: (this.fieldConfig.enableBatchEdit ? 'checkboxmodel' : 'rowmodel')
             },
+            multiSelect: true,
             columnLines: true,
             stripeRows: true,
             columns: {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -442,7 +442,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                     }.bind(this)
                 }
             },
-            selModel: Ext.create('Ext.selection.RowModel', {}),
+            multiSelect: true,
             columns: {
                 defaults: {
                     sortable: false

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -185,8 +185,7 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
             store: this.store,
             border: true,
             style: "margin-bottom: 10px",
-
-            selModel: Ext.create('Ext.selection.RowModel', {}),
+            multiSelect: true,
             viewConfig: {
                 markDirty: false,
                 plugins: {


### PR DESCRIPTION
Currently in object edit mode you can only select 1 referenced item for a relational field at the same time. This PR adds multi-select. This is for example useful when you want to move multiple objects via drag & drop. Multiple items can be selected via Shift or Ctrl key + mouseclick.