### PR TITLE
[Ecommerce][Productindex][Elasticsearch] fix reindex mode locking

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/DefaultElasticSearch5.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/DefaultElasticSearch5.php
@@ -360,4 +360,24 @@ class DefaultElasticSearch5 extends AbstractElasticSearch
     {
         return new \Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\ProductList\ElasticSearch\DefaultElasticSearch5($this->tenantConfig);
     }
+
+    /**
+     * Blocks all write operations
+     *
+     * @param string $indexName the name of the index.
+     */
+    protected function blockIndexWrite(string $indexName)
+    {
+        // Currently not tested in Elasticsearch < 6 and therefore disabled
+    }
+
+    /**
+     * Blocks all write operations
+     *
+     * @param string $indexName the name of the index.
+     */
+    protected function unblockIndexWrite(string $indexName)
+    {
+        // Currently not tested in Elasticsearch < 6 and therefore disabled
+    }
 }


### PR DESCRIPTION
The reindex locking currently does not work correctly due some limitations of Symfony lock.

This PR changes the behaviour to a lock mechanism based on a tmp store entry. Additionally write operations to the old index are disabled to avoid race conditions. This write disable mechanism is currently disabled for Elasticsearch 5 as I was not able to test it. In theory it should work for 5 too. 