### PR TITLE
Fix trackCheckoutComplete event name in GTM

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Tracking/Tracker/GoogleTagManager.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/Tracker/GoogleTagManager.php
@@ -192,7 +192,7 @@ class GoogleTagManager extends Tracker implements
         $items = $this->trackingItemBuilder->buildCheckoutItems($order);
 
         $call = [
-            'event' => 'checkout',
+            'event' => 'purchase',
             'ecommerce' => [
                 'currencyCode' => $order->getCurrency(),
                 'purchase' => [

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -3,6 +3,7 @@
 ## 10.1.0
 - [InstallBundle] Installer preconfiguration path changed from `app\config/installer.yml` to `config/installer.yaml`
 - [Core] composer.json: `symfony/symfony` package requirement has been replaced by `symfony/*` individual bundles. **Note for Bundles**: if you are using `symfony/symfony` dependency, it will now conflict with package `pimcore/pimcore`. Please move your bundle requirements to Symfony individual component packages.
+- [[Ecommerce][TrackingManager] event name in method `trackCheckoutComplete()` changed from `checkout` to `purchase` for `GoogleTagManager` implementation](https://github.com/pimcore/pimcore/pull/9366/files)
 
 ## 10.0.0
 


### PR DESCRIPTION
Change event name in method `trackCheckoutComplete()` from `checkout` to `purchase` for `GoogleTagManager` Implementation.

