### PR TITLE
[Docs] Fix upgrade instructions

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
@@ -45,7 +45,7 @@ Update composer.json as per [skeleton](https://github.com/pimcore/skeleton/blob/
 Important changes:
 - Move configs from `app/config/*.yml` to `config/*.yaml`
 - Move templates from `app/Resources/views` to `templates` and bundles templates from `app/Resources/XYZBundle/views` to `templates/bundles/XYZBundle`
-- Move `app/AppKernel.php` to `src/App/Kernel.php` and edit it to have `namespace App;` and class name `Kernel`
+- Move `app/AppKernel.php` to `src/Kernel.php` and edit it to have `namespace App;` and class name `Kernel`
 - Rename `web/` to `public/` & `web/app.php` to `public/index.php`
 
 ### Add .env environment file

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
@@ -45,7 +45,7 @@ Update composer.json as per [skeleton](https://github.com/pimcore/skeleton/blob/
 Important changes:
 - Move configs from `app/config/*.yml` to `config/*.yaml`
 - Move templates from `app/Resources/views` to `templates` and bundles templates from `app/Resources/XYZBundle/views` to `templates/bundles/XYZBundle`
-- Move `app/AppKernel.php` to `src/App/Kernel.php`
+- Move `app/AppKernel.php` to `src/App/Kernel.php` and edit it to have `namespace App;` and class name `Kernel`
 - Rename `web/` to `public/` & `web/app.php` to `public/index.php`
 
 ### Add .env environment file

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
@@ -67,7 +67,7 @@ points to consider:
 ### Flush your `/tmp` directories
 ```bash
 rm -r var/tmp
-rm -r web/var/tmp
+rm -r public/var/tmp
 ```
 
 ### Flush your recycle-bin


### PR DESCRIPTION
`web/var/tmp` does not exist anymore after the step `Rename web/ to public/` is done.

After moving `app/AppKernel.php` you have to put it to namespace `App` and rename the class to `Kernel`, otherwise you get `Defined Kernel Class \App\Kernel not found`