### PR TITLE
Placeholder/Twig functionality is missing with PdfReactor

### DIFF
--- a/lib/Web2Print/Processor/PdfReactor.php
+++ b/lib/Web2Print/Processor/PdfReactor.php
@@ -142,7 +142,7 @@ class PdfReactor extends Processor
         $pdfreactor = $this->getClient();
 
         $reactorConfig = $this->getConfig($config);
-        $reactorConfig['document'] = $html;
+        $reactorConfig['document'] = $this->processHtml($html, $params);
 
         $event = new PrintConfigEvent($this, ['config' => $config, 'reactorConfig' => $reactorConfig, 'document' => $document]);
         \Pimcore::getEventDispatcher()->dispatch(DocumentEvents::PRINT_MODIFY_PROCESSING_CONFIG, $event);


### PR DESCRIPTION
It is only in WkHtmlToPdf and in the buildPdfFromString (which is only used in the test page)