### PR TITLE
Add startup logic to installer

### DIFF
--- a/bin/pimcore-install
+++ b/bin/pimcore-install
@@ -47,6 +47,14 @@ Bootstrap::defineConstants();
 
 Debug::enable(PIMCORE_PHP_ERROR_REPORTING);
 
+// Load a startup file if it exists - this is a good place to preconfigure the system
+// before the kernel is loaded - e.g. to set trusted proxies on the request object
+$startupFile = PIMCORE_PROJECT_ROOT . '/app/startup.php';
+if (file_exists($startupFile)) {
+    include_once $startupFile;
+}
+
+
 $kernel = new InstallerKernel(PIMCORE_PROJECT_ROOT, Config::getEnvironment(), true);
 Pimcore::setKernel($kernel);
 


### PR DESCRIPTION
This PR enables adding logic to the startup process also on fresh installation, which it should do according to the  documentation:

[Getting Started/Configuration](https://pimcore.com/docs/pimcore/current/Development_Documentation/Getting_Started/Configuration.html): 
> If you need to execute code to influence Pimcore's startup process, you can do so by adding a file in `/app/startup.php` which will be automatically included as part of the bootstrap process.  Specifically, it will be loaded after all other bootstrapping (loading the autoloader, parsing constants, ...) is done, but before the kernel is loaded and booted. 

I encountered this issue when I was trying to implement [the documented Amazon S3 setup](https://pimcore.com/docs/pimcore/current/Development_Documentation/Installation_and_Upgrade/System_Setup_and_Hosting/Amazon_AWS_Setup/Amazon_AWS_S3_Setup.html), which relies on `/app/startup.php`, but encountered the following error on a fresh install:
```
 [ERROR] The following errors were encountered during installation              

 * Warning: file_exists(): Unable to find the wrapper "s3" - did you forget to enable it when you configured PHP?
```

## Changes in this pull request  
Added the startup file initialization to the installer. The implementation is mirrored from [lib/Bootstrap.php](https://github.com/pimcore/pimcore/blob/master/lib/Bootstrap.php)

## Additional info  
I didn't create an issue as a PR was preferred, hopefully that's okay.  Let me know if there's anything I can help in regards to the PR, or if there's an oversight on my part.
