### PR TITLE
[Document] Fixed editmode flickering

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/edit/startup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/edit/startup.js
@@ -171,9 +171,9 @@ Ext.onReady(function () {
             ) {
                 new Ext.ToolTip({
                     target: tmpEl,
-                    showDelay: 100,
+                    showDelay: 1000,
                     hideDelay: 0,
-                    trackMouse: true,
+                    trackMouse: false,
                     html: t("click_right_for_more_options")
                 });
             }


### PR DESCRIPTION
fixes #8419

Obviously caused by the tooltips - extending the timeout and disabling mouse tracking solves the issue and is imho better experience anyway. 