### PR TITLE
Improve error message when missing permission to create assets

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -396,7 +396,6 @@ class AssetController extends ElementControllerBase implements EventedController
      */
     protected function addAsset(Request $request, Config $config)
     {
-        $success = false;
         $defaultUploadPath = $config['assets']['default_upload_path'] ?? '/';
 
         if (array_key_exists('Filedata', $_FILES)) {
@@ -478,28 +477,29 @@ class AssetController extends ElementControllerBase implements EventedController
         $filename = $this->getSafeFilename($parentAsset->getRealFullPath(), $filename);
         $asset = null;
 
-        if ($parentAsset->isAllowed('create')) {
-            if (is_file($sourcePath) && filesize($sourcePath) < 1) {
-                throw new \Exception('File is empty!');
-            } elseif (!is_file($sourcePath)) {
-                throw new \Exception('Something went wrong, please check upload_max_filesize and post_max_size in your php.ini and write permissions of ' . PIMCORE_PUBLIC_VAR);
-            }
-
-            $asset = Asset::create($parentId, [
-                'filename' => $filename,
-                'sourcePath' => $sourcePath,
-                'userOwner' => $this->getAdminUser()->getId(),
-                'userModification' => $this->getAdminUser()->getId(),
-            ]);
-            $success = true;
-
-            @unlink($sourcePath);
-        } else {
-            Logger::debug('prevented creating asset because of missing permissions, parent asset is ' . $parentAsset->getRealFullPath());
+        if (!$parentAsset->isAllowed('create')) {
+            throw $this->createAccessDeniedHttpException(
+                'Missing the permission to create new assets in the folder: ' . $parentAsset->getRealFullPath()
+            );
         }
 
+        if (is_file($sourcePath) && filesize($sourcePath) < 1) {
+            throw new \Exception('File is empty!');
+        } elseif (!is_file($sourcePath)) {
+            throw new \Exception('Something went wrong, please check upload_max_filesize and post_max_size in your php.ini and write permissions of ' . PIMCORE_PUBLIC_VAR);
+        }
+
+        $asset = Asset::create($parentId, [
+            'filename' => $filename,
+            'sourcePath' => $sourcePath,
+            'userOwner' => $this->getAdminUser()->getId(),
+            'userModification' => $this->getAdminUser()->getId(),
+        ]);
+
+        @unlink($sourcePath);
+
         return [
-            'success' => $success,
+            'success' => true,
             'asset' => $asset,
         ];
     }


### PR DESCRIPTION
### Current behaviour

Given that you don't have the "create" permission for an asset folder, then the frontend will automatically hide many of the options for uploading files to that folder, but there's still some options left, where it will be up to the backend to reject the upload. I've found two:

1. when you drag-n-drop a file onto any folder
2. when you upload a file to a media component on a data object.

In those cases, AssetController returns a 200 response with `{status: false}`, which results in a rather sparse error message:

![Screenshot 2021-01-04 at 18 44 27](https://user-images.githubusercontent.com/434495/103563917-e86a5400-4ebd-11eb-87b6-fa77ffe03c11.png)

### Proposed change

This PR uses `createAccessDeniedHttpException()` method to create a proper exception, resulting in a 403 response and an error message like this:

![Screenshot 2021-01-04 at 19 45 06](https://user-images.githubusercontent.com/434495/103568163-6120de80-4ec5-11eb-9e85-e72f293a202e.png)

I chose to use the word "create" over "upload", since it's the name of the permission you need.
