### PR TITLE
Fix race condition in workflow transition saves

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/WorkflowController.php
+++ b/bundles/AdminBundle/Controller/Admin/WorkflowController.php
@@ -110,7 +110,7 @@ class WorkflowController extends AdminController implements KernelControllerEven
 
         if ($workflow->can($this->element, $request->get('transition'))) {
             try {
-                $workflowManager->applyWithAdditionalData($workflow, $this->element, $request->get('transition'), $workflowOptions, true);
+                $workflowManager->applyWithAdditionalData($workflow, $this->element, $request->get('transition'), $workflowOptions);
 
                 $data = [
                     'success' => true,

--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -241,25 +241,13 @@ class Manager
      * @throws ValidationException
      * @throws \Exception
      */
-    public function applyWithAdditionalData(Workflow $workflow, $subject, string $transition, array $additionalData, $saveSubject = false)
+    public function applyWithAdditionalData(Workflow $workflow, $subject, string $transition, array $additionalData)
     {
         $this->notesSubscriber->setAdditionalData($additionalData);
 
         $marking = $workflow->apply($subject, $transition);
 
         $this->notesSubscriber->setAdditionalData([]);
-
-        $transition = $this->getTransitionByName($workflow->getName(), $transition);
-        $changePublishedState = $transition instanceof Transition ? $transition->getChangePublishedState() : null;
-
-        if ($saveSubject && $subject instanceof ElementInterface) {
-            if (method_exists($subject, 'getPublished')
-                && (!$subject->getPublished() || $changePublishedState === ChangePublishedStateSubscriber::SAVE_VERSION)) {
-                $subject->saveVersion();
-            } else {
-                $subject->save();
-            }
-        }
 
         return $marking;
     }

--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -234,7 +234,6 @@ class Manager
      * @param Asset|Concrete|PageSnippet $subject
      * @param string $transition
      * @param array $additionalData
-     * @param bool $saveSubject
      *
      * @return Marking
      *


### PR DESCRIPTION
This fixes a problem where a save is overwritten with an older save when you save an object in a event triggered by a transition. After saving the object, another save is triggered in the WorkflowManager that puts the object in an older state again undoing everything we did in the transistion event itself. The save itself seems not needed since both notes and transitions are being updated correctly even without this save

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

