### PR TITLE
[Assets] Fix "allowed memory size exhausted" error

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -2041,7 +2041,11 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                     if ($a->isAllowed('view')) {
                         if (!$a instanceof Asset\Folder) {
                             // add the file with the relative path to the parent directory
-                            $zip->addFile($a->getFileSystemPath(), preg_replace('@^' . preg_quote($asset->getRealPath(), '@') . '@i', '', $a->getRealFullPath()));
+                            if(stream_is_local($a->getFileSystemPath())) {
+                                $zip->addFile($a->getFileSystemPath(), preg_replace('@^' . preg_quote($asset->getRealPath(), '@') . '@i', '', $a->getRealFullPath()));
+                            } else {
+                                $zip->addFromString(preg_replace('@^' . preg_quote($asset->getRealPath(), '@') . '@i', '', $a->getRealFullPath()), file_get_contents($a->getFileSystemPath()));
+                            }
                         }
                     }
                 }

--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -2041,7 +2041,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                     if ($a->isAllowed('view')) {
                         if (!$a instanceof Asset\Folder) {
                             // add the file with the relative path to the parent directory
-                            $zip->addFromString(preg_replace('@^' . preg_quote($asset->getRealPath(), '@') . '@i', '', $a->getRealFullPath()), file_get_contents($a->getFileSystemPath()));
+                            $zip->addFile($a->getFileSystemPath(), preg_replace('@^' . preg_quote($asset->getRealPath(), '@') . '@i', '', $a->getRealFullPath()));
                         }
                     }
                 }


### PR DESCRIPTION
Fix an error, which occurs when using "Download selected items as ZIP" function at a folder view in assets.
It occurs when selecting large files. In our case there where 3 Videos ~200M. PHP Memory Limit was at 256M or 512M.
The function "file_get_contents" reads the whole file into memory before inserting it into the ZIP archive. With "addFile" of the class "ZipArchive" this limitation is bypassed.