### PR TITLE
[PimcoreX] Translations Table migration is allowed to fail

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20210324152822.php
+++ b/bundles/CoreBundle/Migrations/Version20210324152822.php
@@ -31,19 +31,15 @@ final class Version20210324152822 extends AbstractMigration
      */
     public function up(Schema $schema): void
     {
-        try {
-            $db = Db::get();
+        $db = Db::get();
 
-            $translationsTables = $db->fetchAll("SHOW TABLES LIKE 'translations\_%'");
-            foreach ($translationsTables as $table) {
-                $translationsTable = current($table);
+        $translationsTables = $db->fetchAll("SHOW TABLES LIKE 'translations\_%'");
+        foreach ($translationsTables as $table) {
+            $translationsTable = current($table);
 
-                if (!$schema->getTable($translationsTable)->hasColumn('type')) {
-                    $this->addSql('ALTER TABLE `'.$translationsTable.'` ADD COLUMN `type` varchar(10) DEFAULT NULL AFTER `key`');
-                }
+            if (!$schema->getTable($translationsTable)->hasColumn('type')) {
+                $this->addSql('ALTER TABLE `'.$translationsTable.'` ADD COLUMN `type` varchar(10) DEFAULT NULL AFTER `key`');
             }
-        } catch (\Exception $e) {
-            $this->write('An error occurred while performing migrations: ' . $e->getMessage());
         }
     }
 
@@ -52,19 +48,15 @@ final class Version20210324152822 extends AbstractMigration
      */
     public function down(Schema $schema): void
     {
-        try {
-            $db = Db::get();
+        $db = Db::get();
 
-            $translationsTables = $db->fetchAll("SHOW TABLES LIKE 'translations\_%'");
-            foreach ($translationsTables as $table) {
-                $translationsTable = current($table);
+        $translationsTables = $db->fetchAll("SHOW TABLES LIKE 'translations\_%'");
+        foreach ($translationsTables as $table) {
+            $translationsTable = current($table);
 
-                if ($schema->getTable($translationsTable)->hasColumn('type')) {
-                    $this->addSql('ALTER TABLE `'.$translationsTable.'` DROP COLUMN `type`');
-                }
+            if ($schema->getTable($translationsTable)->hasColumn('type')) {
+                $this->addSql('ALTER TABLE `'.$translationsTable.'` DROP COLUMN `type`');
             }
-        } catch (\Exception $e) {
-            $this->write('An error occurred while performing migrations: ' . $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
Migration failed for a different reason, but didn't told me. so it should fail and not further proceed. Otherwise you'll end up with following error when trying to access pimcore:

```
InvalidFieldNameException
An exception occurred while executing 'INSERT INTO `translations_admin` (`key`, `type`, `language`, `text`, `modificationDate`, `creationDate`) VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE `key` = ?, `type` = ?, `language` = ?, `text` = ?, `modificationDate` = ?, `creationDate` = ?;' with params ["login", null, "en", "", 1619684040, 1619684040, "login", null, "en", "", 1619684040, 1619684040]: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'type' in 'field list'
```