### PR TITLE
Fix: Assets Paths not working for Login Sreen Image after update to 6.9

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/Login/layout.html.php
+++ b/bundles/AdminBundle/Resources/views/Admin/Login/layout.html.php
@@ -28,6 +28,8 @@ $config = $this->config;
     //https://github.com/pimcore/pimcore/issues/8129
     if (preg_match('@^https?://@', $customImage)) {
         $backgroundImageUrl = $customImage;
+    } elseif (is_file(PIMCORE_WEB_ROOT . '/var/assets' . $customImage)) {
+        $backgroundImageUrl = $customImage;
     } elseif (is_file(PIMCORE_WEB_ROOT . $customImage)) {
         $backgroundImageUrl = $customImage;
     } else {


### PR DESCRIPTION
See #9012 for Pimcore X