### PR TITLE
Fix classificationstore bugs

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -646,16 +646,23 @@ final class ClassificationstoreController extends AdminController implements Ker
     /**
      * @Route("/list-stores", name="pimcore_admin_dataobject_classificationstore_liststores", methods={"GET"})
      *
-     * @param Request $request
-     *
      * @return JsonResponse
      */
-    public function listStoresAction(Request $request)
+    public function listStoresAction()
     {
-        $list = new Classificationstore\StoreConfig\Listing();
-        $list = $list->load();
+        $storeConfigs = [];
+        $storeConfigListing = new Classificationstore\StoreConfig\Listing();
+        $storeConfigListing->load();
 
-        return $this->adminJson($list);
+        foreach ($storeConfigListing as $storeConfig) {
+            $storeConfigs[] = [
+                'id' => $storeConfig->getId(),
+                'name' => $storeConfig->getName(),
+                'description' => $storeConfig->getDescription(),
+            ];
+        }
+
+        return $this->adminJson($storeConfigs);
     }
 
     /**

--- a/models/DataObject/Classificationstore/StoreConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/StoreConfig/Listing/Dao.php
@@ -34,10 +34,14 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function load()
     {
-        $sql = 'SELECT id FROM ' . DataObject\Classificationstore\StoreConfig\Dao::TABLE_NAME_STORES . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit();
+        $sql = 'SELECT id FROM '
+            . DataObject\Classificationstore\StoreConfig\Dao::TABLE_NAME_STORES
+            . $this->getCondition()
+            . $this->getOrder()
+            . $this->getOffsetLimit();
         $configsData = $this->db->fetchCol($sql, $this->model->getConditionVariables());
-
         $configData = [];
+
         foreach ($configsData as $config) {
             $configData[] = DataObject\Classificationstore\StoreConfig::getById($config);
         }


### PR DESCRIPTION
There are two bug-fixes in this Pull-Request. Next time I'll split that into two PRs - sorry!

## Bug 1 - Classification-Store limitation
### Description
The selected fields of a classificaton store are not all included in the GRID view.

> Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`

The bug exists in Pimcore X (10) and also in Pimcore 6. How you will handel it?

### Steps to reproduce
1. Create a Group and assign more than 15 keys:
![Group Relations](https://user-images.githubusercontent.com/31919154/113453306-020c3080-9406-11eb-9f97-e3ff1b8347b7.png)

2. Select more than 15 keys in the GRID-View relation panel:
![Key-Selection](https://user-images.githubusercontent.com/31919154/113453308-02a4c700-9406-11eb-9ccf-41b845301864.png)

3. Only 15 keys are included in the GRID view
![only 15](https://user-images.githubusercontent.com/31919154/113453309-02a4c700-9406-11eb-81cb-025d778798c7.png)


## Bug 2 - Empty classificationstore names in class definition
### Description
The select field in the class definition shows options but without a name.

The bug only exists in Pimcore X (10). The serializer called by "adminJson" can't handle the "StoreConfig"-DataObject.
The serializer could be causing problems at other places?

### Steps to reproduce
1. Create one ore more classificationstores
2. Place the data field "Classfication Store" in a class definition
3. Scroll down in the field definition to "Store" option
![image](https://user-images.githubusercontent.com/31919154/113454177-ebff6f80-9407-11eb-9bb3-fa43930538ff.png)

After save and reopen the class definition the extjs id is displayed:
![image](https://user-images.githubusercontent.com/31919154/113454211-ff123f80-9407-11eb-92d6-155c7f1a3e2d.png)
