### PR TITLE
Fix default value for document editable select

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/select.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/select.js
@@ -29,7 +29,9 @@ pimcore.document.editables.select = Class.create(pimcore.document.editable, {
         config.name = id + "_editable";
         config.triggerAction = 'all';
         config.editable = false;
-        config.value = data;
+        if (data || ! "value" in config) {
+            config.value = data;
+        }
 
         this.config = config;
     },


### PR DESCRIPTION
With this fix it is possible to define a default / initial value for a select editable in documents.
