### PR TITLE
[Data Object] unpublish publish permission fix

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1255,7 +1255,7 @@ class DataObjectController extends ElementControllerBase implements EventedContr
             $object->setOmitMandatoryCheck(true);
         }
 
-        if (($request->get('task') == 'publish' && $object->isAllowed('publish')) || ($request->get('task') == 'unpublish' && $object->isAllowed('unpublish'))) {
+        if (($request->get('task') == 'publish') || ($request->get('task') == 'unpublish')) {
             if ($data) {
                 if (!$this->performFieldcollectionModificationCheck($request, $object, $originalModificationDate, $data)) {
                     return $this->adminJson(['success' => false, 'message' => 'Could be that someone messed around with the fieldcollection in the meantime. Please reload and try again']);

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1238,10 +1238,15 @@ class DataObjectController extends ElementControllerBase implements EventedContr
         $this->assignPropertiesFromEditmode($request, $object);
         $this->applySchedulerDataToElement($request, $object);
 
-        if ($request->get('task') == 'unpublish' && $object->isAllowed('unpublish')) {
+        if (($request->get('task') === 'unpublish' && !$object->isAllowed('unpublish')) || ($request->get('task') === 'publish' && !$object->isAllowed('publish'))) {
+            throw $this->createAccessDeniedHttpException();
+        }
+
+        if ($request->get('task') == 'unpublish') {
             $object->setPublished(false);
         }
-        if ($request->get('task') == 'publish' && $object->isAllowed('publish')) {
+
+        if ($request->get('task') == 'publish') {
             $object->setPublished(true);
         }
 


### PR DESCRIPTION
## Changes in this pull request  
The DataObjectController::saveAction() will now throw errors when unpublishing/publishing is not allowed. Otherwise the DataObject will get crossed out while no publishing/unpublishing is actually done.


## Additional info  
If a customer wants to publish/unpublish an object via context menu, where he/she doesn't has any permissions, the saveAction() will end up in the final elseif-Condition `elseif ($object->isAllowed('save'))`. 
Therefor even if the user has no permissions, a new (per default) unpublished version is stored and the response treeData contains `published: false`.

This fix is an adaption of https://github.com/pimcore/pimcore/pull/7101/files

