### PR TITLE
Fixed all KernelEvent::isMasterRequest() deprecation messages

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -2696,8 +2696,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
@@ -1712,8 +1712,8 @@ class ClassController extends AdminController implements KernelControllerEventIn
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -1529,8 +1529,8 @@ class ClassificationstoreController extends AdminController implements KernelCon
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -2244,8 +2244,8 @@ class DataObjectController extends ElementControllerBase implements KernelContro
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -1573,8 +1573,8 @@ class DocumentController extends ElementControllerBase implements KernelControll
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentControllerBase.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentControllerBase.php
@@ -315,8 +315,8 @@ abstract class DocumentControllerBase extends AdminController implements KernelC
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/Admin/External/AdminerController.php
+++ b/bundles/AdminBundle/Controller/Admin/External/AdminerController.php
@@ -119,8 +119,8 @@ namespace Pimcore\Bundle\AdminBundle\Controller\Admin\External {
          */
         public function onKernelControllerEvent(ControllerEvent $event)
         {
-            $isMasterRequest = $event->isMasterRequest();
-            if (!$isMasterRequest) {
+            $isMainRequest = $event->isMainRequest();
+            if (!$isMainRequest) {
                 return;
             }
 

--- a/bundles/AdminBundle/Controller/Admin/External/OpcacheController.php
+++ b/bundles/AdminBundle/Controller/Admin/External/OpcacheController.php
@@ -56,8 +56,8 @@ class OpcacheController extends AdminController implements KernelControllerEvent
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/Admin/PortalController.php
+++ b/bundles/AdminBundle/Controller/Admin/PortalController.php
@@ -426,8 +426,8 @@ class PortalController extends AdminController implements KernelControllerEventI
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/Admin/RecyclebinController.php
+++ b/bundles/AdminBundle/Controller/Admin/RecyclebinController.php
@@ -200,8 +200,8 @@ class RecyclebinController extends AdminController implements KernelControllerEv
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/Admin/TargetingController.php
+++ b/bundles/AdminBundle/Controller/Admin/TargetingController.php
@@ -314,8 +314,8 @@ class TargetingController extends AdminController implements KernelControllerEve
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -1009,8 +1009,8 @@ class UserController extends AdminController implements KernelControllerEventInt
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/Admin/WorkflowController.php
+++ b/bundles/AdminBundle/Controller/Admin/WorkflowController.php
@@ -427,8 +427,8 @@ class WorkflowController extends AdminController implements KernelControllerEven
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/GDPR/AdminController.php
+++ b/bundles/AdminBundle/Controller/GDPR/AdminController.php
@@ -49,7 +49,7 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/GDPR/AssetController.php
+++ b/bundles/AdminBundle/Controller/GDPR/AssetController.php
@@ -39,8 +39,8 @@ class AssetController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/GDPR/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/GDPR/DataObjectController.php
@@ -37,8 +37,8 @@ class DataObjectController extends \Pimcore\Bundle\AdminBundle\Controller\AdminC
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/GDPR/PimcoreUsersController.php
+++ b/bundles/AdminBundle/Controller/GDPR/PimcoreUsersController.php
@@ -36,8 +36,8 @@ class PimcoreUsersController extends \Pimcore\Bundle\AdminBundle\Controller\Admi
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/GDPR/SentMailController.php
+++ b/bundles/AdminBundle/Controller/GDPR/SentMailController.php
@@ -36,8 +36,8 @@ class SentMailController extends \Pimcore\Bundle\AdminBundle\Controller\AdminCon
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/Controller/Reports/AnalyticsController.php
+++ b/bundles/AdminBundle/Controller/Reports/AnalyticsController.php
@@ -507,8 +507,8 @@ class AnalyticsController extends ReportsControllerBase implements KernelControl
      */
     public function onKernelControllerEvent(ControllerEvent $event)
     {
-        $isMasterRequest = $event->isMasterRequest();
-        if (!$isMasterRequest) {
+        $isMainRequest = $event->isMainRequest();
+        if (!$isMainRequest) {
             return;
         }
 

--- a/bundles/AdminBundle/EventListener/AdminAuthenticationDoubleCheckListener.php
+++ b/bundles/AdminBundle/EventListener/AdminAuthenticationDoubleCheckListener.php
@@ -87,7 +87,7 @@ class AdminAuthenticationDoubleCheckListener implements EventSubscriberInterface
 
     public function onKernelController(ControllerEvent $event)
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/AdminBundle/EventListener/CustomAdminEntryPointCheckListener.php
+++ b/bundles/AdminBundle/EventListener/CustomAdminEntryPointCheckListener.php
@@ -54,7 +54,7 @@ class CustomAdminEntryPointCheckListener implements EventSubscriberInterface
     public function onKernelRequest(RequestEvent $event)
     {
         $request = $event->getRequest();
-        if ($event->isMasterRequest() && $this->customAdminPathIdentifier && $this->matchesPimcoreContext($request, PimcoreContextResolver::CONTEXT_ADMIN)) {
+        if ($event->isMainRequest() && $this->customAdminPathIdentifier && $this->matchesPimcoreContext($request, PimcoreContextResolver::CONTEXT_ADMIN)) {
             if ($this->customAdminPathIdentifier !== $request->cookies->get('pimcore_custom_admin')) {
                 // display standard 404 error page, we don't expose that /admin exists but access is prohibited
                 throw new NotFoundHttpException();

--- a/bundles/AdminBundle/EventListener/EnablePreviewTimeSliderListener.php
+++ b/bundles/AdminBundle/EventListener/EnablePreviewTimeSliderListener.php
@@ -73,7 +73,7 @@ class EnablePreviewTimeSliderListener implements EventSubscriberInterface
 
     public function onKernelResponse(ResponseEvent $event)
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/AdminBundle/EventListener/HttpCacheListener.php
+++ b/bundles/AdminBundle/EventListener/HttpCacheListener.php
@@ -64,7 +64,7 @@ class HttpCacheListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/AdminBundle/EventListener/UsageStatisticsListener.php
+++ b/bundles/AdminBundle/EventListener/UsageStatisticsListener.php
@@ -65,7 +65,7 @@ class UsageStatisticsListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/AdminBundle/EventListener/UserPerspectiveListener.php
+++ b/bundles/AdminBundle/EventListener/UserPerspectiveListener.php
@@ -62,7 +62,7 @@ class UserPerspectiveListener implements EventSubscriberInterface, LoggerAwareIn
     {
         $request = $event->getRequest();
 
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/CoreBundle/EventListener/Frontend/BlockStateListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/BlockStateListener.php
@@ -75,7 +75,7 @@ class BlockStateListener implements EventSubscriberInterface, LoggerAwareInterfa
         }
 
         // master request already has a state on the stack
-        if ($event->isMasterRequest()) {
+        if ($event->isMainRequest()) {
             return;
         }
 

--- a/bundles/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
@@ -128,7 +128,7 @@ class DocumentFallbackListener implements EventSubscriberInterface
             return;
         }
 
-        if ($event->isMasterRequest()) {
+        if ($event->isMainRequest()) {
             // no document found yet - try to find the nearest document by request path
             // this is only done on the master request as a sub-request's pathInfo is _fragment when
             // rendered via actions helper
@@ -180,7 +180,7 @@ class DocumentFallbackListener implements EventSubscriberInterface
             return;
         }
 
-        if ($this->fallbackDocument && $event->isMasterRequest()) {
+        if ($this->fallbackDocument && $event->isMainRequest()) {
             $this->documentResolver->setDocument($event->getRequest(), $this->fallbackDocument);
         }
     }

--- a/bundles/CoreBundle/EventListener/Frontend/DocumentMetaDataListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/DocumentMetaDataListener.php
@@ -75,7 +75,7 @@ class DocumentMetaDataListener implements EventSubscriberInterface
         $request = $event->getRequest();
 
         // just add meta data on master request
-        if (!$event->isMasterRequest() && !$event->getRequest()->attributes->get(self::FORCE_INJECTION)) {
+        if (!$event->isMainRequest() && !$event->getRequest()->attributes->get(self::FORCE_INJECTION)) {
             return;
         }
 

--- a/bundles/CoreBundle/EventListener/Frontend/EditmodeListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/EditmodeListener.php
@@ -115,7 +115,7 @@ class EditmodeListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return; // only resolve editmode in frontend
         }
 
@@ -133,7 +133,7 @@ class EditmodeListener implements EventSubscriberInterface
         $request = $event->getRequest();
         $response = $event->getResponse();
 
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return; // only master requests inject editmode assets
         }
 

--- a/bundles/CoreBundle/EventListener/Frontend/ElementListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/ElementListener.php
@@ -99,7 +99,7 @@ class ElementListener implements EventSubscriberInterface, LoggerAwareInterface
 
     public function onKernelController(ControllerEvent $event)
     {
-        if ($event->isMasterRequest()) {
+        if ($event->isMainRequest()) {
             $request = $event->getRequest();
             if (!$this->matchesPimcoreContext($request, PimcoreContextResolver::CONTEXT_DEFAULT)) {
                 return;

--- a/bundles/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
@@ -175,7 +175,7 @@ class FullPageCacheListener
 
         $request = $event->getRequest();
 
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 
@@ -345,7 +345,7 @@ class FullPageCacheListener
      */
     public function onKernelResponse(ResponseEvent $event)
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/CoreBundle/EventListener/Frontend/GoogleAnalyticsCodeListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/GoogleAnalyticsCodeListener.php
@@ -53,7 +53,7 @@ class GoogleAnalyticsCodeListener
         }
 
         $request = $event->getRequest();
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/CoreBundle/EventListener/Frontend/GoogleSearchConsoleVerificationListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/GoogleSearchConsoleVerificationListener.php
@@ -42,7 +42,7 @@ class GoogleSearchConsoleVerificationListener implements EventSubscriberInterfac
     public function onKernelRequest(RequestEvent $event)
     {
         $request = $event->getRequest();
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/CoreBundle/EventListener/Frontend/GoogleTagManagerListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/GoogleTagManagerListener.php
@@ -98,7 +98,7 @@ class GoogleTagManagerListener
         }
 
         $request = $event->getRequest();
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/CoreBundle/EventListener/Frontend/HardlinkCanonicalListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/HardlinkCanonicalListener.php
@@ -65,7 +65,7 @@ class HardlinkCanonicalListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/CoreBundle/EventListener/Frontend/InternalWysiwygHtmlAttributeFilterListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/InternalWysiwygHtmlAttributeFilterListener.php
@@ -45,7 +45,7 @@ class InternalWysiwygHtmlAttributeFilterListener implements EventSubscriberInter
     {
         $request = $event->getRequest();
 
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/CoreBundle/EventListener/Frontend/LocaleListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/LocaleListener.php
@@ -78,7 +78,7 @@ class LocaleListener implements EventSubscriberInterface
 
     public function onKernelResponse(ResponseEvent $event)
     {
-        if ($this->lastLocale && $event->isMasterRequest()) {
+        if ($this->lastLocale && $event->isMainRequest()) {
             $response = $event->getResponse();
             $response->headers->set('Content-Language', strtolower(str_replace('_', '-', $this->lastLocale)), true);
         }

--- a/bundles/CoreBundle/EventListener/Frontend/OutputTimestampListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/OutputTimestampListener.php
@@ -52,7 +52,7 @@ class OutputTimestampListener implements EventSubscriberInterface
 
     public function onKernelRequest(RequestEvent $event)
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/CoreBundle/EventListener/Frontend/RoutingListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/RoutingListener.php
@@ -94,7 +94,7 @@ class RoutingListener implements EventSubscriberInterface
 
     public function onKernelRequest(RequestEvent $event)
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/CoreBundle/EventListener/MaintenancePageListener.php
+++ b/bundles/CoreBundle/EventListener/MaintenancePageListener.php
@@ -78,7 +78,7 @@ class MaintenancePageListener
      */
     public function onKernelRequest(RequestEvent $event)
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/CoreBundle/EventListener/PimcoreContextListener.php
+++ b/bundles/CoreBundle/EventListener/PimcoreContextListener.php
@@ -73,7 +73,7 @@ class PimcoreContextListener implements EventSubscriberInterface, LoggerAwareInt
     {
         $request = $event->getRequest();
 
-        if ($event->isMasterRequest() || $event->getRequest()->attributes->has(self::ATTRIBUTE_PIMCORE_CONTEXT_FORCE_RESOLVING)) {
+        if ($event->isMainRequest() || $event->getRequest()->attributes->has(self::ATTRIBUTE_PIMCORE_CONTEXT_FORCE_RESOLVING)) {
             $context = $this->resolver->getPimcoreContext($request);
 
             if ($context) {

--- a/bundles/CoreBundle/EventListener/PimcoreHeaderListener.php
+++ b/bundles/CoreBundle/EventListener/PimcoreHeaderListener.php
@@ -36,7 +36,7 @@ class PimcoreHeaderListener implements EventSubscriberInterface
      */
     public function onKernelResponse(ResponseEvent $event)
     {
-        if ($event->isMasterRequest()) {
+        if ($event->isMainRequest()) {
             $response = $event->getResponse();
             $response->headers->set('X-Powered-By', 'pimcore', true);
         }

--- a/bundles/CoreBundle/EventListener/ResponseStackListener.php
+++ b/bundles/CoreBundle/EventListener/ResponseStackListener.php
@@ -52,7 +52,7 @@ class ResponseStackListener implements EventSubscriberInterface
 
     public function onKernelResponse(ResponseEvent $event)
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/CoreBundle/EventListener/TranslationDebugListener.php
+++ b/bundles/CoreBundle/EventListener/TranslationDebugListener.php
@@ -58,7 +58,7 @@ class TranslationDebugListener implements EventSubscriberInterface
 
     public function onKernelRequest(RequestEvent $event)
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/CoreBundle/EventListener/WebDebugToolbarListener.php
+++ b/bundles/CoreBundle/EventListener/WebDebugToolbarListener.php
@@ -90,7 +90,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
      */
     public function onKernelResponse(RequestEvent $event)
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/bundles/EcommerceFrameworkBundle/EventListener/Frontend/TrackingCodeFlashMessageListener.php
+++ b/bundles/EcommerceFrameworkBundle/EventListener/Frontend/TrackingCodeFlashMessageListener.php
@@ -68,7 +68,7 @@ class TrackingCodeFlashMessageListener implements EventSubscriberInterface
             return;
         }
 
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     "doctrine/doctrine-bundle": "^2.2.1",
     "doctrine/doctrine-migrations-bundle": "^3.0.1",
     "doctrine/inflector": "^1.4.0 || ^2.0.0",
-    "symfony/doctrine-messenger": "^5.2.0",
+    "symfony/doctrine-messenger": "^5.3.0",
     "egulias/email-validator": "^3.0.0",
     "endroid/qr-code": "^3.4.4",
     "friendsofsymfony/jsrouting-bundle": "^2.6",

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
     "symfony-cmf/routing-bundle": "^2.0",
     "symfony/contracts": "^2.0",
     "symfony/monolog-bundle": "^3.1.0",
-    "symfony/symfony": "^5.2.0",
+    "symfony/symfony": "^5.3.0",
     "tijsverkoyen/css-to-inline-styles": "^2.2.1",
     "twig/twig": "^3.0",
     "twig/string-extra": "^3.0",

--- a/lib/Targeting/EventListener/TargetingListener.php
+++ b/lib/Targeting/EventListener/TargetingListener.php
@@ -108,7 +108,7 @@ class TargetingListener implements EventSubscriberInterface
             return;
         }
 
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 
@@ -171,7 +171,7 @@ class TargetingListener implements EventSubscriberInterface
         $visitorInfo = $this->visitorInfoStorage->getVisitorInfo();
         $response = $event->getResponse();
 
-        if ($event->isMasterRequest()) {
+        if ($event->isMainRequest()) {
             $this->startStopwatch('Targeting:responseActions', 'targeting');
 
             // handle recorded actions on response

--- a/lib/Targeting/EventListener/ToolbarListener.php
+++ b/lib/Targeting/EventListener/ToolbarListener.php
@@ -116,7 +116,7 @@ class ToolbarListener implements EventSubscriberInterface
 
     public function onKernelResponse(ResponseEvent $event)
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/` -> target branch `10.x`
- [x] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [x] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Fixes the deprecation messages in the log about isMasterRequest deprecation, changed all of them into isMainRequest as per Symfony standard.

## Additional info  

