### PR TITLE
[Data Objects] Retry transaction when tables for newly added locale do not exist yet

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/editorSettings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/editorSettings.js
@@ -54,7 +54,7 @@ pimcore.settings.user.editorSettings = Class.create({
             width: 500,
             columns: [
                 {text: t("language"), sortable: true, dataIndex: 'value', editor: new Ext.form.TextField({}),
-                    width: 200},
+                    flex: 1},
                 {text: t("abbreviation"), sortable: true, dataIndex: 'key', editor: new Ext.form.TextField({}),
                     width: 200},
                 {

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -17,7 +17,7 @@
 
 namespace Pimcore\Model\DataObject;
 
-use Doctrine\DBAL\Exception\DeadlockException;
+use Doctrine\DBAL\Exception\RetryableException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Pimcore\Cache;
 use Pimcore\Cache\Runtime;
@@ -675,11 +675,13 @@ class AbstractObject extends Model\Element\AbstractElement
 
                     if ($e instanceof UniqueConstraintViolationException) {
                         throw new Element\ValidationException('unique constraint violation', 0, $e);
-                    } elseif ($e instanceof DeadlockException) {
+                    }
+
+                    if ($e instanceof RetryableException) {
                         // we try to start the transaction $maxRetries times again (deadlocks, ...)
                         if ($retries < ($maxRetries - 1)) {
                             $run = $retries + 1;
-                            $waitTime = rand(1, 5) * 100000; // microseconds
+                            $waitTime = random_int(1, 5) * 100000; // microseconds
                             Logger::warn('Unable to finish transaction (' . $run . ". run) because of the following reason '" . $e->getMessage() . "'. --> Retrying in " . $waitTime . ' microseconds ... (' . ($run + 1) . ' of ' . $maxRetries . ')');
 
                             usleep($waitTime); // wait specified time until we restart the transaction

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -17,6 +17,7 @@
 
 namespace Pimcore\Model\DataObject\Localizedfield;
 
+use Doctrine\DBAL\Exception\DeadlockException;
 use Pimcore\Db;
 use Pimcore\Logger;
 use Pimcore\Model;
@@ -215,7 +216,9 @@ class Dao extends Model\Dao\AbstractDao
                 if (strpos($e->getMessage(), 'exist')) {
                     $this->db->rollBack();
                     $this->createUpdateTable();
-                    throw new \Exception('missing table created, start next run ... ;-)');
+
+                    // throw exception which gets caught in AbstractObject::save() -> retry saving
+                    throw new LanguageTableDoesNotExistException('missing table created, start next run ... ;-)');
                 }
                 throw $e;
             }
@@ -254,7 +257,7 @@ class Dao extends Model\Dao\AbstractDao
                         $this->createUpdateTable();
 
                         // at this point we throw an exception so that the transaction gets repeated in DataObject::save()
-                        throw new \Exception('missing table created, start next run ... ;-)');
+                        throw new LanguageTableDoesNotExistException('missing table created, start next run ... ;-)');
                     }
                 }
 

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -17,7 +17,6 @@
 
 namespace Pimcore\Model\DataObject\Localizedfield;
 
-use Doctrine\DBAL\Exception\DeadlockException;
 use Pimcore\Db;
 use Pimcore\Logger;
 use Pimcore\Model;

--- a/models/DataObject/Localizedfield/LanguageTableDoesNotExistException.php
+++ b/models/DataObject/Localizedfield/LanguageTableDoesNotExistException.php
@@ -1,0 +1,10 @@
+<?php
+namespace Pimcore\Model\DataObject\Localizedfield;
+
+
+use Doctrine\DBAL\Exception\RetryableException;
+use Exception;
+
+class LanguageTableDoesNotExistException extends Exception implements RetryableException
+{
+}


### PR DESCRIPTION
Steps to reproduce bug:
* Create data object class `Test` with localized text field `test`
* Add new locale in system settings > localization / i18n
* Create new object of class `Test`
* An exception occurs `missing table created, start next run ... ;-)`

As https://github.com/pimcore/pimcore/blob/eb493066f5c3bafc68f1a9540886bd42161758d9/models/DataObject/Localizedfield/Dao.php#L260-L261 says this exception should cause the saving transaction to be retried - but currently this is not done because https://github.com/pimcore/pimcore/blob/eb493066f5c3bafc68f1a9540886bd42161758d9/models/DataObject/AbstractObject.php#L665-L695 does not handle this type of exception separately.
This PR fixes this by introducing a new exception class `LanguageTableDoesNotExistException` (which inherits DBAL's RetryableException) and by restarting the save transaction for all RetryableExceptions (not only DeadlockException).

And as little side note it fixes the little UI quirk in editor languages settings (table is broader than columns):
Before:
<img width="527" alt="editor-settings-bug" src="https://user-images.githubusercontent.com/8749138/102071365-aa1ecf00-3e00-11eb-8696-ba0109f8b6c4.png">

After:
<img width="517" alt="editor-settings-bug-solved" src="https://user-images.githubusercontent.com/8749138/102071381-ae4aec80-3e00-11eb-9f34-75e5842ef51a.png">
