### PR TITLE
generate public url through asset listeners

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -25,6 +25,7 @@ use Pimcore\Db;
 use Pimcore\Event\Admin\ElementAdminStyleEvent;
 use Pimcore\Event\AdminEvents;
 use Pimcore\Event\AssetEvents;
+use Pimcore\Event\FrontendEvents;
 use Pimcore\File;
 use Pimcore\Loader\ImplementationLoader\Exception\UnsupportedException;
 use Pimcore\Logger;
@@ -121,7 +122,7 @@ class AssetController extends ElementControllerBase implements EventedController
                 $data['data'] = false;
             }
         } elseif ($asset instanceof Asset\Document) {
-            $data['pdfPreviewAvailable'] = (bool) $this->getDocumentPreviewPdf($asset);
+            $data['pdfPreviewAvailable'] = (bool)$this->getDocumentPreviewPdf($asset);
         } elseif ($asset instanceof Asset\Video) {
             $videoInfo = [];
 
@@ -168,7 +169,7 @@ class AssetController extends ElementControllerBase implements EventedController
                 $imageInfo['dimensions']['height'] = $asset->getHeight();
             }
 
-            $imageInfo['exiftoolAvailable'] = (bool) \Pimcore\Tool\Console::getExecutable('exiftool');
+            $imageInfo['exiftoolAvailable'] = (bool)\Pimcore\Tool\Console::getExecutable('exiftool');
 
             if (!$asset->getEmbeddedMetaData(false)) {
                 $asset->getEmbeddedMetaData(true, false); // read Exif, IPTC and XPM like in the old days ...
@@ -182,10 +183,24 @@ class AssetController extends ElementControllerBase implements EventedController
         $data['versionDate'] = $asset->getModificationDate();
         $data['filesizeFormatted'] = $asset->getFileSize(true);
         $data['filesize'] = $asset->getFileSize();
-        $data['url'] = Tool::getHostUrl(null, $request) . $asset->getRealFullPath();
         $data['fileExtension'] = File::getFileExtension($asset->getFilename());
         $data['idPath'] = Element\Service::getIdPath($asset);
         $data['userPermissions'] = $asset->getUserPermissions();
+
+        // get real public url
+        $path = $asset->getPath() . $asset->getFilename();
+        $path = urlencode_ignore_slash($path);
+        $event = new GenericEvent($asset, [
+            'frontendPath' => $path,
+        ]);
+        \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::ASSET_PATH, $event);
+        $publicUrl = $event->getArgument('frontendPath');
+
+        if (!strpos($publicUrl, 'http')) {
+            $publicUrl = Tool::getHostUrl(null, $request) . $path;
+        }
+
+        $data['url'] = $publicUrl;
 
         $this->addAdminStyle($asset, ElementAdminStyleEvent::CONTEXT_EDITOR, $data);
 
@@ -258,13 +273,13 @@ class AssetController extends ElementControllerBase implements EventedController
 
                 $condition = 'parentId = ' . $db->quote($asset->getId()) . ' AND
                 (
-                    (SELECT list FROM users_workspaces_asset WHERE userId IN (' . implode(',', $userIds) . ') AND LOCATE(CONCAT(path,filename),cpath)=1 ORDER BY LENGTH(cpath) DESC, FIELD(userId, '. $this->getAdminUser()->getId() .') DESC, list DESC LIMIT 1)=1
+                    (SELECT list FROM users_workspaces_asset WHERE userId IN (' . implode(',', $userIds) . ') AND LOCATE(CONCAT(path,filename),cpath)=1 ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $this->getAdminUser()->getId() . ') DESC, list DESC LIMIT 1)=1
                     or
-                    (SELECT list FROM users_workspaces_asset WHERE userId IN (' . implode(',', $userIds) . ') AND LOCATE(cpath,CONCAT(path,filename))=1 ORDER BY LENGTH(cpath) DESC, FIELD(userId, '. $this->getAdminUser()->getId() .') DESC, list DESC LIMIT 1)=1
+                    (SELECT list FROM users_workspaces_asset WHERE userId IN (' . implode(',', $userIds) . ') AND LOCATE(cpath,CONCAT(path,filename))=1 ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $this->getAdminUser()->getId() . ') DESC, list DESC LIMIT 1)=1
                 )';
             }
 
-            if (! is_null($filter)) {
+            if (!is_null($filter)) {
                 $db = Db::get();
 
                 $condition = '(' . $condition . ')' . ' AND  CAST(assets.filename AS CHAR CHARACTER SET utf8) COLLATE utf8_general_ci LIKE ' . $db->quote($filter);
@@ -564,7 +579,7 @@ class AssetController extends ElementControllerBase implements EventedController
         $newFileExt = File::getFileExtension($newFilename);
         $currentFileExt = File::getFileExtension($asset->getFilename());
         if ($newFileExt != $currentFileExt) {
-            $newFilename = preg_replace('/\.' . $currentFileExt . '$/i', '.'.$newFileExt, $asset->getFilename());
+            $newFilename = preg_replace('/\.' . $currentFileExt . '$/i', '.' . $newFileExt, $asset->getFilename());
             $newFilename = Element\Service::getSaveCopyName('asset', $newFilename, $asset->getParent());
             $asset->setFilename($newFilename);
         }
@@ -907,7 +922,7 @@ class AssetController extends ElementControllerBase implements EventedController
             $publicDir = new Asset\WebDAV\Folder($homeDir);
             $objectTree = new Asset\WebDAV\Tree($publicDir);
             $server = new \Sabre\DAV\Server($objectTree);
-            $server->setBaseUri($this->generateUrl('pimcore_admin_webdav', [ 'path' => '/' ]));
+            $server->setBaseUri($this->generateUrl('pimcore_admin_webdav', ['path' => '/']));
 
             // lock plugin
             $lockBackend = new \Sabre\DAV\Locks\Backend\File(PIMCORE_SYSTEM_TEMP_DIRECTORY . '/webdav-locks.dat');
@@ -1210,7 +1225,7 @@ class AssetController extends ElementControllerBase implements EventedController
 
             $exiftool = \Pimcore\Tool\Console::getExecutable('exiftool');
             if ($thumbnailConfig->getFormat() == 'JPEG' && $exiftool && isset($config['dpi']) && $config['dpi']) {
-                \Pimcore\Tool\Console::exec($exiftool . ' -overwrite_original -xresolution=' . escapeshellarg((int) $config['dpi']) . ' -yresolution=' . escapeshellarg((int) $config['dpi']) . ' -resolutionunit=inches ' . escapeshellarg($thumbnailFile));
+                \Pimcore\Tool\Console::exec($exiftool . ' -overwrite_original -xresolution=' . escapeshellarg((int)$config['dpi']) . ' -yresolution=' . escapeshellarg((int)$config['dpi']) . ' -resolutionunit=inches ' . escapeshellarg($thumbnailFile));
             }
         }
         if ($thumbnail) {
@@ -1309,7 +1324,7 @@ class AssetController extends ElementControllerBase implements EventedController
         }
 
         if ($request->get('treepreview')) {
-            $thumbnailConfig = Asset\Image\Thumbnail\Config::getPreviewConfig((bool) $request->get('hdpi'));
+            $thumbnailConfig = Asset\Image\Thumbnail\Config::getPreviewConfig((bool)$request->get('hdpi'));
         }
 
         $cropPercent = $request->get('cropPercent');
@@ -1330,7 +1345,7 @@ class AssetController extends ElementControllerBase implements EventedController
         if ($fileinfo) {
             return $this->adminJson([
                 'width' => $thumbnail->getWidth(),
-                'height' => $thumbnail->getHeight(), ]);
+                'height' => $thumbnail->getHeight(),]);
         }
 
         $thumbnailFile = $thumbnail->getFileSystemPath();
@@ -1372,7 +1387,7 @@ class AssetController extends ElementControllerBase implements EventedController
         $thumbnail = array_merge($request->request->all(), $request->query->all());
 
         if ($request->get('treepreview')) {
-            $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig((bool) $request->get('hdpi'));
+            $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig((bool)$request->get('hdpi'));
         }
 
         $time = null;
@@ -1435,7 +1450,7 @@ class AssetController extends ElementControllerBase implements EventedController
         }
 
         if ($request->get('treepreview')) {
-            $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig((bool) $request->get('hdpi'));
+            $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig((bool)$request->get('hdpi'));
         }
 
         $page = 1;
@@ -1683,7 +1698,7 @@ class AssetController extends ElementControllerBase implements EventedController
 
         $conditionFilters = [];
         $list = new Asset\Listing();
-        $conditionFilters[] = 'path LIKE ' . ($folder->getRealFullPath() == '/' ? "'/%'" : $list->quote($list->escapeLike($folder->getRealFullPath()) . '/%')) ." AND type != 'folder'";
+        $conditionFilters[] = 'path LIKE ' . ($folder->getRealFullPath() == '/' ? "'/%'" : $list->quote($list->escapeLike($folder->getRealFullPath()) . '/%')) . " AND type != 'folder'";
 
         if (!$this->getAdminUser()->isAdmin()) {
             $userIds = $this->getAdminUser()->getRoles();
@@ -1935,7 +1950,7 @@ class AssetController extends ElementControllerBase implements EventedController
                 //add a condition if id numbers are specified
                 $conditionFilters[] = 'id IN (' . implode(',', $quotedSelectedIds) . ')';
             }
-            $conditionFilters[] = 'path LIKE ' . $db->quote($db->escapeLike($parentPath) . '/%') .' AND type != ' . $db->quote('folder');
+            $conditionFilters[] = 'path LIKE ' . $db->quote($db->escapeLike($parentPath) . '/%') . ' AND type != ' . $db->quote('folder');
             if (!$this->getAdminUser()->isAdmin()) {
                 $userIds = $this->getAdminUser()->getRoles();
                 $userIds[] = $this->getAdminUser()->getId();

--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -186,7 +186,7 @@ class AssetController extends ElementControllerBase implements EventedController
         $data['fileExtension'] = File::getFileExtension($asset->getFilename());
         $data['idPath'] = Element\Service::getIdPath($asset);
         $data['userPermissions'] = $asset->getUserPermissions();
-        $data['url'] = $asset->getFullPath(true);
+        $data['url'] = $asset->getFrontendFullPath();
 
         $this->addAdminStyle($asset, ElementAdminStyleEvent::CONTEXT_EDITOR, $data);
 

--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -186,21 +186,7 @@ class AssetController extends ElementControllerBase implements EventedController
         $data['fileExtension'] = File::getFileExtension($asset->getFilename());
         $data['idPath'] = Element\Service::getIdPath($asset);
         $data['userPermissions'] = $asset->getUserPermissions();
-
-        // get real public url
-        $path = $asset->getPath() . $asset->getFilename();
-        $path = urlencode_ignore_slash($path);
-        $event = new GenericEvent($asset, [
-            'frontendPath' => $path,
-        ]);
-        \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::ASSET_PATH, $event);
-        $publicUrl = $event->getArgument('frontendPath');
-
-        if (!strpos($publicUrl, 'http')) {
-            $publicUrl = Tool::getHostUrl(null, $request) . $path;
-        }
-
-        $data['url'] = $publicUrl;
+        $data['url'] = $asset->getFullPath(true);
 
         $this->addAdminStyle($asset, ElementAdminStyleEvent::CONTEXT_EDITOR, $data);
 

--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -25,7 +25,6 @@ use Pimcore\Db;
 use Pimcore\Event\Admin\ElementAdminStyleEvent;
 use Pimcore\Event\AdminEvents;
 use Pimcore\Event\AssetEvents;
-use Pimcore\Event\FrontendEvents;
 use Pimcore\File;
 use Pimcore\Loader\ImplementationLoader\Exception\UnsupportedException;
 use Pimcore\Logger;

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -873,24 +873,37 @@ class Asset extends Element\AbstractElement
     /**
      * Returns the full path of the asset including the filename
      *
-     * @param bool $forceFrontendUrl
      * @return string
      */
-    public function getFullPath($forceFrontendUrl = false)
+    public function getFullPath()
     {
         $path = $this->getPath() . $this->getFilename();
 
-        if (Tool::isFrontend() || $forceFrontendUrl) {
-            $path = urlencode_ignore_slash($path);
-
-            $event = new GenericEvent($this, [
-                'frontendPath' => $path,
-            ]);
-            \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::ASSET_PATH, $event);
-            $path = $event->getArgument('frontendPath');
+        if (Tool::isFrontend()) {
+            return $this->getFrontendFullPath();
         }
 
         return $path;
+    }
+
+    /**
+     * Returns the full path of the asset (listener aware)
+     *
+     * @return string
+     * @internal
+     */
+    public function getFrontendFullPath()
+    {
+        $path = $this->getPath() . $this->getFilename();
+        $path = urlencode_ignore_slash($path);
+
+        $event = new GenericEvent($this, [
+            'frontendPath' => $path,
+        ]);
+
+        \Pimcore::getEventDispatcher()->dispatch(FrontendEvents::ASSET_PATH, $event);
+
+        return $event->getArgument('frontendPath');
     }
 
     /**

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -28,6 +28,7 @@ use Pimcore\Model\Asset\Listing;
 use Pimcore\Model\Asset\MetaData\ClassDefinition\Data\Data;
 use Pimcore\Model\Asset\MetaData\ClassDefinition\Data\DataDefinitionInterface;
 use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Tool;
 use Pimcore\Tool\Mime;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -437,7 +438,7 @@ class Asset extends Element\AbstractElement
 
         foreach ($mappings as $assetType => $patterns) {
             foreach ($patterns as $pattern) {
-                if (preg_match($pattern, $mimeType . ' .'. File::getFileExtension($filename))) {
+                if (preg_match($pattern, $mimeType . ' .' . File::getFileExtension($filename))) {
                     $type = $assetType;
                     break;
                 }
@@ -609,7 +610,7 @@ class Asset extends Element\AbstractElement
         if ($this->getId() != 1) { // not for the root node
 
             if (!Element\Service::isValidKey($this->getKey(), 'asset')) {
-                throw new \Exception("invalid filename '".$this->getKey()."' for asset with id [ " . $this->getId() . ' ]');
+                throw new \Exception("invalid filename '" . $this->getKey() . "' for asset with id [ " . $this->getId() . ' ]');
             }
 
             if ($this->getParentId() == $this->getId()) {
@@ -679,7 +680,7 @@ class Asset extends Element\AbstractElement
         $dirPath = dirname($destinationPath);
         if (!is_dir($dirPath)) {
             if (!File::mkdir($dirPath)) {
-                throw new \Exception('Unable to create directory: '. $dirPath . ' for asset :' . $this->getId());
+                throw new \Exception('Unable to create directory: ' . $dirPath . ' for asset :' . $this->getId());
             }
         }
 
@@ -690,7 +691,7 @@ class Asset extends Element\AbstractElement
         $newPath = dirname($this->getFileSystemPath());
         if (!is_dir($newPath)) {
             if (!File::mkdir($newPath)) {
-                throw new \Exception('Unable to create directory: '. $newPath . ' for asset :' . $this->getId());
+                throw new \Exception('Unable to create directory: ' . $newPath . ' for asset :' . $this->getId());
             }
         }
 
@@ -749,7 +750,7 @@ class Asset extends Element\AbstractElement
         } else {
             if (!is_dir($destinationPath) && !is_dir($this->getFileSystemPath())) {
                 if (!File::mkdir($this->getFileSystemPath())) {
-                    throw new \Exception('Unable to create directory: '. $this->getFileSystemPath() . ' for asset :' . $this->getId());
+                    throw new \Exception('Unable to create directory: ' . $this->getFileSystemPath() . ' for asset :' . $this->getId());
                 }
             }
         }
@@ -872,13 +873,14 @@ class Asset extends Element\AbstractElement
     /**
      * Returns the full path of the asset including the filename
      *
+     * @param bool $forceFrontendUrl
      * @return string
      */
-    public function getFullPath()
+    public function getFullPath($forceFrontendUrl = false)
     {
         $path = $this->getPath() . $this->getFilename();
 
-        if (\Pimcore\Tool::isFrontend()) {
+        if (Tool::isFrontend() || $forceFrontendUrl) {
             $path = urlencode_ignore_slash($path);
 
             $event = new GenericEvent($this, [
@@ -1110,7 +1112,7 @@ class Asset extends Element\AbstractElement
      */
     public function getId()
     {
-        return (int) $this->id;
+        return (int)$this->id;
     }
 
     /**
@@ -1118,7 +1120,7 @@ class Asset extends Element\AbstractElement
      */
     public function getFilename()
     {
-        return (string) $this->filename;
+        return (string)$this->filename;
     }
 
     /**
@@ -1136,7 +1138,7 @@ class Asset extends Element\AbstractElement
      */
     public function getModificationDate()
     {
-        return (int) $this->modificationDate;
+        return (int)$this->modificationDate;
     }
 
     /**
@@ -1170,7 +1172,7 @@ class Asset extends Element\AbstractElement
      */
     public function setCreationDate($creationDate)
     {
-        $this->creationDate = (int) $creationDate;
+        $this->creationDate = (int)$creationDate;
 
         return $this;
     }
@@ -1182,7 +1184,7 @@ class Asset extends Element\AbstractElement
      */
     public function setId($id)
     {
-        $this->id = (int) $id;
+        $this->id = (int)$id;
 
         return $this;
     }
@@ -1194,7 +1196,7 @@ class Asset extends Element\AbstractElement
      */
     public function setFilename($filename)
     {
-        $this->filename = (string) $filename;
+        $this->filename = (string)$filename;
 
         return $this;
     }
@@ -1220,7 +1222,7 @@ class Asset extends Element\AbstractElement
     {
         $this->markFieldDirty('modificationDate');
 
-        $this->modificationDate = (int) $modificationDate;
+        $this->modificationDate = (int)$modificationDate;
 
         return $this;
     }
@@ -1232,7 +1234,7 @@ class Asset extends Element\AbstractElement
      */
     public function setParentId($parentId)
     {
-        $this->parentId = (int) $parentId;
+        $this->parentId = (int)$parentId;
         $this->parent = null;
 
         return $this;
@@ -1484,7 +1486,7 @@ class Asset extends Element\AbstractElement
      */
     public function setUserOwner($userOwner)
     {
-        $this->userOwner = (int) $userOwner;
+        $this->userOwner = (int)$userOwner;
 
         return $this;
     }
@@ -1498,7 +1500,7 @@ class Asset extends Element\AbstractElement
     {
         $this->markFieldDirty('userModification');
 
-        $this->userModification = (int) $userModification;
+        $this->userModification = (int)$userModification;
 
         return $this;
     }
@@ -1608,7 +1610,7 @@ class Asset extends Element\AbstractElement
         }
 
         if ($customSettings instanceof \stdClass) {
-            $customSettings = (array) $customSettings;
+            $customSettings = (array)$customSettings;
         }
 
         if (!is_array($customSettings)) {
@@ -1641,11 +1643,11 @@ class Asset extends Element\AbstractElement
     }
 
     /**
-     * @internal
-     *
      * @param array $metadata for each array item: mandatory keys: name, type - optional keys: data, language
      *
      * @return self
+     * @internal
+     *
      */
     public function setMetadataRaw($metadata)
     {
@@ -1691,7 +1693,7 @@ class Asset extends Element\AbstractElement
      */
     public function setHasMetaData($hasMetaData)
     {
-        $this->hasMetaData = (bool) $hasMetaData;
+        $this->hasMetaData = (bool)$hasMetaData;
 
         return $this;
     }
@@ -2029,7 +2031,7 @@ class Asset extends Element\AbstractElement
      */
     public function setVersionCount(?int $versionCount): ElementInterface
     {
-        $this->versionCount = (int) $versionCount;
+        $this->versionCount = (int)$versionCount;
 
         return $this;
     }


### PR DESCRIPTION
## Description of the bug 

The public url displayed in the admin backend of pimcore always displays an url, with the hostname of the Pimcore application as a base. 

If you use AWS S3 or AWS Cloudfront for example, the public url should be the specific url of the used system.


## Changes in this pull request  
This PR generates the public url of an asset via the asset events. 
If the url does not include http (no public url) it will prepend the hostname of the Pimcore application.

