### PR TITLE
Fix: update path when changing relation via search popup

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -376,6 +376,7 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
         this.data.id = data.id;
         this.data.type = data.type;
         this.data.subtype = data.subtype;
+        this.data.path = data.fullpath;
         this.dataChanged = true;
         this.component.removeCls("strikeThrough");
         if (data.published === false) {


### PR DESCRIPTION
The path property wasn't updated when the relation field was changed via the search popup. This causes PathFormatters based on the path value to return a string based on the old value.

## Additional info  
Steps to reproduce:

1. Create a path formatter implementation displaying only the key instead of full path:
```
    public function formatPath(array $result, ElementInterface $source, array $targets, array $params): array
    {
        foreach ($targets as $key => $item) {
            if (!array_key_exists('path', $item) || $item['path'] === null) {
                continue;
            }

            $pathParts = explode('/', $item['path']);
            $result[$key] = array_pop($pathParts);
        }

        return $result;
    }
```
2. Create a ManyToOne relation field with that path formatter
3. Update relation via drag-and-drop: working fine
4. Update relation via search popup: old value is still displayed (until save&reload)

