### PR TITLE
Simplify regex for static files in nginx config

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
@@ -109,7 +109,7 @@ server {
 
     # Assets
     # Still use a whitelist approach to prevent each and every missing asset to go through the PHP Engine.
-    location ~* ^(?!/admin/asset/webdav/)(?!/admin)(.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|ogg|ogv|webm|pdf|docx?|xlsx?|pptx?)$ {
+    location ~* ^(?!/admin)(.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|ogg|ogv|webm|pdf|docx?|xlsx?|pptx?)$ {
         try_files /var/assets$uri $uri =404;
         expires 2w;
         access_log off;
@@ -384,7 +384,7 @@ server {
 
     # Assets
     # Still use a whitelist approach to prevent each and every missing asset to go through the PHP Engine.
-    location ~* ^(?!/admin/asset/webdav/)(?!/admin)(.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|ogg|ogv|webm|pdf|docx?|xlsx?|pptx?)$ {
+    location ~* ^(?!/admin)(.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|ogg|ogv|webm|pdf|docx?|xlsx?|pptx?)$ {
         try_files /var/assets$uri $uri =404;
         expires 2w;
         access_log off;


### PR DESCRIPTION
This is a followup to #4372

In the regex for static file serving in the nginx config the `(?!/admin/asset/webdav/)(?!/admin)` part is redundant, because when the path may not start with `/admin`, it may not start with `/admin/asset/webdav/` either, no need to specify this explicitly again.