### PR TITLE
Make "GoogleTagManager::formatPrice()" compatible with its default value

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Tracking/Tracker/GoogleTagManager.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/Tracker/GoogleTagManager.php
@@ -298,7 +298,7 @@ class GoogleTagManager extends Tracker implements
      */
     private function formatPrice($price = null)
     {
-        return Decimal::fromNumeric($price)->asString();
+        return is_scalar($price) ? Decimal::fromNumeric($price)->asString() : '';
     }
 
     /**


### PR DESCRIPTION
`GoogleTagManager::formatPrice()` accepts and defaults to NULL for `$price`. But `Decimal::fromNumeric($price)` wont work with that and throw a `\InvalidArgumentException`.
Add a check to be compatible with the method signature - similar to the code handling in `EnhancedEcommerce::transformProductImpression()`
