### PR TITLE
Query builder missing condition variables

### DIFF
--- a/lib/Model/Listing/Dao/QueryBuilderHelperTrait.php
+++ b/lib/Model/Listing/Dao/QueryBuilderHelperTrait.php
@@ -76,7 +76,8 @@ trait QueryBuilderHelperTrait
         }
 
         if ($condition) {
-            $queryBuilder->where($condition);
+            $queryBuilder->where($condition)
+                ->setParameters($this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
         }
     }
 

--- a/models/DataObject/Listing/Dao.php
+++ b/models/DataObject/Listing/Dao.php
@@ -90,7 +90,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
         $queryBuilder = $this->getQueryBuilder();
         $this->prepareQueryBuilderForTotalCount($queryBuilder);
 
-        $totalCount = $this->db->fetchOne($queryBuilder, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
+        $totalCount = $this->db->fetchOne((string) $queryBuilder, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         return (int) $totalCount;
     }


### PR DESCRIPTION
Doing $list->getQuery()->execute() where $list is DataObject\Listing would fail because conditionVariables weren't set in QueryBuilder