### PR TITLE
Fix getDefaultConfig of imagegallery.js overwriting previously set configuration

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/imagegallery.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/imagegallery.js
@@ -107,7 +107,6 @@ pimcore.object.tags.imageGallery = Class.create(pimcore.object.tags.abstract, {
         var fieldConfig = Object.assign({}, this.fieldConfig, {
             width: itemWidth,
             height: itemHeight,
-            uploadPath: this.fieldConfig.uploadPath
         });
     
         return fieldConfig;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/imagegallery.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/imagegallery.js
@@ -103,13 +103,13 @@ pimcore.object.tags.imageGallery = Class.create(pimcore.object.tags.abstract, {
     getDefaultFieldConfig: function () {
         var itemWidth = this.fieldConfig.width ? this.fieldConfig.width : 150;
         var itemHeight = this.fieldConfig.height ? this.fieldConfig.height : 150;
-
-        var fieldConfig = {
+    
+        var fieldConfig = Object.assign({}, this.fieldConfig, {
             width: itemWidth,
             height: itemHeight,
-            uploadPath: this.fieldConfig.uploadPath,
-        };
-
+            uploadPath: this.fieldConfig.uploadPath
+        });
+    
         return fieldConfig;
     },
 


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/` -> target branch `master`
- [x] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [x] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [x] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

The `getDefaultFieldConfig` function of `imagegallery.js` returns a fieldConfig object that doesn't take the previously set configuration in consideration. This is problematic since this config gets passed to the hotspotimage constructor in line 146.
E.g. When a "predefined data template" is present on the ImageGallery this template will not be passed to the hotspot image and so will not be taken into account inside of `hotspotimage.js`.


```js
// imagegallery.js
  var fieldConfig = this.getDefaultFieldConfig();
  var hotspotImage = new pimcore.object.tags.hotspotimage(itemData, fieldConfig, this.hotspotConfig);
 ```
 ```js
 // hotspotimage.js
  if (fieldConfig.predefinedDataTemplates) {
    try {
      this.predefinedDataTemplates = Ext.decode(fieldConfig.predefinedDataTemplates);
    } catch (e) {
      console.log(e);
    }
  }
 ```
 
 In this example the `predefinedDataTemplates` option of `hotspotimage` will be null, since the `getDefaultConfig` function doesn't return the full fieldConfig object. This is probably not intended since the opened edit window of the Hotspotimage will not contain the definied config.
 
 This PR aims to fix this issue by assigning all previously set configuration options to the fieldConfig object inside of `getDefaultFieldConfig` .