### PR TITLE
Increase imagick minimum suggested version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
     "composer/composer": "*"
   },
   "suggest": {
-    "ext-imagick": "^3.2.0",
+    "ext-imagick": "^3.4.0",
     "ext-redis": "*",
     "elasticsearch/elasticsearch": "Required for Elastic Search service"
   },


### PR DESCRIPTION
PHP 7 support was [added in version 3.4.0](https://github.com/Imagick/imagick/blob/master/ChangeLog#L187..L189), any earlier version requirement should be moot
