### PR TITLE
[Grid] Auto-adjust column width depending on currently shown content

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/folder/search.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/folder/search.js
@@ -289,7 +289,16 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
             viewConfig: {
                 forceFit: false,
                 xtype: 'patchedgridview',
-                enableTextSelection: true
+                enableTextSelection: true,
+                listeners: {
+                    refresh: function (dataview) {
+                        Ext.each(dataview.panel.columns, function (column) {
+                            if (column.autoSizeColumn === true) {
+                                column.autoSize();
+                            }
+                        })
+                    }
+                },
             },
             listeners: {
                 celldblclick: function(grid, td, cellIndex, record, tr, rowIndex, e, eOpts) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
@@ -213,17 +213,40 @@ pimcore.object.helpers.grid = Class.create({
         for (var i = 0; i < fields.length; i++) {
             var field = fields[i];
 
+            var width = this.getColumnWidth(field, null);
             if(field.key == "subtype") {
-                gridColumns.push({text: t("type"), width: this.getColumnWidth(field, 40), sortable: true, dataIndex: 'subtype',
+                var columnConfig = {
+                    text: t("type"),
+                    sortable: true,
+                    dataIndex: 'subtype',
                     hidden: !this.showSubtype,
                     locked: this.getColumnLock(field),
                     renderer: function (value, metaData, record, rowIndex, colIndex, store) {
                         return '<div style="height: 16px;" class="pimcore_icon_asset  pimcore_icon_'
-                        + value + '" name="' + t(record.data.subtype) + '">&nbsp;</div>';
-                    }});
+                            + value + '" name="' + t(record.data.subtype) + '">&nbsp;</div>';
+                    }
+                };
+                if (width === null) {
+                    columnConfig.autoSizeColumn = true;
+                } else {
+                    columnConfig.width = width;
+                }
+                gridColumns.push(columnConfig);
             } else if(field.key == "id") {
-                gridColumns.push({text: 'ID', width: this.getColumnWidth(field, this.getColumnWidth(field, 40)), sortable: true,
-                    dataIndex: 'id', filter: 'numeric', locked: this.getColumnLock(field)});
+                var columnConfig = {
+                    text: 'ID',
+                    sortable: true,
+                    dataIndex: 'id',
+                    filter: 'numeric',
+                    locked: this.getColumnLock(field)
+                };
+
+                if (width === null) {
+                    columnConfig.autoSizeColumn = true;
+                } else {
+                    columnConfig.width = width;
+                }
+                gridColumns.push(columnConfig);
             } else if(field.key == "published") {
                 gridColumns.push(new Ext.grid.column.Check({
                     text: t("published"),
@@ -235,32 +258,94 @@ pimcore.object.helpers.grid = Class.create({
                     locked: this.getColumnLock(field)
                 }));
             } else if(field.key == "fullpath") {
-                gridColumns.push({text: t("path"), width: this.getColumnWidth(field, 200), sortable: true,
-                    dataIndex: 'fullpath', filter: "string", locked: this.getColumnLock(field)});
+                var columnConfig = {
+                    text: t("path"),
+                    sortable: true,
+                    dataIndex: 'fullpath',
+                    filter: "string",
+                    locked: this.getColumnLock(field)
+                };
+                if (width === null) {
+                    columnConfig.autoSizeColumn = true;
+                } else {
+                    columnConfig.width = width;
+                }
+
+                gridColumns.push(columnConfig);
             } else if(field.key == "filename") {
-                gridColumns.push({text: t("filename"), width: this.getColumnWidth(field, 200), sortable: true,
-                    dataIndex: 'filename', hidden: !showKey, locked: this.getColumnLock(field)});
+                var columnConfig = {
+                    text: t("filename"),
+                    sortable: true,
+                    dataIndex: 'filename',
+                    hidden: !showKey,
+                    locked: this.getColumnLock(field)
+                };
+
+                if (width === null) {
+                    columnConfig.autoSizeColumn = true;
+                } else {
+                    columnConfig.width = width;
+                }
+                gridColumns.push(columnConfig);
             } else if(field.key == "key") {
-                gridColumns.push({text: t("key"), width: this.getColumnWidth(field, 200), sortable: true,
-                    dataIndex: 'key', hidden: !showKey, filter: 'string', locked: this.getColumnLock(field)});
+                var columnConfig = {
+                    text: t("key"),
+                    sortable: true,
+                    dataIndex: 'key',
+                    hidden: !showKey,
+                    filter: 'string',
+                    locked: this.getColumnLock(field)
+                };
+
+                if (width === null) {
+                    columnConfig.autoSizeColumn = true;
+                } else {
+                    columnConfig.width = width;
+                }
+
+                gridColumns.push(columnConfig);
             } else if(field.key == "classname") {
-                gridColumns.push({text: t("class"), width: this.getColumnWidth(field, 200), sortable: true,
-                    dataIndex: 'classname', locked: this.getColumnLock(field), renderer: function(v){return t(v);}/*, hidden: true*/});
+                var columnConfig = {
+                    text: t("class"),
+                    sortable: true,
+                    dataIndex: 'classname',
+                    locked: this.getColumnLock(field),
+                    renderer: function (v) {return t(v);}
+                }
+
+                if (width === null) {
+                    columnConfig.autoSizeColumn = true;
+                } else {
+                    columnConfig.width = width;
+                }
+
+                gridColumns.push(columnConfig);
             } else if(field.key == "creationDate") {
-                gridColumns.push({text: t("creationdate") + " (System)", width: this.getColumnWidth(field, 200), sortable: true,
+                gridColumns.push({text: t("creationdate") + " (System)", width: this.getColumnWidth(field, 160), sortable: true,
                     dataIndex: "creationDate", filter: 'date', editable: false, locked: this.getColumnLock(field), renderer: function(d) {
                         return Ext.Date.format(d, "Y-m-d H:i:s");
                     }/*, hidden: !propertyVisibility.creationDate*/});
             } else if(field.key == "modificationDate") {
-                gridColumns.push({text: t("modificationdate") + " (System)", width: this.getColumnWidth(field, 200), sortable: true,
+                gridColumns.push({text: t("modificationdate") + " (System)", width: this.getColumnWidth(field, 160), sortable: true,
                     dataIndex: "modificationDate", filter: 'date', editable: false, locked: this.getColumnLock(field), renderer: function(d) {
 
                         return Ext.Date.format(d, "Y-m-d H:i:s");
                     }/*, hidden: !propertyVisibility.modificationDate*/});
             } else {
                 if (fields[i].isOperator) {
-                    var operatorColumnConfig = {text: field.attributes.label ? field.attributes.label : field.attributes.key, width: field.width ? field.width : 200, locked: this.getColumnLock(field), sortable: false,
-                        dataIndex: fields[i].key, editable: false};
+                    var operatorColumnConfig = {
+                        text: field.attributes.label ? field.attributes.label : field.attributes.key,
+                        locked: this.getColumnLock(field),
+                        sortable: false,
+                        dataIndex: fields[i].key,
+                        editable: false
+                    };
+
+                    if (width === null) {
+                        operatorColumnConfig.autoSizeColumn = true;
+                    } else {
+                        operatorColumnConfig.width = width;
+                    }
 
                     if (field.attributes.renderer && pimcore.object.tags[field.attributes.renderer]) {
                         var tag = new pimcore.object.tags[field.attributes.renderer]({}, {});
@@ -288,7 +373,12 @@ pimcore.object.helpers.grid = Class.create({
                     var tag = pimcore.object.tags[fieldType];
                     if (tag) {
                         var fc = tag.prototype.getGridColumnConfig(field);
-                        fc.width = this.getColumnWidth(field, 100);
+
+                        if(width === null) {
+                            fc.autoSizeColumn = true;
+                        } else {
+                            fc.width = width;
+                        }
                         
                         if (field.layout.decimalPrecision) {
                             fc.decimalPrecision = field.layout.decimalPrecision;


### PR DESCRIPTION
Currently in the grid view the columns have fixed width which can get overridden by setting the width in the field definitions. But this fixed width is not optimal in most situations and leads to a lot of the columns being cropped - in this simple case ID and path are truncated:
<img width="716" alt="Bildschirmfoto 2020-11-26 um 08 01 29" src="https://user-images.githubusercontent.com/8749138/100318495-6df50d00-2fbe-11eb-8495-145a6de9de14.png">

This PR changes this behaviour by automatically adjusting the column width depending on the contents which are currently shown. Of course the widths can still be overridden in the field definitions. Without any other changes the grid from above screenshot now looks like this:
<img width="1157" alt="Bildschirmfoto 2020-11-26 um 08 05 41" src="https://user-images.githubusercontent.com/8749138/100318614-9bda5180-2fbe-11eb-96cd-f4ab41f26cf0.png">

Of course this might lead to very big columns for text fields but imho it is still a better default setting than to truncate nearly all columns and nevertheless waste much space to the right.