### PR TITLE
[Mail] renamed setHtml/TextBody() back to the original name, deprecat…

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/EmailController.php
+++ b/bundles/AdminBundle/Controller/Admin/EmailController.php
@@ -296,11 +296,11 @@ class EmailController extends AdminController
             }
 
             if ($html = $emailLog->getHtmlLog()) {
-                $mail->setHtmlBody($html);
+                $mail->html($html);
             }
 
             if ($text = $emailLog->getTextLog()) {
-                $mail->setTextBody($text);
+                $mail->text($text);
             }
 
             foreach (['From', 'To', 'Cc', 'Bcc', 'ReplyTo'] as $field) {
@@ -396,9 +396,9 @@ class EmailController extends AdminController
         $mail->setIgnoreDebugMode(true);
 
         if ($request->get('emailType') == 'text') {
-            $mail->setTextBody($request->get('content'));
+            $mail->text($request->get('content'));
         } elseif ($request->get('emailType') == 'html') {
-            $mail->setHtmlBody($request->get('content'));
+            $mail->html($request->get('content'));
         } elseif ($request->get('emailType') == 'document') {
             $doc = \Pimcore\Model\Document::getByPath($request->get('documentPath'));
 

--- a/bundles/AdminBundle/Controller/Admin/LoginController.php
+++ b/bundles/AdminBundle/Controller/Admin/LoginController.php
@@ -200,7 +200,7 @@ class LoginController extends AdminController implements BruteforceProtectedCont
                     if ($event->getSendMail()) {
                         $mail = Tool::getMail([$user->getEmail()], 'Pimcore lost password service');
                         $mail->setIgnoreDebugMode(true);
-                        $mail->setTextBody("Login to pimcore and change your password using the following link. This temporary login link will expire in 24 hours: \r\n\r\n" . $loginUrl);
+                        $mail->text("Login to pimcore and change your password using the following link. This temporary login link will expire in 24 hours: \r\n\r\n" . $loginUrl);
                         $mail->send();
                     }
 

--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -1174,7 +1174,7 @@ class UserController extends AdminController implements KernelControllerEventInt
                 try {
                     $mail = Tool::getMail([$user->getEmail()], 'Pimcore login invitation for ' . Tool::getHostname());
                     $mail->setIgnoreDebugMode(true);
-                    $mail->setTextBody("Login to pimcore and change your password using the following link. This temporary login link will expire in  24 hours: \r\n\r\n" . $loginUrl);
+                    $mail->text("Login to pimcore and change your password using the following link. This temporary login link will expire in  24 hours: \r\n\r\n" . $loginUrl);
                     $mail->send();
 
                     $success = true;

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/25_Email_Framework/01_Pimcore_Mail.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/25_Email_Framework/01_Pimcore_Mail.md
@@ -61,7 +61,7 @@ $mail->send();
  
 $mail = new \Pimcore\Mail();
 $mail->addTo('example@pimcore.org');
-$mail->setTextBody("This is just plain text");
+$mail->text("This is just plain text");
 $mail->send();
  
 // Sending a rich text (HTML) email with Twig expressions 
@@ -71,7 +71,7 @@ $mail->addBcc("bcc@pimcore.org");
 $mail->setParams([
     'myParam' => 'Just a simple text'
 ]);
-$mail->setHtmlBody("<b>some</b> rich text: {{ myParam }}");
+$mail->html("<b>some</b> rich text: {{ myParam }}");
 $mail->send();
  
 //adding an asset as attachment
@@ -87,6 +87,6 @@ $mail->embed($asset->getData(), 'logo', $asset->getMimetype());
 //or
 $mail->embedFromPath($asset->getFileSystemPath(), 'logo', $asset->getMimetype());
 
-$mail->setHtmlBody("Embedded Image: <img src='cid:logo'>"); //image name(passed second argument in embed) as ref
+$mail->html("Embedded Image: <img src='cid:logo'>"); //image name(passed second argument in embed) as ref
 $mail->send();
 ```

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/25_Email_Framework/README.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/25_Email_Framework/README.md
@@ -60,6 +60,6 @@ $mail->send();
 $mail = new \Pimcore\Mail();
 $mail->addTo('example@pimcore.org');
 $mail->addBcc("bcc@pimcore.org");
-$mail->setHtmlBody("<b>some</b> rich text");
+$mail->html("<b>some</b> rich text");
 $mail->send();
 ```

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -288,8 +288,8 @@
     After:
     ```php
         $mail= new \Pimcore\Mail($headers = null, $body = null, $contentType = null);
-        $mail->setTextBody("This is just plain text");
-        $mail->setHtmlBody("<b>some</b> rich text: {{ myParam }}");
+        $mail->text("This is just plain text");
+        $mail->html("<b>some</b> rich text: {{ myParam }}");
         ...
     ```
 

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -477,13 +477,13 @@ class Mail extends Email
     {
         $bodyHtmlRendered = $this->getBodyHtmlRendered();
         if ($bodyHtmlRendered) {
-            $this->setHtmlBody($bodyHtmlRendered);
+            $this->html($bodyHtmlRendered);
         }
 
         $bodyTextRendered = $this->getBodyTextRendered();
         if ($bodyTextRendered) {
             //add mime part for plain text body
-            $this->setTextBody($bodyTextRendered);
+            $this->text($bodyTextRendered);
         }
 
         $this->subject($this->getSubjectRendered());
@@ -693,7 +693,7 @@ class Mail extends Email
 
     /**
      * Renders the content (Twig) and returns
-     * the rendered text if a text was set with "$mail->setTextBody()"
+     * the rendered text if a text was set with "$mail->text()"
      * @internal
      * @return string
      */
@@ -701,7 +701,7 @@ class Mail extends Email
     {
         $text = $this->getTextBody();
 
-        //if the content was manually set with $obj->setTextBody(); this content will be used
+        //if the content was manually set with $obj->text(); this content will be used
         if ($text) {
             $content = $this->renderParams($text);
         } else {
@@ -820,7 +820,7 @@ class Mail extends Email
      *
      * @return $this
      */
-    public function setTextBody($bodyText, string $charset = 'utf-8')
+    public function setBodyText($bodyText, string $charset = 'utf-8')
     {
         return $this->text($bodyText, $charset);
     }
@@ -832,7 +832,7 @@ class Mail extends Email
      *
      * @return \Pimcore\Mail
      */
-    public function setHtmlBody($body, string $charset = 'utf-8')
+    public function setBodyHtml($body, string $charset = 'utf-8')
     {
         return $this->html($body, $charset);
     }

--- a/lib/Mail/Plugins/RedirectingPlugin.php
+++ b/lib/Mail/Plugins/RedirectingPlugin.php
@@ -135,14 +135,14 @@ final class RedirectingPlugin
                 $html = preg_replace("!(</\s*body\s*>)!is", "$debugInformation\\1", $html);
                 $html = preg_replace("!(<\s*head\s*>)!is", "\\1$debugInformationStyling", $html);
 
-                $message->setHtmlBody($html);
+                $message->html($html);
             } elseif (!empty($text)) {
                 $originalData['text'] = $text;
 
                 $rawText = $text;
                 $debugInformation = MailHelper::getDebugInformation('text', $message);
                 $rawText .= $debugInformation;
-                $message->setTextBody($rawText);
+                $message->text($rawText);
             }
 
             //setting debug subject
@@ -188,10 +188,10 @@ final class RedirectingPlugin
         $originalData = $message->getOriginalData();
 
         if (isset($originalData['html']) && $originalData['html']) {
-            $message->setHtmlBody($originalData['html']);
+            $message->html($originalData['html']);
         }
         if (isset($originalData['text']) && $originalData['text']) {
-            $message->setTextBody($originalData['text']);
+            $message->text($originalData['text']);
         }
         if (isset($originalData['subject']) && $originalData['subject']) {
             $message->setSubject($originalData['subject']);

--- a/lib/Maintenance/Tasks/LogMailMaintenanceTask.php
+++ b/lib/Maintenance/Tasks/LogMailMaintenanceTask.php
@@ -85,7 +85,7 @@ class LogMailMaintenanceTask implements TaskInterface
                     $html = "<pre>$html</pre>";
                     $mail = new \Pimcore\Mail();
                     $mail->setIgnoreDebugMode(true);
-                    $mail->setHtmlBody($html);
+                    $mail->html($html);
                     $mail->addTo($receivers);
                     $mail->setSubject('Error Log '.\Pimcore\Tool::getHostUrl());
                     $mail->send();

--- a/lib/Tool/Newsletter.php
+++ b/lib/Tool/Newsletter.php
@@ -73,7 +73,7 @@ class Newsletter
         }
 
         if (strlen(trim($newsletterDocument->getPlaintext())) > 0) {
-            $mail->setTextBody(trim($newsletterDocument->getPlaintext()));
+            $mail->text(trim($newsletterDocument->getPlaintext()));
         }
 
         $contentHTML = $mail->getBodyHtmlRendered();
@@ -116,12 +116,12 @@ class Newsletter
             $html->clear();
             unset($html);
 
-            $mail->setHtmlBody($contentHTML);
+            $mail->html($contentHTML);
         }
 
-        $mail->setHtmlBody($contentHTML);
+        $mail->html($contentHTML);
         // Adds the plain text part to the message, that it becomes a multipart email
-        $mail->setTextBody($contentText);
+        $mail->text($contentText);
         $mail->setSubject($mail->getSubjectRendered());
 
         return $mail;

--- a/lib/Workflow/Notification/NotificationEmailService.php
+++ b/lib/Workflow/Notification/NotificationEmailService.php
@@ -178,7 +178,7 @@ class NotificationEmailService extends AbstractNotificationService
             $this->translator->trans('workflow_change_email_notification_subject', [$subjectType . ' ' . $subject->getFullPath(), $workflow->getName()], 'admin', $language)
         );
 
-        $mail->setTextBody($this->getHtmlBody($subjectType, $subject, $workflow, $action, $language, $mailPath, $deeplink));
+        $mail->text($this->getHtmlBody($subjectType, $subject, $workflow, $action, $language, $mailPath, $deeplink));
 
         $mail->send();
     }

--- a/tests/Unit/Mail/MailTest.php
+++ b/tests/Unit/Mail/MailTest.php
@@ -137,7 +137,7 @@ class MailTest extends TestCase
     public function testTextBodyRenderedWithParams()
     {
         $mail = new \Pimcore\Mail();
-        $mail->setTextBody('Hi, {{ firstname }} {{ lastname }}.');
+        $mail->text('Hi, {{ firstname }} {{ lastname }}.');
         $mail->setParams([
             'firstname' => 'John',
             'lastname' => 'Doe',
@@ -152,7 +152,7 @@ class MailTest extends TestCase
     public function testHtmlBodyRenderedWithParams()
     {
         $mail = new \Pimcore\Mail();
-        $mail->setHtmlBody('Hi, {{ firstname }} {{ lastname }}.');
+        $mail->html('Hi, {{ firstname }} {{ lastname }}.');
         $mail->setParams([
             'firstname' => 'John',
             'lastname' => 'Doe',


### PR DESCRIPTION
…e it and use text() and html() instead (Symfony Mailer). 

resolves #9003
