### PR TITLE
[Thumbnails] Fallback if clipping by embedded clipping path does not work

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -151,12 +151,16 @@ class Imagick extends Adapter
                 if (strpos($identifyRaw, 'Clipping path') && strpos($identifyRaw, '<svg')) {
                     // if there's a clipping path embedded, apply the first one
 
-                    // known issues:
-                    // - it seems that -clip doesnt work with the ImageMagick version
-                    //   ImageMagick 6.9.7-4 Q16 x86_64 20170114 (which is used in Debian 9)
-                    // - Imagick 3.4.4 with ImageMagick 7 on OSX has horrible broken clipping support
-                    $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_TRANSPARENT);
-                    $i->clipImage();
+                    try {
+                        // known issues:
+                        // - it seems that -clip doesnt work with the ImageMagick version
+                        //   ImageMagick 6.9.7-4 Q16 x86_64 20170114 (which is used in Debian 9)
+                        // - Imagick 3.4.4 with ImageMagick 7 on OSX has horrible broken clipping support
+                        $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_TRANSPARENT);
+                        $i->clipImage();
+                    } catch (\Exception $e) {
+                        Logger::info('Although automatic clipping support is enabled, your current ImageMagick / Imagick version does not support this operation');
+                    }
 
                     // Imagick version compatibility
                     // Since Imagick 3.4.4 compiled against ImageMagick 7 ALPHACHANNEL_OPAQUE was removed for whatever reason
@@ -167,6 +171,7 @@ class Imagick extends Adapter
                         $alphaChannel = \Imagick::ALPHACHANNEL_OPAQUE;
                     }
                     $i->setImageAlphaChannel($alphaChannel);
+
                 }
             }
         } catch (\Exception $e) {

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -159,7 +159,7 @@ class Imagick extends Adapter
                         $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_TRANSPARENT);
                         $i->clipImage();
                     } catch (\Exception $e) {
-                        Logger::info('Although automatic clipping support is enabled, your current ImageMagick / Imagick version does not support this operation');
+                        Logger::info(sprintf('Although automatic clipping support is enabled, your current ImageMagick / Imagick version does not support this operation on the image %s', $imagePath));
                     }
 
                     // Imagick version compatibility


### PR DESCRIPTION
When there is a clipping path embedded in a JPG it is tried to clip the image by this path. When this goes wrong for whatever reason, you get an error with the default placeholder image. 
The reason in our case was that ImageMagick did not support SVG: `ImagickException: no decode delegate for this image format "SVG"`

This PR adds a fallback that if clipping goes wrong for whatever reason, then the unclipped image will get delivered.
This is especially useful because `clip_auto_support` is enabled by default and when upgrading Pimcore versions some image thumbnails might suddenly break.