### PR TITLE
[XLIFF Export] Export translated target document settings

### DIFF
--- a/lib/Translation/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
+++ b/lib/Translation/ExportDataExtractorService/DataExtractor/DocumentDataExtractor.php
@@ -129,15 +129,30 @@ class DocumentDataExtractor extends AbstractElementDataExtractor
      */
     protected function addSettings(Document $document, AttributeSet $result): DocumentDataExtractor
     {
+        $service = new Document\Service;
+        $translations = $service->getTranslations($document);
+
         if ($document instanceof Document\Page) {
             $data = [
                 'title' => $document->getTitle(),
                 'description' => $document->getDescription(),
             ];
 
+            $targetData = [];
+            foreach ($result->getTargetLanguages() as $targetLanguage) {
+                if (isset($translations[$targetLanguage])) {
+                    $targetDocument = Document::getById($translations[$targetLanguage]);
+
+                    if ($targetDocument instanceof  Document\PageSnippet) {
+                        $targetData['title'][$targetLanguage] = $document->getTitle();
+                        $targetData['description'][$targetLanguage] = $document->getDescription();
+                    }
+                }
+            }
+
             foreach ($data as $key => $content) {
                 if (!empty(trim($content))) {
-                    $result->addAttribute(Attribute::TYPE_SETTINGS, $key, $content);
+                    $result->addAttribute(Attribute::TYPE_SETTINGS, $key, $content, false, $targetData[$key] ?? []);
                 }
             }
         }


### PR DESCRIPTION
## Changes in this pull request  
related to #8361

## Additional info  
If a target document has translated value in settings "title" & "description" then it should be added as target tag. 
