### PR TITLE
[Grid] Enable inheritance for grid operators

### DIFF
--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -545,12 +545,14 @@ class Service extends Model\Element\Service
             return null;
         }
 
+        $inheritanceEnabled = AbstractObject::getGetInheritedValues();
+        AbstractObject::setGetInheritedValues(true);
         $result = $config->getLabeledValue($object);
         if (isset($result->value)) {
             $result = $result->value;
 
             if (!empty($config->renderer)) {
-                $classname = 'Pimcore\\Model\\DataObject\\ClassDefinition\\Data\\' . ucfirst($config->renderer);
+                $classname = 'Pimcore\\Model\\DataObject\\ClassDefinition\\Data\\'.ucfirst($config->renderer);
                 /** @var Model\DataObject\ClassDefinition\Data $rendererImpl */
                 $rendererImpl = new $classname();
                 if (method_exists($rendererImpl, 'getDataForGrid')) {
@@ -560,6 +562,7 @@ class Service extends Model\Element\Service
 
             return $result;
         }
+        AbstractObject::setGetInheritedValues($inheritanceEnabled);
 
         return null;
     }

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -552,7 +552,7 @@ class Service extends Model\Element\Service
             $result = $result->value;
 
             if (!empty($config->renderer)) {
-                $classname = 'Pimcore\\Model\\DataObject\\ClassDefinition\\Data\\'.ucfirst($config->renderer);
+                $classname = 'Pimcore\\Model\\DataObject\\ClassDefinition\\Data\\' . ucfirst($config->renderer);
                 /** @var Model\DataObject\ClassDefinition\Data $rendererImpl */
                 $rendererImpl = new $classname();
                 if (method_exists($rendererImpl, 'getDataForGrid')) {


### PR DESCRIPTION
Currently when you use grid operators you have to manually enable inheritance, otherwise values do not get inherited by parent elements. But for normal fields (without operators) inherited values do get shown by default. 

To reproduce this:
1. Create class Product, enable inheritance, add many-to-many object relation `test`
2. Create an object `/related`
2. Create an object `/parent` and assign `/related` in the relation field `test`
3. Create an object `/parent/child`.
4. Create a PHP class in `src/AppBundle/Operator/Attributes.php` with the follwoing code:
```php
<?php
namespace AppBundle\Operator;

use Pimcore\DataObject\GridColumnConfig\Operator\AbstractOperator;
use Pimcore\DataObject\GridColumnConfig\ResultContainer;
use Pimcore\Model\DataObject;

class Attributes extends AbstractOperator
{
    public function __construct(\stdClass $config, $context = null)
    {
        parent::__construct($config, $context);
    }

    public function getLabeledValue($element)
    {
        $output = implode('<br>', array_map(function($element) {
            return $element->getFullPath();
        }, $element->getTest()));

        $result = new ResultContainer();
        $result->setValue($output);

        return $result;
    }
}
```
4. Open grid, in grid config add field `test` and add operator `PHP code` with PHP class `AppBundle\Operator\Attributes`
The result looks like this:
<img width="268" alt="Bildschirmfoto 2021-03-30 um 12 37 14" src="https://user-images.githubusercontent.com/8749138/112976062-acf5c380-9154-11eb-814e-4c57b2e411a6.png">
You see that although in column `Test` there are related items, in the operator column there is only for the parent element, not for the child.

With this PR the result looks like this:
<img width="266" alt="Bildschirmfoto 2021-03-30 um 12 39 33" src="https://user-images.githubusercontent.com/8749138/112976301-ffcf7b00-9154-11eb-86a3-8db8761f8d44.png">