### PR TITLE
Pimcore Backend | Grid View | Value "0" is not shown

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -491,7 +491,7 @@ class Select extends Data implements ResourcePersistenceAwareInterface, QueryRes
             if ($params['purpose'] == 'editmode') {
                 $result = $data;
             } else {
-                $result = ['value' => $data ? $data : null, 'options' => $this->getOptions()];
+                $result = ['value' => isset($data) ? $data : null, 'options' => $this->getOptions()];
             }
 
             return $result;


### PR DESCRIPTION
Bugfix: when a select field has the value "0", then the actual select name should be shown in the grid view, not an empty value.

See screenshot:

![image](https://user-images.githubusercontent.com/16687355/104916387-499c2800-5992-11eb-8da2-c2abf8123d70.png)
