### PR TITLE
Classificationstore Multiselct -> empty values

### DIFF
--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -238,6 +238,10 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
             $nonEmpty = true;
         }
 
+        if ($dataDefinition instanceof Model\DataObject\ClassDefinition\Data\Multiselect && is_array($value) && empty($value)) {
+            $nonEmpty = true;
+        }
+
         if ($nonEmpty || $value) {
             $this->items[$groupId][$keyId][$language] = $value;
         } elseif (isset($this->items[$groupId][$keyId][$language])) {


### PR DESCRIPTION
Problem: Empty values are not saved in the classificationstore when a Multiselect is used.

Reproduce:

select some values in the multiselect -> save -> data is saved correctly
unselect all values -> save object -> and reload the object in the admin interface
-> The old values appear because the empty selection was not saved.