### PR TITLE
Config::setSystemConfig sets it to the runtime but getSystemConfig never gets it from there

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -136,7 +136,7 @@ class Config implements \ArrayAccess
     }
 
     /**
-     * @internal
+     * @internal ONLY FOR TESTING PURPOSES IF NEEDED FOR SPECIFIC TEST CASES
      *
      * @param null|array $configuration
      * @param null|mixed $offset

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -138,6 +138,23 @@ class Config implements \ArrayAccess
     /**
      * @internal
      *
+     * @param null|array $configuration
+     * @param null|mixed $offset
+     */
+    public static function setSystemConfiguration($configuration, $offset = null)
+    {
+        if (null !== $offset) {
+            self::getSystemConfiguration();
+            static::$systemConfig[$offset] = $configuration;
+        } else {
+            static::$systemConfig = $configuration;
+        }
+    }
+
+
+    /**
+     * @internal
+     *
      * @param null|mixed $offset
      *
      * @return null|array


### PR DESCRIPTION
resolves #8825
