### PR TITLE
Possibility to overwrite executables with env variables

### DIFF
--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -76,6 +76,11 @@ class Console
         if (method_exists(__CLASS__, $customSetupMethod)) {
             self::$customSetupMethod();
         }
+        
+        // CHECK for ENV variables
+        if ($value = getenv('PIMCORE_EXECUTABLE_' . strtoupper($name))) {
+            return $value;
+        }
 
         // use DI to provide the ability to customize / overwrite paths
         if (\Pimcore::hasContainer() && \Pimcore::getContainer()->hasParameter('pimcore_executable_' . $name)) {

--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -77,7 +77,7 @@ class Console
             self::$customSetupMethod();
         }
         
-        // CHECK for ENV variables
+        // Check for env variables
         if ($value = getenv('PIMCORE_EXECUTABLE_' . strtoupper($name))) {
             return $value;
         }

--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -61,7 +61,7 @@ class Console
      * @param string $name
      * @param bool $throwException
      *
-     * @return bool|mixed|string
+     * @return bool|string
      *
      * @throws \Exception
      */
@@ -76,20 +76,22 @@ class Console
         if (method_exists(__CLASS__, $customSetupMethod)) {
             self::$customSetupMethod();
         }
-        
-        // Check for env variables
-        if ($value = getenv('PIMCORE_EXECUTABLE_' . strtoupper($name))) {
-            return $value;
-        }
 
         // use DI to provide the ability to customize / overwrite paths
         if (\Pimcore::hasContainer() && \Pimcore::getContainer()->hasParameter('pimcore_executable_' . $name)) {
             $value = \Pimcore::getContainer()->getParameter('pimcore_executable_' . $name);
-            if (!$value && $throwException) {
-                throw new \Exception("'$name' executable was disabled manually in parameters.yml");
+
+            if ($value === false) {
+                if ($throwException) {
+                    throw new \Exception("'$name' executable was disabled manually in parameters.yml");
+                }
+
+                return false;
             }
 
-            return $value;
+            if ($value) {
+                return $value;
+            }
         }
 
         $systemConfig = Config::getSystemConfiguration('general');


### PR DESCRIPTION
I want set the executables via .env and .env.local files.

Now it is possible to set it via symfony parameters:

```
parameters:
    pimcore_executable_php: '%env(PIMCORE_EXECUTABLE_PHP)%'
```

But if the env doesn't exists, Pimcore now deactivate the executeable and do not check with `whereis`.

I think it would be good if Pimcore itself looks for these env variables.