### PR TITLE
[Document version preview] Prevent error when xvfb-run is not available

### DIFF
--- a/lib/Image/HtmlToImage.php
+++ b/lib/Image/HtmlToImage.php
@@ -78,7 +78,7 @@ class HtmlToImage
             $command = [$xvfb, '--auto-servernum', '--server-args=-screen 0, 1280x1024x24',
                 self::getWkhtmltoimageBinary(), '--use-xserver', ];
         } else {
-            $command = self::getWkhtmltoimageBinary();
+            $command = [self::getWkhtmltoimageBinary()];
         }
         $command = array_merge($command, $options);
         Console::addLowProcessPriority($command);


### PR DESCRIPTION
WIthout this PR you get the error `Warning: array_merge(): Expected parameter 1 to be an array, string given` when trying to display a document version.