### PR TITLE
random_bytes for default passwords

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -1161,7 +1161,7 @@ final class UserController extends AdminController implements KernelControllerEv
             if (empty($message)) {
                 //generate random password if user has no password
                 if (!$user->getPassword()) {
-                    $user->setPassword(random_bytes(16));
+                    $user->setPassword(bin2hex(random_bytes(16)));
                     $user->save();
                 }
 

--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -1161,7 +1161,7 @@ final class UserController extends AdminController implements KernelControllerEv
             if (empty($message)) {
                 //generate random password if user has no password
                 if (!$user->getPassword()) {
-                    $user->setPassword(md5(uniqid()));
+                    $user->setPassword(random_bytes(16));
                     $user->save();
                 }
 

--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -633,7 +633,7 @@ class Installer
     {
         $defaultConfig = [
             'username' => 'admin',
-            'password' => md5(microtime()),
+            'password' => random_bytes(16),
         ];
 
         $settings = array_replace_recursive($defaultConfig, $config);

--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -633,7 +633,7 @@ class Installer
     {
         $defaultConfig = [
             'username' => 'admin',
-            'password' => random_bytes(16),
+            'password' => bin2hex(random_bytes(16)),
         ];
 
         $settings = array_replace_recursive($defaultConfig, $config);


### PR DESCRIPTION
By scanning the net for fresh installations or enumerating new accounts on existing sites an attacker could potentially get an idea of the default password. E.g. catching the when the new account appeared, or the creationDate of the root document or the basic Pimcore assets given by visiting the site could clue the attacker in. To prevent this (small) security hole we remove the dependency on `microtime()`.

For the controller, `uniqid()` is also based on microtime and `md5()`:ing it is actually ever so slightly decreasing the strength of the string given by `uniqid()`.

If nothing else this will prevent naive code analysis tools from warning us that *OMG the words "md5" and "password" appears on the same line in the code: must be insecure* ;)