### PR TITLE
[Document] block editable styling fix for initial controls

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/block.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/block.js
@@ -190,6 +190,8 @@ pimcore.document.editables.block = Class.create(pimcore.document.editable, {
 
     addBlock : function (element, amountbox) {
 
+        Ext.get(this.id).removeCls("pimcore_block_buttons");
+
         var index = this.getElementIndex(element) + 1;
         var amount = 1;
 


### PR DESCRIPTION
After adding the first block (without reload) the entire block stayed semi-transparent. 

![image](https://user-images.githubusercontent.com/142037/113555422-339a1d00-95fb-11eb-9c31-f5e3797a06c6.png)
