### PR TITLE
[Cache] Default PDO cache should also use PDO for storing the tag information

### DIFF
--- a/bundles/CoreBundle/Resources/config/cache.yml
+++ b/bundles/CoreBundle/Resources/config/cache.yml
@@ -16,7 +16,7 @@ services:
 
     pimcore.cache.adapter.null_tag_aware:
         class: Symfony\Component\Cache\Adapter\TagAwareAdapter
-        arguments: ['@pimcore.cache.adapter.null']
+        arguments: ['@pimcore.cache.adapter.null', null]
 
     pimcore.cache.adapter.pdo:
         class: Symfony\Component\Cache\Adapter\PdoAdapter

--- a/bundles/CoreBundle/Resources/config/cache.yml
+++ b/bundles/CoreBundle/Resources/config/cache.yml
@@ -27,7 +27,7 @@ services:
 
     pimcore.cache.adapter.pdo_tag_aware:
         class: Symfony\Component\Cache\Adapter\TagAwareAdapter
-        arguments: [ '@pimcore.cache.adapter.pdo' ]
+        arguments: [ '@pimcore.cache.adapter.pdo', null ]
 
     pimcore.cache.adapter.redis_tag_aware:
         class: Symfony\Component\Cache\Adapter\RedisTagAwareAdapter


### PR DESCRIPTION
Until now it used `FilesystemAdapter` because of DI, no idea why (actually it should be null and use the same as for `$itemsPool`). Probably because it's somewhere bound to `Symfony\Component\Cache\Adapter\AdapterInterface` by a bundle or Symfony itself. 