### PR TITLE
[Versions] renewReferences() restores current key even if $doNotRestoreKeyAndPath is true

### DIFF
--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -780,7 +780,7 @@ class Service extends Model\AbstractModel
             } else {
 
                 // if this is the initial element set the correct path and key
-                if ($data instanceof ElementInterface && $initial) {
+                if ($data instanceof ElementInterface && $initial && !DataObject\AbstractObject::doNotRestoreKeyAndPath()) {
                     $originalElement = self::getElementById(self::getElementType($data), $data->getId());
 
                     if ($originalElement) {
@@ -795,9 +795,7 @@ class Service extends Model\AbstractModel
                             $data->setKey($originalElement->getKey());
                         }
 
-                        if (!DataObject\AbstractObject::doNotRestoreKeyAndPath()) {
-                            $data->setPath($originalElement->getRealPath());
-                        }
+                        $data->setPath($originalElement->getRealPath());
                     }
                 }
 


### PR DESCRIPTION
In https://github.com/pimcore/pimcore/blob/195588073f72e797da83ec4b850252d18f4b7c46/models/Element/Service.php#L783-L802
path and key of elements get restored. This happens for example when you unserialize a version. But while https://github.com/pimcore/pimcore/blob/195588073f72e797da83ec4b850252d18f4b7c46/models/Element/Service.php#L798-L800 
respects `AbstractObject::$doNotRestoreKeyAndPath` setting, the above lines where the key gets restored do not. This PR fixes this.

Script to reproduce:
```php
<?php
$object = \Pimcore\Model\DataObject\Concrete::getById(123);
var_dump('Original Key: '.$object->getKey());
$object->setKey('a');
var_dump('New Key: '.$object->getKey());
\Pimcore\Model\DataObject\AbstractObject::$doNotRestoreKeyAndPath = true;
$objectLatestVersion = $object->getLatestVersion(true)->getData();
var_dump('Latest Version Key: '.$objectLatestVersion->getKey()); // should output original key
```

Output is:
```
string(20) "Original Key: assasa"
string(10) "New Key: a"
string(21) "Latest Version Key: a"
```

With this PR output is:
```
string(20) "Original Key: assasa"
string(10) "New Key: a"
string(26) "Latest Version Key: assasa"
```