### PR TITLE
[Thumbnails] Performance improvements for cleaning thumbnails

### DIFF
--- a/bundles/CoreBundle/Command/ThumbnailsClearCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsClearCommand.php
@@ -63,9 +63,9 @@ class ThumbnailsClearCommand extends AbstractCommand
         /** @var Asset\Image\Thumbnail\Config|Asset\Video\Thumbnail\Config $thumbConfig */
         $thumbConfig = $configClass::getByName($input->getOption('name'));
         if (!$thumbConfig) {
-            $this->writeError(sprintf('Unable to find %s thumbnail config with name: %s', $input->getOption('type'), $input->getOption('name')));
-
-            return 1;
+            $this->writeError(sprintf('Unable to find %s thumbnail config with name: %s. Nevertheless trying to delete remaining files', $input->getOption('type'), $input->getOption('name')));
+            $thumbConfig = new $configClass();
+            $thumbConfig->setName($input->getOption('name'));
         }
 
         $thumbConfig->clearTempFiles();

--- a/doc/Development_Documentation/07_Workflow_Management/09_Working_with_PHP_API.md
+++ b/doc/Development_Documentation/07_Workflow_Management/09_Working_with_PHP_API.md
@@ -25,7 +25,7 @@ $workflow = $workflowRegistry->get($object, 'workflow');
 
 if($workflow->can($object, 'content_ready')) {
 
-    //modify workflow via Symfony APi and without saving additional data
+    //modify workflow via Symfony API and without saving additional data
     $workflow->apply($object, 'content_ready');
     
     //make sure you save the workflow subject afterwards if any data was changed during transition 

--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -24,7 +24,7 @@ use Pimcore\Tool\Serialize;
 /**
  * @method \Pimcore\Model\Asset\Image\Thumbnail\Config\Dao getDao()
  * @method void save(bool $forceClearTempFiles = false)
- * @method void delete()
+ * @method void delete(bool $forceClearTempFiles = false)
  */
 class Config extends Model\AbstractModel
 {

--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -23,7 +23,7 @@ use Pimcore\Tool\Serialize;
 
 /**
  * @method \Pimcore\Model\Asset\Image\Thumbnail\Config\Dao getDao()
- * @method void save()
+ * @method void save(bool $autoClearThumbnails = true)
  * @method void delete()
  */
 class Config extends Model\AbstractModel

--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -23,7 +23,7 @@ use Pimcore\Tool\Serialize;
 
 /**
  * @method \Pimcore\Model\Asset\Image\Thumbnail\Config\Dao getDao()
- * @method void save(bool $autoClearThumbnails = true)
+ * @method void save(bool $forceClearTempFiles = false)
  * @method void delete()
  */
 class Config extends Model\AbstractModel

--- a/models/Asset/Image/Thumbnail/Config/Dao.php
+++ b/models/Asset/Image/Thumbnail/Config/Dao.php
@@ -128,14 +128,12 @@ class Dao extends Model\Dao\PhpArrayTable
         $enabled = \Pimcore::getContainer()->getParameter('pimcore.config')['assets']['image']['thumbnails']['auto_clear_temp_files'];
         if ($enabled) {
             $arguments = [
-                Console::getPhpCli(),
-                PIMCORE_PROJECT_ROOT.'/bin/console',
                 'pimcore:thumbnails:clear',
                 '--type=image',
                 '--name='.$this->model->getName()
             ];
 
-            Console::execInBackground(implode(' ', $arguments));
+            Console::runPhpScriptInBackground(realpath(PIMCORE_PROJECT_ROOT.DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'console'), implode(' ', $arguments));
         }
     }
 }

--- a/models/Asset/Image/Thumbnail/Config/Dao.php
+++ b/models/Asset/Image/Thumbnail/Config/Dao.php
@@ -132,7 +132,7 @@ class Dao extends Model\Dao\PhpArrayTable
                 '--name='.$this->model->getName()
             ];
 
-            Console::runPhpScriptInBackground(realpath(PIMCORE_PROJECT_ROOT.DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'console'), implode(' ', $arguments));
+            Console::runPhpScriptInBackground(realpath(PIMCORE_PROJECT_ROOT.DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'console'), $arguments);
         }
     }
 }

--- a/models/Asset/Image/Thumbnail/Config/Dao.php
+++ b/models/Asset/Image/Thumbnail/Config/Dao.php
@@ -98,7 +98,7 @@ class Dao extends Model\Dao\PhpArrayTable
             $thumbnailDefinitionAlreadyExisted = $this->db->getById($this->model->getName()) !== null;
             $this->db->insertOrUpdate($data, $this->model->getName());
 
-            if (!$thumbnailDefinitionAlreadyExisted) {
+            if ($thumbnailDefinitionAlreadyExisted) {
                 $this->autoClearTempFiles();
             }
         }

--- a/models/Asset/Image/Thumbnail/Config/Dao.php
+++ b/models/Asset/Image/Thumbnail/Config/Dao.php
@@ -18,6 +18,8 @@
 namespace Pimcore\Model\Asset\Image\Thumbnail\Config;
 
 use Pimcore\Model;
+use Pimcore\Tool\Console;
+use Symfony\Component\Process\Process;
 
 /**
  * @internal
@@ -106,7 +108,16 @@ class Dao extends Model\Dao\PhpArrayTable
     {
         $enabled = \Pimcore::getContainer()->getParameter('pimcore.config')['assets']['image']['thumbnails']['auto_clear_temp_files'];
         if ($enabled) {
-            $this->model->clearTempFiles();
+            $arguments = [
+                Console::getPhpCli(),
+                PIMCORE_PROJECT_ROOT.'/bin/console',
+                'pimcore:thumbnails:clear',
+                'image',
+                $this->model->getName()
+            ];
+
+            $process = new Process($arguments);
+            $process->start();
         }
     }
 }

--- a/models/Asset/Image/Thumbnail/Config/Dao.php
+++ b/models/Asset/Image/Thumbnail/Config/Dao.php
@@ -93,15 +93,19 @@ class Dao extends Model\Dao\PhpArrayTable
         }
 
         if($forceClearTempFiles) {
+            $this->db->insertOrUpdate($data, $this->model->getName());
             $this->model->clearTempFiles();
         } else {
             $thumbnailDefinitionAlreadyExisted = $this->db->getById($this->model->getName()) !== null;
+
             $this->db->insertOrUpdate($data, $this->model->getName());
 
             if ($thumbnailDefinitionAlreadyExisted) {
                 $this->autoClearTempFiles();
             }
         }
+
+
     }
 
     /**

--- a/models/Asset/Image/Thumbnail/Config/Dao.php
+++ b/models/Asset/Image/Thumbnail/Config/Dao.php
@@ -112,8 +112,8 @@ class Dao extends Model\Dao\PhpArrayTable
                 Console::getPhpCli(),
                 PIMCORE_PROJECT_ROOT.'/bin/console',
                 'pimcore:thumbnails:clear',
-                'image',
-                $this->model->getName()
+                '--type=image',
+                '--name='.$this->model->getName()
             ];
 
             $process = new Process($arguments);

--- a/models/Asset/Image/Thumbnail/Config/Dao.php
+++ b/models/Asset/Image/Thumbnail/Config/Dao.php
@@ -120,8 +120,7 @@ class Dao extends Model\Dao\PhpArrayTable
                 '--name='.$this->model->getName()
             ];
 
-            $process = new Process($arguments);
-            $process->start();
+            Console::execInBackground(implode(' ', $arguments));
         }
     }
 }

--- a/models/Asset/Image/Thumbnail/Config/Dao.php
+++ b/models/Asset/Image/Thumbnail/Config/Dao.php
@@ -114,6 +114,8 @@ class Dao extends Model\Dao\PhpArrayTable
 
         if($forceClearTempFiles) {
             $this->model->clearTempFiles();
+        } else {
+            $this->autoClearTempFiles();
         }
     }
 

--- a/models/Asset/Image/Thumbnail/Config/Dao.php
+++ b/models/Asset/Image/Thumbnail/Config/Dao.php
@@ -91,8 +91,12 @@ class Dao extends Model\Dao\PhpArrayTable
             }
         }
 
+        $thumbnailDefinitionAlreadyExisted = $this->db->getById($this->model->getName()) !== null;
         $this->db->insertOrUpdate($data, $this->model->getName());
-        $this->autoClearTempFiles();
+
+        if(!$thumbnailDefinitionAlreadyExisted) {
+            $this->autoClearTempFiles();
+        }
     }
 
     /**

--- a/models/Asset/Image/Thumbnail/Config/Dao.php
+++ b/models/Asset/Image/Thumbnail/Config/Dao.php
@@ -71,7 +71,7 @@ class Dao extends Model\Dao\PhpArrayTable
     /**
      * @throws \Exception
      */
-    public function save()
+    public function save($autoClearThumbnails = true)
     {
         $ts = time();
         if (!$this->model->getCreationDate()) {
@@ -94,7 +94,7 @@ class Dao extends Model\Dao\PhpArrayTable
         $thumbnailDefinitionAlreadyExisted = $this->db->getById($this->model->getName()) !== null;
         $this->db->insertOrUpdate($data, $this->model->getName());
 
-        if(!$thumbnailDefinitionAlreadyExisted) {
+        if(!$thumbnailDefinitionAlreadyExisted && $autoClearThumbnails) {
             $this->autoClearTempFiles();
         }
     }
@@ -102,10 +102,13 @@ class Dao extends Model\Dao\PhpArrayTable
     /**
      * Deletes object from database
      */
-    public function delete()
+    public function delete($autoClearThumbnails = true)
     {
         $this->db->delete($this->model->getName());
-        $this->autoClearTempFiles();
+
+        if($autoClearThumbnails) {
+            $this->autoClearTempFiles();
+        }
     }
 
     protected function autoClearTempFiles()

--- a/models/Asset/Image/Thumbnail/Config/Dao.php
+++ b/models/Asset/Image/Thumbnail/Config/Dao.php
@@ -69,9 +69,10 @@ class Dao extends Model\Dao\PhpArrayTable
     }
 
     /**
+     * @param bool $forceClearTempFiles force removing generated thumbnail files of saved thumbnail config
      * @throws \Exception
      */
-    public function save($autoClearThumbnails = true)
+    public function save($forceClearTempFiles = false)
     {
         $ts = time();
         if (!$this->model->getCreationDate()) {
@@ -91,23 +92,28 @@ class Dao extends Model\Dao\PhpArrayTable
             }
         }
 
-        $thumbnailDefinitionAlreadyExisted = $this->db->getById($this->model->getName()) !== null;
-        $this->db->insertOrUpdate($data, $this->model->getName());
+        if($forceClearTempFiles) {
+            $this->model->clearTempFiles();
+        } else {
+            $thumbnailDefinitionAlreadyExisted = $this->db->getById($this->model->getName()) !== null;
+            $this->db->insertOrUpdate($data, $this->model->getName());
 
-        if(!$thumbnailDefinitionAlreadyExisted && $autoClearThumbnails) {
-            $this->autoClearTempFiles();
+            if (!$thumbnailDefinitionAlreadyExisted) {
+                $this->autoClearTempFiles();
+            }
         }
     }
 
     /**
      * Deletes object from database
+     * @param bool $forceClearTempFiles force removing generated thumbnail files of saved thumbnail config
      */
-    public function delete($autoClearThumbnails = true)
+    public function delete($forceClearTempFiles = false)
     {
         $this->db->delete($this->model->getName());
 
-        if($autoClearThumbnails) {
-            $this->autoClearTempFiles();
+        if($forceClearTempFiles) {
+            $this->model->clearTempFiles();
         }
     }
 

--- a/models/Asset/Thumbnail/ClearTempFilesTrait.php
+++ b/models/Asset/Thumbnail/ClearTempFilesTrait.php
@@ -34,7 +34,7 @@ trait ClearTempFilesTrait
 
         /** @var \SplFileInfo $fileInfo */
         foreach (new \RecursiveIteratorIterator($directoryIterator, \RecursiveIteratorIterator::SELF_FIRST, \RecursiveIteratorIterator::CATCH_GET_CHILD) as $fileInfo) {
-            if (preg_match('@^(image|video)-thumb__[\d]+__'.$thumbnail.'(?:_auto_.+)?$@', $fileInfo->getFilename(), $matches) && is_dir($fileInfo->getPathname())) {
+            if (preg_match('@^(image|video)-thumb__[\d]+__'.$thumbnail.'(?:_auto_.+)?$@', $fileInfo->getFilename(), $matches) && $fileInfo->isDir()) {
                 recursiveDelete($fileInfo->getPathname());
             }
         }

--- a/models/Asset/Thumbnail/ClearTempFilesTrait.php
+++ b/models/Asset/Thumbnail/ClearTempFilesTrait.php
@@ -34,13 +34,8 @@ trait ClearTempFilesTrait
 
         /** @var \SplFileInfo $fileInfo */
         foreach (new \RecursiveIteratorIterator($directoryIterator, \RecursiveIteratorIterator::SELF_FIRST, \RecursiveIteratorIterator::CATCH_GET_CHILD) as $fileInfo) {
-            if ($fileInfo->isDir()) {
-                if (
-                    preg_match('@/(image|video)\-thumb__[\d]+__' . $thumbnail . '$@', $fileInfo->getPathname(), $matches) ||
-                    preg_match('@/(image|video)\-thumb__[\d]+__' . $thumbnail . '_auto_@', $fileInfo->getPathname(), $matches)
-                ) {
-                    recursiveDelete($fileInfo->getPathname());
-                }
+            if (preg_match('@^(image|video)-thumb__[\d]+__'.$thumbnail.'(?:_auto_.+)?$@', $fileInfo->getFilename(), $matches) && is_dir($fileInfo->getPathname())) {
+                recursiveDelete($fileInfo->getPathname());
             }
         }
 

--- a/tests/_support/Util/TestHelper.php
+++ b/tests/_support/Util/TestHelper.php
@@ -922,7 +922,7 @@ class TestHelper
             $pipe = new Asset\Image\Thumbnail\Config();
             $pipe->setName($name);
             $pipe->addItem('rotate', ['angle' => $angle], 'default');
-            $pipe->save(false);
+            $pipe->save(true);
             self::$thumbnail_configs[] = $name;
         }
 
@@ -945,7 +945,7 @@ class TestHelper
             $pipe = new Asset\Image\Thumbnail\Config($name);
             $pipe->setName($name);
             $pipe->addItem('scaleByWidth', ['width' => $width, 'forceResize' => $forceResize], 'default');
-            $pipe->save(false);
+            $pipe->save(true);
             self::$thumbnail_configs[] = $name;
         }
 

--- a/tests/_support/Util/TestHelper.php
+++ b/tests/_support/Util/TestHelper.php
@@ -896,7 +896,7 @@ class TestHelper
     {
         $pipe = Asset\Image\Thumbnail\Config::getByName($name);
         if ($pipe) {
-            $pipe->delete();
+            $pipe->delete(false);
         }
     }
 
@@ -922,7 +922,7 @@ class TestHelper
             $pipe = new Asset\Image\Thumbnail\Config();
             $pipe->setName($name);
             $pipe->addItem('rotate', ['angle' => $angle], 'default');
-            $pipe->save();
+            $pipe->save(false);
             self::$thumbnail_configs[] = $name;
         }
 
@@ -945,7 +945,7 @@ class TestHelper
             $pipe = new Asset\Image\Thumbnail\Config($name);
             $pipe->setName($name);
             $pipe->addItem('scaleByWidth', ['width' => $width, 'forceResize' => $forceResize], 'default');
-            $pipe->save();
+            $pipe->save(false);
             self::$thumbnail_configs[] = $name;
         }
 

--- a/tests/_support/Util/TestHelper.php
+++ b/tests/_support/Util/TestHelper.php
@@ -896,7 +896,7 @@ class TestHelper
     {
         $pipe = Asset\Image\Thumbnail\Config::getByName($name);
         if ($pipe) {
-            $pipe->delete(false);
+            $pipe->delete(true);
         }
     }
 


### PR DESCRIPTION
This PR merges the 2 regular expressions and uses `SplFileInfo::getFilename()` for the check. I also moved the `isDir()` call after the regular expression check because file system calls can be quite slow - especially when using stream wrappers (we currently have > 100000 files in Google Cloud Storage).

And the cleanup of temporary files is delegated to `pimcore:thumbnails:clear` command in the background.

PS: I actually tried to enhance performance even more but as https://github.com/googleapis/google-cloud-php-storage does currently not support `glob` operations we really have to loop through every asset. It is especially bad that the iterator also returns files but I did not find a way to change this (tried RecursiveCallbackFilterIterator but this has to return `true` for all directories, otherwise recursion does not work).