### PR TITLE
Show not found executables only in verbose and without complete stack trace

### DIFF
--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -32,7 +32,7 @@ class Ghostscript extends Adapter
     /**
      * @var string|null
      */
-    private $version = null;
+    private $version;
 
     /**
      * @return bool
@@ -46,7 +46,7 @@ class Ghostscript extends Adapter
                 return true;
             }
         } catch (\Exception $e) {
-            Logger::warning($e);
+            Logger::notice($e->getMessage());
         }
 
         return false;
@@ -59,7 +59,6 @@ class Ghostscript extends Adapter
      */
     public function isFileTypeSupported($fileType)
     {
-
         // it's also possible to pass a path or filename
         if (preg_match("/\.?pdf$/i", $fileType)) {
             return true;

--- a/lib/Document/Adapter/LibreOffice.php
+++ b/lib/Document/Adapter/LibreOffice.php
@@ -39,7 +39,7 @@ class LibreOffice extends Ghostscript
                 return true;
             }
         } catch (\Exception $e) {
-            Logger::warning($e);
+            Logger::notice($e->getMessage());
         }
 
         return false;
@@ -52,7 +52,6 @@ class LibreOffice extends Ghostscript
      */
     public function isFileTypeSupported($fileType)
     {
-
         // it's also possible to pass a path or filename
         if (preg_match("/\.?(pdf|doc|docx|odt|xls|xlsx|ods|ppt|pptx|odp)$/i", $fileType)) {
             return true;
@@ -62,13 +61,13 @@ class LibreOffice extends Ghostscript
     }
 
     /**
-     * @return mixed
+     * @return string
      *
      * @throws \Exception
      */
     public static function getLibreOfficeCli()
     {
-        return \Pimcore\Tool\Console::getExecutable('soffice', true);
+        return Console::getExecutable('soffice', true);
     }
 
     /**


### PR DESCRIPTION
Now I get following warnings/errors in the maintenance cronjob, when a user add new PDFs:
```
php bin/console maintenance
17:02:26 WARNING   [pimcore] Exception: No 'soffice' executable found, please install the application or add it to the PATH (in system settings or to your PATH environment variable in /var/www/html/vendor/pimcore/pimcore/lib/Tool/Console.php:132
Stack trace:
#0 /var/www/html/vendor/pimcore/pimcore/lib/Document/Adapter/LibreOffice.php(71): Pimcore\Tool\Console::getExecutable('soffice', true)
#1 /var/www/html/vendor/pimcore/pimcore/lib/Document/Adapter/LibreOffice.php(37): Pimcore\Document\Adapter\LibreOffice::getLibreOfficeCli()
#2 /var/www/html/vendor/pimcore/pimcore/lib/Document.php(98): Pimcore\Document\Adapter\LibreOffice->isAvailable()
#3 /var/www/html/vendor/pimcore/pimcore/lib/Document.php(59): Pimcore\Document::getDefaultAdapter()
#4 /var/www/html/vendor/pimcore/pimcore/models/Asset/Document.php(73): Pimcore\Document::isAvailable()
#5 /var/www/html/vendor/pimcore/pimcore/lib/Maintenance/Tasks/AssetDocumentConversionTask.php(56): Pimcore\Model\Asset\Document->processPageCount()
#6 /var/www/html/vendor/pimcore/pimcore/lib/Maintenance/Executor.php(94): Pimcore\Maintenance\Tasks\AssetDocumentConversionTask->execute()
#7 /var/www/html/vendor/pimcore/pimcore/bundles/CoreBundle/Command/MaintenanceCommand.php(94): Pimcore\Maintenance\Executor->executeMaintenance(Array, Array, false)
#8 /var/www/html/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php(255): Pimcore\Bundle\CoreBundle\Command\MaintenanceCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /var/www/html/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php(1027): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#10 /var/www/html/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php(97): Symfony\Component\Console\Application->doRunCommand(Object(Pimcore\Bundle\CoreBundle\Command\MaintenanceCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 /var/www/html/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php(273): Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand(Object(Pimcore\Bundle\CoreBundle\Command\MaintenanceCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /var/www/html/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php(83): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 /var/www/html/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php(149): Symfony\Bundle\FrameworkBundle\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#14 /var/www/html/bin/console(26): Symfony\Component\Console\Application->run()
#15 {main}
```
After this I get only a notice when I activate verbose (-v):
```
php bin/console maintenance -v
17:04:16 NOTICE    [pimcore] No 'soffice' executable found, please install the application or add it to the PATH (in system settings or to your PATH environment variable
```