### PR TITLE
[Workflows] Fix object not unpublished with force_unpublished option

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,6 +1,7 @@
 # Upgrade Notes
 
 ## 6.9.0
+- [Workflows] Fixed wrong behavior of force_unpublished option, which created a new version (in case of published) instead of unpublishing the object. If you still want to save version, just use save_version option.
 - [Documents] Announcement: Run the `pimcore:documents:migrate-elements` command before (!) you upgrade to Pimcore 10. Not needed if you don't intend to keep your document versions.   
 - [Templating] If you are using Twig, then overriding templating helpers will no effect on Twig extension calls on frontend. Please override Twig extensions instead.
 - [Data Objects] Deprecated `\Pimcore\Model\DataObject\ClassDefinition\Data\DataInterface` as it isn't used anymore. Will be removed in Pimcore 10.

--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -254,8 +254,7 @@ class Manager
         $changePublishedState = $transition instanceof Transition ? $transition->getChangePublishedState() : null;
 
         if ($saveSubject && $subject instanceof AbstractElement) {
-            if (method_exists($subject, 'getPublished')
-                && (!$subject->getPublished() || $changePublishedState === ChangePublishedStateSubscriber::SAVE_VERSION)) {
+            if ($changePublishedState === ChangePublishedStateSubscriber::SAVE_VERSION) {
                 $subject->saveVersion();
             } else {
                 $subject->save();


### PR DESCRIPTION
## Changes in this pull request  
Resolves #7586

## Additional info  

[Fix] Call element `saveVersion()` when workflow option `save_version` is set, otherwise call element `save()`. This allows element to unpublish when `force_unpublished` option is set.

