### PR TITLE
[Core] Override Symfony Authentication Provider service to use security encoder_factory

### DIFF
--- a/bundles/CoreBundle/Resources/config/services.yml
+++ b/bundles/CoreBundle/Resources/config/services.yml
@@ -38,6 +38,15 @@ services:
         arguments: ['@pimcore.security.encoder_factory.inner', '@?']
         public: false
 
+    security.authentication.provider.dao:
+        class: Symfony\Component\Security\Core\Authentication\Provider\DaoAuthenticationProvider
+        arguments:
+            - !abstract User Provider
+            - !abstract User Checker
+            - !abstract  Provider-shared Key
+            - '@security.encoder_factory'
+            - '%security.authentication.hide_user_not_found%'
+        deprecated: 'The "%service_id%" service is deprecated, use the new authenticator system instead.'
     #
     # INFRASTRUCTURE
     #


### PR DESCRIPTION
## Changes in this pull request  
Resolves #9394

## Additional info  
- Starting with Symfony 5.3, Security encoder factory service has been deprecated in favor of new password hasher service. and `security.authentication.provider.dao` service has been deprecated and updated(at the same time) to use new password hasher service. so we override it to use the old encoder factory.