### PR TITLE
Migration to increase prettyUrl field size to 255

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20210428145320.php
+++ b/bundles/CoreBundle/Migrations/Version20210428145320.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210428145320 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Increases prettyUrl field size to 255';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE `documents_page` CHANGE `prettyUrl` `prettyUrl` varchar(255) NULL AFTER `metaData`;");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE `documents_page` CHANGE `prettyUrl` `prettyUrl` varchar(190) NULL AFTER `metaData`;");
+    }
+}

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -183,7 +183,7 @@ CREATE TABLE `documents_page` (
   `title` varchar(255) DEFAULT NULL,
   `description` varchar(383) DEFAULT NULL,
   `metaData` text,
-  `prettyUrl` varchar(190) DEFAULT NULL,
+  `prettyUrl` varchar(255) DEFAULT NULL,
   `contentMasterDocumentId` int(11) DEFAULT NULL,
   `targetGroupIds` varchar(255) DEFAULT NULL,
   `missingRequiredEditable` tinyint(1) unsigned DEFAULT NULL,


### PR DESCRIPTION
## Changes in this pull request  

If the UI field already allows 255 characters, so should the database. Keeping it short is an editorial issue.

https://github.com/pimcore/pimcore/blob/c4f055340935b9028b358f459267fe9ae42137f3/bundles/AdminBundle/Resources/public/js/pimcore/document/pages/settings.js#L213-L217