### PR TITLE
Add context when getting localized parentContainer

### DIFF
--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -484,6 +484,7 @@ class Localizedfield extends Model\AbstractModel implements
                                 $localizedFields = $parentContainer->getLocalizedFields();
                                 if ($localizedFields instanceof Localizedfield) {
                                     if ($localizedFields->getObject()->getId() != $this->getObject()->getId()) {
+                                        $localizedFields->setContext($this->getContext());
                                         $data = $localizedFields->getLocalizedValue($name, $language, true);
                                     }
                                 }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #7967

## Additional info  
The only way i could find to fix the supportInheritance error is to set the correct context in `\Pimcore\Model\DataObject\Localizedfield::getLocalizedValue`.