### PR TITLE
Consider parameters in fallback translations

### DIFF
--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -357,7 +357,7 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
                     // update fallback value in original catalogue otherwise multiple calls to the same id will not work
                     $this->getCatalogue($locale)->set($normalizedId, $fallbackValue, $domain);
 
-                    return $this->translator->trans($fallbackValue, $parameters);
+                    return strtr($fallbackValue, $parameters);
                 }
             }
         }

--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -357,7 +357,7 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
                     // update fallback value in original catalogue otherwise multiple calls to the same id will not work
                     $this->getCatalogue($locale)->set($normalizedId, $fallbackValue, $domain);
 
-                    return $fallbackValue;
+                    return $this->translator->trans($fallbackValue, $parameters);
                 }
             }
         }


### PR DESCRIPTION
# Bugfix

Steps to reproduce the bug:

1. Setup two languages, one the fallback of the other (i.e. de and de_at, de is fallback for de_AT)
2. Now create a translation for de_AT with a placeholder i.e. cart.incl-vat --> "Taxrate is %percent%%", where %percent% is the placeholder which should be replaced.
3. The output will be "Taxrate is %percent%%" and thus the parameters won't be replaced.
4. On second call the translation will be right, the output is i.e. "Taxrate is 20%"

With this PR this behaviour gets fixed and the parameters are already replaced at the very first call.