### PR TITLE
Add all default formats of Symfonys OutputFormatter to AbstractCommand

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/11_Console_CLI.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/11_Console_CLI.md
@@ -61,6 +61,15 @@ class AwesomeCommand extends AbstractCommand
         
         // Output as white text on red background.
         $this->writeError('oh noes!');
+
+        // Output as green text.
+        $this->writeInfo('info');
+
+        // Output as blue text.
+        $this->writeComment('comment');
+
+        // Output as yellow text.
+        $this->writeQuestion('question');
     }
 }
 ```

--- a/lib/Console/AbstractCommand.php
+++ b/lib/Console/AbstractCommand.php
@@ -96,4 +96,28 @@ abstract class AbstractCommand extends Command
     {
         $this->output->writeln(sprintf('<error>ERROR: %s</error>', $message));
     }
+
+    /**
+     * @param string $message
+     */
+    protected function writeInfo($message)
+    {
+        $this->output->writeln(sprintf('<info>INFO: %s</info>', $message));
+    }
+
+    /**
+     * @param string $message
+     */
+    protected function writeComment($message)
+    {
+        $this->output->writeln(sprintf('<comment>COMMENT: %s</comment>', $message));
+    }
+
+    /**
+     * @param string $message
+     */
+    protected function writeQuestion($message)
+    {
+        $this->output->writeln(sprintf('<question>QUESTION: %s</question>', $message));
+    }
 }


### PR DESCRIPTION
## Changes in this pull request  
This PR adds all default formats of Symfonys OutputFormatter to AbstractCommand.

## Additional info  
The AbstractCommand currently only supports `error`. With this PR `info`, `comment` and `question` will be added.
