### PR TITLE
Follow-up on PR #8598 (Classificationstore changes)

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -1202,7 +1202,7 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
         $activeGroupIds = $classificationStore->getActiveGroups();
 
         if ($activeGroupIds) {
-            $activeGroups = array_keys($activeGroupIds, true, true);
+            $activeGroups = array_filter($activeGroupIds);
         }
 
         $class = $object->getClass();


### PR DESCRIPTION
## Changes in this pull request 
Turns out my cleanup prior to committing my [previous changes](https://github.com/pimcore/pimcore/pull/8598) were too hasty and introduced a bug.

`$activeGroups` should keep the format `[id => bool]` in  `recursiveGetActiveGroupsIds()` previous change incorrectly changed it to `[int => id]`, see:
![image](https://user-images.githubusercontent.com/279826/113415724-1cbbb680-93c0-11eb-8ba6-0b33de86fc39.png)


## Additional info  

Might actually need a new 6.8.x release as previous incorrect change makes editing Classification Stores hard in the admin UI as not all groups were properly returned.