### PR TITLE
[Grid Config] Admins should be able to change + delete shared grid configurations

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -186,7 +186,7 @@ final class DataObjectHelperController extends AdminController
         }
         $success = false;
         if ($gridConfig) {
-            if ($gridConfig->getOwnerId() != $this->getAdminUser()->getId()) {
+            if ($gridConfig->getOwnerId() != $this->getAdminUser()->getId() && !$this->getAdminUser()->isAdmin()) {
                 throw new \Exception("don't mess with someone elses grid config");
             }
 
@@ -315,13 +315,13 @@ final class DataObjectHelperController extends AdminController
                         $userIds = array_merge($userIds, $this->getAdminUser()->getRoles());
                     }
                     $userIds = implode(',', $userIds);
-                    $shared = ($savedGridConfig->getOwnerId() != $userId && $savedGridConfig->isShareGlobally()) || $db->fetchOne('select * from gridconfig_shares where sharedWithUserId IN (' . $userIds . ') and gridConfigId = ' . $savedGridConfig->getId());
+                    $shared = ($savedGridConfig->getOwnerId() != $userId && !$this->getAdminUser()->isAdmin() && $savedGridConfig->isShareGlobally()) || $db->fetchOne('select * from gridconfig_shares where sharedWithUserId IN (' . $userIds . ') and gridConfigId = ' . $savedGridConfig->getId());
 
 //                    $shared = $savedGridConfig->isShareGlobally() ||GridConfigShare::getByGridConfigAndSharedWithId($savedGridConfig->getId(), $this->getUser()->getId());
                 } catch (\Exception $e) {
                 }
 
-                if (!$shared && $savedGridConfig->getOwnerId() != $this->getAdminUser()->getId()) {
+                if (!$shared && $savedGridConfig->getOwnerId() != $this->getAdminUser()->getId() && !$this->getAdminUser()->isAdmin()) {
                     throw new \Exception('you are neither the onwner of this config nor it is shared with you');
                 }
                 $gridConfigId = $savedGridConfig->getId();
@@ -905,7 +905,7 @@ final class DataObjectHelperController extends AdminController
                     } catch (\Exception $e) {
                     }
                 }
-                if ($gridConfig && $gridConfig->getOwnerId() != $this->getAdminUser()->getId()) {
+                if ($gridConfig && $gridConfig->getOwnerId() != $this->getAdminUser()->getId() && !$this->getAdminUser()->isAdmin()) {
                     throw new \Exception("don't mess around with somebody elses configuration");
                 }
 
@@ -940,7 +940,7 @@ final class DataObjectHelperController extends AdminController
                 $settings['gridConfigName'] = $gridConfig->getName();
                 $settings['gridConfigDescription'] = $gridConfig->getDescription();
                 $settings['shareGlobally'] = $gridConfig->isShareGlobally();
-                $settings['isShared'] = !$gridConfig || ($gridConfig->getOwnerId() != $this->getAdminUser()->getId());
+                $settings['isShared'] = !$gridConfig || ($gridConfig->getOwnerId() != $this->getAdminUser()->getId() && !$this->getAdminUser()->isAdmin());
 
                 return $this->adminJson(['success' => true,
                         'settings' => $settings,
@@ -970,7 +970,7 @@ final class DataObjectHelperController extends AdminController
             return;
         }
 
-        if ($gridConfig->getOwnerId() != $this->getAdminUser()->getId()) {
+        if ($gridConfig->getOwnerId() != $user->getId() && !$user->isAdmin()) {
             throw new \Exception("don't mess with someone elses grid config");
         }
         $combinedShares = [];

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -328,6 +328,12 @@ final class DataObjectHelperController extends AdminController
                 $gridConfig = $savedGridConfig->getConfig();
                 $gridConfig = json_decode($gridConfig, true);
                 $gridConfigName = $savedGridConfig->getName();
+                $owner = $savedGridConfig->getOwnerId();
+                $ownerObject = User::getById($owner);
+                if($ownerObject instanceof User) {
+                    $owner = $ownerObject->getName();
+                }
+                $modificationDate = $savedGridConfig->getModificationDate();
                 $gridConfigDescription = $savedGridConfig->getDescription();
                 $sharedGlobally = $savedGridConfig->isShareGlobally();
             }
@@ -512,6 +518,8 @@ final class DataObjectHelperController extends AdminController
         $settings['gridConfigId'] = (int)$gridConfigId;
         $settings['gridConfigName'] = $gridConfigName ?? null;
         $settings['gridConfigDescription'] = $gridConfigDescription ?? null;
+        $settings['owner'] = $owner ?? null;
+        $settings['modificationDate'] = $modificationDate ?? null;
         $settings['shareGlobally'] = $sharedGlobally ?? null;
         $settings['isShared'] = !$gridConfigId || ($shared ?? null);
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/helpers/gridConfigDialog.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/helpers/gridConfigDialog.js
@@ -144,10 +144,9 @@ pimcore.element.helpers.gridConfigDialog = Class.create({
     },
 
     getSaveAndSharePanel: function () {
-
         var user = pimcore.globalmanager.get("user");
-        if (user.isAllowed("share_configurations")) {
 
+        if (user.isAllowed("share_configurations")) {
             this.userStore = new Ext.data.JsonStore({
                 autoDestroy: true,
                 autoLoad: true,
@@ -194,6 +193,24 @@ pimcore.element.helpers.gridConfigDialog = Class.create({
             value: this.settings ? this.settings.gridConfigDescription : ""
         });
 
+        var ownerField = new Ext.form.TextField({
+            fieldLabel: t('userowner'),
+            name: 'owner',
+            length: 50,
+            readOnly: true,
+            width: '100%',
+            value: this.settings.owner ? this.settings.owner : user.name
+        });
+
+        var modificationDateField = new Ext.form.TextField({
+            fieldLabel: t('modificationdate'),
+            name: 'modificationDate',
+            length: 50,
+            readOnly: true,
+            width: '100%',
+            value: this.settings.modificationDate > 0 ? new Date(this.settings.modificationDate * 1000) : new Date()
+        });
+
         if (user.isAllowed("share_configurations")) {
             this.userSharingField = Ext.create('Ext.form.field.Tag', {
                 name: "sharedUserIds",
@@ -230,9 +247,8 @@ pimcore.element.helpers.gridConfigDialog = Class.create({
             });
         }
 
-        var items = [this.nameField, this.descriptionField];
+        var items = [this.nameField, this.descriptionField, ownerField, modificationDateField];
 
-        var user = pimcore.globalmanager.get("user");
         if (user.admin) {
             this.shareGlobally = new Ext.form.field.Checkbox(
                 {

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -40,7 +40,7 @@
   "mimetype": "MIME-Type",
   "creationdate": "Creation Date",
   "usermodification": "User Modification",
-  "userowner": "User Owner",
+  "userowner": "Owner",
   "languages": "Languages",
   "password_was_not_changed": "Password wasn't changed because it isn't secure enough",
   "marketing": "Marketing",


### PR DESCRIPTION
Currently only the owner of a shared grid configuration (aka the person who created the grid config) can change and delete it. With this PR also admin users are allowed to change and delete shared grid configurations.

Additionally this PR adds 2 readonly fields in the grid config `Save & Share` panel for the owner and the modification timestamp. This way users can find out the owner of a shared grid config if they want to suggest changes. 