### PR TITLE
[Versions] Show current database version for unpublished elements

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/versions.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/versions.js
@@ -107,9 +107,15 @@ pimcore.document.versions = Class.create({
                             var versionCount = cellValues.get('versionCount');
                             var index = cellValues.get('index');
 
-                            if (this.document.data.published && index === 0 && d == this.document.data.versionDate && versionCount == this.document.data.versionCount) {
-                                metaData.tdCls = "pimcore_icon_publish";
+                            if (index === 0 && d == this.document.data.versionDate && versionCount == this.document.data.versionCount) {
+                                if(this.document.data.published) {
+                                    metaData.tdCls = "pimcore_icon_publish";
+                                } else {
+                                    metaData.tdCls = "pimcore_icon_sql";
+                                    metaData.tdAttr = 'data-qtip="' + t('version_currently_saved_in_database') + '"';
+                                }
                             }
+
                             return "";
                         }.bind(this),
                         editable: false

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/versions.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/versions.js
@@ -87,8 +87,13 @@ pimcore.object.versions = Class.create({
                             var d = cellValues.get('date');
                             var versionCount = cellValues.get('versionCount');
                             var index = cellValues.get('index');
-                            if (this.object.data.general.o_published && index === 0 && d == this.object.data.general.versionDate && versionCount == this.object.data.general.versionCount) {
-                                metaData.tdCls = "pimcore_icon_publish";
+                            if (index === 0 && d == this.object.data.general.versionDate && versionCount == this.object.data.general.versionCount) {
+                                if(this.object.data.general.o_published) {
+                                    metaData.tdCls = "pimcore_icon_publish";
+                                } else {
+                                    metaData.tdCls = "pimcore_icon_sql";
+                                    metaData.tdAttr = 'data-qtip="' + t('version_currently_saved_in_database') + '"';
+                                }
                             }
                             return "";
                         }.bind(this),

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -959,5 +959,6 @@
   "batch_change_language": "Batch update language",
   "generate_type_declarations" : "Generate Type Declarations",
   "brick_limit_reached": "Limit ({bricklimit}) reached for brick: {brickname}",
-  "preview_item": "Preview Item"
+  "preview_item": "Preview Item",
+  "version_currently_saved_in_database": "Currently saved in database"
 }

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -960,5 +960,5 @@
   "generate_type_declarations" : "Generate Type Declarations",
   "brick_limit_reached": "Limit ({bricklimit}) reached for brick: {brickname}",
   "preview_item": "Preview Item",
-  "version_currently_saved_in_database": "Currently saved in database"
+  "version_currently_saved_in_database": "Currently saved in database (but not published)"
 }


### PR DESCRIPTION
When a data object is unpublished there currently is no way to recognize which version in the versions tab currently is saved in the database. This PR changes this with a new icon in the `Published` column:

Before:
<img width="470" alt="Bildschirmfoto 2021-01-25 um 13 44 11" src="https://user-images.githubusercontent.com/8749138/105707568-6ea11580-5f13-11eb-96bf-63ac53526f68.png">

After:
<img width="509" alt="Bildschirmfoto 2021-01-25 um 13 47 05" src="https://user-images.githubusercontent.com/8749138/105707860-df483200-5f13-11eb-95d1-fdcd59177268.png">

If the object is published, everything stays the same.