### PR TITLE
wysiwyg.js and pimcore_disable_thumbnail

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/wysiwyg.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/wysiwyg.js
@@ -164,7 +164,7 @@ pimcore.object.tags.wysiwyg = Class.create(pimcore.object.tags.abstract, {
             entities: false,
             entities_greek: false,
             entities_latin: false,
-            extraAllowedContent: "*[pimcore_type,pimcore_id]",
+            extraAllowedContent: "*[pimcore_type,pimcore_id,pimcore_disable_thumbnail]",
             baseFloatZIndex: 40000 // prevent that the editor gets displayed behind the grid cell editor window
         };
 


### PR DESCRIPTION

## Changes in this pull request  
### Resolves
When we drop asset image in wysiwyg block thumbnail is always generated. Reason: additional property "pimcore_disable_thumbnail" disappears.
## Additional info  
We need to add "pimcore_disable_thumbnail" in extraAllowedContent as this functionality doesn't work: https://github.com/pimcore/pimcore/blob/master/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/wysiwyg.js#L300

