### PR TITLE
Fix recycle-bin restore for objects with non-existent parent

### DIFF
--- a/models/Element/Recyclebin/Item.php
+++ b/models/Element/Recyclebin/Item.php
@@ -156,7 +156,7 @@ class Item extends Model\AbstractModel
 
         if (\Pimcore\Tool\Admin::getCurrentUser()) {
             $parent = $element->getParent();
-            if (!$parent->isAllowed('publish')) {
+            if ($parent && !$parent->isAllowed('publish')) {
                 throw new \Exception('Not sufficient permissions');
             }
         }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #8236

## Additional info  

