### PR TITLE
[DataObjects] Quantity Value: Fix adding new units

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/QuantityValueController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/QuantityValueController.php
@@ -110,7 +110,7 @@ class QuantityValueController extends AdminController
                 $data = json_decode($request->get('data'), true);
                 $unit = Unit::getById($data['id']);
                 if (!empty($unit)) {
-                    if ($data['baseunit'] === -1) {
+                    if (isset($data['baseunit']) && $data['baseunit'] === -1) {
                         $data['baseunit'] = null;
                     }
                     $unit->setValues($data);


### PR DESCRIPTION
(Fix is based on master as it doesn't occur in current 6.9).

This fixes adding and editing new units by checking for an undefined index 'baseunit'. There seems to be a changed behavior (no property 'baseunit' in payload) how newly persisted entries are updated.

How to reproduce:
1) Click "new unit" and enter ID "g" into modal.
2) Edit abbreviation to "g".
3) Lose focus, so entry is saved.
4) Exception is shown instead of update.
