### PR TITLE
[Documents] Editable Dialog Box - Fix dialogbox editable naming when used in area

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/editmode.css
+++ b/bundles/AdminBundle/Resources/public/css/editmode.css
@@ -459,11 +459,9 @@ input.cke_dialog_ui_input_tel {
 
 .pimcore_area_entry .pimcore_area_dialog,
 .pimcore_editable_area .pimcore_area_dialog {
-    position:absolute;
-    width:25px;
-    height:25px;
-    right:5px;
-    top:5px;
+    position:relative;
+    float: right;
+    z-index: 10001;
 }
 
 .pimcore_areablock_dialogBox .x-fieldset-body {

--- a/models/Document/Editable/Area.php
+++ b/models/Document/Editable/Area.php
@@ -49,38 +49,12 @@ class Area extends Model\Document\Editable
      */
     public function admin()
     {
-        $areabrickManager = \Pimcore::getContainer()->get(AreabrickManagerInterface::class);
-
-        $dialogConfig = null;
-        $brick = $areabrickManager->getBrick($this->config['type']);
-        $info = $this->buildInfoObject();
-        if ($this->getEditmode() && $brick instanceof EditableDialogBoxInterface) {
-            $dialogConfig = $brick->getEditableDialogBoxConfiguration($this, $info);
-            $dialogConfig->setId('dialogBox-' . $this->getName());
-        }
-
         $attributes = $this->getEditmodeElementAttributes();
         $attributeString = HtmlUtils::assembleAttributeString($attributes);
         $this->outputEditmode('<div ' . $attributeString . '>');
-
-        if ($dialogConfig) {
-            $dialogAttributes = [
-                'data-dialog-id' => $dialogConfig->getId(),
-            ];
-
-            $dialogAttributes = HtmlUtils::assembleAttributeString($dialogAttributes);
-            $this->outputEditmode('<div class="pimcore_area_dialog" data-name="' . $attributes['data-name'] . '" data-real-name="' . $attributes['data-real-name'] . '" ' . $dialogAttributes . '></div>');
-        }
-
         $this->frontend();
 
         $this->outputEditmode('</div>');
-
-        if ($dialogConfig) {
-            $editableRenderer = \Pimcore::getContainer()->get(EditableRenderer::class);
-            $this->outputEditmode('<template id="dialogBoxConfig-' . $dialogConfig->getId() . '">' . \json_encode($dialogConfig) . '</template>');
-            $this->renderDialogBoxEditables($dialogConfig->getItems(), $editableRenderer, $dialogConfig->getId());
-        }
     }
 
     /**
@@ -165,6 +139,27 @@ class Area extends Model\Document\Editable
         // start at first index
         $blockState->pushIndex(1);
 
+        $areabrickManager = \Pimcore::getContainer()->get(AreabrickManagerInterface::class);
+
+        $dialogConfig = null;
+        $brick = $areabrickManager->getBrick($this->config['type']);
+        $info = $this->buildInfoObject();
+        if ($this->getEditmode() && $brick instanceof EditableDialogBoxInterface) {
+            $dialogConfig = $brick->getEditableDialogBoxConfiguration($this, $info);
+            $dialogConfig->setId('dialogBox-' . $this->getName());
+        }
+
+        if ($dialogConfig) {
+            $attributes = $this->getEditmodeElementAttributes();
+            $dialogAttributes = [
+                'data-dialog-id' => $dialogConfig->getId(),
+            ];
+
+            $dialogAttributes = HtmlUtils::assembleAttributeString($dialogAttributes);
+            $this->outputEditmode('<div class="pimcore_area_dialog" data-name="' . $attributes['data-name'] . '" data-real-name="' . $attributes['data-real-name'] . '" ' . $dialogAttributes . '></div>');
+        }
+
+
         $params = [];
         if (isset($config['params']) && is_array($config['params']) && array_key_exists($config['type'], $config['params'])) {
             if (is_array($config['params'][$config['type']])) {
@@ -173,6 +168,12 @@ class Area extends Model\Document\Editable
         }
 
         $info->setParams($params);
+
+        if ($dialogConfig) {
+            $editableRenderer = \Pimcore::getContainer()->get(EditableRenderer::class);
+            $this->outputEditmode('<template id="dialogBoxConfig-' . $dialogConfig->getId() . '">' . \json_encode($dialogConfig) . '</template>');
+            $this->renderDialogBoxEditables($dialogConfig->getItems(), $editableRenderer, $dialogConfig->getId());
+        }
 
         echo $editableHandler->renderAreaFrontend($info);
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #8890

## Additional info
- Additionally fixes edit button overlapping css when multiple areas are used on a page