### PR TITLE
Bugfix for incorrect maxDepth comparison

### DIFF
--- a/lib/Navigation/Builder.php
+++ b/lib/Navigation/Builder.php
@@ -332,7 +332,7 @@ class Builder
 
                 $page->setClass($page->getClass() . $classes);
 
-                if ($child->hasChildren() && (!$maxDepth || $maxDepth > $this->currentLevel)) {
+                if ($child->hasChildren() && (!$maxDepth || $maxDepth >= $this->currentLevel)) {
                     $childPages = $this->buildNextLevel($child, false, $pageCallback, $parents, $maxDepth);
                     $page->setPages($childPages);
                 }


### PR DESCRIPTION
## Changes in this pull request  

Resolves a bug which would happen in only specific instances.

Consider the following scenario:

```twig
{% set menuOptions = { active: document, maxDepth: 5, expandSiblingNodesOfActiveBranch: true, onlyActiveBranch: true } %}
{{ pimcore_render_nav(pageNavigation, 'menu', 'renderMenu', menuOptions) }}
```

With a document structure that is at least 2 levels deeper than `maxDepth`, example where _Produkter_ is the root document for this menu.

![image](https://user-images.githubusercontent.com/279826/115725121-dbe10d00-a381-11eb-990e-1e860cec09da.png)

This issue seems to be sensitive to cache:ing, so to reproduce it, first click around in the rendered menu to make sure it has been cached. Also good to do this in a clean browser session for some reason.

Then, *Unpublish* the page at the same level as the configured `maxDepth` by right-clicking and using the context menu option. In the screenshot above this would be _BLL produkter_.

Now click around in the menu again. Most pages will work fine until you once again click on the page which in the screen shot corresponds to _Energi_. At which point the rendered HTML will break.

This bug does not manifest if the unpublished page is on any other level than the exact one set in `maxDepth`.