### PR TITLE
[Assets] Fix updating default metadata - Integrity constraint violation

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/metadata/grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/metadata/grid.js
@@ -66,19 +66,19 @@ pimcore.asset.metadata.grid = Class.create({
             if (this.dataProvider.getItemCount() < 1) {
                 // default fields
                 if (this.asset.data.type == "image") {
-                    this.dataProvider.getData().push({
+                    this.dataProvider.update({
                         name: "title",
                         type: "input",
                         language: "",
                         data: ""
                     });
-                    this.dataProvider.getData().push({
+                    this.dataProvider.update({
                         name: "alt",
                         type: "input",
                         language: "",
                         data: ""
                     });
-                    this.dataProvider.getData().push({
+                    this.dataProvider.update({
                         name: "copyright",
                         type: "input",
                         language: "",


### PR DESCRIPTION
## Changes in this pull request  
Steps:
- Upload new Asset.
- Update "title" metadata.
- Click Save & Publish.
![image](https://user-images.githubusercontent.com/5137917/121894267-3dd54780-cd1f-11eb-89ab-813a6ce75fdb.png)


## Additional info  
Regression of #6835