### PR TITLE
Bugfix: getCurrentIndex returns invalid index

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "abytemore/pimcore",
+  "name": "pimcore/pimcore",
   "type": "library",
   "description": "Content & Product Management Framework (CMS/PIM/E-Commerce)",
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "pimcore/pimcore",
+  "name": "abytemore/pimcore",
   "type": "library",
   "description": "Content & Product Management Framework (CMS/PIM/E-Commerce)",
   "keywords": [

--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -669,7 +669,7 @@ class Areablock extends Model\Document\Editable implements BlockInterface
      */
     public function getCurrentIndex()
     {
-        return $this->indices[$this->getCurrent()]['key'] ?? null;
+        return $this->indices[$this->current]['key'] ?? null;
     }
 
     /**


### PR DESCRIPTION
Calling `{% set brickKey = brick.getEditable().getCurrentIndex() %}` in view returns incorrect key. This PR fixed this issue for me.

