### PR TITLE
Updated incorrect link in documentation

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/01_V5_to_V6.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/01_V5_to_V6.md
@@ -73,7 +73,7 @@ Alternatively you can add the database configuration directly to your project's 
 or any other loaded config file. 
 
 #### Update your `web/app.php`
-Update your `web/app.php` to the latest available version here: [https://raw.githubusercontent.com/pimcore/skeleton/067de35ebc629607eefc5a5240fe61a7c83f908f/web/app.php](https://raw.githubusercontent.com/pimcore/skeleton/067de35ebc629607eefc5a5240fe61a7c83f908f/web/app.php)
+Update your `web/app.php` to the latest available version here: [https://raw.githubusercontent.com/pimcore/skeleton/2.8/web/app.php](https://raw.githubusercontent.com/pimcore/skeleton/2.8/web/app.php)
 
 #### Update your Config
 If your're using `pimcore_admin.dataObjects` in your config, please rename `dataObjects` to `objects`. 


### PR DESCRIPTION
This PR updates the link in the documentation for [updating from V5 to V6](https://pimcore.com/docs/pimcore/current/Development_Documentation/Installation_and_Upgrade/Updating_Pimcore/V5_to_V6.html#page_Update-your).