### PR TITLE
[Assets] Show asset filesizes in UI when using stream wrappers + [WebDAV] Bugfix uploading new files + show assets without files

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -351,7 +351,7 @@ class Asset extends Element\AbstractElement
             } else {
                 $mimeType = Mime::detect($data['sourcePath'], $data['filename']);
                 if (is_file($data['sourcePath'])) {
-                    $data['stream'] = fopen($data['sourcePath'], 'r', false, File::getContext());
+                    $data['stream'] = fopen($data['sourcePath'], 'rb', false, File::getContext());
                 }
 
                 unset($data['sourcePath']);
@@ -708,7 +708,7 @@ class Asset extends Element\AbstractElement
                         unlink($destinationPath);
                     }
 
-                    $dest = fopen($destinationPath, 'w', false, File::getContext());
+                    $dest = fopen($destinationPath, 'wb', false, File::getContext());
                     if ($dest) {
                         stream_copy_to_stream($src, $dest);
                         if (!fclose($dest)) {
@@ -724,7 +724,7 @@ class Asset extends Element\AbstractElement
                 @chmod($destinationPath, File::getDefaultMode());
 
                 // check file exists
-                if (!is_file($destinationPath)) {
+                if (!file_exists($destinationPath)) {
                     throw new \Exception("couldn't create new asset, file " . $destinationPath . " doesn't exist");
                 }
 

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -213,8 +213,7 @@ class Service extends Model\Element\Service
                         $data[$field] = self::getPreviewThumbnail($asset, ['treepreview' => true, 'width' => 108, 'height' => 70, 'frame' => true]);
                     } elseif ($fieldDef[0] === 'size') {
                         /** @var Asset $asset */
-                        $filename = PIMCORE_ASSET_DIRECTORY . '/' . $asset->getRealFullPath();
-                        $size = @filesize($filename);
+                        $size = @filesize($asset->getFileSystemPath());
                         $data[$field] = formatBytes($size);
                     }
                 } else {

--- a/models/Asset/WebDAV/File.php
+++ b/models/Asset/WebDAV/File.php
@@ -178,6 +178,6 @@ class File extends DAV\File
      */
     public function getSize()
     {
-        return filesize($this->asset->getFileSystemPath());
+        return @filesize($this->asset->getFileSystemPath());
     }
 }

--- a/models/Asset/WebDAV/Folder.php
+++ b/models/Asset/WebDAV/Folder.php
@@ -110,7 +110,7 @@ class Folder extends DAV\Collection
 
     /**
      * @param string $name
-     * @param string|null $data
+     * @param string|resource|null $data
      *
      * @throws DAV\Exception\Forbidden
      *
@@ -119,6 +119,9 @@ class Folder extends DAV\Collection
     public function createFile($name, $data = null)
     {
         $tmpFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/asset-dav-tmp-file-' . uniqid();
+        if(is_resource($data)) {
+            @rewind($data);
+        }
         file_put_contents($tmpFile, $data);
 
         $user = AdminTool::getCurrentUser();

--- a/models/Asset/WebDAV/Folder.php
+++ b/models/Asset/WebDAV/Folder.php
@@ -136,7 +136,9 @@ class Folder extends DAV\Collection
             return null;
         }
 
-        throw new DAV\Exception\Forbidden();
+        unlink($tmpFile);
+
+        throw new DAV\Exception\Forbidden('Missing "create" permission');
     }
 
     /**
@@ -156,7 +158,7 @@ class Folder extends DAV\Collection
                 'userOwner' => $user->getId(),
             ]);
         } else {
-            throw new DAV\Exception\Forbidden();
+            throw new DAV\Exception\Forbidden('Missing "create" permission');
         }
     }
 
@@ -169,7 +171,7 @@ class Folder extends DAV\Collection
         if ($this->asset->isAllowed('delete')) {
             $this->asset->delete();
         } else {
-            throw new DAV\Exception\Forbidden();
+            throw new DAV\Exception\Forbidden('Missing "delete" permission');
         }
     }
 
@@ -187,7 +189,7 @@ class Folder extends DAV\Collection
             $this->asset->setFilename(Element\Service::getValidKey($name, 'asset'));
             $this->asset->save();
         } else {
-            throw new DAV\Exception\Forbidden();
+            throw new DAV\Exception\Forbidden('Missing "rename" permission');
         }
 
         return $this;


### PR DESCRIPTION
In https://github.com/pimcore/pimcore/blob/de3119d12fd5a003db20dc896e757c7d7342664d/models/Asset/Service.php#L217
the file name contains an additional slash between `PIMCORE_ASSET_DIRECTORY` and the asset's full path. While this is no problem with local storage it becomes a problem with stream wrappers. Additionally there is no need to build the path here as `Asset::getFileSystemPath()` does it correctly anyway:
https://github.com/pimcore/pimcore/blob/de3119d12fd5a003db20dc896e757c7d7342664d/models/Asset.php#L466-L469
This is for Pimcore backend (sorry for mixing this in this WebDAV PR):
Before:
<img width="1199" alt="Bildschirmfoto 2021-01-20 um 17 12 16" src="https://user-images.githubusercontent.com/8749138/105318517-eabdf500-5bc3-11eb-9390-3259dd913893.png">

After:
<img width="1097" alt="Bildschirmfoto 2021-01-21 um 08 36 54" src="https://user-images.githubusercontent.com/8749138/105318469-dd086f80-5bc3-11eb-8593-656e0b2847fc.png">

The other important change in this PR is that in Pimcore backend you also see assets whose files do not exist anymore. To have the same behavior in WebDAV we need to suppress errors in https://github.com/pimcore/pimcore/blob/de3119d12fd5a003db20dc896e757c7d7342664d/models/Asset/WebDAV/File.php#L181
Compare this to https://github.com/pimcore/pimcore/blob/de3119d12fd5a003db20dc896e757c7d7342664d/models/Asset/Service.php#L218 which gets used when listing assets in Pimcore backend.

And a 3rd thing added: When I use Cyberduck as WebDAV client uploading new files did not work at first. The reason was that the stream was not at the beginning in https://github.com/pimcore/pimcore/blob/de3119d12fd5a003db20dc896e757c7d7342664d/models/Asset/WebDAV/Folder.php#L121-L122
Because other than the PHPdoc previously said `$data` is a stream here - at least when this method gets called from https://github.com/sabre-io/dav/blob/4258420f15425a5f128fe5cad454e00ab4a68ae5/lib/DAV/CorePlugin.php#L504
Beware that this does not happen when using the WebDAV browser interface because this sends POST requests and not PUT.

The other things are just minor fixes.