### PR TITLE
[Application Logger] Support opening FileObject when using stream wrappers in PIMCORE_LOG_FILEOBJECT_DIRECTORY

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/LogController.php
+++ b/bundles/AdminBundle/Controller/Admin/LogController.php
@@ -232,9 +232,13 @@ class LogController extends AdminController implements KernelControllerEventInte
     public function showFileObjectAction(Request $request)
     {
         $filePath = $request->get('filePath');
-        $filePath = PIMCORE_PROJECT_ROOT . DIRECTORY_SEPARATOR . $filePath;
-        $filePath = realpath($filePath);
-        $fileObjectPath = realpath(PIMCORE_LOG_FILEOBJECT_DIRECTORY);
+        if (!filter_var($filePath, FILTER_VALIDATE_URL)) {
+            $filePath = PIMCORE_PROJECT_ROOT . DIRECTORY_SEPARATOR . $filePath;
+            $filePath = realpath($filePath);
+            $fileObjectPath = realpath(PIMCORE_LOG_FILEOBJECT_DIRECTORY);
+        } else {
+            $fileObjectPath = PIMCORE_LOG_FILEOBJECT_DIRECTORY;
+        }
 
         if (!preg_match('@^' . $fileObjectPath . '@', $filePath)) {
             throw new AccessDeniedHttpException('Accessing file out of scope');


### PR DESCRIPTION
Currently stream wrappers are not supported when using a `Pimcore\Log\FileObject` together with stream wrappers in constant `PIMCORE_LOG_FILEOBJECT_DIRECTORY`. This PR solves that.