### PR TITLE
[X installation] Make migrations idempotent

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20210408153226.php
+++ b/bundles/CoreBundle/Migrations/Version20210408153226.php
@@ -30,8 +30,15 @@ class Version20210408153226 extends AbstractMigration
      */
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `versions` ADD `autoSave` TINYINT(4) NOT NULL DEFAULT 0');
-        $this->addSql('ALTER TABLE `versions` ADD INDEX `autoSave` (`autoSave`)');
+        $versionsTable = $schema->getTable('versions');
+
+        if(!$versionsTable->hasColumn('autoSave')) {
+            $this->addSql('ALTER TABLE `versions` ADD `autoSave` TINYINT(4) NOT NULL DEFAULT 0');
+        }
+
+        if (!$versionsTable->hasIndex('autoSave')) {
+            $this->addSql('ALTER TABLE `versions` ADD INDEX `autoSave` (`autoSave`)');
+        }
     }
 
     /**

--- a/bundles/CoreBundle/Migrations/Version20210412112812.php
+++ b/bundles/CoreBundle/Migrations/Version20210412112812.php
@@ -32,8 +32,14 @@ final class Version20210412112812 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `notes_data` DROP INDEX `id`;');
-        $this->addSql('ALTER TABLE `notes_data` ADD PRIMARY KEY (`id`, `name`);');
+        $notesTable = $schema->getTable('notes_data');
+        if($notesTable->hasIndex('id')) {
+            $this->addSql('ALTER TABLE `notes_data` DROP INDEX `id`;');
+        }
+
+        if(!$notesTable->hasPrimaryKey()) {
+            $this->addSql('ALTER TABLE `notes_data` ADD PRIMARY KEY (`id`, `name`);');
+        }
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
Steps to reproduce problem:
1. Install Pimcore 10 with `composer create-project --prefer-dist pimcore/skeleton:dev-master` and `./vendor/bin/pimcore-install`
2. Directly after run `composer update`

Without this PR a migration will fail with 
```
An exception occurred while executing 'ALTER TABLE `versions` ADD `autoSave` TINYINT(4) NOT NULL DEFAULT 0':                                                                                                                                                                                                       
SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'autoSave' 
```

The actual reason is that this operation is already done in https://github.com/pimcore/pimcore/blob/7fbbbf9413885e0b97fe64f2d52871021a7da0da/bundles/InstallBundle/Resources/install.sql#L723
This PR makes the migration idempotent so that it does not matter if the column exists or not, result will always be the same.

When you think one step further the question is what we should put in `/bundles/InstallBundle/Resources/install.sql` - I usually put the initial setup there and freeze this forever. All the changes are only done with migrations. This way you never endanger to execute a change in both: install SQL and migration. WDYT?