### PR TITLE
New Classificationstore groups added to variant is not visible

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -1258,7 +1258,7 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
         if ($inheritanceAllowed) {
             $parent = DataObject\Service::hasInheritableParentObject($object);
             if ($parent) {
-                $activeGroups = $this->recursiveGetActiveGroupsIds($parent, $activeGroups);
+                $activeGroups += $this->recursiveGetActiveGroupsIds($parent, $activeGroups);
             }
         }
 


### PR DESCRIPTION
When adding a new classificationstore group to a variant and then do a refresh of the variant in the admin interface results in the added group is gone and only the parents groups are visible.
The fault is that recursiveGetActiveGroupsIds throws away the variant groupid's instead of adding them to the parent ids.
The fix consists of adding the parent id:s to the variant instead of overwriting the array with the parent ids.

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `10.x`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

