### PR TITLE
[DataObject] ObjectBrick/FieldCollection - Fix error when importing json definition

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/fieldcollections/field.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/fieldcollections/field.js
@@ -183,8 +183,9 @@ pimcore.object.fieldcollections.field = Class.create(pimcore.object.classes.klas
                 success: function (response) {
                     this.data = Ext.decode(response.responseText);
                     this.parentPanel.getEditPanel().removeAll();
-                    this.addLayout();
+                    this.addTree();
                     this.initLayoutFields();
+                    this.addLayout();
                     pimcore.layout.refresh();
                 }.bind(this)
             });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbricks/field.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbricks/field.js
@@ -370,8 +370,9 @@ pimcore.object.objectbricks.field = Class.create(pimcore.object.classes.klass, {
                 success: function (response) {
                     this.data = Ext.decode(response.responseText);
                     this.parentPanel.getEditPanel().removeAll();
-                    this.addLayout();
+                    this.addTree();
                     this.initLayoutFields();
+                    this.addLayout();
                     pimcore.layout.refresh();
                 }.bind(this)
             });


### PR DESCRIPTION
Currently there is an error when trying to import a brick definition via a JSON file. After uploading the file, the panel just disappears, JS console shows an error - and the complete Pimcore backend is not usable anymore. You have to reload the backend but as it was not possible to save the imported object brick definition, you are not being able to import the brick definition at all.

To be honest, I did not check what actually happens in the changed code, I just copied the code from https://github.com/pimcore/pimcore/blob/7f802ce45eef4b43da2468b2a622b23c2cb6f41a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js#L169-L171

PS: I used base branch 6.8 as this is clearly a bugfix. If I shall use master, please comment.