### PR TITLE
[Editables] - Select - Empty value (even with defaultValue) on initial load

### DIFF
--- a/models/Document/Editable/Select.php
+++ b/models/Document/Editable/Select.php
@@ -90,6 +90,18 @@ class Select extends Model\Document\Editable
     }
 
     /**
+     * @param array $config
+     * @return $this
+     */
+    public function setConfig($config)
+    {
+        $this->config = $config;
+        $this->text = $this->text ?? $this->config['defaultValue'] ?? null;
+
+        return $this;
+    }
+
+    /**
      * @return bool
      */
     public function isEmpty()


### PR DESCRIPTION
# Bug Report
<!--

IMPORTANT: DO NOT SUBMIT ISSUES WHICH WERE NOT VERIFIED ON THE LATEST VERSION OF PIMCORE! 
Bug reports that do not meet the conditions listed below will be closed/deleted without comment.

- [ ] Do not submit reports for unsupported versions, supported versions can be viewed here https://github.com/pimcore/pimcore/milestones
- [ ] This is not a security issue / vulnerability -> use [this form](https://pimcorehq.wufoo.com/forms/pimcore-security-report/) instead
- [ ] Behavior is reproducible on https://demo.pimcore.fun/admin/ (admin/demo)
or on a clean install of the latest build (out of your project, to avoid problems with custom code, plugins, ...)
- [ ] You're not able to fix the problem yourself and send us a pull request instead of filing an issue.
- [ ] There's no existing ticket for the same issue
- [ ] Remove unused sections from below and this bullet points, submit only clean reports

## Please answer the following questions
-->

### Expected behavior
Since 6.8 there is an config for dialog options. A select-type can have a defaultValue via Code which should be accessible right in the twig template right after adding the brick.

### Actual behavior
After adding the brick and accessing the value from the select in the optionDialog, the value will always be null
Only if you reload the current page, the defaultValue will be used if no other value has been set in the meantime.

### Steps to reproduce

add a select type in the dialog option
```php
public function getEditableDialogBoxConfiguration(Document\Editable $area, ?\Pimcore\Model\Document\Editable\Area\Info $info): EditableDialogBoxConfiguration {
        $config = new EditableDialogBoxConfiguration();
        $config
            ->setWidth(700)
            ->setHeight(570)
            ->setReloadOnClose(true)
            ->setItems([
                [
                    'type' => 'select',
                    'label' => 'my cool label',
                    'name' => 'my-identifier',
                    'config' => [
                        'store' => [
                            ['default', 'my-default-label'],
                            ['anothervalue', 'my-other-label'],
                        ],
                        'defaultValue' => 'default',
                    ],
                ],
            ])
        ;

        return $config;
    }
```

```twig
{{ dump(pimcore_select('my-identifier').data) }} {# this will be null right after adding the brick and have the default value after reload / save&reload #}
```

### Steps to solve
Right after the config is set to the select, check if there is a defaultValue coming with the passed array and if so and if the current $text is null, then set the defaultValue to the $text variable
