### PR TITLE
Remove `final` keyword in ConnectionFactory.php

### DIFF
--- a/lib/Storage/Redis/ConnectionFactory.php
+++ b/lib/Storage/Redis/ConnectionFactory.php
@@ -105,11 +105,11 @@ class ConnectionFactory
         ];
     }
 
-    final private function __construct()
+    private function __construct()
     {
     }
 
-    final private function __clone()
+    private function __clone()
     {
     }
 }


### PR DESCRIPTION
## Changes in this pull request  
Fixes PHP Warning: `Warning: Private methods cannot be final as they are never overridden by other classes in /var/www/pimcore/vendor/pimcore/pimcore/lib/Storage/Redis/ConnectionFactory.php on line 112`

