### PR TITLE
Fix `Pimcore 6 CE` EOL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For details, please have a look at our [contributing guide](CONTRIBUTING.md).
 | -------- |    :---:  | :---: |    :---:      |   :---:          |
 | `<= 4.x` |    ❌     |  ❌    |               | `2017-09-28`     |
 | `5.x`    |    ❌     |  ✅    | `5.8`         | `2019-12-09`     |
-| `6.x`    |    ✅     |  ✅    | `6.9`         | `2021-06-14`     |
+| `6.x`    |    ✅     |  ✅    | `6.9`         | `2021-06-23`     |
 | `10.x`   |    ✅     |  ❌    |               |                  |
 
 ** [Long-term support](https://pimcore.com/en/services/lts) is only available as part of our [enterprise subscription](https://pimcore.com/en/platform/subscription).   


### PR DESCRIPTION
According to the milestone for [Pimcore 6.9.6](https://github.com/pimcore/pimcore/milestone/130) the EOL for Pimcore 6.x is 23.06.21.