### PR TITLE
Fix overwriting where condition in customviews

### DIFF
--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -970,7 +970,7 @@ class Service extends Model\AbstractModel
             $childsList->onCreateQueryBuilder(static function (DoctrineQueryBuilder $select) use ($cv) {
                 $where = $cv['where'] ?? null;
                 if ($where) {
-                    $select->where($where);
+                    $select->andWhere($where);
                 }
 
                 $fromAlias = $select->getQueryPart('form')[1];


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [X] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request 
Allow adding extra where conditions in customviews. (It broke in 6.9, works in 6.8)

## Additional info  
DoctrineQueryBuilder `where` function overrides the complete where condition, thus in customviews you cannot add a simple where condition to the existing one.

Previously in 6.8, in customviews you could add a simple extra filter to the query like `o_published = 1`, so only the published elements would show up in the tree. In 6.9 (using Doctrine Query Builder) currently the whole `where` condition would be only `o_published = 1` and the original where conditions built in the `DataObjectController::treeGetChildsByIdAction` method are lost.