### PR TITLE
Update Thumbnail.php

### DIFF
--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -244,7 +244,7 @@ final class Thumbnail
 
             if (isset($options['previewDataUri'])) {
                 $sourceTagAttributes['data-srcset'] = $sourceTagAttributes['srcset'];
-                unset($sourceTagAttributes['srcset']);
+                $sourceTagAttributes['srcset'] = 'data:,1w';
             }
 
             $sourceTagAttributes['type'] = $thumb->getMimeType();


### PR DESCRIPTION
when I use "lowQualityPlaceholder" in pimcore_image, "srcset" is replaced by "data-srcset". That is correct, but w3c validator is complaining that srcset is not available. For this I think it is better not to delete this attribute but fill it with small content.

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

