### PR TITLE
Fixed typo in web2print settings translation

### DIFF
--- a/bundles/CoreBundle/Resources/translations/nl.extended.json
+++ b/bundles/CoreBundle/Resources/translations/nl.extended.json
@@ -421,7 +421,7 @@
     "web2print_wkhtmltopdf_settings": "Wkhtmltopdf instellingen",
     "web2print_wkhtmltopdf_options": "Opties",
     "web2print_hostname": "Hostnaam",
-    "web2print_settings": "Web2print instelligen",
+    "web2print_settings": "Web2print instellingen",
     "php_info": "PHP info",
     "system_requirements_check": "Systeemvereisten check",
     "server_info": "Server informatie",


### PR DESCRIPTION
## Changes in this pull request  
Fixed a typo in the Dutch translation of "Web2print settings"

