### PR TITLE
Extract method for processing result in AbstractElasticSearch

### DIFF
--- a/bundles/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
@@ -168,6 +168,10 @@ class FullPageCacheListener
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
+        if(!$this->isEnabled()) {
+            return;
+        }
+
         $request = $event->getRequest();
 
         if (!$event->isMasterRequest()) {

--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -1170,31 +1170,45 @@ abstract class AbstractElasticSearch implements ProductListInterface
 
             // send request
             $result = $this->sendRequest($params);
+            
+            // process result from elasticsearch
+            $this->processResult($result);
 
-            if ($result['aggregations']) {
-                foreach ($result['aggregations'] as $fieldname => $aggregation) {
-                    $buckets = $this->searchForBuckets($aggregation);
-
-                    $groupByValueResult = [];
-                    if ($buckets) {
-                        foreach ($buckets as $bucket) {
-                            if ($this->getVariantMode() == self::VARIANT_MODE_INCLUDE_PARENT_OBJECT) {
-                                $groupByValueResult[] = ['value' => $bucket['key'], 'count' => $bucket['objectCount']['value']];
-                            } else {
-                                $data = $this->convertBucketValues($bucket);
-                                $groupByValueResult[] = $data;
-                            }
-                        }
-                    }
-
-                    $this->preparedGroupByValuesResults[$fieldname] = $groupByValueResult;
-                }
-            }
         } else {
             $this->preparedGroupByValuesResults = [];
         }
 
         $this->preparedGroupByValuesLoaded = true;
+    }
+    
+     /**
+     * process the result array from elasticsearch
+     *
+     * @param array $result
+     *
+     * @return void
+     */
+    protected function processResult(array $result)
+    {
+        if ($result['aggregations']) {
+            foreach ($result['aggregations'] as $fieldname => $aggregation) {
+                $buckets = $this->searchForBuckets($aggregation);
+
+                $groupByValueResult = [];
+                if ($buckets) {
+                    foreach ($buckets as $bucket) {
+                        if ($this->getVariantMode() == self::VARIANT_MODE_INCLUDE_PARENT_OBJECT) {
+                            $groupByValueResult[] = ['value' => $bucket['key'], 'count' => $bucket['objectCount']['value']];
+                        } else {
+                            $data = $this->convertBucketValues($bucket);
+                            $groupByValueResult[] = $data;
+                        }
+                    }
+                }
+
+                $this->preparedGroupByValuesResults[$fieldname] = $groupByValueResult;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  

In order to use or modify results from Elasticsearch queries other than [Bucket Aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket.html#search-aggregations-bucket) (cf. metrics or pipeline aggregations) in the `doLoadGroupByValues()` method this functionality was extracted into its own method.