### PR TITLE
[Data objects] Do not create non-unique index in object_store table

### DIFF
--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/README.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/README.md
@@ -135,8 +135,8 @@ languages. Please see the article about Translations to find out how to add obje
 * `visible in search result`: Determines if the field's data column is shown in the search results grid, or hidden 
   (meaning it has to be activated manually)
 * `indexed`: puts an index on this column in the database
-Moreover, each data field can have a `tooltip`, which is shown when the mouse hovers over the input field.
-* `unique`: currently the `input`, `numeric` and `user` data types allow to add a unique constraint. If checked, the values will also be indexed. Note that only works on top level attributes and not on nested stuff inside localized fields etc.
+* `unique`: If checked, the value has to be unique across all objects of this class. Note that only works on top level attributes and not on nested stuff inside localized fields etc. Beware that this does not add a database index to the query table which `Listing` classes use.
+* Moreover, each data field can have a `tooltip`, which is shown when the mouse hovers over the input field.
 
 ![Data Field Settings](../../../img/classes-datatypes1.jpg)
 ![Data Field Settings](../../../img/classes-datatypes2.jpg)

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -171,6 +171,8 @@ class Dao extends Model\Dao\AbstractDao
                             $protectedDatastoreColumns[] = $key;
                         }
                     }
+
+                    $this->addIndexToField($value, $objectDatastoreTable, 'getColumnType', true);
                 }
 
                 if ($value instanceof DataObject\ClassDefinition\Data\QueryResourcePersistenceAwareInterface) {

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -171,8 +171,6 @@ class Dao extends Model\Dao\AbstractDao
                             $protectedDatastoreColumns[] = $key;
                         }
                     }
-
-                    $this->addIndexToField($value, $objectDatastoreTable, 'getColumnType', true);
                 }
 
                 if ($value instanceof DataObject\ClassDefinition\Data\QueryResourcePersistenceAwareInterface) {
@@ -187,7 +185,7 @@ class Dao extends Model\Dao\AbstractDao
                         $protectedColumns[] = $key;
                     }
 
-                    $this->addIndexToField($value, $objectTable, 'getQueryColumnType', true);
+                    $this->addIndexToField($value, $objectTable, 'getQueryColumnType');
                 }
             }
         }

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -187,7 +187,7 @@ class Dao extends Model\Dao\AbstractDao
                         $protectedColumns[] = $key;
                     }
 
-                    $this->addIndexToField($value, $objectTable, 'getQueryColumnType');
+                    $this->addIndexToField($value, $objectTable, 'getQueryColumnType', true);
                 }
             }
         }

--- a/models/DataObject/ClassDefinition/Helper/Dao.php
+++ b/models/DataObject/ClassDefinition/Helper/Dao.php
@@ -31,7 +31,7 @@ trait Dao
         $columnType = $field->$columnTypeGetter();
 
         $prefixes = [
-            'p_index_' => ['enabled' => $field->getIndex(), 'unique' => false],
+            'p_index_' => ['enabled' => !$considerUniqueIndex && $field->getIndex(), 'unique' => false],
             'u_index_' => ['enabled' => $considerUniqueIndex && $field->getUnique(), 'unique' => true],
 
         ];


### PR DESCRIPTION
Follow-up of #8409

Currently when you tick `indexed` and `unique` checkboxes for a field 2 indexes get created in the `object_store_*` table slowing down write performance. With this PR `object_store_*` tables only get unique indexes (if `unique` is ticked) and `object_query_*` tables only get non-unique indexes (when `indexed` is ticked).