### PR TITLE
Document\Editable: renamed buildChildElementTagName() to buildChildEditableName()

### DIFF
--- a/models/Document/Editable.php
+++ b/models/Document/Editable.php
@@ -758,7 +758,7 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
      *
      * @throws \Exception
      */
-    public static function buildChildElementTagName(string $name, string $type, array $parentBlockNames, int $index): string
+    public static function buildChildEditableName(string $name, string $type, array $parentBlockNames, int $index): string
     {
         if (count($parentBlockNames) === 0) {
             throw new \Exception(sprintf(

--- a/models/Document/Editable/Area.php
+++ b/models/Document/Editable/Area.php
@@ -149,7 +149,7 @@ class Area extends Model\Document\Editable
         $parentBlockNames = $this->getParentBlockNames();
         $parentBlockNames[] = $this->getName();
 
-        $id = Model\Document\Editable::buildChildElementTagName($name, 'area', $parentBlockNames, 1);
+        $id = Model\Document\Editable::buildChildEditableName($name, 'area', $parentBlockNames, 1);
         $editable = $document->getEditable($id);
 
         if ($editable) {

--- a/models/Document/Editable/Block/AbstractBlockItem.php
+++ b/models/Document/Editable/Block/AbstractBlockItem.php
@@ -62,7 +62,7 @@ abstract class AbstractBlockItem
      */
     public function getEditable(string $name)
     {
-        $id = Document\Editable::buildChildElementTagName($name, $this->getItemType(), $this->parentBlockNames, $this->index);
+        $id = Document\Editable::buildChildEditableName($name, $this->getItemType(), $this->parentBlockNames, $this->index);
         $editable = $this->document->getEditable($id);
 
         if ($editable) {


### PR DESCRIPTION
Related to #8177 and #7303