### PR TITLE
Fix Ghostscript::getVersion()

### DIFF
--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -185,7 +185,7 @@ class Ghostscript extends Adapter
     protected function getVersion()
     {
         if (is_null($this->version)) {
-            $this->version = Console::exec(self::getGhostscriptCli() . ' --version');
+            $this->version = trim(Console::exec(self::getGhostscriptCli() . ' --version'));
         }
 
         return $this->version;


### PR DESCRIPTION
Removes possible line breaks around Ghostscript's console output of `--version`.

Fixes #7683