### PR TITLE
[Data object version preview] Show brick name for localized brick fields

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/diffVersions.html.php
@@ -198,7 +198,7 @@ $fields = $this->object1->getClass()->getFieldDefinitions();
                         <?php foreach (\Pimcore\Tool::getValidLanguages() as $language) { ?>
                             <?php foreach ($lfd->getFieldDefinitions() as $localizedFieldDefinition) { ?>
                                 <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                                    <td><?= $this->translate($localizedFieldDefinition->getTitle()) ?> (<?= $language; ?>)</td>
+                                    <td><?= ucfirst($asAllowedType)." - ".$this->translate($localizedFieldDefinition->getTitle()) ?> (<?= $language; ?>)</td>
                                     <td><?= $localizedFieldDefinition->getName() ?></td>
 
                                     <?php

--- a/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/previewVersion.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/previewVersion.html.php
@@ -83,7 +83,7 @@ $fields = $this->object->getClass()->getFieldDefinitions();
                         <?php foreach (\Pimcore\Tool::getValidLanguages() as $language) { ?>
                             <?php foreach ($lfd->getFieldDefinitions() as $localizedFieldDefinition) { ?>
                                 <tr<?php if ($c % 2) { ?> class="odd"<?php } ?>>
-                                    <td><?= $this->translate($localizedFieldDefinition->getTitle()) ?> (<?= $language; ?>)</td>
+                                    <td><?= ucfirst($asAllowedType)." - ".$this->translate($localizedFieldDefinition->getTitle()) ?> (<?= $language; ?>)</td>
                                     <td><?= $localizedFieldDefinition->getName() ?></td>
                                     <td>
                                         <?php


### PR DESCRIPTION
Currently the brick name does not get displayed for localized object brick fields. This can lead to confusion because it looks like the field was actually a class field:
<img width="398" alt="Bildschirmfoto 2021-04-28 um 14 09 24" src="https://user-images.githubusercontent.com/8749138/116512891-09214400-a8c9-11eb-9dcb-87362e1fbdd5.png">
The field "Test" is actually in the object brick "Bodywork".

With this PR it looks like this:
<img width="412" alt="Bildschirmfoto 2021-04-28 um 14 09 00" src="https://user-images.githubusercontent.com/8749138/116512933-1dfdd780-a8c9-11eb-993b-deb75492384d.png">
