### PR TITLE
Fix Notice: Undefined index: locked

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -500,8 +500,9 @@ class DataObjectHelperController extends AdminController
                             'key' => $key,
                             'type' => 'system',
                             'label' => $key,
-                            'locked' => $sc['locked'],
-                            'position' => $sc['position'], ];
+                            'locked' => $sc['locked'] ?? null,
+                            'position' => $sc['position'],
+                        ];
                         if (isset($sc['width'])) {
                             $colConfig['width'] = $sc['width'];
                         }
@@ -599,8 +600,9 @@ class DataObjectHelperController extends AdminController
                                         if (isset($sc['width'])) {
                                             $fieldConfig['width'] = $sc['width'];
                                         }
-
-                                        $fieldConfig['locked'] = $sc['locked'];
+                                        if (isset($sc['locked'])) {
+                                            $fieldConfig['locked'] = $sc['locked'];
+                                        }
                                         $availableFields[] = $fieldConfig;
                                     }
                                 }


### PR DESCRIPTION
I get following error if I load a object grid with error reporting E_ALL:
![image](https://user-images.githubusercontent.com/998558/98663965-0bf3a100-234a-11eb-932b-ca253a88c035.png)
