### PR TITLE
Fix Array to string conversion

### DIFF
--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -126,7 +126,7 @@ class Composer
             try {
                 static::executeCommand($event, $consoleDir, 'pimcore:migrations:migrate -b '.$bundle['Bundle']);
             } catch (\Throwable $e) {
-                $event->getIO()->write('<comment>Skipping migrations for bundle "'.$bundle.'": '.PHP_EOL.$e.'</comment>', true);
+                $event->getIO()->write('<comment>Skipping migrations for bundle "'.$bundle['Bundle'].'": '.PHP_EOL.$e.'</comment>', true);
             }
         }
 


### PR DESCRIPTION
If a bundle throws an exception in a migration, it shows only: "Notice: Array to string conversion"