### PR TITLE
Remove leftover QR-Code parts

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -1551,39 +1551,6 @@ class DocumentController extends ElementControllerBase implements KernelControll
     }
 
     /**
-     * @Route("/qr-code", name="pimcore_admin_document_document_qrcode", methods={"GET"})
-     *
-     * @param Request $request
-     *
-     * @return BinaryFileResponse
-     */
-    public function qrCodeAction(Request $request)
-    {
-        $document = Document::getById($request->query->get('id'));
-        $url = $request->getScheme() . '://' . $request->getHttpHost() . $document->getFullPath();
-
-        $code = new \Endroid\QrCode\QrCode;
-        $code->setWriterByName('png');
-        $code->setText($url);
-        $code->setSize(500);
-
-        $tmpFile = PIMCORE_PRIVATE_VAR . '/qr-code-' . uniqid() . '.png';
-        $code->writeFile($tmpFile);
-
-        $response = new BinaryFileResponse($tmpFile);
-        $response->headers->set('Content-Type', 'image/png');
-
-        if ($request->query->get('download')) {
-            $code->setSize(4000);
-            $response->setContentDisposition('attachment', 'qrcode-preview.png');
-        }
-
-        $response->deleteFileAfterSend(true);
-
-        return $response;
-    }
-
-    /**
      * @param ControllerEvent $event
      */
     public function onKernelControllerEvent(ControllerEvent $event)

--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -1551,6 +1551,39 @@ class DocumentController extends ElementControllerBase implements KernelControll
     }
 
     /**
+     * @Route("/qr-code", name="pimcore_admin_document_document_qrcode", methods={"GET"})
+     *
+     * @param Request $request
+     *
+     * @return BinaryFileResponse
+     */
+    public function qrCodeAction(Request $request)
+    {
+        $document = Document::getById($request->query->get('id'));
+        $url = $request->getScheme() . '://' . $request->getHttpHost() . $document->getFullPath();
+
+        $code = new \Endroid\QrCode\QrCode;
+        $code->setWriterByName('png');
+        $code->setText($url);
+        $code->setSize(500);
+
+        $tmpFile = PIMCORE_PRIVATE_VAR . '/qr-code-' . uniqid() . '.png';
+        $code->writeFile($tmpFile);
+
+        $response = new BinaryFileResponse($tmpFile);
+        $response->headers->set('Content-Type', 'image/png');
+
+        if ($request->query->get('download')) {
+            $code->setSize(4000);
+            $response->setContentDisposition('attachment', 'qrcode-preview.png');
+        }
+
+        $response->deleteFileAfterSend(true);
+
+        return $response;
+    }
+
+    /**
      * @param ControllerEvent $event
      */
     public function onKernelControllerEvent(ControllerEvent $event)

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/pages/preview.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/pages/preview.js
@@ -57,10 +57,10 @@ pimcore.document.pages.preview = Class.create({
                     text: t("qr_codes"),
                     iconCls: "pimcore_icon_qrcode",
                     handler: function () {
-                        var codeUrl = Routing.generate('pimcore_admin_document_document_qrcode', {id: this.page.id});
+                        var codeUrl = Routing.generate('pimcore_admin_document_page_qrcode', {id: this.page.id});
 
                         var download = function () {
-                            var codeUrl = Routing.generate('pimcore_admin_document_document_qrcode', {id: this.page.id, download: true});
+                            var codeUrl = Routing.generate('pimcore_admin_document_page_qrcode', {id: this.page.id, download: true});
                             pimcore.helpers.download(codeUrl);
                         };
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/pages/preview.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/pages/preview.js
@@ -57,10 +57,10 @@ pimcore.document.pages.preview = Class.create({
                     text: t("qr_codes"),
                     iconCls: "pimcore_icon_qrcode",
                     handler: function () {
-                        var codeUrl = Routing.generate('pimcore_admin_reports_qrcode_code', {documentId: this.page.id});
+                        var codeUrl = Routing.generate('pimcore_admin_document_document_qrcode', {id: this.page.id});
 
                         var download = function () {
-                            var codeUrl = Routing.generate('pimcore_admin_reports_qrcode_code', {documentId: this.page.id, download: true});
+                            var codeUrl = Routing.generate('pimcore_admin_document_document_qrcode', {id: this.page.id, download: true});
                             pimcore.helpers.download(codeUrl);
                         };
 

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/05_Database_Model.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/05_Database_Model.md
@@ -52,7 +52,6 @@ These tables are created during Pimcore install and are always the same.
 | objects | List of all objects with metadata like id, class name, path, parent, ...|
 | object_url_slugs | [URL Slug](../05_Objects/01_Object_Classes/01_Data_Types/65_Others.md) data|
 | properties | Data from the `properties` tab |
-| qr_codes | Edit QR Code configurations | 
 | quantityvalue_units | Available quantities for quantity value object data type |
 | recyclebin | Stores metadata of deleted elements |
 | redirects | Stores redirects | 

--- a/doc/Development_Documentation/22_Administration_of_Pimcore/07_Users_and_Roles.md
+++ b/doc/Development_Documentation/22_Administration_of_Pimcore/07_Users_and_Roles.md
@@ -42,7 +42,6 @@ The following list outlines what the different system permissions (available for
 * **Notes & Events**: Notes & Events are visible 
 * **Objects**: objects tree is visible 
 * **Predefined Properties**: User can create and modify predefined properties
-* **QR-Codes**: User can create and modify QR codes
 * **Recycle Bin**: User has access to recycle bin
 * **Redirects**: User can create and modify redirects
 * **Reports**: User has access to reports module


### PR DESCRIPTION
QR-Codes were removed in #7262 but there was still some code left.

The Document preview panel has a "QR-Codes" button that's now broken because the route doesn't exist anymore, as its controller has been removed.

Note: there's a translation with the key `qr_codes` left, that doesn't seem to be used anywhere. Not sure if it should be deleted, too (and if so, in which translation files - only English or all?)