### PR TITLE
[Templating] Fix setCharset error on helpers

### DIFF
--- a/lib/Templating/Helper/HelperCharsetTrait.php
+++ b/lib/Templating/Helper/HelperCharsetTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Templating\Helper;
+
+/**
+ * @deprecated remove in Pimcore 10
+ */
+trait HelperCharsetTrait
+{
+    protected $charset = 'UTF-8';
+
+    /**
+     * Sets the default charset.
+     *
+     * @param string $charset The charset
+     */
+    public function setCharset(string $charset)
+    {
+        $this->charset = $charset;
+    }
+
+    /**
+     * Gets the default charset.
+     *
+     * @return string The default charset
+     */
+    public function getCharset()
+    {
+        return $this->charset;
+    }
+}

--- a/lib/Twig/Extension/Templating/Action.php
+++ b/lib/Twig/Extension/Templating/Action.php
@@ -16,11 +16,14 @@ namespace Pimcore\Twig\Extension\Templating;
 
 use Pimcore\Model\Document\PageSnippet;
 use Pimcore\Targeting\Document\DocumentTargetingConfigurator;
+use Pimcore\Templating\Helper\HelperCharsetTrait;
 use Pimcore\Templating\Renderer\ActionRenderer;
 use Twig\Extension\RuntimeExtensionInterface;
 
 class Action implements RuntimeExtensionInterface
 {
+    use HelperCharsetTrait;
+
     /**
      * @var ActionRenderer
      */

--- a/lib/Twig/Extension/Templating/Inc.php
+++ b/lib/Twig/Extension/Templating/Inc.php
@@ -16,11 +16,14 @@ namespace Pimcore\Twig\Extension\Templating;
 
 use Pimcore\Http\Request\Resolver\EditmodeResolver;
 use Pimcore\Model\Document\PageSnippet;
+use Pimcore\Templating\Helper\HelperCharsetTrait;
 use Pimcore\Templating\Renderer\IncludeRenderer;
 use Twig\Extension\RuntimeExtensionInterface;
 
 class Inc implements RuntimeExtensionInterface
 {
+    use HelperCharsetTrait;
+
     /**
      * @var IncludeRenderer
      */

--- a/lib/Twig/Extension/Templating/Navigation.php
+++ b/lib/Twig/Extension/Templating/Navigation.php
@@ -24,6 +24,7 @@ use Pimcore\Navigation\Renderer\Breadcrumbs;
 use Pimcore\Navigation\Renderer\Menu;
 use Pimcore\Navigation\Renderer\Menu as MenuRenderer;
 use Pimcore\Navigation\Renderer\RendererInterface;
+use Pimcore\Templating\Helper\HelperCharsetTrait;
 use Pimcore\Twig\Extension\Templating\Navigation\Exception\InvalidRendererException;
 use Pimcore\Twig\Extension\Templating\Navigation\Exception\RendererNotFoundException;
 use Psr\Container\ContainerInterface;
@@ -37,6 +38,8 @@ use Twig\Extension\RuntimeExtensionInterface;
  */
 class Navigation implements RuntimeExtensionInterface
 {
+    use HelperCharsetTrait;
+
     /**
      * @var Builder
      */

--- a/lib/Twig/Extension/Templating/PimcoreUrl.php
+++ b/lib/Twig/Extension/Templating/PimcoreUrl.php
@@ -16,11 +16,13 @@ namespace Pimcore\Twig\Extension\Templating;
 
 use Pimcore\Http\RequestHelper;
 use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Templating\Helper\HelperCharsetTrait;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Extension\RuntimeExtensionInterface;
 
 class PimcoreUrl implements RuntimeExtensionInterface
 {
+    use HelperCharsetTrait;
     /**
      * @var UrlGeneratorInterface
      */

--- a/lib/Twig/Extension/Templating/Placeholder/AbstractExtension.php
+++ b/lib/Twig/Extension/Templating/Placeholder/AbstractExtension.php
@@ -38,6 +38,7 @@
 namespace Pimcore\Twig\Extension\Templating\Placeholder;
 
 use Twig\Extension\RuntimeExtensionInterface;
+use Pimcore\Templating\Helper\HelperCharsetTrait;
 
 /**
  * @method void set(mixed $value)
@@ -58,6 +59,8 @@ use Twig\Extension\RuntimeExtensionInterface;
  */
 abstract class AbstractExtension implements \IteratorAggregate, \Countable, \ArrayAccess, RuntimeExtensionInterface
 {
+    use HelperCharsetTrait;
+
     /**
      * @var ContainerService
      */
@@ -326,4 +329,4 @@ abstract class AbstractExtension implements \IteratorAggregate, \Countable, \Arr
     }
 }
 
-class_alias(AbstractExtension::class, 'Pimcore\Templating\Helper\Placeholder\AbstractExtension');
+class_alias(AbstractExtension::class, 'Pimcore\Templating\Helper\Placeholder\AbstractHelper');


### PR DESCRIPTION
## Changes in this pull request  
In #7463 Templating helpers are deprecated and changed to extend from respective twig extensions, which causes problem when phpEngine call setCharset() on helpers. This PR adds a trait to support the charset calls and the same will be removed with PhpEngine on Pimcore 10.

## Additional info  
- Also fixes AbstractHelper alias.