### PR TITLE
Fixup: tags filter not works if tags are uppercase

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/TagsController.php
+++ b/bundles/AdminBundle/Controller/Admin/TagsController.php
@@ -109,13 +109,13 @@ class TagsController extends AdminController
     public function treeGetChildrenByIdAction(Request $request)
     {
         $showSelection = $request->get('showSelection') == 'true';
-        $assginmentCId = intval($request->get('assignmentCId'));
-        $assginmentCType = strip_tags($request->get('assignmentCType'));
+        $assignmentCId = intval($request->get('assignmentCId'));
+        $assignmentCType = strip_tags($request->get('assignmentCType'));
 
         $recursiveChildren = false;
         $assignedTagIds = [];
-        if ($assginmentCId && $assginmentCType) {
-            $assignedTags = Tag::getTagsForElement($assginmentCType, $assginmentCId);
+        if ($assignmentCId && $assignmentCType) {
+            $assignedTags = Tag::getTagsForElement($assignmentCType, $assignmentCId);
 
             foreach ($assignedTags as $assignedTag) {
                 $assignedTagIds[$assignedTag->getId()] = $assignedTag;

--- a/bundles/AdminBundle/Controller/Admin/TagsController.php
+++ b/bundles/AdminBundle/Controller/Admin/TagsController.php
@@ -133,7 +133,7 @@ class TagsController extends AdminController
         if (!empty($request->get('filter'))) {
             $filterIds = [0];
             $filterTagList = new Tag\Listing();
-            $filterTagList->setCondition('LOWER(`name`) LIKE '. $filterTagList->quote('%'. strtolower($request->get('filter')) .'%'));
+            $filterTagList->setCondition('LOWER(`name`) LIKE ?', ['%' . $filterTagList->escapeLike(mb_strtolower($request->get('filter'))) . '%']);
             foreach ($filterTagList->load() as $filterTag) {
                 if ($parentId = $filterTag->getParentId() == 0) {
                     $filterIds[] = $filterTag->getId();

--- a/bundles/AdminBundle/Controller/Admin/TagsController.php
+++ b/bundles/AdminBundle/Controller/Admin/TagsController.php
@@ -135,7 +135,7 @@ class TagsController extends AdminController
             $filterTagList = new Tag\Listing();
             $filterTagList->setCondition('LOWER(`name`) LIKE ?', ['%' . $filterTagList->escapeLike(mb_strtolower($request->get('filter'))) . '%']);
             foreach ($filterTagList->load() as $filterTag) {
-                if ($parentId = $filterTag->getParentId() == 0) {
+                if ($filterTag->getParentId() == 0) {
                     $filterIds[] = $filterTag->getId();
                 } else {
                     $ids = explode('/', $filterTag->getIdPath());

--- a/bundles/AdminBundle/Controller/Admin/TagsController.php
+++ b/bundles/AdminBundle/Controller/Admin/TagsController.php
@@ -133,7 +133,7 @@ class TagsController extends AdminController
         if (!empty($request->get('filter'))) {
             $filterIds = [0];
             $filterTagList = new Tag\Listing();
-            $filterTagList->setCondition('LOWER(`name`) LIKE '. $filterTagList->quote('%'. $request->get('filter') .'%'));
+            $filterTagList->setCondition('LOWER(`name`) LIKE '. $filterTagList->quote('%'. strtolower($request->get('filter')) .'%'));
             foreach ($filterTagList->load() as $filterTag) {
                 if ($parentId = $filterTag->getParentId() == 0) {
                     $filterIds[] = $filterTag->getId();


### PR DESCRIPTION
This is a fixup for #7610 

Like I said in that branch, I would not rely on the input and call `strtolower` nonetheless.