### PR TITLE
[Image thumbnails] Do not filter requested attributes for image thumbnail HTML

### DIFF
--- a/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
+++ b/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
@@ -129,6 +129,9 @@ $height = $thumbnail->getHeight();
  
 // get the html "img" tag for the thumbnail incl. custom class:
 echo $thumbnail->getHtml(["class" => "custom-class"]);
+
+// get the html "img" tag including attribute to enable lazy.loading
+echo $thumbnail->getHtml(["loading" => "lazy"]);
  
 // get the path to the thumbnail
 $path = $thumbnail->getPath();
@@ -160,10 +163,8 @@ echo $thumbnail; // prints something like /var/tmp/....png
 <?= $asset->getThumbnail("content")->getHtml(['alt' => 'top priority alt']) ?>
 // or
 <?= $asset->getThumbnail("content")->getHtml(['defaultalt' => 'default alt, if not set in image']) ?>
-
-
 ```
-
+Additionally there are some special parameters to [customize generated image HTML code](https://pimcore.com/docs/pimcore/current/Development_Documentation/Documents/Editables/Image.html#page_Configuration).
 
 ## Using ICC Color Profiles for CMYK -> RGB 
 Pimcore supports ICC color profiles to get better results when converting CMYK images (without embedded color profile) 

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -202,11 +202,6 @@ class Thumbnail
             }
         }
 
-        $w3cImgAttributes = ['alt', 'align', 'border', 'height', 'hspace', 'ismap', 'longdesc', 'usemap',
-            'vspace', 'width', 'class', 'dir', 'id', 'lang', 'style', 'title', 'xml:lang', 'onmouseover',
-            'onabort', 'onclick', 'ondblclick', 'onmousedown', 'onmousemove', 'onmouseout', 'onmouseup',
-            'onkeydown', 'onkeypress', 'onkeyup', 'itemprop', 'itemscope', 'itemtype', ];
-
         $customAttributes = [];
         if (isset($options['attributes']) && is_array($options['attributes'])) {
             $customAttributes = $options['attributes'];
@@ -257,11 +252,7 @@ class Thumbnail
         $attributesRaw = array_merge($options, $customAttributes);
 
         foreach ($attributesRaw as $key => $value) {
-            if (!(is_string($value) || is_numeric($value) || is_bool($value))) {
-                continue;
-            }
-
-            if (!(in_array($key, $w3cImgAttributes) || isset($customAttributes[$key]) || strpos($key, 'data-') === 0)) {
+            if (!is_scalar($value)) {
                 continue;
             }
 


### PR DESCRIPTION
Resolves #7438

Currently it is possible to set arbitrary attributes to generated HTML code for image thumbnails. For the W3C-specified ones you can provide them directly, e.g. `$image->getThumbnail()->getHtml(['class' => 'my-image'])`. But for those not specified in https://github.com/pimcore/pimcore/blob/530098ea48745926d8f155cce5e6228c222968ac/models/Asset/Image/Thumbnail.php#L205-L208 you have to use a special `attributes` array key, e.g. `$image->getThumbnail()->getHtml(['attributes' => ['loading' => 'lazy']])`
Although this `loading` attribute might not be in an official W3C standard, it is implemented by most browser vendors, so imho it does not make much sense to distinguish between W3C attributes and custom ones.

Additionally in the [documentation](https://pimcore.com/docs/pimcore/current/Development_Documentation/Assets/Working_with_Thumbnails/Image_Thumbnails.html#page_Advanced-Examples) this special `attributes` options key is not mentioned.