### PR TITLE
Untouched relations get lost when contained in localizes fields in object bricks on save

### DIFF
--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -135,12 +135,11 @@ class Dao extends Model\Dao\AbstractDao
          */
         DataObject\Concrete\Dao\InheritanceHelper::setUseRuntimeCache(true);
         foreach ($validLanguages as $language) {
-            if ((!isset($params['newParent']) || !$params['newParent'])
-                && isset($params['isUpdate'])
-                && $params['isUpdate']
+            if (empty($params['newParent'])
+                && !empty($params['isUpdate'])
                 && !$this->model->isLanguageDirty($language)
-                 && !$forceUpdate
-                ) {
+                && !$forceUpdate
+            ) {
                 continue;
             }
             $inheritedValues = DataObject\AbstractObject::doGetInheritedValues();

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -135,9 +135,12 @@ class Dao extends Model\Dao\AbstractDao
          */
         DataObject\Concrete\Dao\InheritanceHelper::setUseRuntimeCache(true);
         foreach ($validLanguages as $language) {
-            if ((!isset($params['newParent']) || !$params['newParent']) && isset($params['isUpdate']) && $params['isUpdate'] && !$this->model->isLanguageDirty(
-                    $language
-                )) {
+            if ((!isset($params['newParent']) || !$params['newParent'])
+                && isset($params['isUpdate'])
+                && $params['isUpdate']
+                && !$this->model->isLanguageDirty($language)
+                 && !$forceUpdate
+                ) {
                 continue;
             }
             $inheritedValues = DataObject\AbstractObject::doGetInheritedValues();

--- a/tests/Model/LazyLoading/ManyToManyRelationTest.php
+++ b/tests/Model/LazyLoading/ManyToManyRelationTest.php
@@ -342,8 +342,16 @@ class ManyToManyRelationTest extends AbstractLazyLoadingTest
         //prepare data object
         $object = $this->createDataObject();
         $brick = new LazyLoadingLocalizedTest($object);
-        $brick->getLocalizedfields()->setLocalizedValue('lrelations', $this->loadRelations()->load(), 'en');
-        $brick->getLocalizedfields()->setLocalizedValue('lrelations', $this->loadRelations()->load(), 'de');
+
+        $relations = $this->loadRelations()->load();
+        $relation = $relations[0];
+
+        $brick->getLocalizedfields()->setLocalizedValue('lrelations', $relations, 'en');
+        $brick->getLocalizedfields()->setLocalizedValue('lrelations', $relations, 'de');
+
+        $brick->getLocalizedfields()->setLocalizedValue('lrelation', $relation, 'en');
+        $brick->getLocalizedfields()->setLocalizedValue('lrelation', $relation, 'de');
+
 
         $object->getBricks()->setLazyLoadingLocalizedTest($brick);
         $object->save();
@@ -354,8 +362,13 @@ class ManyToManyRelationTest extends AbstractLazyLoadingTest
         $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelations('en')) > 0);
         $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelations('de')) > 0);
 
+        $this->assertNotNull($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelation('en'));
+        $this->assertNotNull($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelation('de'));
+
+
         $object = Concrete::getById($object->getId(), true);
         $newRelations = $this->loadRelations()->load();
+        $newRelation = $newRelations[1];
         array_pop($newRelations);
         $brick = $object->getBricks()->getLazyLoadingLocalizedTest();
 
@@ -363,12 +376,15 @@ class ManyToManyRelationTest extends AbstractLazyLoadingTest
 
         // change one language and make sure that it does not affect the other one
         $lFields->setLocalizedValue('lrelations', $newRelations, 'de');
+        $lFields->setLocalizedValue('lrelation', $newRelation, 'de');
         $object->save();
 
         $object = Concrete::getById($object->getId(), true);
         $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelations('en')) > 0);
         $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelations('de')) > 0);
 
+        $this->assertNotNull($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelation('en'));
+        $this->assertNotNull($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelation('de'));
 
         $parentId = $object->getId();
         $childId = $this->createChildDataObject($object)->getId();

--- a/tests/Model/LazyLoading/ManyToManyRelationTest.php
+++ b/tests/Model/LazyLoading/ManyToManyRelationTest.php
@@ -344,14 +344,9 @@ class ManyToManyRelationTest extends AbstractLazyLoadingTest
         $brick = new LazyLoadingLocalizedTest($object);
 
         $relations = $this->loadRelations()->load();
-        $relation = $relations[0];
 
         $brick->getLocalizedfields()->setLocalizedValue('lrelations', $relations, 'en');
         $brick->getLocalizedfields()->setLocalizedValue('lrelations', $relations, 'de');
-
-        $brick->getLocalizedfields()->setLocalizedValue('lrelation', $relation, 'en');
-        $brick->getLocalizedfields()->setLocalizedValue('lrelation', $relation, 'de');
-
 
         $object->getBricks()->setLazyLoadingLocalizedTest($brick);
         $object->save();
@@ -362,13 +357,8 @@ class ManyToManyRelationTest extends AbstractLazyLoadingTest
         $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelations('en')) > 0);
         $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelations('de')) > 0);
 
-        $this->assertNotNull($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelation('en'));
-        $this->assertNotNull($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelation('de'));
-
-
         $object = Concrete::getById($object->getId(), true);
         $newRelations = $this->loadRelations()->load();
-        $newRelation = $newRelations[1];
         array_pop($newRelations);
         $brick = $object->getBricks()->getLazyLoadingLocalizedTest();
 
@@ -376,15 +366,11 @@ class ManyToManyRelationTest extends AbstractLazyLoadingTest
 
         // change one language and make sure that it does not affect the other one
         $lFields->setLocalizedValue('lrelations', $newRelations, 'de');
-        $lFields->setLocalizedValue('lrelation', $newRelation, 'de');
         $object->save();
 
         $object = Concrete::getById($object->getId(), true);
         $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelations('en')) > 0);
         $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelations('de')) > 0);
-
-        $this->assertNotNull($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelation('en'));
-        $this->assertNotNull($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelation('de'));
 
         $parentId = $object->getId();
         $childId = $this->createChildDataObject($object)->getId();

--- a/tests/Model/LazyLoading/ManyToManyRelationTest.php
+++ b/tests/Model/LazyLoading/ManyToManyRelationTest.php
@@ -342,7 +342,8 @@ class ManyToManyRelationTest extends AbstractLazyLoadingTest
         //prepare data object
         $object = $this->createDataObject();
         $brick = new LazyLoadingLocalizedTest($object);
-        $brick->getLocalizedfields()->setLocalizedValue('lrelations', $this->loadRelations()->load());
+        $brick->getLocalizedfields()->setLocalizedValue('lrelations', $this->loadRelations()->load(), 'en');
+        $brick->getLocalizedfields()->setLocalizedValue('lrelations', $this->loadRelations()->load(), 'de');
 
         $object->getBricks()->setLazyLoadingLocalizedTest($brick);
         $object->save();
@@ -350,7 +351,24 @@ class ManyToManyRelationTest extends AbstractLazyLoadingTest
         $brick->setLInput(uniqid());
         $object->save();
         $object = Concrete::getById($object->getId(), true);
-        $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelations()) > 0);
+        $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelations('en')) > 0);
+        $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelations('de')) > 0);
+
+        $object = Concrete::getById($object->getId(), true);
+        $newRelations = $this->loadRelations()->load();
+        array_pop($newRelations);
+        $brick = $object->getBricks()->getLazyLoadingLocalizedTest();
+
+        $lFields = $brick->getLocalizedfields();
+
+        // change one language and make sure that it does not affect the other one
+        $lFields->setLocalizedValue('lrelations', $newRelations, 'de');
+        $object->save();
+
+        $object = Concrete::getById($object->getId(), true);
+        $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelations('en')) > 0);
+        $this->assertTrue(count($object->getBricks()->getLazyLoadingLocalizedTest()->getLRelations('de')) > 0);
+
 
         $parentId = $object->getId();
         $childId = $this->createChildDataObject($object)->getId();


### PR DESCRIPTION
resolves #7302