### PR TITLE
Opcache Preloading Integration

### DIFF
--- a/bundles/CoreBundle/Resources/config/services.yml
+++ b/bundles/CoreBundle/Resources/config/services.yml
@@ -40,6 +40,11 @@ services:
         tags:
             - { name: kernel.cache_warmer }
 
+    Pimcore\HttpKernel\CacheWarmer\PimcoreCoreCacheWarmer:
+        public: false
+        tags:
+            - { name: kernel.cache_warmer }
+
     Pimcore\Cache\Symfony\CacheClearer:
         public: true
 

--- a/lib/HttpKernel/CacheWarmer/PimcoreCoreCacheWarmer.php
+++ b/lib/HttpKernel/CacheWarmer/PimcoreCoreCacheWarmer.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\HttpKernel\CacheWarmer;
+
+use Pimcore\Model\DataObject;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+class PimcoreCoreCacheWarmer implements CacheWarmerInterface
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function isOptional()
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function warmUp($cacheDir)
+    {
+        $classes = [];
+
+        // load all data object classes
+        $list = new DataObject\ClassDefinition\Listing();
+        $list = $list->load();
+
+        foreach ($list as $classDefinition) {
+            $className = DataObject::class . '\\' . ucfirst($classDefinition->getName());
+            $listingClass = $className . '\\Listing';
+
+            $classes[] = $className;
+            $classes[] = $listingClass;
+        }
+
+
+        $list = new DataObject\Objectbrick\Definition\Listing();
+        $list = $list->load();
+
+        foreach ($list as $brickDefinition) {
+            $className = 'Pimcore\\Model\\DataObject\\Objectbrick\\Data' . ucfirst($brickDefinition->getKey());
+
+            $classes[] = $className;
+        }
+
+        $list = new DataObject\Fieldcollection\Definition\Listing();
+        $list = $list->load();
+
+        foreach ($list as $fcDefinition) {
+            $className = 'Pimcore\\Model\\DataObject\\Fieldcollection\\Data' . ucfirst($fcDefinition->getKey());
+
+            $classes[] = $className;
+        }
+
+
+        return $classes;
+    }
+}


### PR DESCRIPTION
resolves #5387

Usage see: https://symfony.com/doc/current/performance.html#use-the-opcache-class-preloading

`memory_limit` should be set to at least `200M` when using preloading with Pimcore. 
Most of the classes used by Pimcore and not used as Symfony services should be covered. 