### PR TITLE
[UI] Increase timeout of buildDefaultStore

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers/generic-grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers/generic-grid.js
@@ -22,6 +22,7 @@ pimcore.helpers.grid.buildDefaultStore = function (url, fields, itemsPerPage, cu
     }
 
     var proxy = new Ext.data.proxy.Ajax({
+        timeout: 120000,
         batchActions: false,
         type: 'ajax',
         reader: {


### PR DESCRIPTION
# Enhancement

I suggest to increase the default timeout of proxy stores created via `pimcore.helpers.grid.buildDefaultStore` from 30s to 120s.

This is espcially useful for `/chart` or `/data` requests of custom report, which may take longer depending on the implementation.

 
![image](https://user-images.githubusercontent.com/9052094/109291439-487bd780-7829-11eb-8022-5d5a6ccf5747.png)


