### PR TITLE
Xliff Import add a line break before and after the content of transla…

### DIFF
--- a/lib/Translation/Escaper/Xliff12Escaper.php
+++ b/lib/Translation/Escaper/Xliff12Escaper.php
@@ -120,8 +120,8 @@ class Xliff12Escaper
 
         $content = $node->asXML();
 
-        $content = preg_replace("/<\?xml version=\"\d\.\d\"\?>/i", '', $content);
-        $content = preg_replace("/<\/?(target|mrk)([^>.]+)?>/i", '', $content);
+        $content = preg_replace("/<\?xml version=\"\d\.\d\"\?>\s?/i", '', $content);
+        $content = preg_replace("/<\/?(target|mrk)([^>.]+)?>\s?/i", '', $content);
         // we have to do this again but with html entities because of CDATA content
         $content = preg_replace("/&lt;\/?(target|mrk)((?!&gt;).)*&gt;/i", '', $content);
 


### PR DESCRIPTION
Xliff Import add a line break before and after the content

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
### Expected behavior
Xliff Import import the content of translated field, without adding line break before and after.

### Actual behavior
Xliff Import add a line break before and after the content of translated field, in some case (xml node target with children node).

### Steps to reproduce
- Go to Pimcore Admin / Tools / Translation / Xliff Export/Import
- Export some objects with translated fields, and no value in the target language
Note : there is a source node for each values, but no target node.
- Add translation in target language, with some software. Save Xliff file.
Note : the translated value is in a target node.
- Import the translated xliff file
- Use the pimcore php api to load the imported value and dump the result. It is not visible in the admin gui, in pimcore 6.9.3.

### dumps

 In pimcore/lib/Translation/Escaper/Xliff12Escaper.php line 93, in function unescapeXliff, $content look like this :
```xml
"<target xml:lang="es" state="final">Trattamento test</target>"
```

In Xliff12Escaper.php line 127, function parseInnerXml:
```xml
"""
<?xml version="1.0"?>
<target xml:lang="es" state="final">Trattamento test</target>

"""
```
--> $node->asXML() has line break, after <?xml version="1.0"?>

In Xliff12Escaper.php line 129:
```xml
"""

<target xml:lang="es" state="final">Trattamento test</target>

"""
```
--> but first preg_replace don't remove the line break added by asXML()

In Xliff12Escaper.php line 131:
```xml
"""

Trattamento test

"""
```
--> but second preg_replace don't remove the line break added by asXML()

In Xliff12Escaper.php line 134:
```xml
"""

Trattamento test

"""
```

## Additional info  

