### PR TITLE
[Ecommerce][Productindex][Elasticsearch] do not close index on index creation

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -769,16 +769,21 @@ abstract class AbstractElasticSearch extends Worker\ProductCentricBatchProcessin
         $esClient = $this->getElasticSearchClient();
 
         Logger::info('Index-Actions - creating new Index. Name: ' . $indexName);
+
+        $configuredSettings = $this->tenantConfig->getIndexSettings();
+        $synonymSettings = $this->extractMinimalSynonymFiltersTreeFromTenantConfig();
+        if (isset($synonymSettings['analysis'])) {
+            $configuredSettings['analysis']['filter'] = array_replace_recursive($configuredSettings['analysis']['filter'], $synonymSettings['analysis']['filter']);
+        }
+
         $result = $esClient->indices()->create([
             'index' => $indexName,
-            'body' => ['settings' => $this->tenantConfig->getIndexSettings()],
+            'body' => ['settings' => $configuredSettings],
         ]);
 
         if (!$result['acknowledged']) {
             throw new \Exception('Index creation failed. IndexName: ' . $indexName);
         }
-
-        $this->updateSynonyms($indexName, true, true);
     }
 
     /**


### PR DESCRIPTION
AWS hosted Elasticsearch version 6.x does not support the index close operation therefore index creation currently fails.

Therefore this PR directly adds the synonyms to the create index call. This way everything works correctly and the only drawback is that you can't use the `bin/console ecommerce:indexservice:elasticsearch-sync update-synonyms` command which isn't a real problem as you can still use the `bin/console ecommerce:indexservice:elasticsearch-sync reindex` command which is the better choice on live environments anyways.