### PR TITLE
Feature/pimcore block shuffle

### DIFF
--- a/doc/Development_Documentation/03_Documents/01_Editables/06_Block.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/06_Block.md
@@ -15,6 +15,7 @@ The items in the loop as well as their order can be defined by the editor with t
 | `default`   | integer   | If block is empty, this specifies the iterations at startup.                                                                 |
 | `manual`    | bool      | Forces the manual mode, which enables a complete custom HTML implementation for blocks, for example using `<table>` elements |
 | `class`     | string    | A CSS class that is added to the surrounding container of this element in editmode                                           |
+| `shuffle`   | bool      | Shuffle the output-order of the block-elements                                                                               |
 
 ## Methods
 

--- a/models/Document/Editable/Block.php
+++ b/models/Document/Editable/Block.php
@@ -137,6 +137,10 @@ class Block extends Model\Document\Editable implements BlockInterface
             $manual = true;
         }
 
+        if (($this->config['shuffle'] ?? false) == true) {
+            shuffle($this->indices);
+        }
+
         $this->setDefault();
 
         if ($this->current > 0) {


### PR DESCRIPTION
## Changes in this pull request  
The Pimcore Block-Editable get's the new option `shuffle` which allows to randomize the output-order.

## Additional info  
In some of our client-cases we wanted to use pimcore-blocks to configure slideshows or accordions. These modules also had to be outputted randomly. Therefor we created a Twig-Extension which shuffled the indizes of the Block-Editable. A cleaner option would be to have a dedicated option for this.
