### PR TITLE
[Data objects] Disable mouse wheel scrolling for numeric, quantity value fields

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/numeric.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/numeric.js
@@ -26,6 +26,7 @@ pimcore.document.editables.numeric = Class.create(pimcore.document.editable, {
         config.value = data;
         config.name = id + "_editable";
         config.decimalPrecision = 20;
+        config.mouseWheelEnabled = false;
 
         if(config["required"]) {
             this.required = config["required"];

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/numeric.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/numeric.js
@@ -83,7 +83,8 @@ pimcore.object.tags.numeric = Class.create(pimcore.object.tags.abstract, {
         var input = {
             fieldLabel: this.fieldConfig.title,
             name: this.fieldConfig.name,
-            componentCls: "object_field object_field_type_" + this.type
+            componentCls: "object_field object_field_type_" + this.type,
+            mouseWheelEnabled: false
         };
 
         if (!isNaN(this.data)) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
@@ -114,7 +114,7 @@ pimcore.object.tags.quantityValue = Class.create(pimcore.object.tags.abstract, {
             updateCompatibleUnitsToolTipContent();
         });
 
-        var input = {};
+        var input = {mouseWheelEnabled: false};
 
         if (this.data && !isNaN(this.data.value)) {
             input.value = this.data.value;


### PR DESCRIPTION
Currently when you edit a data object and click a numeric / quantity value field and afterwards want to scroll down (or up) to another field the value in the field gets changed (due to the mouse wheel scroll). As in a PIM system I think nearly nobody uses the mouse scroll wheel to change a field's value this PR proposes to disable this "feature". 

And now I am waiting for comments who do use the mouse wheel to change numeric fields' values so that we have to add a checkbox in the field definition ;-)