### PR TITLE
Fixes Unique constraint violation on UrlSlugs

### DIFF
--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -264,7 +264,7 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
 
                 /* relation needs to be an array with src_id, dest_id, type, fieldname*/
                 try {
-                    $db->insert('object_url_slugs', $slug);
+                    $db->insertOrUpdate('object_url_slugs', $slug);
                 } catch (\Exception $e) {
                     Logger::error($e);
                     if ($e instanceof UniqueConstraintViolationException) {


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Upon saving a *product variant* this would throw an error even if it was actually unique: `Unique constraint violated. Slug already used by object` which resolved the issue



