### PR TITLE
[EDITABLES] Fix wrong array key check

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/RenderletController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/RenderletController.php
@@ -94,7 +94,7 @@ class RenderletController extends AdminController
 
         // setting locale manually here before rendering the action to make sure editables use the right locale - if this
         // is needed in multiple places, move this to the tag handler instead (see #1834)
-        if ($attributes['_locale']) {
+        if (isset($attributes['_locale'])) {
             $localeService->setLocale($attributes['_locale']);
         }
 


### PR DESCRIPTION
Correct way to check for array key existence to prevent errors / warnings

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `6.6`
- Feature/Improvement: choose `master` 

> All bug fixes merged into the latest maintenance branch are also merged to the master on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `master`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch latest maintenance branch, e.g. `6.6`
- [ ] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Correct check for array key existence
## Additional info  

