### PR TITLE
[Admin] Fix IndexActionSettingsEvent addSetting not showing up in pimcore.settings

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/IndexController.php
+++ b/bundles/AdminBundle/Controller/Admin/IndexController.php
@@ -107,9 +107,9 @@ class IndexController extends AdminController implements KernelResponseEventInte
         }
 
         // allow to alter settings via an event
-        $settingsEvent = new IndexActionSettingsEvent($templateParams);
+        $settingsEvent = new IndexActionSettingsEvent($templateParams['settings'] ?? []);
         $this->eventDispatcher->dispatch($settingsEvent, AdminEvents::INDEX_ACTION_SETTINGS);
-        $templateParams = $settingsEvent->getSettings();
+        $templateParams['settings'] = $settingsEvent->getSettings();
 
         return $this->render('@PimcoreAdmin/Admin/Index/index.html.twig', $templateParams);
     }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #9396
## Additional info  

