### PR TITLE
Fix migration error when upgrading from 6.9.3 to 10.0

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20210324152821.php
+++ b/bundles/CoreBundle/Migrations/Version20210324152821.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210324152821 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Removes BC view `translations_website`';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('DROP VIEW IF EXISTS translations_website;');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('CREATE OR REPLACE VIEW translations_website AS SELECT * FROM translations_messages;');
+    }
+}

--- a/bundles/CoreBundle/Migrations/Version20210324152822.php
+++ b/bundles/CoreBundle/Migrations/Version20210324152822.php
@@ -33,7 +33,7 @@ final class Version20210324152822 extends AbstractMigration
     {
         $db = Db::get();
 
-        $translationsTables = $db->fetchAll("SHOW TABLES LIKE 'translations\_%'");
+        $translationsTables = $db->fetchAll("SHOW FULL TABLES WHERE Tables_in_{$db->getDatabase()} LIKE 'translations\_%' AND Table_type = 'BASE TABLE'");
         foreach ($translationsTables as $table) {
             $translationsTable = current($table);
 
@@ -50,7 +50,7 @@ final class Version20210324152822 extends AbstractMigration
     {
         $db = Db::get();
 
-        $translationsTables = $db->fetchAll("SHOW TABLES LIKE 'translations\_%'");
+        $translationsTables = $db->fetchAll("SHOW FULL TABLES WHERE Tables_in_{$db->getDatabase()} LIKE 'translations\_%' AND Table_type = 'BASE TABLE'");
         foreach ($translationsTables as $table) {
             $translationsTable = current($table);
 


### PR DESCRIPTION
Migration error upgrading from 6.9.3 to 10.0:
![Screenshot from 2021-05-13 21-34-13](https://user-images.githubusercontent.com/16133208/118184301-755c8580-b43b-11eb-9c55-ad3951afc3db.png)
  

## Changes in this pull request  
Resolves #

## Additional info  
Migration 20210324152822 will fail when upgrading from 6.9:
https://github.com/pimcore/pimcore/blob/1a33a2b93782be8c43683935623e3e771d5caef9/bundles/CoreBundle/Migrations/Version20210324152822.php#L32-L44
The reason is translation tables are dynamically retrieved with `SHOW TABLES` which returns both tables and views causing error.

Table `translations_website` was renamed here and a BC view was created:
https://github.com/pimcore/pimcore/blob/b36e6568fd3adb39980b7b65c456d049abee97ab/bundles/CoreBundle/Migrations/Version20201222101114.php#L16-L24

This PR add a migration, before of 20210324152822, to remove the BC view which had to be removed in v10 in #7808 as described [here](https://github.com/pimcore/pimcore/pull/7800#discussion_r549352650)
