### PR TITLE
Use `JSON_THROW_ON_ERROR` instead of custom JSON error handling

### DIFF
--- a/lib/Document/Editable/EditmodeEditableDefinitionCollector.php
+++ b/lib/Document/Editable/EditmodeEditableDefinitionCollector.php
@@ -108,12 +108,7 @@ final class EditmodeEditableDefinitionCollector
 
     private function getJson(): string
     {
-        $json = json_encode($this->getDefinitions(), JSON_PRETTY_PRINT);
-        if (json_last_error()) {
-            throw new \Exception('json encode failed: ' . json_last_error_msg());
-        }
-
-        return $json;
+        return json_encode($this->getDefinitions(), JSON_PRETTY_PRINT|JSON_THROW_ON_ERROR);
     }
 
     public function getHtml(): string


### PR DESCRIPTION
Since this was added to `master` in #8420 and #8435 we should use PHP >= 7.3 features.