### PR TITLE
AbstractOrderList:getItems doesn't match interface

### DIFF
--- a/bundles/EcommerceFrameworkBundle/OrderManager/AbstractOrderList.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/AbstractOrderList.php
@@ -126,7 +126,7 @@ abstract class AbstractOrderList implements OrderListInterface
     }
 
     /**
-     * @return OrderListItemInterface[]
+     * @return OrderListInterface
      */
     public function load()
     {
@@ -164,9 +164,8 @@ abstract class AbstractOrderList implements OrderListInterface
     public function getItems($offset, $itemCountPerPage)
     {
         // load
-        return $this
-            ->setLimit($itemCountPerPage, $offset)
-            ->load();
+        $this->setLimit($itemCountPerPage, $offset)->load();
+        return $this->list->getArrayCopy();
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/OrderManager/OrderListInterface.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/OrderListInterface.php
@@ -35,7 +35,7 @@ interface OrderListInterface extends SeekableIterator, ArrayAccess, PaginateList
     public function getQueryBuilder(): DoctrineQueryBuilder;
 
     /**
-     * @return \Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\OrderListItemInterface[]
+     * @return OrderListInterface
      */
     public function load();
 


### PR DESCRIPTION
fixed #8261

related to #8118