### PR TITLE
Fix undefined getFieldDefinition in ClassRebuildCommand

### DIFF
--- a/bundles/CoreBundle/Command/ClassesRebuildCommand.php
+++ b/bundles/CoreBundle/Command/ClassesRebuildCommand.php
@@ -126,7 +126,11 @@ class ClassesRebuildCommand extends AbstractCommand
                 $output->writeln(sprintf('%s saved', $brickDefinition->getKey()));
             }
 
-            $brickDefinition->save(false);
+            try {
+                $brickDefinition->save(false);
+            } catch (\Exception $e) {
+                $output->write((string)$e);
+            }
         }
 
         if ($output->isVerbose()) {

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -452,6 +452,9 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
                 $containerDefinition[$cl['classname']][$cl['fieldname']][] = $this->key;
 
                 $class = DataObject\ClassDefinition::getByName($cl['classname']);
+                if (!$class) {
+                    throw new \Exception('Could not load class ' . $cl['classname']);
+                }
 
                 $fd = $class->getFieldDefinition($cl['fieldname']);
                 if (!$fd instanceof DataObject\ClassDefinition\Data\Objectbricks) {


### PR DESCRIPTION
If you have a new class definition with an object brick and execute follow command (without this class definition in the db), you get an exception:
```
php bin/console pimcore:deployment:classes-rebuild -n
```