### PR TITLE
Remove operator from first condition

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PricingManager/Condition/Bracket.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Condition/Bracket.php
@@ -65,6 +65,11 @@ class Bracket implements BracketInterface
 
             // test condition
             $check = $condition->check($environment);
+            
+            if ($num === 0) {
+                $state = $check;
+                continue;
+            }
 
             // check
             switch ($this->operator[$num]) {


### PR DESCRIPTION
The first condition should not have an operator (currently it is AND)

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #4056

## Additional info  

Due to uncomfortable merge conflicts in https://github.com/pimcore/pimcore/pull/7902, I created a new branch/PR

