### PR TITLE
Fix JSON parse error, when clicking on edit button of a brick

### DIFF
--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -439,7 +439,7 @@ class Areablock extends Model\Document\Editable implements BlockInterface
 
         if ($dialogConfig) {
             $editableRenderer = \Pimcore::getContainer()->get(EditableRenderer::class);
-            $this->outputEditmode('<template id="dialogBoxConfig-' . $dialogConfig->getId() . '">' . \json_encode($dialogConfig) . '</template>');
+            $this->outputEditmode('<template id="dialogBoxConfig-' . $dialogConfig->getId() . '">' . \htmlspecialchars(\json_encode($dialogConfig)) . '</template>');
             $this->renderDialogBoxEditables($dialogConfig->getItems(), $editableRenderer, $dialogConfig->getId());
         }
     }


### PR DESCRIPTION
There was an JSON parse error, when I clicked on the edit button of a brick with the following code:
```php
    public function getEditableDialogBoxConfiguration(Document\Editable $area, ?Info $info): EditableDialogBoxConfiguration
    {
        $config = new EditableDialogBoxConfiguration();

        $config->setItems([
            [
                'type' => 'select',
                'name' => 'test',
                'config' => [
                    'store' => [
                        ["image 1", '<img src="/bundles/pimcoreadmin/img/flat-color-icons/idea.svg">'],
                    ],
                ],
            ]
        ]);

        return $config;
    }
```
This pull request fixes the error.