### PR TITLE
Get exclusive lock when writing PHP config files

### DIFF
--- a/lib/File.php
+++ b/lib/File.php
@@ -15,6 +15,8 @@
 
 namespace Pimcore;
 
+use Throwable;
+
 class File
 {
     /**
@@ -99,7 +101,12 @@ class File
             self::mkdir(dirname($path));
         }
 
-        $return = file_put_contents($path, $data, null, self::getContext());
+        try {
+            $return = file_put_contents($path, $data, LOCK_EX, self::getContext());
+        } catch(Throwable $e) {
+            $return = file_put_contents($path, $data, null, self::getContext());
+        }
+
         @chmod($path, self::$defaultMode);
 
         return $return;

--- a/lib/File.php
+++ b/lib/File.php
@@ -15,8 +15,6 @@
 
 namespace Pimcore;
 
-use Throwable;
-
 class File
 {
     /**
@@ -103,7 +101,7 @@ class File
 
         try {
             $return = file_put_contents($path, $data, LOCK_EX, self::getContext());
-        } catch(Throwable $e) {
+        } catch(\Throwable $e) {
             $return = file_put_contents($path, $data, null, self::getContext());
         }
 


### PR DESCRIPTION
When you have a (temporarily) slow write I/O on the server you might get the problem that generated PHP config files get messed up. We experienced this in the context of #9019. When you create a predefined metadata field, the ExtJS store automatically saves this. When you then create another field before the first save operation is finished `var/config/predefined-asset-metadata.php` might end up with something like
```php
<?php 

return [
    1 => [
        "id" => 1,
        "name" => "author",
        "description" => "",
        "type" => "input",
        "targetSubtype" => NULL,
        "data" => "",
        "config" => NULL,
        "language" => NULL,
        "creationDate" => 1557394593,
        "modificationDate" => 1566383852
    ]
];
];
```

Of course this gives errors afterwards as this file is no valid PHP. You can only fix this manually.

The try-catch is for filesystems which do not support exclusive locking - for those the behaviour remains the same.