### PR TITLE
Hobex Payment Provider: if transaction was already processed, query transaction

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Hobex.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Hobex.php
@@ -478,7 +478,7 @@ class Hobex extends AbstractPayment implements PaymentInterface, LoggerAwareInte
     }
 
     /**
-     * @param $checkoutId
+     * @param string $checkoutId
      *
      * @return string|null
      * @throws \Exception
@@ -505,7 +505,7 @@ class Hobex extends AbstractPayment implements PaymentInterface, LoggerAwareInte
     }
 
     /**
-     * @param $status
+     * @param string $status
      *
      * @return bool
      */

--- a/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Hobex.php
+++ b/bundles/EcommerceFrameworkBundle/PaymentManager/Payment/Hobex.php
@@ -32,7 +32,7 @@ use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Intl\Exception\NotImplementedException;
-use Symfony\Component\Lock\Factory as LockFactory;
+use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Templating\EngineInterface;
 


### PR DESCRIPTION
if checkout-resource (v1/checkouts/xxxx/payment) is called twice after
transaction is completed (e.g. if user reloads page before transaction is
completed), hobex will throw an error.
To avoid this, check if transaction was already processed (=> hobex-Brick
exists and status != pending); if this is the case, transaction can
be queried from /v1/query/{transactionid}

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

