### PR TITLE
[AdminBundle] Fix icon library

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/Misc/iconList.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/Misc/iconList.html.twig
@@ -1,6 +1,5 @@
 {% set webRoot = constant('PIMCORE_WEB_ROOT') %}
 
-{% set site = pimcore_site() %}
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
The icon library could not be opened and threw an exception in the Twig template.

```
Too few arguments to function Pimcore\Model\Site::getById(), 0 passed in /var/www/pimcore-master/var/cache/dev/twig/.....php on line 48 and exactly 1 expected
```