### PR TITLE
Fix formatDebugReceivers for rfc2822 3.6.2 validation

### DIFF
--- a/lib/Helper/Mail.php
+++ b/lib/Helper/Mail.php
@@ -129,17 +129,17 @@ CSS;
      */
     protected static function formatDebugReceivers(array $receivers)
     {
-        $tmpString = '';
-        foreach ($receivers as $mail => $name) {
-            $tmpString .= $mail;
-            if (isset($name)) {
-                $tmpString .= ' (' . $name . ')';
-            }
-            $tmpString .= ', ';
-        }
-        $tmpString = substr($tmpString, 0, strrpos($tmpString, ','));
+        $formatedReceiversArray = [];
 
-        return $tmpString;
+        foreach ($receivers as $mail => $name) {
+            if (strlen(trim($name)) > 0) {
+                $formatedReceiversArray[] = $name . ' <' . $mail . '>';
+            } else {
+                $formatedReceiversArray[] = $mail; 
+            }
+        }
+
+        return implode(', ', $formatedReceiversArray);
     }
 
     /**


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves a bug where rfc2822 3.6.2 did not validate on re-sending email from the admin log due to:

https://github.com/pimcore/pimcore/blob/cf90256bcbd3dc55b7ad49159c26575d524c966e/lib/Helper/Mail.php#L408-L436

and Swiftmailer:

https://github.com/swiftmailer/swiftmailer/blob/f7d2961c858520dc83a594c66cde9d550f6d2226/lib/classes/Swift/Mime/Headers/MailboxHeader.php#L345-L357

## Additional info  

Pimcore would prior to this patch save the email in the Mail Log in the format `address@domain.ext (Name)` but it would then fail.