### PR TITLE
[Roles] Sort permissions by label

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/role/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/role/settings.js
@@ -90,6 +90,8 @@ pimcore.settings.user.role.settings = Class.create({
                 title += " " + t(key);
             }
 
+            itemsPerSection[key].sort((a, b) => a.boxLabel.localeCompare(b.boxLabel));
+
             sectionArray.push(new Ext.form.FieldSet({
                 collapsible: true,
                 title: title,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
@@ -535,6 +535,8 @@ pimcore.settings.user.user.settings = Class.create({
                 title += " " + t(key);
             }
 
+            itemsPerSection[key].sort((a, b) => a.boxLabel.localeCompare(b.boxLabel));
+
             sectionArray.push(new Ext.form.FieldSet({
                 collapsible: true,
                 title: title,


### PR DESCRIPTION
Currently permissions are not sorted at all, making it difficult to find a certain one (especially if there are some plugin- / project-specific ones added or if the current user's language is not english):
<img width="475" alt="Bildschirmfoto 2020-10-12 um 15 00 18" src="https://user-images.githubusercontent.com/8749138/95749323-abfed180-0c9b-11eb-98d5-710f48531aec.png">

This PR sorts permissions based on their (translated) labels.


Resolves #7245