### PR TITLE
Localized fields in bricks translation import bugfix

### DIFF
--- a/lib/Translation/ImporterService/Importer/DataObjectImporter.php
+++ b/lib/Translation/ImporterService/Importer/DataObjectImporter.php
@@ -50,7 +50,7 @@ class DataObjectImporter extends AbstractElementImporter
 
             if (method_exists($brickContainer, $brickGetter)) {
                 $brick = $brickContainer->$brickGetter();
-                if ($brick instanceof DataObject\Objectbrick) {
+                if ($brick instanceof DataObject\Objectbrick\Data\AbstractData) {
                     $localizedFields = $brick->get('localizedfields');
                     if ($localizedFields instanceof DataObject\Localizedfield) {
                         $localizedFields->setLocalizedValue($field, $attribute->getContent(), $targetLanguage);


### PR DESCRIPTION
The translation import of localized fields in bricks currently does not work anymore. The reason is that a PHPStan level 2 fix added a check for a wrong parent class. 

Generally it would be a good idea to test each single line if we do such fixes/changes. I appreciate it really much if we improve the PHPStan level, but in this case I've got really serious problems and needed to fix missing data via scripts...