### PR TITLE
Fixed admin translations order key

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -448,8 +448,6 @@ final class TranslationController extends AdminController
                         'language' => $orderKey,
                     ];
                     $list->setOrderKey($orderKey);
-                } else {
-                    $list->setOrderKey($tableName . '.' . $sortingSettings['orderKey'], false);
                 }
             }
             if ($sortingSettings['order']) {


### PR DESCRIPTION
## Changes in this pull request  

Fixed issue where fetching admin translations was returning a query error if sorting/order key was previously set in a language which wasn't available anymore. 

**CASE:** Admin translations were sorted by orderKey "_uk" (Ukrainian), when changing config to limit languages to en (English) and de (German) in admin translations `if (in_array(trim($orderKey, '_'), $validLanguages))` would return false since the sorting language doesn't exist anymore in `$validLanguages` and the order key would be set `$list->setOrderKey($tableName . '.key' . $sortingSettings['orderKey'], false);` which would cause an error since it would search for a column in admin_translations table with the name of e.g. "_uk" which doesn't exist. Also by default if the language does not exist in `$validLanguages` the sorting would remain by key, defined on line 436 `$list->setOrderKey($tableName . '.key', false);`.

