### PR TITLE
2FA login form should use relative url

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/Login/twoFactorAuthentication.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/Login/twoFactorAuthentication.html.php
@@ -21,7 +21,7 @@ $this->get("translate")->setDomain("admin");
     </div>
 <?php } ?>
 
-<form method="post" action="<?=$this->url('pimcore_admin_2fa-verify')?>">
+<form method="post" action="<?=$view->router()->path('pimcore_admin_2fa-verify')?>">
     <input name="_auth_code" id="_auth_code" autocomplete="one-time-code" type="password" placeholder="<?= $this->translate("2fa_code"); ?>" required autofocus>
     <input type="hidden" name="csrfToken" value="<?= $this->csrfToken ?>">
 


### PR DESCRIPTION
Here should be a relative not absolute URL. It makes problems if Pimcore is behind a proxy.

Original output of the view:

`<form method="post" action="http://xyx.cz/admin/login/2fa-verify">`

After the change

`<form method="post" action="/admin/login/2fa-verify">`