### PR TITLE
Correct AbstractCart::isValidCartItem Warning Message

### DIFF
--- a/bundles/EcommerceFrameworkBundle/CartManager/AbstractCart.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/AbstractCart.php
@@ -952,7 +952,7 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
     protected static function isValidCartItem(CartItemInterface $item)
     {
         $product = $item->getProduct();
-        if (!$product instanceof MockProduct) {
+        if ($product instanceof CheckoutableInterface && !$product instanceof MockProduct) {
             return true;
         }
 

--- a/bundles/EcommerceFrameworkBundle/CartManager/AbstractCart.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/AbstractCart.php
@@ -952,11 +952,11 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
     protected static function isValidCartItem(CartItemInterface $item)
     {
         $product = $item->getProduct();
-        if ($product instanceof CheckoutableInterface && !$product instanceof MockProduct) {
+        if (!$product instanceof MockProduct) {
             return true;
         }
 
-        Logger::warn('product ' . $item->getProduct()->getId() . ' not found');
+        Logger::warn('Product ' . $item->getProduct()->getId() . ' not found');
 
         return false;
     }

--- a/bundles/EcommerceFrameworkBundle/CartManager/AbstractCartItem.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/AbstractCartItem.php
@@ -118,6 +118,7 @@ abstract class AbstractCartItem extends \Pimcore\Model\AbstractModel implements 
         } else {
             // actual product is not available or not checkoutable (e.g. deleted in Admin)
             $product = new MockProduct();
+            $product->setId($this->productId);
             $this->product = $product;
         }
 


### PR DESCRIPTION
MockProduct should have the ID from the missing Object