### PR TITLE
[Ecommerce] Fix pricing rule save misleading result message

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/item.js
+++ b/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/item.js
@@ -426,7 +426,7 @@ pimcore.bundle.EcommerceFramework.pricing.config.item = Class.create({
     /**
      * saved
      */
-    saveOnComplete: function () {
+    saveOnComplete: function (response) {
         this.parent.refresh(this.parent.getTree().getRootNode());
 
         var response = Ext.decode(response.responseText);

--- a/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/item.js
+++ b/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/item.js
@@ -428,7 +428,14 @@ pimcore.bundle.EcommerceFramework.pricing.config.item = Class.create({
      */
     saveOnComplete: function () {
         this.parent.refresh(this.parent.getTree().getRootNode());
-        pimcore.helpers.showNotification(t("success"), t("saved_successfully"), "success");
+
+        var response = Ext.decode(response.responseText);
+
+        if (response.success) {
+            pimcore.helpers.showNotification(t("success"), t("saved_successfully"), "success");
+        } else {
+            pimcore.helpers.showNotification(t("error"), t(response.message), "error", );
+        }
     },
 
     recalculateButtonStatus: function () {


### PR DESCRIPTION
# Bugfix

Clicking the save button inside a pricing rule's tab always showed a success notification, not considering the actual response. With this PR the returned result is taken into account and the response message is shown to the user.