### PR TITLE
fix mail sender on GUI + enrich doc for email address format

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/25_Email_Framework/README.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/25_Email_Framework/README.md
@@ -23,6 +23,8 @@ recipients, add Dynamic Placeholders... and pass this document to the `Pimcore\M
 nasty stuff (creating valid URLs, embedding CSS, compile Less files, rendering the document..) is 
 automatically handled by the `Pimcore\Mail` object.
 
+In the `Settings` section of the `Email Document` you can use `Full Username <user@domain.fr>` or `Full Username (user@domain.fr)` to set full username.
+
 ## Usage Example
 Lets assume that we have created a `Email Document` in the Pimcore Backen UI (`/email/myemaildocument`) 
 which looks like this:

--- a/lib/Helper/Mail.php
+++ b/lib/Helper/Mail.php
@@ -432,7 +432,7 @@ CSS;
         if ($emailArray) {
             foreach ($emailArray as $emailStringEntry) {
                 $entryAddress = trim($emailStringEntry);
-                $entryName = null;
+                $entryName = ''; // Symfony mailer want a string
                 $matches = [];
                 if (preg_match('/(.*)<(.*)>/', $entryAddress, $matches)) {
                     $entryAddress = trim($matches[2]);


### PR DESCRIPTION
Hello,

This PR fix a bug when using address email in settings of document email in back-office. Symfony wants a string and trigger an error because it was null (if we use the classic format `user@mail.com` to set emails in the GUI).

I added a hint to documentation to use the extended format to pass full username as well (I discovered it by parsing the code !! 😄)

Thanks.