### PR TITLE
TemporaryFileHelperTrait follow-up

### DIFF
--- a/lib/Helper/TemporaryFileHelperTrait.php
+++ b/lib/Helper/TemporaryFileHelperTrait.php
@@ -3,6 +3,9 @@ namespace Pimcore\Helper;
 
 use Pimcore\File;
 
+/**
+ * @internal
+ */
 trait TemporaryFileHelperTrait
 {
     /**
@@ -12,35 +15,8 @@ trait TemporaryFileHelperTrait
      * @throws \Exception
      */
     private function getLocalFile($stream): string {
-        if (!stream_is_local($stream) || true) {
-            if(is_string($stream)) {
-                $src = fopen($stream, 'rb');
-                $fileExtension = File::getFileExtension($stream);
-            } else {
-                $src = $stream;
-                $streamMeta = stream_get_meta_data($src);
-                $fileExtension = File::getFileExtension($streamMeta['uri']);
-            }
-
-            $tmpFilePath = sprintf('%s/temp-file-%s.%s',
-                PIMCORE_SYSTEM_TEMP_DIRECTORY,
-                uniqid() . '-' .  bin2hex(random_bytes(15)),
-                $fileExtension
-            );
-
-            $dest = fopen($tmpFilePath, 'wb', false, File::getContext());
-            if(!$dest) {
-                throw new \Exception(sprintf('Unable to create temporary file in %s', $tmpFilePath));
-            }
-
-            stream_copy_to_stream($src, $dest);
-            fclose($dest);
-
-            register_shutdown_function(static function() use ($tmpFilePath) {
-                @unlink($tmpFilePath);
-            });
-
-            $stream = $tmpFilePath;
+        if (!stream_is_local($stream)) {
+            $stream = $this->getTemporaryFileFromStream($stream);
         }
 
         if(is_resource($stream)) {
@@ -49,5 +25,42 @@ trait TemporaryFileHelperTrait
         }
 
         return $stream;
+    }
+
+    /**
+     * @param resource|string $stream
+     * @return string
+     * @throws \Exception
+     */
+    private function getTemporaryFileFromStream($stream): string
+    {
+        if(is_string($stream)) {
+            $src = fopen($stream, 'rb');
+            $fileExtension = File::getFileExtension($stream);
+        } else {
+            $src = $stream;
+            $streamMeta = stream_get_meta_data($src);
+            $fileExtension = File::getFileExtension($streamMeta['uri']);
+        }
+
+        $tmpFilePath = sprintf('%s/temp-file-%s.%s',
+            PIMCORE_SYSTEM_TEMP_DIRECTORY,
+            uniqid() . '-' .  bin2hex(random_bytes(15)),
+            $fileExtension
+        );
+
+        $dest = fopen($tmpFilePath, 'wb', false, File::getContext());
+        if(!$dest) {
+            throw new \Exception(sprintf('Unable to create temporary file in %s', $tmpFilePath));
+        }
+
+        stream_copy_to_stream($src, $dest);
+        fclose($dest);
+
+        register_shutdown_function(static function() use ($tmpFilePath) {
+            @unlink($tmpFilePath);
+        });
+
+        return $tmpFilePath;
     }
 }

--- a/lib/Helper/TemporaryFileHelperTrait.php
+++ b/lib/Helper/TemporaryFileHelperTrait.php
@@ -7,26 +7,47 @@ trait TemporaryFileHelperTrait
 {
     /**
      * Get local file path of the given file or URL
-     * @param string $path file path or URL
+     * @param string|resource $stream local path, wrapper or file handle
      * @return string path to local file
+     * @throws \Exception
      */
-    private function getLocalFile($path): string {
-        if (!stream_is_local($path)) {
-            $tmpFilename = 'tmpfile_'.md5($path).'.'.File::getFileExtension($path);
-            $tmpFilePath = PIMCORE_SYSTEM_TEMP_DIRECTORY.'/'.$tmpFilename;
+    private function getLocalFile($stream): string {
+        if (!stream_is_local($stream) || true) {
+            if(is_string($stream)) {
+                $src = fopen($stream, 'rb');
+                $fileExtension = File::getFileExtension($stream);
+            } else {
+                $src = $stream;
+                $streamMeta = stream_get_meta_data($src);
+                $fileExtension = File::getFileExtension($streamMeta['uri']);
+            }
+
+            $tmpFilePath = sprintf('%s/temp-file-%s.%s',
+                PIMCORE_SYSTEM_TEMP_DIRECTORY,
+                uniqid() . '-' .  bin2hex(random_bytes(15)),
+                $fileExtension
+            );
+
+            $dest = fopen($tmpFilePath, 'wb', false, File::getContext());
+            if(!$dest) {
+                throw new \Exception(sprintf('Unable to create temporary file in %s', $tmpFilePath));
+            }
+
+            stream_copy_to_stream($src, $dest);
+            fclose($dest);
 
             register_shutdown_function(static function() use ($tmpFilePath) {
                 @unlink($tmpFilePath);
             });
 
-            $src = fopen($path, 'rb');
-            $dest = fopen($tmpFilePath, 'wb', false, File::getContext());
-            stream_copy_to_stream($src, $dest);
-            fclose($dest);
-
-            $path = $tmpFilePath;
+            $stream = $tmpFilePath;
         }
 
-        return $path;
+        if(is_resource($stream)) {
+            $streamMeta = stream_get_meta_data($stream);
+            $stream = $streamMeta['uri'];
+        }
+
+        return $stream;
     }
 }

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1542,7 +1542,7 @@ class Asset extends Element\AbstractElement
      */
     public function getTemporaryFile()
     {
-        $destinationPath = $this->getLocalFile($this->getFileSystemPath());
+        $destinationPath = $this->getLocalFile($this->getStream());
         @chmod($destinationPath, File::getDefaultMode());
 
         return $destinationPath;

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1542,7 +1542,7 @@ class Asset extends Element\AbstractElement
      */
     public function getTemporaryFile()
     {
-        $destinationPath = $this->getLocalFile($this->getStream());
+        $destinationPath = $this->getTemporaryFileFromStream($this->getStream());
         @chmod($destinationPath, File::getDefaultMode());
 
         return $destinationPath;

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -203,11 +203,6 @@ class Asset extends Element\AbstractElement
     protected $versionCount;
 
     /**
-     * @var string[]
-     */
-    protected $_temporaryFiles = [];
-
-    /**
      *
      * @return array
      */
@@ -1351,12 +1346,9 @@ class Asset extends Element\AbstractElement
             $isRewindable = @rewind($this->stream);
 
             if (!$isRewindable) {
-                $tmpFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/asset-create-tmp-file-' . uniqid() . '.' . File::getFileExtension($this->getFilename());
-                $dest = fopen($tmpFile, 'w+', false, File::getContext());
-                stream_copy_to_stream($this->stream, $dest);
+                $tempFile = $this->getLocalFile($this->stream);
+                $dest = fopen($tempFile, 'w+', false, File::getContext());
                 $this->stream = $dest;
-
-                $this->_temporaryFiles[] = $tmpFile;
             }
         } elseif (is_null($stream)) {
             $this->stream = null;
@@ -1946,7 +1938,7 @@ class Asset extends Element\AbstractElement
     public function __sleep()
     {
         $parentVars = parent::__sleep();
-        $blockedVars = ['_temporaryFiles', 'scheduledTasks', 'hasChildren', 'versions', 'parent', 'stream'];
+        $blockedVars = ['scheduledTasks', 'hasChildren', 'versions', 'parent', 'stream'];
 
         if ($this->isInDumpState()) {
             // this is if we want to make a full dump of the asset (eg. for a new version), including children for recyclebin
@@ -2011,13 +2003,6 @@ class Asset extends Element\AbstractElement
     {
         // close open streams
         $this->closeStream();
-
-        // delete temporary files
-        foreach ($this->_temporaryFiles as $tempFile) {
-            if (file_exists($tempFile)) {
-                @unlink($tempFile);
-            }
-        }
     }
 
     /**

--- a/models/Asset/MetaData/EmbeddedMetaDataTrait.php
+++ b/models/Asset/MetaData/EmbeddedMetaDataTrait.php
@@ -74,9 +74,6 @@ trait EmbeddedMetaDataTrait
 
         if ($exiftool && $useExifTool) {
             $path = escapeshellarg($filePath);
-            if (!file_exists($path)) {
-                $path = escapeshellarg($this->getTemporaryFile());
-            }
             $output = Tool\Console::exec($exiftool . ' -j ' . $path);
             $embeddedMetaData = $this->flattenArray((array) json_decode($output)[0]);
 


### PR DESCRIPTION
follow up to #8335

- `TemporaryFileHelperTrait`:  added support for streams
- removed temporary file handling from Asset
