### PR TITLE
[Data objects] Do not try to load deleted object bricks

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Objectbricks.php
+++ b/models/DataObject/ClassDefinition/Data/Objectbricks.php
@@ -139,6 +139,11 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
         if ($object) {
             $parent = DataObject\Service::hasInheritableParentObject($object);
         }
+
+        if(!method_exists($data, $getter)) {
+            return null;
+        }
+
         /** @var DataObject\Objectbrick\Definition $item */
         $item = $data->$getter();
         if (!$item && !empty($parent)) {


### PR DESCRIPTION
At our customer's system there was the problem that a data object could not be opened anymore in Pimcore backend because its object brick container contained an object brick which had been removed since last saving. I do not know exactly how the brick got deleted, I cannot reproduce the problem in the Pimcore demo. But nevertheless I think it is a good idea to check if the called dynamic method exists.