### PR TITLE
Add to conflicts "laminas/laminas-code": ">=4.4" to solve Symfony 3.4 class compatibility issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,8 @@
     "phpstan/phpstan": "0.12.55",
     "symfony/symfony": "3.4.43 || 4.4.11",
     "webmozarts/console-parallelization": "1.2.2",
-    "symfony/monolog-bundle": "3.6.0"
+    "symfony/monolog-bundle": "3.6.0",
+    "laminas/laminas-code": "<4.4"
   },
   "require-dev": {
     "cache/integration-tests": "^0.16.0",


### PR DESCRIPTION
## Changes in this pull request  
tests are failing for Symfony 3.4 with error:
```
Fatal error: Could not check compatibility between Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\LazyLoadingValueHolderGenerator::generate(ReflectionClass $originalClass, Zend\Code\Generator\ClassGenerator $classGenerator) and ProxyManager\ProxyGenerator\LazyLoadingValueHolderGenerator::generate(ReflectionClass $originalClass, Laminas\Code\Generator\ClassGenerator $classGenerator), because class Zend\Code\Generator\ClassGenerator is not available in /home/runner/work/pimcore/pimcore/vendor/symfony/symfony/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/LazyLoadingValueHolderGenerator.php on line 25
Script Pimcore\Composer::clearCache handling the pimcore-scripts event terminated with an exception
```
## Additional info  

