### PR TITLE
Ecommerce index service problem with fraction numbers in elastic search

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/AbstractBatchProcessingWorker.php
@@ -266,11 +266,14 @@ abstract class AbstractBatchProcessingWorker extends AbstractWorker implements B
                 Localizedfield::setGetFallbackValues($getFallbackLanguagesMemory);
 
                 $subTenantData = $this->tenantConfig->prepareSubTenantEntries($object, $subObjectId);
-                $jsonData = json_encode([
-                    'data' => $data,
-                    'relations' => ($relationData ? $relationData : []),
-                    'subtenants' => ($subTenantData ? $subTenantData : []),
-                ]);
+                $jsonData = json_encode(
+                    [
+                        'data' => $data,
+                        'relations' => ($relationData ? $relationData : []),
+                        'subtenants' => ($subTenantData ? $subTenantData : []),
+                    ],
+                    JSON_PRESERVE_ZERO_FRACTION
+                );
 
                 $jsonLastError = \json_last_error();
                 $generalErrors = [];


### PR DESCRIPTION
Let's say we have double type in ES, and some getter on a product returns e.g.: 5.0, but without this flag `JSON_PRESERVE_ZERO_FRACTION`, we'll end up with integer instead after json_encode, and this leads to an error during indexing new products.

This is only the case for numbers like 1.0, 2.0, 3.0, and so on.
Every other fraction number works ok.