### PR TITLE
Add timeout option to elastic search client

### DIFF
--- a/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/07_Elastic_Search/01_Configuration_Details.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/07_Elastic_Search/01_Configuration_Details.md
@@ -19,6 +19,8 @@ also [elasticsearch Docs](https://www.elastic.co/guide/en/elasticsearch/client/p
 - `hosts`: Array of hosts of the elasticsearch cluster to use. 
 - `indexType`: Necessary for elasticsearch 5 - defines the type name of products in index.
   For elasticsearch 6 it is optional, do not use it for elasticsearch 7.    
+- `timeoutMs`: optional parameter for setting the client timeout (frontend) in milliseconds.
+- `timeoutMsBackend`: optional parameter for setting the client timeout (CLI) in milliseconds. This value is typically higher than ``timeoutMs``.
 
 ##### `synonym_providers`
 Specify synonym providers for synonym filters defined in filter section of index settings. 
@@ -39,6 +41,8 @@ pimcore_ecommerce_framework:
                         hosts:
                             - '%elasticsearch.host%'
                         indexType: '_doc' # optional for elasticsearch 6, not needed for elasticsearch 7
+                        timeoutMs: 20000, # 20 seconds
+                        timeoutMsBackend: 120000 # 2 minutes
 
                     index_settings:
                         number_of_shards: 5


### PR DESCRIPTION
Resolves #7803 by adding default timeout parameters and the possibility to overwrite them via ecommerce index settings.