### PR TITLE
[WIP] improve display of scheduled versions

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/ElementController.php
+++ b/bundles/AdminBundle/Controller/Admin/ElementController.php
@@ -602,7 +602,7 @@ class ElementController extends AdminController
                         if ($task->getActive()) {
                             if ($task->getAction() === 'publish-version' && $task->getVersion()) {
                                 $schedules[$task->getVersion()] = $task->getDate();
-                            } else {
+                            } elseif ($task->getAction() === 'publish') {
                                 $hasSchedule = $task->getDate();
                             }
                         }

--- a/bundles/AdminBundle/Controller/Admin/ElementController.php
+++ b/bundles/AdminBundle/Controller/Admin/ElementController.php
@@ -597,18 +597,25 @@ class ElementController extends AdminController
                 if ($element->isAllowed('versions')) {
                     $schedule = $element->getScheduledTasks();
                     $schedules = [];
+                    $hasSchedule = false;
                     foreach ($schedule as $task) {
                         if ($task->getActive()) {
-                            $schedules[$task->getVersion()] = $task->getDate();
+                            if ($task->getAction() === 'publish-version' && $task->getVersion()) {
+                                $schedules[$task->getVersion()] = $task->getDate();
+                            } else {
+                                $hasSchedule = $task->getDate();
+                            }
                         }
                     }
 
-                    $versions = $element->getVersions();
-                    $versions = Model\Element\Service::getSafeVersionInfo($versions);
+                    $versions = Model\Element\Service::getSafeVersionInfo($element->getVersions());
                     $versions = array_reverse($versions); //reverse array to sort by ID DESC
                     foreach ($versions as &$version) {
                         $version['scheduled'] = null;
-                        if (array_key_exists($version['id'], $schedules)) {
+
+                        if ($hasSchedule && $version['versionCount'] === $element->getVersionCount()) {
+                            $version['scheduled'] = $hasSchedule;
+                        } elseif (isset($schedules[$version['id']])) {
                             $version['scheduled'] = $schedules[$version['id']];
                         }
                     }


### PR DESCRIPTION
Today I studied the scheduled publication of documents a bit and I find the current scheduling behavior very confusing.

My observations so far are as follows:

1. The "Version" field in the "Schedule" tab is only considered when the "Publish Version" action is selected - but if you select another action (Publish, Unpublish, Delete) you can still select a version if you want to.
1.1. If you *do* select a version, the according version gets displayed as "Scheduled" in the "Versions" tab by displaying the time of the task in this column. But if the action is not "Publish Version", this version is **not** the version that the task operates on!

2. If you select the "Publish" action, some "opaque" version will be published when the task runs. 
2.1. Which version this will be can nowhere be seen (as far as I know).
2.2. I expected this to be the latest available version, but apparently it's the version that was published last - which means it will be the **first** version (the raw document that was created when the user clicked "add page" - without any changes) if the page has never been published yet.

#### So my question is: if you want to publish a document for the first time using the scheduler, you **have** to use the "Publish Version" action if you don't want a blank page to be published. Is that correct?

---

To tackle the problems described in `1.1` and `2.1` I tried to improve this a bit with the PoC in this PR:
1.1: With this code only the selected versions of "Publish Version" tasks are considered in the "Versions" task. 
2.1: Additionally, the next scheduled "Publish" task gets displayed at the real version it operates on. 

The "Unpublish" or "Delete" tasks don't get displayed in the "Versions" tab because they operate independent of the versions displayed there:
- "Unpublish" unpublishes the currently published version (there can only be one)
- "Delete" deletes the whole document, independent of any versions