### PR TITLE
Require `matomo/device-detector` instead of `piwik/device-detector`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
     "ocramius/package-versions": "^1.2",
     "pear/net_url2": "^2.2",
     "phive/twig-extensions-deferred": "^2.0",
-    "piwik/device-detector": "^3.9",
+    "matomo/device-detector": "^3.9",
     "presta/sitemap-bundle": "^1.7 || ^2.1",
     "ramsey/uuid": "^3.8",
     "sabre/dav": "^3.2",


### PR DESCRIPTION
Piwik changed its name to Matomo some time ago and the package got a new name, too. The old one is abandoned.