### PR TITLE
Update PriceInfo.php

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PricingManager/PriceInfo.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/PriceInfo.php
@@ -147,9 +147,6 @@ class PriceInfo implements PriceInfoInterface
     public function getPrice(): PriceInterface
     {
         $price = clone $this->priceInfo->getPrice();
-        if ($price == null) {
-            return null;
-        }
 
         if (!$this->rulesApplied || $this->environmentHashChanged()) {
             $this->setAmount($price->getAmount());


### PR DESCRIPTION
$price cannot be null according to the Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\PriceInfoInterface

Looks like this was already resolved in Pimcore X
