### PR TITLE
[Areablock editable] Support twig condition for "areablock is (not) empty"

### DIFF
--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -31,7 +31,7 @@ use Pimcore\Tool\HtmlUtils;
 /**
  * @method \Pimcore\Model\Document\Editable\Dao getDao()
  */
-class Areablock extends Model\Document\Editable implements BlockInterface
+class Areablock extends Model\Document\Editable implements BlockInterface, \Countable
 {
     /**
      * Contains an array of indices, which represent the order of the elements in the block
@@ -617,6 +617,11 @@ class Areablock extends Model\Document\Editable implements BlockInterface
     public function getCount()
     {
         return count($this->indices);
+    }
+
+    public function count()
+    {
+        return $this->getCount();
     }
 
     /**


### PR DESCRIPTION
When you have a document template with an area block like this:
```twig
{% set areablock = pimcore_areablock('container') %}

{% if areablock is not empty %}
    {{ areablock | raw }}
 {% endif %}
```
then you will see the area block's contents duplicated. This is because of how Twig checks for `empty`, see https://twig.symfony.com/doc/2.x/tests/empty.html - the problematic part is `For objects that implement the __toString() magic method (and not Countable), it will check if an empty string is returned.` Without this PR this means that https://github.com/pimcore/pimcore/blob/7e0b0a68cc32fa09b16e75d8de3ee8e49a4b8dc7/models/Document/Editable.php#L463-L469 gets called and this renders the area block items.
With this PR this does not happen because Twig then uses the `count()` method to check if the area block is empty.