### PR TITLE
Boolean select preview

### DIFF
--- a/models/DataObject/ClassDefinition/Data/BooleanSelect.php
+++ b/models/DataObject/ClassDefinition/Data/BooleanSelect.php
@@ -205,7 +205,13 @@ class BooleanSelect extends Data implements ResourcePersistenceAwareInterface, Q
      */
     public function getVersionPreview($data, $object = null, $params = [])
     {
-        return $data;
+        if ($data === true) {
+            return $this->getYesLabel();
+        } elseif ($data === false) {
+            return $this->getNoLabel();
+        }
+
+        return '';
     }
 
     /** True if change is allowed in edit mode.

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -350,7 +350,7 @@ class Concrete extends AbstractObject implements LazyLoadedFieldsInterface
             return $value;
         }
 
-        return false;
+        return null;
     }
 
     /**


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request 

Fixed version preview of Boolean Select fields. Currently, false and empty values are indistinguishable and appear as empty strings.

## Additional info  

The reason for the change in `DataObject\Concrete` is that its method is called in `bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/previewVersion.html.php:207` which makes it impossible to later distinguish a field that's unset/empty from a field with value false.