### PR TITLE
Incompatibilities due to fixed Doctrine server_version

### DIFF
--- a/bundles/CoreBundle/Resources/config/pimcore/default.yml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yml
@@ -47,7 +47,6 @@ doctrine:
                 charset: UTF8MB4
                 logging: false
                 profiling: false
-                server_version: '5.6'
                 default_table_options:
                     charset: UTF8MB4
                     collate: utf8mb4_general_ci

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -55,6 +55,8 @@ CREATE TABLE `assets_metadata` (
 	INDEX `name` (`name`)
 ) DEFAULT CHARSET=utf8mb4;
 
+DROP TABLE IF EXISTS `cache_items`; /* this table is created by the installer (see: Pimcore\Bundle\InstallBundle\Installer::setupDatabase) */
+
 DROP TABLE IF EXISTS `classes` ;
 CREATE TABLE `classes` (
 	`id` VARCHAR(50) NOT NULL,


### PR DESCRIPTION
reverts 12c936dc6695dd9ac40ec6acc84b194194bd33b3

The problem with hard-coding the `server_version` is that schema/table comparisons are platform specific. This causes problems when for example running `./bin/console doctrine:migrations:version --all --add -n -q`. 

```text

In MetadataStorageError.php line 13:

  The metadata storage is not up to date, please run the sync-metadata-storage command to fix this issue.


doctrine:migrations:version [--add] [--delete] [--all] [--range-from [RANGE-FROM]] [--range-to [RANGE-TO]] [--configuration CONFIGURATION] [--db-configuration DB-CONFIGURATION] [--prefix [PREFIX]] [--] [<version>]
```