### PR TITLE
Fixes/improvements to sort in MiscController

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/MiscController.php
+++ b/bundles/AdminBundle/Controller/Admin/MiscController.php
@@ -49,7 +49,7 @@ class MiscController extends AdminController
 
         sort($bundles, SORT_NATURAL | SORT_FLAG_CASE);
 
-        $result = array_map(function (BundleInterface $bundle) {
+        $result = array_map(static function (BundleInterface $bundle) {
             return [
                 'name' => $bundle->getName(),
             ];
@@ -76,7 +76,7 @@ class MiscController extends AdminController
 
         sort($controllers, SORT_NATURAL | SORT_FLAG_CASE);
 
-        $result = array_map(function ($controller) {
+        $result = array_map(static function ($controller) {
             return [
                 'name' => $controller,
             ];
@@ -112,7 +112,7 @@ class MiscController extends AdminController
 
         sort($actions, SORT_NATURAL | SORT_FLAG_CASE);
 
-        $result = array_map(function ($action) {
+        $result = array_map(static function ($action) {
             return [
                 'name' => $action,
             ];
@@ -136,7 +136,7 @@ class MiscController extends AdminController
 
         sort($templates, SORT_NATURAL | SORT_FLAG_CASE);
 
-        $result = array_map(function ($template) {
+        $result = array_map(static function ($template) {
             return [
                 'path' => $template,
             ];

--- a/bundles/AdminBundle/Controller/Admin/MiscController.php
+++ b/bundles/AdminBundle/Controller/Admin/MiscController.php
@@ -47,13 +47,13 @@ class MiscController extends AdminController
         // convert to normal array
         $bundles = array_values($provider->getBundles());
 
+        sort($bundles, SORT_NATURAL | SORT_FLAG_CASE);
+
         $result = array_map(function (BundleInterface $bundle) {
             return [
                 'name' => $bundle->getName(),
             ];
         }, $bundles);
-
-        sort($result);
 
         return $this->adminJson([
             'data' => $result,
@@ -74,13 +74,13 @@ class MiscController extends AdminController
         $bundle = $request->get('moduleName');
         $controllers = $provider->getControllers($bundle, $routingDefaults['bundle']);
 
+        sort($controllers, SORT_NATURAL | SORT_FLAG_CASE);
+
         $result = array_map(function ($controller) {
             return [
                 'name' => $controller,
             ];
         }, $controllers);
-
-        sort($result);
 
         return $this->adminJson([
             'data' => $result,
@@ -110,13 +110,13 @@ class MiscController extends AdminController
 
         $actions = $provider->getActions($controller, $bundle);
 
+        sort($actions, SORT_NATURAL | SORT_FLAG_CASE);
+
         $result = array_map(function ($action) {
             return [
                 'name' => $action,
             ];
         }, $actions);
-
-        sort($result);
 
         return $this->adminJson([
             'data' => $result,
@@ -134,13 +134,13 @@ class MiscController extends AdminController
     {
         $templates = $provider->getTemplates();
 
+        sort($templates, SORT_NATURAL | SORT_FLAG_CASE);
+
         $result = array_map(function ($template) {
             return [
                 'path' => $template,
             ];
         }, $templates);
-
-        sort($result);
 
         return $this->adminJson([
             'data' => $result,


### PR DESCRIPTION
## Changes in this pull request  

Sorts Actions, Bundles, Controllers, Templates better. The previous `sort()` method was triggered on a nested array and did not actually work. Also adds flag to sort naturally case insensitive.

Previously:
```
Areas/templage.twig
Documents/template.twig
bundles/template.twig
```

Now:
```
Areas/templage.twig
bundles/template.twig
Documents/template.twig
```