### PR TITLE
fix. bad formatting in classification store documentation

### DIFF
--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/15_Classification_Store.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/15_Classification_Store.md
@@ -197,10 +197,10 @@ $collectionConfig = new \Pimcore\Model\DataObject\Classificationstore\Collection
 $collectionConfig->setName($name);
 $collectionConfig->setDescription($description);
 $collectionConfig->save();
-```
 
 // Add a group to a collection
 $rel = new CollectionGroupRelation();
 $rel->setGroupId($groupConfig->getId();
 $rel->setColId($collectionConfig->getId();
 $rel->save();
+```


### PR DESCRIPTION
# Changes in this pull request  

Simply fixes a formatting issue in the classification store documentation.
