### PR TITLE
[Data objects] Throw ValidationException in case same item got assigned multiple times to a relational field

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
@@ -450,7 +450,7 @@ abstract class AbstractRelations extends Data implements
                     }
 
                     if ($elementHash === null) {
-                        throw new \Exception('Passing relations without ID or type not allowed anymore!');
+                        throw new Element\ValidationException('Passing relations without ID or type not allowed anymore!');
                     } elseif (!isset($relationItems[$elementHash])) {
                         $relationItems[$elementHash] = $item;
                     } else {

--- a/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
@@ -430,7 +430,7 @@ abstract class AbstractRelations extends Data implements
      *
      * @param array|null $data*
      *
-     * @throws \Exception
+     * @throws Element\ValidationException
      */
     public function performMultipleAssignmentCheck($data)
     {

--- a/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
@@ -461,7 +461,7 @@ abstract class AbstractRelations extends Data implements
                             $message .= ", Reason: 'Allow Multiple Assignments' setting is disabled in class definition. ";
                         }
 
-                        throw new \Exception($message);
+                        throw new Element\ValidationException($message);
                     }
                 }
             }

--- a/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
@@ -428,7 +428,7 @@ abstract class AbstractRelations extends Data implements
      *
      * @internal
      *
-     * @param array|null $data*
+     * @param array|null $data
      *
      * @throws Element\ValidationException
      */


### PR DESCRIPTION
The `checkValidity` methods for Many to many (object) relations and blocks usually throw `ValidationException`s - with one exception: When the same item gets assigned multiple times although the relational field does not allow this just `Exception` gets thrown. This PR changes this to always throw `ValidationException`.

An an example: https://github.com/pimcore/pimcore/blob/18a268ae3993daea952e8b1ac94155cdc0b38814/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php#L358-L388