### PR TITLE
Move Twig Helpers from coreshop/pimcore to pimcore/pimcore

### DIFF
--- a/bundles/CoreBundle/Resources/config/templating_twig.yml
+++ b/bundles/CoreBundle/Resources/config/templating_twig.yml
@@ -75,6 +75,13 @@ services:
 
     Pimcore\Twig\Extension\Templating\Placeholder\CacheBusterAware: ~
 
+    Pimcore\Twig\Extension\AssetHelperExtensions: ~
+    
+    Pimcore\Twig\Extension\DataObjectHelperExtensions: ~
+
+    Pimcore\Twig\Extension\DocumentHelperExtensions: ~
+
+    Pimcore\Twig\Extension\ImageThumbnailExtension: ~
 
     # the deferred extension is needed for placeholder helpers to work
     # as otherwise the placeholder block would be rendered before any
@@ -84,4 +91,3 @@ services:
     # provides truncate and wordwrap filters
     Twig_Extensions_Extension_Text:
         class: Twig_Extensions_Extension_Text
-

--- a/lib/Twig/Extension/AssetHelperExtensions.php
+++ b/lib/Twig/Extension/AssetHelperExtensions.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Twig\Extension;
+
+use Pimcore\Model\Asset;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigTest;
+
+final class AssetHelperExtensions extends AbstractExtension
+{
+    public function getTests(): array
+    {
+        return [
+            new TwigTest('pimcore_asset', static function ($object) {
+                return is_object($object) && $object instanceof Asset;
+            }),
+            new TwigTest('pimcore_asset_archive', static function ($object) {
+                return is_object($object) && $object instanceof Asset\Archive;
+            }),
+            new TwigTest('pimcore_asset_audio',static  function ($object) {
+                return is_object($object) && $object instanceof Asset\Audio;
+            }),
+            new TwigTest('pimcore_asset_document', static function ($object) {
+                return is_object($object) && $object instanceof Asset\Document;
+            }),
+            new TwigTest('pimcore_asset_folder', static function ($object) {
+                return is_object($object) && $object instanceof Asset\Folder;
+            }),
+            new TwigTest('pimcore_asset_image', static function ($object) {
+                return is_object($object) && $object instanceof Asset\Image;
+            }),
+            new TwigTest('pimcore_asset_text', static function ($object) {
+                return is_object($object) && $object instanceof Asset\Text;
+            }),
+            new TwigTest('pimcore_asset_unknown', static function ($object) {
+                return is_object($object) && $object instanceof Asset\Unknown;
+            }),
+            new TwigTest('pimcore_asset_video', static function ($object) {
+                return is_object($object) && $object instanceof Asset\Video;
+            }),
+        ];
+    }
+}

--- a/lib/Twig/Extension/AssetHelperExtensions.php
+++ b/lib/Twig/Extension/AssetHelperExtensions.php
@@ -27,31 +27,31 @@ final class AssetHelperExtensions extends AbstractExtension
     {
         return [
             new TwigTest('pimcore_asset', static function ($object) {
-                return is_object($object) && $object instanceof Asset;
+                return $object instanceof Asset;
             }),
             new TwigTest('pimcore_asset_archive', static function ($object) {
-                return is_object($object) && $object instanceof Asset\Archive;
+                return $object instanceof Asset\Archive;
             }),
             new TwigTest('pimcore_asset_audio',static  function ($object) {
-                return is_object($object) && $object instanceof Asset\Audio;
+                return $object instanceof Asset\Audio;
             }),
             new TwigTest('pimcore_asset_document', static function ($object) {
-                return is_object($object) && $object instanceof Asset\Document;
+                return $object instanceof Asset\Document;
             }),
             new TwigTest('pimcore_asset_folder', static function ($object) {
-                return is_object($object) && $object instanceof Asset\Folder;
+                return $object instanceof Asset\Folder;
             }),
             new TwigTest('pimcore_asset_image', static function ($object) {
-                return is_object($object) && $object instanceof Asset\Image;
+                return $object instanceof Asset\Image;
             }),
             new TwigTest('pimcore_asset_text', static function ($object) {
-                return is_object($object) && $object instanceof Asset\Text;
+                return $object instanceof Asset\Text;
             }),
             new TwigTest('pimcore_asset_unknown', static function ($object) {
-                return is_object($object) && $object instanceof Asset\Unknown;
+                return $object instanceof Asset\Unknown;
             }),
             new TwigTest('pimcore_asset_video', static function ($object) {
-                return is_object($object) && $object instanceof Asset\Video;
+                return $object instanceof Asset\Video;
             }),
         ];
     }

--- a/lib/Twig/Extension/DataObjectHelperExtensions.php
+++ b/lib/Twig/Extension/DataObjectHelperExtensions.php
@@ -32,10 +32,10 @@ final class DataObjectHelperExtensions extends AbstractExtension
     {
         return [
             new TwigTest('pimcore_data_object', static function ($object) {
-                return is_object($object) && $object instanceof DataObject\Concrete;
+                return $object instanceof DataObject\Concrete;
             }),
             new TwigTest('pimcore_data_object_folder', static function ($object) {
-                return is_object($object) && $object instanceof DataObject\Folder;
+                return $object instanceof DataObject\Folder;
             }),
             new TwigTest('pimcore_data_object_class', static function ($object, $className) {
                 $className = ucfirst($className);

--- a/lib/Twig/Extension/DataObjectHelperExtensions.php
+++ b/lib/Twig/Extension/DataObjectHelperExtensions.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Twig\Extension;
+
+use Pimcore\Model\DataObject;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+use Twig\TwigTest;
+
+final class DataObjectHelperExtensions extends AbstractExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getTests()
+    {
+        return [
+            new TwigTest('pimcore_data_object', static function ($object) {
+                return is_object($object) && $object instanceof DataObject\Concrete;
+            }),
+            new TwigTest('pimcore_data_object_folder', static function ($object) {
+                return is_object($object) && $object instanceof DataObject\Folder;
+            }),
+            new TwigTest('pimcore_data_object_class', static function ($object, $className) {
+                $className = ucfirst($className);
+                $className = 'Pimcore\\Model\\DataObject\\' . $className;
+
+                return class_exists($className) && $object instanceof $className;
+            }),
+            new TwigTest('pimcore_data_object_gallery', static function ($object) {
+                return $object instanceof DataObject\Data\ImageGallery;
+            }),
+            new TwigTest('pimcore_data_object_hotspot_image', static function ($object) {
+                return $object instanceof DataObject\Data\Hotspotimage;
+            }),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('pimcore_data_object_select_options', static function ($object, $field) {
+                return DataObject\Service::getOptionsForSelectField($object, $field);
+            }),
+        ];
+    }
+}

--- a/lib/Twig/Extension/DocumentHelperExtensions.php
+++ b/lib/Twig/Extension/DocumentHelperExtensions.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Twig\Extension;
+
+use Pimcore\Model\Document;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigTest;
+
+final class DocumentHelperExtensions extends AbstractExtension
+{
+    public function getTests(): array
+    {
+        return [
+            new TwigTest('pimcore_document', static function ($object) {
+                return is_object($object) && $object instanceof Document;
+            }),
+            new TwigTest('pimcore_document_email', static function ($object) {
+                return is_object($object) && $object instanceof Document\Email;
+            }),
+            new TwigTest('pimcore_document_folder', static function ($object) {
+                return is_object($object) && $object instanceof Document\Folder;
+            }),
+            new TwigTest('pimcore_document_hardlink', static function ($object) {
+                return is_object($object) && $object instanceof Document\Hardlink;
+            }),
+            new TwigTest('pimcore_document_newsletter', static function ($object) {
+                return is_object($object) && $object instanceof Document\Newsletter;
+            }),
+            new TwigTest('pimcore_document_page', static function ($object) {
+                return is_object($object) && $object instanceof Document\Page;
+            }),
+            new TwigTest('pimcore_document_link', static function ($object) {
+                return is_object($object) && $object instanceof Document\Link;
+            }),
+            new TwigTest('pimcore_document_page_snippet', static function ($object) {
+                return is_object($object) && $object instanceof Document\PageSnippet;
+            }),
+            new TwigTest('pimcore_document_print',static  function ($object) {
+                return is_object($object) && $object instanceof Document\PrintAbstract;
+            }),
+            new TwigTest('pimcore_document_print_container', static function ($object) {
+                return is_object($object) && $object instanceof Document\Printcontainer;
+            }),
+            new TwigTest('pimcore_document_print_page', static function ($object) {
+                return is_object($object) && $object instanceof Document\Printpage;
+            }),
+            new TwigTest('pimcore_document_snippet', static function ($object) {
+                return is_object($object) && $object instanceof Document\Snippet;
+            }),
+        ];
+    }
+}

--- a/lib/Twig/Extension/DocumentHelperExtensions.php
+++ b/lib/Twig/Extension/DocumentHelperExtensions.php
@@ -27,40 +27,40 @@ final class DocumentHelperExtensions extends AbstractExtension
     {
         return [
             new TwigTest('pimcore_document', static function ($object) {
-                return is_object($object) && $object instanceof Document;
+                return $object instanceof Document;
             }),
             new TwigTest('pimcore_document_email', static function ($object) {
-                return is_object($object) && $object instanceof Document\Email;
+                return $object instanceof Document\Email;
             }),
             new TwigTest('pimcore_document_folder', static function ($object) {
-                return is_object($object) && $object instanceof Document\Folder;
+                return $object instanceof Document\Folder;
             }),
             new TwigTest('pimcore_document_hardlink', static function ($object) {
-                return is_object($object) && $object instanceof Document\Hardlink;
+                return $object instanceof Document\Hardlink;
             }),
             new TwigTest('pimcore_document_newsletter', static function ($object) {
-                return is_object($object) && $object instanceof Document\Newsletter;
+                return $object instanceof Document\Newsletter;
             }),
             new TwigTest('pimcore_document_page', static function ($object) {
-                return is_object($object) && $object instanceof Document\Page;
+                return $object instanceof Document\Page;
             }),
             new TwigTest('pimcore_document_link', static function ($object) {
-                return is_object($object) && $object instanceof Document\Link;
+                return $object instanceof Document\Link;
             }),
             new TwigTest('pimcore_document_page_snippet', static function ($object) {
-                return is_object($object) && $object instanceof Document\PageSnippet;
+                return $object instanceof Document\PageSnippet;
             }),
             new TwigTest('pimcore_document_print',static  function ($object) {
-                return is_object($object) && $object instanceof Document\PrintAbstract;
+                return $object instanceof Document\PrintAbstract;
             }),
             new TwigTest('pimcore_document_print_container', static function ($object) {
-                return is_object($object) && $object instanceof Document\Printcontainer;
+                return $object instanceof Document\Printcontainer;
             }),
             new TwigTest('pimcore_document_print_page', static function ($object) {
-                return is_object($object) && $object instanceof Document\Printpage;
+                return $object instanceof Document\Printpage;
             }),
             new TwigTest('pimcore_document_snippet', static function ($object) {
-                return is_object($object) && $object instanceof Document\Snippet;
+                return $object instanceof Document\Snippet;
             }),
         ];
     }

--- a/lib/Twig/Extension/ImageThumbnailExtension.php
+++ b/lib/Twig/Extension/ImageThumbnailExtension.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Twig\Extension;
+
+use Pimcore\Model\Asset\Image;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+final class ImageThumbnailExtension extends AbstractExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('pimcore_image_thumbnail', [$this, 'getImageThumbnail'], ['is_safe' => ['html']]),
+            new TwigFilter('pimcore_image_thumbnail_html', [$this, 'getImageThumbnailHtml'], ['is_safe' => ['html']]),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('pimcore_image_thumbnail', [$this, 'getImageThumbnail'], ['is_safe' => ['html']]),
+            new TwigFunction('pimcore_image_thumbnail_html', [$this, 'getImageThumbnailHtml'], ['is_safe' => ['html']]),
+        ];
+    }
+
+    /**
+     * @param Image  $image
+     * @param string $thumbnail
+     * @param bool   $deferred
+     *
+     * @return Image\Thumbnail
+     */
+    public function getImageThumbnail(Image $image, string $thumbnail, bool $deferred = true): Image\Thumbnail
+    {
+        return $image->getThumbnail($thumbnail, $deferred);
+    }
+
+    /**
+     * @param Image  $image
+     * @param string $thumbnail
+     * @param array  $options
+     * @param array  $removeAttributes
+     * @param bool   $deferred
+     *
+     * @return string
+     */
+    public function getImageThumbnailHtml(
+        Image $image,
+        string $thumbnail,
+        array $options = [],
+        array $removeAttributes = [],
+        bool $deferred = true
+    ): string {
+        return $this->getImageThumbnail($image, $thumbnail, $deferred)->getHTML($options, $removeAttributes);
+    }
+}

--- a/lib/Twig/Extension/ImageThumbnailExtension.php
+++ b/lib/Twig/Extension/ImageThumbnailExtension.php
@@ -69,7 +69,7 @@ final class ImageThumbnailExtension extends AbstractExtension
      */
     public function getImageThumbnailHtml(
         Image $image,
-        string $thumbnail,
+        string|array|Image\Thumbnail\Config $thumbnail,
         array $options = [],
         array $removeAttributes = [],
         bool $deferred = true

--- a/lib/Twig/Extension/ImageThumbnailExtension.php
+++ b/lib/Twig/Extension/ImageThumbnailExtension.php
@@ -48,7 +48,7 @@ final class ImageThumbnailExtension extends AbstractExtension
 
     /**
      * @param Image  $image
-     * @param string|array|Image\Thumbnail\Config $thumbnail
+     * @param string $thumbnail
      * @param bool   $deferred
      *
      * @return Image\Thumbnail
@@ -69,7 +69,7 @@ final class ImageThumbnailExtension extends AbstractExtension
      */
     public function getImageThumbnailHtml(
         Image $image,
-        string|array|Image\Thumbnail\Config $thumbnail,
+        string $thumbnail,
         array $options = [],
         array $removeAttributes = [],
         bool $deferred = true

--- a/lib/Twig/Extension/ImageThumbnailExtension.php
+++ b/lib/Twig/Extension/ImageThumbnailExtension.php
@@ -48,7 +48,7 @@ final class ImageThumbnailExtension extends AbstractExtension
 
     /**
      * @param Image  $image
-     * @param string $thumbnail
+     * @param string|array|Image\Thumbnail\Config $thumbnail
      * @param bool   $deferred
      *
      * @return Image\Thumbnail


### PR DESCRIPTION
These are quite some handy twig extensions that should be part of the Core.

@brusch there are many more things in coreshop/pimcore that might make sense, if you mgiht take a look at it what you think might help here as well: https://github.com/coreshop/CoreShop/tree/master/src/CoreShop/Component/Pimcore