### PR TITLE
Update docs: Section on .env files

### DIFF
--- a/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
+++ b/doc/Development_Documentation/21_Deployment/03_Multi_Environment.md
@@ -117,12 +117,18 @@ When running `./bin/console` application, set the environment by `--env=dev`.
 
 ### `.env`
 
-Pimcore loads a `.env` file if it exists. See [DotEnv Component Documentation](https://symfony.com/doc/3.4/components/dotenv.html)
-for details.
+Pimcore loads environment variables from `.env` files if they exist.
+It's good practice to add defaults to `.env`, which is committed to your repository, and local overrides to `.env.local`, which is not committed.
+See [Symfony Configuration Based on Environment Variables](https://symfony.com/doc/current/configuration.html#configuration-based-on-environment-variables) for details.
 
 ```
 # .env
 PIMCORE_ENVIRONMENT=dev
+```
+
+```
+# .env.local
+PIMCORE_ENVIRONMENT=prod
 ```
 
 ### Switching Environments Dynamically


### PR DESCRIPTION
Coming from a non-Symfony background, I was accustomed with `.env` files, but not with the way Symfony 4 recommends using them. Which is a bit different from most (all?) other approaches I've seen, in that it recommends keeping the actual values (which you don't want to commit) in `.env.local`, not `.env`, so I think that's worth pointing out. 

Also updated the link to go a more updated documentation page.
