### PR TITLE
Update pimcore image gallery hotspots from database type text to longtext

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ImageGallery.php
+++ b/models/DataObject/ClassDefinition/Data/ImageGallery.php
@@ -44,7 +44,7 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
      *
      * @var array
      */
-    public $queryColumnType = ['images' => 'text', 'hotspots' => 'text'];
+    public $queryColumnType = ['images' => 'text', 'hotspots' => 'longtext'];
 
     /**
      * Type for the column
@@ -53,7 +53,7 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
      *
      * @var array
      */
-    public $columnType = ['images' => 'text', 'hotspots' => 'text'];
+    public $columnType = ['images' => 'text', 'hotspots' => 'longtext'];
 
     /**
      * @internal


### PR DESCRIPTION
## Changes in this pull request  
when adding a lot of hotspots with additional data (objects, e.g.) the database datatype text is not sufficient.
the hotspots text is then cut off and the hotspots won't load anymore in the pimcore backend. 
Therefore I propose to update to database type longtext instead to make sure all hotspots are stored correctly


