### PR TITLE
[Calculated value fields] Support display type HTML

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/calculatedValue.js
@@ -52,7 +52,8 @@ pimcore.object.classes.data.calculatedValue = Class.create(pimcore.object.classe
                 labelWidth: 140,
                 store: [
                     ['input', t('input')],
-                    ['textarea', t('textarea')]
+                    ['textarea', t('textarea')],
+                    ['html', t('HTML')]
                 ]
             },
             {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/calculatedValue.js
@@ -53,7 +53,7 @@ pimcore.object.classes.data.calculatedValue = Class.create(pimcore.object.classe
                 store: [
                     ['input', t('input')],
                     ['textarea', t('textarea')],
-                    ['html', t('HTML')]
+                    ['html', t('html')]
                 ]
             },
             {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
@@ -61,6 +61,8 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
 
         if(this.fieldConfig.elementType === 'textarea') {
             this.component = new Ext.form.field.TextArea(input);
+        } else if (this.fieldConfig.elementType === 'html') {
+            this.component = new Ext.form.field.Display(input);
         } else {
             this.component = new Ext.form.field.Text(input);
         }


### PR DESCRIPTION
Currently calculated value fields support display types "input field" and "textbox". This PR adds support for HTML output allowing to fully flexibilize calculated field output. In the end this seems to be the same as dynamic text layout element but this for example lacks multi-language support and a getter method. So to support dynamically generated HTML in the "Edit" panel of the object which is also possible to be reused via its getter method I added the "HTML" display type to calculated value fields.