### PR TITLE
Update Redirect Listing Dao.php

### DIFF
--- a/models/Redirect/Listing/Dao.php
+++ b/models/Redirect/Listing/Dao.php
@@ -36,7 +36,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
             $redirects[] = Model\Redirect::getById($redirectData);
         }
 
-        $this->model->setRedirects($redirects);
+        $this->model->setRedirects(array_filter($redirects));
 
         return $redirects;
     }


### PR DESCRIPTION
There's the possibility that when dao tries to load redirects with a certain condition it will end up with a list of mixed-up nulls and redirects objects because somebody removed some before dao loaded it. 