### PR TITLE
[Geographical Point] Correct order of latitude and longitude in version preview

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Geopoint.php
+++ b/models/DataObject/ClassDefinition/Data/Geopoint.php
@@ -190,7 +190,7 @@ class Geopoint extends AbstractGeo implements
     public function getVersionPreview($data, $object = null, $params = [])
     {
         if ($data instanceof DataObject\Data\GeoCoordinates) {
-            return $data->getLongitude() . ',' . $data->getLatitude();
+            return $data->getLatitude().','.$data->getLongitude();
         }
 
         return '';


### PR DESCRIPTION
Currently it is displayed as longitude, latitude. The usual order is latitude, longitude - as for example used in CSV exports:
https://github.com/pimcore/pimcore/blob/d1b4d14b599950f892a6fbdcfdccc215081eb4d6/models/DataObject/ClassDefinition/Data/Geopoint.php#L206