### PR TITLE
Revert "Bugfix for incorrect maxDepth comparison"

### DIFF
--- a/lib/Navigation/Builder.php
+++ b/lib/Navigation/Builder.php
@@ -337,7 +337,7 @@ class Builder
 
                 $page->setClass($page->getClass() . $classes);
 
-                if ($child->hasChildren() && (!$maxDepth || $maxDepth >= $this->currentLevel)) {
+                if ($child->hasChildren() && (!$maxDepth || $maxDepth > $this->currentLevel)) {
                     $childPages = $this->buildNextLevel($child, false, $pageCallback, $parents, $maxDepth);
                     $page->setPages($childPages);
                 }


### PR DESCRIPTION
Follow up to #8910 for `6.9` branch. 
Reverts  #8863