### PR TITLE
[Glossary] Fix Processor xmlParseEntityRef: noname warning

### DIFF
--- a/lib/Tool/Glossary/Processor.php
+++ b/lib/Tool/Glossary/Processor.php
@@ -127,7 +127,6 @@ class Processor
             $tmpData['replace'][] = $entry['replace'];
         }
 
-        $result = '';
         $data = $tmpData;
         $data['count'] = array_fill(0, count($data['search']), 0);
 
@@ -153,7 +152,7 @@ class Processor
 
                 $domNode = $parentNode->getNode(0);
                 $fragment = $domNode->ownerDocument->createDocumentFragment();
-                $fragment->appendXML($text);
+                $fragment->appendXML(sprintf('<![CDATA[%s]]>', $text));
                 $clone = $domNode->cloneNode();
                 $clone->appendChild($fragment);
                 $domNode->parentNode->replaceChild($clone, $domNode);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #
![image](https://user-images.githubusercontent.com/5137917/117479526-b991e680-af60-11eb-98bd-1a63cfbd43db.png)

## Additional info  

