### PR TITLE
[QuickSearch] fix mb-issue in quick-search

### DIFF
--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -523,7 +523,7 @@ class SearchController extends AdminController
             if (strlen($shortPath) <= 50 || $i === 0) {
                 break;
             }
-            array_splice($parts, $i - 1, 1, '...');
+            array_splice($parts, $i - 1, 1, '…');
         }
 
         if (mb_strlen($shortPath) > 50) {

--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -526,8 +526,8 @@ class SearchController extends AdminController
             array_splice($parts, $i - 1, 1, '...');
         }
 
-        if (strlen($shortPath) > 50) {
-            $shortPath = substr($shortPath, 0, 47) . '...';
+        if (mb_strlen($shortPath) > 50) {
+            $shortPath = mb_strstr($shortPath, 0, 47) . '...';
         }
 
         return $shortPath;

--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -527,7 +527,7 @@ class SearchController extends AdminController
         }
 
         if (mb_strlen($shortPath) > 50) {
-            $shortPath = mb_strstr($shortPath, 0, 47) . '...';
+            $shortPath = mb_strstr($shortPath, 0, 49) . '…';
         }
 
         return $shortPath;


### PR DESCRIPTION
when path contains utf8 characters like umlauts quicksearch sometimes looked like 

![image](https://user-images.githubusercontent.com/8792145/116421349-0aa62a00-a83f-11eb-9637-e967470ad3d0.png)

