### PR TITLE
fix asset frontend public URL with and without frontend prefixes

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -191,7 +191,9 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $data['fileExtension'] = File::getFileExtension($asset->getFilename());
         $data['idPath'] = Element\Service::getIdPath($asset);
         $data['userPermissions'] = $asset->getUserPermissions();
-        $data['url'] = $request->getSchemeAndHttpHost() . $asset->getFrontendFullPath();
+        $data['url'] = preg_match('/^http(s)?:\\/\\/.+/', $asset->getFrontendFullPath()) ?
+            $asset->getFrontendFullPath() :
+            $request->getSchemeAndHttpHost() . $asset->getFrontendFullPath();
 
         $this->addAdminStyle($asset, ElementAdminStyleEvent::CONTEXT_EDITOR, $data);
 

--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -191,9 +191,10 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $data['fileExtension'] = File::getFileExtension($asset->getFilename());
         $data['idPath'] = Element\Service::getIdPath($asset);
         $data['userPermissions'] = $asset->getUserPermissions();
-        $data['url'] = preg_match('/^http(s)?:\\/\\/.+/', $asset->getFrontendFullPath()) ?
-            $asset->getFrontendFullPath() :
-            $request->getSchemeAndHttpHost() . $asset->getFrontendFullPath();
+        $frontendPath = $asset->getFrontendFullPath();
+        $data['url'] = preg_match('/^http(s)?:\\/\\/.+/', $frontendPath) ?
+            $frontendPath :
+            $request->getSchemeAndHttpHost() . $frontendPath;
 
         $this->addAdminStyle($asset, ElementAdminStyleEvent::CONTEXT_EDITOR, $data);
 


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `10.x`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
This change allows to use the `source` of `frontend_prefixes` and keeps the context scheme and host

## Additional info  
if we use a different asset file system and we want to change the URL prefix:
```
pimcore:
    assets:
        frontend_prefixes:
            source: 'https://storage.googleapis.com/%env(GCP_BUCKET_NAME)%'
```

Or if you change the `frontendPath` in the event `pimcore.frontend.path.asset`

The frontend URL will always be something like: `url: "http://localhosthttps://storage.googleapis.com/....`
