### PR TITLE
Fixes `aspectration` to `aspectratio` in wysiwyg.js

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/wysiwyg.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/wysiwyg.js
@@ -297,7 +297,7 @@ pimcore.object.tags.wysiwyg = Class.create(pimcore.object.tags.abstract, {
                 // converted by the pimcore thumbnailing service so that they can be displayed in the editor
                 var defaultWidth = 600;
                 var additionalAttributes = "";
-                uri = Routing.generate('pimcore_admin_asset_getimagethumbnail', {id: id, width: defaultWidth, aspectration: true});
+                uri = Routing.generate('pimcore_admin_asset_getimagethumbnail', {id: id, width: defaultWidth, aspectratio: true});
 
                 if(typeof node.data.imageWidth != "undefined") {
                     if(node.data.imageWidth < defaultWidth


### PR DESCRIPTION
## Changes in this pull request  

The incorrect parameter can be seen when dragging an asset into a WYSIWYG field and inspecting image properties.