### PR TITLE
Conflict only with PHPStan 0.12.55

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
   },
   "conflict": {
     "monolog/monolog": ">=2",
-    "phpstan/phpstan": "^0.12.55",
+    "phpstan/phpstan": "0.12.55",
     "symfony/symfony": "3.4.43 || 4.4.11",
     "symfony/monolog-bundle": "3.6.0"
   },


### PR DESCRIPTION
This is a followup of #7541

Apparently the bug in PHPStan has been fixed in `0.12.56`, so only the broken version `0.12.55` should be listed in composers `conflict` section.