### PR TITLE
Add noopener and noreferrer to admin login

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/Login/login.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/Login/login.html.twig
@@ -27,10 +27,10 @@
     </div>
 
     <div class="text browserinfo">
-        <a href="http://www.google.com/chrome/" target="_blank" rel="noopener noreferrer" title="Chrome"><img src="/bundles/pimcoreadmin/img/login/chrome.svg" alt="Chrome"/></a>
-        <a href="http://www.mozilla.org/" target="_blank" rel="noopener noreferrer" title="Firefox"><img src="/bundles/pimcoreadmin/img/login/firefox.svg" alt="Firefox"/></a>
-        <a href="http://www.apple.com/safari/" target="_blank" rel="noopener noreferrer" title="Safari"><img src="/bundles/pimcoreadmin/img/login/safari.svg" alt="Safari"/></a>
-        <a href="http://www.microsoft.com/" target="_blank" rel="noopener noreferrer" title="Edge"><img src="/bundles/pimcoreadmin/img/login/edge.svg" alt="Edge"/></a>
+        <a href="https://www.google.com/chrome" target="_blank" rel="noopener noreferrer" title="Chrome"><img src="/bundles/pimcoreadmin/img/login/chrome.svg" alt="Chrome"/></a>
+        <a href="https://www.mozilla.org/firefox" target="_blank" rel="noopener noreferrer" title="Firefox"><img src="/bundles/pimcoreadmin/img/login/firefox.svg" alt="Firefox"/></a>
+        <a href="https://www.apple.com/safari" target="_blank" rel="noopener noreferrer" title="Safari"><img src="/bundles/pimcoreadmin/img/login/safari.svg" alt="Safari"/></a>
+        <a href="https://www.microsoft.com/edge" target="_blank" rel="noopener noreferrer" title="Edge"><img src="/bundles/pimcoreadmin/img/login/edge.svg" alt="Edge"/></a>
     </div>
 
     <a href="#" onclick="showLogin();">{{ 'Click here to proceed'|trans([], 'admin') }}</a>

--- a/bundles/AdminBundle/Resources/views/Admin/Login/login.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/Login/login.html.twig
@@ -27,10 +27,10 @@
     </div>
 
     <div class="text browserinfo">
-        <a href="http://www.google.com/chrome/" target="_blank" title="Chrome"><img src="/bundles/pimcoreadmin/img/login/chrome.svg" alt="Chrome"/></a>
-        <a href="http://www.mozilla.org/" target="_blank" title="Firefox"><img src="/bundles/pimcoreadmin/img/login/firefox.svg" alt="Firefox"/></a>
-        <a href="http://www.apple.com/safari/" target="_blank" title="Safari"><img src="/bundles/pimcoreadmin/img/login/safari.svg" alt="Safari"/></a>
-        <a href="http://www.microsoft.com/" target="_blank" title="Edge"><img src="/bundles/pimcoreadmin/img/login/edge.svg" alt="Edge"/></a>
+        <a href="http://www.google.com/chrome/" target="_blank" rel="noopener noreferrer" title="Chrome"><img src="/bundles/pimcoreadmin/img/login/chrome.svg" alt="Chrome"/></a>
+        <a href="http://www.mozilla.org/" target="_blank" rel="noopener noreferrer" title="Firefox"><img src="/bundles/pimcoreadmin/img/login/firefox.svg" alt="Firefox"/></a>
+        <a href="http://www.apple.com/safari/" target="_blank" rel="noopener noreferrer" title="Safari"><img src="/bundles/pimcoreadmin/img/login/safari.svg" alt="Safari"/></a>
+        <a href="http://www.microsoft.com/" target="_blank" rel="noopener noreferrer" title="Edge"><img src="/bundles/pimcoreadmin/img/login/edge.svg" alt="Edge"/></a>
     </div>
 
     <a href="#" onclick="showLogin();">{{ 'Click here to proceed'|trans([], 'admin') }}</a>


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
## Explanation
Older browsers are not allowed to access the admin backend. Instead,
a set of links to more up-to-date browsers is presented. These utilize
<a> with target="_blank" to open a new window upon clicking a link,
however they are vulnerable to `window.opener`.

## Changes in this pull request  
Adding noopener and noreferrer prevents this in the first place and clears the CVSS score.

## Additional info  
While an extremely unlikely case to cause a security issue, this is still a vulnerablity marked with a CVSS score of 4.8 for Deep Scans, e.g. detectify.com.

Reference: https://dev.to/ben/the-targetblank-vulnerability-by-example
