### PR TITLE
AND NOT condition needs to consider existing state

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PricingManager/Condition/Bracket.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Condition/Bracket.php
@@ -95,7 +95,8 @@ class Bracket implements BracketInterface
                     if ($check === true) {
                         return false;
                     } else {
-                        $state = true;
+                        //consider current state with check, if not default.
+                        $state = ($state === null) ? !$check : (!$check && $state);
                     }
                     break;
 


### PR DESCRIPTION
I think this hunk was missed during the refactoring by #8148
An AND  condition always has to consider the existing state if available no matter if AND or AND NOT.
Not sure if this is somehow related to #7855 - unlikely due to timeline but sound somewhat familiar.