### PR TITLE
[Ecommerce][PricingRules] Fix first condition is always ignored

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PricingManager/Condition/Bracket.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Condition/Bracket.php
@@ -57,22 +57,24 @@ class Bracket implements BracketInterface
         }
 
         // default
-        $state = false;
+        $state = null;
 
         // check all conditions
         foreach ($this->conditions as $num => $condition) {
             /* @var ConditionInterface $condition */
 
+            //The first condition shouldn't have an operator.
+            //https://github.com/pimcore/pimcore/pull/7902
+            $operator = $this->operator[$num];
+            if ($num === 0) {
+                $operator = null;
+            }
+
             // test condition
             $check = $condition->check($environment);
 
-            if ($num === 0) {
-                $state = $check;
-                continue;
-            }
-
             // check
-            switch ($this->operator[$num]) {
+            switch ($operator) {
                 // first condition
                 case null:
                     $state = $check;
@@ -83,7 +85,8 @@ class Bracket implements BracketInterface
                     if ($check === false) {
                         return false;
                     } else {
-                        $state = true;
+                        //consider current state with check, if not default.
+                        $state = ($state === null) ? $check : ($check && $state);
                     }
                     break;
 
@@ -105,7 +108,7 @@ class Bracket implements BracketInterface
             }
         }
 
-        return $state;
+        return $state ?? false;
     }
 
     /**

--- a/tests/Ecommerce/PricingManager/CombinedRuleTest.php
+++ b/tests/Ecommerce/PricingManager/CombinedRuleTest.php
@@ -11,7 +11,9 @@ namespace Pimcore\Tests\Ecommerce\PricingManager;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Action\CartDiscount;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Action\FreeShipping;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Action\ProductDiscount;
+use Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Condition\Bracket;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Condition\CartAmount;
+use Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Condition\CatalogProduct;
 use Pimcore\Tests\Ecommerce\PricingManager\Rule\AbstractRuleTest;
 
 class CombinedRuleTest extends AbstractRuleTest
@@ -357,4 +359,192 @@ class CombinedRuleTest extends AbstractRuleTest
 
         $this->doAssertions($ruleDefinitions, $productDefinitions, $tests);
     }
+
+
+    public function testTwoAndConditions() {
+
+        $ruleDefinitions = [
+            'testrule' => [
+                'actions' => [
+                    [
+                        'class' => ProductDiscount::class,
+                        'amount' => 10,
+                    ],
+                ],
+                'condition' => [
+                    'class' => Bracket::class,
+                    'conditions' => [
+                        [
+                            'condition' => [
+                                'class' => CatalogProduct::class,
+                                'products' => [$this->mockProductForCondition(5)],
+                            ],
+                            'operator' => Bracket::OPERATOR_AND,
+                        ],
+                        [
+                            'condition' => [
+                                'class' => CatalogProduct::class,
+                                'products' => [$this->mockProductForCondition(4)],
+                            ],
+                            'operator' => Bracket::OPERATOR_AND,
+                        ],
+                    ],
+                ],
+
+            ]
+        ];
+
+        $productDefinitions = [
+            'singleProduct' => [
+                'id' => 4,
+                'price' => 100,
+            ],
+            'cart' => [
+                [
+                    'id' => 4,
+                    'price' => 100,
+                ],
+                [
+                    'id' => 5,
+                    'price' => 50,
+                ],
+            ],
+        ];
+
+        $tests = [
+            'productPriceSingle' => 100,
+            'productPriceTotal' => 200,
+            'cartSubTotal' => 150,
+            'cartGrandTotal' => 150,
+            'cartSubTotalModificators' => 150,
+            'cartGrandTotalModificators' => 160,
+        ];
+
+        $this->doAssertions($ruleDefinitions, $productDefinitions, $tests);
+
+
+        $productDefinitions = [
+            'singleProduct' => [
+                'id' => 5,
+                'price' => 50,
+            ],
+            'cart' => [
+                [
+                    'id' => 4,
+                    'price' => 100,
+                ],
+                [
+                    'id' => 5,
+                    'price' => 50,
+                ],
+            ],
+        ];
+
+        $tests = [
+            'productPriceSingle' => 50,
+            'productPriceTotal' => 100,
+            'cartSubTotal' => 150,
+            'cartGrandTotal' => 150,
+            'cartSubTotalModificators' => 150,
+            'cartGrandTotalModificators' => 160,
+        ];
+
+        $this->doAssertions($ruleDefinitions, $productDefinitions, $tests);
+
+    }
+
+
+    public function testTwoOrConditions() {
+
+        $ruleDefinitions = [
+            'testrule' => [
+                'actions' => [
+                    [
+                        'class' => ProductDiscount::class,
+                        'amount' => 10,
+                    ],
+                ],
+                'condition' => [
+                    'class' => Bracket::class,
+                    'conditions' => [
+                        [
+                            'condition' => [
+                                'class' => CatalogProduct::class,
+                                'products' => [$this->mockProductForCondition(5)],
+                            ],
+                            'operator' => Bracket::OPERATOR_AND,
+                        ],
+                        [
+                            'condition' => [
+                                'class' => CatalogProduct::class,
+                                'products' => [$this->mockProductForCondition(4)],
+                            ],
+                            'operator' => Bracket::OPERATOR_OR,
+                        ],
+                    ],
+                ],
+
+            ]
+        ];
+
+        $productDefinitions = [
+            'singleProduct' => [
+                'id' => 4,
+                'price' => 100,
+            ],
+            'cart' => [
+                [
+                    'id' => 4,
+                    'price' => 100,
+                ],
+                [
+                    'id' => 5,
+                    'price' => 50,
+                ],
+            ],
+        ];
+
+        $tests = [
+            'productPriceSingle' => 90,
+            'productPriceTotal' => 180,
+            'cartSubTotal' => 130,
+            'cartGrandTotal' => 130,
+            'cartSubTotalModificators' => 130,
+            'cartGrandTotalModificators' => 140,
+        ];
+
+        $this->doAssertions($ruleDefinitions, $productDefinitions, $tests);
+
+
+        $productDefinitions = [
+            'singleProduct' => [
+                'id' => 5,
+                'price' => 50,
+            ],
+            'cart' => [
+                [
+                    'id' => 4,
+                    'price' => 100,
+                ],
+                [
+                    'id' => 5,
+                    'price' => 50,
+                ],
+            ],
+        ];
+
+        $tests = [
+            'productPriceSingle' => 40,
+            'productPriceTotal' => 80,
+            'cartSubTotal' => 130,
+            'cartGrandTotal' => 130,
+            'cartSubTotalModificators' => 130,
+            'cartGrandTotalModificators' => 140,
+        ];
+
+        $this->doAssertions($ruleDefinitions, $productDefinitions, $tests);
+
+    }
+
+
 }

--- a/tests/Ecommerce/PricingManager/Rule/AbstractRuleTest.php
+++ b/tests/Ecommerce/PricingManager/Rule/AbstractRuleTest.php
@@ -199,11 +199,12 @@ class AbstractRuleTest extends EcommerceTestCase
         );
 
         $priceInfo = $pricingManager->applyProductRules($priceInfo);
+        $product = $this->setUpProduct($productDefinitions['singleProduct']['id'], $productDefinitions['singleProduct']['price'], $pricingManager);
+        $priceInfo->getEnvironment()->setProduct($product);
 
         $this->assertTrue($priceInfo->getPrice()->getAmount()->equals(Decimal::create($tests['productPriceSingle'])), 'check single product price: ' . $priceInfo->getPrice()->getAmount() . ' vs. ' . $tests['productPriceSingle']);
         $this->assertTrue($priceInfo->getTotalPrice()->getAmount()->equals(Decimal::create($tests['productPriceTotal'])), 'check total product price: ' . $priceInfo->getTotalPrice()->getAmount() . ' vs. ' . $tests['productPriceTotal']);
 
-        $product = $this->setUpProduct($productDefinitions['singleProduct']['id'], $productDefinitions['singleProduct']['price'], $pricingManager);
         $this->assertTrue($product->getOSPrice()->getAmount()->equals(Decimal::create($tests['productPriceSingle'])), 'check single product price via product object');
 
         $cart = $this->setUpCart($pricingManager, false);
@@ -370,5 +371,26 @@ class AbstractRuleTest extends EcommerceTestCase
         }
 
         return $rules;
+    }
+
+    /**
+     * @param int $id
+     * @param int|null $parentId
+     *
+     * @return AbstractProduct
+     */
+    protected function mockProductForCondition($id, $parentId = null)
+    {
+        $product = $this->getMockBuilder(AbstractProduct::class)->getMock();
+        $product->method('getId')->willReturn($id);
+
+        if ($parentId) {
+            $subProduct = $this->mockProduct($parentId);
+            $product->method('getParent')->willReturn($subProduct);
+        } else {
+            $product->method('getParent')->willReturn(null);
+        }
+
+        return $product;
     }
 }


### PR DESCRIPTION
## Changes in this pull request  
Fixes Pricing Rule issues:
 - First condition is always ignored. Resolves #8142
 - first condition(without brackets) shouldn't have an operator. #7902
 - Previous state is ignored when AND condition results to true


## Additional info  
