### PR TITLE
8300 Change varchar size for quantity value unit ids

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/QuantityValueController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/QuantityValueController.php
@@ -134,6 +134,10 @@ class QuantityValueController extends AdminController
                     throw new \Exception('unit with ID [' . $id . '] already exists');
                 }
 
+                if (mb_strlen($id) > 50) {
+                    throw new \Exception('The maximal character length for the unit ID is 50 characters, the provided ID has ' . mb_strlen($id) . ' characters.');
+                }
+
                 $unit = new Unit();
                 $unit->setValues($data);
                 $unit->save();

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -98,7 +98,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
      */
     public $queryColumnType = [
         'value' => 'double',
-        'unit' => 'varchar(50)',
+        'unit' => 'varchar(64)',
     ];
 
     /**
@@ -110,7 +110,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
      */
     public $columnType = [
         'value' => 'double',
-        'unit' => 'varchar(50)',
+        'unit' => 'varchar(64)',
     ];
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
Resolves #8300 

## Additional info
The column definition for quantity value units was recently changed from bigint(20) to varchar(50). If you have many quantity value data fields in one class, the maximum row length of the innodb table is reached very quickly. This pr increases the varchar length to 64. Then the values are stored in overflow pages. It also adds an exception, when creating a unit with length greater than 50.
