### PR TITLE
[DOCS] fix twig example of params in Area

### DIFF
--- a/doc/Development_Documentation/03_Documents/01_Editables/04_Area.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/04_Area.md
@@ -59,7 +59,9 @@ into a block element, and the editor cannot choose which area is used, this has 
     {{ pimcore_area('myArea', {
         type: 'gallery-single-images',
         params: {
-            'param1': 123,
+            'gallery-single-images': {
+                'param1': 123,
+            }
         }
     }) }}
 </div>


### PR DESCRIPTION
## Changes in this pull request  
fixes the wrong Twig parameter example in pimcore_area

## Additional info  
The php example seems to be correct here, since I only got it running in Twig when I followed the php structure.
