### PR TITLE
Command pimcore:thumbnails:image / get thumbnail image of remotely stored assets

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -26,6 +26,7 @@ use Pimcore\Event\Admin\ElementAdminStyleEvent;
 use Pimcore\Event\AdminEvents;
 use Pimcore\Event\AssetEvents;
 use Pimcore\File;
+use Pimcore\Helper\TemporaryFileHelperTrait;
 use Pimcore\Loader\ImplementationLoader\Exception\UnsupportedException;
 use Pimcore\Logger;
 use Pimcore\Model;
@@ -52,6 +53,7 @@ class AssetController extends ElementControllerBase implements EventedController
     use AdminStyleTrait;
     use ElementEditLockHelperTrait;
     use ApplySchedulerDataTrait;
+    use TemporaryFileHelperTrait;
 
     /**
      * @var Asset\Service
@@ -1206,7 +1208,7 @@ class AssetController extends ElementControllerBase implements EventedController
             }
 
             $thumbnail = $image->getThumbnail($thumbnailConfig);
-            $thumbnailFile = $thumbnail->getFileSystemPath();
+            $thumbnailFile = $this->getLocalFile($thumbnail->getFileSystemPath());
 
             $exiftool = \Pimcore\Tool\Console::getExecutable('exiftool');
             if ($thumbnailConfig->getFormat() == 'JPEG' && $exiftool && isset($config['dpi']) && $config['dpi']) {

--- a/lib/Document/Adapter.php
+++ b/lib/Document/Adapter.php
@@ -15,9 +15,12 @@
 namespace Pimcore\Document;
 
 use Pimcore\File;
+use Pimcore\Helper\TemporaryFileHelperTrait;
 
 abstract class Adapter
 {
+    use TemporaryFileHelperTrait;
+
     /**
      * @var array
      */
@@ -30,14 +33,7 @@ abstract class Adapter
      */
     protected function preparePath($path)
     {
-        if (!stream_is_local($path)) {
-            // gs is only able to deal with local files
-            // if your're using custom stream wrappers this wouldn't work, so we create a temp. local copy
-            $tmpFilePath = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/imagick-tmp-' . uniqid() . '.' . File::getFileExtension($path);
-            copy($path, $tmpFilePath);
-            $path = $tmpFilePath;
-            $this->tmpFiles[] = $path;
-        }
+        $path = $this->getLocalFile($path);
 
         return $path;
     }

--- a/lib/Helper/TemporaryFileHelperTrait.php
+++ b/lib/Helper/TemporaryFileHelperTrait.php
@@ -5,7 +5,12 @@ use Pimcore\File;
 
 trait TemporaryFileHelperTrait
 {
-    private function getLocalFile($path) {
+    /**
+     * Get local file path of the given file or URL
+     * @param string $path file path or URL
+     * @return string path to local file
+     */
+    private function getLocalFile($path): string {
         if (!stream_is_local($path)) {
             $tmpFilename = 'tmpfile_'.md5($path).'.'.File::getFileExtension($path);
             $tmpFilePath = PIMCORE_SYSTEM_TEMP_DIRECTORY.'/'.$tmpFilename;

--- a/lib/Helper/TemporaryFileHelperTrait.php
+++ b/lib/Helper/TemporaryFileHelperTrait.php
@@ -1,6 +1,8 @@
 <?php
 namespace Pimcore\Helper;
 
+use Pimcore\File;
+
 trait TemporaryFileHelperTrait
 {
     private function getLocalFile($path) {

--- a/lib/Helper/TemporaryFileHelperTrait.php
+++ b/lib/Helper/TemporaryFileHelperTrait.php
@@ -1,0 +1,25 @@
+<?php
+namespace Pimcore\Helper;
+
+trait TemporaryFileHelperTrait
+{
+    private function getLocalFile($path) {
+        if (!stream_is_local($path)) {
+            $tmpFilename = 'tmpfile_'.md5($path).'.'.File::getFileExtension($path);
+            $tmpFilePath = PIMCORE_SYSTEM_TEMP_DIRECTORY.'/'.$tmpFilename;
+
+            register_shutdown_function(static function() use ($tmpFilePath) {
+                @unlink($tmpFilePath);
+            });
+
+            $src = fopen($path, 'rb');
+            $dest = fopen($tmpFilePath, 'wb', false, File::getContext());
+            stream_copy_to_stream($src, $dest);
+            fclose($dest);
+
+            $path = $tmpFilePath;
+        }
+
+        return $path;
+    }
+}

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -59,23 +59,19 @@ class Imagick extends Adapter
 
         // support image URLs
         if (!stream_is_local($imagePath)) {
-            if (isset($options['asset'])) {
-                // imagick is only able to deal with local files
-                // if your're using custom stream wrappers this wouldn't work, so we create a temp. local copy
-                $imagePath = $options['asset']->getTemporaryFile();
-            } else {
-                $tmpFilename = 'imagick_auto_download_'.md5($imagePath).'.'.File::getFileExtension($imagePath);
-                $tmpFilePath = PIMCORE_SYSTEM_TEMP_DIRECTORY.'/'.$tmpFilename;
+            // imagick is only able to deal with local files
+            // if your're using custom stream wrappers this wouldn't work, so we create a temp. local copy
+            $tmpFilename = 'imagick_auto_download_'.md5($imagePath).'.'.File::getFileExtension($imagePath);
+            $tmpFilePath = PIMCORE_SYSTEM_TEMP_DIRECTORY.'/'.$tmpFilename;
 
-                $this->tmpFiles[] = $tmpFilePath;
+            $this->tmpFiles[] = $tmpFilePath;
 
-                $src = fopen($imagePath, 'rb');
-                $dest = fopen($tmpFilePath, 'wb', false, File::getContext());
-                stream_copy_to_stream($src, $dest);
-                fclose($dest);
+            $src = fopen($imagePath, 'rb');
+            $dest = fopen($tmpFilePath, 'wb', false, File::getContext());
+            stream_copy_to_stream($src, $dest);
+            fclose($dest);
 
-                $imagePath = $tmpFilePath;
-            }
+            $imagePath = $tmpFilePath;
         }
 
         if (isset($options['asset']) && preg_match('@\.svgz?$@', $imagePath) && preg_match('@[^a-zA-Z0-9\-\.~_/]+@', $imagePath)) {

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -17,11 +17,14 @@ namespace Pimcore\Image\Adapter;
 use Pimcore\Cache;
 use Pimcore\Config;
 use Pimcore\File;
+use Pimcore\Helper\TemporaryFileHelperTrait;
 use Pimcore\Image\Adapter;
 use Pimcore\Logger;
 
 class Imagick extends Adapter
 {
+    use TemporaryFileHelperTrait;
+
     /**
      * @var string
      */
@@ -57,22 +60,7 @@ class Imagick extends Adapter
             $this->setPreserveColor($options['preserveColor']);
         }
 
-        // support image URLs
-        if (!stream_is_local($imagePath)) {
-            // imagick is only able to deal with local files
-            // if your're using custom stream wrappers this wouldn't work, so we create a temp. local copy
-            $tmpFilename = 'imagick_auto_download_'.md5($imagePath).'.'.File::getFileExtension($imagePath);
-            $tmpFilePath = PIMCORE_SYSTEM_TEMP_DIRECTORY.'/'.$tmpFilename;
-
-            $this->tmpFiles[] = $tmpFilePath;
-
-            $src = fopen($imagePath, 'rb');
-            $dest = fopen($tmpFilePath, 'wb', false, File::getContext());
-            stream_copy_to_stream($src, $dest);
-            fclose($dest);
-
-            $imagePath = $tmpFilePath;
-        }
+        $imagePath = $this->getLocalFile($imagePath);
 
         if (isset($options['asset']) && preg_match('@\.svgz?$@', $imagePath) && preg_match('@[^a-zA-Z0-9\-\.~_/]+@', $imagePath)) {
             // Imagick/Inkscape delegate has problems with special characters in the file path, eg. "ß" causes

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -78,8 +78,6 @@ class Imagick extends Adapter
             }
         }
 
-
-
         if (isset($options['asset']) && preg_match('@\.svgz?$@', $imagePath) && preg_match('@[^a-zA-Z0-9\-\.~_/]+@', $imagePath)) {
             // Imagick/Inkscape delegate has problems with special characters in the file path, eg. "ß" causes
             // Inkscape to completely go crazy -> Debian 8.10, Inkscape 0.48.5 r10040, Imagick 6.8.9-9 Q16, Imagick 3.4.3

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -15,6 +15,7 @@
 namespace Pimcore\Video\Adapter;
 
 use Pimcore\File;
+use Pimcore\Helper\TemporaryFileHelperTrait;
 use Pimcore\Logger;
 use Pimcore\Tool\Console;
 use Pimcore\Video\Adapter;
@@ -22,6 +23,8 @@ use Symfony\Component\Process\Process;
 
 class Ffmpeg extends Adapter
 {
+    use TemporaryFileHelperTrait;
+
     /**
      * @var string
      */
@@ -78,11 +81,7 @@ class Ffmpeg extends Adapter
      */
     public function load($file, $options = [])
     {
-        if (!stream_is_local($file) && isset($options['asset'])) {
-            $tmpFile = $options['asset']->getTemporaryFile();
-            $file = $tmpFile;
-            $this->tmpFiles[] = $tmpFile;
-        }
+        $file = $this->getLocalFile($file);
 
         $this->file = $file;
         $this->setProcessId(uniqid());

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -22,6 +22,7 @@ use Pimcore\Event\AssetEvents;
 use Pimcore\Event\FrontendEvents;
 use Pimcore\Event\Model\AssetEvent;
 use Pimcore\File;
+use Pimcore\Helper\TemporaryFileHelperTrait;
 use Pimcore\Loader\ImplementationLoader\Exception\UnsupportedException;
 use Pimcore\Logger;
 use Pimcore\Model\Asset\Listing;
@@ -40,6 +41,8 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class Asset extends Element\AbstractElement
 {
+    use TemporaryFileHelperTrait;
+
     /**
      * possible types of an asset
      *
@@ -1547,19 +1550,8 @@ class Asset extends Element\AbstractElement
      */
     public function getTemporaryFile()
     {
-        $destinationPath = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/asset-temporary/asset_' . $this->getId() . '_' . md5(microtime()) . '__' . $this->getFilename();
-        if (!is_dir(dirname($destinationPath))) {
-            File::mkdir(dirname($destinationPath));
-        }
-
-        $src = $this->getStream();
-        $dest = fopen($destinationPath, 'wb', false, File::getContext());
-        stream_copy_to_stream($src, $dest);
-        fclose($dest);
-
+        $destinationPath = $this->getLocalFile($this->getFileSystemPath());
         @chmod($destinationPath, File::getDefaultMode());
-
-        $this->_temporaryFiles[] = $destinationPath;
 
         return $destinationPath;
     }

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1313,17 +1313,14 @@ class Asset extends Element\AbstractElement
         if ($this->stream) {
             if (get_resource_type($this->stream) !== 'stream') {
                 $this->stream = null;
-            } else {
-                $streamMeta = stream_get_meta_data($this->stream);
-                if (!@rewind($this->stream) && $streamMeta['stream_type'] === 'STDIO') {
-                    $this->stream = null;
-                }
+            } elseif (!@rewind($this->stream)) {
+                $this->stream = null;
             }
         }
 
-        if (!$this->stream && $this->getType() != 'folder') {
+        if (!$this->stream && $this->getType() !== 'folder') {
             if (file_exists($this->getFileSystemPath())) {
-                $this->stream = fopen($this->getFileSystemPath(), 'r', false, File::getContext());
+                $this->stream = fopen($this->getFileSystemPath(), 'rb', false, File::getContext());
             } else {
                 $this->stream = tmpfile();
             }
@@ -1556,7 +1553,7 @@ class Asset extends Element\AbstractElement
         }
 
         $src = $this->getStream();
-        $dest = fopen($destinationPath, 'w+', false, File::getContext());
+        $dest = fopen($destinationPath, 'wb', false, File::getContext());
         stream_copy_to_stream($src, $dest);
         fclose($dest);
 

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -19,6 +19,7 @@ namespace Pimcore\Model\Asset;
 
 use Pimcore\Event\FrontendEvents;
 use Pimcore\File;
+use Pimcore\Helper\TemporaryFileHelperTrait;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -29,6 +30,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 class Image extends Model\Asset
 {
     use Model\Asset\MetaData\EmbeddedMetaDataTrait;
+    use TemporaryFileHelperTrait;
 
     /**
      * @var string
@@ -144,7 +146,7 @@ class Image extends Model\Asset
         if ($facedetectBin) {
             $faceCoordinates = [];
             $thumbnail = $this->getThumbnail(Image\Thumbnail\Config::getPreviewConfig());
-            $image = $thumbnail->getFileSystemPath();
+            $image = $this->getLocalFile($thumbnail->getFileSystemPath());
             $imageWidth = $thumbnail->getWidth();
             $imageHeight = $thumbnail->getHeight();
 

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -30,7 +30,6 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 class Image extends Model\Asset
 {
     use Model\Asset\MetaData\EmbeddedMetaDataTrait;
-    use TemporaryFileHelperTrait;
 
     /**
      * @var string

--- a/models/Asset/MetaData/EmbeddedMetaDataTrait.php
+++ b/models/Asset/MetaData/EmbeddedMetaDataTrait.php
@@ -17,10 +17,13 @@
 
 namespace Pimcore\Model\Asset\MetaData;
 
+use Pimcore\Helper\TemporaryFileHelperTrait;
 use Pimcore\Tool;
 
 trait EmbeddedMetaDataTrait
 {
+    use TemporaryFileHelperTrait;
+
     /**
      * @param bool $force
      * @param bool $useExifTool
@@ -62,13 +65,14 @@ trait EmbeddedMetaDataTrait
     protected function readEmbeddedMetaData(bool $useExifTool = true, ?string $filePath = null): array
     {
         $exiftool = \Pimcore\Tool\Console::getExecutable('exiftool');
-        $embeddedMetaData = [];
 
         if (!$filePath) {
             $filePath = $this->getFileSystemPath();
         }
 
-        if (stream_is_local($this->getStream()) && $exiftool && $useExifTool) {
+        $filePath = $this->getLocalFile($filePath);
+
+        if ($exiftool && $useExifTool) {
             $path = escapeshellarg($filePath);
             if (!file_exists($path)) {
                 $path = escapeshellarg($this->getTemporaryFile());


### PR DESCRIPTION
When asset files are stored on a cloud hosting provider (in our case Google Cloud Storage), there was an error 
```
[pimcore] ImagickException: insufficient image data in file `/var/www/html/var/tmp/asset-temporary/asset_739_30573635c4f669ded2c13782092cf497__xyz.jpg' @ error/jpeg.c/ReadJPEGImage/1117 in /var/www/html/vendor/pimcore/pimcore/lib/Image/Adapter/Imagick.php:126
```

This happens when the stream cannot be rewinded - but until now the stream was not reopened in this case when the file was not locally, see https://github.com/pimcore/pimcore/blob/234360e575cdc6cdc6d812082b6585055817d882/models/Asset.php#L1322

While I fixed this I stumbled upon https://github.com/pimcore/pimcore/blob/234360e575cdc6cdc6d812082b6585055817d882/lib/Image/Adapter/Imagick.php#L61-L75
As this was too hard-coded to HTTP(S) and AWS S3 in my opinion I changed it in analogy to https://github.com/pimcore/pimcore/blob/234360e575cdc6cdc6d812082b6585055817d882/models/Asset.php#L1553-L1570

And I removed https://github.com/pimcore/pimcore/blob/234360e575cdc6cdc6d812082b6585055817d882/lib/Image/Adapter/Imagick.php#L81 because this temporary file gets already handled by https://github.com/pimcore/pimcore/blob/234360e575cdc6cdc6d812082b6585055817d882/models/Asset.php#L2029-L2033