### PR TITLE
fix missing argument when defining workflows

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Compiler/WorkflowPass.php
+++ b/bundles/CoreBundle/DependencyInjection/Compiler/WorkflowPass.php
@@ -176,6 +176,7 @@ final class WorkflowPass implements CompilerPassInterface
                 $workflowDefinition->replaceArgument(1, $markingStoreDefinition);
             }
             $workflowDefinition->replaceArgument(3, $workflowName);
+            $workflowDefinition->replaceArgument(4, $workflowConfig['events_to_dispatch'] ?? null);
 
             // Store to container
             $container->setDefinition($workflowId, $workflowDefinition);

--- a/bundles/CoreBundle/Resources/config/services_symfony_workflow.yml
+++ b/bundles/CoreBundle/Resources/config/services_symfony_workflow.yml
@@ -13,6 +13,8 @@ services:
             - null
             - '@event_dispatcher'
             - ~
+            - ~
+
     state_machine.abstract:
         class: Symfony\Component\Workflow\StateMachine
         abstract: true
@@ -22,6 +24,8 @@ services:
             - null
             - '@event_dispatcher'
             - ~
+            - ~
+
     workflow.marking_store.multiple_state:
         class: Symfony\Component\Workflow\MarkingStore\MethodMarkingStore
         abstract: true


### PR DESCRIPTION
error message when building the container 
```
Argument 5 of service "state_machine.abstract" is abstract: events to dispatch
```

when other bundles also define workflows... 