### PR TITLE
Allow resetting offset to 0 in Listings

### DIFF
--- a/lib/Model/Listing/AbstractListing.php
+++ b/lib/Model/Listing/AbstractListing.php
@@ -170,7 +170,7 @@ abstract class AbstractListing extends AbstractModel implements \Iterator, \Coun
     {
         $this->setData(null);
 
-        if (intval($offset) > 0) {
+        if (intval($offset) >= 0) {
             $this->offset = intval($offset);
         }
 


### PR DESCRIPTION
There is currently no way to reset a listing offset to 0.

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [X] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Allows resetting offset to 0 in Listing classes.

## Additional info  
If using KnpPaginator, you can set it to fix the pagination if the paginator runs out of bounds. The paginator resets the offset to the last available page. If there is only 1 page, the offset is reset to 0, but `Listing` class only allows numbers greater than 0
.
https://github.com/pimcore/pimcore/blob/055d64a90e8cd145795ed1e28f16c24fc7629c10/lib/Model/Listing/AbstractListing.php#L169-L178