### PR TITLE
[Documents] Blocks - fix data loss when using similar names for block and editables

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/block.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/block.js
@@ -252,7 +252,7 @@ pimcore.document.editables.block = Class.create(pimcore.document.editable, {
                     let editable = Ext.clone(editableDef);
                     editable['id'] = editable['id'].replace(new RegExp('pimcore_editable_([^"]+)_1000000_' + this.getRealName() + '_'), 'pimcore_editable_' + this.getName().replaceAll(/(:|\.)/g, '_') + '_');
                     editable['id'] = editable['id'].replaceAll('_1000000_', '_' + nextKey + '_');
-                    editable['name'] = editable['name'].replace(new RegExp('^([^"]+):1000000.' + this.getRealName()), this.getName());
+                    editable['name'] = editable['name'].replace(new RegExp('^([^"]+):1000000.' + this.getRealName() + ':'), this.getName() + ':');
                     editable['name'] = editable['name'].replaceAll(':1000000.', ':' + nextKey + '.');
                     editableManager.addByDefinition(editable);
                 });


### PR DESCRIPTION
## Changes in this pull request  
Resolves #9421


## Additional info  
when using similar names for block and editables. editable names are saved without block index in db (block index is replaced in regex here https://github.com/pimcore/pimcore/blob/10.x/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/block.js#L255)
![image](https://user-images.githubusercontent.com/5137917/122540174-a9bdf580-d028-11eb-8142-e307733f395e.png)

After change:
![image](https://user-images.githubusercontent.com/5137917/122540538-09b49c00-d029-11eb-8a90-c4400ac6a8f4.png)
