### PR TITLE
Fix first rule condition is always AND

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PricingManager/Condition/Bracket.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Condition/Bracket.php
@@ -62,6 +62,11 @@ class Bracket implements BracketInterface
         // check all conditions
         foreach ($this->conditions as $num => $condition) {
             /* @var ConditionInterface $condition */
+            
+            if ($num === 0) {
+                $state = $check;
+                continue;
+            }
 
             // test condition
             $check = $condition->check($environment);

--- a/bundles/EcommerceFrameworkBundle/PricingManager/Condition/Bracket.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Condition/Bracket.php
@@ -62,14 +62,14 @@ class Bracket implements BracketInterface
         // check all conditions
         foreach ($this->conditions as $num => $condition) {
             /* @var ConditionInterface $condition */
-            
+
+            // test condition
+            $check = $condition->check($environment);
+
             if ($num === 0) {
                 $state = $check;
                 continue;
             }
-
-            // test condition
-            $check = $condition->check($environment);
 
             // check
             switch ($this->operator[$num]) {


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/4056

## Additional info  

As you can see in [this issue](https://github.com/pimcore/pimcore/issues/4056), the first operator is always `AND`

The first condition in a bracket shouldn't have an operator.
