### PR TITLE
fix asset frontend URL with and without frontend prefixes

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -191,7 +191,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $data['fileExtension'] = File::getFileExtension($asset->getFilename());
         $data['idPath'] = Element\Service::getIdPath($asset);
         $data['userPermissions'] = $asset->getUserPermissions();
-        $data['url'] = $request->getSchemeAndHttpHost() . $asset->getFrontendFullPath();
+        $data['url'] = $asset->getFrontendFullPath();
 
         $this->addAdminStyle($asset, ElementAdminStyleEvent::CONTEXT_EDITOR, $data);
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -873,6 +873,14 @@ class Asset extends Element\AbstractElement
         $path = urlencode_ignore_slash($path);
 
         $prefix = \Pimcore::getContainer()->getParameter('pimcore.config')['assets']['frontend_prefixes']['source'];
+        if (!$prefix) {
+            $prefix = sprintf(
+                '%s://%s',
+                \Pimcore::getContainer()->getParameter('router.request_context.scheme'),
+                \Pimcore::getContainer()->getParameter('router.request_context.host')
+            );
+        }
+
         $path = $prefix . $path;
 
         $event = new GenericEvent($this, [


### PR DESCRIPTION

## Changes in this pull request  
This change allows to use the `source` of `frontend_prefixes` and keeps the context scheme and host

## Additional info  
if we use a different asset file system and we want to change the URL prefix:
```
pimcore:
    assets:
        frontend_prefixes:
            source: 'https://storage.googleapis.com/%env(GCP_BUCKET_NAME)%'
```

Or if you change the `frontendPath` in the event `pimcore.frontend.path.asset`

The frontend URL will always be something like: `url: "http://localhosthttps://storage.googleapis.com/....`