### PR TITLE
ElementInterface: added upgrade note for getParent()

### DIFF
--- a/models/Element/ElementInterface.php
+++ b/models/Element/ElementInterface.php
@@ -171,6 +171,12 @@ interface ElementInterface extends ModelInterface
     public function getParentId();
 
     /**
+     * This method will be required in Pimcore 10
+     * @return mixed
+     */
+    //public function getParent();
+
+    /**
      * @return string
      */
     public function getCacheTag();


### PR DESCRIPTION
which will be required in Pimcore 10. 

In preparation for #7905
