### PR TITLE
Fix: Asset\Listing::getTotalCount() returns wrong count after update to 6.9

### DIFF
--- a/lib/Model/Listing/Dao/QueryBuilderHelperTrait.php
+++ b/lib/Model/Listing/Dao/QueryBuilderHelperTrait.php
@@ -172,6 +172,7 @@ trait QueryBuilderHelperTrait
                 }
             }
         } elseif ($queryBuilder instanceof ZendCompatibilityQueryBuilder) {
+            $queryBuilder->reset(ZendCompatibilityQueryBuilder::COLUMNS);
             $queryBuilder->columns([new Expression('COUNT(*)')]);
             $queryBuilder->reset(ZendCompatibilityQueryBuilder::LIMIT_COUNT);
             $queryBuilder->reset(ZendCompatibilityQueryBuilder::LIMIT_OFFSET);


### PR DESCRIPTION
Fix #9098 