### PR TITLE
Symfony Cache Tags

### DIFF
--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -609,6 +609,7 @@ class CoreCacheHandler implements LoggerAwareInterface
         $item->set($data);
         $item->expiresAfter($lifetime);
         $item->tag($tags);
+        $item->tag($key);
         $result = $this->pool->save($item);
 
         if ($result) {


### PR DESCRIPTION
Symfony Cache does not consider the key a tag, add key as tag in CoreCacheHandler
