### PR TITLE
[Settings] Fulltext search in locale dropdown

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/system.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/system.js
@@ -316,6 +316,7 @@ pimcore.settings.system = Class.create({
                                     valueField: 'language',
                                     forceSelection: true,
                                     typeAhead: true,
+                                    anyMatch: true,
                                     width: 450
                                 }, {
                                     xtype: "button",


### PR DESCRIPTION
In System settings > Localization & Internationalization (i18n/l10n) there is a combo box for adding new locales. Currently this only supports searching for prefixes. I just had the pleasure to find `en_gb` in this list - took me nearly a minute ;-)
With this PR the typeahead feature does full text search on all available locales instead of only prefix search.