### PR TITLE
[Data object grid] Prevent ambiguous columns when filtering / sorting by object brick field

### DIFF
--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -557,6 +557,9 @@ class GridHelperService
                         $orderKey = $orderKeyParts[0].'.'.$orderKeyParts[1];
                         $doNotQuote = true;
                     }
+                } else {
+                    $orderKey = $list->getDao()->getTableName().'.'.$orderKey;
+                    $doNotQuote = true;
                 }
             }
         }

--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -234,7 +234,7 @@ class GridHelperService
                     //if the definition doesn't exist check for object brick
                     $keyParts = explode('~', $filterField);
 
-                    if (substr($filterField, 0, 1) == '~') {
+                    if (substr($filterField, 0, 1) === '~') {
                         // not needed for now
 //                            $type = $keyParts[1];
 //                            $field = $keyParts[2];
@@ -532,7 +532,7 @@ class GridHelperService
         }
         if ($sortingSettings['orderKey'] !== null && strlen($sortingSettings['orderKey']) > 0) {
             $orderKey = $sortingSettings['orderKey'];
-            if (!(substr($orderKey, 0, 1) == '~')) {
+            if (substr($orderKey, 0, 1) !== '~') {
                 if (array_key_exists($orderKey, $colMappings)) {
                     $orderKey = $colMappings[$orderKey];
                 } elseif ($orderKey === 'fullpath') {
@@ -553,10 +553,9 @@ class GridHelperService
                         $db = Db::get();
                         $orderKey = $db->quoteIdentifier($brickDescriptor['containerKey'] . '_localized') . '.' . $db->quoteIdentifier($brickDescriptor['brickfield']);
                         $doNotQuote = true;
-                    } else {
-                        if (count($orderKeyParts) == 2) {
-                            $orderKey = $orderKeyParts[1];
-                        }
+                    } elseif (count($orderKeyParts) === 2) {
+                        $orderKey = $orderKeyParts[0].'.'.$orderKeyParts[1];
+                        $doNotQuote = true;
                     }
                 }
             }

--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -174,7 +174,7 @@ class GridHelperService
      *
      * @return string
      */
-    public function getFilterCondition($filterJson, ClassDefinition $class): string
+    public function getFilterCondition($filterJson, ClassDefinition $class, $tablePrefix = null): string
     {
         $systemFields = Model\DataObject\Service::getSystemFields();
 
@@ -310,14 +310,14 @@ class GridHelperService
                     if (is_array($filter['value'])) {
                         $fieldConditions = [];
                         foreach ($filter['value'] as $filterValue) {
-                            $fieldConditions[] = $field->getFilterCondition($filterValue, $operator);
+                            $fieldConditions[] = $field->getFilterCondition($filterValue, $operator, ['brickPrefix' => ($tablePrefix?$tablePrefix.'.':null)]);
                         }
 
                         if (!empty($fieldConditions)) {
                             $conditionPartsFilters[] = '(' . implode(' OR ', $fieldConditions) . ')';
                         }
                     } else {
-                        $conditionPartsFilters[] = $field->getFilterCondition($filter['value'], $operator);
+                        $conditionPartsFilters[] = $field->getFilterCondition($filter['value'], $operator, ['brickPrefix' => ($tablePrefix ? $tablePrefix.'.' : null)]);
                     }
                 } elseif (in_array('o_' . $filterField, $systemFields)) {
                     // system field
@@ -594,7 +594,7 @@ class GridHelperService
 
         // create filter condition
         if (!empty($requestParams['filter'])) {
-            $conditionFilters[] = $this->getFilterCondition($requestParams['filter'], $class);
+            $conditionFilters[] = $this->getFilterCondition($requestParams['filter'], $class, $list->getDao()->getTableName());
             $featureAndSlugFilters = $this->getFeatureAndSlugFilters($requestParams['filter'], $class, $requestedLanguage);
             if ($featureAndSlugFilters) {
                 $featureJoins = array_merge($featureJoins, $featureAndSlugFilters['featureJoins']);

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -620,6 +620,9 @@ abstract class Data
         $db = \Pimcore\Db::get();
         $name = $params['name'] ? $params['name'] : $this->name;
         $key = $db->quoteIdentifier($name);
+        if (!empty($params['brickPrefix'])) {
+            $key = $params['brickPrefix'].$key;
+        }
 
         if ($value === 'NULL') {
             if ($operator == '=') {
@@ -637,9 +640,9 @@ abstract class Data
 
         if (in_array($operator, DataObject\ClassDefinition\Data::$validFilterOperators)) {
             return $key . ' ' . $operator . ' ' . $value . ' ';
-        } else {
-            return '';
         }
+
+        return '';
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -416,11 +416,18 @@ class Multiselect extends Data implements ResourcePersistenceAwareInterface, Que
      */
     public function getFilterConditionExt($value, $operator, $params = [])
     {
-        if ($operator == '=') {
+        if ($operator === '=') {
             $name = $params['name'] ? $params['name'] : $this->name;
+
+            $db = \Pimcore\Db::get();
+            $key = $db->quoteIdentifier($name);
+            if (!empty($params['brickPrefix'])) {
+                $key = $params['brickPrefix'].$key;
+            }
+
             $value = "'%,".$value.",%'";
 
-            return '`'.$name.'` LIKE '.$value.' ';
+            return $key.' LIKE '.$value.' ';
         }
 
         return null;

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -520,10 +520,18 @@ class Select extends Data implements ResourcePersistenceAwareInterface, QueryRes
         $value = is_array($value) ? current($value) : $value;
         $name = $params['name'] ?: $this->name;
 
+        $db = \Pimcore\Db::get();
+        $key = $db->quoteIdentifier($name);
+        if (!empty($params['brickPrefix'])) {
+            $key = $params['brickPrefix'].$key;
+        }
+
         if ($operator === '=') {
-            return '`'.$name.'` = '."\"$value\"".' ';
-        } elseif ($operator === 'LIKE') {
-            return '`'.$name.'` LIKE '."\"%$value%\"".' ';
+            return $key.' = '."\"$value\"".' ';
+        }
+
+        if ($operator === 'LIKE') {
+            return $key.' LIKE '."\"%$value%\"".' ';
         }
 
         return null;


### PR DESCRIPTION
Steps to reproduce problem:
1. Create class `Product`. Add a `select` field `test` and option `A`and `B`. Add an object brick field named `bricks`.
2. Create an object brick `Brick`. Add a `select` field `test` and option `A`and `B`. Assign `Product.bricks` as allowed brick field.
3. Create an object `/A` of class `Product`, assign object brick `Brick`, select `A` in `Brick.test`.
4. Click `Home` in data object tree, click `Grid options` add field `test` from object brick `Brick`
5. Sort by field `test` -> first ambiguous column error appears
6. Filter by field `test=A` -> second ambiguous column error appears

This PR prefixes the sort / filter field names with the brick table alias.