### PR TITLE
[CoreBundle] Invalid definition for service GeoIp : lint:container

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -355,7 +355,7 @@ class PimcoreCoreExtension extends ConfigurableExtension implements PrependExten
         $container->setParameter('pimcore.targeting.enabled', $config['enabled']);
         $container->setParameter('pimcore.targeting.conditions', $config['conditions']);
         if (!$container->hasParameter('pimcore.geoip.db_file')) {
-            $container->setParameter('pimcore.geoip.db_file', null);
+            $container->setParameter('pimcore.geoip.db_file', '');
         }
 
         $loader->load('targeting.yml');


### PR DESCRIPTION
On my environment Pimcore 6.8.7 (PHP 7.4) I have this error when  I run Symfony command lint:container 

````bash
/www/current $ php bin/console lint:container

In CheckTypeDeclarationsPass.php line 302:
                                                                                                                                                                 
  Invalid definition for service "Pimcore\Targeting\DataProvider\GeoIp": argument 1 of "GeoIp2\Database\Reader::__construct()" accepts "string", "NULL" passed.  
 ````

This  PR fixes this error, setting an empty string instead of null value.
