### PR TITLE
Enrich Layout for CS Attributes in Grid

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -875,6 +875,7 @@ class ClassificationstoreController extends AdminController implements EventedCo
             $type = $config->getType();
             $definition = json_decode($config->getDefinition());
             $definition = \Pimcore\Model\DataObject\Classificationstore\Service::getFieldDefinitionFromJson($definition, $type);
+            DataObject\Service::enrichLayoutDefinition($definition);
 
             $item = [
                 'keyId' => $config->getKeyId(),


### PR DESCRIPTION
## Changes in this pull request  
Without enriching the layout definition, batch editing does not work for selects / multiselect with static options. By enriching the layout before sending it to the grid proxy the options are correctly provided and batch editing also works for select / multiselect.

