### PR TITLE
[DataObjects] Fix Service::getOptionsForSelectField not working with optionsProviderClass

### DIFF
--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -849,7 +849,16 @@ class Service extends Model\Element\Service
             }
 
             if ($definition instanceof ClassDefinition\Data\Select || $definition instanceof ClassDefinition\Data\Multiselect) {
-                $_options = $definition->getOptions();
+                $optionsProvider = DataObject\ClassDefinition\Helper\OptionsProviderResolver::resolveProvider(
+                    $definition->getOptionsProviderClass(),
+                    DataObject\ClassDefinition\Helper\OptionsProviderResolver::MODE_MULTISELECT
+                );
+
+                if ($optionsProvider instanceof DataObject\ClassDefinition\DynamicOptionsProvider\MultiSelectOptionsProviderInterface) {
+                    $_options = $optionsProvider->getOptions(['fieldname' => $definition->getName()], $definition);
+                } else {
+                    $_options = $definition->getOptions();
+                }
 
                 foreach ($_options as $option) {
                     $options[$option['value']] = $option['key'];


### PR DESCRIPTION
## Changes in this pull request  
Resolves #9340


## Additional info  
- not sure how this worked on ver. 6.8
