### PR TITLE
Replace html2text/html2text with soundasleep/html2text and removed deprecated methods from Mail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,7 @@
     "laminas/laminas-servicemanager": "^3.2",
     "scheb/two-factor-bundle": "^3.26",
     "phpoffice/phpspreadsheet": "^1.9",
-    "html2text/html2text": "^4.2.1",
+    "soundasleep/html2text": "^1.1.0",
     "webmozarts/console-parallelization": "^1.1.0",
     "onnov/detect-encoding": "^1.2"
   },

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/25_Email_Framework/01_Pimcore_Mail.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/25_Email_Framework/01_Pimcore_Mail.md
@@ -29,9 +29,6 @@ to the html with a `<style>` tag because the image paths are also normalised.
 | getSubjectRendered()              | Renders the content as a Twig template with the provided params and returns the resulting Subject                                                                                                                                |
 | getBodyHtmlRendered()             | Renders the content as a Twig template with the content and returns the resulting HTML                                                                                                                                   |
 | getBodyTextRendered()             | Renders the content as a Twig template with the content and returns the resulting text if a text was set with `$mail->setBodyText()`. If no text was set, a text version on the html email will be automatically created |
-| enableHtml2textBinary()           | `html2text` from Martin Bayer (http://www.mbayer.de/html2text/index.shtml) - throws an Exception if html2text is not installed!     (deprecated since 6.6.0 and will be removed in 7.0)                                                                       |
-| setHtml2TextOptions($options)     | set options for html2text (only for binary version)                                                                                                                                                        |
-
 
 ## Usage Example
 

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/25_Email_Framework/01_Pimcore_Mail.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/25_Email_Framework/01_Pimcore_Mail.md
@@ -29,6 +29,8 @@ to the html with a `<style>` tag because the image paths are also normalised.
 | getSubjectRendered()              | Renders the content as a Twig template with the provided params and returns the resulting Subject                                                                                                                                |
 | getBodyHtmlRendered()             | Renders the content as a Twig template with the content and returns the resulting HTML                                                                                                                                   |
 | getBodyTextRendered()             | Renders the content as a Twig template with the content and returns the resulting text if a text was set with `$mail->setBodyText()`. If no text was set, a text version on the html email will be automatically created |
+| setHtml2TextOptions($options)     | set options for html2text (only for binary version)                                                                                                                                                        |
+
 
 ## Usage Example
 

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -833,7 +833,7 @@ class Mail extends \Swift_Message
 
         if (!empty($htmlContent)) {
             try {
-                $content = Html2Text::convert($content, $this->getHtml2TextOptions());
+                $content = Html2Text::convert($htmlContent, $this->getHtml2TextOptions());
             } catch (\Exception $e) {
 
             }

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -21,6 +21,7 @@ use Pimcore\Event\MailEvents;
 use Pimcore\Event\Model\MailEvent;
 use Pimcore\Helper\Mail as MailHelper;
 use Soundasleep\Html2Text;
+use Soundasleep\Html2TextException;
 
 class Mail extends \Swift_Message
 {
@@ -834,8 +835,8 @@ class Mail extends \Swift_Message
         if (!empty($htmlContent)) {
             try {
                 $content = Html2Text::convert($htmlContent, $this->getHtml2TextOptions());
-            } catch (\Exception $e) {
-
+            } catch (Html2TextException $e) {
+                Logger::warning('Converting HTML to plain text failed, no plain text part will be attached to the sent email');
             }
         }
 

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -59,6 +59,15 @@ class Mail extends \Swift_Message
     protected $params = [];
 
     /**
+     * Options passed to html2text
+     *
+     * @var array
+     */
+    protected $html2textOptions = [
+        'ignore_errors' => true
+    ];
+
+    /**
      * Prevent adding debug information
      *
      * @var bool
@@ -259,6 +268,30 @@ class Mail extends \Swift_Message
     public function getEnableLayoutOnRendering()
     {
         return $this->enableLayoutOnRendering;
+    }
+
+    /**
+     * Sets options that are passed to html2text
+     *
+     * @param array $options
+     *
+     * @return \Pimcore\Mail
+     */
+    public function setHtml2TextOptions(array $options = [])
+    {
+        $this->html2textOptions = $options;
+
+        return $this;
+    }
+
+    /**
+     * Returns options for html2text
+     *
+     * @return array
+     */
+    public function getHtml2TextOptions()
+    {
+        return $this->html2textOptions;
     }
 
     /**
@@ -800,9 +833,7 @@ class Mail extends \Swift_Message
 
         if (!empty($htmlContent)) {
             try {
-                $content = Html2Text::convert($content, [
-                    'ignore_errors' => true
-                ]);
+                $content = Html2Text::convert($content, $this->getHtml2TextOptions());
             } catch (\Exception $e) {
 
             }

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -16,11 +16,11 @@ namespace Pimcore;
 
 use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\RFCValidation;
-use Html2Text\Html2Text;
 use Pimcore\Bundle\CoreBundle\EventListener\Frontend\ElementListener;
 use Pimcore\Event\MailEvents;
 use Pimcore\Event\Model\MailEvent;
 use Pimcore\Helper\Mail as MailHelper;
+use Soundasleep\Html2Text;
 
 class Mail extends \Swift_Message
 {
@@ -57,13 +57,6 @@ class Mail extends \Swift_Message
      * @var array
      */
     protected $params = [];
-
-    /**
-     * Options passed to html2text
-     *
-     * @var array
-     */
-    protected $html2textOptions = [];
 
     /**
      * Prevent adding debug information
@@ -266,50 +259,6 @@ class Mail extends \Swift_Message
     public function getEnableLayoutOnRendering()
     {
         return $this->enableLayoutOnRendering;
-    }
-
-    /**
-     * @deprecated Pimcore\Mail::determineHtml2TextIsInstalled is deprecated since 6.6.0 and will be removed with 7.0
-     *
-     * Determines if mbayer html2text is installed (more information at http://www.mbayer.de/html2text/)
-     * and uses it to automatically create a text version of the html email
-     *
-     * @static
-     *
-     * @return bool
-     */
-    public static function determineHtml2TextIsInstalled()
-    {
-        return true;
-    }
-
-    /**
-     * Sets options that are passed to html2text
-     *
-     * @param array $options
-     *
-     * @return \Pimcore\Mail
-     */
-    public function setHtml2TextOptions($options = [])
-    {
-        if (is_array($options)) {
-            $this->html2textOptions = $options;
-        } else {
-            Logger::warn('Pimcore\Mail::setHtml2TextOptions only accepts array since version 6.6.0.' .
-                ' Please see available options: https://github.com/mtibben/html2text/blob/master/src/Html2Text.php#L212');
-        }
-
-        return $this;
-    }
-
-    /**
-     * Returns options for html2text
-     *
-     * @return array
-     */
-    public function getHtml2TextOptions()
-    {
-        return $this->html2textOptions;
     }
 
     /**
@@ -841,41 +790,6 @@ class Mail extends \Swift_Message
     }
 
     /**
-     * @deprecated Pimcore\Mail::getHtml2TextBinaryEnabled is deprecated since 6.6.0 and will be removed with 7.0
-     *
-     * @return bool
-     */
-    public function getHtml2TextBinaryEnabled()
-    {
-        return false;
-    }
-
-    /**
-     * @deprecated Pimcore\Mail::enableHtml2textBinary is deprecated since 6.6.0 and will be removed with 7.0
-     *
-     * @return $this
-     *
-     * @throws \Exception
-     */
-    public function enableHtml2textBinary()
-    {
-        return $this;
-    }
-
-    /**
-     * @deprecated Pimcore\Mail::getHtml2textInstalled is deprecated since 6.6.0 and will be removed with 7.0
-     *
-     * @static
-     * returns  html2text binary installation status
-     *
-     * @return bool
-     */
-    public static function getHtml2textInstalled()
-    {
-        return true;
-    }
-
-    /**
      * @param string $htmlContent
      *
      * @return string
@@ -885,8 +799,13 @@ class Mail extends \Swift_Message
         $content = '';
 
         if (!empty($htmlContent)) {
-            $html = new Html2Text($htmlContent, $this->getHtml2TextOptions());
-            $content = $html->getText();
+            try {
+                $content = Html2Text::convert($content, [
+                    'ignore_errors' => true
+                ]);
+            } catch (\Exception $e) {
+
+            }
         }
 
         return $content;


### PR DESCRIPTION
fixes #7602
