### PR TITLE
Consider existing parameters in DataObject Linkgenerators

### DIFF
--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -250,7 +250,7 @@ class Link extends Model\Document\Editable
         $url = $this->data['path'] ?? '';
 
         if (strlen($this->data['parameters'] ?? '') > 0) {
-            $url .= '?'.str_replace('?', '', $this->getParameters());
+            $url .= (strpos($url, '?') === false ? '&' : '?') . str_replace('?', '', $this->getParameters());
         }
 
         if (strlen($this->data['anchor'] ?? '') > 0) {

--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -250,7 +250,7 @@ class Link extends Model\Document\Editable
         $url = $this->data['path'] ?? '';
 
         if (strlen($this->data['parameters'] ?? '') > 0) {
-            $url .= (strpos($url, '?') === false ? '&' : '?') . str_replace('?', '', $this->getParameters());
+            $url .= (strpos($url, '?') !== false ? '&' : '?') . str_replace('?', '', $this->getParameters());
         }
 
         if (strlen($this->data['anchor'] ?? '') > 0) {


### PR DESCRIPTION
# Bugfix

Consider additional parameters in object linkgenerators.

## Use Case:
The link generator produces a link with querystring zB www.example.com?test1=123

In the Pimcore backend additional parameters get configured zB test2=123

The currently resulting link is www.example.com?test1=123?test2=123

This PR changes the behaviour to the following result: www.example.com?test1=123&test2=123

