### PR TITLE
[AdminBundle] Fix opening application logger

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/log/admin.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/log/admin.js
@@ -294,14 +294,6 @@ pimcore.log.admin = Class.create({
                     handler: this.find.bind(this),
                     iconCls: "pimcore_icon_search"
                 }],
-                listeners: {
-                    afterRender: function(formCmp) {
-                        this.keyNav = Ext.create('Ext.util.KeyNav', formCmp.el, {
-                            enter: formSearch,
-                            scope: this
-                        });
-                    }
-                },
                 items: [ {
                     xtype:'fieldset',
                     autoHeight:true,


### PR DESCRIPTION
Ext JS KeyNav constructor doesn't support multiple arguments anymore and
thus threw an exception. The functionality "search on key ENTER" was
already fixed/implemented in #2539, so this code seems obsolete.
