### PR TITLE
[Maintenance] fix remove duplicate lock for CacheCleanupTask and LowQualityImagePreviewTask

### DIFF
--- a/lib/Maintenance/Tasks/CacheCleanupTask.php
+++ b/lib/Maintenance/Tasks/CacheCleanupTask.php
@@ -17,8 +17,6 @@ namespace Pimcore\Maintenance\Tasks;
 use Pimcore\Cache\Core\CoreHandlerInterface;
 use Pimcore\Maintenance\TaskInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Lock\Factory as LockFactory;
-use Symfony\Component\Lock\LockInterface;
 
 final class CacheCleanupTask implements TaskInterface
 {
@@ -33,20 +31,13 @@ final class CacheCleanupTask implements TaskInterface
     private $logger;
 
     /**
-     * @var LockInterface
-     */
-    private $lock;
-
-    /**
      * @param CoreHandlerInterface $cacheHandler
      * @param LoggerInterface $logger
-     * @param LockFactory $lockFactory
      */
-    public function __construct(CoreHandlerInterface $cacheHandler, LoggerInterface $logger, LockFactory $lockFactory)
+    public function __construct(CoreHandlerInterface $cacheHandler)
     {
         $this->cacheHandler = $cacheHandler;
         $this->logger = $logger;
-        $this->lock = $lockFactory->createLock(self::class, 86400);
     }
 
     /**
@@ -54,9 +45,8 @@ final class CacheCleanupTask implements TaskInterface
      */
     public function execute()
     {
-        if (!$this->lock->isAcquired() && date('H') <= 4) {
+        if (date('H') <= 4) {
             // execution should be only sometime between 0:00 and 4:59 -> less load expected
-            $this->lock->acquire();
             $this->logger->debug('Execute purge() on cache handler');
             $this->cacheHandler->purge();
         } else {

--- a/lib/Maintenance/Tasks/LowQualityImagePreviewTask.php
+++ b/lib/Maintenance/Tasks/LowQualityImagePreviewTask.php
@@ -17,8 +17,6 @@ namespace Pimcore\Maintenance\Tasks;
 use Pimcore\Maintenance\TaskInterface;
 use Pimcore\Model\Asset;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Lock\Factory as LockFactory;
-use Symfony\Component\Lock\LockInterface;
 
 final class LowQualityImagePreviewTask implements TaskInterface
 {
@@ -28,17 +26,11 @@ final class LowQualityImagePreviewTask implements TaskInterface
     private $logger;
 
     /**
-     * @var LockInterface
-     */
-    private $lock;
-
-    /**
      * @param LoggerInterface $logger
      */
-    public function __construct(LoggerInterface $logger, LockFactory $lockFactory)
+    public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
-        $this->lock = $lockFactory->createLock(self::class, 86400 * 2);
     }
 
     /**
@@ -46,9 +38,8 @@ final class LowQualityImagePreviewTask implements TaskInterface
      */
     public function execute()
     {
-        if (!$this->lock->isAcquired() && date('H') <= 4) {
+        if (date('H') <= 4) {
             // execution should be only sometime between 0:00 and 4:59 -> less load expected
-            $this->lock->acquire();
             $this->logger->debug('Execute low quality image preview generation');
 
             $listing = new Asset\Listing();


### PR DESCRIPTION
Executor is handling all task locks. Remove own lock handling from CacheCleanupTask and LowQualityImagePreviewTask
to prevent duplicate lock entries in lock_keys table.

@dvesh3 @brusch 
