### PR TITLE
Fix: NotificationService::sendToGroup() has unsafe role condition

### DIFF
--- a/models/Notification/Service/NotificationService.php
+++ b/models/Notification/Service/NotificationService.php
@@ -96,17 +96,25 @@ class NotificationService
             throw new \UnexpectedValueException(sprintf('No group found with the ID %d', $groupId));
         }
 
-        $filter = [
-            'id != ?' => $fromUser,
-            'active = ?' => 1,
-            'roles LIKE ?' => '%' . $groupId . '%',
-        ];
-
-        $condition = implode(' AND ', array_keys($filter));
-        $conditionVariables = array_values($filter);
-
         $listing = new User\Listing();
-        $listing->setCondition($condition, $conditionVariables);
+        $listing->setCondition(
+            'id != ?
+            AND active = ?
+            AND (
+                roles = ?
+                OR roles LIKE ?
+                OR roles LIKE ? 
+                OR roles LIKE ?
+            )',
+            [
+                $fromUser,
+                1,
+                $groupId,
+                '%,' . $groupId,
+                $groupId . ',%',
+                '%,' . $groupId . ',%'
+            ]
+        );
         $listing->setOrderKey('name');
         $listing->setOrder('ASC');
         $listing->load();


### PR DESCRIPTION
If I send a notification to a role with ID 2, I will also send notifications to role 20 and others.

Maybe it would be better if there was a leading and a trailing comma in this type of column.