### PR TITLE
Removed colon-in-path-workaround for imagemagick

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -111,10 +111,6 @@ class Imagick extends Adapter
 
             $imagePathLoad = $imagePath;
 
-            if (strpos($imagePathLoad, ':') !== false) {
-                $imagePathLoad = ':' . $imagePathLoad;
-            }
-
             $imagePathLoad = $imagePathLoad . '[0]';
 
             if (!$i->readImage($imagePathLoad) || !filesize($imagePath)) {


### PR DESCRIPTION
## Changes in this pull request

Resolves an issue where imagemagick couldn't find images with a colon ( : ) in the path.
The removed workaround prefixes a path that contains a colon with another colon and therefore imagemagick can't find the image and throws an error (the error is from a Windows system, but was reproducible with Ubuntu):
`
pimcore.ERROR: ImagickException: UnableToOpenBlob ':C:\folder\structure/public/var/assets/logo/logo-3x.png[0]': Invalid argument @ error/blob.c/OpenBlob/3315
`

## Additional info

The workaround was introduced in #2829 but the underlying issue was fixed later that year by imagemagick itself ImageMagick/ImageMagick#1402.
This only affects ImageMagick v7
