### PR TITLE
[Image thumbnails] Do not delete downloaded thumbnails when permanent thumbnail definition is used

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/AssetController.php
@@ -1147,6 +1147,7 @@ class AssetController extends ElementControllerBase implements EventedController
         $thumbnail = null;
         $thumbnailName = $request->get('thumbnail');
         $thumbnailFile = null;
+        $deleteThumbnail = true;
 
         if ($request->get('config')) {
             $config = $this->decodeJson($request->get('config'));
@@ -1178,6 +1179,7 @@ class AssetController extends ElementControllerBase implements EventedController
             $config = $predefined[$request->get('type')];
         } elseif ($thumbnailName) {
             $thumbnail = $image->getThumbnail($thumbnailName);
+            $deleteThumbnail = false;
         }
 
         if ($config) {
@@ -1235,7 +1237,7 @@ class AssetController extends ElementControllerBase implements EventedController
             $response->headers->set('Content-Type', $thumbnail->getMimeType());
             $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $downloadFilename);
             $this->addThumbnailCacheHeaders($response);
-            $response->deleteFileAfterSend(true);
+            $response->deleteFileAfterSend($deleteThumbnail);
 
             return $response;
         }


### PR DESCRIPTION
Assume you have created a thumbnail definition and enabled it to be listed as a download option for assets. When you download an asset from the asset detail page in the Pimcore backend, then the thumbnail file gets deleted afterwards. Actually it could be reused if the same thumbnail definition from this asset gets accessed again. But even worse: It gets even deleted if it existed before (e.g. when it got created by a frontend application or whatever called `$image->getThumbnail('name-of-thumbnail-config')`). So this breaks the whole create-once-always-reuse-lifecycle of asset thumbnails.