### PR TITLE
Remove innodb_file_format

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/01_System_Requirements.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/01_System_Requirements.md
@@ -64,7 +64,6 @@ All permissions on database level, specifically:
 #### System Variables
 ```
 [mysqld]
-innodb_file_format = Barracuda
 innodb_large_prefix = 1
 innodb_file_per_table = 1
 


### PR DESCRIPTION
As of mariadb 10.2.2 this option is deprecated and as of 10.3.1 removed. See: https://mariadb.com/kb/en/innodb-system-variables/#innodb_file_format

The value defaults to `Barracuda`.