### PR TITLE
Areabrick names are not translated

### DIFF
--- a/lib/Document/Editable/EditableHandler.php
+++ b/lib/Document/Editable/EditableHandler.php
@@ -181,7 +181,7 @@ class EditableHandler implements EditableHandlerInterface, LoggerAwareInterface
                 }
             }
 
-            if ($view->getEditmode) {
+            if ($view->editmode) {
                 $name = $this->translator->trans($name);
                 $desc = $this->translator->trans($desc);
             }


### PR DESCRIPTION
After upgrade from 6.7.* to 6.8.* all areabrick names are not translated anymore.

We use translation keys as names. so this is a blocker :(