### PR TITLE
[Image thumbnails] Bugfix: Automatic image clipping by embedded path

### DIFF
--- a/bundles/CoreBundle/Resources/config/services.yml
+++ b/bundles/CoreBundle/Resources/config/services.yml
@@ -225,4 +225,6 @@ services:
     Pimcore\Image\Adapter\Imagick:
         shared: false
         public: true
-    Pimcore\Image\Adapter\GD: ~
+    Pimcore\Image\Adapter\GD:
+        shared: false
+        public: true

--- a/bundles/CoreBundle/Resources/config/services.yml
+++ b/bundles/CoreBundle/Resources/config/services.yml
@@ -222,5 +222,7 @@ services:
         arguments:
             $locator: !tagged_locator { tag: flysystem.storage }
 
-    Pimcore\Image\Adapter\Imagick: ~
+    Pimcore\Image\Adapter\Imagick:
+        shared: false
+        public: true
     Pimcore\Image\Adapter\GD: ~

--- a/bundles/CoreBundle/Resources/config/services.yml
+++ b/bundles/CoreBundle/Resources/config/services.yml
@@ -225,6 +225,7 @@ services:
     Pimcore\Image\Adapter\Imagick:
         shared: false
         public: true
+
     Pimcore\Image\Adapter\GD:
         shared: false
         public: true

--- a/bundles/CoreBundle/Resources/config/services.yml
+++ b/bundles/CoreBundle/Resources/config/services.yml
@@ -221,3 +221,6 @@ services:
         public: true
         arguments:
             $locator: !tagged_locator { tag: flysystem.storage }
+
+    Pimcore\Image\Adapter\Imagick: ~
+    Pimcore\Image\Adapter\GD: ~

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -14,6 +14,7 @@
 
 namespace Pimcore;
 
+use Pimcore;
 use Pimcore\Image\Adapter;
 
 class Image
@@ -42,9 +43,9 @@ class Image
     {
         try {
             if (extension_loaded('imagick')) {
-                return new Adapter\Imagick();
+                return Pimcore::getContainer()->get(Adapter\Imagick::class);
             } else {
-                return new Adapter\GD();
+                return Pimcore::getContainer()->get(Adapter\GD::class);
             }
         } catch (\Exception $e) {
             Logger::crit('Unable to load image extensions: ' . $e->getMessage());

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -135,27 +135,11 @@ class Imagick extends Adapter
                 $identifyRaw = $i->identifyImage(true)['rawOutput'];
                 if (strpos($identifyRaw, 'Clipping path') && strpos($identifyRaw, '<svg')) {
                     // if there's a clipping path embedded, apply the first one
-
                     try {
-                        // known issues:
-                        // - it seems that -clip doesnt work with the ImageMagick version
-                        //   ImageMagick 6.9.7-4 Q16 x86_64 20170114 (which is used in Debian 9)
-                        // - Imagick 3.4.4 with ImageMagick 7 on OSX has horrible broken clipping support
-                        $i->setImageAlphaChannel(\Imagick::ALPHACHANNEL_TRANSPARENT);
                         $i->clipImage();
                     } catch (\Exception $e) {
                         Logger::info(sprintf('Although automatic clipping support is enabled, your current ImageMagick / Imagick version does not support this operation on the image %s', $imagePath));
                     }
-
-                    // Imagick version compatibility
-                    // Since Imagick 3.4.4 compiled against ImageMagick 7 ALPHACHANNEL_OPAQUE was removed for whatever reason
-                    // ImageMagick is still defining and using OpaqueAlphaChannel in ImageMagick 7 releases
-                    // Let's hardcode the current ImageMagick 7 enum number to workaround this issue
-                    $alphaChannel = 11;
-                    if (defined('Imagick::ALPHACHANNEL_OPAQUE')) {
-                        $alphaChannel = \Imagick::ALPHACHANNEL_OPAQUE;
-                    }
-                    $i->setImageAlphaChannel($alphaChannel);
                 }
             }
         } catch (\Exception $e) {


### PR DESCRIPTION
We have a problem with images like the following (with embedded clipping path AND transparency) with enabled `clip_auto_support`
[217001-00-WTAL__ANW-010.tif.zip](https://github.com/pimcore/pimcore/files/6302523/217001-00-WTAL__ANW-010.tif.zip)

WIth current code it looks like this:
<img width="597" alt="Bildschirmfoto 2021-04-13 um 11 09 24" src="https://user-images.githubusercontent.com/8749138/114528154-0841ae80-9c49-11eb-8545-31b73efe7ac1.png">

With this PR applied it looks like this:
<img width="564" alt="Bildschirmfoto 2021-04-13 um 11 11 52" src="https://user-images.githubusercontent.com/8749138/114528207-17286100-9c49-11eb-8e39-b65e32c32b77.png">

This project uses Imagick 3.4.4, and Image Magick 
```
Version: ImageMagick 6.9.7-4 Q16 x86_64 20170114 http://www.imagemagick.org
Copyright: © 1999-2017 ImageMagick Studio LLC
License: http://www.imagemagick.org/script/license.php
Features: Cipher DPC Modules OpenMP 
Delegates (built-in): bzlib djvu fftw fontconfig freetype jbig jng jpeg lcms lqr ltdl lzma openexr pangocairo png tiff wmf x xml zlib
```

When I upload this file to https://demo.pimcore.fun/ the preview looks even worse:
<img width="800" alt="Bildschirmfoto 2021-04-13 um 11 30 41" src="https://user-images.githubusercontent.com/8749138/114531035-d120cc80-9c4b-11eb-9312-086d3f5ade0a.png">
But with this PR it also works there:
<img width="802" alt="Bildschirmfoto 2021-04-13 um 11 33 01" src="https://user-images.githubusercontent.com/8749138/114531260-07f6e280-9c4c-11eb-97e1-81b50507ebaa.png">

I am quite sure that this PR is not the solution because I removed code which is actually there to ensure compatiblity with different image magick versions. But perhaps we can find a way to correctly display above image and also keep the current behaviour for other image magick versions? 
