### PR TITLE
Tags filter not works if tags are uppercase

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/TagsController.php
+++ b/bundles/AdminBundle/Controller/Admin/TagsController.php
@@ -133,7 +133,7 @@ class TagsController extends AdminController
         if (!empty($request->get('filter'))) {
             $filterIds = [0];
             $filterTagList = new Tag\Listing();
-            $filterTagList->setCondition('`name` LIKE '. $filterTagList->quote('%'. $request->get('filter') .'%'));
+            $filterTagList->setCondition('LOWER(`name`) LIKE '. $filterTagList->quote('%'. $request->get('filter') .'%'));
             foreach ($filterTagList->load() as $filterTag) {
                 if ($parentId = $filterTag->getParentId() == 0) {
                     $filterIds[] = $filterTag->getId();


### PR DESCRIPTION
I have uppercase tags, but when i search on tags filter section, i don't find nothing.