### PR TITLE
[Cache/Core] No error message if storeCacheItem() returns false

### DIFF
--- a/lib/Cache/Core/CoreHandler.php
+++ b/lib/Cache/Core/CoreHandler.php
@@ -903,9 +903,6 @@ class CoreHandler implements LoggerAwareInterface, CoreHandlerInterface
             // item shouldn't go to the cache (either because it's tags are ignored or were cleared within this process) -> see $this->prepareCacheTags();
             } else {
                 $result = $this->storeCacheItem($queueItem->getCacheItem(), $queueItem->getData(), $queueItem->isForce());
-                if (!$result) {
-                    $this->logger->error('Unable to write item {key} to cache', ['key' => $key]);
-                }
             }
 
             $processedKeys[] = $key;


### PR DESCRIPTION
Additional error message is not necessary, all messages are logged in storeCacheItem(). Not every return=false is an error, in this case we get a false negative.

  