### PR TITLE
[Data Objects] Fieldcollection with Localized Fields deletes and overwrites content after unpublished save

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/localizedfields.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/localizedfields.js
@@ -492,6 +492,7 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
     getValue: function () {
         var localizedData = {};
         var currentLanguage;
+        var ignoreIsDirty = ['fieldcollection'].includes(this.getContext().containerType)
 
         for (var i = 0; i < this.frontendLanguages.length; i++) {
             currentLanguage = this.frontendLanguages[i];
@@ -502,8 +503,7 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
 
             for (var s = 0; s < this.languageElements[currentLanguage].length; s++) {
                 try {
-
-                    if (this.languageElements[currentLanguage][s].isDirty()) {
+                    if (ignoreIsDirty || this.languageElements[currentLanguage][s].isDirty()) {
                         localizedData[currentLanguage][this.languageElements[currentLanguage][s].getName()]
                             = this.languageElements[currentLanguage][s].getValue();
                     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/localizedfields.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/localizedfields.js
@@ -492,7 +492,7 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
     getValue: function () {
         var localizedData = {};
         var currentLanguage;
-        var ignoreIsDirty = ['fieldcollection','block'].includes(this.getContext().containerType)
+        var ignoreIsDirty = ['fieldcollection'].includes(this.getContext().containerType) || ['block'].includes(this.getContext().subContainerType);
 
         for (var i = 0; i < this.frontendLanguages.length; i++) {
             currentLanguage = this.frontendLanguages[i];

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/localizedfields.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/localizedfields.js
@@ -492,7 +492,7 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
     getValue: function () {
         var localizedData = {};
         var currentLanguage;
-        var ignoreIsDirty = ['fieldcollection'].includes(this.getContext().containerType)
+        var ignoreIsDirty = ['fieldcollection','block'].includes(this.getContext().containerType)
 
         for (var i = 0; i < this.frontendLanguages.length; i++) {
             currentLanguage = this.frontendLanguages[i];


### PR DESCRIPTION
## Changes in this pull request  
Resolves #7974

## Additional info  
Fieldcollections and Blocks always send their data without checking if content isDirty, but a LocalizedFields element itself checks again the isDirty() function of its children.

Therefore, a small check of the context container allows to ignore the isDirty() function of LocalizedFields in Fieldcollections and Blocks.