### PR TITLE
Deprecated calling AbstractModel::setValues() including an `id` 

### DIFF
--- a/lib/Model/AbstractModel.php
+++ b/lib/Model/AbstractModel.php
@@ -179,6 +179,11 @@ abstract class AbstractModel implements ModelInterface
     public function setValues($data = [])
     {
         if (is_array($data) && count($data) > 0) {
+
+            if(isset($data['id'])) {
+                @trigger_error(sprintf('Calling %s including `id` key in the data-array is deprecated and will throw an exception in Pimcore 10', __METHOD__), E_USER_DEPRECATED);
+            }
+
             foreach ($data as $key => $value) {
                 $this->setValue($key, $value);
             }


### PR DESCRIPTION
in preparation of #6801