### PR TITLE
[Data object grid] Validate grid export form on submit

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/gridexport/csv.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/gridexport/csv.js
@@ -26,7 +26,8 @@ pimcore.asset.gridexport.csv = Class.create(pimcore.element.gridexport.abstract,
                     name: 'delimiter',
                     maxLength: 1,
                     labelWidth: 200,
-                    value: ';'
+                    value: ';',
+                    allowBlank: false
                 })
             ]
         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -2700,8 +2700,10 @@ pimcore.helpers.exportWarning = function (type, callback) {
         buttons: [{
             text: t("OK"),
             handler: function () {
-                callback(formPanel.getValues());
-                window.close();
+                if (formPanel.isValid()) {
+                    callback(formPanel.getValues());
+                    window.close();
+                }
             }.bind(this)
         },
             {


### PR DESCRIPTION
There is no validation currently for grid exports. For example when you request a CSV export without a column separator you will get something like 
`"id""fullpath""published""creationDate""modificationDate""name""shortDescription"`

This PR adds validation and also makes the column separator a required field.
The validation also makes sense for custom exports which perhaps also might need some validation.