### PR TITLE
Fix input filter type elasticsearch illegal offset type

### DIFF
--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/Input.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/Input.php
@@ -22,7 +22,7 @@ class Input extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\Filte
 {
     public function addCondition(AbstractFilterDefinitionType $filterDefinition, ProductListInterface $productList, $currentFilter, $params, $isPrecondition = false)
     {
-        $field = $filterDefinition->getField();
+        $field = $this->getField($filterDefinition);
         $preSelect = $filterDefinition->getPreSelect($filterDefinition);
 
         $value = $params[$field] ?? null;

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/Input.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/Input.php
@@ -25,7 +25,6 @@ class Input extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\Filte
         $field = $this->getField($filterDefinition);
         $preSelect = $filterDefinition->getPreSelect($filterDefinition);
 
-
         $value = $params[$field] ?? null;
         $isReload = $params['is_reload'] ?? null;
 

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/Input.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/ElasticSearch/Input.php
@@ -25,6 +25,7 @@ class Input extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\Filte
         $field = $this->getField($filterDefinition);
         $preSelect = $filterDefinition->getPreSelect($filterDefinition);
 
+
         $value = $params[$field] ?? null;
         $isReload = $params['is_reload'] ?? null;
 


### PR DESCRIPTION
"Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\FilterType\ElasticSearch\Input.php" currently has error where in line 25 return object insted of string, that later cause error "Illegal offset type" at line 28 and 38. Fix that I implemented is nothing more that copy of code from other FilterType.