### PR TITLE
[Data objects Grid] Fix search

### DIFF
--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -593,7 +593,7 @@ class GridHelperService
         if (!empty($requestParams['query'])) {
             $query = $this->filterQueryParam($requestParams['query']);
             if (!empty($query)) {
-                $conditionFilters[] = 'oo_id IN (SELECT id FROM search_backend_data WHERE MATCH (`data`,`properties`) AGAINST (' . $list->quote($query) . ' IN BOOLEAN MODE))';
+                $conditionFilters[] = 'oo_id IN (SELECT id FROM search_backend_data WHERE maintype = "object" AND MATCH (`data`,`properties`) AGAINST (' . $list->quote($query) . ' IN BOOLEAN MODE))';
             }
         }
 


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [X] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [X] Features need to be proper documented in `doc/` -> target branch `master`
- [X] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [X] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [X] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
The problem appears when apply search in data objects grid, where objects that don't match the search could be found
if there are documents or assets with the same id which match the search

## Steps to reproduce  
The following steps were performed on the current demo.
1. Open Product Data/Cars folder & search "fiat"
![Screenshot from 2020-11-26 22-27-12](https://user-images.githubusercontent.com/16133208/100392531-278fc480-3037-11eb-87ec-3f66d1677fb4.png)

2. The selected items don't match the search but there are documents/assets with the same id which match the search
![Screenshot from 2020-11-26 22-33-46](https://user-images.githubusercontent.com/16133208/100392755-df24d680-3037-11eb-9dba-ac094fd23b85.png)
![Screenshot from 2020-11-26 22-33-24](https://user-images.githubusercontent.com/16133208/100392758-e1873080-3037-11eb-8e18-4e641bf2c4bc.png)


