### PR TITLE
[Maintenance] fix not updating TmpStore on executing maintenance task

### DIFF
--- a/lib/Maintenance/Executor.php
+++ b/lib/Maintenance/Executor.php
@@ -119,7 +119,7 @@ final class Executor implements ExecutorInterface
      */
     public function setLastExecution()
     {
-        TmpStore::add($this->pidFileName, time());
+        TmpStore::set($this->pidFileName, time());
     }
 
     /**


### PR DESCRIPTION
TmpStore does not get updated till default expiration time of 7 days (86400 * 7).
Just use TmpStore::set instead of TmpStore:add to always update the maintenance entry as soon
it is executed.

fixes #7347