### PR TITLE
Use searchSring instead of filter in website translation activation

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/translation/website.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/translation/website.js
@@ -29,7 +29,7 @@ pimcore.settings.translation.website = Class.create(pimcore.settings.translation
 
     activate: function (filter) {
         if(filter){
-            this.store.getProxy().setExtraParam("filter", filter);
+            this.store.getProxy().setExtraParam("searchString", filter);
             this.store.load();
             this.filterField.setValue(filter);
         }


### PR DESCRIPTION
After hitting the `pimcore.globalmanager.get('translationwebsitemanager').activate` method,  the request will raise a json exception since the wrong parameter `filter` gets passed. I just adapted the logic from the admin translation class: 

https://github.com/solverat/pimcore/blob/2f700bd6beb4ce4c3c7844369e20a8a0dd272ddc/bundles/AdminBundle/Resources/public/js/pimcore/settings/translation/admin.js#L32