### PR TITLE
[Core] Use ElementInterface instead of AbstractElement

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetHelperController.php
@@ -752,7 +752,7 @@ class AssetHelperController extends AdminController
                         $data = $asset->getMetadata($field, $language, true);
                     }
 
-                    if ($data instanceof Element\AbstractElement) {
+                    if ($data instanceof Element\ElementInterface) {
                         $data = $data->getFullPath();
                     }
                     $dataRows[] = $data;

--- a/bundles/AdminBundle/Controller/Admin/Document/RenderletController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/RenderletController.php
@@ -21,7 +21,6 @@ use Pimcore\Bundle\AdminBundle\Controller\AdminController;
 use Pimcore\Document\Editable\EditableHandler;
 use Pimcore\Localization\LocaleServiceInterface;
 use Pimcore\Model\Document;
-use Pimcore\Model\Element\AbstractElement;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
 use Pimcore\Model\Tool\Targeting\TargetGroup;
@@ -116,10 +115,8 @@ class RenderletController extends AdminController
             throw $this->createNotFoundException(sprintf('Element with type %s and ID %d was not found', $type ?: 'null', $id ?: 'null'));
         }
 
-        if ($element instanceof AbstractElement) {
-            if (!$element->isAllowed('view')) {
-                throw $this->createAccessDeniedException(sprintf('Access to element with type %s and ID %d is not allowed', $type, $id));
-            }
+        if (!$element->isAllowed('view')) {
+            throw $this->createAccessDeniedException(sprintf('Access to element with type %s and ID %d is not allowed', $type, $id));
         }
 
         return $element;

--- a/bundles/AdminBundle/Controller/Admin/ElementController.php
+++ b/bundles/AdminBundle/Controller/Admin/ElementController.php
@@ -320,7 +320,7 @@ class ElementController extends AdminController
         $limit = intval($request->get('limit', 50));
         $offset = intval($request->get('start', 0));
 
-        if ($element instanceof Element\AbstractElement) {
+        if ($element instanceof Element\ElementInterface) {
             $total = $element->getDependencies()->getRequiredByTotalCount();
 
             if ($request->get('sort')) {
@@ -383,7 +383,7 @@ class ElementController extends AdminController
             $element = Element\Service::getElementByPath($request->get('type'), $request->get('path'));
         }
 
-        if ($element instanceof Element\AbstractElement) {
+        if ($element instanceof Element\ElementInterface) {
             return $this->adminJson([
                 'success' => true,
                 'jobs' => $element->getDependencies()->getRequiredBy(),

--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -737,7 +737,7 @@ class TranslationController extends AdminController
                 }
 
                 if (isset($element['relations']) && $element['relations']) {
-                    if (!$el instanceof Element\AbstractElement) {
+                    if (!$el instanceof Element\ElementInterface) {
                         $el = Element\Service::getElementById($element['type'], $element['id']);
                     }
 

--- a/bundles/AdminBundle/Resources/views/SearchAdmin/Search/Quicksearch/info-table.html.php
+++ b/bundles/AdminBundle/Resources/views/SearchAdmin/Search/Quicksearch/info-table.html.php
@@ -1,6 +1,6 @@
 <?php
     /**
-     * @var \Pimcore\Model\Element\AbstractElement $element
+     * @var \Pimcore\Model\Element\ElementInterface $element
      */
     $element = $this->element;
     $this->get("translate")->setDomain("admin");

--- a/bundles/CoreBundle/EventListener/ElementTagsListener.php
+++ b/bundles/CoreBundle/EventListener/ElementTagsListener.php
@@ -44,9 +44,9 @@ class ElementTagsListener implements EventSubscriberInterface
     public function onPostCopy(ElementEventInterface $e)
     {
         $elementType = Service::getElementType($e->getElement());
-        /** @var \Pimcore\Model\Element\AbstractElement $copiedElement */
+        /** @var \Pimcore\Model\Element\ElementInterface $copiedElement */
         $copiedElement = $e->getElement();
-        /** @var \Pimcore\Model\Element\AbstractElement $baseElement */
+        /** @var \Pimcore\Model\Element\ElementInterface $baseElement */
         $baseElement = $e->getArgument('base_element');
         \Pimcore\Model\Element\Tag::setTagsForElement(
             $elementType,

--- a/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
+++ b/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
@@ -24,7 +24,7 @@ use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\Concrete as ConcreteObject;
 use Pimcore\Model\Document;
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
 use Pimcore\Model\Element\WorkflowState;
 use Pimcore\Workflow\ActionsButtonService;
@@ -248,7 +248,7 @@ class WorkflowManagementListener implements EventSubscriberInterface
     /**
      * @param GenericEvent $e
      *
-     * @return AbstractElement
+     * @return ElementInterface
      *
      * @throws \Exception
      */

--- a/bundles/EcommerceFrameworkBundle/IndexService/Interpreter/DefaultRelations.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Interpreter/DefaultRelations.php
@@ -15,7 +15,7 @@
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Interpreter;
 
 use Pimcore\Model\DataObject\Data\ObjectMetadata;
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
 
 class DefaultRelations implements RelationInterpreterInterface
@@ -36,7 +36,7 @@ class DefaultRelations implements RelationInterpreterInterface
 
                 $result[] = ['dest' => $v->getId(), 'type' => Service::getElementType($v)];
             }
-        } elseif ($value instanceof AbstractElement) {
+        } elseif ($value instanceof ElementInterface) {
             $result[] = ['dest' => $value->getId(), 'type' => Service::getElementType($value)];
         }
 

--- a/doc/Development_Documentation/18_Tools_and_Features/39_Sitemaps.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/39_Sitemaps.md
@@ -15,7 +15,7 @@ an event handler and start to add entries.
 ## Exposing Sitemaps
 
 Sitemaps can either be exposed by being generated on-the-fly or by being dumped to static files. What to use depends on the size
-of your site (e.g. the size of the tree which needs to be processed). In general it's recommended to create static files 
+of your site (e.g. the size of the tree which needs to be processed). In general it's recommended to create static files
 as it reduces the overhead of creating the sitemap on every crawler request. If you want to serve the sitemap directly,
 you need to register the sitemaps routes in your routing config (see [PrestaSitemapBundle Documentation](https://github.com/prestaconcept/PrestaSitemapBundle/blob/master/Resources/doc/1-installation.md)
 for details).
@@ -48,7 +48,7 @@ using the `presta:sitemaps:dump` command, you can override those parameters by p
 
 For details see:
 
-* [Bundle Documentation](https://github.com/prestaconcept/PrestaSitemapBundle/blob/master/Resources/doc/2-configuration.md#configuring-your-application-base-url) 
+* [Bundle Documentation](https://github.com/prestaconcept/PrestaSitemapBundle/blob/master/Resources/doc/2-configuration.md#configuring-your-application-base-url)
 * [Symfony Documentation on the Request Context](http://symfony.com/doc/3.4/console/request_context.html#configuring-the-request-context-globally)
 * [`UrlGenerator`](https://github.com/pimcore/pimcore/blob/master/lib/Sitemap/UrlGenerator.php)
 
@@ -91,7 +91,7 @@ pimcore:
                 enabled: true
                 priority: 50
                 generator_id: AppBundle\Sitemaps\NewsGenerator
-            
+
             # Pimcore ships a default document tree generator which is enabled by default
             # but you can easily disable it here.
             pimcore_documents:
@@ -232,7 +232,7 @@ In the example above, the URL is created by using a [Link Generator](../05_Objec
 > It's important that your link generator is able to generate an absolute URL for the given object. Above is only an example, but
   you can have a look at the [demo](https://github.com/pimcore/demo-basic/tree/master/src/AppBundle)
   for a working example building sitemap entries for News objects.
-  
+
 After creating the generator, register it as service and add it to the config. Use filters and processors to reuse already
 implemented behaviour.
 
@@ -252,7 +252,7 @@ services:
                 - '@Pimcore\Sitemap\Element\Filter\PropertiesFilter'
             $processors:
                 - '@Pimcore\Sitemap\Element\Processor\ModificationDateProcessor'
-                - '@Pimcore\Sitemap\Element\Processor\PropertiesProcessor'               
+                - '@Pimcore\Sitemap\Element\Processor\PropertiesProcessor'
 ```
 
 Make the generator available to the core listener by registering it on the configuration:
@@ -278,7 +278,7 @@ date older than a year could look like the following:
 
 namespace AppBundle\Sitemaps\Filter;
 
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Sitemap\Element\FilterInterface;
 use Pimcore\Sitemap\Element\GeneratorContextInterface;
 
@@ -294,7 +294,7 @@ class AgeFilter implements FilterInterface
         $this->maxYears = $maxYears;
     }
 
-    public function canBeAdded(AbstractElement $element, GeneratorContextInterface $context): bool
+    public function canBeAdded(ElementInterface $element, GeneratorContextInterface $context): bool
     {
         $modicationDate = \DateTimeImmutable::createFromFormat('U', (string)$element->getModificationDate());
         $now            = new \DateTimeImmutable();
@@ -305,7 +305,7 @@ class AgeFilter implements FilterInterface
         return $diff->y < $this->maxYears;
     }
 
-    public function handlesChildren(AbstractElement $element, GeneratorContextInterface $context): bool
+    public function handlesChildren(ElementInterface $element, GeneratorContextInterface $context): bool
     {
         // not matching the age constraint does not mean not handling children
         return true;
@@ -321,13 +321,13 @@ services:
         autowire: true
         autoconfigure: true
         public: false
-        
+
     AppBundle\Sitemaps\Filter\AgeFilter: ~
 
     AppBundle\Sitemaps\BlogGenerator:
         arguments:
             $filters:
-                - '@AppBundle\Sitemaps\Filter\AgeFilter'   
+                - '@AppBundle\Sitemaps\Filter\AgeFilter'
 ```
 
 
@@ -341,7 +341,7 @@ to each entry.
 
 namespace AppBundle\Sitemaps\Processor;
 
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Sitemap\Element\GeneratorContextInterface;
 use Pimcore\Sitemap\Element\ProcessorInterface;
 use Presta\SitemapBundle\Sitemap\Url\Url;
@@ -349,7 +349,7 @@ use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
 
 class RandomPriorityProcessor implements ProcessorInterface
 {
-    public function process(Url $url, AbstractElement $element, GeneratorContextInterface $context)
+    public function process(Url $url, ElementInterface $element, GeneratorContextInterface $context)
     {
         if ($url instanceof UrlConcrete) {
             $url->setPriority(rand(0, 10) / 10);
@@ -375,13 +375,13 @@ services:
         autowire: true
         autoconfigure: true
         public: false
-        
+
     AppBundle\Sitemaps\Processor\RandomPriorityProcessor: ~
 
     AppBundle\Sitemaps\BlogGenerator:
         arguments:
             $processors:
-                - '@AppBundle\Sitemaps\Processor\RandomPriorityProcessor'   
+                - '@AppBundle\Sitemaps\Processor\RandomPriorityProcessor'
 ```
 
 
@@ -397,7 +397,7 @@ for details. As example how to use the URL generator in a processor:
 
 namespace AppBundle\Sitemaps\Processor;
 
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Sitemap\Element\GeneratorContextInterface;
 use Pimcore\Sitemap\Element\ProcessorInterface;
 use Pimcore\Sitemap\UrlGeneratorInterface;
@@ -416,7 +416,7 @@ class RandomPathProcessor implements ProcessorInterface
         $this->urlGenerator = $urlGenerator;
     }
 
-    public function process(Url $url, AbstractElement $element, GeneratorContextInterface $context)
+    public function process(Url $url, ElementInterface $element, GeneratorContextInterface $context)
     {
         $path = $this->urlGenerator->generateUrl('/foo/bar');
         $url  = new UrlConcrete($path);

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -17,7 +17,7 @@ namespace Pimcore;
 use Pimcore\Cache\Runtime;
 use Pimcore\Config\EnvironmentConfig;
 use Pimcore\Config\EnvironmentConfigInterface;
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\User\UserRole;
 use Pimcore\Model\WebsiteSetting;
 use Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter;
@@ -305,7 +305,7 @@ class Config implements \ArrayAccess
             } else {
                 $data = $config->toArray();
                 foreach ($data as $key => $setting) {
-                    if ($setting instanceof AbstractElement) {
+                    if ($setting instanceof ElementInterface) {
                         $elementCacheKey = $setting->getCacheTag();
                         if (!Runtime::isRegistered($elementCacheKey)) {
                             Runtime::set($elementCacheKey, $setting);

--- a/lib/Sitemap/Document/Filter/DocumentTypeFilter.php
+++ b/lib/Sitemap/Document/Filter/DocumentTypeFilter.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
 namespace Pimcore\Sitemap\Document\Filter;
 
 use Pimcore\Model\Document;
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Sitemap\Element\FilterInterface;
 use Pimcore\Sitemap\Element\GeneratorContextInterface;
 
@@ -54,7 +54,7 @@ class DocumentTypeFilter implements FilterInterface
         }
     }
 
-    public function canBeAdded(AbstractElement $element, GeneratorContextInterface $context): bool
+    public function canBeAdded(ElementInterface $element, GeneratorContextInterface $context): bool
     {
         if (!$element instanceof Document || $element instanceof Document\Hardlink\Wrapper\WrapperInterface) {
             return false;
@@ -63,7 +63,7 @@ class DocumentTypeFilter implements FilterInterface
         return in_array($element->getType(), $this->documentTypes);
     }
 
-    public function handlesChildren(AbstractElement $element, GeneratorContextInterface $context): bool
+    public function handlesChildren(ElementInterface $element, GeneratorContextInterface $context): bool
     {
         if (!$element instanceof Document) {
             return false;

--- a/lib/Sitemap/Document/Filter/SiteRootFilter.php
+++ b/lib/Sitemap/Document/Filter/SiteRootFilter.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
 namespace Pimcore\Sitemap\Document\Filter;
 
 use Pimcore\Model\Document;
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Site;
 use Pimcore\Sitemap\Document\DocumentGeneratorContext;
 use Pimcore\Sitemap\Element\FilterInterface;
@@ -35,7 +35,7 @@ class SiteRootFilter implements FilterInterface
      */
     private $siteRoots;
 
-    public function canBeAdded(AbstractElement $element, GeneratorContextInterface $context): bool
+    public function canBeAdded(ElementInterface $element, GeneratorContextInterface $context): bool
     {
         if (!$element instanceof Document) {
             return false;
@@ -53,7 +53,7 @@ class SiteRootFilter implements FilterInterface
         return true;
     }
 
-    public function handlesChildren(AbstractElement $element, GeneratorContextInterface $context): bool
+    public function handlesChildren(ElementInterface $element, GeneratorContextInterface $context): bool
     {
         return $this->canBeAdded($element, $context);
     }

--- a/lib/Sitemap/Element/AbstractElementGenerator.php
+++ b/lib/Sitemap/Element/AbstractElementGenerator.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Sitemap\Element;
 
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Sitemap\GeneratorInterface;
 use Presta\SitemapBundle\Sitemap\Url\Url;
 
@@ -76,12 +76,12 @@ abstract class AbstractElementGenerator implements GeneratorInterface
     /**
      * Determines if the element can be added.
      *
-     * @param AbstractElement $element
+     * @param ElementInterface $element
      * @param GeneratorContextInterface $context
      *
      * @return bool
      */
-    protected function canBeAdded(AbstractElement $element, GeneratorContextInterface $context): bool
+    protected function canBeAdded(ElementInterface $element, GeneratorContextInterface $context): bool
     {
         foreach ($this->filters as $filter) {
             if (!$filter->canBeAdded($element, $context)) {
@@ -96,12 +96,12 @@ abstract class AbstractElementGenerator implements GeneratorInterface
      * Determines if the element handles children (only used from generators
      * supporting tree structures).
      *
-     * @param AbstractElement $element
+     * @param ElementInterface $element
      * @param GeneratorContextInterface $context
      *
      * @return bool
      */
-    protected function handlesChildren(AbstractElement $element, GeneratorContextInterface $context): bool
+    protected function handlesChildren(ElementInterface $element, GeneratorContextInterface $context): bool
     {
         foreach ($this->filters as $filter) {
             if (!$filter->handlesChildren($element, $context)) {
@@ -117,12 +117,12 @@ abstract class AbstractElementGenerator implements GeneratorInterface
      * or null to exclude the Url.
      *
      * @param Url $url
-     * @param AbstractElement $element
+     * @param ElementInterface $element
      * @param GeneratorContextInterface $context
      *
      * @return null|Url
      */
-    protected function process(Url $url, AbstractElement $element, GeneratorContextInterface $context)
+    protected function process(Url $url, ElementInterface $element, GeneratorContextInterface $context)
     {
         foreach ($this->processors as $processor) {
             $url = $processor->process($url, $element, $context);

--- a/lib/Sitemap/Element/Filter/PropertiesFilter.php
+++ b/lib/Sitemap/Element/Filter/PropertiesFilter.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Sitemap\Element\Filter;
 
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Sitemap\Element\FilterInterface;
 use Pimcore\Sitemap\Element\GeneratorContextInterface;
 
@@ -29,7 +29,7 @@ class PropertiesFilter implements FilterInterface
     const PROPERTY_EXCLUDE = 'sitemaps_exclude';
     const PROPERTY_EXCLUDE_CHILDREN = 'sitemaps_exclude_children';
 
-    public function canBeAdded(AbstractElement $element, GeneratorContextInterface $context): bool
+    public function canBeAdded(ElementInterface $element, GeneratorContextInterface $context): bool
     {
         if ($this->getBoolProperty($element, self::PROPERTY_EXCLUDE)) {
             return false;
@@ -38,7 +38,7 @@ class PropertiesFilter implements FilterInterface
         return true;
     }
 
-    public function handlesChildren(AbstractElement $element, GeneratorContextInterface $context): bool
+    public function handlesChildren(ElementInterface $element, GeneratorContextInterface $context): bool
     {
         if ($this->getBoolProperty($element, self::PROPERTY_EXCLUDE_CHILDREN)) {
             return false;
@@ -47,7 +47,7 @@ class PropertiesFilter implements FilterInterface
         return true;
     }
 
-    private function getBoolProperty(AbstractElement $document, string $property): bool
+    private function getBoolProperty(ElementInterface $document, string $property): bool
     {
         if (!$document->hasProperty($property)) {
             return false;

--- a/lib/Sitemap/Element/Filter/PublishedFilter.php
+++ b/lib/Sitemap/Element/Filter/PublishedFilter.php
@@ -17,13 +17,13 @@ declare(strict_types=1);
 
 namespace Pimcore\Sitemap\Element\Filter;
 
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Sitemap\Element\FilterInterface;
 use Pimcore\Sitemap\Element\GeneratorContextInterface;
 
 class PublishedFilter implements FilterInterface
 {
-    public function canBeAdded(AbstractElement $element, GeneratorContextInterface $context): bool
+    public function canBeAdded(ElementInterface $element, GeneratorContextInterface $context): bool
     {
         if (method_exists($element, 'isPublished')) {
             return (bool)$element->isPublished();
@@ -32,7 +32,7 @@ class PublishedFilter implements FilterInterface
         return true;
     }
 
-    public function handlesChildren(AbstractElement $element, GeneratorContextInterface $context): bool
+    public function handlesChildren(ElementInterface $element, GeneratorContextInterface $context): bool
     {
         return $this->canBeAdded($element, $context);
     }

--- a/lib/Sitemap/Element/FilterInterface.php
+++ b/lib/Sitemap/Element/FilterInterface.php
@@ -17,11 +17,11 @@ declare(strict_types=1);
 
 namespace Pimcore\Sitemap\Element;
 
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 
 interface FilterInterface
 {
-    public function canBeAdded(AbstractElement $element, GeneratorContextInterface $context): bool;
+    public function canBeAdded(ElementInterface $element, GeneratorContextInterface $context): bool;
 
-    public function handlesChildren(AbstractElement $element, GeneratorContextInterface $context): bool;
+    public function handlesChildren(ElementInterface $element, GeneratorContextInterface $context): bool;
 }

--- a/lib/Sitemap/Element/Processor/ModificationDateProcessor.php
+++ b/lib/Sitemap/Element/Processor/ModificationDateProcessor.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Sitemap\Element\Processor;
 
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Sitemap\Element\GeneratorContextInterface;
 use Pimcore\Sitemap\Element\ProcessorInterface;
 use Presta\SitemapBundle\Sitemap\Url\Url;
@@ -28,7 +28,7 @@ use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
  */
 class ModificationDateProcessor implements ProcessorInterface
 {
-    public function process(Url $url, AbstractElement $element, GeneratorContextInterface $context)
+    public function process(Url $url, ElementInterface $element, GeneratorContextInterface $context)
     {
         if (!$url instanceof UrlConcrete) {
             return $url;

--- a/lib/Sitemap/Element/Processor/PropertiesProcessor.php
+++ b/lib/Sitemap/Element/Processor/PropertiesProcessor.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Sitemap\Element\Processor;
 
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Sitemap\Element\GeneratorContextInterface;
 use Pimcore\Sitemap\Element\ProcessorInterface;
 use Presta\SitemapBundle\Sitemap\Url\Url;
@@ -31,7 +31,7 @@ class PropertiesProcessor implements ProcessorInterface
     const PROPERTY_CHANGE_FREQUENCY = 'sitemaps_changefreq';
     const PROPERTY_PRIORITY = 'sitemaps_priority';
 
-    public function process(Url $url, AbstractElement $element, GeneratorContextInterface $context)
+    public function process(Url $url, ElementInterface $element, GeneratorContextInterface $context)
     {
         if (!$url instanceof UrlConcrete) {
             return $url;

--- a/lib/Sitemap/Element/ProcessorInterface.php
+++ b/lib/Sitemap/Element/ProcessorInterface.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Sitemap\Element;
 
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Presta\SitemapBundle\Sitemap\Url\Url;
 
 interface ProcessorInterface
@@ -26,10 +26,10 @@ interface ProcessorInterface
      * Processes an URL. The processor is expected to return the same or a new URL instance or null
      *
      * @param Url $url
-     * @param AbstractElement $element
+     * @param ElementInterface $element
      * @param GeneratorContextInterface $context
      *
      * @return Url|null
      */
-    public function process(Url $url, AbstractElement $element, GeneratorContextInterface $context);
+    public function process(Url $url, ElementInterface $element, GeneratorContextInterface $context);
 }

--- a/lib/Workflow/ActionsButtonService.php
+++ b/lib/Workflow/ActionsButtonService.php
@@ -15,7 +15,7 @@
 namespace Pimcore\Workflow;
 
 use Pimcore\Model\DataObject\AbstractObject;
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Symfony\Component\Workflow\Workflow;
 
 class ActionsButtonService
@@ -32,11 +32,11 @@ class ActionsButtonService
 
     /**
      * @param Workflow $workflow
-     * @param AbstractElement $element
+     * @param ElementInterface $element
      *
      * @return array
      */
-    public function getAllowedTransitions(Workflow $workflow, AbstractElement $element)
+    public function getAllowedTransitions(Workflow $workflow, ElementInterface $element)
     {
         $allowedTransitions = [];
 
@@ -62,11 +62,11 @@ class ActionsButtonService
 
     /**
      * @param Workflow $workflow
-     * @param AbstractElement $element
+     * @param ElementInterface $element
      *
      * @return array
      */
-    public function getGlobalActions(Workflow $workflow, AbstractElement $element)
+    public function getGlobalActions(Workflow $workflow, ElementInterface $element)
     {
         $globalActions = [];
         foreach ($this->workflowManager->getGlobalActions($workflow->getName()) as $globalAction) {

--- a/lib/Workflow/EventSubscriber/NotesSubscriber.php
+++ b/lib/Workflow/EventSubscriber/NotesSubscriber.php
@@ -16,7 +16,7 @@ namespace Pimcore\Workflow\EventSubscriber;
 
 use Pimcore\Event\Workflow\GlobalActionEvent;
 use Pimcore\Event\WorkflowEvents;
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\ValidationException;
 use Pimcore\Workflow;
 use Pimcore\Workflow\Transition;
@@ -60,7 +60,7 @@ class NotesSubscriber implements EventSubscriberInterface
             return;
         }
 
-        /** @var AbstractElement $subject */
+        /** @var ElementInterface $subject */
         $subject = $event->getSubject();
         /** @var Transition $transition */
         $transition = $event->getTransition();
@@ -79,7 +79,7 @@ class NotesSubscriber implements EventSubscriberInterface
             return;
         }
 
-        /** @var AbstractElement $subject */
+        /** @var ElementInterface $subject */
         $subject = $event->getSubject();
         /** @var Transition $transition */
         $transition = $event->getTransition();
@@ -123,11 +123,11 @@ class NotesSubscriber implements EventSubscriberInterface
 
     /**
      * @param Workflow\Notes\NotesAwareInterface $notesAware
-     * @param AbstractElement $subject
+     * @param ElementInterface $subject
      *
      * @throws ValidationException
      */
-    private function handleNotesPreWorkflow(Workflow\Notes\NotesAwareInterface $notesAware, AbstractElement $subject)
+    private function handleNotesPreWorkflow(Workflow\Notes\NotesAwareInterface $notesAware, ElementInterface $subject)
     {
         if (($setterFn = $notesAware->getNotesCommentSetterFn()) && ($notes = $this->getNotesComment())) {
             $subject->$setterFn($notes);
@@ -157,11 +157,11 @@ class NotesSubscriber implements EventSubscriberInterface
 
     /**
      * @param Workflow\Notes\NotesAwareInterface $notesAware
-     * @param AbstractElement $subject
+     * @param ElementInterface $subject
      *
      * @throws ValidationException
      */
-    private function handleNotesPostWorkflow(Workflow\Notes\NotesAwareInterface $notesAware, AbstractElement $subject)
+    private function handleNotesPostWorkflow(Workflow\Notes\NotesAwareInterface $notesAware, ElementInterface $subject)
     {
         $additionalFieldsData = [];
         foreach ($notesAware->getNotesAdditionalFields() as $additionalFieldConfig) {
@@ -202,13 +202,13 @@ class NotesSubscriber implements EventSubscriberInterface
     {
         return $this->isEnabled()
                && $event->getTransition() instanceof Transition
-               && $event->getSubject() instanceof AbstractElement;
+               && $event->getSubject() instanceof ElementInterface;
     }
 
     private function checkGlobalActionEvent(GlobalActionEvent $event): bool
     {
         return $this->isEnabled()
-               && $event->getSubject() instanceof AbstractElement;
+               && $event->getSubject() instanceof ElementInterface;
     }
 
     /**

--- a/lib/Workflow/EventSubscriber/NotificationSubscriber.php
+++ b/lib/Workflow/EventSubscriber/NotificationSubscriber.php
@@ -15,7 +15,7 @@
 namespace Pimcore\Workflow\EventSubscriber;
 
 use Pimcore\Model\DataObject\Concrete;
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
 use Pimcore\Model\Element\ValidationException;
 use Pimcore\Workflow;
@@ -92,7 +92,7 @@ class NotificationSubscriber implements EventSubscriberInterface
             return;
         }
 
-        /** @var AbstractElement $subject */
+        /** @var ElementInterface $subject */
         $subject = $event->getSubject();
         /** @var Transition $transition */
         $transition = $event->getTransition();
@@ -120,13 +120,13 @@ class NotificationSubscriber implements EventSubscriberInterface
     /**
      * @param Transition $transition
      * @param \Symfony\Component\Workflow\Workflow $workflow
-     * @param AbstractElement $subject
+     * @param ElementInterface $subject
      * @param string $mailType
      * @param string $mailPath
      * @param array $notifyUsers
      * @param array $notifyRoles
      */
-    private function handleNotifyPostWorkflowEmail(Transition $transition, \Symfony\Component\Workflow\Workflow $workflow, AbstractElement $subject, string $mailType, string $mailPath, array $notifyUsers, array $notifyRoles)
+    private function handleNotifyPostWorkflowEmail(Transition $transition, \Symfony\Component\Workflow\Workflow $workflow, ElementInterface $subject, string $mailType, string $mailPath, array $notifyUsers, array $notifyRoles)
     {
         //notify users
         $subjectType = ($subject instanceof Concrete ? $subject->getClassName() : Service::getType($subject));
@@ -146,11 +146,11 @@ class NotificationSubscriber implements EventSubscriberInterface
     /**
      * @param Transition $transition
      * @param \Symfony\Component\Workflow\Workflow $workflow
-     * @param AbstractElement $subject
+     * @param ElementInterface $subject
      * @param array $notifyUsers
      * @param array $notifyRoles
      */
-    private function handleNotifyPostWorkflowPimcoreNotification(Transition $transition, \Symfony\Component\Workflow\Workflow $workflow, AbstractElement $subject, array $notifyUsers, array $notifyRoles)
+    private function handleNotifyPostWorkflowPimcoreNotification(Transition $transition, \Symfony\Component\Workflow\Workflow $workflow, ElementInterface $subject, array $notifyUsers, array $notifyRoles)
     {
         $subjectType = ($subject instanceof Concrete ? $subject->getClassName() : Service::getType($subject));
         $this->pimcoreNotificationService->sendPimcoreNotification(
@@ -174,7 +174,7 @@ class NotificationSubscriber implements EventSubscriberInterface
     {
         return $this->isEnabled()
             && $event->getTransition() instanceof Transition
-            && $event->getSubject() instanceof AbstractElement;
+            && $event->getSubject() instanceof ElementInterface;
     }
 
     /**

--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -19,7 +19,7 @@ use Pimcore\Event\WorkflowEvents;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Document\PageSnippet;
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\ValidationException;
 use Pimcore\Workflow\EventSubscriber\ChangePublishedStateSubscriber;
 use Pimcore\Workflow\EventSubscriber\NotesSubscriber;
@@ -252,7 +252,7 @@ class Manager
         $transition = $this->getTransitionByName($workflow->getName(), $transition);
         $changePublishedState = $transition instanceof Transition ? $transition->getChangePublishedState() : null;
 
-        if ($saveSubject && $subject instanceof AbstractElement) {
+        if ($saveSubject && $subject instanceof ElementInterface) {
             if (method_exists($subject, 'getPublished')
                 && (!$subject->getPublished() || $changePublishedState === ChangePublishedStateSubscriber::SAVE_VERSION)) {
                 $subject->saveVersion();
@@ -305,7 +305,7 @@ class Manager
         $this->eventDispatcher->dispatch(WorkflowEvents::POST_GLOBAL_ACTION, $event);
         $this->notesSubscriber->setAdditionalData([]);
 
-        if ($saveSubject && $subject instanceof AbstractElement) {
+        if ($saveSubject && $subject instanceof ElementInterface) {
             $subject->save();
         }
 

--- a/lib/Workflow/Notification/NotificationEmailService.php
+++ b/lib/Workflow/Notification/NotificationEmailService.php
@@ -15,7 +15,7 @@
 namespace Pimcore\Workflow\Notification;
 
 use Pimcore\Model\DataObject\AbstractObject;
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\User;
 use Pimcore\Tool;
 use Pimcore\Workflow\EventSubscriber\NotificationSubscriber;
@@ -62,12 +62,12 @@ class NotificationEmailService extends AbstractNotificationService
      * @param array $roles
      * @param Workflow $workflow
      * @param string $subjectType
-     * @param AbstractElement $subject
+     * @param ElementInterface $subject
      * @param string $action
      * @param string $mailType
      * @param string $mailPath
      */
-    public function sendWorkflowEmailNotification(array $users, array $roles, Workflow $workflow, string $subjectType, AbstractElement $subject, string $action, string $mailType, string $mailPath)
+    public function sendWorkflowEmailNotification(array $users, array $roles, Workflow $workflow, string $subjectType, ElementInterface $subject, string $action, string $mailType, string $mailPath)
     {
         try {
             $recipients = $this->getNotificationUsersByName($users, $roles);
@@ -124,14 +124,14 @@ class NotificationEmailService extends AbstractNotificationService
     /**
      * @param User[] $recipients
      * @param string $subjectType
-     * @param AbstractElement $subject
+     * @param ElementInterface $subject
      * @param Workflow $workflow
      * @param string $action
      * @param string $language
      * @param string $mailPath
      * @param string $deeplink
      */
-    protected function sendPimcoreDocumentMail(array $recipients, string $subjectType, AbstractElement $subject, Workflow $workflow, string $action, string $language, string $mailPath, string $deeplink)
+    protected function sendPimcoreDocumentMail(array $recipients, string $subjectType, ElementInterface $subject, Workflow $workflow, string $action, string $language, string $mailPath, string $deeplink)
     {
         $mail = new \Pimcore\Mail(['document' => $mailPath, 'params' => $this->getNotificationEmailParameters($subjectType, $subject, $workflow, $action, $deeplink, $language)]);
 
@@ -145,14 +145,14 @@ class NotificationEmailService extends AbstractNotificationService
     /**
      * @param User[] $recipients
      * @param string $subjectType
-     * @param AbstractElement $subject
+     * @param ElementInterface $subject
      * @param Workflow $workflow
      * @param string $action
      * @param string $language
      * @param string $mailPath
      * @param string $deeplink
      */
-    protected function sendTemplateMail(array $recipients, string $subjectType, AbstractElement $subject, Workflow $workflow, string $action, string $language, string $mailPath, string $deeplink)
+    protected function sendTemplateMail(array $recipients, string $subjectType, ElementInterface $subject, Workflow $workflow, string $action, string $language, string $mailPath, string $deeplink)
     {
         $mail = new \Pimcore\Mail();
 
@@ -171,7 +171,7 @@ class NotificationEmailService extends AbstractNotificationService
 
     /**
      * @param string $subjectType
-     * @param AbstractElement $subject
+     * @param ElementInterface $subject
      * @param Workflow $workflow
      * @param string $action
      * @param string $language
@@ -180,7 +180,7 @@ class NotificationEmailService extends AbstractNotificationService
      *
      * @return string
      */
-    protected function getHtmlBody(string $subjectType, AbstractElement $subject, Workflow $workflow, string $action, string $language, string $mailPath, string $deeplink): string
+    protected function getHtmlBody(string $subjectType, ElementInterface $subject, Workflow $workflow, string $action, string $language, string $mailPath, string $deeplink): string
     {
         // allow retrieval of inherited values
         $inheritanceBackup = AbstractObject::getGetInheritedValues();
@@ -204,7 +204,7 @@ class NotificationEmailService extends AbstractNotificationService
 
     /**
      * @param string $subjectType
-     * @param AbstractElement $subject
+     * @param ElementInterface $subject
      * @param Workflow $workflow
      * @param string $action
      * @param string $deeplink
@@ -212,7 +212,7 @@ class NotificationEmailService extends AbstractNotificationService
      *
      * @return array
      */
-    protected function getNotificationEmailParameters(string $subjectType, AbstractElement $subject, Workflow $workflow, string $action, string $deeplink, string $language): array
+    protected function getNotificationEmailParameters(string $subjectType, ElementInterface $subject, Workflow $workflow, string $action, string $deeplink, string $language): array
     {
         $noteDescription = $this->getNoteInfo($subject->getId());
 

--- a/lib/Workflow/Notification/PimcoreNotificationService.php
+++ b/lib/Workflow/Notification/PimcoreNotificationService.php
@@ -14,7 +14,7 @@
 
 namespace Pimcore\Workflow\Notification;
 
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Notification\Service\NotificationService;
 use Symfony\Component\Workflow\Workflow;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -43,7 +43,7 @@ class PimcoreNotificationService extends AbstractNotificationService
         $this->translator = $translator;
     }
 
-    public function sendPimcoreNotification(array $users, array $roles, Workflow $workflow, string $subjectType, AbstractElement $subject, string $action)
+    public function sendPimcoreNotification(array $users, array $roles, Workflow $workflow, string $subjectType, ElementInterface $subject, string $action)
     {
         try {
             $recipients = $this->getNotificationUsersByName($users, $roles, true);

--- a/lib/Workflow/Service.php
+++ b/lib/Workflow/Service.php
@@ -94,7 +94,7 @@ class Service
     /**
      * Creates a note for an action with a transition
      *
-     * @param Element\AbstractElement $element
+     * @param Element\ElementInterface $element
      * @param string $type
      * @param string $title
      * @param string $description
@@ -103,7 +103,7 @@ class Service
      *
      * @return Element\Note $note
      */
-    public static function createActionNote($element, $type, $title, $description, $noteData, $user = null)
+    public static function createActionNote(Element\ElementInterface $element, $type, $title, $description, $noteData, $user = null)
     {
         //prepare some vars for creating the note
         if (!$user) {

--- a/models/Asset/MetaData/ClassDefinition/Data/Asset.php
+++ b/models/Asset/MetaData/ClassDefinition/Data/Asset.php
@@ -17,7 +17,6 @@
 
 namespace Pimcore\Model\Asset\MetaData\ClassDefinition\Data;
 
-use Pimcore\Model\Element\AbstractElement;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
 
@@ -186,7 +185,7 @@ class Asset extends Data
     public function getDataFromListfolderGrid($data, $params = [])
     {
         $data = \Pimcore\Model\Asset::getByPath($data);
-        if ($data instanceof AbstractElement) {
+        if ($data instanceof ElementInterface) {
             return $data->getId();
         }
 

--- a/models/Asset/MetaData/ClassDefinition/Data/DataObject.php
+++ b/models/Asset/MetaData/ClassDefinition/Data/DataObject.php
@@ -18,7 +18,6 @@
 namespace Pimcore\Model\Asset\MetaData\ClassDefinition\Data;
 
 use Pimcore\Model\DataObject\AbstractObject;
-use Pimcore\Model\Element\AbstractElement;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
 
@@ -187,7 +186,7 @@ class DataObject extends Data
     public function getDataFromListfolderGrid($data, $params = [])
     {
         $data = AbstractObject::getByPath($data);
-        if ($data instanceof AbstractElement) {
+        if ($data instanceof ElementInterface) {
             return $data->getId();
         }
 

--- a/models/Asset/MetaData/ClassDefinition/Data/Document.php
+++ b/models/Asset/MetaData/ClassDefinition/Data/Document.php
@@ -17,7 +17,6 @@
 
 namespace Pimcore\Model\Asset\MetaData\ClassDefinition\Data;
 
-use Pimcore\Model\Element\AbstractElement;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
 
@@ -187,7 +186,7 @@ class Document extends Data
     {
         $data = \Pimcore\Model\Document::getByPath($data);
 
-        if ($data instanceof AbstractElement) {
+        if ($data instanceof ElementInterface) {
             return $data->getId();
         }
 

--- a/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
@@ -595,7 +595,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
     }
 
     /**
-     * @param Element\AbstractElement[]|null $data
+     * @param Element\ElementInterface[]|null $data
      *
      * @return array
      */

--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -273,7 +273,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
     /**
      * @see Data::getDataForEditmode
      *
-     * @param Element\AbstractElement|null $data
+     * @param Element\ElementInterface|null $data
      * @param null|DataObject\Concrete $object
      * @param array|null $params
      *
@@ -281,7 +281,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      */
     public function getDataForEditmode($data, $object = null, $params = [])
     {
-        if ($data instanceof Element\AbstractElement) {
+        if ($data instanceof Element\ElementInterface) {
             $r = [
                 'id' => $data->getId(),
                 'path' => $data->getRealFullPath(),
@@ -327,7 +327,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
     }
 
     /**
-     * @param Element\AbstractElement|null $data
+     * @param Element\ElementInterface|null $data
      * @param DataObject\Concrete $object
      * @param array $params
      *
@@ -341,7 +341,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
     /**
      * @see Data::getVersionPreview
      *
-     * @param Element\AbstractElement|null $data
+     * @param Element\ElementInterface|null $data
      * @param null|DataObject\Concrete $object
      * @param mixed $params
      *
@@ -349,7 +349,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      */
     public function getVersionPreview($data, $object = null, $params = [])
     {
-        if ($data instanceof Element\AbstractElement) {
+        if ($data instanceof Element\ElementInterface) {
             return Element\Service::getElementType($data).' '.$data->getRealFullPath();
         }
 
@@ -459,7 +459,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
     }
 
     /**
-     * @param Element\AbstractElement|null $data
+     * @param Element\ElementInterface|null $data
      *
      * @return array
      */

--- a/models/DataObject/Data/ElementMetadata.php
+++ b/models/DataObject/Data/ElementMetadata.php
@@ -189,7 +189,7 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
     }
 
     /**
-     * @return Model\Element\AbstractElement|null
+     * @return Model\Element\ElementInterface|null
      */
     public function getElement()
     {

--- a/models/Element/ElementInterface.php
+++ b/models/Element/ElementInterface.php
@@ -17,6 +17,7 @@
 
 namespace Pimcore\Model\Element;
 
+use Pimcore\Model\Dependency;
 use Pimcore\Model\ModelInterface;
 use Pimcore\Model\Property;
 use Pimcore\Model\Schedule\Task;
@@ -143,6 +144,24 @@ interface ElementInterface extends ModelInterface
     public function getProperties();
 
     /**
+     * Get specific property data or the property object itself ($asContainer=true) by its name, if the
+     * property doesn't exists return null
+     *
+     * @param string $name
+     * @param bool $asContainer
+     *
+     * @return mixed
+     */
+    public function getProperty($name, $asContainer = false);
+
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasProperty($name);
+
+    /**
      * returns true if the element is locked
      *
      * @return bool
@@ -237,4 +256,14 @@ interface ElementInterface extends ModelInterface
      * @return Version[]
      */
     public function getVersions();
+
+    /**
+     * @return Dependency
+     */
+    public function getDependencies();
+
+    /**
+     * @return string
+     */
+    public function __toString();
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,16 +36,6 @@ parameters:
 			path: bundles/AdminBundle/Resources/views/Admin/Login/twoFactorAuthentication.html.php
 
 		-
-			message: "#^Cannot call method getUser\\(\\) on string\\|Stringable\\|Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\.$#"
-			count: 1
-			path: bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
-
-		-
-			message: "#^Call to an undefined method Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\:\\:setLocale\\(\\)\\.$#"
-			count: 1
-			path: bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
-
-		-
 			message: "#^Property Pimcore\\\\Bundle\\\\AdminBundle\\\\Security\\\\LogoutSuccessHandler\\:\\:\\$tokenStorage \\(Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\Storage\\\\TokenStorage\\) does not accept Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\Storage\\\\TokenStorageInterface\\.$#"
 			count: 1
 			path: bundles/AdminBundle/Security/LogoutSuccessHandler.php
@@ -101,11 +91,6 @@ parameters:
 			path: bundles/CoreBundle/Command/ThumbnailsVideoCommand.php
 
 		-
-			message: "#^Method Pimcore\\\\Bundle\\\\CoreBundle\\\\Controller\\\\PublicServicesController\\:\\:qrcodeAction\\(\\) should return Symfony\\\\Component\\\\HttpFoundation\\\\RedirectResponse but return statement is missing\\.$#"
-			count: 1
-			path: bundles/CoreBundle/Controller/PublicServicesController.php
-
-		-
 			message: "#^Call to an undefined method Pimcore\\\\Event\\\\Model\\\\ElementEventInterface\\:\\:getArgument\\(\\)\\.$#"
 			count: 1
 			path: bundles/CoreBundle/EventListener/ElementTagsListener.php
@@ -144,11 +129,6 @@ parameters:
 			message: "#^Property Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\CartManager\\\\AbstractCart\\:\\:\\$creationDateTimestamp \\(int\\) does not accept null\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/CartManager/AbstractCart.php
-
-		-
-			message: "#^Method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\IndexService\\\\ProductList\\\\DefaultMysql\\:\\:load\\(\\) should return array\\<Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\IndexableInterface\\> but returns array\\<int, array\\|Pimcore\\\\Model\\\\DataObject\\\\AbstractObject\\>\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultMysql.php
 
 		-
 			message: "#^Property Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\CartManager\\\\AbstractCart\\:\\:\\$creationDate \\(DateTime\\) does not accept null\\.$#"
@@ -444,26 +424,6 @@ parameters:
 			message: "#^Parameter \\$filterDefinition of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\FilterService\\\\FilterType\\\\ElasticSearch\\\\SelectRelation\\:\\:addCondition\\(\\) has invalid typehint type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterRelation\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/SelectRelation.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractFilterDefinitionType\\:\\:getUseAndCondition\\(\\)\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/FactFinder/MultiSelect.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractFilterDefinitionType\\:\\:getPreSelectFrom\\(\\)\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/FactFinder/NumberRange.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractFilterDefinitionType\\:\\:getPreSelectTo\\(\\)\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/FactFinder/NumberRange.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractFilterDefinitionType\\:\\:getAvailableCategories\\(\\)\\.$#"
-			count: 2
-			path: bundles/EcommerceFrameworkBundle/FilterService/FilterType/FactFinder/SelectCategory.php
 
 		-
 			message: "#^PHPDoc tag @param for parameter \\$filterDefinition with type Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\FilterMultiSelect is not subtype of native type Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractFilterDefinitionType\\.$#"
@@ -826,41 +786,6 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/IndexService/Config/OptimizedMysql.php
 
 		-
-			message: "#^Property Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\IndexService\\\\ProductList\\\\DefaultFactFinder\\:\\:\\$tenantConfig \\(Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\IndexService\\\\Config\\\\FactFinderConfigInterface\\) does not accept Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\IndexService\\\\Config\\\\ConfigInterface\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFactFinder.php
-
-		-
-			message: "#^Method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\IndexService\\\\ProductList\\\\DefaultFactFinder\\:\\:getProducts\\(\\) should return array\\<Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractProduct\\> but returns array\\<Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\IndexableInterface\\>\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFactFinder.php
-
-		-
-			message: "#^Property Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\IndexService\\\\ProductList\\\\DefaultFactFinder\\:\\:\\$products \\(array\\<Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\IndexableInterface\\>\\) does not accept null\\.$#"
-			count: 14
-			path: bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFactFinder.php
-
-		-
-			message: "#^Cannot assign new offset to string\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFactFinder.php
-
-		-
-			message: "#^Property Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\IndexService\\\\ProductList\\\\DefaultFactFinder\\:\\:\\$conditionPriceFrom \\(float\\) does not accept null\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFactFinder.php
-
-		-
-			message: "#^Property Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\IndexService\\\\ProductList\\\\DefaultFactFinder\\:\\:\\$conditionPriceTo \\(float\\) does not accept null\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFactFinder.php
-
-		-
-			message: "#^Offset 'elements' does not exist on string\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFactFinder.php
-
-		-
 			message: "#^Property Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\IndexService\\\\ProductList\\\\DefaultFindologic\\:\\:\\$tenantConfig \\(Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\IndexService\\\\Config\\\\FindologicConfigInterface\\) does not accept Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\IndexService\\\\Config\\\\ConfigInterface\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultFindologic.php
@@ -926,7 +851,7 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultMysql.php
 
 		-
-			message: "#^Method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\IndexService\\\\ProductList\\\\DefaultMysql\\:\\:load\\(\\) should return array\\<Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\IndexableInterface\\> but returns array\\<int, \\(array\\)\\|Pimcore\\\\Model\\\\DataObject\\\\AbstractObject\\>\\.$#"
+			message: "#^Method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\IndexService\\\\ProductList\\\\DefaultMysql\\:\\:load\\(\\) should return array\\<Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\IndexableInterface\\> but returns array\\<int, array\\|Pimcore\\\\Model\\\\DataObject\\\\AbstractObject\\>\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/IndexService/ProductList/DefaultMysql.php
 
@@ -1311,11 +1236,6 @@ parameters:
 			path: lib/Analytics/Piwik/Api/SitesManager.php
 
 		-
-			message: "#^Cannot access offset 0 on false\\.$#"
-			count: 1
-			path: lib/Browser.php
-
-		-
 			message: "#^Return type \\(Pimcore\\\\Cache\\\\Pool\\\\PimcoreCacheItemInterface\\) of method Pimcore\\\\Cache\\\\Pool\\\\AbstractCacheItemPool\\:\\:getItem\\(\\) should be compatible with return type \\(Symfony\\\\Component\\\\Cache\\\\CacheItem\\) of method Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface\\:\\:getItem\\(\\)$#"
 			count: 1
 			path: lib/Cache/Pool/AbstractCacheItemPool.php
@@ -1341,11 +1261,6 @@ parameters:
 			path: lib/Cache/Pool/PimcoreCacheItemPoolInterface.php
 
 		-
-			message: "#^Method Pimcore\\\\Cache\\\\Pool\\\\Redis\\:\\:doClear\\(\\) should return bool but returns Credis_Client\\|string\\.$#"
-			count: 1
-			path: lib/Cache/Pool/Redis.php
-
-		-
 			message: "#^Method Pimcore\\\\Config\\:\\:getConfigInstance\\(\\) should return Pimcore\\\\Config\\\\Config\\|null but returns array\\.$#"
 			count: 1
 			path: lib/Config.php
@@ -1354,11 +1269,6 @@ parameters:
 			message: "#^Property Pimcore\\\\Console\\\\AbstractCommand\\:\\:\\$output \\(Symfony\\\\Component\\\\Console\\\\Output\\\\ConsoleOutput\\) does not accept Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface\\.$#"
 			count: 1
 			path: lib/Console/AbstractCommand.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Templating\\\\Model\\\\ViewModelInterface\\:\\:getAllParameters\\(\\)\\.$#"
-			count: 1
-			path: lib/Controller/FrontendController.php
 
 		-
 			message: "#^Method Pimcore\\\\DataObject\\\\GridColumnConfig\\\\Operator\\\\LFExpander\\:\\:getLabeledValue\\(\\) should return stdClass\\|null but returns Pimcore\\\\DataObject\\\\GridColumnConfig\\\\ResultContainer\\.$#"
@@ -1419,16 +1329,6 @@ parameters:
 			message: "#^Cannot access offset int on Pimcore\\\\Model\\\\DataObject\\\\Listing\\.$#"
 			count: 1
 			path: lib/Document/Newsletter/AddressSourceAdapter/ReportAdapter.php
-
-		-
-			message: "#^Access to an undefined property Pimcore\\\\Templating\\\\Model\\\\ViewModelInterface\\:\\:\\$editmode\\.$#"
-			count: 3
-			path: lib/Document/Tag/TagHandler.php
-
-		-
-			message: "#^Property Pimcore\\\\Document\\\\Editable\\\\EditableUsageResolver\\:\\:\\$subscriber \\(Pimcore\\\\Document\\\\Editable\\\\UsageRecorderSubscriber\\) does not accept null\\.$#"
-			count: 1
-			path: lib/Document/Editable/EditableUsageResolver.php
 
 		-
 			message: "#^Property Pimcore\\\\Event\\\\Admin\\\\Login\\\\LoginFailedEvent\\:\\:\\$credentials \\(string\\) does not accept array\\.$#"
@@ -1501,11 +1401,6 @@ parameters:
 			path: lib/Localization/IntlFormatter.php
 
 		-
-			message: "#^Array \\(array\\<IntlDateFormatter\\>\\) does not accept Symfony\\\\Component\\\\Intl\\\\DateFormatter\\\\IntlDateFormatter\\.$#"
-			count: 1
-			path: lib/Localization/IntlFormatter.php
-
-		-
 			message: "#^Property Pimcore\\\\Log\\\\ApplicationLogger\\:\\:\\$component \\(null\\) does not accept string\\.$#"
 			count: 1
 			path: lib/Log/ApplicationLogger.php
@@ -1524,11 +1419,6 @@ parameters:
 			message: "#^Property Pimcore\\\\Log\\\\Handler\\\\Mail\\:\\:\\$address \\(null\\) does not accept int\\.$#"
 			count: 1
 			path: lib/Log/Handler/Mail.php
-
-		-
-			message: "#^Offset 0 does not exist on array\\(\\)\\.$#"
-			count: 1
-			path: lib/Mail.php
 
 		-
 			message: "#^Property Pimcore\\\\Mail\\:\\:\\$document \\(Pimcore\\\\Model\\\\Document\\\\Email\\) does not accept Pimcore\\\\Model\\\\Document\\.$#"
@@ -1581,11 +1471,6 @@ parameters:
 			path: lib/Targeting/Document/DocumentTargetingConfigurator.php
 
 		-
-			message: "#^Call to an undefined method Pimcore\\\\Model\\\\Document&Pimcore\\\\Model\\\\Document\\\\Targeting\\\\TargetingDocumentInterface\\:\\:getElements\\(\\)\\.$#"
-			count: 1
-			path: lib/Targeting/Document/DocumentTargetingConfigurator.php
-
-		-
 			message: "#^Call to an undefined method Pimcore\\\\Targeting\\\\ActionHandler\\\\ActionHandlerInterface\\:\\:getActionHandler\\(\\)\\.$#"
 			count: 2
 			path: lib/Targeting/EventListener/TargetingListener.php
@@ -1599,6 +1484,11 @@ parameters:
 			message: "#^Cannot access property \\$type on string\\.$#"
 			count: 2
 			path: lib/Templating/Helper/HeadMeta.php
+
+		-
+			message: "#^Property Pimcore\\\\Templating\\\\Renderer\\\\EditableRenderer\\:\\:\\$editableLoader \\(Pimcore\\\\Model\\\\Document\\\\Editable\\\\Loader\\\\EditableLoader\\) does not accept Pimcore\\\\Model\\\\Document\\\\Editable\\\\Loader\\\\EditableLoaderInterface\\.$#"
+			count: 1
+			path: lib/Templating/Renderer/EditableRenderer.php
 
 		-
 			message: "#^Call to an undefined method Pimcore\\\\Model\\\\User\\:\\:setLastLoginDate\\(\\)\\.$#"
@@ -1784,25 +1674,4 @@ parameters:
 			message: "#^Access to an undefined property Pimcore\\\\Model\\\\DataObject\\\\ClassDefinition\\\\Data\\\\Fieldcollections\\:\\:\\$layoutId\\.$#"
 			count: 1
 			path: models/DataObject/Service.php
-
-		-
-			message: "#^Invalid array key type object\\.$#"
-			count: 2
-			path: models/Element/Import/Service.php
-
-		-
-			message: "#^Property Pimcore\\\\Templating\\\\Renderer\\\\EditableRenderer\\:\\:\\$editableLoader \\(Pimcore\\\\Model\\\\Document\\\\Editable\\\\Loader\\\\EditableLoader\\) does not accept Pimcore\\\\Model\\\\Document\\\\Editable\\\\Loader\\\\EditableLoaderInterface\\.$#"
-			count: 1
-			path: lib/Templating/Renderer/EditableRenderer.php
-
-		-
-			message: "#^Parameter \\$event of method Pimcore\\\\Controller\\\\KernelControllerEventInterface\\:\\:onKernelControllerEvent\\(\\) has invalid typehint type Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\ControllerEvent#"
-			count: 2
-			path: lib/Controller/KernelControllerEventInterface.php
-
-		-
-			message: "#^Parameter \\$event of method Pimcore\\\\Controller\\\\KernelResponseEventInterface\\:\\:onKernelResponseEvent\\(\\) has invalid typehint type Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\ResponseEvent#"
-			count: 2
-			path: lib/Controller/KernelResponseEventInterface.php
-
 

--- a/tests/_support/Util/TestHelper.php
+++ b/tests/_support/Util/TestHelper.php
@@ -9,7 +9,6 @@ use Pimcore\Model\DataObject as ObjectModel;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Unittest;
 use Pimcore\Model\Document;
-use Pimcore\Model\Element\AbstractElement;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Property;
 use Pimcore\Tests\Helper\DataType\TestDataHelper;
@@ -784,10 +783,10 @@ class TestHelper
     }
 
     /**
-     * @param AbstractElement $root
+     * @param ElementInterface $root
      * @param string $type
      */
-    public static function cleanUpTree(AbstractElement $root, $type)
+    public static function cleanUpTree(ElementInterface $root, $type)
     {
         if (!($root instanceof AbstractObject || $root instanceof Document || $root instanceof Asset)) {
             throw new \InvalidArgumentException(sprintf('Cleanup root type for %s needs to be one of: AbstractObject, Document, Asset', $type));
@@ -801,7 +800,7 @@ class TestHelper
             $children = $root->getChildren();
         }
 
-        /** @var AbstractElement|AbstractObject|Document|Asset $child */
+        /** @var ElementInterface $child */
         foreach ($children as $child) {
             codecept_debug(sprintf('Deleting %s %s (%d)', $type, $child->getFullPath(), $child->getId()));
             $child->delete();


### PR DESCRIPTION
In some places a check or type hint is made for the AbstractElement class instead of the ElementInterface. 

With a major release coming up now, I think we could change that.