### PR TITLE
[BUGFIX] fix format() of Grid DateFormatter

### DIFF
--- a/lib/DataObject/GridColumnConfig/Operator/DateFormatter.php
+++ b/lib/DataObject/GridColumnConfig/Operator/DateFormatter.php
@@ -89,7 +89,7 @@ class DateFormatter extends AbstractOperator
     {
         $timestamp = null;
         if (is_int($theValue)) {
-            $timestamp = Carbon::createFromTimestamp($theValue);
+            $theValue = Carbon::createFromTimestamp($theValue);
         }
         if ($theValue instanceof Carbon) {
             $timestamp = $theValue->getTimestamp();


### PR DESCRIPTION
## Changes in this pull request  

Steps to reproduce
Using DateFormatter in DataObject Grid failed.

If `$theValue` was an `int` it would have been returned as such when no `$this->format` is not defined and resulted in an error otherwise because `date()` was passed a `Carbon` instance instead of an `int` timestamp. This fixes it.
