### PR TITLE
Add better layout possibilities for editable dialog box of a brick

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
@@ -1054,9 +1054,17 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.editable, {
                 manageHeight: false,
                 items: this.buildEditableDialogLayout(config['items'], editablesInBox, nextLevel)
             };
-
-            if(config['title']) {
-                container['title'] = config['title'];
+            let allowedConfigElements = [
+                'layout',
+                'flex',
+                'defaults',
+                'title'
+            ];
+            for (let i in allowedConfigElements) {
+                let cfgElement = allowedConfigElements[i];
+                if(config[cfgElement]) {
+                    container[cfgElement] = config[cfgElement];
+                }
             }
 
             return container;


### PR DESCRIPTION
Add better layout possibilities for editable dialog box of a brick.
So you can use table layout or vbox layout.

Example:
```php
    public function getEditableDialogBoxConfiguration(Document\Editable $area, ?Info $info): EditableDialogBoxConfiguration
    {
        $config = new EditableDialogBoxConfiguration();

        $config->setItems([
            [
                'type' => 'panel',
                'layout' => 'column',
                'defaults' => [
                    'columnWidth' => '0.5',
                ],
                'items' => [
                    [
                        'type' => 'panel',
                        'title' => 'Column 1',
                        'items' => [
                            [
                                'type' => 'input',
                                'name' => 'input1'
                            ]
                        ],
                    ],
                    [
                        'type' => 'panel',
                        'title' => 'Column 2',
                        'items' => [
                            [
                                'type' => 'input',
                                'name' => 'input2'
                            ]
                        ],
                    ]
                ]
            ]
        ]);

        return $config;
    }