### PR TITLE
Defaults for Symfony Mailer transports used by Pimcore

### DIFF
--- a/bundles/CoreBundle/Resources/config/pimcore/default.yml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yml
@@ -24,6 +24,9 @@ framework:
     assets: ~
     mailer:
         enabled: true
+        transports:
+            main: native://default
+            pimcore_newsletter: native://default
 
 # Twig Configuration
 twig:


### PR DESCRIPTION
Pimcore should use PHP default settings for mail delivery. 