### PR TITLE
Youtube Video Error (no query)

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -476,10 +476,12 @@ class Video extends Model\Document\Editable
             if ($youtubeId = $this->id) {
                 if (strpos($youtubeId, '//') !== false) {
                     $parts = parse_url($this->id);
-                    parse_str($parts['query'], $vars);
+                    if( array_key_exists('query', $parts) ){
+                        parse_str($parts['query'], $vars);
 
-                    if ($vars['v']) {
-                        $youtubeId = $vars['v'];
+                        if ($vars['v']) {
+                            $youtubeId = $vars['v'];
+                        }
                     }
 
                     //get youtube id if form urls like  http://www.youtube.com/embed/youtubeId


### PR DESCRIPTION
if the link looks like: https://youtu.be/bKgd_08Rpg0 there is no query part!
