### PR TITLE
Proper method name and fewer if-checks in Imagick adapter

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -98,20 +98,6 @@ class Imagick extends Adapter
             $i = new \Imagick();
             $this->imagePath = $imagePath;
 
-            if (!$this->isPreserveColor()) {
-                $this->setColorspaceToRGB();
-
-                if (method_exists($i, 'setColorspace')) {
-                    $i->setColorspace(\Imagick::COLORSPACE_SRGB);
-                }
-
-                if ($this->isVectorGraphic($imagePath)) {
-                    // only for vector graphics
-                    // the below causes problems with PSDs when target format is PNG32 (nobody knows why ;-))
-                    $i->setBackgroundColor(new \ImagickPixel('transparent'));
-                }
-            }
-
             if (isset($options['resolution'])) {
                 // set the resolution to 2000x2000 for known vector formats
                 // otherwise this will cause problems with eg. cropPercent in the image editable (select specific area)
@@ -128,6 +114,20 @@ class Imagick extends Adapter
             }
 
             $this->resource = $i;
+
+            if (!$this->isPreserveColor()) {
+                if (method_exists($i, 'setColorspace')) {
+                    $i->setColorspace(\Imagick::COLORSPACE_SRGB);
+                }
+
+                if ($this->isVectorGraphic($imagePath)) {
+                    // only for vector graphics
+                    // the below causes problems with PSDs when target format is PNG32 (nobody knows why ;-))
+                    $i->setBackgroundColor(new \ImagickPixel('transparent'));
+                }
+
+                $this->setColorspaceToRGB();
+            }
 
             // set dimensions
             $dimensions = $this->getDimensions();

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -98,14 +98,18 @@ class Imagick extends Adapter
             $i = new \Imagick();
             $this->imagePath = $imagePath;
 
-            if (!$this->isPreserveColor() && method_exists($i, 'setcolorspace')) {
-                $i->setcolorspace(\Imagick::COLORSPACE_SRGB);
-            }
+            if (!$this->isPreserveColor()) {
+                $this->setColorspaceToRGB();
 
-            if (!$this->isPreserveColor() && $this->isVectorGraphic($imagePath)) {
-                // only for vector graphics
-                // the below causes problems with PSDs when target format is PNG32 (nobody knows why ;-))
-                $i->setBackgroundColor(new \ImagickPixel('transparent'));
+                if (method_exists($i, 'setColorspace')) {
+                    $i->setColorspace(\Imagick::COLORSPACE_SRGB);
+                }
+
+                if ($this->isVectorGraphic($imagePath)) {
+                    // only for vector graphics
+                    // the below causes problems with PSDs when target format is PNG32 (nobody knows why ;-))
+                    $i->setBackgroundColor(new \ImagickPixel('transparent'));
+                }
             }
 
             if (isset($options['resolution'])) {
@@ -140,10 +144,6 @@ class Imagick extends Adapter
                 if ($alphaChannel) {
                     $this->setIsAlphaPossible(true);
                 }
-            }
-
-            if (!$this->isPreserveColor()) {
-                $this->setColorspaceToRGB();
             }
 
             if ($this->checkPreserveAnimation($i->getImageFormat(), $i, false)) {


### PR DESCRIPTION
- `setcolorspace` -> `setColorspace` method name
- Fewer checks for `!$this->isPreserveColor()`