### PR TITLE
Fix: "Call to undefined method getInherited" when saving a document a second time

### DIFF
--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -682,9 +682,24 @@ abstract class PageSnippet extends Model\Document
     /**
      * @TODO: remove with $this->elements
      */
+    public function __clone()
+    {
+        unset($this->elements, $this->inheritedElements, $this->editables, $this->inheritedEditables);
+
+        $this->inheritedEditables = [];
+        $this->elements = & $this->editables;
+        $this->inheritedElements = & $this->inheritedEditables;
+
+        parent::__clone();
+    }
+
+    /**
+     * @TODO: remove with $this->elements
+     */
     public function __wakeup()
     {
-        $this->editables = & $this->elements;
+        $this->elements = & $this->editables;
+        $this->inheritedElements = & $this->inheritedEditables;
 
         parent::__wakeup();
     }


### PR DESCRIPTION
Resolve #7760

If the document is cloned in the save process (checkMissingRequiredEditable and saveVersion), the editable is referenced to the original document.
DeepCopy copy the element array and so the original objects are lost in the source. When DeepCopy copies the editable array the hashes can based on other objects.