### PR TITLE
Make AbstractOrder/AbstractOrderItem methods abstract and add missing methods

### DIFF
--- a/bundles/EcommerceFrameworkBundle/CartManager/AbstractCart.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/AbstractCart.php
@@ -170,7 +170,6 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
      * @return bool
      *
      * @throws InvalidConfigException
-     * @throws \Pimcore\Bundle\EcommerceFrameworkBundle\Exception\UnsupportedException
      *
      * @deprecated use checkout implementation V7 instead
      */

--- a/bundles/EcommerceFrameworkBundle/Model/AbstractOrder.php
+++ b/bundles/EcommerceFrameworkBundle/Model/AbstractOrder.php
@@ -426,4 +426,11 @@ abstract class AbstractOrder extends Concrete
      * @return \Pimcore\Model\DataObject\OnlineShopOrder
      */
     abstract public function setVoucherTokens($voucherTokens);
+
+    /**
+     * Get cartHash - Cart Hash
+     *
+     * @return float|null
+     */
+    abstract public function getCartHash();
 }

--- a/bundles/EcommerceFrameworkBundle/Model/AbstractOrder.php
+++ b/bundles/EcommerceFrameworkBundle/Model/AbstractOrder.php
@@ -14,704 +14,380 @@
 
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
 
-use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\UnsupportedException;
-use Pimcore\Logger;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Fieldcollection;
 
 /**
  * Abstract base class for order pimcore objects
  */
-class AbstractOrder extends \Pimcore\Model\DataObject\Concrete
+abstract class AbstractOrder extends Concrete
 {
-    const ORDER_STATE_COMMITTED = 'committed';
-    const ORDER_STATE_CANCELLED = 'cancelled';
-    const ORDER_STATE_PAYMENT_PENDING = 'paymentPending';
-    const ORDER_STATE_PAYMENT_INIT = 'paymentInit';
-    const ORDER_STATE_PAYMENT_AUTHORIZED = 'paymentAuthorized';
-    const ORDER_STATE_ABORTED = 'aborted';
-    const ORDER_PAYMENT_STATE_ABORTED_BUT_RESPONSE = 'abortedButResponseReceived';
+    public const ORDER_STATE_COMMITTED = 'committed';
+    public const ORDER_STATE_CANCELLED = 'cancelled';
+    public const ORDER_STATE_PAYMENT_PENDING = 'paymentPending';
+    public const ORDER_STATE_PAYMENT_INIT = 'paymentInit';
+    public const ORDER_STATE_PAYMENT_AUTHORIZED = 'paymentAuthorized';
+    public const ORDER_STATE_ABORTED = 'aborted';
+    public const ORDER_PAYMENT_STATE_ABORTED_BUT_RESPONSE = 'abortedButResponseReceived';
 
     /**
      * @return string
-     *
-     * @throws UnsupportedException
      */
-    public function getOrdernumber()
-    {
-        throw new UnsupportedException('getOrdernumber is not implemented for ' . get_class($this));
-    }
+    abstract public function getOrdernumber();
 
     /**
      * @param string $ordernumber
-     *
-     * @throws UnsupportedException
      */
-    public function setOrdernumber($ordernumber)
-    {
-        throw new UnsupportedException('setOrdernumber is not implemented for ' . get_class($this));
-    }
+    abstract public function setOrdernumber($ordernumber);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return float
      */
-    public function getSubTotalPrice()
-    {
-        throw new UnsupportedException('getSubTotalPrice is not implemented for ' . get_class($this));
-    }
-
-    /**
-     * @throws UnsupportedException
-     *
-     * @param float $subTotalPrice
-     */
-    public function setSubTotalPrice($subTotalPrice)
-    {
-        throw new UnsupportedException('setSubTotalPrice is not implemented for ' . get_class($this));
-    }
-
-    /**
-     * Should return a float
-     *
-     * @return void
-     */
-    public function getSubTotalNetPrice()
-    {
-        // @TODO Throw UnsupportedException or change to abstract method in v7.0
-        Logger::err('getSubTotalNetPrice not implemented for ' . get_class($this));
-    }
+    abstract public function getSubTotalPrice();
 
     /**
      * @param float $subTotalPrice
      */
-    public function setSubTotalNetPrice($subTotalPrice)
-    {
-        // @TODO Throw UnsupportedException or change to abstract method in v7.0
-        Logger::err('setSubTotalNetPrice not implemented for ' . get_class($this));
-    }
+    abstract public function setSubTotalPrice($subTotalPrice);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return float
      */
-    public function getTotalPrice()
-    {
-        throw new UnsupportedException('getTotalPrice is not implemented for ' . get_class($this));
-    }
+    abstract public function getSubTotalNetPrice();
 
     /**
-     * @throws UnsupportedException
-     *
-     * @param float $totalPrice
+     * @param float $subTotalPrice
      */
-    public function setTotalPrice($totalPrice)
-    {
-        throw new UnsupportedException('setTotalPrice is not implemented for ' . get_class($this));
-    }
+    abstract public function setSubTotalNetPrice($subTotalPrice);
 
     /**
-     * Should return a float
-     *
-     * @return void
+     * @return float
      */
-    public function getTotalNetPrice()
-    {
-        // @TODO Throw UnsupportedException or change to abstract method in v7.0
-        Logger::err('getTotalNetPrice not implemented for ' . get_class($this));
-    }
+    abstract public function getTotalPrice();
 
     /**
      * @param float $totalPrice
      */
-    public function setTotalNetPrice($totalPrice)
-    {
-        // @TODO Throw UnsupportedException or change to abstract method in v7.0
-        Logger::err('setTotalNetPrice not implemented for ' . get_class($this));
-    }
+    abstract public function setTotalPrice($totalPrice);
 
     /**
-     * Should return an array
-     *
+     * @return float
+     */
+    abstract public function getTotalNetPrice();
+
+    /**
+     * @param float $totalPrice
+     */
+    abstract public function setTotalNetPrice($totalPrice);
+
+    /**
      * @return array
      */
-    public function getTaxInfo()
-    {
-        // @TODO Throw UnsupportedException or change to abstract method in v7.0
-        Logger::err('getTaxInfo not implemented for ' . get_class($this));
-    }
+    abstract public function getTaxInfo();
 
     /**
      * @param array $taxInfo
      */
-    public function setTaxInfo($taxInfo)
-    {
-        // @TODO Throw UnsupportedException or change to abstract method in v7.0
-        Logger::err('setTaxInfo not implemented for ' . get_class($this));
-    }
+    abstract public function setTaxInfo($taxInfo);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return \DateTime
      */
-    public function getOrderdate()
-    {
-        throw new UnsupportedException('getOrderdate is not implemented for ' . get_class($this));
-    }
+    abstract public function getOrderdate();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param \DateTime $orderdate
      */
-    public function setOrderdate($orderdate)
-    {
-        throw new UnsupportedException('setOrderdate is not implemented for ' . get_class($this));
-    }
+    abstract public function setOrderdate($orderdate);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return AbstractOrderItem[]
      */
-    public function getItems()
-    {
-        throw new UnsupportedException('getItems is not implemented for ' . get_class($this));
-    }
+    abstract public function getItems();
 
     /**
      * @param AbstractOrderItem[] $items
-     *
-     * @throws UnsupportedException
      */
-    public function setItems($items)
-    {
-        throw new UnsupportedException('setItems is not implemented for ' . get_class($this));
-    }
+    abstract public function setItems($items);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return AbstractOrderItem[]
      */
-    public function getGiftItems()
-    {
-        throw new UnsupportedException('getGiftItems is not implemented for ' . get_class($this));
-    }
+    abstract public function getGiftItems();
 
     /**
      * @param AbstractOrderItem[] $giftItems
      */
-    public function setGiftItems($giftItems)
-    {
-        // @TODO Throw UnsupportedException or change to abstract method in v7.0
-        Logger::err('setGiftItems not implemented for ' . get_class($this));
-    }
+    abstract public function setGiftItems($giftItems);
 
     /**
-     * @throws UnsupportedException
-     * committed
-     *
-     * @return mixed
+     * @return \Pimcore\Model\DataObject\Customer
      */
-    public function getCustomer()
-    {
-        throw new UnsupportedException('getCustomer is not implemented for ' . get_class($this));
-    }
+    abstract public function getCustomer();
 
     /**
-     * @throws UnsupportedException
-     *
-     * @param mixed $customer
+     * @param \Pimcore\Model\DataObject\Customer $customer
      */
-    public function setCustomer($customer)
-    {
-        throw new UnsupportedException('setCustomer is not implemented for ' . get_class($this));
-    }
+    abstract public function setCustomer($customer);
 
     /**
-     * @throws UnsupportedException
-     *
-     * @return \Pimcore\Model\DataObject\Fieldcollection
+     * @return Fieldcollection
      */
-    public function getPriceModifications()
-    {
-        throw new UnsupportedException('getPriceModifications is not implemented for ' . get_class($this));
-    }
+    abstract public function getPriceModifications();
 
     /**
-     * @throws UnsupportedException
-     *
-     * @param \Pimcore\Model\DataObject\Fieldcollection $priceModifications
-     *
-     * @return void
+     * @param Fieldcollection $priceModifications
      */
-    public function setPriceModifications($priceModifications)
-    {
-        throw new UnsupportedException('setPriceModifications is not implemented for ' . get_class($this));
-    }
+    abstract public function setPriceModifications($priceModifications);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return string
      */
-    public function getOrderState()
-    {
-        throw new UnsupportedException('getOrderState is not implemented for ' . get_class($this));
-    }
+    abstract public function getOrderState();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $orderState
      *
      * @return $this
      */
-    public function setOrderState($orderState)
-    {
-        throw new UnsupportedException('setOrderState is not implemented for ' . get_class($this));
-    }
+    abstract public function setOrderState($orderState);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return int
      */
-    public function getCartId()
-    {
-        throw new UnsupportedException('getCartId is not implemented for ' . get_class($this));
-    }
+    abstract public function getCartId();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param int $cartId
      *
      * @return void
      */
-    public function setCartId($cartId)
-    {
-        throw new UnsupportedException('setCartId is not implemented for ' . get_class($this));
-    }
+    abstract public function setCartId($cartId);
 
     /**
-     * @throws UnsupportedException
-     *
-     * @return \Pimcore\Model\DataObject\Fieldcollection
+     * @return Fieldcollection
      */
-    public function getPaymentInfo()
-    {
-        throw new UnsupportedException('getPaymentInfo is not implemented for ' . get_class($this));
-    }
+    abstract public function getPaymentInfo();
 
     /**
-     * @throws UnsupportedException
-     *
-     * @param \Pimcore\Model\DataObject\Fieldcollection $paymentInfo
-     *
-     * @return void
+     * @param Fieldcollection $paymentInfo
      */
-    public function setPaymentInfo($paymentInfo)
-    {
-        throw new UnsupportedException('setPaymentInfo is not implemented for ' . get_class($this));
-    }
+    abstract public function setPaymentInfo($paymentInfo);
 
     /**
      * returns latest payment info entry
      *
-     * @return \Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractPaymentInformation
+     * @return AbstractPaymentInformation
      */
     public function getLastPaymentInfo()
     {
         if ($this->getPaymentInfo()) {
             $items = $this->getPaymentInfo()->getItems();
 
-            return end($items);
-        } else {
-            return null;
+            $item = end($items);
+
+            if ($item instanceof AbstractPaymentInformation) {
+                return $item;
+            }
         }
+
+        return null;
     }
 
     /**
-     * @throws UnsupportedException
-     *
-     * @return mixed
+     * @return string
      */
-    public function getComment()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getComment();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $comment
      *
      * @return $this
      */
-    public function setComment($comment)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setComment($comment);
 
     /**
-     * @throws UnsupportedException
-     *
-     * @return mixed
+     * @return string
      */
-    public function getCustomerEMail()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getCustomerEMail();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $customerEMail
      *
      * @return $this
      */
-    public function setCustomerEMail($customerEMail)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setCustomerEMail($customerEMail);
 
     /**
-     * @throws UnsupportedException
-     *
-     * @return mixed
+     * @return string
      */
-    public function getCustomerCountry()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getCustomerCountry();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $customerCountry
      *
      * @return $this
      */
-    public function setCustomerCountry($customerCountry)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setCustomerCountry($customerCountry);
 
     /**
-     * @throws UnsupportedException
-     *
-     * @return mixed
+     * @return string
      */
-    public function getCustomerCity()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getCustomerCity();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $customerCity
      *
      * @return $this
      */
-    public function setCustomerCity($customerCity)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setCustomerCity($customerCity);
 
     /**
-     * @throws UnsupportedException
-     *
-     * @return mixed
+     * @return string
      */
-    public function getCustomerZip()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getCustomerZip();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $customerZip
      *
      * @return $this
      */
-    public function setCustomerZip($customerZip)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setCustomerZip($customerZip);
 
     /**
-     * @throws UnsupportedException
-     *
-     * @return mixed
+     * @return string
      */
-    public function getCustomerStreet()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getCustomerStreet();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $customerStreet
      *
      * @return $this
      */
-    public function setCustomerStreet($customerStreet)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setCustomerStreet($customerStreet);
 
     /**
-     * @throws UnsupportedException
-     *
-     * @return mixed
+     * @return string
      */
-    public function getCustomerCompany()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getCustomerCompany();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $customerCompany
      *
      * @return $this
      */
-    public function setCustomerCompany($customerCompany)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setCustomerCompany($customerCompany);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return string
      */
-    public function getCustomerFirstname()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getCustomerFirstname();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $customerFirstname
      *
      * @return $this
      */
-    public function setCustomerFirstname($customerFirstname)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setCustomerFirstname($customerFirstname);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return string
      */
-    public function getCustomerLastname()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getCustomerLastname();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $customerLastname
      *
      * @return $this
      */
-    public function setCustomerLastname($customerLastname)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setCustomerLastname($customerLastname);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return string
      */
-    public function getDeliveryEMail()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getDeliveryCountry();
 
     /**
-     * @throws UnsupportedException
-     *
-     * @param string $deliveryEMail
-     *
-     * @return $this
-     */
-    public function setDeliveryEMail($deliveryEMail)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
-
-    /**
-     * @throws UnsupportedException
-     *
-     * @return string
-     */
-    public function getDeliveryCountry()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
-
-    /**
-     * @throws UnsupportedException
-     *
      * @param string $deliveryCountry
      *
      * @return $this
      */
-    public function setDeliveryCountry($deliveryCountry)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setDeliveryCountry($deliveryCountry);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return string
      */
-    public function getDeliveryCity()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getDeliveryCity();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $deliveryCity
      *
      * @return $this
      */
-    public function setDeliveryCity($deliveryCity)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setDeliveryCity($deliveryCity);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return string
      */
-    public function getDeliveryZip()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getDeliveryZip();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $deliveryZip
      *
      * @return $this
      */
-    public function setDeliveryZip($deliveryZip)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setDeliveryZip($deliveryZip);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return string
      */
-    public function getDeliveryStreet()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getDeliveryStreet();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $deliveryStreet
      *
      * @return $this
      */
-    public function setDeliveryStreet($deliveryStreet)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setDeliveryStreet($deliveryStreet);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return string
      */
-    public function getDeliveryCompany()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getDeliveryCompany();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $deliveryCompany
      *
      * @return $this
      */
-    public function setDeliveryCompany($deliveryCompany)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setDeliveryCompany($deliveryCompany);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return string
      */
-    public function getDeliveryFirstname()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getDeliveryFirstname();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $deliveryFirstname
      *
      * @return $this
      */
-    public function setDeliveryFirstname($deliveryFirstname)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setDeliveryFirstname($deliveryFirstname);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return string
      */
-    public function getDeliveryLastname()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getDeliveryLastname();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $deliveryLastname
      *
      * @return $this
      */
-    public function setDeliveryLastname($deliveryLastname)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setDeliveryLastname($deliveryLastname);
 
     /**
      * @return bool
-     *
-     * @throws UnsupportedException
      */
     public function hasDeliveryAddress()
     {
@@ -724,62 +400,30 @@ class AbstractOrder extends \Pimcore\Model\DataObject\Concrete
     }
 
     /**
-     * @throws UnsupportedException
-     *
      * @param string $currency
      *
      * @return $this
      */
-    public function setCurrency($currency)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setCurrency($currency);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return string
      */
-    public function getCurrency()
-    {
-        throw new UnsupportedException('setPaymentInfo is not implemented for ' . get_class($this));
-    }
+    abstract public function getCurrency();
 
     /**
      * Get voucherTokens - Voucher Tokens
      *
-     * @throws UnsupportedException
-     *
      * @return array
      */
-    public function getVoucherTokens()
-    {
-        throw new UnsupportedException('getVoucherTokens is not implemented for ' . get_class($this));
-    }
+    abstract public function getVoucherTokens();
 
     /**
      * Set voucherTokens - Voucher Tokens
-     *
-     * @throws UnsupportedException
      *
      * @param array $voucherTokens
      *
      * @return \Pimcore\Model\DataObject\OnlineShopOrder
      */
-    public function setVoucherTokens($voucherTokens)
-    {
-        throw new UnsupportedException('setVoucherTokens is not implemented for ' . get_class($this));
-    }
-
-    /**
-     * return cart modification time stamp
-     *
-     * @throws UnsupportedException
-     *
-     * @return int
-     */
-    public function getCartModificationTimestamp()
-    {
-        throw new UnsupportedException('getCartModificationTimestamp is not implemented for ' . get_class($this));
-    }
+    abstract public function setVoucherTokens($voucherTokens);
 }

--- a/bundles/EcommerceFrameworkBundle/Model/AbstractOrderItem.php
+++ b/bundles/EcommerceFrameworkBundle/Model/AbstractOrderItem.php
@@ -14,217 +14,129 @@
 
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
 
-use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\UnsupportedException;
-use Pimcore\Logger;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Fieldcollection;
 
 /**
  * Abstract base class for order item pimcore objects
  */
-class AbstractOrderItem extends \Pimcore\Model\DataObject\Concrete
+abstract class AbstractOrderItem extends Concrete
 {
     /**
-     * @throws UnsupportedException
-     *
-     * @return \Pimcore\Bundle\EcommerceFrameworkBundle\Model\CheckoutableInterface
+     * @return CheckoutableInterface
      */
-    public function getProduct()
-    {
-        throw new UnsupportedException('getProduct is not implemented for ' . get_class($this));
-    }
+    abstract public function getProduct();
 
     /**
-     * @param \Pimcore\Bundle\EcommerceFrameworkBundle\Model\CheckoutableInterface $product
-     *
-     * @throws UnsupportedException
+     * @param CheckoutableInterface $product
      */
-    public function setProduct($product)
-    {
-        throw new UnsupportedException('setProduct is not implemented for ' . get_class($this));
-    }
+    abstract public function setProduct($product);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return string
      */
-    public function getProductNumber()
-    {
-        throw new UnsupportedException('getProductNumber is not implemented for ' . get_class($this));
-    }
+    abstract public function getProductNumber();
 
     /**
      * @param string $productNumber
-     *
-     * @throws UnsupportedException
      */
-    public function setProductNumber($productNumber)
-    {
-        throw new UnsupportedException('setProductNumber is not implemented for ' . get_class($this));
-    }
+    abstract public function setProductNumber($productNumber);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return string
      */
-    public function getProductName()
-    {
-        throw new UnsupportedException('getProductName is not implemented for ' . get_class($this));
-    }
+    abstract public function getProductName();
 
     /**
      * @param string $productName
-     *
-     * @throws UnsupportedException
      */
-    public function setProductName($productName)
-    {
-        throw new UnsupportedException('setProductName is not implemented for ' . get_class($this));
-    }
+    abstract public function setProductName($productName);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return float
      */
-    public function getAmount()
-    {
-        throw new UnsupportedException('getAmount is not implemented for ' . get_class($this));
-    }
+    abstract public function getAmount();
 
     /**
      * @param float $amount
-     *
-     * @throws UnsupportedException
      */
-    public function setAmount($amount)
-    {
-        throw new UnsupportedException('setAmount is not implemented for ' . get_class($this));
-    }
+    abstract public function setAmount($amount);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return float
      */
-    public function getTotalPrice()
-    {
-        throw new UnsupportedException('getTotalPrice is not implemented for ' . get_class($this));
-    }
+    abstract public function getTotalPrice();
 
     /**
-     * @throws UnsupportedException
-     *
      * @param float $totalPrice
      */
-    public function setTotalPrice($totalPrice)
-    {
-        throw new UnsupportedException('setTotalPrice is not implemented for ' . get_class($this));
-    }
+    abstract public function setTotalPrice($totalPrice);
 
     /**
-     * Should return a float
-     *
-     * @return void
+     * @return float
      */
-    public function getTotalNetPrice()
-    {
-        // @TODO Throw UnsupportedException or change to abstract method in v7.0
-        Logger::err('getTotalNetPrice not implemented for ' . get_class($this));
-    }
+    abstract public function getTotalNetPrice();
 
     /**
      * @param float $totalNetPrice
      */
-    public function setTotalNetPrice($totalNetPrice)
-    {
-        // @TODO Throw UnsupportedException or change to abstract method in v7.0
-        Logger::err('setTotalNetPrice not implemented for ' . get_class($this));
-    }
+    abstract public function setTotalNetPrice($totalNetPrice);
 
     /**
-     * Should return an array
-     *
-     * @return void
+     * @return array
      */
-    public function getTaxInfo()
-    {
-        // @TODO Throw UnsupportedException or change to abstract method in v7.0
-        Logger::err('getTaxInfo not implemented for ' . get_class($this));
-    }
+    abstract public function getTaxInfo();
 
     /**
      * @param array $taxInfo
      */
-    public function setTaxInfo($taxInfo)
-    {
-        // @TODO Throw UnsupportedException or change to abstract method in v7.0
-        Logger::err('setTaxInfo not implemented for ' . get_class($this));
-    }
+    abstract public function setTaxInfo($taxInfo);
 
     /**
      * @return AbstractOrderItem[]
-     *
-     * @throws UnsupportedException
      */
-    public function getSubItems()
-    {
-        throw new UnsupportedException('getSubItems is not implemented for ' . get_class($this));
-    }
+    abstract public function getSubItems();
 
     /**
      * @param AbstractOrderItem[] $subItems
-     *
-     * @throws UnsupportedException
      */
-    public function setSubItems($subItems)
-    {
-        throw new UnsupportedException('setSubItems is not implemented for ' . get_class($this));
-    }
+    abstract public function setSubItems($subItems);
 
     /**
-     * @throws UnsupportedException
-     *
-     * @return \Pimcore\Model\DataObject\Fieldcollection
+     * @return Fieldcollection
      */
-    public function getPricingRules()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getPricingRules();
 
     /**
-     * @param \Pimcore\Model\DataObject\Fieldcollection $pricingRules
-     *
-     * @throws UnsupportedException
+     * @param Fieldcollection $pricingRules
      *
      * @return $this
      */
-    public function setPricingRules($pricingRules)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setPricingRules($pricingRules);
 
     /**
-     * @throws UnsupportedException
-     *
      * @return string
      */
-    public function getOrderState()
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function getOrderState();
 
     /**
      * @param string $orderState
      *
-     * @throws UnsupportedException
+     * @return $this
+     */
+    abstract public function setOrderState($orderState);
+
+    /**
+     * @return string
+     */
+    abstract public function getComment();
+
+    /**
+     * @param string $comment
      *
      * @return $this
      */
-    public function setOrderState($orderState)
-    {
-        throw new UnsupportedException(__FUNCTION__ . ' is not implemented for ' . get_class($this));
-    }
+    abstract public function setComment($comment);
 
     /**
      * is the order item cancel able

--- a/bundles/EcommerceFrameworkBundle/Model/AbstractProduct.php
+++ b/bundles/EcommerceFrameworkBundle/Model/AbstractProduct.php
@@ -142,8 +142,6 @@ class AbstractProduct extends \Pimcore\Model\DataObject\Concrete implements Prod
      * there should either be a attribute in pro product object or
      * it should be overwritten in mapped sub classes of product classes
      *
-     * @throws UnsupportedException
-     *
      * @return string
      */
     public function getAvailabilitySystemName()

--- a/bundles/EcommerceFrameworkBundle/Model/DefaultMockup.php
+++ b/bundles/EcommerceFrameworkBundle/Model/DefaultMockup.php
@@ -14,7 +14,6 @@
 
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
 
-use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\UnsupportedException;
 use Pimcore\Logger;
 
 class DefaultMockup implements ProductInterface
@@ -192,8 +191,6 @@ class DefaultMockup implements ProductInterface
     /**
      * returns array of categories.
      * has to be overwritten either in pimcore object or mapped sub class.
-     *
-     * @throws UnsupportedException
      *
      * @return array
      */

--- a/bundles/EcommerceFrameworkBundle/OfferTool/AbstractOfferToolProduct.php
+++ b/bundles/EcommerceFrameworkBundle/OfferTool/AbstractOfferToolProduct.php
@@ -61,8 +61,6 @@ class AbstractOfferToolProduct extends \Pimcore\Model\DataObject\Concrete implem
      * defines the name of the availability system for this product.
      * for offline tool there are no availability systems implemented
      *
-     * @throws UnsupportedException
-     *
      * @return string
      */
     public function getAvailabilitySystemName()

--- a/bundles/EcommerceFrameworkBundle/OrderManager/Order/Agent.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/Order/Agent.php
@@ -384,8 +384,6 @@ class Agent implements OrderAgentInterface
      * @param string $paymentState
      *
      * @return PaymentInfo
-     *
-     * @throws UnsupportedException
      */
     protected function createNewOrderInformation(Order $order, string $paymentState)
     {
@@ -506,8 +504,6 @@ class Agent implements OrderAgentInterface
      *  - all product numbers
      *
      * @return int
-     *
-     * @throws UnsupportedException
      */
     protected function getFingerprintOfOrder()
     {

--- a/bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
@@ -17,7 +17,6 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager;
 use Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItemInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\EnvironmentInterface;
-use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\UnsupportedException;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Factory;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractOrder;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractOrderItem;
@@ -297,7 +296,6 @@ class OrderManager implements OrderManagerInterface
      * @return AbstractOrder
      *
      * @throws \Exception
-     * @throws UnsupportedException
      *
      */
     public function getOrCreateOrderFromCart(CartInterface $cart)
@@ -386,20 +384,11 @@ class OrderManager implements OrderManagerInterface
     protected function cleanupZombieOrderItems(AbstractOrder $order)
     {
         $validItemIds = [];
-        try {
-            foreach ($order->getItems() ?: [] as $item) {
-                $validItemIds[] = $item->getId();
-            }
-        } catch (UnsupportedException $e) {
-            Logger::info('getItems not implemented for ' . get_class($order));
+        foreach ($order->getItems() ?: [] as $item) {
+            $validItemIds[] = $item->getId();
         }
-
-        try {
-            foreach ($order->getGiftItems() ?: [] as $giftItem) {
-                $validItemIds[] = $giftItem->getId();
-            }
-        } catch (UnsupportedException $e) {
-            Logger::info('getGiftItems not implemented for ' . get_class($order));
+        foreach ($order->getGiftItems() ?: [] as $giftItem) {
+            $validItemIds[] = $giftItem->getId();
         }
 
         $orderItemChildren = $order->getChildren();
@@ -494,8 +483,6 @@ class OrderManager implements OrderManagerInterface
      * @param AbstractOrder $order
      *
      * @return AbstractOrder
-     *
-     * @throws UnsupportedException
      */
     protected function setCurrentCustomerToOrder(AbstractOrder $order)
     {

--- a/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderManager.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderManager.php
@@ -18,7 +18,6 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItemInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\EnvironmentInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\OrderUpdateNotPossibleException;
-use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\UnsupportedException;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractOrder;
 use Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\OrderAgentFactoryInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\ModificatedPriceInterface;
@@ -64,7 +63,6 @@ class OrderManager extends \Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager
      * @return AbstractOrder
      *
      * @throws \Exception
-     * @throws UnsupportedException
      *
      */
     public function getOrCreateOrderFromCart(CartInterface $cart)
@@ -178,8 +176,6 @@ class OrderManager extends \Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager
      * @param AbstractOrder $order
      *
      * @return bool
-     *
-     * @throws UnsupportedException
      */
     public function orderNeedsUpdate(CartInterface $cart, AbstractOrder $order): bool
     {

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PayPal.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/PayPal.php
@@ -340,8 +340,6 @@ class PayPal extends AbstractPayment
      * @param null|AbstractOrder $order
      *
      * @return \stdClass
-     *
-     * @throws \Pimcore\Bundle\EcommerceFrameworkBundle\Exception\UnsupportedException
      */
     protected function createPaymentDetails(PriceInterface $price, ?AbstractOrder $order = null)
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,24 +6,9 @@ parameters:
 			path: bundles/AdminBundle/Security/LogoutSuccessHandler.php
 
 		-
-			message: "#^Call to an undefined method Pimcore\\\\Event\\\\Model\\\\ElementEventInterface\\:\\:getArgument\\(\\)\\.$#"
-			count: 1
-			path: bundles/CoreBundle/EventListener/ElementTagsListener.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\CheckoutableInterface\\:\\:getId\\(\\)\\.$#"
-			count: 4
-			path: bundles/EcommerceFrameworkBundle/CartManager/AbstractCart.php
-
-		-
 			message: "#^Method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\CartManager\\\\AbstractCart\\:\\:getRecentlyAddedItems\\(\\) should return array\\<Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\CheckoutableInterface\\> but returns array\\<int, Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\CartManager\\\\CartItemInterface\\>\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/CartManager/AbstractCart.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\CheckoutableInterface\\:\\:getId\\(\\)\\.$#"
-			count: 2
-			path: bundles/EcommerceFrameworkBundle/CartManager/AbstractCartItem.php
 
 		-
 			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\CartManager\\\\CartItemInterface\\:\\:setParentItemKey\\(\\)\\.$#"
@@ -54,16 +39,6 @@ parameters:
 			message: "#^Call to an undefined method Pimcore\\\\Model\\\\DataObject\\\\Listing\\:\\:setCartItems\\(\\)\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/CartManager/CartItem/Listing/Dao.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\CheckoutableInterface\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/CartManager/CartPriceCalculator.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\CartManager\\\\CartInterface\\:\\:setItems\\(\\)\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/CartManager/SessionCartItem.php
 
 		-
 			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\OrderManager\\\\OrderManagerInterface\\:\\:isValidOrderForRecurringPayment\\(\\)\\.$#"
@@ -686,16 +661,6 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
 
 		-
-			message: "#^Method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractOrder\\:\\:getTaxInfo\\(\\) should return array but return statement is missing\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/Model/AbstractOrder.php
-
-		-
-			message: "#^Method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractOrder\\:\\:getLastPaymentInfo\\(\\) should return Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractPaymentInformation but returns Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\AbstractData\\|false\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/Model/AbstractOrder.php
-
-		-
 			message: "#^Method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractOrder\\:\\:getLastPaymentInfo\\(\\) should return Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractPaymentInformation but returns null\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/Model/AbstractOrder.php
@@ -704,16 +669,6 @@ parameters:
 			message: "#^Method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractOrderItem\\:\\:getOrder\\(\\) should return Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractOrder but returns Pimcore\\\\Model\\\\DataObject\\\\AbstractObject\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/Model/AbstractOrderItem.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\CheckoutableInterface\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/Model/AbstractSetProductEntry.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\CheckoutableInterface\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/OfferTool/DefaultService.php
 
 		-
 			message: "#^Method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\OrderManager\\\\AbstractOrderList\\:\\:load\\(\\) should return array\\<Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\OrderManager\\\\OrderListItemInterface\\> but returns \\$this\\(Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\OrderManager\\\\AbstractOrderList\\)\\.$#"
@@ -746,27 +701,7 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/OrderManager/Order/Listing/Filter/AbstractSearch.php
 
 		-
-			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\PriceSystem\\\\ModificatedPriceInterface\\:\\:getRule\\(\\)\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractOrderItem\\:\\:setComment\\(\\)\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\CheckoutableInterface\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/OrderManager/OrderManager.php
-
-		-
 			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractOrder\\:\\:setCartHash\\(\\)\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderManager.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractOrder\\:\\:getCartHash\\(\\)\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderManager.php
 
@@ -946,11 +881,6 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/Tracking/AbstractData.php
 
 		-
-			message: "#^PHPDoc tag @implements has invalid value \\(IProductImpression\\)\\: Unexpected token \"\\\\n     \\*\", expected '\\<' at offset 80$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/Tracking/TrackingManager.php
-
-		-
 			message: "#^PHPDoc tag @implements has invalid value \\(ProductInterfaceView\\)\\: Unexpected token \"\\\\n     \", expected '\\<' at offset 123$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/Tracking/TrackingManager.php
@@ -976,49 +906,9 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/VoucherService/Statistic.php
 
 		-
-			message: "#^PHPDoc tag @implements has invalid value \\(IExportableTokenManager\\)\\: Unexpected token \"\\\\n     \", expected '\\<' at offset 137$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/AbstractTokenManager.php
-
-		-
-			message: "#^PHPDoc tag @implements has invalid value \\(IExportableTokenManager\\)\\: Unexpected token \"\\\\n     \", expected '\\<' at offset 149$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/AbstractTokenManager.php
-
-		-
 			message: "#^Method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\VoucherService\\\\TokenManager\\\\Pattern\\:\\:getFinalTokenLength\\(\\) should return int but returns float\\.$#"
 			count: 2
 			path: bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/Pattern.php
-
-		-
-			message: "#^Return type \\(Pimcore\\\\Cache\\\\Pool\\\\PimcoreCacheItemInterface\\) of method Pimcore\\\\Cache\\\\Pool\\\\AbstractCacheItemPool\\:\\:getItem\\(\\) should be compatible with return type \\(Symfony\\\\Component\\\\Cache\\\\CacheItem\\) of method Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface\\:\\:getItem\\(\\)$#"
-			count: 1
-			path: lib/Cache/Pool/AbstractCacheItemPool.php
-
-		-
-			message: "#^Return type \\(array\\<Pimcore\\\\Cache\\\\Pool\\\\PimcoreCacheItemInterface\\>\\|\\(iterable\\<Pimcore\\\\Cache\\\\Pool\\\\PimcoreCacheItemInterface\\>&Traversable\\)\\) of method Pimcore\\\\Cache\\\\Pool\\\\AbstractCacheItemPool\\:\\:getItems\\(\\) should be compatible with return type \\(iterable\\<Symfony\\\\Component\\\\Cache\\\\CacheItem\\>&Traversable\\) of method Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface\\:\\:getItems\\(\\)$#"
-			count: 1
-			path: lib/Cache/Pool/AbstractCacheItemPool.php
-
-		-
-			message: "#^Call to an undefined method Pimcore\\\\Cache\\\\Pool\\\\PimcoreCacheItemInterface\\:\\:getMetadata\\(\\)\\.$#"
-			count: 1
-			path: lib/Cache/Pool/AbstractCacheItemPool.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:\\:execute\\(\\)\\.$#"
-			count: 1
-			path: lib/Cache/Pool/Doctrine.php
-
-		-
-			message: "#^Return type \\(Pimcore\\\\Cache\\\\Pool\\\\PimcoreCacheItemInterface\\) of method Pimcore\\\\Cache\\\\Pool\\\\PimcoreCacheItemPoolInterface\\:\\:getItem\\(\\) should be compatible with return type \\(Symfony\\\\Component\\\\Cache\\\\CacheItem\\) of method Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface\\:\\:getItem\\(\\)$#"
-			count: 1
-			path: lib/Cache/Pool/PimcoreCacheItemPoolInterface.php
-
-		-
-			message: "#^Return type \\(array\\<Pimcore\\\\Cache\\\\Pool\\\\PimcoreCacheItemInterface\\>\\|\\(iterable\\<Pimcore\\\\Cache\\\\Pool\\\\PimcoreCacheItemInterface\\>&Traversable\\)\\) of method Pimcore\\\\Cache\\\\Pool\\\\PimcoreCacheItemPoolInterface\\:\\:getItems\\(\\) should be compatible with return type \\(iterable\\<Symfony\\\\Component\\\\Cache\\\\CacheItem\\>&Traversable\\) of method Symfony\\\\Component\\\\Cache\\\\Adapter\\\\AdapterInterface\\:\\:getItems\\(\\)$#"
-			count: 1
-			path: lib/Cache/Pool/PimcoreCacheItemPoolInterface.php
 
 		-
 			message: "#^Method Pimcore\\\\Config\\:\\:getConfigInstance\\(\\) should return Pimcore\\\\Config\\\\Config\\|null but returns array\\.$#"


### PR DESCRIPTION
Add following methods:

- AbstractOrder::getCartHash()
- AbstractOrderItem::getComment()
- AbstractOrderItem::setComment()

Removed unused methods:

- AbstractOrder::getDeliveryEMail()
- AbstractOrder::setDeliveryEMail()
- AbstractOrder::getCartModificationTimestamp()