### PR TITLE
[Cache] Performance improvements

### DIFF
--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -410,7 +410,10 @@ class CoreCacheHandler implements LoggerAwareInterface
         return false;
     }
 
-    private function cleanupQueue(): void
+    /**
+     * @internal
+     */
+    public function cleanupQueue(): void
     {
         // order by priority
         uasort($this->saveQueue, function (CacheQueueItem $a, CacheQueueItem $b) {

--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -299,7 +299,6 @@ class CoreCacheHandler implements LoggerAwareInterface
 
         if ($item->isHit()) {
             $data = $item->get();
-            $data = unserialize($data);
 
             if (is_object($data)) {
                 $data->____pimcore_cache_item__ = $key; // TODO where is this used?
@@ -397,52 +396,29 @@ class CoreCacheHandler implements LoggerAwareInterface
      */
     protected function addToSaveQueue(CacheQueueItem $item)
     {
-        $this->saveQueue[$item->getKey()] = $item;
+        $data = $this->prepareCacheData($item->getData());
+        if ($data) {
+            $this->saveQueue[$item->getKey()] = $item;
 
-        // order by priority
-        uasort($this->saveQueue, function (CacheQueueItem $a, CacheQueueItem $b) {
-            if ($a->getPriority() === $b->getPriority()) {
-                // records with serialized data have priority, to save cpu cycles. if the item has a CacheItem set, data
-                // was already serialized
-                if (is_scalar($a->getData())) {
-                    return -1;
-                } else {
-                    return 1;
-                }
+            if(count($this->saveQueue) > ($this->maxWriteToCacheItems*3)) {
+                $this->cleanupQueue();
             }
 
-            return $a->getPriority() < $b->getPriority() ? 1 : -1;
+            return true;
+        }
+
+        return false;
+    }
+
+    private function cleanupQueue(): void
+    {
+        // order by priority
+        uasort($this->saveQueue, function (CacheQueueItem $a, CacheQueueItem $b) {
+            return $b->getPriority() <=> $a->getPriority();
         });
 
         // remove overrun
         array_splice($this->saveQueue, $this->maxWriteToCacheItems);
-
-        // check if item is still on queue and serialize the data into a CacheItem
-        if (isset($this->saveQueue[$item->getKey()])) {
-            $data = $this->prepareCacheData($item->getData());
-            if ($data) {
-                // add cache item with serialized data to queue item
-                $item->setData($data);
-
-                return true;
-            } else {
-                // cache item could not be created - remove queue item
-                unset($this->saveQueue[$item->getKey()]);
-
-                // logging is done in prepare method if item could not be created
-                return false;
-            }
-        } else {
-            $this->logger->info(
-                'Not saving {key} to cache as it did not fit into the save queue (max items on queue: {maxItems})',
-                [
-                    'key' => $item->getKey(),
-                    'maxItems' => $this->maxWriteToCacheItems,
-                ]
-            );
-        }
-
-        return false;
     }
 
     /**
@@ -465,18 +441,9 @@ class CoreCacheHandler implements LoggerAwareInterface
             if (!$data->getId()) {
                 return null;
             }
-
-            // Objects implementing ElementInterface are getting serialized later in storeCacheItem()
-            // where we obtain a fresh copy of the element from the database to ensure data-consistency
-            $itemData = $data;
-        } else {
-            // See #1005 - serialize the element now as we don't know what happens until it is actually persisted
-            // on shutdown and we could end up with corrupt objects in cache
-            // TODO symfony cache adapters serialize as well - find a way to avoid double serialization
-            $itemData = serialize($data);
         }
 
-        return $itemData;
+        return $data;
     }
 
     /**
@@ -603,8 +570,6 @@ class CoreCacheHandler implements LoggerAwareInterface
             );
 
             $data = $copier->copy($data);
-
-            $data = serialize($data);
         }
 
         $item = $this->pool->getItem($key);
@@ -890,6 +855,8 @@ class CoreCacheHandler implements LoggerAwareInterface
 
             return false;
         }
+
+        $this->cleanupQueue();
 
         $processedKeys = [];
         foreach ($this->saveQueue as $queueItem) {

--- a/tests/Cache/Core/AbstractCoreHandlerTest.php
+++ b/tests/Cache/Core/AbstractCoreHandlerTest.php
@@ -375,7 +375,7 @@ abstract class AbstractCoreHandlerTest extends TestCase
             $this->getHandlerPropertyValue('saveQueue')
         );
 
-        $this->assertFalse($this->handler->save('additional_item', 'foo'));
+        $this->handler->save('additional_item', 'foo');
         $this->handler->cleanupQueue();
 
         $queue = $this->getHandlerPropertyValue('saveQueue');

--- a/tests/Cache/Core/AbstractCoreHandlerTest.php
+++ b/tests/Cache/Core/AbstractCoreHandlerTest.php
@@ -362,6 +362,7 @@ abstract class AbstractCoreHandlerTest extends TestCase
 
         for ($i = 1; $i <= $maxItems; $i++) {
             $this->assertTrue($this->handler->save('item_' . $i, $i));
+            $this->handler->cleanupQueue();
 
             $this->assertCount(
                 $i,
@@ -375,6 +376,7 @@ abstract class AbstractCoreHandlerTest extends TestCase
         );
 
         $this->assertFalse($this->handler->save('additional_item', 'foo'));
+        $this->handler->cleanupQueue();
 
         $queue = $this->getHandlerPropertyValue('saveQueue');
         for ($i = 1; $i <= $maxItems; $i++) {
@@ -401,6 +403,7 @@ abstract class AbstractCoreHandlerTest extends TestCase
 
         for ($i = 1; $i <= $maxItems; $i++) {
             $this->assertTrue($this->handler->save('item_' . $i, $i));
+            $this->handler->cleanupQueue();
 
             $this->assertCount(
                 $i,
@@ -414,6 +417,7 @@ abstract class AbstractCoreHandlerTest extends TestCase
         );
 
         $this->assertTrue($this->handler->save('additional_item', 'foo', [], null, 10));
+        $this->handler->cleanupQueue();
 
         $queue = $this->getHandlerPropertyValue('saveQueue');
 


### PR DESCRIPTION
Follow up to #9199

- Do not double-serialize data -> let Symfony care about serialization 
- Do not clean up queue on every `save()` call