### PR TITLE
[DataObject] Fix Cannot save object with RGBA color field inside classification-store

### DIFF
--- a/models/DataObject/ClassDefinition/Data/RgbaColor.php
+++ b/models/DataObject/ClassDefinition/Data/RgbaColor.php
@@ -122,16 +122,18 @@ class RgbaColor extends Data implements ResourcePersistenceAwareInterface, Query
      */
     public function getDataFromResource($data, $object = null, $params = [])
     {
-        if ($data && $data[$this->getName() . '__rgb'] && $data[$this->getName() . '__a']) {
+        if (is_array($data) && isset($data[$this->getName() . '__rgb']) && isset($data[$this->getName() . '__a'])) {
             list($r, $g, $b) = sscanf($data[$this->getName() . '__rgb'], '%02x%02x%02x');
             $a = hexdec($data[$this->getName() . '__a']);
-            $color = new Model\DataObject\Data\RgbaColor($r, $g, $b, $a);
+            $data = new Model\DataObject\Data\RgbaColor($r, $g, $b, $a);
+        }
 
+        if ($data instanceof Model\DataObject\Data\RgbaColor) {
             if (isset($params['owner'])) {
-                $color->setOwner($params['owner'], $params['fieldname'], $params['language'] ?? null);
+                $data->setOwner($params['owner'], $params['fieldname'], $params['language'] ?? null);
             }
 
-            return $color;
+            return $data;
         }
 
         return null;
@@ -328,6 +330,8 @@ class RgbaColor extends Data implements ResourcePersistenceAwareInterface, Query
                 'value2' => $a,
             ];
         }
+
+        return $value;
     }
 
     /** See marshal

--- a/models/DataObject/Classificationstore/Dao.php
+++ b/models/DataObject/Classificationstore/Dao.php
@@ -101,7 +101,7 @@ class Dao extends Model\Dao\AbstractDao
                     }
                     $value = $fd->marshal($value, $object);
 
-                    $data['value'] = $value['value'];
+                    $data['value'] = isset($value['value']) ? $value['value'] : '';
                     $data['value2'] = isset($value['value2']) ? $value['value2'] : '';
 
                     $this->db->insertOrUpdate($dataTable, $data);


### PR DESCRIPTION
## Changes in this pull request  
Regression of #6102
`RgbaColor::Unmarshal()` now returns object instead of array

## Additional info  

