### PR TITLE
[Sent emails] Prevent multiple open panels

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/email/log.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/email/log.js
@@ -52,7 +52,7 @@ pimcore.settings.email.log = Class.create({
     activate: function () {
         // this is only for standalone mode (without document set)
         var tabPanel = Ext.getCmp('pimcore_panel_tabs');
-        tabPanel.activate(this.getLayout());
+        tabPanel.setActiveItem("sent_emails");
     },
 
     load: function () {


### PR DESCRIPTION
Currently you can open the "Sent emails" panel multiple times when clicking Tools > Email > Sent Emails in the main menu. This PR fixes this.