### PR TITLE
Allow tags to be dropped to other tags, that don't have children yet

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/tag/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/tag/tree.js
@@ -92,7 +92,7 @@ pimcore.element.tag.tree = Class.create({
                 treePlugins = {
                     ptype: 'treeviewdragdrop',
                     ddGroup: "tags",
-                    appendOnly: true
+                    appendOnly: false
                 };
             }
 


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
With the current settings one can only drop tags to an element if it already has children. Setting to _false_ will allow to set it as children as well.


