### PR TITLE
[Models] Implement JsonSerializable interface

### DIFF
--- a/lib/Model/AbstractModel.php
+++ b/lib/Model/AbstractModel.php
@@ -14,6 +14,7 @@
 
 namespace Pimcore\Model;
 
+use JsonSerializable;
 use Pimcore\Logger;
 use Pimcore\Model\DataObject\Traits\ObjectVarTrait;
 
@@ -25,7 +26,7 @@ use Pimcore\Model\DataObject\Traits\ObjectVarTrait;
  * @method array getValidTableColumns(string $table, bool $cache)
  * @method void resetValidTableColumnsCache(string $table)
  */
-abstract class AbstractModel implements ModelInterface
+abstract class AbstractModel implements ModelInterface, JsonSerializable
 {
     use ObjectVarTrait;
     /**
@@ -274,5 +275,13 @@ abstract class AbstractModel implements ModelInterface
     protected static function getModelFactory()
     {
         return \Pimcore::getContainer()->get('pimcore.model.factory');
+    }
+
+    public function jsonSerialize()
+    {
+        if(method_exists($this, 'getObjectVars')) {
+            return $this->getObjectVars();
+        }
+        return get_object_vars($this);
     }
 }


### PR DESCRIPTION
For exports it would be nice to be able to serialize Pimcore elements to JSON:
```php
$product = Product::getById(123);
echo json_encode($product);
```

For this to work this PR implements PHP's JsonSerialize interface.

Current problem and reason why this is only a draft:
* currently not always works because of `Recursion detected` -> this could be solved with things like https://stackoverflow.com/questions/44323296/recursion-detected-in-json-encode - but this seems ugly and also slow (because of serializing + unserializing the object to remove recursion). Perhaps someone has another idea?

Is this actually interesting for anyone so more research would be worth it?