### PR TITLE
[Data objects] Prevent fatal error when an unpublished version object gets opened after new meta field got added

### DIFF
--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -17,6 +17,7 @@
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
 use Pimcore\Db;
+use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Element;
@@ -239,7 +240,12 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation
                     $columnData = DataObject\Service::gridObjectData($object, $gridFields, null, ['purpose' => 'editmode']);
                     foreach ($this->getColumns() as $c) {
                         $getter = 'get' . ucfirst($c['key']);
-                        $columnData[$c['key']] = $metaObject->$getter();
+
+                        try {
+                            $columnData[$c['key']] = $metaObject->$getter();
+                        } catch(\Exception $e) {
+                            Logger::debug('Meta column '.$c['key'].' does not exist');
+                        }
                     }
 
                     $columnData['rowId'] = $columnData['id'] . self::RELATION_ID_SEPARATOR . $index . self::RELATION_ID_SEPARATOR . $columnData['type'];

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -16,6 +16,7 @@
 
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
+use Exception;
 use Pimcore\Db;
 use Pimcore\Logger;
 use Pimcore\Model;
@@ -326,7 +327,12 @@ class AdvancedManyToManyRelation extends ManyToManyRelation
 
                 foreach ($this->getColumns() as $c) {
                     $getter = 'get' . ucfirst($c['key']);
-                    $itemData[$c['key']] = $metaObject->$getter();
+
+                    try {
+                        $itemData[$c['key']] = $metaObject->$getter();
+                    } catch(Exception $e) {
+                        Logger::debug('Meta column '.$c['key'].' does not exist');
+                    }
                 }
 
                 $itemData['rowId'] = $itemData['id'] . self::RELATION_ID_SEPARATOR . $index . self::RELATION_ID_SEPARATOR . $itemData['type'];


### PR DESCRIPTION
Steps to reproduce:
1. Create class `Product`, add advanced many-to-many relation field `test`, allow assets
2. Create object of class `Product`, assign an asset, click `Only save new version`
3. Add meta column `abc` to field `test` in class `Product`
4. Reload object -> Uncaught exception

The reason is that the serialized `ElementMetadata` object does not have the newly added column but in https://github.com/pimcore/pimcore/blob/881f8a4448f23bddcafb8c01ccc5954cc00dc40f/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php#L342-L345
the current columns of the relational field get used. Thus there is an exception thrown in https://github.com/pimcore/pimcore/blob/881f8a4448f23bddcafb8c01ccc5954cc00dc40f/models/DataObject/Data/ElementMetadata.php#L101