### PR TITLE
 Fix the problem that not all fields are shown in "Visible Fields" at…

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -2300,7 +2300,7 @@ class DataObjectHelperController extends AdminController
         foreach ($fds as $fd) {
             if ($fd instanceof DataObject\ClassDefinition\Data\Fieldcollections || $fd instanceof DataObject\ClassDefinition\Data\Objectbricks
                 || $fd instanceof DataObject\ClassDefinition\Data\Block) {
-                return;
+                continue;
             }
 
             if ($fd instanceof DataObject\ClassDefinition\Data\Localizedfields) {


### PR DESCRIPTION
This pull request fixes an issue in the many to many object relation, where not all fields are shown in "Visible Fields".
If there are two input fields in class Product where the second Input field is after a block field, it is not shown in the "Visible Fields" of the many to many object relation for this class.
In the attached zip File i created an example.
In the ProductGroup class you can see the issue.
The field artnr is not shown when you click at products field.
[classes.zip](https://github.com/pimcore/pimcore/files/5963676/classes.zip)
