### PR TITLE
Allow to create editables in new `pimcore.document.editables` namespace

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/edit/startup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/edit/startup.js
@@ -118,13 +118,18 @@ Ext.onReady(function () {
     Ext.MessageBox.minPromptWidth = 500;
 
     function getEditable(definition) {
+        let type = definition.type
         let name = definition.name;
         let inherited = false;
         if(typeof definition["inherited"] != "undefined") {
             inherited = definition["inherited"];
         }
 
-        let EditableClass = pimcore.document.editables[definition.type] || pimcore.document.tags[definition.type]
+        let EditableClass = pimcore.document.editables[type] || pimcore.document.tags[type]
+
+        if (typeof EditableClass !== 'function') {
+            throw 'Editable of type `' + type + '` with name `' + name + '` could not be found.';
+        }
 
         if (definition.inDialogBox && typeof EditableClass.prototype['render'] !== 'function') {
             throw 'Editable of type `' + type + '` with name `' + name + '` does not support the use in the dialog box.';

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/edit/startup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/edit/startup.js
@@ -124,7 +124,9 @@ Ext.onReady(function () {
             inherited = definition["inherited"];
         }
 
-        if (definition.inDialogBox && typeof pimcore.document.tags[definition.type].prototype['render'] !== 'function') {
+        let EditableClass = pimcore.document.editables[definition.type] || pimcore.document.tags[definition.type]
+
+        if (definition.inDialogBox && typeof EditableClass.prototype['render'] !== 'function') {
             throw 'Editable of type `' + type + '` with name `' + name + '` does not support the use in the dialog box.';
         }
 
@@ -133,8 +135,7 @@ Ext.onReady(function () {
         }
         editableNames.push(name);
 
-        // @TODO: change pimcore.document.tags to pimcore.document.editables in v7
-        var editable = new pimcore.document.tags[definition.type](definition.id, name, definition.config, definition.data, inherited);
+        let editable = new EditableClass(definition.id, name, definition.config, definition.data, inherited);
         editable.setRealName(definition.realName);
         editable.setInDialogBox(definition.inDialogBox);
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/edit/startup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/edit/startup.js
@@ -96,7 +96,7 @@ Ext.onReady(function () {
     try {
         //TODO EXT5
         Ext.getBody().applyStyles("min-height:" +
-        parent.Ext.get('document_iframe_' + window.editWindow.document.id).getHeight() + "px");
+            parent.Ext.get('document_iframe_' + window.editWindow.document.id).getHeight() + "px");
     } catch (e) {
         console.log(e);
     }
@@ -110,7 +110,7 @@ Ext.onReady(function () {
     }
 
     body.on("click", function () {
-       parent.Ext.menu.MenuMgr.hideAll();
+        parent.Ext.menu.MenuMgr.hideAll();
         editWindow.toggleTagHighlighting(false);
     });
 
@@ -130,7 +130,7 @@ Ext.onReady(function () {
             throw 'Editable of type `' + type + '` with name `' + name + '` does not support the use in the dialog box.';
         }
 
-        if(in_array(name,editableNames)) {
+        if (in_array(name, editableNames)) {
             pimcore.helpers.showNotification("ERROR", "Duplicate editable name: " + name, "error");
         }
         editableNames.push(name);
@@ -139,7 +139,7 @@ Ext.onReady(function () {
         editable.setRealName(definition.realName);
         editable.setInDialogBox(definition.inDialogBox);
 
-        if(!definition.inDialogBox) {
+        if (!definition.inDialogBox) {
             if (typeof editable['render'] === 'function') {
                 editable.render();
             }
@@ -197,18 +197,20 @@ Ext.onReady(function () {
         var tmpEl;
         for (var e=0; e<editablesForTooltip.length; e++) {
             tmpEl = Ext.get(editablesForTooltip[e]);
-            if(tmpEl) {
-                if(tmpEl.hasCls("pimcore_tag_inc") || tmpEl.hasCls("pimcore_tag_href")
-                                    || tmpEl.hasCls("pimcore_tag_image") || tmpEl.hasCls("pimcore_tag_renderlet")
-                                    || tmpEl.hasCls("pimcore_tag_snippet")) {
-                    new Ext.ToolTip({
-                        target: tmpEl,
-                        showDelay: 100,
-                        hideDelay: 0,
-                        trackMouse: true,
-                        html: t("click_right_for_more_options")
-                    });
-                }
+
+            if (tmpEl && tmpEl.hasCls("pimcore_tag_inc")
+                || tmpEl.hasCls("pimcore_tag_href")
+                || tmpEl.hasCls("pimcore_tag_image")
+                || tmpEl.hasCls("pimcore_tag_renderlet")
+                || tmpEl.hasCls("pimcore_tag_snippet")
+            ) {
+                new Ext.ToolTip({
+                    target: tmpEl,
+                    showDelay: 100,
+                    hideDelay: 0,
+                    trackMouse: true,
+                    html: t("click_right_for_more_options")
+                });
             }
         }
 
@@ -228,7 +230,7 @@ Ext.onReady(function () {
                             handler: function (item) {
                                 item.parentMenu.destroy();
                                 pimcore.helpers.openDocument(this.getAttribute("pimcore_id"),
-                                                                                this.getAttribute("pimcore_type"));
+                                    this.getAttribute("pimcore_type"));
                             }.bind(this)
                         }));
 
@@ -250,8 +252,3 @@ Ext.onReady(function () {
         editWindow.loadMask.hide();
     }
 });
-
-
-
-
-


### PR DESCRIPTION
The docs say that the JS for custom editables should be created in the `pimcore.document.editables` namespace (since `pimcore.document.tags` was deprecated). But this is currently not possible. This PR fixes that. Also, an improved error message is thrown when an editable class does not exist.
<br>
Note: this PR is best looked at [without whitespace changes](https://github.com/pimcore/pimcore/pull/7776/files?w=1) ;)