### PR TITLE
Fix: Assets Paths not working for Login Sreen Image after update to Pimcore X

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/Login/layout.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/Login/layout.html.twig
@@ -21,6 +21,8 @@
         {# https://github.com/pimcore/pimcore/issues/8129 #}
         {% if customImage matches '@^https?://@' %}
             {% set backgroundImageUrl = customImage %}
+        {% elseif pimcore_file_exists(constant('PIMCORE_WEB_ROOT') ~ '/var/assets' ~ customImage) %}
+            {% set backgroundImageUrl = customImage %}
         {% elseif pimcore_file_exists(constant('PIMCORE_WEB_ROOT') ~ customImage) %}
             {% set backgroundImageUrl = customImage %}
         {% else %}


### PR DESCRIPTION
See #9009 for 6.9