### PR TITLE
Explicitly generate non-HDPI and HDPI system thumbnails

### DIFF
--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -205,15 +205,19 @@ class ThumbnailsImageCommand extends AbstractCommand
             if (!$input->getOption('thumbnails')) {
                 $thumbnailsToGenerate = [];
             }
+
             $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig(false);
+
             if (!$input->getOption('skip-high-res')) {
                 $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig(true);
             }
         } elseif (!$input->getOption('thumbnails')) {
             $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig(false);
+
             if (!$input->getOption('skip-high-res')) {
                 $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig(true);
             }
+
         }
 
         return $thumbnailsToGenerate;

--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -205,9 +205,15 @@ class ThumbnailsImageCommand extends AbstractCommand
             if (!$input->getOption('thumbnails')) {
                 $thumbnailsToGenerate = [];
             }
-            $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig();
+            $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig(false);
+            if (!$input->getOption('skip-high-res')) {
+                $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig(true);
+            }
         } elseif (!$input->getOption('thumbnails')) {
-            $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig();
+            $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig(false);
+            if (!$input->getOption('skip-high-res')) {
+                $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig(true);
+            }
         }
 
         return $thumbnailsToGenerate;


### PR DESCRIPTION
## Changes in this pull request  

Generating system thumbnails using `bin/console pimcore:thumbnails:image --system` only outputs non-HDPI versions. When these thumbnails are then requested by calling `/admin/asset/get-image-thumbnail?hdpi=1`, the HDPI thumbnails are not available and have to generated on the fly which can cause high load (when e.g. the files are Photoshop files).

This PR generates the HDPI versions as well, provided `--skip-high-res` is not set. To make the code more explicit, the existing calls to `Asset\Image\Thumbnail\Config::getPreviewConfig()` now set the first argument to `false` when generating the non-HDPI version.

## Additional info  

The presence of the bug in version 6.8.6 and the absence of the bug with the patch have been verified.