### PR TITLE
Maintainance Task VersionCleanup: set default steps to 10

### DIFF
--- a/lib/Maintenance/Tasks/VersionsCleanupTask.php
+++ b/lib/Maintenance/Tasks/VersionsCleanupTask.php
@@ -58,7 +58,7 @@ final class VersionsCleanupTask implements TaskInterface
 
         foreach ($conf as $elementType => $tConf) {
             $versioningType = 'steps';
-            $value = $tConf['steps'] ?? 0;
+            $value = $tConf['steps'] ?? 10;
 
             if (isset($tConf['days']) && (int)$tConf['days'] > 0) {
                 $versioningType = 'days';


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  

## Changes in this pull request  

We updated a pimcore application from v5 to v6 and between updating the application and running the migration scripts the cronjob deleted some version because it couldn't find the system.yml configs.
The Versioncleanup job deleted all versions because the default step value is set to zero. 


I propose to change the default value to 10, because thats the value that is set when i'm installing pimcore.

