### PR TITLE
Consistently use type casting instead of according functions

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -222,7 +222,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $asset = Asset::getById($allParams['node']);
 
         $filter = $request->get('filter');
-        $limit = intval($allParams['limit']);
+        $limit = (int)$allParams['limit'];
         if (!is_null($filter)) {
             if (substr($filter, -1) != '*') {
                 $filter .= '*';
@@ -235,7 +235,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             $limit = 100000000;
         }
 
-        $offset = isset($allParams['start']) ? intval($allParams['start']) : 0;
+        $offset = isset($allParams['start']) ? (int)$allParams['start'] : 0;
 
         $filteredTotalCount = 0;
 
@@ -310,7 +310,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                 'overflow' => !is_null($filter) && ($filteredTotalCount > $limit),
                 'nodes' => $assets,
                 'filter' => $request->get('filter') ? $request->get('filter') : '',
-                'inSearch' => intval($request->get('inSearch')),
+                'inSearch' => (int)$request->get('inSearch'),
             ]);
         } else {
             return $this->adminJson($assets);
@@ -469,7 +469,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             $parentId = Asset\Service::createFolderByPath($defaultUploadPath)->getId();
         }
 
-        $parentAsset = Asset::getById(intval($parentId));
+        $parentAsset = Asset::getById((int)$parentId);
 
         // check for duplicate filename
         $filename = $this->getSafeFilename($parentAsset->getRealFullPath(), $filename);
@@ -596,7 +596,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     public function addFolderAction(Request $request)
     {
         $success = false;
-        $parentAsset = Asset::getById(intval($request->get('parentId')));
+        $parentAsset = Asset::getById((int)$request->get('parentId'));
         $equalAsset = Asset::getByPath($parentAsset->getRealFullPath() . '/' . $request->get('name'));
 
         if ($parentAsset->isAllowed('create')) {
@@ -630,7 +630,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
             $list = new Asset\Listing();
             $list->setCondition('path LIKE ?', [$list->escapeLike($parentAsset->getRealFullPath()) . '/%']);
-            $list->setLimit(intval($request->get('amount')));
+            $list->setLimit((int)$request->get('amount'));
             $list->setOrderKey('LENGTH(path)', false);
             $list->setOrder('DESC');
 
@@ -1073,7 +1073,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
      */
     public function showVersionAction(Request $request)
     {
-        $id = intval($request->get('id'));
+        $id = (int)$request->get('id');
         $version = Model\Version::getById($id);
         if (!$version) {
             throw $this->createNotFoundException('Version not found');
@@ -1248,7 +1248,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
      */
     public function getAssetAction(Request $request)
     {
-        $image = Asset::getById(intval($request->get('id')));
+        $image = Asset::getById((int)$request->get('id'));
 
         if (!$image) {
             throw $this->createNotFoundException('Asset not found');
@@ -1276,7 +1276,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     public function getImageThumbnailAction(Request $request)
     {
         $fileinfo = $request->get('fileinfo');
-        $image = Asset\Image::getById(intval($request->get('id')));
+        $image = Asset\Image::getById((int)$request->get('id'));
 
         if (!$image) {
             throw $this->createNotFoundException('Asset not found');
@@ -1358,7 +1358,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $video = null;
 
         if ($request->get('id')) {
-            $video = Asset\Video::getById(intval($request->get('id')));
+            $video = Asset\Video::getById((int)$request->get('id'));
         } elseif ($request->get('path')) {
             $video = Asset\Video::getByPath($request->get('path'));
         }
@@ -1379,7 +1379,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         $time = null;
         if ($request->get('time')) {
-            $time = intval($request->get('time'));
+            $time = (int)$request->get('time');
         }
 
         if ($request->get('settime')) {
@@ -1390,7 +1390,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         $image = null;
         if ($request->get('image')) {
-            $image = Asset::getById(intval($request->get('image')));
+            $image = Asset::getById((int)$request->get('image'));
         }
 
         if ($request->get('setimage') && $image) {
@@ -1419,7 +1419,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
      */
     public function getDocumentThumbnailAction(Request $request)
     {
-        $document = Asset\Document::getById(intval($request->get('id')));
+        $document = Asset\Document::getById((int)$request->get('id'));
 
         if (!$document) {
             throw $this->createNotFoundException('could not load document asset');
@@ -1842,13 +1842,13 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     public function copyAction(Request $request)
     {
         $success = false;
-        $sourceId = intval($request->get('sourceId'));
+        $sourceId = (int)$request->get('sourceId');
         $source = Asset::getById($sourceId);
 
         $session = Tool\Session::get('pimcore_copy');
         $sessionBag = $session->get($request->get('transactionId'));
 
-        $targetId = intval($request->get('targetId'));
+        $targetId = (int)$request->get('targetId');
         if ($request->get('targetParentId')) {
             $sourceParent = Asset::getById($request->get('sourceParentId'));
 
@@ -2335,7 +2335,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $data = Tool::getHttpData($request->get('url'));
         $filename = basename($request->get('url'));
         $parentId = $request->get('id');
-        $parentAsset = Asset::getById(intval($parentId));
+        $parentAsset = Asset::getById((int)$parentId);
 
         if (!$parentAsset) {
             throw $this->createNotFoundException('Parent asset not found');

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
@@ -335,7 +335,7 @@ class ClassController extends AdminController implements KernelControllerEventIn
         $configuration = $this->decodeJson($request->get('configuration'));
         $values = $this->decodeJson($request->get('values'));
 
-        $modificationDate = intval($values['modificationDate']);
+        $modificationDate = (int)$values['modificationDate'];
         if ($modificationDate < $customLayout->getModificationDate()) {
             return $this->adminJson(['success' => false, 'msg' => 'custom_layout_changed']);
         }
@@ -966,7 +966,7 @@ class ClassController extends AdminController implements KernelControllerEventIn
     public function getClassDefinitionForColumnConfigAction(Request $request)
     {
         $class = DataObject\ClassDefinition::getById($request->get('id'));
-        $objectId = intval($request->get('oid'));
+        $objectId = (int)$request->get('oid');
 
         $filteredDefinitions = DataObject\Service::getCustomLayoutDefinitionForGridColumnConfig($class, $objectId);
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -236,9 +236,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 'total' => $total,
                 'overflow' => !is_null($filter) && ($filteredTotalCount > $limit),
                 'nodes' => $objects,
-                'fromPaging' => intval($request->get('fromPaging')),
+                'fromPaging' => (int)$request->get('fromPaging'),
                 'filter' => $request->get('filter') ? $request->get('filter') : '',
-                'inSearch' => intval($request->get('inSearch')),
+                'inSearch' => (int)$request->get('inSearch'),
             ]);
         }
 
@@ -256,7 +256,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
         $tmpObject = [
             'id' => $child->getId(),
-            'idx' => intval($child->getIndex()),
+            'idx' => (int)$child->getIndex(),
             'key' => $child->getKey(),
             'sortBy' => $child->getChildrenSortBy(),
             'sortOrder' => $child->getChildrenSortOrder(),
@@ -700,7 +700,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         }
         Element\Editlock::lock($request->get('id'), 'object');
 
-        $object = DataObject::getById(intval($request->get('id')));
+        $object = DataObject::getById((int)$request->get('id'));
         if ($object->isAllowed('view')) {
             $objectData = [];
 
@@ -902,7 +902,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
             $list = new DataObject\Listing();
             $list->setCondition('o_path LIKE ' . $list->quote($list->escapeLike($parentObject->getRealFullPath()) . '/%'));
-            $list->setLimit(intval($request->get('amount')));
+            $list->setLimit((int)$request->get('amount'));
             $list->setOrderKey('LENGTH(o_path)', false);
             $list->setOrder('DESC');
 
@@ -1461,7 +1461,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     {
         DataObject\AbstractObject::setDoNotRestoreKeyAndPath(true);
 
-        $id = intval($request->get('id'));
+        $id = (int)$request->get('id');
         $version = Model\Version::getById($id);
         $object = $version->loadData();
 
@@ -1497,8 +1497,8 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     {
         DataObject\AbstractObject::setDoNotRestoreKeyAndPath(true);
 
-        $id1 = intval($from);
-        $id2 = intval($to);
+        $id1 = (int)$from;
+        $id2 = (int)$to;
 
         $version1 = Model\Version::getById($id1);
         $object1 = $version1->loadData();
@@ -1948,13 +1948,13 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     public function copyAction(Request $request)
     {
         $message = '';
-        $sourceId = intval($request->get('sourceId'));
+        $sourceId = (int)$request->get('sourceId');
         $source = DataObject::getById($sourceId);
 
         $session = Tool\Session::get('pimcore_copy');
         $sessionBag = $session->get($request->get('transactionId'));
 
-        $targetId = intval($request->get('targetId'));
+        $targetId = (int)$request->get('targetId');
         if ($request->get('targetParentId')) {
             $sourceParent = DataObject::getById($request->get('sourceParentId'));
 

--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -128,8 +128,8 @@ class DocumentController extends ElementControllerBase implements KernelControll
         $allParams = array_merge($request->request->all(), $request->query->all());
 
         $filter = $request->get('filter');
-        $limit = intval($allParams['limit'] ?? 100000000);
-        $offset = intval($allParams['start'] ?? 0);
+        $limit = (int)($allParams['limit'] ?? 100000000);
+        $offset = (int)($allParams['start'] ?? 0);
 
         if (!is_null($filter)) {
             if (substr($filter, -1) != '*') {
@@ -217,7 +217,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
                 'total' => $document->getChildAmount($this->getAdminUser()),
                 'nodes' => $documents,
                 'filter' => $request->get('filter') ? $request->get('filter') : '',
-                'inSearch' => intval($request->get('inSearch')),
+                'inSearch' => (int)$request->get('inSearch'),
             ]);
         } else {
             return $this->adminJson($documents);
@@ -237,7 +237,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         $errorMessage = '';
 
         // check for permission
-        $parentDocument = Document::getById(intval($request->get('parentId')));
+        $parentDocument = Document::getById((int)$request->get('parentId'));
         $document = null;
         if ($parentDocument->isAllowed('create')) {
             $intendedPath = $parentDocument->getRealFullPath() . '/' . $request->get('key');
@@ -252,7 +252,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
                 $createValues['key'] = \Pimcore\Model\Element\Service::getValidKey($request->get('key'), 'document');
 
                 // check for a docType
-                $docType = Document\DocType::getById(intval($request->get('docTypeId')));
+                $docType = Document\DocType::getById((int)$request->get('docTypeId'));
                 if ($docType) {
                     $createValues['template'] = $docType->getTemplate();
                     $createValues['controller'] = $docType->getController();
@@ -382,7 +382,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
 
             $list = new Document\Listing();
             $list->setCondition('path LIKE ?', [$list->escapeLike($parentDocument->getRealFullPath()) . '/%']);
-            $list->setLimit(intval($request->get('amount')));
+            $list->setLimit((int)$request->get('amount'));
             $list->setOrderKey('LENGTH(path)', false);
             $list->setOrder('DESC');
 
@@ -614,7 +614,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         };
 
         // if changed the index change also all documents on the same level
-        $newIndex = intval($newIndex);
+        $newIndex = (int)$newIndex;
         $document->saveIndex($newIndex);
 
         $list = new Document\Listing();
@@ -797,9 +797,9 @@ class DocumentController extends ElementControllerBase implements KernelControll
         $domains = str_replace(' ', '', $domains);
         $domains = explode("\n", $domains);
 
-        if (!$site = Site::getByRootId(intval($request->get('id')))) {
+        if (!$site = Site::getByRootId((int)$request->get('id'))) {
             $site = Site::create([
-                'rootId' => intval($request->get('id')),
+                'rootId' => (int)$request->get('id'),
             ]);
         }
 
@@ -822,7 +822,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
      */
     public function removeSiteAction(Request $request)
     {
-        $site = Site::getByRootId(intval($request->get('id')));
+        $site = Site::getByRootId((int)$request->get('id'));
         $site->delete();
 
         return $this->adminJson(['success' => true]);
@@ -982,11 +982,11 @@ class DocumentController extends ElementControllerBase implements KernelControll
     public function copyAction(Request $request)
     {
         $success = false;
-        $sourceId = intval($request->get('sourceId'));
+        $sourceId = (int)$request->get('sourceId');
         $source = Document::getById($sourceId);
         $session = Session::get('pimcore_copy');
 
-        $targetId = intval($request->get('targetId'));
+        $targetId = (int)$request->get('targetId');
 
         $sessionBag = $session->get($request->get('transactionId'));
 

--- a/bundles/AdminBundle/Controller/Admin/Document/PrintpageControllerBase.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PrintpageControllerBase.php
@@ -161,7 +161,7 @@ class PrintpageControllerBase extends DocumentControllerBase
      */
     public function activeGenerateProcessAction(Request $request)
     {
-        $document = Document\PrintAbstract::getById(intval($request->get('id')));
+        $document = Document\PrintAbstract::getById((int)$request->get('id'));
 
         if (!$document) {
             throw $this->createNotFoundException('Document with id ' . $request->get('id') . ' not found.');
@@ -197,7 +197,7 @@ class PrintpageControllerBase extends DocumentControllerBase
      */
     public function pdfDownloadAction(Request $request)
     {
-        $document = Document\PrintAbstract::getById(intval($request->get('id')));
+        $document = Document\PrintAbstract::getById((int)$request->get('id'));
 
         if (!$document) {
             throw $this->createNotFoundException('Document with id ' . $request->get('id') . ' not found.');
@@ -331,7 +331,7 @@ class PrintpageControllerBase extends DocumentControllerBase
      */
     public function cancelGenerationAction(Request $request)
     {
-        Processor::getInstance()->cancelGeneration(intval($request->get('id')));
+        Processor::getInstance()->cancelGeneration((int)$request->get('id'));
 
         return $this->adminJson(['success' => true]);
     }

--- a/bundles/AdminBundle/Controller/Admin/ElementController.php
+++ b/bundles/AdminBundle/Controller/Admin/ElementController.php
@@ -317,8 +317,8 @@ class ElementController extends AdminController
         $success = false;
         $hasHidden = false;
         $total = 0;
-        $limit = intval($request->get('limit', 50));
-        $offset = intval($request->get('start', 0));
+        $limit = (int)$request->get('limit', 50);
+        $offset = (int)$request->get('start', 0);
 
         if ($element instanceof Element\ElementInterface) {
             $total = $element->getDependencies()->getRequiredByTotalCount();
@@ -587,7 +587,7 @@ class ElementController extends AdminController
      */
     public function getVersionsAction(Request $request)
     {
-        $id = intval($request->get('id'));
+        $id = (int)$request->get('id');
         $type = $request->get('elementType');
         $allowedTypes = ['asset', 'document', 'object'];
 

--- a/bundles/AdminBundle/Controller/Admin/ElementControllerBase.php
+++ b/bundles/AdminBundle/Controller/Admin/ElementControllerBase.php
@@ -55,7 +55,7 @@ class ElementControllerBase extends AdminController
 
         $id = 1;
         if ($request->get('id')) {
-            $id = intval($request->get('id'));
+            $id = (int)$request->get('id');
         }
 
         if (in_array($type, $allowedTypes)) {

--- a/bundles/AdminBundle/Controller/Admin/MiscController.php
+++ b/bundles/AdminBundle/Controller/Admin/MiscController.php
@@ -588,8 +588,8 @@ class MiscController extends AdminController
 
         $db = Db::get();
 
-        $limit = intval($request->get('limit'));
-        $offset = intval($request->get('start'));
+        $limit = (int)$request->get('limit');
+        $offset = (int)$request->get('start');
         $sort = $request->get('sort');
         $dir = $request->get('dir');
         $filter = $request->get('filter');

--- a/bundles/AdminBundle/Controller/Admin/RedirectsController.php
+++ b/bundles/AdminBundle/Controller/Admin/RedirectsController.php
@@ -82,7 +82,7 @@ class RedirectsController extends AdminController
 
                 $redirectTarget = $redirect->getTarget();
                 if (is_numeric($redirectTarget)) {
-                    if ($doc = Document::getById(intval($redirectTarget))) {
+                    if ($doc = Document::getById((int)$redirectTarget)) {
                         $redirect->setTarget($doc->getRealFullPath());
                     }
                 }
@@ -111,7 +111,7 @@ class RedirectsController extends AdminController
 
                 $redirectTarget = $redirect->getTarget();
                 if (is_numeric($redirectTarget)) {
-                    if ($doc = Document::getById(intval($redirectTarget))) {
+                    if ($doc = Document::getById((int)$redirectTarget)) {
                         $redirect->setTarget($doc->getRealFullPath());
                     }
                 }
@@ -155,7 +155,7 @@ class RedirectsController extends AdminController
             foreach ($list->getRedirects() as $redirect) {
                 if ($link = $redirect->getTarget()) {
                     if (is_numeric($link)) {
-                        if ($doc = Document::getById(intval($link))) {
+                        if ($doc = Document::getById((int)$link)) {
                             $redirect->setTarget($doc->getRealFullPath());
                         }
                     }

--- a/bundles/AdminBundle/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/Controller/Admin/SettingsController.php
@@ -1010,8 +1010,8 @@ class SettingsController extends AdminController
                 $glossary->save();
 
                 if ($link = $glossary->getLink()) {
-                    if (intval($link) > 0) {
-                        if ($doc = Document::getById(intval($link))) {
+                    if ((int)$link > 0) {
+                        if ($doc = Document::getById((int)$link)) {
                             $glossary->setLink($doc->getRealFullPath());
                         }
                     }
@@ -1036,8 +1036,8 @@ class SettingsController extends AdminController
                 $glossary->save();
 
                 if ($link = $glossary->getLink()) {
-                    if (intval($link) > 0) {
-                        if ($doc = Document::getById(intval($link))) {
+                    if ((int)$link > 0) {
+                        if ($doc = Document::getById((int)$link)) {
                             $glossary->setLink($doc->getRealFullPath());
                         }
                     }
@@ -1067,8 +1067,8 @@ class SettingsController extends AdminController
             $glossaries = [];
             foreach ($list->getGlossary() as $glossary) {
                 if ($link = $glossary->getLink()) {
-                    if (intval($link) > 0) {
-                        if ($doc = Document::getById(intval($link))) {
+                    if ((int)$link > 0) {
+                        if ($doc = Document::getById((int)$link)) {
                             $glossary->setLink($doc->getRealFullPath());
                         }
                     }

--- a/bundles/AdminBundle/Controller/Admin/TagsController.php
+++ b/bundles/AdminBundle/Controller/Admin/TagsController.php
@@ -40,7 +40,7 @@ class TagsController extends AdminController
         try {
             $tag = new Tag();
             $tag->setName(strip_tags($request->get('text')));
-            $tag->setParentId(intval($request->get('parentId')));
+            $tag->setParentId((int)$request->get('parentId'));
             $tag->save();
 
             return $this->adminJson(['success' => true, 'id' => $tag->getId()]);
@@ -85,7 +85,7 @@ class TagsController extends AdminController
         if ($tag) {
             $parentId = $request->get('parentId');
             if ($parentId || $parentId === '0') {
-                $tag->setParentId(intval($parentId));
+                $tag->setParentId((int)$parentId);
             }
             if ($request->get('text')) {
                 $tag->setName(strip_tags($request->get('text')));
@@ -109,7 +109,7 @@ class TagsController extends AdminController
     public function treeGetChildrenByIdAction(Request $request)
     {
         $showSelection = $request->get('showSelection') == 'true';
-        $assginmentCId = intval($request->get('assignmentCId'));
+        $assginmentCId = (int)$request->get('assignmentCId');
         $assginmentCType = strip_tags($request->get('assignmentCType'));
 
         $recursiveChildren = false;
@@ -124,7 +124,7 @@ class TagsController extends AdminController
 
         $tagList = new Tag\Listing();
         if ($request->get('node')) {
-            $tagList->setCondition('parentId = ?', intval($request->get('node')));
+            $tagList->setCondition('parentId = ?', (int)$request->get('node'));
         } else {
             $tagList->setCondition('ISNULL(parentId) OR parentId = 0');
         }
@@ -140,7 +140,7 @@ class TagsController extends AdminController
                 } else {
                     $ids = explode('/', $filterTag->getIdPath());
                     if (isset($ids[1])) {
-                        $filterIds[] = intval($ids[1]);
+                        $filterIds[] = (int)$ids[1];
                     }
                 }
             }
@@ -205,7 +205,7 @@ class TagsController extends AdminController
      */
     public function loadTagsForElementAction(Request $request)
     {
-        $assginmentCId = intval($request->get('assignmentCId'));
+        $assginmentCId = (int)$request->get('assignmentCId');
         $assginmentCType = strip_tags($request->get('assignmentCType'));
 
         $assignedTagArray = [];
@@ -229,9 +229,9 @@ class TagsController extends AdminController
      */
     public function addTagToElementAction(Request $request)
     {
-        $assginmentCId = intval($request->get('assignmentElementId'));
+        $assginmentCId = (int)$request->get('assignmentElementId');
         $assginmentCType = strip_tags($request->get('assignmentElementType'));
-        $tagId = intval($request->get('tagId'));
+        $tagId = (int)$request->get('tagId');
 
         $tag = Tag::getById($tagId);
         if ($tag) {
@@ -252,9 +252,9 @@ class TagsController extends AdminController
      */
     public function removeTagFromElementAction(Request $request)
     {
-        $assginmentCId = intval($request->get('assignmentElementId'));
+        $assginmentCId = (int)$request->get('assignmentElementId');
         $assginmentCType = strip_tags($request->get('assignmentElementType'));
-        $tagId = intval($request->get('tagId'));
+        $tagId = (int)$request->get('tagId');
 
         $tag = Tag::getById($tagId);
         if ($tag) {
@@ -276,7 +276,7 @@ class TagsController extends AdminController
      */
     public function getBatchAssignmentJobsAction(Request $request, EventDispatcherInterface $eventDispatcher)
     {
-        $elementId = intval($request->get('elementId'));
+        $elementId = (int)$request->get('elementId');
         $elementType = strip_tags($request->get('elementType'));
 
         $idList = [];

--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -43,7 +43,7 @@ class UserController extends AdminController implements KernelControllerEventInt
     public function treeGetChildsByIdAction(Request $request)
     {
         $list = new User\Listing();
-        $list->setCondition('parentId = ?', intval($request->get('node')));
+        $list->setCondition('parentId = ?', (int)$request->get('node'));
         $list->setOrder('ASC');
         $list->setOrderKey('name');
         $list->load();
@@ -116,7 +116,7 @@ class UserController extends AdminController implements KernelControllerEventInt
 
             $className = User\Service::getClassNameForType($type);
             $user = $className::create([
-                'parentId' => intval($request->get('parentId')),
+                'parentId' => (int)$request->get('parentId'),
                 'name' => trim($request->get('name')),
                 'password' => '',
                 'active' => $request->get('active'),
@@ -239,7 +239,7 @@ class UserController extends AdminController implements KernelControllerEventInt
      */
     public function deleteAction(Request $request)
     {
-        $user = User\AbstractUser::getById(intval($request->get('id')));
+        $user = User\AbstractUser::getById((int)$request->get('id'));
 
         // only admins are allowed to delete admins and folders
         // because a folder might contain an admin user, so it is simply not allowed for users with the "users" permission
@@ -277,7 +277,7 @@ class UserController extends AdminController implements KernelControllerEventInt
     public function updateAction(Request $request)
     {
         /** @var User|User\Role $user */
-        $user = User\AbstractUser::getById(intval($request->get('id')));
+        $user = User\AbstractUser::getById((int)$request->get('id'));
 
         if ($user instanceof User && $user->isAdmin() && !$this->getAdminUser()->isAdmin()) {
             throw new \Exception('Only admin users are allowed to modify admin users');
@@ -335,7 +335,7 @@ class UserController extends AdminController implements KernelControllerEventInt
                     $newWorkspaces = [];
                     foreach ($spaces as $space) {
                         if (in_array($space['path'], $processedPaths[$type])) {
-                            throw new \Exception('Error saving workspaces as multiple entries found for path "' . $space['path'] .'" in '.$this->trans("$type") . 's');
+                            throw new \Exception('Error saving workspaces as multiple entries found for path "' . $space['path'] .'" in '.$this->trans((string)$type) . 's');
                         }
 
                         $element = Element\Service::getElementByPath($type, $space['path']);
@@ -386,12 +386,12 @@ class UserController extends AdminController implements KernelControllerEventInt
      */
     public function getAction(Request $request, Config $config)
     {
-        if (intval($request->get('id')) < 1) {
+        if ((int)$request->get('id') < 1) {
             return $this->adminJson(['success' => false]);
         }
 
         /** @var User $user */
-        $user = User::getById(intval($request->get('id')));
+        $user = User::getById((int)$request->get('id'));
 
         if ($user->isAdmin() && !$this->getAdminUser()->isAdmin()) {
             throw new \Exception('Only admin users are allowed to modify admin users');
@@ -479,7 +479,7 @@ class UserController extends AdminController implements KernelControllerEventInt
     public function getMinimalAction(Request $request)
     {
         /** @var User $user */
-        $user = User::getById(intval($request->get('id')));
+        $user = User::getById((int)$request->get('id'));
         $user->setPassword(null);
 
         $minimalUserData['id'] = $user->getId();
@@ -646,7 +646,7 @@ class UserController extends AdminController implements KernelControllerEventInt
     public function roleTreeGetChildsByIdAction(Request $request)
     {
         $list = new User\Role\Listing();
-        $list->setCondition('parentId = ?', intval($request->get('node')));
+        $list->setCondition('parentId = ?', (int)$request->get('node'));
         $list->load();
 
         $roles = [];
@@ -706,7 +706,7 @@ class UserController extends AdminController implements KernelControllerEventInt
     public function roleGetAction(Request $request)
     {
         /** @var User\UserRole $role */
-        $role = User\Role::getById(intval($request->get('id')));
+        $role = User\Role::getById((int)$request->get('id'));
 
         // workspaces
         $types = ['asset', 'document', 'object'];
@@ -867,7 +867,7 @@ class UserController extends AdminController implements KernelControllerEventInt
         /**
          * @var User $user
          */
-        $user = User::getById(intval($request->get('id')));
+        $user = User::getById((int)$request->get('id'));
         $success = true;
         $user->setTwoFactorAuthentication('enabled', false);
         $user->setTwoFactorAuthentication('secret', '');
@@ -955,7 +955,7 @@ class UserController extends AdminController implements KernelControllerEventInt
         $q = '%' . $request->get('query') . '%';
 
         $list = new User\Listing();
-        $list->setCondition('name LIKE ? OR firstname LIKE ? OR lastname LIKE ? OR email LIKE ? OR id = ?', [$q, $q, $q, $q, intval($request->get('query'))]);
+        $list->setCondition('name LIKE ? OR firstname LIKE ? OR lastname LIKE ? OR email LIKE ? OR id = ?', [$q, $q, $q, $q, (int)$request->get('query')]);
         $list->setOrder('ASC');
         $list->setOrderKey('name');
         $list->load();

--- a/bundles/AdminBundle/Controller/GDPR/AssetController.php
+++ b/bundles/AdminBundle/Controller/GDPR/AssetController.php
@@ -56,12 +56,12 @@ class AssetController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
         $allParams = array_merge($request->request->all(), $request->query->all());
 
         $result = $service->searchData(
-            intval($allParams['id']),
+            (int)$allParams['id'],
             strip_tags($allParams['firstname']),
             strip_tags($allParams['lastname']),
             strip_tags($allParams['email']),
-            intval($allParams['start']),
-            intval($allParams['limit']),
+            (int)$allParams['start'],
+            (int)$allParams['limit'],
             $allParams['sort'] ?? null
         );
 

--- a/bundles/AdminBundle/Controller/GDPR/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/GDPR/DataObjectController.php
@@ -56,12 +56,12 @@ class DataObjectController extends \Pimcore\Bundle\AdminBundle\Controller\AdminC
         $allParams = array_merge($request->request->all(), $request->query->all());
 
         $result = $service->searchData(
-            intval($allParams['id']),
+            (int)$allParams['id'],
             strip_tags($allParams['firstname']),
             strip_tags($allParams['lastname']),
             strip_tags($allParams['email']),
-            intval($allParams['start']),
-            intval($allParams['limit']),
+            (int)$allParams['start'],
+            (int)$allParams['limit'],
             $allParams['sort'] ?? null
         );
 

--- a/bundles/AdminBundle/Controller/GDPR/PimcoreUsersController.php
+++ b/bundles/AdminBundle/Controller/GDPR/PimcoreUsersController.php
@@ -56,12 +56,12 @@ class PimcoreUsersController extends \Pimcore\Bundle\AdminBundle\Controller\Admi
         $allParams = array_merge($request->request->all(), $request->query->all());
 
         $result = $pimcoreUsers->searchData(
-            intval($allParams['id']),
+            (int)$allParams['id'],
             strip_tags($allParams['firstname']),
             strip_tags($allParams['lastname']),
             strip_tags($allParams['email']),
-            intval($allParams['start']),
-            intval($allParams['limit']),
+            (int)$allParams['start'],
+            (int)$allParams['limit'],
             $allParams['sort'] ?? null
         );
 
@@ -79,7 +79,7 @@ class PimcoreUsersController extends \Pimcore\Bundle\AdminBundle\Controller\Admi
     public function exportUserDataAction(Request $request, PimcoreUsers $pimcoreUsers)
     {
         $this->checkPermission('users');
-        $userData = $pimcoreUsers->getExportData(intval($request->get('id')));
+        $userData = $pimcoreUsers->getExportData((int)$request->get('id'));
 
         $json = $this->encodeJson($userData, [], JsonResponse::DEFAULT_ENCODING_OPTIONS | JSON_PRETTY_PRINT);
         $jsonResponse = new JsonResponse($json, 200, [

--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -71,8 +71,8 @@ class SearchController extends AdminController
         $subtypes = explode(',', $allParams['subtype'] ?? '');
         $classnames = explode(',', $allParams['class'] ?? '');
 
-        $offset = intval($allParams['start']);
-        $limit = intval($allParams['limit']);
+        $offset = (int)$allParams['start'];
+        $limit = (int)$allParams['limit'];
 
         $offset = $offset ? $offset : 0;
         $limit = $limit ? $limit : 50;
@@ -210,10 +210,10 @@ class SearchController extends AdminController
                         $tag = Element\Tag::getById($tagId);
                         if ($tag) {
                             $tagPath = $tag->getFullIdPath();
-                            $conditionParts[] = 'id IN (SELECT cId FROM tags_assignment INNER JOIN tags ON tags.id = tags_assignment.tagid WHERE ctype = ' . $db->quote($type) . ' AND (id = ' . intval($tagId) . ' OR idPath LIKE ' . $db->quote($db->escapeLike($tagPath) . '%') . '))';
+                            $conditionParts[] = 'id IN (SELECT cId FROM tags_assignment INNER JOIN tags ON tags.id = tags_assignment.tagid WHERE ctype = ' . $db->quote($type) . ' AND (id = ' .(int)$tagId. ' OR idPath LIKE ' . $db->quote($db->escapeLike($tagPath) . '%') . '))';
                         }
                     } else {
-                        $conditionParts[] = 'id IN (SELECT cId FROM tags_assignment WHERE ctype = ' . $db->quote($type) . ' AND tagid = ' . intval($tagId) . ')';
+                        $conditionParts[] = 'id IN (SELECT cId FROM tags_assignment WHERE ctype = ' . $db->quote($type) . ' AND tagid = ' .(int)$tagId. ')';
                     }
                 }
             }

--- a/bundles/AdminBundle/Controller/Traits/DocumentTreeConfigTrait.php
+++ b/bundles/AdminBundle/Controller/Traits/DocumentTreeConfigTrait.php
@@ -45,7 +45,7 @@ trait DocumentTreeConfigTrait
 
         $tmpDocument = [
             'id' => $childDocument->getId(),
-            'idx' => intval($childDocument->getIndex()),
+            'idx' => (int)$childDocument->getIndex(),
             'text' => $childDocument->getKey(),
             'type' => $childDocument->getType(),
             'path' => $childDocument->getRealFullPath(),

--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -792,10 +792,10 @@ class GridHelperService
                     $tag = Model\Element\Tag::getById($tagId);
                     if ($tag) {
                         $tagPath = $tag->getFullIdPath();
-                        $conditionFilters[] = 'id IN (SELECT cId FROM `tags_assignment` INNER JOIN `tags` ON tags.id = tags_assignment.tagid WHERE `ctype` = "asset" AND (`id` = ' . intval($tagId) . ' OR `idPath` LIKE ' . $db->quote($tagPath . '%') . '))';
+                        $conditionFilters[] = 'id IN (SELECT cId FROM `tags_assignment` INNER JOIN `tags` ON tags.id = tags_assignment.tagid WHERE `ctype` = "asset" AND (`id` = ' .(int)$tagId. ' OR `idPath` LIKE ' . $db->quote($tagPath . '%') . '))';
                     }
                 } else {
-                    $conditionFilters[] = 'id IN (SELECT cId FROM `tags_assignment` WHERE `ctype` = "asset" AND tagid = ' . intval($tagId) . ')';
+                    $conditionFilters[] = 'id IN (SELECT cId FROM `tags_assignment` WHERE `ctype` = "asset" AND tagid = ' .(int)$tagId. ')';
                 }
             }
         }

--- a/bundles/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
@@ -234,7 +234,7 @@ class FullPageCacheListener
                 }
 
                 if (!empty($conf['exclude_cookie'])) {
-                    $cookies = explode(',', strval($conf['exclude_cookie']));
+                    $cookies = explode(',', (string)$conf['exclude_cookie']);
 
                     foreach ($cookies as $cookie) {
                         if (!empty($cookie) && isset($_COOKIE[trim($cookie)])) {

--- a/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelection.php
+++ b/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelection.php
@@ -334,6 +334,6 @@ class IndexFieldSelection extends Data implements ResourcePersistenceAwareInterf
      */
     public function setWidth($width)
     {
-        $this->width = intval($width);
+        $this->width = (int)$width;
     }
 }

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRangeSelection.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/Findologic/NumberRangeSelection.php
@@ -47,7 +47,7 @@ class NumberRangeSelection extends \Pimcore\Bundle\EcommerceFrameworkBundle\Filt
 
         foreach ($groupByValues as $groupByValue) {
             if ($groupByValue['label']) {
-                $value = floatval($groupByValue['label']);
+                $value = (float)$groupByValue['label'];
 
                 if (!$value) {
                     $value = 0;

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRangeSelection.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/NumberRangeSelection.php
@@ -43,13 +43,13 @@ class NumberRangeSelection extends AbstractFilterType
 
         foreach ($groupByValues as $groupByValue) {
             if ($groupByValue['value'] !== null) {
-                $value = floatval($groupByValue['value']);
+                $value = (float)$groupByValue['value'];
 
                 if (!$value) {
                     $value = 0;
                 }
                 foreach ($ranges->getData() as $row) {
-                    if ((empty($row['from']) || (floatval($row['from']) <= $value)) && (empty($row['to']) || floatval($row['to']) > $value)) {
+                    if ((empty($row['from']) || ((float)$row['from'] <= $value)) && (empty($row['to']) || (float)$row['to'] > $value)) {
                         $counts[$row['from'] . '_' . $row['to']] += $groupByValue['count'];
                         break;
                     }

--- a/bundles/EcommerceFrameworkBundle/FilterService/ListHelper.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/ListHelper.php
@@ -60,7 +60,7 @@ class ListHelper
 
         $offset = 0;
 
-        $pageLimit = isset($params['perPage']) ? intval($params['perPage']) : null;
+        $pageLimit = isset($params['perPage']) ? (int)$params['perPage'] : null;
         if (!$pageLimit) {
             $pageLimit = $filterDefinition->getPageLimit();
         }
@@ -73,7 +73,7 @@ class ListHelper
         }
 
         if (isset($params['page'])) {
-            $params['currentPage'] = intval($params['page']);
+            $params['currentPage'] = (int)$params['page'];
             $offset = $pageLimit * ($params['page'] - 1);
         }
         if ($filterDefinition->getAjaxReload()) {

--- a/bundles/EcommerceFrameworkBundle/IndexService/Interpreter/Numeric.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Interpreter/Numeric.php
@@ -18,6 +18,6 @@ class Numeric implements InterpreterInterface
 {
     public function interpret($value, $config = null)
     {
-        return floatval($value);
+        return (float)$value;
     }
 }

--- a/bundles/EcommerceFrameworkBundle/IndexService/Interpreter/Soundex.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Interpreter/Soundex.php
@@ -26,6 +26,6 @@ class Soundex implements InterpreterInterface
         }
         $soundex = soundex($string);
 
-        return intval(ord(substr($soundex, 0, 1)) . substr($soundex, 1));
+        return (int)(ord(substr($soundex, 0, 1)).substr($soundex, 1));
     }
 }

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
@@ -418,7 +418,7 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
         $workerTimestamp = time();
         $this->db->query(
             'UPDATE ' . $this->getStoreTableName() . ' SET preparation_worker_id = ?, preparation_worker_timestamp = ? WHERE tenant = ? AND in_preparation_queue = 1 '
-           .'AND (ISNULL(preparation_worker_timestamp) OR preparation_worker_timestamp < ?) ORDER BY preparation_status ASC LIMIT ' . intval($limit),
+           .'AND (ISNULL(preparation_worker_timestamp) OR preparation_worker_timestamp < ?) ORDER BY preparation_status ASC LIMIT ' .(int)$limit,
             [$workerId, $workerTimestamp, $this->name, $workerTimestamp - $this->getWorkerTimeout()]
         );
 
@@ -478,7 +478,7 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
             $this->db->beginTransaction();
             $query = "SELECT o_id, data, metadata FROM {$this->getStoreTableName()}
                   WHERE (crc_current != crc_index OR ISNULL(crc_index)) AND tenant = ? AND (ISNULL(worker_timestamp) OR worker_timestamp < ?) LIMIT "
-                . intval($limit) . ' FOR UPDATE';
+                .(int)$limit. ' FOR UPDATE';
 
             $entries = $this->db->fetchAll($query, [$this->name, $workerTimestamp - $this->getWorkerTimeout()]);
 

--- a/bundles/EcommerceFrameworkBundle/OrderManager/Order/Agent.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/Order/Agent.php
@@ -155,7 +155,7 @@ class Agent implements OrderAgentInterface
     public function itemChangeAmount(OrderItem $item, $amount)
     {
         // init
-        $amount = floatval($amount);
+        $amount = (float)$amount;
 
         // add log note
         $note = $this->createNote($item);

--- a/bundles/EcommerceFrameworkBundle/Type/Decimal.php
+++ b/bundles/EcommerceFrameworkBundle/Type/Decimal.php
@@ -331,7 +331,7 @@ class Decimal
     {
         $signum = $this->amount < 0 ? '-' : '';
 
-        $string = strval(abs($this->amount));
+        $string = (string)abs($this->amount);
         $amount = null;
 
         if ($this->scale === 0) {

--- a/bundles/EcommerceFrameworkBundle/VoucherService/Statistic.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/Statistic.php
@@ -90,7 +90,7 @@ class Statistic extends \Pimcore\Model\AbstractModel
     {
         $db = $db = \Pimcore\Db::get();
         try {
-            $db->query('INSERT INTO ' . \Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\Statistic\Dao::TABLE_NAME . ' (voucherSeriesId,date) VALUES (?,NOW())', [intval($seriesId)]);
+            $db->query('INSERT INTO ' . \Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\Statistic\Dao::TABLE_NAME . ' (voucherSeriesId,date) VALUES (?,NOW())', [(int)$seriesId]);
 
             return true;
         } catch (\Exception $e) {

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/31_Extending_a_Backend_User.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/31_Extending_a_Backend_User.md
@@ -44,7 +44,7 @@ use Pimcore\Model\DataObject;
  
 //create a new user for Sydney
 $user = User::create([
-    "parentId" => intval($userGroup->getId()),
+    "parentId" => (int) $userGroup->getId(),
     "username" => "sydney",
     "password" => "password1234",
     "hasCredentials" => true,

--- a/doc/Development_Documentation/26_Best_Practice/85_Using_Tags_for_Filtering.md
+++ b/doc/Development_Documentation/26_Best_Practice/85_Using_Tags_for_Filtering.md
@@ -30,7 +30,7 @@ $tagList = new \Pimcore\Model\Element\Tag\Listing();
 
 //select parent node for tags or use all root tags.
 if ($this->getParam("node")) {
-    $tagList->setCondition("parentId = ?", intval($request->get("node")));
+    $tagList->setCondition("parentId = ?", (int) $request->get("node"));
 } else {
     $tagList->setCondition("ISNULL(parentId) OR parentId = 0");
 }
@@ -127,12 +127,12 @@ Important to know:
                             SELECT cId FROM tags_assignment INNER JOIN tags ON tags.id = tags_assignment.tagid 
                             WHERE 
                                 ctype = 'asset' AND 
-                                (id = " . intval($tagId) . " OR idPath LIKE " . $listing->quote(Db::get()->escapeLike($tagPath) . "%") . ")
+                                (id = " . (int) $tagId . " OR idPath LIKE " . $listing->quote(Db::get()->escapeLike($tagPath) . "%") . ")
                         )";
                     }
                 } else {
                     $conditionParts[] = "id IN (
-                        SELECT cId FROM tags_assignment WHERE ctype = 'asset' AND tagid = " . intval($tagId) . 
+                        SELECT cId FROM tags_assignment WHERE ctype = 'asset' AND tagid = " . (int) $tagId . 
                     ")";
                 }
             }

--- a/lib/DataObject/GridColumnConfig/Operator/TranslateValue.php
+++ b/lib/DataObject/GridColumnConfig/Operator/TranslateValue.php
@@ -49,13 +49,13 @@ class TranslateValue extends AbstractOperator
         $childs = $this->getChilds();
         if (isset($childs[0])) {
             $value = $childs[0]->getLabeledValue($element);
-            if (strval($value->value) != '') {
+            if ((string)$value->value != '') {
                 $currentLocale = $this->translator->getLocale();
                 if (null != $this->locale) {
                     $this->translator->setLocale($this->locale);
                 }
 
-                $value->value = $this->translator->trans($this->prefix . strval($value->value), []);
+                $value->value = $this->translator->trans($this->prefix .(string)$value->value, []);
 
                 $this->translator->setLocale($currentLocale);
             }

--- a/lib/Db/PimcoreExtensionsTrait.php
+++ b/lib/Db/PimcoreExtensionsTrait.php
@@ -497,7 +497,7 @@ trait PimcoreExtensionsTrait
         if ($auto === false) {
             $q = '`';
 
-            return $q . str_replace("$q", "$q$q", $value) . $q;
+            return $q . str_replace((string) $q, "$q$q", $value) . $q;
         }
 
         return $value;
@@ -528,12 +528,12 @@ trait PimcoreExtensionsTrait
      */
     public function limit($sql, $count, $offset = 0)
     {
-        $count = intval($count);
+        $count = (int) $count;
         if ($count <= 0) {
             throw new \Exception("LIMIT argument count=$count is not valid");
         }
 
-        $offset = intval($offset);
+        $offset = (int) $offset;
         if ($offset < 0) {
             throw new \Exception("LIMIT argument offset=$offset is not valid");
         }

--- a/lib/Db/ZendCompatibility/QueryBuilder.php
+++ b/lib/Db/ZendCompatibility/QueryBuilder.php
@@ -1412,12 +1412,12 @@ class QueryBuilder
             $order = [];
             foreach ($this->_parts[self::ORDER] as $term) {
                 if (is_array($term)) {
-                    if (is_numeric($term[0]) && strval(intval($term[0])) == $term[0]) {
+                    if (is_numeric($term[0]) && (string)(int)$term[0] == $term[0]) {
                         $order[] = (int)trim($term[0]) . ' ' . $term[1];
                     } else {
                         $order[] = $this->_adapter->quoteIdentifier($term[0]) . ' ' . $term[1];
                     }
-                } elseif (is_numeric($term) && strval(intval($term)) == $term) {
+                } elseif (is_numeric($term) && (string)(int)$term == $term) {
                     $order[] = (int)trim($term);
                 } else {
                     $order[] = $this->_adapter->quoteIdentifier($term);

--- a/lib/Document/Newsletter/AddressSourceAdapter/ReportAdapter.php
+++ b/lib/Document/Newsletter/AddressSourceAdapter/ReportAdapter.php
@@ -64,7 +64,7 @@ class ReportAdapter implements AddressSourceAdapterInterface
         $result = $this->reportAdapter->getData(null, $this->emailFieldName, 'ASC', null, null);
 
         $this->list = $result['data'];
-        $this->elementsTotal = intval($result['total']);
+        $this->elementsTotal = (int)$result['total'];
 
         $this->emailAddresses = [];
         foreach ($this->list as $row) {

--- a/lib/Google/Cse.php
+++ b/lib/Google/Cse.php
@@ -168,7 +168,7 @@ class Cse implements \Iterator, AdapterInterface, AdapterAggregateInterface
         $this->setRaw($googleResponse);
 
         // set search results
-        $total = intval($googleResponse->getSearchInformation()->getTotalResults());
+        $total = (int)$googleResponse->getSearchInformation()->getTotalResults();
         if ($total > 100) {
             $total = 100;
         }

--- a/lib/Model/Listing/AbstractListing.php
+++ b/lib/Model/Listing/AbstractListing.php
@@ -152,8 +152,8 @@ abstract class AbstractListing extends AbstractModel implements \Iterator, \Coun
     {
         $this->setData(null);
 
-        if (intval($limit) > 0) {
-            $this->limit = intval($limit);
+        if ((int)$limit > 0) {
+            $this->limit = (int)$limit;
         }
 
         return $this;
@@ -168,8 +168,8 @@ abstract class AbstractListing extends AbstractModel implements \Iterator, \Coun
     {
         $this->setData(null);
 
-        if (intval($offset) > 0) {
-            $this->offset = intval($offset);
+        if ((int)$offset > 0) {
+            $this->offset = (int)$offset;
         }
 
         return $this;

--- a/lib/Tool.php
+++ b/lib/Tool.php
@@ -125,7 +125,7 @@ class Tool
                 return [];
             }
 
-            $validLanguages = str_replace(' ', '', strval($config['valid_languages']));
+            $validLanguages = str_replace(' ', '', (string)$config['valid_languages']);
             $languages = explode(',', $validLanguages);
 
             if (!is_array($languages)) {

--- a/lib/Tool/Frontend.php
+++ b/lib/Tool/Frontend.php
@@ -195,7 +195,7 @@ class Frontend
                 foreach ($browsersToCheck as $browser => $version) {
                     if (preg_match('@(' . $browser . ')/([\d]+)@', $userAgent, $matches)) {
                         if ($matches[1] == $browser) {
-                            if (intval($matches[2]) >= $version) {
+                            if ((int)$matches[2] >= $version) {
                                 return true;
                             } else {
 

--- a/lib/Tool/Glossary/Processor.php
+++ b/lib/Tool/Glossary/Processor.php
@@ -236,7 +236,7 @@ class Processor
                 $linkType = 'external';
                 $linkTarget = $d['link'];
 
-                if (intval($d['link'])) {
+                if ((int)$d['link']) {
                     if ($doc = Document::getById($d['link'])) {
                         $d['link'] = $doc->getFullPath();
 

--- a/lib/Tool/Text.php
+++ b/lib/Tool/Text.php
@@ -110,8 +110,8 @@ class Text
 
                         if ((isset($widthAttr[1]) && $widthAttr[1]) || (isset($heightAttr[1]) && $heightAttr[1])) {
                             $config = [
-                                'width' => intval((isset($widthAttr[1]) ? $widthAttr[1] : null)),
-                                'height' => intval((isset($heightAttr[1]) ? $heightAttr[1] : null)),
+                                'width' => (int)(isset($widthAttr[1]) ? $widthAttr[1] : null),
+                                'height' => (int)(isset($heightAttr[1]) ? $heightAttr[1] : null),
                             ];
                         }
 

--- a/lib/Tool/Text/Csv.php
+++ b/lib/Tool/Text/Csv.php
@@ -73,10 +73,10 @@ class Csv
             return "$cr$lf";
         }
         if ($count_cr == 0 && $count_lf > 0) {
-            return "$lf";
+            return (string)$lf;
         }
         if ($count_lf == 0 && $count_cr > 0) {
-            return "$cr";
+            return (string)$cr;
         }
 
         // sane default: cr+lf

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -221,7 +221,7 @@ class Ffmpeg extends Adapter
         $durationParts = explode(':', $durationRaw);
 
         // calculate duration in seconds
-        $duration = (intval($durationParts[0]) * 3600) + (intval($durationParts[1]) * 60) + floatval($durationParts[2]);
+        $duration = ((int)$durationParts[0] * 3600) + ((int)$durationParts[1] * 60) + (float)$durationParts[2];
 
         return $duration;
     }
@@ -306,7 +306,7 @@ class Ffmpeg extends Adapter
      */
     public function setVideoBitrate($videoBitrate)
     {
-        $videoBitrate = intval($videoBitrate);
+        $videoBitrate = (int)$videoBitrate;
 
         $videoBitrate = ceil($videoBitrate / 2) * 2;
 
@@ -326,7 +326,7 @@ class Ffmpeg extends Adapter
      */
     public function setAudioBitrate($audioBitrate)
     {
-        $audioBitrate = intval($audioBitrate);
+        $audioBitrate = (int)$audioBitrate;
 
         $audioBitrate = ceil($audioBitrate / 2) * 2;
 

--- a/lib/Web2Print/Processor/api/PDFreactor.class.php
+++ b/lib/Web2Print/Processor/api/PDFreactor.class.php
@@ -31,7 +31,7 @@ class PDFreactor
 
         $result = file_get_contents($url, false, $context);
 
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -58,7 +58,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -86,7 +86,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -126,7 +126,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -155,7 +155,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -184,7 +184,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -213,7 +213,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -237,7 +237,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -263,7 +263,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {

--- a/lib/Web2Print/Processor/api/v10.0/PDFreactor.class.php
+++ b/lib/Web2Print/Processor/api/v10.0/PDFreactor.class.php
@@ -92,7 +92,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -171,7 +171,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -257,7 +257,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -353,7 +353,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -419,7 +419,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -490,7 +490,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -567,7 +567,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -633,7 +633,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -694,7 +694,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -755,7 +755,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }

--- a/lib/Web2Print/Processor/api/v8.0/PDFreactor.class.php
+++ b/lib/Web2Print/Processor/api/v8.0/PDFreactor.class.php
@@ -31,7 +31,7 @@ class PDFreactor
 
         $result = file_get_contents($url, false, $context);
 
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -58,7 +58,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -86,7 +86,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -126,7 +126,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -155,7 +155,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -184,7 +184,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -213,7 +213,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -237,7 +237,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -263,7 +263,7 @@ class PDFreactor
         ];
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {

--- a/lib/Web2Print/Processor/api/v8.1/PDFreactor.class.php
+++ b/lib/Web2Print/Processor/api/v8.1/PDFreactor.class.php
@@ -74,7 +74,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -125,7 +125,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -177,7 +177,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -259,7 +259,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -320,7 +320,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -381,7 +381,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -442,7 +442,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -490,7 +490,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {
@@ -540,7 +540,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status == 404) {
             throw new Exception('Document with the given ID was not found.');
         } elseif ($status == 422) {

--- a/lib/Web2Print/Processor/api/v9.0/PDFreactor.class.php
+++ b/lib/Web2Print/Processor/api/v9.0/PDFreactor.class.php
@@ -94,7 +94,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -172,7 +172,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -262,7 +262,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -365,7 +365,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -449,7 +449,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -533,7 +533,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -628,7 +628,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -699,7 +699,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }
@@ -772,7 +772,7 @@ class PDFreactor
             $lastError = error_get_last();
             throw new \Exception('Error connecting to PDFreactor Web Service at ' . $this->url . '. Please make sure the PDFreactor Web Service is installed and running (Error: ' . $lastError['message'] . ')');
         }
-        $status = intval(substr($http_response_header[0], 9, 3));
+        $status = (int)substr($http_response_header[0], 9, 3);
         if ($status >= 200 && $status <= 204) {
             $errorMode = false;
         }

--- a/lib/helper-functions.php
+++ b/lib/helper-functions.php
@@ -329,13 +329,13 @@ function filesize2bytes($str)
         'P' => 1024 * 1024 * 1024 * 1024 * 1024,
     ];
 
-    $bytes = floatval($str);
+    $bytes = (float)$str;
 
     if (preg_match('#([KMGTP])?B?$#si', $str, $matches) && (array_key_exists(1, $matches) && !empty($bytes_array[$matches[1]]))) {
         $bytes *= $bytes_array[$matches[1]];
     }
 
-    $bytes = intval(round($bytes, 2));
+    $bytes = (int)round($bytes, 2);
 
     return $bytes;
 }

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -267,7 +267,7 @@ class Asset extends Element\AbstractElement
             return null;
         }
 
-        $id = intval($id);
+        $id = (int)$id;
         $cacheKey = self::getCacheKey($id);
 
         if (!$force && \Pimcore\Cache\Runtime::isRegistered($cacheKey)) {

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -478,7 +478,7 @@ EOT;
             $exif = @exif_read_data($path);
             if (is_array($exif)) {
                 if (array_key_exists('Orientation', $exif)) {
-                    $orientation = intval($exif['Orientation']);
+                    $orientation = (int)$exif['Orientation'];
                     if (in_array($orientation, [5, 6, 7, 8])) {
                         // flip height & width
                         $dimensions = [

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -226,7 +226,7 @@ class Processor
             $exif = @exif_read_data($fileSystemPath);
             if (is_array($exif)) {
                 if (array_key_exists('Orientation', $exif)) {
-                    $orientation = intval($exif['Orientation']);
+                    $orientation = (int)$exif['Orientation'];
 
                     if ($orientation > 1) {
                         $angleMappings = [

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -274,7 +274,7 @@ class AbstractObject extends Model\Element\AbstractElement
             return null;
         }
 
-        $id = intval($id);
+        $id = (int)$id;
         $cacheKey = self::getCacheKey($id);
 
         if (!$force && Runtime::isRegistered($cacheKey)) {

--- a/models/DataObject/ClassDefinition/Data/BooleanSelect.php
+++ b/models/DataObject/ClassDefinition/Data/BooleanSelect.php
@@ -416,9 +416,9 @@ class BooleanSelect extends Data implements ResourcePersistenceAwareInterface, Q
      */
     public function getDataFromEditmode($data, $object = null, $params = [])
     {
-        if (intval($data) === 1) {
+        if ((int)$data === 1) {
             return true;
-        } elseif (intval($data) === -1) {
+        } elseif ((int)$data === -1) {
             return false;
         }
 

--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -101,7 +101,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
      */
     public function setWidth($width)
     {
-        $this->width = intval($width);
+        $this->width = (int)$width;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Checkbox.php
+++ b/models/DataObject/ClassDefinition/Data/Checkbox.php
@@ -207,7 +207,7 @@ class Checkbox extends Data implements ResourcePersistenceAwareInterface, QueryR
     {
         $data = $this->getDataFromObjectParam($object, $params);
 
-        return strval($data);
+        return (string)$data;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Consent.php
+++ b/models/DataObject/ClassDefinition/Data/Consent.php
@@ -318,7 +318,7 @@ class Consent extends Data implements ResourcePersistenceAwareInterface, QueryRe
     {
         $data = $this->getDataFromObjectParam($object, $params);
 
-        return $data ? strval($data->getConsent()) : '';
+        return $data ? (string)$data->getConsent() : '';
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Date.php
+++ b/models/DataObject/ClassDefinition/Data/Date.php
@@ -252,7 +252,7 @@ class Date extends Data implements ResourcePersistenceAwareInterface, QueryResou
      */
     public function setDefaultValue($defaultValue)
     {
-        if (strlen(strval($defaultValue)) > 0) {
+        if (strlen((string)$defaultValue) > 0) {
             if (is_numeric($defaultValue)) {
                 $this->defaultValue = (int)$defaultValue;
             } else {

--- a/models/DataObject/ClassDefinition/Data/Datetime.php
+++ b/models/DataObject/ClassDefinition/Data/Datetime.php
@@ -295,7 +295,7 @@ class Datetime extends Data implements ResourcePersistenceAwareInterface, QueryR
      */
     public function setDefaultValue($defaultValue)
     {
-        if (strlen(strval($defaultValue)) > 0) {
+        if (strlen((string)$defaultValue) > 0) {
             if (is_numeric($defaultValue)) {
                 $this->defaultValue = (int)$defaultValue;
             } else {

--- a/models/DataObject/ClassDefinition/Data/Image.php
+++ b/models/DataObject/ClassDefinition/Data/Image.php
@@ -141,7 +141,7 @@ class Image extends Data implements ResourcePersistenceAwareInterface, QueryReso
      */
     public function getDataFromResource($data, $object = null, $params = [])
     {
-        if (intval($data) > 0) {
+        if ((int)$data > 0) {
             return Asset\Image::getById($data);
         }
 
@@ -207,7 +207,7 @@ class Image extends Data implements ResourcePersistenceAwareInterface, QueryReso
      */
     public function getDataFromEditmode($data, $object = null, $params = [])
     {
-        if ($data && intval($data['id']) > 0) {
+        if ($data && (int)$data['id'] > 0) {
             return Asset\Image::getById($data['id']);
         }
 
@@ -456,7 +456,7 @@ class Image extends Data implements ResourcePersistenceAwareInterface, QueryReso
     public function unmarshal($value, $object = null, $params = [])
     {
         $id = $value['id'];
-        if (intval($id) > 0) {
+        if ((int)$id > 0) {
             return Asset\Image::getById($id);
         }
     }

--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -243,7 +243,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
     {
         if ($data) {
             if ($data instanceof DataObject\Data\Link) {
-                if (intval($data->getInternal()) > 0) {
+                if ((int)$data->getInternal() > 0) {
                     if ($data->getInternalType() == 'document') {
                         $doc = Document::getById($data->getInternal());
                         if (!$doc instanceof Document) {
@@ -270,7 +270,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
         $dependencies = [];
 
         if ($data instanceof DataObject\Data\Link and $data->getInternal()) {
-            if (intval($data->getInternal()) > 0) {
+            if ((int)$data->getInternal() > 0) {
                 if ($data->getInternalType() == 'document') {
                     if ($doc = Document::getById($data->getInternal())) {
                         $key = 'document_' . $doc->getId();
@@ -308,7 +308,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
         $tags = is_array($tags) ? $tags : [];
 
         if ($data instanceof DataObject\Data\Link and $data->getInternal()) {
-            if (intval($data->getInternal()) > 0) {
+            if ((int)$data->getInternal() > 0) {
                 if ($data->getInternalType() == 'document') {
                     if ($doc = Document::getById($data->getInternal())) {
                         if (!array_key_exists($doc->getCacheTag(), $tags)) {

--- a/models/DataObject/ClassDefinition/Data/Numeric.php
+++ b/models/DataObject/ClassDefinition/Data/Numeric.php
@@ -349,11 +349,11 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
         $scale = self::DECIMAL_PRECISION_DEFAULT;
 
         if (null !== $this->decimalSize) {
-            $precision = intval($this->decimalSize);
+            $precision = (int)$this->decimalSize;
         }
 
         if (null !== $this->decimalPrecision) {
-            $scale = intval($this->decimalPrecision);
+            $scale = (int)$this->decimalPrecision;
         }
 
         if ($precision < 1 || $precision > 65) {
@@ -527,7 +527,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     {
         $data = $this->getDataFromObjectParam($object, $params);
 
-        return strval($data);
+        return (string)$data;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -151,7 +151,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
      */
     public function setDefaultValue($defaultValue)
     {
-        if (strlen(strval($defaultValue)) > 0) {
+        if (strlen((string)$defaultValue) > 0) {
             $this->defaultValue = $defaultValue;
         }
     }

--- a/models/DataObject/ClassDefinition/Data/Slider.php
+++ b/models/DataObject/ClassDefinition/Data/Slider.php
@@ -355,7 +355,7 @@ class Slider extends Data implements ResourcePersistenceAwareInterface, QueryRes
     public function checkValidity($data, $omitMandatoryCheck = false)
     {
         if (!$omitMandatoryCheck and $this->getMandatory() and $data === null) {
-            throw new Model\Element\ValidationException('Empty mandatory field [ '.$this->getName().' ] '.strval($data));
+            throw new Model\Element\ValidationException('Empty mandatory field [ '.$this->getName().' ] '.(string)$data);
         }
 
         if (!empty($data) and !is_numeric($data)) {

--- a/models/DataObject/ClassDefinition/Layout.php
+++ b/models/DataObject/ClassDefinition/Layout.php
@@ -208,7 +208,7 @@ class Layout
     public function setWidth($width)
     {
         if (!empty($width) && is_numeric($width)) {
-            $this->width = intval($width);
+            $this->width = (int)$width;
         } else {
             $this->width = $width;
         }
@@ -224,7 +224,7 @@ class Layout
     public function setHeight($height)
     {
         if (!empty($height) && is_numeric($height)) {
-            $this->height = intval($height);
+            $this->height = (int)$height;
         } else {
             $this->height = $height;
         }

--- a/models/DataObject/Classificationstore/CollectionConfig.php
+++ b/models/DataObject/Classificationstore/CollectionConfig.php
@@ -69,7 +69,7 @@ class CollectionConfig extends Model\AbstractModel
     {
         try {
             $config = new self();
-            $config->getDao()->getById(intval($id));
+            $config->getDao()->getById((int)$id);
 
             return $config;
         } catch (\Exception $e) {

--- a/models/DataObject/Classificationstore/GroupConfig.php
+++ b/models/DataObject/Classificationstore/GroupConfig.php
@@ -86,7 +86,7 @@ class GroupConfig extends Model\AbstractModel
 
             if (!$config = Cache::load($cacheKey)) {
                 $config = new self();
-                $config->getDao()->getById(intval($id));
+                $config->getDao()->getById((int)$id);
                 Cache::save($config, $cacheKey, [], null, 0, true);
             }
 

--- a/models/DataObject/Classificationstore/KeyConfig.php
+++ b/models/DataObject/Classificationstore/KeyConfig.php
@@ -99,7 +99,7 @@ class KeyConfig extends Model\AbstractModel
     public static function getById($id)
     {
         try {
-            $id = intval($id);
+            $id = (int)$id;
             if (self::$cacheEnabled && self::$cache[$id]) {
                 return self::$cache[$id];
             }

--- a/models/DataObject/Classificationstore/StoreConfig.php
+++ b/models/DataObject/Classificationstore/StoreConfig.php
@@ -54,7 +54,7 @@ class StoreConfig extends Model\AbstractModel
     {
         try {
             $config = new self();
-            $config->getDao()->getById(intval($id));
+            $config->getDao()->getById((int)$id);
 
             return $config;
         } catch (\Exception $e) {

--- a/models/Dependency/Dao.php
+++ b/models/Dependency/Dao.php
@@ -223,7 +223,7 @@ class Dao extends Model\Dao\AbstractDao
      */
     public function getRequiredByWithPath($offset = null, $limit = null, $orderBy = null, $orderDirection = null)
     {
-        $targetId = intval($this->model->getSourceId());
+        $targetId = (int)$this->model->getSourceId();
 
         if (in_array($this->model->getSourceType(), ['object', 'document', 'asset'])) {
             $targetType = $this->model->getSourceType();

--- a/models/Document.php
+++ b/models/Document.php
@@ -260,7 +260,7 @@ class Document extends Element\AbstractElement
             return null;
         }
 
-        $id = intval($id);
+        $id = (int)$id;
         $cacheKey = self::getCacheKey($id);
 
         if (!$force && \Pimcore\Cache\Runtime::isRegistered($cacheKey)) {

--- a/models/Document/DocType.php
+++ b/models/Document/DocType.php
@@ -106,7 +106,7 @@ class DocType extends Model\AbstractModel
     {
         try {
             $docType = new self();
-            $docType->getDao()->getById(intval($id));
+            $docType->getDao()->getById((int)$id);
 
             return $docType;
         } catch (\Exception $e) {

--- a/models/Document/Editable/Block.php
+++ b/models/Document/Editable/Block.php
@@ -117,7 +117,7 @@ class Block extends Model\Document\Editable implements BlockInterface
     public function setDefault()
     {
         if (empty($this->indices) && isset($this->config['default']) && $this->config['default']) {
-            for ($i = 0; $i < intval($this->config['default']); $i++) {
+            for ($i = 0; $i < (int)$this->config['default']; $i++) {
                 $this->indices[$i] = $i + 1;
             }
         }

--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -496,7 +496,7 @@ class Link extends Model\Document\Editable
         $isInternal = $this->data['internal'] ?? false;
 
         if (is_array($this->data) && $isInternal) {
-            if (intval($this->data['internalId']) > 0) {
+            if ((int)$this->data['internalId'] > 0) {
                 if ($this->data['internalType'] == 'document') {
                     if ($doc = Document::getById($this->data['internalId'])) {
                         $key = 'document_'.$doc->getId();

--- a/models/Document/Editable/Snippet.php
+++ b/models/Document/Editable/Snippet.php
@@ -181,7 +181,7 @@ class Snippet extends Model\Document\Editable
      */
     public function setDataFromResource($data)
     {
-        if (intval($data) > 0) {
+        if ((int)$data > 0) {
             $this->id = $data;
             $this->snippet = Document\Snippet::getById($this->id);
         }
@@ -198,7 +198,7 @@ class Snippet extends Model\Document\Editable
      */
     public function setDataFromEditmode($data)
     {
-        if (intval($data) > 0) {
+        if ((int)$data > 0) {
             $this->id = $data;
             $this->snippet = Document\Snippet::getById($this->id);
         }

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -636,7 +636,7 @@ class Video extends Model\Document\Editable
 
         // get vimeo id
         if (preg_match("@vimeo.*/([\d]+)@i", $this->id, $matches)) {
-            $vimeoId = intval($matches[1]);
+            $vimeoId = (int)$matches[1];
         } else {
             // for object-videos
             $vimeoId = $this->id;

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -458,8 +458,8 @@ class Service extends Model\AbstractModel
                 // If key already ends with _copy or copy_N, append a digit to avoid _copy_copy_copy naming
                 $keyParts = explode('_', $sourceKey);
                 $counterKey = array_key_last($keyParts);
-                if (intval($keyParts[$counterKey]) > 0) {
-                    $keyParts[$counterKey] = intval($keyParts[$counterKey]) + 1;
+                if ((int)$keyParts[$counterKey] > 0) {
+                    $keyParts[$counterKey] = (int)$keyParts[$counterKey] + 1;
                 } else {
                     $keyParts[] = 1;
                 }

--- a/models/Glossary.php
+++ b/models/Glossary.php
@@ -83,7 +83,7 @@ class Glossary extends AbstractModel
     {
         try {
             $glossary = new self();
-            $glossary->setId(intval($id));
+            $glossary->setId((int)$id);
             $glossary->getDao()->getById();
 
             return $glossary;

--- a/models/Schedule/Task.php
+++ b/models/Schedule/Task.php
@@ -82,7 +82,7 @@ class Task extends Model\AbstractModel
         } catch (\Exception $e) {
             try {
                 $task = new self();
-                $task->getDao()->getById(intval($id));
+                $task->getDao()->getById((int)$id);
                 \Pimcore\Cache\Runtime::set($cacheKey, $task);
             } catch (\Exception $e) {
                 return null;

--- a/models/Site.php
+++ b/models/Site.php
@@ -98,7 +98,7 @@ class Site extends AbstractModel
         } elseif (!$site = \Pimcore\Cache::load($cacheKey)) {
             try {
                 $site = new self();
-                $site->getDao()->getById(intval($id));
+                $site->getDao()->getById((int)$id);
             } catch (\Exception $e) {
                 $site = 'failed';
             }
@@ -124,7 +124,7 @@ class Site extends AbstractModel
     {
         try {
             $site = new self();
-            $site->getDao()->getByRootId(intval($id));
+            $site->getDao()->getByRootId((int)$id);
 
             return $site;
         } catch (\Exception $e) {

--- a/models/Staticroute.php
+++ b/models/Staticroute.php
@@ -156,7 +156,7 @@ class Staticroute extends AbstractModel
         } catch (\Exception $e) {
             try {
                 $route = new self();
-                $route->setId(intval($id));
+                $route->setId((int)$id);
                 $route->getDao()->getById();
                 \Pimcore\Cache\Runtime::set($cacheKey, $route);
             } catch (\Exception $e) {

--- a/models/Tool/CustomReport/Adapter/Analytics.php
+++ b/models/Tool/CustomReport/Adapter/Analytics.php
@@ -84,7 +84,7 @@ class Analytics extends AbstractAdapter
                     $value = str_replace(';', '', addslashes($filter['value']));
                     $gaFilters[] = "{$filter['field']}=~{$value}";
                 } elseif ($filter['type'] == 'numeric') {
-                    $value = floatval($filter['value']);
+                    $value = (float)$filter['value'];
                     $compMapping = [
                         'lt' => '<',
                         'gt' => '>',

--- a/models/Tool/Email/Log.php
+++ b/models/Tool/Email/Log.php
@@ -227,7 +227,7 @@ class Log extends Model\AbstractModel
      */
     public static function getById($id)
     {
-        $id = intval($id);
+        $id = (int)$id;
         if ($id < 1) {
             return null;
         }

--- a/models/Tool/Email/Log/Dao.php
+++ b/models/Tool/Email/Log/Dao.php
@@ -141,7 +141,7 @@ class Dao extends Model\Dao\AbstractDao
     protected function prepareLoggingData($key, $value)
     {
         $class = new \stdClass();
-        $class->key = strval($key); // key has to be a string otherwise the treeGrid won't work
+        $class->key = (string)$key; // key has to be a string otherwise the treeGrid won't work
 
         if (is_string($value) || is_int($value) || is_null($value)) {
             $class->data = ['type' => 'simple',

--- a/models/Tool/Targeting/Rule.php
+++ b/models/Tool/Targeting/Rule.php
@@ -92,7 +92,7 @@ class Rule extends Model\AbstractModel
             $targetId = (int) $target;
         }
 
-        if (array_key_exists('_ptc', $_GET) && intval($targetId) == intval($_GET['_ptc'])) {
+        if (array_key_exists('_ptc', $_GET) && (int)$targetId == (int)$_GET['_ptc']) {
             return true;
         }
 
@@ -110,7 +110,7 @@ class Rule extends Model\AbstractModel
     {
         try {
             $target = new self();
-            $target->getDao()->getById(intval($id));
+            $target->getDao()->getById((int)$id);
 
             return $target;
         } catch (\Exception $e) {

--- a/models/Tool/Targeting/TargetGroup.php
+++ b/models/Tool/Targeting/TargetGroup.php
@@ -58,7 +58,7 @@ class TargetGroup extends Model\AbstractModel
     {
         try {
             $targetGroup = new self();
-            $targetGroup->getDao()->getById(intval($id));
+            $targetGroup->getDao()->getById((int)$id);
 
             return $targetGroup;
         } catch (\Exception $e) {

--- a/models/WebsiteSetting.php
+++ b/models/WebsiteSetting.php
@@ -88,7 +88,7 @@ class WebsiteSetting extends AbstractModel
         } catch (\Exception $e) {
             try {
                 $setting = new self();
-                $setting->getDao()->getById(intval($id));
+                $setting->getDao()->getById((int)$id);
                 \Pimcore\Cache\Runtime::set($cacheKey, $setting);
             } catch (\Exception $e) {
                 return null;

--- a/models/Workflow.php
+++ b/models/Workflow.php
@@ -124,7 +124,7 @@ class Workflow extends AbstractModel
             try {
                 $workflow = new self();
                 \Pimcore\Cache\Runtime::set($cacheKey, $workflow);
-                $workflow->getDao()->getById(intval($id));
+                $workflow->getDao()->getById((int)$id);
             } catch (\Exception $e) {
                 return null;
             }


### PR DESCRIPTION
Like #7004, this is about consistency in the codebase. There are many places where type casting is already used. But on some places the according functions are used. This changes them to be typecasts instead.