### PR TITLE
Order Details Tab - fix inconsistent permission check

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Resources/public/js/bundle.js
+++ b/bundles/EcommerceFrameworkBundle/Resources/public/js/bundle.js
@@ -203,18 +203,16 @@ pimcore.bundle.EcommerceFramework.bundle = Class.create(pimcore.plugin.admin, {
                 object.tab.items.items[1].updateLayout();
                 pimcore.layout.refresh();
             }
+        }
+        if (pimcore.globalmanager.get("user").isAllowed("bundle_ecommerce_back-office_order")) {
 
-            if (pimcore.globalmanager.get("user").isAllowed("bundle_ecommerce_back-office_order")) {
-
-                if (type == "object" && object.data.general.o_className == "OnlineShopOrder") {
-                    var tab = new pimcore.bundle.EcommerceFramework.OrderTab(object, type);
-                    object.tab.items.items[1].insert(0, tab.getLayout());
-                    object.tab.items.items[1].updateLayout();
-                    object.tab.items.items[1].setActiveTab(0);
-                    pimcore.layout.refresh();
-                }
+            if (type == "object" && object.data.general.o_className == "OnlineShopOrder") {
+                var tab = new pimcore.bundle.EcommerceFramework.OrderTab(object, type);
+                object.tab.items.items[1].insert(0, tab.getLayout());
+                object.tab.items.items[1].updateLayout();
+                object.tab.items.items[1].setActiveTab(0);
+                pimcore.layout.refresh();
             }
-
         }
     }
 


### PR DESCRIPTION
The Order Details Tab for the ecommerce backoffice detail view has stricter access check than the actual detail page.
It doesn't seem to be related to `bundle_ecommerce_pricing_rules` but there was an access check for that in place - re-organized.
Maybe the proper base for https://github.com/pimcore/pimcore/pull/7389