### PR TITLE
[Application Logger] Fix open detail page when having fileobject

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/log/detailwindow.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/log/detailwindow.js
@@ -115,7 +115,7 @@ pimcore.log.detailwindow = Class.create({
             if (fileObjectText.length > 60) {
                 fileObjectText = fileObjectText.substr(0, 60) + "...";
             }
-            var url = Routing.generate('pimcore_admin_log_showfileobject', {filePath: record.data.fileobject});
+            var url = Routing.generate('pimcore_admin_log_showfileobject', {filePath: this.data.fileobject});
 
             var html = Ext.String.format('<a href="{0}" target="_blank">{1}</a>', url, fileObjectText);
             items.push({


### PR DESCRIPTION
`record` is undefined. 