### PR TITLE
[Contexts] Allow to extend pimcore.context list and use array keys

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -819,7 +819,8 @@ class Configuration implements ConfigurationInterface
     private function addContextNode(ArrayNodeDefinition $rootNode)
     {
         $contextNode = $rootNode->children()
-            ->arrayNode('context');
+            ->arrayNode('context')
+            ->useAttributeAsKey('name');
 
         /** @var ArrayNodeDefinition|NodeDefinition $prototype */
         $prototype = $contextNode->prototype('array');


### PR DESCRIPTION
When a bundle adds the following configuration:
```yaml
pimcore:
  context:
    context_name:
      routes: ~
```
the contexts are not merged correctly. `bin/console debug:config pimcore context` results in:
```
profiler:
    routes:
        -
            path: '^/_(profiler|wdt)(/.*)?$'
            route: false
            host: false
            methods: {  }
admin:
    routes:
        -
            path: '^/admin(/.*)?$'
            route: false
            host: false
            methods: {  }
        -
            route: ^pimcore_admin_
            path: false
            host: false
            methods: {  }
webservice:
    routes:
        -
            path: '^/webservice(/.*)?$'
            route: false
            host: false
            methods: {  }
        -
            route: ^pimcore_webservice
            path: false
            host: false
            methods: {  }
plugin:
    routes:
        -
            path: '^/plugin(/.*)?$'
            route: false
            host: false
            methods: {  }
0:
    routes: {  }
```

So the context name does not get used but numeric indexing. The reason is documented in https://symfony.com/doc/current/components/config/definition.html#array-node-options
> As of writing this, there is an inconsistency: if only one file provides the configuration in question, the keys (i.e. sf_connection and default) are not lost. But if more than one file provides the configuration, the keys are lost as described above.
> In order to maintain the array keys use the useAttributeAsKey() method:

And exactly this is done by this PR. With this PR `bin/console debug:config pimcore context` returns:
```
profiler:
    routes:
        -
            path: '^/_(profiler|wdt)(/.*)?$'
            route: false
            host: false
            methods: {  }
admin:
    routes:
        -
            path: '^/admin(/.*)?$'
            route: false
            host: false
            methods: {  }
        -
            route: ^pimcore_admin_
            path: false
            host: false
            methods: {  }
webservice:
    routes:
        -
            path: '^/webservice(/.*)?$'
            route: false
            host: false
            methods: {  }
        -
            route: ^pimcore_webservice
            path: false
            host: false
            methods: {  }
plugin:
    routes:
        -
            path: '^/plugin(/.*)?$'
            route: false
            host: false
            methods: {  }
context_name:
    routes: {  }
```

This is especially important because in https://github.com/pimcore/pimcore/blob/b46ca46ec026999730dbc11ba702224c61cdf03d/bundles/CoreBundle/EventListener/PimcoreContextListener.php#L79-L88
there is only the check for `if($context)` and with numeric indexes being used, the newly added context gets index `0` and so this condition returns `false`.