### PR TITLE
fix(assets): use Flysystem for size determination

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -1090,7 +1090,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }, 200, [
             'Content-Type' => $asset->getMimetype(),
             'Content-Disposition' => sprintf('attachment; filename="%s"', $asset->getFilename()),
-            'Content-Length' => fstat($stream)['size'],
+            'Content-Length' => $asset->getFileSize(),
         ]);
     }
 


### PR DESCRIPTION
This fix force download route to use Flysystem for file size determination instead of using native PHP function; On that way we will avoid issues on different disk adapters (_e.g. aws (s3)_)

This was tested with `local` adapter and `aws` adapter

## Case
1. I change File storage for assets to use S3, and ACL visibility for files is `private`
```yml
services:
    assets_s3:
        class: 'Aws\S3\S3Client'
        arguments:
            -   endpoint: 'https://s3.eu-central-1.amazonaws.com'
                region: 'eu-central-1'
                version: 'latest'
                credentials:
                    key: '%aws_iam_key%'
                    secret: '%aws_iam_secret%'

flysystem:
    storages:
        pimcore.asset.storage:
            adapter: 'aws'
            options:
                client: 'assets_s3'
                bucket: '%aws_bucket%'
                prefix: '%assets_storage_path%'
```

2. I'm in pimcore administration on asset single screen (_asset type is JPEG image_);
3. When i try download image by click on "Original File" button (_on right side_), this ends with error screen;

> `fstat` is not able to determine information about a file and return `false` which cause error