### PR TITLE
Simpler error handling to display Pimcore or Symfony 404

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -73,7 +73,7 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
                     ->end()
-                    ->setDeprecated('The "%node%" option is deprecated.')
+                    ->setDeprecated('The "%node%" option is deprecated since Pimcore 10.1, it will be removed in Pimcore 11.')
                 ->end()
                 ->arrayNode('bundles')
                     ->addDefaultsIfNotSet()

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -59,21 +59,6 @@ final class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->arrayNode('error_handling')
-                    ->addDefaultsIfNotSet()
-                    ->children()
-                        ->booleanNode('render_error_document')
-                            ->info('Render error document in case of an error instead of showing Symfony\'s error page')
-                            ->defaultTrue()
-                            ->beforeNormalization()
-                                ->ifString()
-                                ->then(function ($v) {
-                                    return (bool)$v;
-                                })
-                            ->end()
-                        ->end()
-                    ->end()
-                ->end()
                 ->arrayNode('bundles')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -59,6 +59,22 @@ final class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->arrayNode('error_handling')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('render_error_document')
+                            ->info('Render error document in case of an error instead of showing Symfony\'s error page')
+                            ->defaultTrue()
+                            ->beforeNormalization()
+                                ->ifString()
+                                ->then(function ($v) {
+                                    return (bool)$v;
+                                })
+                            ->end()
+                        ->end()
+                    ->end()
+                    ->setDeprecated('The "%node%" option is deprecated.')
+                ->end()
                 ->arrayNode('bundles')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -85,8 +85,6 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
 
         $container->setParameter('pimcore.web_profiler.toolbar.excluded_routes', $config['web_profiler']['toolbar']['excluded_routes']);
 
-        $container->setParameter('pimcore.response_exception_listener.render_error_document', $config['error_handling']['render_error_document']);
-
         $container->setParameter('pimcore.maintenance.housekeeping.cleanup_tmp_files_atime_older_than', $config['maintenance']['housekeeping']['cleanup_tmp_files_atime_older_than']);
         $container->setParameter('pimcore.maintenance.housekeeping.cleanup_profiler_files_atime_older_than', $config['maintenance']['housekeeping']['cleanup_profiler_files_atime_older_than']);
 

--- a/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -85,6 +85,9 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
 
         $container->setParameter('pimcore.web_profiler.toolbar.excluded_routes', $config['web_profiler']['toolbar']['excluded_routes']);
 
+        // @deprecated since Pimcore 10.1, parameter will be removed in Pimcore 11
+        $container->setParameter('pimcore.response_exception_listener.render_error_document', $config['error_handling']['render_error_document']);
+
         $container->setParameter('pimcore.maintenance.housekeeping.cleanup_tmp_files_atime_older_than', $config['maintenance']['housekeeping']['cleanup_tmp_files_atime_older_than']);
         $container->setParameter('pimcore.maintenance.housekeeping.cleanup_profiler_files_atime_older_than', $config['maintenance']['housekeeping']['cleanup_profiler_files_atime_older_than']);
 

--- a/bundles/CoreBundle/EventListener/ResponseExceptionListener.php
+++ b/bundles/CoreBundle/EventListener/ResponseExceptionListener.php
@@ -45,11 +45,6 @@ class ResponseExceptionListener implements EventSubscriberInterface
     protected $documentRenderer;
 
     /**
-     * @var bool
-     */
-    protected $renderErrorPage = true;
-
-    /**
      * @var Config
      */
     protected $config;
@@ -62,12 +57,10 @@ class ResponseExceptionListener implements EventSubscriberInterface
     /**
      * @param DocumentRenderer $documentRenderer
      * @param ConnectionInterface $db
-     * @param bool $renderErrorPage
      */
-    public function __construct(DocumentRenderer $documentRenderer, ConnectionInterface $db, Config $config, $renderErrorPage = true)
+    public function __construct(DocumentRenderer $documentRenderer, ConnectionInterface $db, Config $config)
     {
         $this->documentRenderer = $documentRenderer;
-        $this->renderErrorPage = (bool)$renderErrorPage;
         $this->db = $db;
         $this->config = $config;
     }
@@ -97,9 +90,7 @@ class ResponseExceptionListener implements EventSubscriberInterface
         // further checks are only valid for default context
         $request = $event->getRequest();
         if ($this->matchesPimcoreContext($request, PimcoreContextResolver::CONTEXT_DEFAULT)) {
-            if ($this->renderErrorPage) {
-                $this->handleErrorPage($event);
-            }
+            $this->handleErrorPage($event);
         }
     }
 
@@ -133,7 +124,8 @@ class ResponseExceptionListener implements EventSubscriberInterface
 
         // Error page rendering
         if (empty($errorPath)) {
-            $errorPath = '/';
+            // if not set, use Symfony error handling
+            return;
         }
 
         $document = Document::getByPath($errorPath);

--- a/bundles/CoreBundle/Resources/config/event_listeners.yml
+++ b/bundles/CoreBundle/Resources/config/event_listeners.yml
@@ -86,8 +86,6 @@ services:
     #
 
     Pimcore\Bundle\CoreBundle\EventListener\ResponseExceptionListener:
-        arguments:
-            $renderErrorPage: '%pimcore.response_exception_listener.render_error_document%'
         calls:
             - [setLogger, ['@logger']]
 

--- a/bundles/CoreBundle/Resources/config/pimcore/default.yml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yml
@@ -79,9 +79,6 @@ pimcore:
         encoder_factories:
             Pimcore\Bundle\AdminBundle\Security\User\User: pimcore_admin.security.password_encoder_factory
 
-    error_handling:
-        render_error_document: true
-
     bundles:
         search_paths:
             - src

--- a/bundles/CoreBundle/Resources/config/pimcore/dev.yml
+++ b/bundles/CoreBundle/Resources/config/pimcore/dev.yml
@@ -27,9 +27,6 @@ monolog:
             channels: ['!event', '!doctrine', '!console', '!cache']
 
 pimcore:
-    error_handling:
-        render_error_document: false
-
     web_profiler:
         toolbar:
             excluded_routes: ~

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -325,7 +325,7 @@ abstract class Kernel extends SymfonyKernel
         ], 60);
 
         // load development bundles only in matching environments
-        if ($this->isDebug() && in_array($this->getEnvironment(), $this->getEnvironmentsForDevBundles(), true)) {
+        if (in_array($this->getEnvironment(), $this->getEnvironmentsForDevBundles(), true)) {
             $collection->addBundles([
                 new DebugBundle(),
                 new WebProfilerBundle(),


### PR DESCRIPTION
Hello,

This is an improvement suggestion to make:
- 404 page error handling easier to manage for developers (testing real display)
- switching APP_DEBUG without any errors on dev environments (with fresh Symfony you can set `dev` with APP_DEBUG 0 or 1 it works out of the box, not for Pimcore)
- use more easily Symfony 404 pages if wanted instead Pimcore error page

Purpose is to make it easy, even on the `dev` environment, after this fix just doing:
- APP_DEBUG=0 => display 404 page
- if error document is set in BO: use this one
- if no error document is set : use the Symfony error page and way of customise it (https://symfony.com/doc/current/controller/error_pages.html)
- APP_DEBUG=1 => display debug page

This is linked to investigation made here: https://github.com/pimcore/pimcore/issues/9141#issuecomment-845465542

This is a proposition, which can make a **breaking change**, because on production instances of Pimcore having not the 404 page set:
- before: redirect to home page
- after: will display the Symfony 404 page (Oops! An Error Occurred):

![image](https://user-images.githubusercontent.com/9025839/119050313-f975b680-b9c1-11eb-8e78-adc6395ae74b.png)

I made this suggestion because, it seems more natural. Now all is handled by APP_DEBUG, so make it simpler for error page like it has been done for email make sense and coherence.

If not, can be closed ; )

Thanks.
