### PR TITLE
[Document] Moved editable duplicate detection to JS to prevent issues…

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/edit/startup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/edit/startup.js
@@ -112,6 +112,22 @@ Ext.onReady(function () {
 
     if (typeof Ext == "object" && typeof pimcore == "object") {
 
+        // check for duplicate editables
+        var editableHtmlEls = {};
+        var foundDuplicate = false;
+        document.querySelectorAll('.pimcore_editable').forEach(editableEl => {
+            if(editableHtmlEls[editableEl.id]) {
+                pimcore.helpers.showNotification("ERROR", "Duplicate editable name: " + editableEl.dataset.name, "error");
+                foundDuplicate = true;
+            }
+            editableHtmlEls[editableEl.id] = true;
+        });
+
+        if(foundDuplicate) {
+            return;
+        }
+
+        // initialize editables
         editableDefinitions.forEach(editableDef => {
             editableManager.addByDefinition(editableDef);
         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/edit/startup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/edit/startup.js
@@ -114,18 +114,14 @@ Ext.onReady(function () {
 
         // check for duplicate editables
         var editableHtmlEls = {};
-        var foundDuplicate = false;
         document.querySelectorAll('.pimcore_editable').forEach(editableEl => {
             if(editableHtmlEls[editableEl.id]) {
-                pimcore.helpers.showNotification("ERROR", "Duplicate editable name: " + editableEl.dataset.name, "error");
-                foundDuplicate = true;
+                let message = "Duplicate editable name: " + editableEl.dataset.name;
+                pimcore.helpers.showNotification("ERROR", message, "error");
+                throw message;
             }
             editableHtmlEls[editableEl.id] = true;
         });
-
-        if(foundDuplicate) {
-            return;
-        }
 
         // initialize editables
         editableDefinitions.forEach(editableDef => {

--- a/lib/Document/Editable/EditmodeEditableDefinitionCollector.php
+++ b/lib/Document/Editable/EditmodeEditableDefinitionCollector.php
@@ -44,10 +44,6 @@ final class EditmodeEditableDefinitionCollector
             return;
         }
 
-        if (isset($this->editableDefinitions[$editable->getName()])) {
-            throw new \Exception(sprintf('Duplicate editable name `%s`', $editable->getName()));
-        }
-
         $this->editableDefinitions[$editable->getName()] = $editable->getEditmodeDefinition();
     }
 


### PR DESCRIPTION
… when an editable it casted to string multiple times

With this fix, the following code doesn't break the editmode anymore. 
```twig
    {% set foo = pimcore_input('title') %}
    {% set miau = foo | default(null) %}
```
