### PR TITLE
Translation fallback kicks in on valid translation

### DIFF
--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -294,7 +294,7 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
         } elseif ($normalizedId == $translated) {
             if ($this->getCatalogue($locale)->has($normalizedId, $domain)) {
                 $translated = $this->getCatalogue($locale)->get($normalizedId, $domain);
-                if ($normalizedId != $translated && $translated) {
+                if ($translated) {
                     return $translated;
                 }
             } elseif ($backend = $this->getBackendForDomain($domain)) {


### PR DESCRIPTION
Scenario:
Translation Key (EN): "Stock"
Translations:
* DE: Lager
* FR: Stock

A call with FR as locale to translator resolves this to "Lager"!
This is because `\Pimcore\Translation\Translator::checkForEmptyTranslation()` triggers the language fallback handler if the translation key and the translated value match.
I think the translator tries to do to much here - if locale catalogue has a value for the key, the value should be used and not necessarily further fiddled with.
Even checking if the value is non empty might be already to much post processing in terms of expected behavior - it means that you can't "hide" / "remove" an irrelevant translation in a language.

Obviously you could workaround by using a dedicated translation key - but insisting on that would likely collide with a loooot of real world usage (https://symfony.com/doc/current/translation.html#using-real-or-keyword-messages).