### PR TITLE
[Dashboard] Set flex=1 for columns without specified width for custom report portlet

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/layout/portlets/customreports.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/layout/portlets/customreports.js
@@ -409,6 +409,8 @@ pimcore.layout.portlets.customreports = Class.create(pimcore.layout.portlets.abs
 
             if(colConfig["width"]) {
                 gridColConfig["width"] = intval(colConfig["width"]);
+            } else {
+                gridColConfig["flex"] = 1;
             }
 
             if(colConfig["filter"]) {


### PR DESCRIPTION
Like in https://github.com/pimcore/pimcore/blob/12900c5c22d5cde7284295ba155f9a23dce8ba99/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/report.js#L71-L75 this PR sets flex width for columns, which do not have a width being explicitly set, to use the full availyble width of the portlet.