### PR TITLE
Make Note->addData() chainable

### DIFF
--- a/models/Element/Note.php
+++ b/models/Element/Note.php
@@ -94,6 +94,8 @@ class Note extends Model\AbstractModel
      * @param string $name
      * @param string $type
      * @param mixed $data
+     *
+     * @return $this
      */
     public function addData($name, $type, $data)
     {
@@ -101,6 +103,8 @@ class Note extends Model\AbstractModel
             'type' => $type,
             'data' => $data,
         ];
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Since the other methods on `Note` support chaining, it would be nice if `addData()` did too, so you could do stuff like this:

```php
(new Note())
    ->setElement($product)
    ->setType('notice')
    ->setTitle('Text')
    ->addData('originalPath', 'text', $oldPath)
    ->save();
```

Not completely sure if this should be considered a bugfix or an improvement though :) An improvement I think, but let me know if I should rebase it against 6.9.