### PR TITLE
Fix failling versioncleanup maintenance job

### DIFF
--- a/lib/Maintenance/Tasks/VersionsCleanupTask.php
+++ b/lib/Maintenance/Tasks/VersionsCleanupTask.php
@@ -86,6 +86,10 @@ class VersionsCleanupTask implements TaskInterface
 
         foreach ($conf as $elementType => $tConf) {
             $versioningType = 'steps';
+            //skip cleanup if element is null
+            if(is_null($tConf)){
+                continue;
+            }
             //skip cleanup if both, 'steps' & 'days', is null
             if (is_null($tConf['steps']) && is_null($tConf['days'])) {
                 continue;


### PR DESCRIPTION
Excuse me, I messed up the branches so this now replaces #9384.

## Changes in this pull request  
This PR just adds 3 lines of code with an early check if the element is null and skips the cleanup in this case (as it is already done if the assets contain only `null`).
```php
 if (is_null($tConf) ) {
    continue;
}
```

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [] Features need to be proper documented in `doc/` -> target branch `10.x`
- [x] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [x] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  
## Bug description

Running `bin/console pimcore/maintenance` or `bin/console pimcore:maintenance -f -j versioncleanup` after creating a fresh pimcore setup from [pimcore/skeleton](https://github.com/pimcore/skeleton) results in:  `ERROR Failed to execute job with ID versioncleanup: ErrorException [...]`
<details>
<summary>
Full error
</summary>
```
ERROR     [app] Failed to execute job with ID versioncleanup: ErrorException {#message: "Warning: Trying to access array offset on value of type null"#code: 0#file: "./vendor/pimcore/pimcore/lib/Maintenance/Tasks/VersionsCleanupTask.php"#line: 90#severity: E_WARNINGtrace: {./vendor/pimcore/pimcore/lib/Maintenance/Tasks/VersionsCleanupTask.php:90 { …}./vendor/pimcore/pimcore/lib/Maintenance/Tasks/VersionsCleanupTask.php:57 { …}./vendor/pimcore/pimcore/lib/Maintenance/Executor.php:97 { …}./vendor/pimcore/pimcore/bundles/CoreBundle/Command/MaintenanceCommand.php:97 { …}./vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:288 { …}./vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:992 { …}./vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:96 { …}./vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:291 { …}./vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:82 { …}./vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:167 { …}./bin/console:46 {› $application = new \Pimcore\Console\Application($kernel);› $application->run();› } …}} ["id" => "versioncleanup","exception" => ErrorException { …}]
```
</details>


### Steps to reproduce
- Setup a new pimcore installation from skeleton
- run pimcore installation
- Do not create any objects, assets or documents
- Try to run `bin/console pimcore/maintenance`

