### PR TITLE
Fix: Empty Bundle List

### DIFF
--- a/lib/Tool/ClassUtils.php
+++ b/lib/Tool/ClassUtils.php
@@ -40,6 +40,9 @@ class ClassUtils
      *
      * @param \SplFileInfo $file
      *
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
+     *
      * @return string
      */
     public static function findClassName(\SplFileInfo $file): string
@@ -54,7 +57,6 @@ class ClassUtils
             throw new \InvalidArgumentException(sprintf('File %s does not exist or is not readable', $file->getPathname()));
         }
 
-        $content = '';
         if ($file instanceof SplFileInfo) {
             $content = $file->getContents();
         } else {
@@ -68,14 +70,14 @@ class ClassUtils
 
         foreach (token_get_all($content) as $token) {
             // start collecting as soon as we find the namespace token
-            if (is_array($token) && $token[0] == T_NAMESPACE) {
+            if (is_array($token) && $token[0] === T_NAMESPACE) {
                 $gettingNamespace = true;
             } elseif (is_array($token) && $token[0] === T_CLASS) {
                 $gettingClass = true;
             }
 
             if ($gettingNamespace) {
-                if (is_array($token) && in_array($token[0], [T_STRING, T_NS_SEPARATOR])) {
+                if (is_array($token) && $token[0] === T_NAME_QUALIFIED) {
                     // append to namespace
                     $namespace .= $token[1];
                 } elseif ($token === ';') {

--- a/tests/Unit/Tool/ClassUtilsTest.php
+++ b/tests/Unit/Tool/ClassUtilsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Tests\Unit\Tool;
+
+use Pimcore\Tests\Test\TestCase;
+use Pimcore\Tool\ClassUtils;
+
+class ClassUtilsTest extends TestCase
+{
+    public function testFindClassName()
+    {
+        $file = new \SplFileInfo(__FILE__);
+        $className = ClassUtils::findClassName($file);
+
+        $this->assertEquals($className, self::class);
+    }
+}


### PR DESCRIPTION
In Skeleton is no Bundle in the ExtensionManager. It should be at least PimcoreEcommerceFrameworkBundle.

PHP 8 has a new tokenizer constant T_NAME_QUALIFIED.