### PR TITLE
[Object bricks] Brick container class might contain removed brick types after unserializing

### DIFF
--- a/models/DataObject/Objectbrick.php
+++ b/models/DataObject/Objectbrick.php
@@ -135,12 +135,9 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
      */
     public function getBrickGetters()
     {
-        $getters = [];
-        foreach ($this->brickGetters as $bg) {
-            $getters[] = 'get' . ucfirst($bg);
-        }
-
-        return $getters;
+        return array_map(function($brickType) {
+            return 'get'.ucfirst($brickType);
+        }, $this->getAllowedBrickTypes());
     }
 
     /**
@@ -148,7 +145,21 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
      */
     public function getAllowedBrickTypes()
     {
-        return is_array($this->brickGetters) ? $this->brickGetters : [];
+        if(!is_array($this->brickGetters)) {
+            return [];
+        }
+
+        $brickTypes = [];
+        foreach ($this->brickGetters as $brickType) {
+            $getter = 'get' . ucfirst($brickType);
+
+            // necessary because when data object gets serialized and later unserialized `$this->brickGetters` property gets restored to the state of serialization -> if bricks got removed meanwhile the getter might not exist anymore
+            if (method_exists($this, $getter)) {
+                $brickTypes[] = $brickType;
+            }
+        }
+
+        return $brickTypes;
     }
 
     /**

--- a/models/DataObject/Objectbrick.php
+++ b/models/DataObject/Objectbrick.php
@@ -149,17 +149,10 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
             return [];
         }
 
-        $brickTypes = [];
-        foreach ($this->brickGetters as $brickType) {
+        return array_filter($this->brickGetters, function($brickType) {
             $getter = 'get' . ucfirst($brickType);
-
-            // necessary because when data object gets serialized and later unserialized `$this->brickGetters` property gets restored to the state of serialization -> if bricks got removed meanwhile the getter might not exist anymore
-            if (method_exists($this, $getter)) {
-                $brickTypes[] = $brickType;
-            }
-        }
-
-        return $brickTypes;
+            return method_exists($this, $getter);
+        });
     }
 
     /**

--- a/models/DataObject/Objectbrick.php
+++ b/models/DataObject/Objectbrick.php
@@ -135,7 +135,7 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
      */
     public function getBrickGetters()
     {
-        return array_map(function($brickType) {
+        return array_map(static function($brickType) {
             return 'get'.ucfirst($brickType);
         }, $this->getAllowedBrickTypes());
     }


### PR DESCRIPTION
In the same context like in #7407 we now had the problem that we could not save an object which previously had an object brick assigned which got removed in the meantime. The problem is that the brick container class gets serialized together with the data object - and so `$this->brickGetters` also contains the brick type which got removed in the meantime. When we now want to save the object the following code gets executed: 
https://github.com/pimcore/pimcore/blob/69b4285b91e926eb6c70d9ccc83f301d7a32bdf8/models/DataObject/Objectbrick.php#L177-L180
Here the getter for the removed brick type gets called causing a fatal error because the getter does not exist anymore.

So the main problem is that the non-existing brick type remains present in `$this->brickGetters`. I also tried to remove the non-existing brick type in the `wakeUp` method https://github.com/pimcore/pimcore/blob/69b4285b91e926eb6c70d9ccc83f301d7a32bdf8/models/DataObject/Objectbrick.php#L325-L328 but this did not work but I have not researched any further why.