### PR TITLE
Add getId method to ProductInterface

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Model/ProductInterface.php
+++ b/bundles/EcommerceFrameworkBundle/Model/ProductInterface.php
@@ -20,6 +20,11 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
 interface ProductInterface
 {
     /**
+     * @return int
+     */
+    public function getId();
+
+    /**
      * called by default CommitOrderProcessor to get the product name to store it in the order item
      * should be overwritten in mapped sub classes of product classes
      *


### PR DESCRIPTION
Is used very often. For example:
https://github.com/pimcore/pimcore/blob/b926dc320b5ccda17e20665303ca239404a3d821/bundles/EcommerceFrameworkBundle/Model/AbstractSetProductEntry.php#L82