### PR TITLE
Fixes array_to_html_attribute_string to allow value-less attributes

### DIFF
--- a/lib/helper-functions.php
+++ b/lib/helper-functions.php
@@ -222,7 +222,7 @@ function array_toquerystring($args)
 }
 
 /**
- * @param array $array
+ * @param array $array with attribute names as keys, and values as values
  *
  * @return string
  */

--- a/lib/helper-functions.php
+++ b/lib/helper-functions.php
@@ -235,6 +235,8 @@ function array_to_html_attribute_string($array)
                 $data .= ' ';
             }
             $data .= $key . '="' . htmlspecialchars($value) . '"';
+        } elseif (is_string($key) && is_null($value)) {
+            $data .= $key;
         }
     }
 

--- a/lib/helper-functions.php
+++ b/lib/helper-functions.php
@@ -228,19 +228,17 @@ function array_toquerystring($args)
  */
 function array_to_html_attribute_string($array)
 {
-    $data = '';
+    $data = [];
+
     foreach ($array as $key => $value) {
         if (is_scalar($value)) {
-            if (!empty($data)) {
-                $data .= ' ';
-            }
-            $data .= $key . '="' . htmlspecialchars($value) . '"';
+            $data[] = $key . '="' . htmlspecialchars($value) . '"';
         } elseif (is_string($key) && is_null($value)) {
-            $data .= $key;
+            $data[] = $key;
         }
     }
 
-    return $data;
+    return implode(' ', $data);
 }
 
 /**


### PR DESCRIPTION
Allows attributes such as `data-*`, `contenteditable`, `required`, or `autofocus` now which may be used without any value by using the attribute name as key and `null` as the value.