### PR TITLE
[Navigation] Improve active trail fallback code

### DIFF
--- a/lib/Navigation/Builder.php
+++ b/lib/Navigation/Builder.php
@@ -150,7 +150,7 @@ class Builder
         // pages have priority, if we don't find any active page, we use all we found
         $tmpPages = [];
         foreach ($activePages as $page) {
-            if ($page instanceof DocumentPage && $page->getDocumentType() != 'link') {
+            if ($page instanceof DocumentPage && $page->getDocumentType() !== 'link') {
                 $tmpPages[] = $page;
             }
         }
@@ -163,18 +163,17 @@ class Builder
             foreach ($activePages as $activePage) {
                 $this->addActiveCssClasses($activePage, true);
             }
-        } else {
-            // we don't have an active document, so we try to build the trail on our own
+        } elseif ($activeDocument instanceof Document) {
+            // we didn't find the active document, so we try to build the trail on our own
             $allPages = $navigation->findAllBy('uri', '/.*/', true);
 
             foreach ($allPages as $page) {
                 $activeTrail = false;
 
-                if ($activeDocument instanceof Document && $page instanceof Url && $page->getUri()) {
+                if ($page instanceof Url && $page->getUri()) {
                     if (strpos($activeDocument->getRealFullPath(), $page->getUri() . '/') === 0) {
                         $activeTrail = true;
-                    }
-                    if (
+                    } elseif (
                         $page instanceof DocumentPage &&
                         $page->getDocumentType() === 'link' &&
                         strpos($activeDocument->getFullPath(), $page->getUri() . '/') === 0


### PR DESCRIPTION
This code was improved by #7487 a bit, but we can do a little better.

Actually, if `$activeDocument` isn't an instance of `Document`, we don't even need to try building the trail, because `$activeTrail` would always be false anyways.