### PR TITLE
Remove deprecated getElement() method on NotificationEvent and TranslationEvent

### DIFF
--- a/lib/Event/Model/NotificationEvent.php
+++ b/lib/Event/Model/NotificationEvent.php
@@ -18,7 +18,7 @@ use Pimcore\Event\Traits\ArgumentsAwareTrait;
 use Pimcore\Model\Notification;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class NotificationEvent extends Event implements ElementEventInterface
+class NotificationEvent extends Event
 {
     use ArgumentsAwareTrait;
 
@@ -53,15 +53,5 @@ class NotificationEvent extends Event implements ElementEventInterface
     public function setNotification($notification)
     {
         $this->notification = $notification;
-    }
-
-    /**
-     * @deprecated use getNotification() instead - will be removed in Pimcore 10
-     *
-     * @return Notification
-     */
-    public function getElement()
-    {
-        return $this->getNotification();
     }
 }

--- a/lib/Event/Model/TranslationEvent.php
+++ b/lib/Event/Model/TranslationEvent.php
@@ -18,7 +18,7 @@ use Pimcore\Event\Traits\ArgumentsAwareTrait;
 use Pimcore\Model\Translation\AbstractTranslation;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class TranslationEvent extends Event implements ElementEventInterface
+class TranslationEvent extends Event
 {
     use ArgumentsAwareTrait;
 
@@ -53,15 +53,5 @@ class TranslationEvent extends Event implements ElementEventInterface
     public function setTranslation(AbstractTranslation $translation)
     {
         $this->translation = $translation;
-    }
-
-    /**
-     * @deprecated use getTranslation() instead - will be removed in Pimcore 10
-     *
-     * @return AbstractTranslation
-     */
-    public function getElement()
-    {
-        return $this->getTranslation();
     }
 }


### PR DESCRIPTION
See #7077