### PR TITLE
ClassDefinition::allowVariants should be a boolean

### DIFF
--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -1186,7 +1186,7 @@ class ClassDefinition extends Model\AbstractModel
      */
     public function setAllowVariants($allowVariants)
     {
-        $this->allowVariants = (bool)$allowVariants ? true : null;
+        $this->allowVariants = (bool)$allowVariants;
 
         return $this;
     }


### PR DESCRIPTION
The attribute is set initially to false. But if you use the setter it will be set to null. It's very confused