### PR TITLE
Fix search and replace functionality

### DIFF
--- a/models/Dependency/Dao.php
+++ b/models/Dependency/Dao.php
@@ -229,17 +229,17 @@ class Dao extends Model\Dao\AbstractDao
                 SELECT d.sourceid as id, d.sourcetype as type, CONCAT(o.o_path, o.o_key) as path
                 FROM dependencies d
                 JOIN objects o ON o.o_id = d.sourceid
-                WHERE d.targetid = ' . $targetId . " AND  d.targettype = '" . $targetType. "'
+                WHERE d.targetid = ' . $targetId . " AND  d.targettype = '" . $targetType. "' AND d.sourceType = 'object'
                 UNION
                 SELECT d.sourceid as id, d.sourcetype as type, CONCAT(doc.path, doc.key) as path
                 FROM dependencies d
                 JOIN documents doc ON doc.id = d.sourceid
-                WHERE d.targetid = " . $targetId . " AND  d.targettype = '" . $targetType. "'
+                WHERE d.targetid = " . $targetId . " AND  d.targettype = '" . $targetType. "' AND d.sourceType = 'document'
                 UNION
                 SELECT d.sourceid as id, d.sourcetype as type, CONCAT(a.path, a.filename) as path
                 FROM dependencies d
                 JOIN assets a ON a.id = d.sourceid
-                WHERE d.targetid = " . $targetId . " AND  d.targettype = '" . $targetType. "'
+                WHERE d.targetid = " . $targetId . " AND  d.targettype = '" . $targetType. "' AND d.sourceType = 'asset'
             ) dep
             ORDER BY " . $orderBy . ' ' . $orderDirection;
 


### PR DESCRIPTION
## Changes in this pull request  
The dependency query that is used in the search & replace functionality is fixed by adding the correct condition for the sourceType. If an id exists in more than one of the tables objects, documents or assets, the outcome of the query is not correct at the moment.

Resolves
https://github.com/pimcore/pimcore/issues/6973

