### PR TITLE
Symfony 5.3 Compatibility - Override session service to use NamespacedAttributeBag

### DIFF
--- a/bundles/CoreBundle/Resources/config/services.yml
+++ b/bundles/CoreBundle/Resources/config/services.yml
@@ -7,6 +7,14 @@ services:
     # SESSION
     #
 
+    session:
+        public: true
+        class: Symfony\Component\HttpFoundation\Session\Session
+        arguments: [ '@session.storage', '@session.namespacedattributebag', '@session.flash_bag' ]
+
+    session.namespacedattributebag:
+        class: Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag
+
     # Sessions need to be configured (e.g. adding custom attribute bags) before they are started. The configurator handles
     # a collection of configurator instances which can be added via addConfigurator or by using the pimcore.session.configurator
     # DI tag. See the SessionConfiguratorPass for details.


### PR DESCRIPTION
## Changes in this pull request  
Resolves #

## Additional info  

