### PR TITLE
Update phpstan-symfony (Non-empty parameter array might be empty in different environment)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
     "codeception/module-symfony": "^1.6.0",
     "codeception/phpunit-wrapper": "^9",
     "phpstan/phpstan": "^0.12.85",
-    "phpstan/phpstan-symfony": "^0.12.30",
+    "phpstan/phpstan-symfony": "^0.12.32",
     "phpunit/phpunit": "^9",
     "spiritix/php-chrome-html2pdf": "^1.5",
     "elasticsearch/elasticsearch": "^7.11",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: bundles/CoreBundle/Command/Bundle/ListCommand.php
 
 		-
-			message: "#^Empty array passed to foreach\\.$#"
-			count: 1
-			path: bundles/CoreBundle/DependencyInjection/Compiler/WorkflowPass.php
-
-		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 3
 			path: bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php


### PR DESCRIPTION
The new phpstan-symfony version ignores empty array parameters now.
See https://github.com/phpstan/phpstan-symfony/releases/tag/0.12.32