### PR TITLE
[Data object versions] Show version note

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1475,14 +1475,14 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 return $this->render('@PimcoreAdmin/Admin/DataObject/DataObject/previewVersion.html.twig',
                     [
                         'object' => $object,
+                        'versionNote' => $version->getNote(),
                         'validLanguages' => Tool::getValidLanguages(),
                     ]);
-            } else {
-                throw $this->createAccessDeniedException('Permission denied, version id [' . $id . ']');
             }
-        } else {
-            throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
+            throw $this->createAccessDeniedException('Permission denied, version id [' . $id . ']');
         }
+
+        throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
     }
 
     /**
@@ -1516,15 +1516,17 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 return $this->render('@PimcoreAdmin/Admin/DataObject/DataObject/diffVersions.html.twig',
                     [
                         'object1' => $object1,
+                        'versionNote1' => $version1->getNote(),
                         'object2' => $object2,
+                        'versionNote2' => $version2->getNote(),
                         'validLanguages' => Tool::getValidLanguages(),
                     ]);
-            } else {
-                throw $this->createAccessDeniedException('Permission denied, version ids [' . $id1 . ', ' . $id2 . ']');
             }
-        } else {
-            throw $this->createNotFoundException('Version with ids [' . $id1 . ', ' . $id2 . "] doesn't exist");
+
+            throw $this->createAccessDeniedException('Permission denied, version ids [' . $id1 . ', ' . $id2 . ']');
         }
+
+        throw $this->createNotFoundException('Version with ids [' . $id1 . ', ' . $id2 . "] doesn't exist");
     }
 
     /**

--- a/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.twig
@@ -25,14 +25,6 @@
             <th>Version 2</th>
         {% endif %}
     </tr>
-    {% if versionNote1 or versionNote2 %}
-        <tr class="system">
-            <td>Version Note</td>
-            <td>&nbsp;</td>
-            <td>{{ versionNote1 }}</td>
-            <td>{{ versionNote2 }}</td>
-        </tr>
-    {% endif %}
     <tr class="system">
         <td>Date</td>
         <td>o_modificationDate</td>
@@ -59,6 +51,14 @@
         {% set modifiedPublishedClass = object1.getPublished() is not same as(object2.getPublished()) ? 'modified' : ''  %}
         <td class="{{ modifiedPublishedClass }}">{{ object2.getPublished() ? 'true' : 'false' }}</td>
     </tr>
+    {% if versionNote1 or versionNote2 %}
+        <tr class="system">
+            <td>Version Note</td>
+            <td>&nbsp;</td>
+            <td>{{ versionNote1 }}</td>
+            <td>{{ versionNote2 }}</td>
+        </tr>
+    {% endif %}
     <tr class="system">
         <td>Id</td>
         <td>o_id</td>

--- a/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.twig
@@ -25,6 +25,14 @@
             <th>Version 2</th>
         {% endif %}
     </tr>
+    {% if versionNote1 or versionNote2 %}
+        <tr class="system">
+            <td>Version Note</td>
+            <td>&nbsp;</td>
+            <td>{{ versionNote1 }}</td>
+            <td>{{ versionNote2 }}</td>
+        </tr>
+    {% endif %}
     <tr class="system">
         <td>Date</td>
         <td>o_modificationDate</td>

--- a/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/previewVersion.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/previewVersion.html.twig
@@ -16,6 +16,14 @@
         <th>Key</th>
         <th>Value</th>
     </tr>
+    {% if versionNote %}
+        <tr class="system">
+            <td>Version Note</td>
+            <td>&nbsp;</td>
+            <td>{{ versionNote }}</td>
+        </tr>
+        <p><b>Version Note: </b> {versionNote}</p>
+    {% endif %}
     <tr class="system">
         <td>Date</td>
         <td>o_modificationDate</td>

--- a/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/previewVersion.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/previewVersion.html.twig
@@ -16,14 +16,6 @@
         <th>Key</th>
         <th>Value</th>
     </tr>
-    {% if versionNote %}
-        <tr class="system">
-            <td>Version Note</td>
-            <td>&nbsp;</td>
-            <td>{{ versionNote }}</td>
-        </tr>
-        <p><b>Version Note: </b> {versionNote}</p>
-    {% endif %}
     <tr class="system">
         <td>Date</td>
         <td>o_modificationDate</td>
@@ -39,6 +31,13 @@
         <td>o_published</td>
         <td>{{ object.getPublished() ? 'true' : 'false' }}</td>
     </tr>
+    {% if versionNote %}
+        <tr class="system">
+            <td>Version Note</td>
+            <td>&nbsp;</td>
+            <td>{{ versionNote }}</td>
+        </tr>
+    {% endif %}
 
     <tr class="">
         <td colspan="3">&nbsp;</td>


### PR DESCRIPTION
In some use-cases it is good to add a description or some meta data to data object versions. There is a field `note` in the `versions` table. Currently this can only be filled by manually calling the `Version::setNote()` method as far as I know. But currently this field is not displayed anywhere in the Pimcore backend. With this PR the version note gets shown in the data object preview / comparison - only if it is filled. So for projects which do not use version notes everything will look the same as before but for those which do the version note is displayed.