### PR TITLE
sylius/theme-bundle allows translations per theme, by that it adds the theme-name to the locale with @

### DIFF
--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -176,7 +176,7 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
      */
     public function lazyInitialize($domain, $locale)
     {
-        $cacheKey = 'translation_data_' . $domain . '_' . $locale;
+        $cacheKey = 'translation_data_' . md5($domain . '_' . $locale);
 
         if (isset($this->initializedCatalogues[$cacheKey])) {
             return;


### PR DESCRIPTION
Resulting in Pimcore in an error that the cache is using invalid characters. I think we should allow any character here, since symfony does too
