### PR TITLE
Override isEmpty in Classificationstore.php

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -648,6 +648,20 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
     }
 
     /**
+     * @param DataObject\Classificationstore|null $data
+     *
+     * @return bool
+     */
+    public function isEmpty($data)
+    {
+        if ($data instanceof DataObject\Classificationstore) {
+            return empty($data->getItems());
+        }
+
+        return is_null($data);
+    }
+    
+    /**
      * @return array
      */
     public function getChildren()


### PR DESCRIPTION
When using variants that inherits classificationstores the overridden/inherited values is not fetched because isEmpty will check if the classificationstore object is empty/null - which it never is. Hence we need to override isEmpty (like all other Data-classes) and check if the classificationstores *items* are empty, not the object itself.
