### PR TITLE
style: remove unnecessary space in export filename

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -276,7 +276,7 @@ class TranslationController extends AdminController
         $response = new Response("\xEF\xBB\xBF" . $csv);
         $response->headers->set('Content-Encoding', 'UTF-8');
         $response->headers->set('Content-Type', 'text/csv; charset=UTF-8');
-        $response->headers->set('Content-Disposition', 'attachment; filename="export_ ' . $suffix . '_translations.csv"');
+        $response->headers->set('Content-Disposition', 'attachment; filename="export_' . $suffix . '_translations.csv"');
         ini_set('display_errors', false); //to prevent warning messages in csv
 
         return $response;


### PR DESCRIPTION
**Filename before:**
`export_ website_translations.csv`

**Filename after:**
`export_website_translations.csv`