### PR TITLE
Fix: Change the published state, regardless of the previous settings.

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -148,13 +148,6 @@ class PageController extends DocumentControllerBase
 
         $page->setUserModification($this->getAdminUser()->getId());
 
-        if ($request->get('task') == 'unpublish') {
-            $page->setPublished(false);
-        }
-        if ($request->get('task') == 'publish') {
-            $page->setPublished(true);
-        }
-
         if ($request->get('missingRequiredEditable') !== null) {
             $page->setMissingRequiredEditable(($request->get('missingRequiredEditable') == 'true') ? true : false);
         }
@@ -181,6 +174,13 @@ class PageController extends DocumentControllerBase
         // only save when publish or unpublish
         if (($request->get('task') == 'publish' && $page->isAllowed('publish')) || ($request->get('task') == 'unpublish' && $page->isAllowed('unpublish'))) {
             $this->setValuesToDocument($request, $page);
+
+            if ($request->get('task') == 'unpublish') {
+                $page->setPublished(false);
+            }
+            if ($request->get('task') == 'publish') {
+                $page->setPublished(true);
+            }
 
             $page->save();
             $this->saveToSession($page);

--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -177,8 +177,7 @@ class PageController extends DocumentControllerBase
 
             if ($request->get('task') == 'unpublish') {
                 $page->setPublished(false);
-            }
-            if ($request->get('task') == 'publish') {
+            } elseif ($request->get('task') == 'publish') {
                 $page->setPublished(true);
             }
 


### PR DESCRIPTION
## Changes in this pull request  
If you open a document, switch to the "settings" tab and then try to publish or unpublish the document, the new status is not applied.

### Reason:
If you switch to the tab "settings", all settings - including the current published/unpublished status - are transferred to the controller, which overwrites the new desired status.

### Solution:
Set the new status after all other settings are set.