### PR TITLE
[Documents] format key to lower case dashed

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
@@ -1373,7 +1373,7 @@ pimcore.document.tree = Class.create({
                         },
                         keyup: function (el) {
                             pageForm.getComponent("name").setValue(el.getValue());
-                            pageForm.getComponent("key").setValue(el.getValue());
+                            pageForm.getComponent("key").setValue(el.getValue().replace(/\s+/g, '-').toLowerCase());
                         }.bind(this)
                     }
                 },{


### PR DESCRIPTION
Automatically format key to lower case dashed when adding a document.
Relates to #8907