### PR TITLE
[ApplicationLogger] Fix default value for log archive threshold

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -389,7 +389,7 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                         ->scalarNode('archive_treshold')
                             ->info('Archive threshold in days')
-                            ->defaultValue('')
+                            ->defaultValue(30)
                         ->end()
                         ->scalarNode('archive_alternative_database')
                             ->info('Archive database name (optional). Tables will get archived to a different database, recommended when huge amounts of logs will be generated')


### PR DESCRIPTION
# Bug Report

Application Logger entries are immediately rotated to archive table when maintenance job is installed.

As `lib/Maintenance/Tasks/LogArchiveTask.php` with `$archive_threshold = (int) ($this->config['applicationlog']['archive_treshold'] ?? 30);` tests for a null value, a default of `''` (empty string) leads to immediate (0 days) log rotation in case no override in `config/config.yaml` has been set (Pimcore skeleton doesn't define one).

### Expected behavior

Proper default or no rotation at all.

### Actual behavior

Instant rotation.

### Steps to reproduce

* Use skeleton without overrriding config `archive_treshold`
* Log to Application Logger
* Execute maintenance tasks
* Entry is moved to archive 

### Alternate fixes

- `defaultNull()`
- Change null coalescing in task