### PR TITLE
Revert execInBackground

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/NewsletterController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/NewsletterController.php
@@ -364,10 +364,10 @@ class NewsletterController extends DocumentControllerBase
             'progress' => 0,
         ], 'newsletter');
 
-        Console::runPhpScript(
+        Console::runPhpScriptInBackground(
             realpath(PIMCORE_PROJECT_ROOT . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'console'),
-            ['internal:newsletter-document-send', $document->getTmpStoreId(), \Pimcore\Tool::getHostUrl()],
-            PIMCORE_LOG_DIRECTORY . DIRECTORY_SEPARATOR . 'newsletter-sending-output.log', null, true
+            'internal:newsletter-document-send ' . escapeshellarg($document->getTmpStoreId()) . ' ' . escapeshellarg(\Pimcore\Tool::getHostUrl()),
+            PIMCORE_LOG_DIRECTORY . DIRECTORY_SEPARATOR . 'newsletter-sending-output.log'
         );
 
         return $this->adminJson(['success' => true]);

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -53,6 +53,7 @@
   `CartInterface::COUNT_MAIN_ITEMS_ONLY`, `CartInterface::COUNT_MAIN_AND_SUB_ITEMS`, `CartInterface::COUNT_MAIN_OR_SUB_ITEMS` 
   instead. 
 - `Pimcore\Targeting\Storage\Cookie\JWT\Decoder` class has been deprecated and will be removed in Pimcore 10.
+- `Pimcore\Tool\Console`: Methods `getSystemEnvironment()`, `exec()`, `execInBackground()` and `runPhpScriptInBackground()` have been deprecated, use `Symfony\Component\Process\Process` instead where possible. For long running background tasks (which should run even when parent process has exited), switch to a queue implementation.
 
 #### Migrating legacy module/controller/action configurations to new controller references
 You can use `./bin/console migration:controller-reference` to migrate your existing Documents, 

--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -273,11 +273,10 @@ class Console
      * @param string|array $arguments
      * @param string|null $outputFile
      * @param int|null $timeout
-     * @param bool $background
      *
-     * @return string|int
+     * @return string
      */
-    public static function runPhpScript($script, $arguments = '', $outputFile = null, $timeout = null, $background = false)
+    public static function runPhpScript($script, $arguments = '', $outputFile = null, $timeout = null)
     {
         $cmd = self::buildPhpScriptCmd($script, $arguments);
         self::addLowProcessPriority($cmd);
@@ -289,15 +288,15 @@ class Console
 
         if (!empty($outputFile)) {
             $logHandle = fopen($outputFile, 'a');
-            $exitCode = $process->wait(function ($type, $buffer) use ($logHandle) {
+            $process->wait(function ($type, $buffer) use ($logHandle) {
                 fwrite($logHandle, $buffer);
             });
             fclose($logHandle);
         } else {
-            $exitCode = $process->wait();
+            $process->wait();
         }
 
-        return $background ? $exitCode : $process->getOutput();
+        return $process->getOutput();
     }
 
     /**

--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -301,7 +301,8 @@ class Console
     }
 
     /**
-     * @deprecated since v6.9. Use runPhpScript instead.
+     * @deprecated since v6.9. For long running background tasks switch to a queue implementation.
+     *
      * @param string $script
      * @param string $arguments
      * @param string|null $outputFile
@@ -310,7 +311,8 @@ class Console
      */
     public static function runPhpScriptInBackground($script, $arguments = '', $outputFile = null)
     {
-        return self::runPhpScript($script, $arguments, $outputFile);
+        $cmd = self::buildPhpScriptCmd($script, $arguments);
+        return self::execInBackground(implode(' ', $cmd), $outputFile);
     }
 
     /**
@@ -361,8 +363,7 @@ class Console
     }
 
     /**
-     *
-     * @deprecated since v.6.9. Use Symfony\Component\Process\Process instead.
+     * @deprecated since v.6.9. Use Symfony\Component\Process\Process instead. For long running background tasks use queues.
      * @static
      *
      * @param string $cmd
@@ -372,7 +373,6 @@ class Console
      */
     public static function execInBackground($cmd, $outputFile = null)
     {
-
         // windows systems
         if (self::getSystemEnvironment() == 'windows') {
             return self::execInBackgroundWindows($cmd, $outputFile);
@@ -384,7 +384,7 @@ class Console
     }
 
     /**
-     * @deprecated since v.6.9.
+     * @deprecated since v.6.9. For long running background tasks use queues.
      * @static
      *
      * @param string $cmd
@@ -434,7 +434,7 @@ class Console
     }
 
     /**
-     * @deprecated since v.6.9.
+     * @deprecated since v.6.9. For long running background tasks use queues.
      * @static
      *
      * @param string $cmd

--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -304,7 +304,7 @@ class Console
      * @deprecated since v6.9. For long running background tasks switch to a queue implementation.
      *
      * @param string $script
-     * @param string $arguments
+     * @param string|array $arguments
      * @param string|null $outputFile
      *
      * @return int

--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -312,7 +312,9 @@ class Console
     public static function runPhpScriptInBackground($script, $arguments = '', $outputFile = null)
     {
         $cmd = self::buildPhpScriptCmd($script, $arguments);
-        return self::execInBackground(implode(' ', $cmd), $outputFile);
+        $process = new Process($cmd);
+        $commandLine = $process->getCommandLine();
+        return self::execInBackground($commandLine, $outputFile);
     }
 
     /**

--- a/models/Asset/Video/Thumbnail/Processor.php
+++ b/models/Asset/Video/Thumbnail/Processor.php
@@ -251,7 +251,7 @@ class Processor
     public function convert()
     {
         $this->save();
-        Console::runPhpScript(realpath(PIMCORE_PROJECT_ROOT . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'console'), ['internal:video-converter', $this->getProcessId()], null, null, true);
+        Console::runPhpScriptInBackground(realpath(PIMCORE_PROJECT_ROOT . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'console'), 'internal:video-converter ' . $this->getProcessId());
     }
 
     /**


### PR DESCRIPTION
Symfony Process background processes are terminated as soon as parent process exists. So this is a change in behavior. 
For now, reverted execInBackground, will switch to queue implementations in Pimcore X.x versions. 

fixes #8355