### PR TITLE
Fix Wrong language used if key equals translation in shared translations

### DIFF
--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -284,7 +284,7 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
             $normalizedId = mb_strtolower($id);
         }
 
-        if (isset($parameters['%count%'])) {
+        if (isset($parameters['%count%']) && $translated) {
             $normalizedId = $id = $translated;
         }
 
@@ -294,7 +294,7 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
         } elseif ($normalizedId == $translated) {
             if ($this->getCatalogue($locale)->has($normalizedId, $domain)) {
                 $translated = $this->getCatalogue($locale)->get($normalizedId, $domain);
-                if ($translated != $normalizedId) {
+                if ($normalizedId != $translated && $translated) {
                     return $translated;
                 }
             } elseif ($backend = $this->getBackendForDomain($domain)) {
@@ -352,7 +352,6 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
                 if ($fallbackValue && $normalizedId != $fallbackValue) {
                     // update fallback value in original catalogue otherwise multiple calls to the same id will not work
                     $this->getCatalogue($locale)->set($normalizedId, $fallbackValue, $domain);
-
                     return strtr($fallbackValue, $parameters);
                 }
             }

--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -235,10 +235,6 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
                             $translationKey = mb_strtolower($translationKey);
                         }
 
-                        if (empty($translationTerm)) {
-                            $translationTerm = $translationKey;
-                        }
-
                         $data[$translationKey] = $translationTerm;
                     }
                 }
@@ -292,7 +288,7 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
             $normalizedId = $id = $translated;
         }
 
-        $lookForFallback = $normalizedId == $translated;
+        $lookForFallback = empty($translated);
         if ($normalizedId != $translated && $translated) {
             return $translated;
         } elseif ($normalizedId == $translated) {
@@ -366,7 +362,7 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
             }
         }
 
-        return $translated;
+        return !empty($translated) ? $translated : $id;
     }
 
     /**

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -43,10 +43,13 @@ class TranslatorTest extends TestCase
         'en' => [
             'simple_key' => 'EN Text',
             'Text As Key' => 'EN Text',
+            'count_key' => '%count% Count',
+            'count_key_190' => 'This is a translated text generated from translator service, using count parameter to be replaced from passed parameters and having %count% characters to test text greater than 190 characters.'
         ],
         'de' => [
             'simple_key' => 'DE Text',
             'Text As Key' => '',
+            'count_key' => '',
         ],
         'fr' => [
             'simple_key' => 'FR Text',
@@ -116,7 +119,7 @@ class TranslatorTest extends TestCase
         $this->translator->setLocale('en');
         $this->assertEquals($this->translations['en']['Text As Key'], $this->translator->trans('Text As Key'));
 
-        //Returns Fallback value
+        //Returns Fallback("en") value
         $this->translator->setLocale('de');
         $this->assertEquals($this->translations['en']['simple_key'], $this->translator->trans('Text As Key'));
 
@@ -124,4 +127,21 @@ class TranslatorTest extends TestCase
         $this->translator->setLocale('fr');
         $this->assertEquals('Text As Key', $this->translator->trans('Text As Key'));
     }
+
+    public function testTranslateWithCountParam()
+    {
+        $this->translator->setLocale('en');
+        $this->assertEquals('2 Count', $this->translator->trans('count_key',['%count%' => 2]));
+
+        //fallback
+        $this->translator->setLocale('de');
+        $this->assertEquals('2 Count', $this->translator->trans('count_key',['%count%' => 2]));
+    }
+
+    public function testTranslateLongerTextWithCountParam()
+    {
+        $this->translator->setLocale('en');
+        $this->assertEquals(strtr($this->translations['en']['count_key_190'], ['%count%' => 192]), $this->translator->trans('count_key_190',['%count%' => 192]));
+    }
+
 }

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Unit\Translation;
 
-use Pimcore\Model\Translation\AbstractTranslation;
+use Codeception\Util\Stub;
 use Pimcore\Model\Translation\Website;
 use Pimcore\Translation\Translator;
 use Pimcore\Tests\Test\TestCase;
@@ -44,7 +44,9 @@ class TranslatorTest extends TestCase
             'simple_key' => 'EN Text',
             'Text As Key' => 'EN Text',
             'count_key' => '%count% Count',
-            'count_key_190' => 'This is a translated text generated from translator service, using count parameter to be replaced from passed parameters and having %count% characters to test text greater than 190 characters.'
+            'count_key_190' => 'This is a translated text generated from translator service, using count parameter to be replaced from passed parameters and having %count% characters to test text greater than 190 characters.',
+            'case_key' => 'Lower Case Key',
+            'CASE_KEY' => 'Upper Case Key'
         ],
         'de' => [
             'simple_key' => 'DE Text',
@@ -141,6 +143,23 @@ class TranslatorTest extends TestCase
     {
         $this->translator->setLocale('en');
         $this->assertEquals(strtr($this->translations['en']['count_key_190'], ['%count%' => 192]), $this->translator->trans('count_key_190',['%count%' => 192]));
+    }
+
+    public function testTranslateCaseSensitive()
+    {
+        // Case sensitive
+        $this->translator->setLocale('en');
+        //Lower case key
+        $this->assertEquals($this->translations['en']['case_key'], $this->translator->trans('case_key'));
+
+        //Upper case key
+        $this->assertEquals($this->translations['en']['CASE_KEY'], $this->translator->trans('CASE_KEY'));
+
+        // Case Insensitive
+        /** @var Translator $translator */
+        $translator = Stub::construct(Translator::class, [$this->translator, true]);
+
+        $this->assertEquals($this->translations['en']['case_key'], $translator->trans('CASE_KEY'));
     }
 
 }

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -43,14 +43,16 @@ class TranslatorTest extends TestCase
         'en' => [
             'simple_key' => 'EN Text',
             'Text As Key' => 'EN Text',
+            'text_params' => 'Text with %Param1% and %Param2%',
             'count_key' => '%count% Count',
             'count_key_190' => 'This is a translated text generated from translator service, using count parameter to be replaced from passed parameters and having %count% characters to test text greater than 190 characters.',
             'case_key' => 'Lower Case Key',
-            'CASE_KEY' => 'Upper Case Key'
+            'CASE_KEY' => 'Upper Case Key',
         ],
         'de' => [
             'simple_key' => 'DE Text',
             'Text As Key' => '',
+            'text_params' => '',
             'count_key' => '',
         ],
         'fr' => [
@@ -127,6 +129,39 @@ class TranslatorTest extends TestCase
         //Returns Key value (no translation + no fallback)
 //        $this->translator->setLocale('fr');
 //        $this->assertEquals('Text As Key', $this->translator->trans('Text As Key'));
+    }
+
+    public function testTranslateTextWithParams()
+    {
+        //Returns Translated value with params value
+        $this->translator->setLocale('en');
+        $this->assertEquals(
+            strtr($this->translations['en']['text_params'],
+                [   '%Param1%' => 'First Parameter',
+                    '%Param2%' => 'Second Parameter'
+                ]
+            ),
+            $this->translator->trans('text_params',
+                [   '%Param1%' => 'First Parameter',
+                    '%Param2%' => 'Second Parameter'
+                ]
+            )
+        );
+
+        //Returns Fallback("en") value with params value
+        $this->translator->setLocale('de');
+        $this->assertEquals(
+            strtr($this->translations['en']['text_params'],
+                [   '%Param1%' => 'First Parameter',
+                    '%Param2%' => 'Second Parameter'
+                ]
+            ),
+            $this->translator->trans('text_params',
+                [   '%Param1%' => 'First Parameter',
+                    '%Param2%' => 'Second Parameter'
+                ]
+            )
+        );
     }
 
     public function testTranslateWithCountParam()

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -78,8 +78,7 @@ class TranslatorTest extends TestCase
     {
         foreach ($this->locales as $locale => $fallback) {
             foreach ($this->translations[$locale] as $transKey => $trans) {
-                $t = new Website();
-                $t->setKey($transKey);
+                $t = Website::getByKey($transKey, true);
                 $t->addTranslation($locale, $trans ?? '');
                 $t->save();
             }

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -122,7 +122,6 @@ class TranslatorTest extends TestCase
         $this->translator->setLocale('de');
         $this->assertEquals($this->translations['en']['simple_key'], $this->translator->trans('Text As Key'));
 
-        p_r(\Pimcore\Tool::getFallbackLanguagesFor("fr")); die;
         //Returns Key value (no translation + no fallback)
 //        $this->translator->setLocale('fr');
 //        $this->assertEquals('Text As Key', $this->translator->trans('Text As Key'));

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Tests\Unit\Translation;
+
+use Pimcore\Model\Translation\AbstractTranslation;
+use Pimcore\Model\Translation\Website;
+use Pimcore\Translation\Translator;
+use Pimcore\Tests\Test\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class TranslatorTest extends TestCase
+{
+    /** @var Translator */
+    protected $translator;
+
+    /**
+     * ['locale' => 'fallback']
+     *
+     * @var array
+     */
+    protected $locales = [
+        'en' => '',
+        'de' => 'en',
+        'fr' => '',
+    ];
+
+    protected $translations = [
+        'en' => [
+            'simple_key' => 'EN Text',
+            'Text As Key' => 'EN Text',
+        ],
+        'de' => [
+            'simple_key' => 'DE Text',
+            'Text As Key' => '',
+        ],
+        'fr' => [
+            'simple_key' => 'FR Text',
+            'Text As Key' => '',
+        ]
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->translator = \Pimcore::getContainer()->get(TranslatorInterface::class);
+        $this->addTranslations();
+    }
+
+    protected function tearDown()
+    {
+        $this->removeTranslations();
+        parent::tearDown();
+    }
+
+    private function addTranslations()
+    {
+        foreach ($this->locales as $locale => $fallback) {
+            foreach ($this->translations[$locale] as $transKey => $trans) {
+                $t = new Website();
+                $t->setKey($transKey);
+                $t->addTranslation($locale, $trans ?? '');
+                $t->save();
+            }
+        }
+    }
+
+    private function removeTranslations()
+    {
+        foreach ($this->locales as $locale => $fallback) {
+            foreach ($this->translations[$locale] as $transKey => $trans) {
+                $t = Website::getByKey($transKey);
+                if ($t instanceof Website) {
+                   $t->delete();
+                }
+            }
+        }
+    }
+
+    public function testTranslateSimpleText()
+    {
+        //Translate en
+        $this->translator->setLocale('en');
+        $this->assertEquals($this->translations['en']['simple_key'], $this->translator->trans('simple_key'));
+
+        //Translate de
+        $this->translator->setLocale('de');
+        $this->assertEquals($this->translations['de']['simple_key'], $this->translator->trans('simple_key'));
+
+        //Translate fr
+        $this->translator->setLocale('fr');
+        $this->assertEquals($this->translations['fr']['simple_key'], $this->translator->trans('simple_key'));
+    }
+
+    public function testTranslateTextAsKey()
+    {
+        //Returns Translated value
+        $this->translator->setLocale('en');
+        $this->assertEquals($this->translations['en']['Text As Key'], $this->translator->trans('Text As Key'));
+
+        //Returns Fallback value
+        $this->translator->setLocale('de');
+        $this->assertEquals($this->translations['en']['simple_key'], $this->translator->trans('Text As Key'));
+
+        //Returns Key value (no translation + no fallback)
+        $this->translator->setLocale('fr');
+        $this->assertEquals('Text As Key', $this->translator->trans('Text As Key'));
+    }
+}

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -122,9 +122,10 @@ class TranslatorTest extends TestCase
         $this->translator->setLocale('de');
         $this->assertEquals($this->translations['en']['simple_key'], $this->translator->trans('Text As Key'));
 
+        p_r(\Pimcore\Tool::getFallbackLanguagesFor("fr")); die;
         //Returns Key value (no translation + no fallback)
-        $this->translator->setLocale('fr');
-        $this->assertEquals('Text As Key', $this->translator->trans('Text As Key'));
+//        $this->translator->setLocale('fr');
+//        $this->assertEquals('Text As Key', $this->translator->trans('Text As Key'));
     }
 
     public function testTranslateWithCountParam()


### PR DESCRIPTION
## Changes in this pull request  
Resolves #8117 

## Additional info  

