### PR TITLE
Fixes deleting a Website Setting not clearing it from cache

### DIFF
--- a/models/WebsiteSetting.php
+++ b/models/WebsiteSetting.php
@@ -20,7 +20,6 @@ use Pimcore\Model\Element\Service;
 /**
  * @method \Pimcore\Model\WebsiteSetting\Dao getDao()
  * @method void save()
- * @method void delete()
  */
 class WebsiteSetting extends AbstractModel
 {
@@ -310,5 +309,20 @@ class WebsiteSetting extends AbstractModel
     public function clearDependentCache()
     {
         \Pimcore\Cache::clearTag('website_config');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete()
+    {
+        $nameCacheKey = $name . '~~~' . $siteId . '~~~' . $language;
+
+        // Remove cached element to avoid returning it with e.g. getByName() after if it is deleted
+        if (array_key_exists($nameCacheKey, self::$nameIdMappingCache)) {
+            unset(self::$nameIdMappingCache[$nameCacheKey]);
+        }
+
+        $this->getDao()->delete($this->getId());
     }
 }

--- a/models/WebsiteSetting.php
+++ b/models/WebsiteSetting.php
@@ -316,13 +316,13 @@ class WebsiteSetting extends AbstractModel
      */
     public function delete()
     {
-        $nameCacheKey = $name . '~~~' . $siteId . '~~~' . $language;
+        $nameCacheKey = $this->getName() . '~~~' . $this->getSiteId() . '~~~' . $this->getLanguage();
 
         // Remove cached element to avoid returning it with e.g. getByName() after if it is deleted
         if (array_key_exists($nameCacheKey, self::$nameIdMappingCache)) {
             unset(self::$nameIdMappingCache[$nameCacheKey]);
         }
 
-        $this->getDao()->delete($this->getId());
+        $this->getDao()->delete();
     }
 }

--- a/models/WebsiteSetting.php
+++ b/models/WebsiteSetting.php
@@ -71,6 +71,17 @@ class WebsiteSetting extends AbstractModel
     protected static $nameIdMappingCache = [];
 
     /**
+     * @param string $name
+     * @param null $siteId
+     * @param null $language
+     * @return string
+     */
+    protected static function getCacheKey($name, $siteId = null, $language = null): string
+    {
+        return $name . '~~~' . $siteId . '~~~' . $language;
+    }
+
+    /**
      * @param int $id
      *
      * @return WebsiteSetting|null
@@ -107,7 +118,7 @@ class WebsiteSetting extends AbstractModel
      */
     public static function getByName($name, $siteId = null, $language = null, $fallbackLanguage = null)
     {
-        $nameCacheKey = $name . '~~~' . $siteId . '~~~' . $language;
+        $nameCacheKey = static::getCacheKey($name, $siteId, $language);
 
         // check if pimcore already knows the id for this $name, if yes just return it
         if (array_key_exists($nameCacheKey, self::$nameIdMappingCache)) {
@@ -316,7 +327,7 @@ class WebsiteSetting extends AbstractModel
      */
     public function delete()
     {
-        $nameCacheKey = $this->getName() . '~~~' . $this->getSiteId() . '~~~' . $this->getLanguage();
+        $nameCacheKey = static::getCacheKey($this->getName(), $this->getSiteId(), $this->getLanguage());
 
         // Remove cached element to avoid returning it with e.g. getByName() after if it is deleted
         if (array_key_exists($nameCacheKey, self::$nameIdMappingCache)) {


### PR DESCRIPTION
If a setting is first deleted:

```php
$settingObject->delete();
```

It was then still available to the process and returned via 

```php
WebsiteSetting::getByName()
```

Which should not have happened. This overrides the Dao to to resolve the issue.