### PR TITLE
[Data Objects] Allow HTML-returning path formatter for many to one relation

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -80,9 +80,8 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
             href.width = 300;
         }
 
-        href.enableKeyEvents = true;
-        href.fieldCls = "pimcore_droptarget_input";
-        this.component = new Ext.form.TextField(href);
+        href.fieldBodyCls = 'pimcore_droptarget_input x-form-trigger-wrap';
+        this.component = new Ext.form.field.Display(href);
         if (this.data.published === false) {
             this.component.addCls("strikeThrough");
         }
@@ -104,7 +103,6 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
                 onNodeDrop: this.onNodeDrop.bind(this)
             });
 
-
             el.getEl().on("contextmenu", this.onContextMenu.bind(this));
 
             el.getEl().on('dblclick', function(){
@@ -115,11 +113,6 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
 
                 pimcore.helpers.openElement(this.data.id, this.data.type, subtype);
             }.bind(this));
-        }.bind(this));
-
-        // disable typing into the textfield
-        this.component.on("keyup", function (element, event) {
-            element.setValue(this.data.path);
         }.bind(this));
 
         var items = [this.component, {


### PR DESCRIPTION
Currently the assigned object of a many-to-one relation is displayed in a text field. This PR changes it to a [`DisplayField`](https://docs.sencha.com/extjs/6.2.0/classic/Ext.form.field.Display.html). This has the advantage that you can use a path formatter which returns HTML:
<img width="862" alt="Bildschirmfoto 2021-04-06 um 15 45 54" src="https://user-images.githubusercontent.com/8749138/113721559-ecda1f00-96ef-11eb-80ca-3f4db467e112.png">


As far as I know the capabilities of a text field are not used anyway (e.g. direct typing is disabled).