### PR TITLE
Support numeric fields in workflow notes.

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/workflow/transitionPanel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/workflow/transitionPanel.js
@@ -230,7 +230,7 @@ pimcore.workflow.transitionPanel = Class.create({
         Ext.each(additional, function(a) {
             //add a new field
             var field = {};
-            var supportedTags = ['input', 'textarea', 'select', 'datetime', 'date', 'user', 'checkbox'];
+            var supportedTags = ['input', 'numeric', 'textarea', 'select', 'datetime', 'date', 'user', 'checkbox'];
 
             var c = a.fieldTypeSettings;
             c.name = 'workflow[additional][' + a.name + ']';

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -1683,7 +1683,7 @@ class Configuration implements ConfigurationInterface
                                                                         ->scalarNode('name')->isRequired()->info('The technical name used in the input form.')->end()
                                                                         ->enumNode('fieldType')
                                                                             ->isRequired()
-                                                                            ->values(['input', 'textarea', 'select', 'datetime', 'date', 'user', 'checkbox'])
+                                                                            ->values(['input', 'numeric', 'textarea', 'select', 'datetime', 'date', 'user', 'checkbox'])
                                                                             ->info('The data component name/field type.')
                                                                         ->end()
                                                                         ->scalarNode('title')->info('The label used by the field')->end()

--- a/doc/Development_Documentation/07_Workflow_Management/01_Configuration_Details/README.md
+++ b/doc/Development_Documentation/07_Workflow_Management/01_Configuration_Details/README.md
@@ -212,7 +212,7 @@ pimcore:
                                     name:                 ~ # Required
 
                                     # The data component name/field type.
-                                    fieldType:            ~ # One of "input"; "textarea"; "select"; "datetime"; "date"; "user"; "checkbox", Required
+                                    fieldType:            ~ # One of "input"; "numeric"; "textarea"; "select"; "datetime"; "date"; "user"; "checkbox", Required
 
                                     # The label used by the field
                                     title:                ~


### PR DESCRIPTION
# Feature request

This PR enables the configuration of numeric fields in Pimcore workflow notes.

Screenshot:

![image](https://user-images.githubusercontent.com/16687355/98224959-6957ae80-1f54-11eb-8c38-5950e2e484c0.png)

Example configuration:
```yml
pimcore:
    workflows:       
      production_workflow:
        ...
         transitions:
                  ...
                  notes:
                    commentEnabled: true
                    commentRequired: true
                    commentSetterFn: setRejectReason
                    additionalFields:
                      - name: 'trackedHours'
                        title: 'Totally tracked hours'
                        fieldType: "numeric" #todo -> PR for numeric fields
                        fieldTypeSettings:
                          minValue: 0
```
