### PR TITLE
lazy load fix when using localized field

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -180,7 +180,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
         foreach ($dataItems as $language => $values) {
             foreach ($this->getFieldDefinitions() as $fd) {
                 if ($fd instanceof LazyLoadingSupportInterface && $fd->getLazyLoading()) {
-                    $lazyKey = $fd->getName() . DataObject\LazyLoadedFieldsInterface::LAZY_KEY_SEPARATOR . $language;
+                    $lazyKey = $data->buildLazyKey($fd->getName(), $language);
                     if (!$data->isLazyKeyLoaded($lazyKey) && $fd instanceof CustomResourcePersistingInterface) {
                         $params['language'] = $language;
                         $params['object'] = $object;

--- a/models/DataObject/LazyLoadedFieldsInterface.php
+++ b/models/DataObject/LazyLoadedFieldsInterface.php
@@ -28,11 +28,6 @@ interface LazyLoadedFieldsInterface
 
     /**
      * @param string $key
-     */
-    public function unmarkLazyKeyAsLoaded(string $key);
-
-    /**
-     * @param string $key
      *
      * @return bool
      */
@@ -44,12 +39,4 @@ interface LazyLoadedFieldsInterface
      * @return bool
      */
     public function isAllLazyKeysMarkedAsLoaded(): bool;
-
-    /**
-     * @param string $name
-     * @param string $language
-     * 
-     * @return string
-     */
-    public function buildLazyKey(string $name, string $language) : string;
 }

--- a/models/DataObject/LazyLoadedFieldsInterface.php
+++ b/models/DataObject/LazyLoadedFieldsInterface.php
@@ -44,4 +44,12 @@ interface LazyLoadedFieldsInterface
      * @return bool
      */
     public function isAllLazyKeysMarkedAsLoaded(): bool;
+
+    /**
+     * @param string $name
+     * @param string $language
+     * 
+     * @return string
+     */
+    public function buildLazyKey(string $name, string $language) : string;
 }

--- a/models/DataObject/LazyLoadedFieldsInterface.php
+++ b/models/DataObject/LazyLoadedFieldsInterface.php
@@ -28,6 +28,11 @@ interface LazyLoadedFieldsInterface
 
     /**
      * @param string $key
+     */
+    public function unmarkLazyKeyAsLoaded(string $key);
+
+    /**
+     * @param string $key
      *
      * @return bool
      */

--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -385,7 +385,7 @@ class Localizedfield extends Model\AbstractModel implements
      */
     private function loadLazyField(Model\DataObject\ClassDefinition\Data $fieldDefinition, $name, $language)
     {
-        $lazyKey = $name . LazyLoadedFieldsInterface::LAZY_KEY_SEPARATOR . $language;
+        $lazyKey = $this->buildLazyKey($name, $language);
         if (!$this->isLazyKeyLoaded($lazyKey) && $fieldDefinition instanceof Model\DataObject\ClassDefinition\Data\CustomResourcePersistingInterface) {
             $params['language'] = $language;
             $params['object'] = $this->getObject();
@@ -577,7 +577,7 @@ class Localizedfield extends Model\AbstractModel implements
         $forceLanguageDirty = false;
         $isLazyLoadedField = ($fieldDefinition instanceof LazyLoadingSupportInterface || method_exists($fieldDefinition, 'getLazyLoading'))
                                     && $fieldDefinition->getLazyLoading();
-        $lazyKey = $name . LazyLoadedFieldsInterface::LAZY_KEY_SEPARATOR . $language;
+        $lazyKey = $this->buildLazyKey($name, $language);
 
         if ($isLazyLoadedField) {
             if (!$this->isLazyKeyLoaded($lazyKey)) {
@@ -636,7 +636,7 @@ class Localizedfield extends Model\AbstractModel implements
                 foreach (Tool::getValidLanguages() as $language) {
                     unset($this->items[$language][$fieldName]);
 
-                    $lazyKey = $fieldName . LazyLoadedFieldsInterface::LAZY_KEY_SEPARATOR . $language;
+                    $lazyKey = $this->buildLazyKey($fieldName, $language);
                     $this->unmarkLazyKeyAsLoaded($lazyKey);
                 }
             }

--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -635,6 +635,9 @@ class Localizedfield extends Model\AbstractModel implements
             foreach ($lazyLoadedFields as $fieldName) {
                 foreach (Tool::getValidLanguages() as $language) {
                     unset($this->items[$language][$fieldName]);
+
+                    $lazyKey = $fieldName . LazyLoadedFieldsInterface::LAZY_KEY_SEPARATOR . $language;
+                    $this->unmarkLazyKeyAsLoaded($lazyKey);
                 }
             }
         }

--- a/models/DataObject/Traits/LazyLoadedRelationTrait.php
+++ b/models/DataObject/Traits/LazyLoadedRelationTrait.php
@@ -34,6 +34,14 @@ trait LazyLoadedRelationTrait
 
     /**
      * @param string $key
+     */
+    public function unmarkLazyKeyAsLoaded(string $key)
+    {
+        unset($this->loadedLazyKeys[$key]);
+    }
+
+    /**
+     * @param string $key
      *
      * @return bool
      */

--- a/models/DataObject/Traits/LazyLoadedRelationTrait.php
+++ b/models/DataObject/Traits/LazyLoadedRelationTrait.php
@@ -17,6 +17,8 @@
 
 namespace Pimcore\Model\DataObject\Traits;
 
+use Pimcore\Model\DataObject\LazyLoadedFieldsInterface;
+
 trait LazyLoadedRelationTrait
 {
     /**
@@ -54,5 +56,16 @@ trait LazyLoadedRelationTrait
         $isset = isset($this->loadedLazyKeys[$key]);
 
         return $isset;
+    }
+
+    /**
+     * @param string $name
+     * @param string $language
+     * 
+     * @return string
+     */
+    public function buildLazyKey(string $name, string $language) : string
+    {
+        return $name . LazyLoadedFieldsInterface::LAZY_KEY_SEPARATOR . $language;
     }
 }


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Please review the fix for the lazy loading issue inside localized fields. 

After lazy loaded fields are removed on serialization for cache, the lazy loaded fields are now also unmarked as loaded.

## Additional info  
There is an issue with lazy loading when using localized fields.

Steps to reproduce:
1. On a class, add "one-to-many" relation type under localized fields.
2. When the relation field is requested for the first time, the value gets lazy loaded.
3. When it is called the second time in a row, it returns null.

What happens is that after the object is loaded from the database and its lazy loaded values are retrieved, the object gets serialized for cache.

In Pimcore\Model\DataObject\Localizedfield.php, inside __sleep() method, all lazy loaded fields are unset before writing to cache.
However, there is also $this->loadedLazyKeys array (inside LazyLoadedRelationTrait) that still keeps the key marked as loaded.

That causes the issue on the next object load, because the object is pulled from cache (without lazy loaded fields), and $this->isLazyKeyLoaded (used in loadLazyField method inside Localizedfield.php) returns true because the key stayed marked as loaded. Therefore, the localized field value is not fetched from the database and it returns null.

The proposed solution would be to also unmark lazy loaded key as loaded, after the lazy loaded values are removed on serialization for cache. When that's done, $this->isLazyKeyLoaded will return false and the lazy loaded field will be loaded when requested.
