### PR TITLE
fix ClassUtils.php with single-level namespaces

### DIFF
--- a/lib/Tool/ClassUtils.php
+++ b/lib/Tool/ClassUtils.php
@@ -77,7 +77,7 @@ class ClassUtils
             }
 
             if ($gettingNamespace) {
-                if (is_array($token) && $token[0] === T_NAME_QUALIFIED) {
+                if (is_array($token) && ($token[0] === T_NAME_QUALIFIED || $token[0] === T_STRING)) {
                     // append to namespace
                     $namespace .= $token[1];
                 } elseif ($token === ';') {

--- a/tests/Unit/Tool/ClassUtilsTest.php
+++ b/tests/Unit/Tool/ClassUtilsTest.php
@@ -29,4 +29,20 @@ class ClassUtilsTest extends TestCase
 
         $this->assertEquals($className, self::class);
     }
+
+    public function testFindNamespaceClassName() {
+
+        //find classname for DummyNamespace/ClassX
+        $file = new \SplFileInfo(__DIR__ . '/../../_support/Resources/dummyfiles/ClassX.php');
+        $className = ClassUtils::findClassName($file);
+
+        $this->assertEquals('DummyNamespace\\ClassX', $className);
+
+        //find classname for DummyNamespace/ClassY
+        $file = new \SplFileInfo(__DIR__ . '/../../_support/Resources/dummyfiles/ClassY.php');
+        $className = ClassUtils::findClassName($file);
+
+        $this->assertEquals('Pimcore\\DummyNamespace\\ClassY', $className);
+    }
+
 }

--- a/tests/_support/Resources/dummyfiles/ClassX.php
+++ b/tests/_support/Resources/dummyfiles/ClassX.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace DummyNamespace;
+
+class ClassX {
+
+}

--- a/tests/_support/Resources/dummyfiles/ClassY.php
+++ b/tests/_support/Resources/dummyfiles/ClassY.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Pimcore\DummyNamespace;
+
+
+class ClassY
+{
+
+}


### PR DESCRIPTION
namespaces like `Test\TestClass` were not detected correctly. 