### PR TITLE
Update NotificationEmailService.php

### DIFF
--- a/lib/Workflow/Notification/NotificationEmailService.php
+++ b/lib/Workflow/Notification/NotificationEmailService.php
@@ -74,6 +74,17 @@ class NotificationEmailService extends AbstractNotificationService
             if (!count($recipients)) {
                 return;
             }
+            
+            // Decide what kind of link to create
+            $objectType = $type = "object";
+            if ($subject instanceof \Pimcore\Model\Document) {
+                $objectType = "document";
+                $type = $subject->getType();
+            }
+            if ($subject instanceof \Pimcore\Model\Asset) {
+                $objectType = "asset";
+                $type = $subject->getType();
+            }
 
             $deeplink = '';
             $hostUrl = Tool::getHostUrl();


### PR DESCRIPTION
Allows notification email to link correctly to items other than objects. Changing a document or asset and submitting a workflow against the item produces an email with a link to an object "...object_ID_object..."

This code selects the appropriate type from the currently available types or just defaults to object.

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

I am getting object links when I am editing pages.

For instance here is the deeplink to the page: https://www.site.com/admin/login/deeplink?document_1824_page

Here is the link that came in the email when i edited the page and submitted the workflow: https://www.site.com/admin/login/deeplink?object_1824_object

The ID is correct but the link is wrong.
