### PR TITLE
Fixed property type definition

### DIFF
--- a/models/Document/Editable/Snippet.php
+++ b/models/Document/Editable/Snippet.php
@@ -45,7 +45,7 @@ class Snippet extends Model\Document\Editable
      *
      * @var Document\Snippet|null
      */
-    protected ?Document\Snippet $snippet = null;
+    protected $snippet = null;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
regression of #8684

Causes saving documents to fail, because of `Service::cloneMe()` that creates a deep copy of the object and replaces references to documents with `ElementDescriptor`. 

See: 
https://github.com/pimcore/pimcore/blob/c2b5b40217a6d3fcfe7bbf18ba65745d28ebc213/models/Document/PageSnippet.php#L636