### PR TITLE
Correct file path to fosjsrouting router.js

### DIFF
--- a/bundles/CoreBundle/EventListener/Frontend/EditmodeListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/EditmodeListener.php
@@ -318,7 +318,7 @@ class EditmodeListener implements EventSubscriberInterface
     {
         return array_merge(
             [
-                $this->package->getUrl('bundles/fosjsrouting/js/router.js'),
+                '/bundles/fosjsrouting/js/router.js',
                 '/bundles/pimcoreadmin/js/pimcore/functions.js',
                 '/bundles/pimcoreadmin/js/pimcore/overrides.js',
                 '/bundles/pimcoreadmin/js/pimcore/tool/milestoneslider.js',


### PR DESCRIPTION
Identical to #7370 but with the author email corrected so that the CLA can be approved.
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  
## Issue
Pull #6146 introduced an issue that causes editmode to break in the admin if you are using asset versioning. A file path is generated using `$this->package->getUrl()` which also includes asset versioning (if used) in the path, and since the file is fetched with `file_get_contents()` at one point, this fails because `file_get_contents()` does not understand the query param appended to the path.

## Steps to reproduce
Add this to your `app/config/config.yml` file and load a document in editmode.

```
  framework:
      assets:
          version: 'xxx'
```

You should get an error from file_get_contents() failing to read from a path like this:

`/var/www/html/web/bundles/fosjsrouting/js/router.js?23471` <-- see query param

## Solution
Using a relative path (like the other files included) seems to work just fine. I also commented on the [original PR](https://github.com/pimcore/pimcore/pull/6146#issuecomment-712938852) to check if the contributor (@dpfaffenbauer) knew the reason for the `getUrl()` call, but he's not sure anymore.