### PR TITLE
Cache warming should not depend on database

### DIFF
--- a/lib/HttpKernel/CacheWarmer/PimcoreCoreCacheWarmer.php
+++ b/lib/HttpKernel/CacheWarmer/PimcoreCoreCacheWarmer.php
@@ -14,6 +14,7 @@
 
 namespace Pimcore\HttpKernel\CacheWarmer;
 
+use Doctrine\DBAL\Driver\DriverException;
 use Pimcore\Bootstrap;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
@@ -43,7 +44,12 @@ class PimcoreCoreCacheWarmer implements CacheWarmerInterface
         $this->modelClasses($classes);
 
         if (\Pimcore::isInstalled()) {
-            $this->dataObjectClasses($classes);
+            try {
+                $this->dataObjectClasses($classes);
+            }
+            catch (DriverException $exception) {
+                //Ignore. Database might not be setup yet
+            }
         }
 
         return $classes;


### PR DESCRIPTION
Clearing the cache where Pimcore thinks it is installed (by only checking if a connection can be done) still depends on the database. what if the database is empty or does not yet exist? that will still throw an error.