### PR TITLE
[Application Logger] Stream log file object

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/LogController.php
+++ b/bundles/AdminBundle/Controller/Admin/LogController.php
@@ -23,6 +23,7 @@ use Pimcore\Log\Handler\ApplicationLoggerDb;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Routing\Annotation\Route;

--- a/bundles/AdminBundle/Controller/Admin/LogController.php
+++ b/bundles/AdminBundle/Controller/Admin/LogController.php
@@ -250,6 +250,7 @@ class LogController extends AdminController implements KernelControllerEventInte
                 static function () use ($filePath) {
                     $handle = fopen($filePath, 'rb');
                     fpassthru($handle);
+                    fclose($handle);
                 }
             );
             $response->headers->set('Content-Type', 'text/plain');


### PR DESCRIPTION
When the log file object is very big memory problems can arise with `file_get_contents()`. With this PR the log file gets streamed to prevent this.