### PR TITLE
Quoting null value when for preparation_worker_id leads to '' being the value

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
@@ -351,7 +351,7 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
         } elseif ($currentEntry['crc_current'] != $data['crc_current']) {
             $this->executeTransactionalQuery(function () use ($data, $subObjectId) {
                 $data['preparation_worker_timestamp'] = 0;
-                $data['preparation_worker_id'] = $this->db->quote(null);
+                $data['preparation_worker_id'] = null;
 
                 $this->db->updateWhere($this->getStoreTableName(), $data, 'o_id = ' . $this->db->quote((string)$subObjectId) . ' AND tenant = ' . $this->db->quote($this->name));
             });


### PR DESCRIPTION

It seems that quoting the null value to insert into preparation_worker_id `$data['preparation_worker_id'] = $this->db->quote(null);` leads to the value stored being `''`. This means preparation_worker_id is not empty which will prevent the processor from picking up the entry!
