### PR TITLE
Docs: Fix link to DoctrineMigrationsBundle

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/37_Migrations.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/37_Migrations.md
@@ -3,7 +3,7 @@
 A common tasks in evolving applications is the need to migrate data and data structures to a specific format. Common examples
 are adding a new column to a database table or changing data.
 
-To be able to execute migration changes across environments, Pimcore integrates the [Doctrine Migrations Bundle](https://symfony.com/doc/5.2/bundles/DoctrineMigrationsBundle/index.html)
+To be able to execute migration changes across environments, Pimcore integrates the [Doctrine Migrations Bundle](https://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html)
 library which provides a powerful migration framework. 
 
 To create your project or bundle specific migrations you can just follow the official guide linked above. 


### PR DESCRIPTION
DoctrineMigrationsBundle uses a different versioning, so 5.2 doesn't exist. We can either link to "3.1" or to "current". I suggest using "current", and rather change the link to a fixed version in the future if Pimcore at some point no longer supports the current version.
