### PR TITLE
[Ecommerce][Productindex][Elasticsearch] fix execution of process update index queue command with multiple tenants

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Command/IndexService/ProcessUpdateIndexQueueCommand.php
+++ b/bundles/EcommerceFrameworkBundle/Command/IndexService/ProcessUpdateIndexQueueCommand.php
@@ -159,7 +159,13 @@ class ProcessUpdateIndexQueueCommand extends AbstractIndexServiceCommand
             }
         }
 
-        $this->childWorkerList = $workerList;
+        // collect all workers from all processed tenants
+        $this->childWorkerList = $this->childWorkerList ?? [];
+        $childWorkerList = [];
+        foreach(array_merge($this->childWorkerList, $workerList) as $worker) {
+            $childWorkerList[$worker->getTenantConfig()->getTenantName()] = $worker;
+        }
+        $this->childWorkerList = array_values($childWorkerList);
 
         return $workerList;
     }


### PR DESCRIPTION
The `ecommerce:indexservice:process-update-queue` does not work corretly if used with multiple tenants (which do not contain the same products). The `commitBatchToIndex()` will only be executed for the tenants of the first combined product row. Therefore it's needed to call the command multiple times to get all items processed.

This PR collects all relevant workers of all rows and therefore the `commitBatchToIndex()` will be executed for all of them. Now a single call of the command is enough to process all items in the queue!