### PR TITLE
[Data objects] Create unique index in query table when unique checkbox is checked

### DIFF
--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -187,7 +187,7 @@ class Dao extends Model\Dao\AbstractDao
                         $protectedColumns[] = $key;
                     }
 
-                    $this->addIndexToField($value, $objectTable, 'getQueryColumnType');
+                    $this->addIndexToField($value, $objectTable, 'getQueryColumnType', true);
                 }
             }
         }


### PR DESCRIPTION
Currently no index gets created in the `object_query_*` database table when the unique checkbox is checked but the `Indexed` checkbox is not checked. The unique index is only created in the `object_store_*` table. The [documentation](https://pimcore.com/docs/pimcore/current/Development_Documentation/Objects/Object_Classes/Data_Types/index.html#page_General-Aspects) says:
`unique: currently the input, numeric and user data types allow to add a unique constraint. If checked, the values will also be indexed`
Until now I thought that this applies also for the query table. With no index being created performance is slow when using `Listing` classes.
With this PR unique index gets also created for the query table.