### PR TITLE
Fix missing parameters for translation listings

### DIFF
--- a/models/Translation/Listing/Dao.php
+++ b/models/Translation/Listing/Dao.php
@@ -86,7 +86,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
 
             $queryBuilder = $this->getQueryBuilderCompatibility(['*']);
             $queryBuilder->setMaxResults(NULL); //retrieve all results
-            $translationsData = $this->db->fetchAll((string) $queryBuilder);
+            $translationsData = $this->db->fetchAll((string) $queryBuilder, $this->model->getConditionVariables());
 
             foreach ($translationsData as $t) {
                 if (!isset($translations[$t['key']])) {
@@ -136,7 +136,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
         $translationsData = $this->db->fetchAll((string) $queryBuilder, $this->model->getConditionVariables());
 
         foreach ($translationsData as $t) {
-            $translations[] = $allTranslations[$t['key']];
+            $translations[] = $allTranslations[$t['key']] ?? '';
         }
 
         $this->model->setTranslations($translations);

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Pimcore\Tests\Unit\Translation;
 
 use Codeception\Util\Stub;
+use Pimcore\Model\Translation;
 use Pimcore\Model\Translation\Website;
 use Pimcore\Tests\Test\TestCase;
 use Pimcore\Translation\Translator;
@@ -195,5 +196,23 @@ class TranslatorTest extends TestCase
         $translator = Stub::construct(Translator::class, [$this->translator, true]);
 
         $this->assertEquals($this->translations['en']['case_key'], $translator->trans('CASE_KEY'));
+    }
+
+    public function testLoadingTranslationList() {
+
+        $translations = new Translation\Listing();
+        $translations->setDomain('messages');
+
+        $translations = $translations->getTranslations();
+        $this->assertCount(7, $translations);
+
+
+        $translations = new Translation\Listing();
+        $translations->setDomain('messages');
+        $translations->addConditionParam('`key` like :key', ['key' => "simple%"]);
+
+        $translations = $translations->getTranslations();
+        $this->assertCount(1, $translations);
+
     }
 }

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -213,7 +213,7 @@ class TranslatorTest extends TestCase
         $translations->setDomain('messages');
 
         $translations = $translations->getTranslations();
-        $this->assertCount(7, $translations);
+        $this->assertCount(9, $translations);
 
 
         $translations = new Translation\Listing();

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -213,7 +213,7 @@ class TranslatorTest extends TestCase
         $translations->setDomain('messages');
 
         $translations = $translations->getTranslations();
-        $this->assertCount(9, $translations);
+        $this->assertCount(count($this->translations['en']), $translations);
 
 
         $translations = new Translation\Listing();


### PR DESCRIPTION
doing something like fails: 

```
$translations = new Translation\Listing();
$translations->setDomain('messages');
$translations = $translations->getTranslations(); 
```

tests fail because of https://github.com/pimcore/pimcore/issues/8369
