### PR TITLE
ocramius/package-versions: ^2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
     "myclabs/deep-copy": "^1.7",
     "neitanod/forceutf8": "^2.0.4",
     "nesbot/carbon": "^1.34.0 || ^2.11.0",
-    "ocramius/package-versions": "^2.0",
+    "ocramius/package-versions": "^2.3",
     "pear/net_url2": "^2.2",
     "phive/twig-extensions-deferred": "^2.0",
     "matomo/device-detector": "^3.9",


### PR DESCRIPTION
Follow up to #7869 should be merged after #7844 was merged (PHP 8 dependency)