### PR TITLE
[Data Objects] New items in class definition editor shouldn't be called Root

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
@@ -63,6 +63,7 @@ pimcore.object.classes.klass = Class.create({
                 }
             }
         });
+        this.tree.getStore().setDefaultRootText("");
     },
 
     addLayout: function () {


### PR DESCRIPTION
resolves #9231
