### PR TITLE
Redirect CSV export needs same handling as RedirectHandler

### DIFF
--- a/lib/Routing/Redirect/Csv.php
+++ b/lib/Routing/Redirect/Csv.php
@@ -23,6 +23,7 @@ use League\Csv\Statement;
 use League\Csv\Writer;
 use Pimcore\Model\Document;
 use Pimcore\Model\Redirect;
+use Pimcore\Model\Site;
 use Pimcore\Tool\Admin;
 use Pimcore\Tool\ArrayNormalizer;
 use Pimcore\Tool\Text;

--- a/lib/Routing/Redirect/Csv.php
+++ b/lib/Routing/Redirect/Csv.php
@@ -77,7 +77,12 @@ class Csv
                 $document = Document::getById((int)$redirect->getTarget());
 
                 if ($document) {
-                    $target = $document->getRealFullPath();
+                    $targetSiteId = $redirect->getTargetSite();
+                    $targetSite = Site::getById($targetSiteId);
+                    $rootDocument = $targetSite->getRootDocument();
+                    $rootDocumentPath = $rootDocument->getFullPath();
+                    $target = $document->getFullPath();
+                    $target = preg_replace('@^' . $rootDocumentPath . '/@', '/', $target);
                 }
             }
 

--- a/lib/Routing/Redirect/Csv.php
+++ b/lib/Routing/Redirect/Csv.php
@@ -78,12 +78,16 @@ class Csv
                 $document = Document::getById((int)$redirect->getTarget());
 
                 if ($document) {
+                    $target = $document->getRealFullPath();
                     $targetSiteId = $redirect->getTargetSite();
-                    $targetSite = Site::getById($targetSiteId);
-                    $rootDocument = $targetSite->getRootDocument();
-                    $rootDocumentPath = $rootDocument->getFullPath();
-                    $target = $document->getFullPath();
-                    $target = preg_replace('@^' . $rootDocumentPath . '/@', '/', $target);
+                    if ($targetSite = Site::getById($targetSiteId)) {
+                        // if the target site is specified and and the target-path is starting at root (not absolute to site)
+                        // the root-path will be replaced
+                        $rootDocument = $targetSite->getRootDocument();
+                        $rootDocumentPath = $rootDocument->getFullPath();
+                        $target = $document->getFullPath();
+                        $target = preg_replace('@^' . $rootDocumentPath . '/@', '/', $target);
+                    }
                 }
             }
 


### PR DESCRIPTION
Because the CSV-export is not a site request the function Document->getFullPath will return the target with the root document path.
I essentially copied what the RedirectHandler does.
(The same problem exists for RedirectController that shows the wrong target for auto-created redirects)

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `10.x`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

