### PR TITLE
DB mapping types should be written by installer and not set in defaults

### DIFF
--- a/.github/ci/files/config/packages/test/config.yaml
+++ b/.github/ci/files/config/packages/test/config.yaml
@@ -22,6 +22,9 @@ doctrine:
                 dbname: ~
                 user: ~
                 password: ~
+                mapping_types:
+                    enum: string
+                    bit: boolean
 
 parameters:
     pimcore_test.db.dsn: '%env(PIMCORE_TEST_DB_DSN)%'

--- a/bundles/CoreBundle/Resources/config/pimcore/default.yml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yml
@@ -50,9 +50,6 @@ doctrine:
                 default_table_options:
                     charset: UTF8MB4
                     collate: utf8mb4_general_ci
-                mapping_types:
-                    enum: string
-                    bit: boolean
 
 # Monolog Configuration
 monolog:

--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -360,6 +360,11 @@ class Installer
             unset($dbConfig['driverOptions']);
         }
 
+        $dbConfig['mapping_types'] = [
+            'enum' => 'string',
+            'bit' => 'boolean',
+        ];
+
         $this->createConfigFiles([
             'doctrine' => [
                 'dbal' => [


### PR DESCRIPTION
Causes issues when building the container without having a DB connection configured (e.g. before running the installer -> 
Composer install)

See also: #7847 , 12c936dc6695dd9ac40ec6acc84b194194bd33b3 and pimcore/demo#202