### PR TITLE
 [DOCS] Preparation for Deep copy in Version::marshalData() corrupts in-memory Document object

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,4 +1,10 @@
 # Upgrade Notes
+
+## 6.9.0
+
+- `PageSnippet::$elements` property visibility changed from `protected` to `private`
+- `PageSnippet::$inheritedElements` property visibility changed from `protected` to `private` 
+
 ## 6.8.0
 - HybridAuth integration is deprecated and will be removed in Pimcore 7.
 - `Pimcore\Browser` is deprecated and will be replaced by `\Browser` in Pimcore 7. [#7084](https://github.com/pimcore/pimcore/pull/7084)


### PR DESCRIPTION
see #7706 which is targeted for 6.9