### PR TITLE
Restrict symfony/symfony to 5.2.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
     "symfony-cmf/routing-bundle": "^2.0",
     "symfony/contracts": "^2.0",
     "symfony/monolog-bundle": "^3.1.0",
-    "symfony/symfony": "^5.2.0",
+    "symfony/symfony": "5.2.*",
     "tijsverkoyen/css-to-inline-styles": "^2.2.1",
     "twig/twig": "^3.0",
     "twig/string-extra": "^3.0",


### PR DESCRIPTION
Symfony 5.3 got released yesterday, see https://github.com/symfony/symfony/releases/tag/v5.3.0
But it seems to be incompatible with Pimcore. I cannot even access the backend login, I get
```
Message: The SessionBagInterface 'pimcore_admin' is not registered.
Trace:
in [Pimcore root]/vendor/symfony/symfony/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php:317
#0 [Pimcore root]/vendor/symfony/symfony/src/Symfony/Component/HttpFoundation/Session/Session.php(257): Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage->getBag('pimcore_admin')
#1 [Pimcore root]/vendor/pimcore/pimcore/bundles/AdminBundle/Session/Handler/AdminSessionHandler.php(153): Symfony\Component\HttpFoundation\Session\Session->getBag('pimcore_admin')
#2 [Pimcore root]/vendor/pimcore/pimcore/bundles/AdminBundle/Session/Handler/AdminSessionHandler.php(97): Pimcore\Bundle\AdminBundle\Session\Handler\AdminSessionHandler->loadAttributeBag('pimcore_admin', Object(Symfony\Component\HttpFoundation\Session\Session))
#3 [Pimcore root]/vendor/pimcore/pimcore/bundles/AdminBundle/Session/Handler/AdminSessionHandler.php(114): Pimcore\Bundle\AdminBundle\Session\Handler\AdminSessionHandler->useSessionAttributeBag(Object(Closure), 'pimcore_admin')
#4 [Pimcore root]/vendor/pimcore/pimcore/lib/Tool/Session.php(135): Pimcore\Bundle\AdminBundle\Session\Handler\AdminSessionHandler->getReadOnlyAttributeBag('pimcore_admin')
#5 [Pimcore root]/vendor/pimcore/pimcore/bundles/AdminBundle/Security/CsrfProtectionHandler.php(78): Pimcore\Tool\Session::getReadOnly()
#6 [Pimcore root]/vendor/pimcore/pimcore/bundles/AdminBundle/Security/CsrfProtectionHandler.php(107): Pimcore\Bundle\AdminBundle\Security\CsrfProtectionHandler->getCsrfToken()
#7 [Pimcore root]/vendor/pimcore/pimcore/bundles/AdminBundle/EventListener/CsrfProtectionListener.php(72): Pimcore\Bundle\AdminBundle\Security\CsrfProtectionHandler->generateCsrfToken()
#8 [Pimcore root]/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php(117): Pimcore\Bundle\AdminBundle\EventListener\CsrfProtectionListener->handleRequest(Object(Symfony\Component\HttpKernel\Event\RequestEvent), 'kernel.request', Object(Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher))
#9 [Pimcore root]/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php(230): Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke(Object(Symfony\Component\HttpKernel\Event\RequestEvent), 'kernel.request', Object(Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher))
#10 [Pimcore root]/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php(59): Symfony\Component\EventDispatcher\EventDispatcher->callListeners(Array, 'kernel.request', Object(Symfony\Component\HttpKernel\Event\RequestEvent))
#11 [Pimcore root]/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php(151): Symfony\Component\EventDispatcher\EventDispatcher->dispatch(Object(Symfony\Component\HttpKernel\Event\RequestEvent), 'kernel.request')
#12 [Pimcore root]/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(133): Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch(Object(Symfony\Component\HttpKernel\Event\RequestEvent), 'kernel.request')
#13 [Pimcore root]/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(79): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#14 [Pimcore root]/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php(199): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#15 [Pimcore root]/public/index.php(35): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#16 {main}
```

This PR just prevents Composer from installing symfony/symfony 5.3 - but of course we need a follow-up PR to actually fix the problem (or Symfony reverts the BC break).