### PR TITLE
[Notifications] Prevent exception when trying to open deleted notification

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/NotificationController.php
+++ b/bundles/AdminBundle/Controller/Admin/NotificationController.php
@@ -102,7 +102,16 @@ class NotificationController extends AdminController
         $this->checkPermission('notifications');
 
         $id = (int) $request->get('id', 0);
-        $notification = $service->findAndMarkAsRead($id, $this->getAdminUser()->getId());
+        try {
+            $notification = $service->findAndMarkAsRead($id, $this->getAdminUser()->getId());
+        } catch(\UnexpectedValueException $e) {
+            return $this->adminJson(
+                [
+                    'success' => false
+                ]
+            );
+        }
+
         $data = $service->format($notification);
 
         return $this->adminJson([

--- a/bundles/AdminBundle/Resources/public/js/pimcore/notification/helper.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/notification/helper.js
@@ -116,6 +116,7 @@ pimcore.notification.helper.openDetails = function (id, callback) {
         success: function (response) {
             response = Ext.decode(response.responseText);
             if (!response.success) {
+                Ext.MessageBox.alert(t("error"), t("element_not_found"));
                 return;
             }
             pimcore.notification.helper.openDetailsWindow(

--- a/models/Notification/Service/NotificationService.php
+++ b/models/Notification/Service/NotificationService.php
@@ -141,6 +141,8 @@ class NotificationService
      * @param int|null $recipientId
      *
      * @return Notification
+     *
+     * @throws \UnexpectedValueException
      */
     public function findAndMarkAsRead(int $id, ?int $recipientId = null): Notification
     {


### PR DESCRIPTION
When a user receives a notification he can open the notification with one of the icons in the appearing modal in the bottom-right corner. If the notification got deleted in the meantime an exception gots thrown. This PR fixes this so that he gets the usual message "Element not found" (as when trying top open an object which got deleted in the meantime).