### PR TITLE
[Grid config] Error when opening saved configuration which contains fields of deleted object brick

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -551,6 +551,7 @@ class DataObjectHelperController extends AdminController
 
                             $brickClass = DataObject\Objectbrick\Definition::getByKey($brick);
 
+                            $fd = null;
                             if ($brickClass instanceof DataObject\Objectbrick\Definition) {
                                 if ($brickDescriptor) {
                                     $innerContainer = $brickDescriptor['innerContainer'] ?? 'localizedfields';
@@ -562,7 +563,7 @@ class DataObjectHelperController extends AdminController
                                 }
                             }
 
-                            if (!empty($fd)) {
+                            if ($fd !== null) {
                                 $fieldConfig = $this->getFieldGridConfig($fd, $gridType, $sc['position'], true, $keyPrefix, $class, $objectId);
                                 if (!empty($fieldConfig)) {
                                     if (isset($sc['width'])) {

--- a/models/DataObject/Listing/Concrete/Dao.php
+++ b/models/DataObject/Listing/Concrete/Dao.php
@@ -249,6 +249,10 @@ CONDITION;
         $objectbricks = $this->model->getObjectbricks();
         if (!empty($objectbricks)) {
             foreach ($objectbricks as $ob) {
+                $brickDefinition = DataObject\Objectbrick\Definition::getByKey($ob);
+                if (!$brickDefinition instanceof DataObject\Objectbrick\Definition) {
+                    continue;
+                }
 
                 // join info
                 $table = 'object_brick_query_' . $ob . '_' . $this->model->getClassId();
@@ -265,7 +269,7 @@ CONDITION
                     ''
                 );
 
-                $brickDefinition = DataObject\Objectbrick\Definition::getByKey($ob);
+
                 if ($brickDefinition->getFieldDefinition('localizedfields')) {
                     $langugage = $this->getLocalizedBrickLanguage();
                     //TODO wrong pattern

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -797,24 +797,26 @@ QUERY;
 
         /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedFieldDefinition */
         $localizedFieldDefinition = $container->getFieldDefinition('localizedfields', ['suppressEnrichment' => true]);
-        foreach ($localizedFieldDefinition->getFieldDefinitions(['suppressEnrichment' => true]) as $value) {
-            if ($value instanceof ResourcePersistenceAwareInterface || method_exists($value, 'getDataForResource')) {
-                /** @var DataObject\ClassDefinition\Data & ResourcePersistenceAwareInterface $value */
-                if ($value->getColumnType()) {
-                    $key = $value->getName();
+        if($localizedFieldDefinition instanceof DataObject\ClassDefinition\Data\Localizedfields) {
+            foreach ($localizedFieldDefinition->getFieldDefinitions(['suppressEnrichment' => true]) as $value) {
+                if ($value instanceof ResourcePersistenceAwareInterface || method_exists($value, 'getDataForResource')) {
+                    /** @var DataObject\ClassDefinition\Data & ResourcePersistenceAwareInterface $value */
+                    if ($value->getColumnType()) {
+                        $key = $value->getName();
 
-                    if (is_array($value->getColumnType())) {
-                        // if a datafield requires more than one column
-                        foreach ($value->getColumnType() as $fkey => $fvalue) {
-                            $this->addModifyColumn($table, $key . '__' . $fkey, $fvalue, '', 'NULL');
-                            $protectedColumns[] = $key . '__' . $fkey;
+                        if (is_array($value->getColumnType())) {
+                            // if a datafield requires more than one column
+                            foreach ($value->getColumnType() as $fkey => $fvalue) {
+                                $this->addModifyColumn($table, $key . '__' . $fkey, $fvalue, '', 'NULL');
+                                $protectedColumns[] = $key . '__' . $fkey;
+                            }
+                        } elseif ($value->getColumnType()) {
+                            $this->addModifyColumn($table, $key, $value->getColumnType(), '', 'NULL');
+                            $protectedColumns[] = $key;
                         }
-                    } elseif ($value->getColumnType()) {
-                        $this->addModifyColumn($table, $key, $value->getColumnType(), '', 'NULL');
-                        $protectedColumns[] = $key;
-                    }
 
-                    $this->addIndexToField($value, $table, 'getColumnType', true, true);
+                        $this->addIndexToField($value, $table, 'getColumnType', true, true);
+                    }
                 }
             }
         }
@@ -847,16 +849,21 @@ QUERY;
 
                 DataObject\ClassDefinition\Service::updateTableDefinitions($this->tableDefinitions, [$queryTable]);
 
+                $fieldDefinitions = [];
                 if ($container instanceof DataObject\Objectbrick\Definition) {
                     $containerKey = $context['containerKey'];
                     $container = DataObject\Objectbrick\Definition::getByKey($containerKey);
+
                     /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedfields */
                     $localizedfields = $container->getFieldDefinition('localizedfields', ['suppressEnrichment' => true]);
                     $fieldDefinitions = $localizedfields->getFieldDefinitions(['suppressEnrichment' => true]);
                 } else {
                     /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedfields */
                     $localizedfields = $this->model->getClass()->getFieldDefinition('localizedfields', ['suppressEnrichment' => true]);
-                    $fieldDefinitions = $localizedfields->getFieldDefinitions(['suppressEnrichment' => true]);
+
+                    if($localizedfields instanceof DataObject\ClassDefinition\Data\Localizedfields) {
+                        $fieldDefinitions = $localizedfields->getFieldDefinitions(['suppressEnrichment' => true]);
+                    }
                 }
 
                 // add non existing columns in the table

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -358,7 +358,7 @@ class Service extends Model\Element\Service
                         /** @var Model\DataObject\ClassDefinition\Data\Localizedfields $localizedFields */
                         $localizedFields = $brickClass->getFieldDefinition($innerContainer);
                         $def = $localizedFields->getFieldDefinition($brickDescriptor['brickfield']);
-                    } else {
+                    } elseif($brickClass instanceof Objectbrick\Definition) {
                         $def = $brickClass->getFieldDefinition($brickKey, $context);
                     }
                 }


### PR DESCRIPTION
Steps to reproduce:
1. Create class `Test` with `object brick` field `bricks`
2. Create object brick `testbrick` with an input field `testfield`
3. Create object `A` in `Home` folder (tree root)
4. Open `Home` in grid view
5. Edit table configuration and add field `testfield` of brick `testbrick`
6. Save configuration under `My configuration`
7. Delete object brick `testbrick`
8. Reload grid for `Home` folder
9. Try to open previously saved table configuration `My configuration` -> results in error `Call to a member function getFieldDefinition() on null`

This PR fixes that. If the brick of a field in the saved table configuration does not exist anymore, this field will be skipped when generating the table.