### PR TITLE
Update minimal supported browser versions for admin backend

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/Login/login.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/Login/login.html.php
@@ -7,19 +7,19 @@ $this->get("translate")->setDomain("admin");
 //detect browser
 $supported      = false;
 $browser        = new \Pimcore\Browser();
-$browserVersion = (int)$browser->getVersion();
+$browserVersion = (float)$browser->getVersion();
 $platform       = $browser->getPlatform();
 
-if ($browser->getBrowser() == \Pimcore\Browser::BROWSER_FIREFOX && $browserVersion >= 52) {
+if ($browser->getBrowser() == \Pimcore\Browser::BROWSER_FIREFOX && $browserVersion >= 72) {
     $supported = true;
 }
 if ($browser->getBrowser() == \Pimcore\Browser::BROWSER_CHROME && $browserVersion >= 84) {
     $supported = true;
 }
-if ($browser->getBrowser() == \Pimcore\Browser::BROWSER_SAFARI && $browserVersion >= 10) {
+if ($browser->getBrowser() == \Pimcore\Browser::BROWSER_SAFARI && $browserVersion >= 13.1) {
     $supported = true;
 }
-if ($browser->getBrowser() == \Pimcore\Browser::BROWSER_OPERA && $browserVersion >= 42) {
+if ($browser->getBrowser() == \Pimcore\Browser::BROWSER_OPERA && $browserVersion >= 67) {
     $supported = true;
 }
 if ($browser->getBrowser() == \Pimcore\Browser::BROWSER_EDGE && $browserVersion >= 84) {


### PR DESCRIPTION
Since Pimcore 6.8 the minimal supported browser versions for the admin backend changed through the use of the "nullish coalescing operator" (`??`).

The browsers that support this operator natively can be seen on [caniuse.com](https://caniuse.com/mdn-javascript_operators_nullish_coalescing). 
I updated the versions accordingly.

The PR that introduced that operator is #6923 (see [here](https://github.com/pimcore/pimcore/commit/8454a72a679a77198a722d4472461be0eda953af#diff-d986a526693963b97de953733d579ff291655b6e02b08d0485cddfeda2cc957fR69) and [here](https://github.com/pimcore/pimcore/commit/8454a72a679a77198a722d4472461be0eda953af#diff-550243b2690103c1c4129a6d7627b0b75e2067d9623b27d50871ae72944e82adR1041)).
Another commit that uses this operator is [this one](https://github.com/pimcore/pimcore/commit/dc2eeed9d7a1159fc0854199afbfbefec45a2e88#diff-550243b2690103c1c4129a6d7627b0b75e2067d9623b27d50871ae72944e82adR1035).