### PR TITLE
[Permissions] Allow setting permission category after creating it

### DIFF
--- a/models/User/Permission/Definition/Dao.php
+++ b/models/User/Permission/Definition/Dao.php
@@ -30,7 +30,7 @@ class Dao extends Model\Dao\AbstractDao
     public function save()
     {
         try {
-            $this->db->insert('users_permission_definitions', [
+            $this->db->insertOrUpdate('users_permission_definitions', [
                 'key' => $this->model->getKey(),
                 'category' => $this->model->getCategory() ? $this->model->getCategory() : '',
             ]);


### PR DESCRIPTION
Currently the code 
```php
$permission = \Pimcore\Model\User\Permission\Definition::create('my_permission');
$permission->setCategory('my category');
$permission->save();
```
does result in a permission `my_permission` but without category `my category`. This PR changes that by allowing to set a permission category after creating it.