### PR TITLE
[Maintenance] fix parallel execution of maintenance tasks

### DIFF
--- a/lib/Maintenance/Executor.php
+++ b/lib/Maintenance/Executor.php
@@ -81,15 +81,13 @@ final class Executor implements ExecutorInterface
 
             $lock = $this->lockFactory->createLock('maintenance-' . $name, 86400);
 
-            if ($lock->isAcquired() && !$force) {
+            if (!$lock->acquire() && !$force) {
                 $this->logger->info('Skipped job with ID {id} because it already being executed', [
                     'id' => $name,
                 ]);
 
                 continue;
             }
-
-            $lock->acquire();
 
             try {
                 $task->execute();


### PR DESCRIPTION
`$lock->isAquired` respects only aquired locks from the SAME process.
This will never happen. Like the maintenance task is ment it should check over
all running proccesses (tasks) if a lock with the process name exists and skip

See as well Symfony docs:

![image](https://user-images.githubusercontent.com/38670469/96992214-d9643e80-1529-11eb-9688-a8ff5b284565.png)


We run on several instances the maintenance task every 5 Minutes in parallel overlapping mode......means if the maintenance task is still not finished (for whatever reason...image optimisation etc) 5 minutes later cron is starting the next maintenance task process. To avoid conflicts it should skip the task already running in another process
 