### PR TITLE
Relational fields within non-lazy field collections were unpopulated

### DIFF
--- a/models/DataObject/Fieldcollection/Dao.php
+++ b/models/DataObject/Fieldcollection/Dao.php
@@ -90,10 +90,8 @@ class Dao extends Model\Dao\AbstractDao
 
                     if ($fd instanceof CustomResourcePersistingInterface) {
                         $doLoad = true;
-                        if ($fd instanceof LazyLoadingSupportInterface) {
-                            if ($fd->getLazyLoading()) {
-                                $doLoad = false;
-                            }
+                        if ($fd instanceof LazyLoadingSupportInterface && $fd->getLazyLoading() && $fieldDef->getLazyLoading()) {
+                            $doLoad = false;
                         }
 
                         if ($doLoad) {

--- a/models/DataObject/Fieldcollection/Data/AbstractData.php
+++ b/models/DataObject/Fieldcollection/Data/AbstractData.php
@@ -167,6 +167,11 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
      */
     protected function getLazyLoadedFieldNames(): array
     {
+        $fieldCollectionDefinition = $this->getObject()->getClass()->getFieldDefinition($this->getFieldname());
+        if($fieldCollectionDefinition instanceof LazyLoadingSupportInterface && !$fieldCollectionDefinition->getLazyLoading()) {
+            return [];
+        }
+
         $lazyLoadedFieldNames = [];
         $fields = $this->getDefinition()->getFieldDefinitions(['suppressEnrichment' => true]);
         foreach ($fields as $field) {


### PR DESCRIPTION
Currently there is a problem when you have a non-lazy field collection which contains a relational field - in our case it was an advanced many-to-many object relation.
When loading the object from cache the relation is `null` and also with the getter method you cannot get its value. Here is the call stack:
The cache gets populated when the object gets loaded in
https://github.com/pimcore/pimcore/blob/e64b91426a24b60e70e6b2b56a3a065b9dc4ba80/models/DataObject/AbstractObject.php#L335-L354

From line 344 we jump to
https://github.com/pimcore/pimcore/blob/e64b91426a24b60e70e6b2b56a3a065b9dc4ba80/models/DataObject/Concrete/Dao.php#L61

As FieldCollections implement `CustomResourcePersistingInterface` and `getLazyLoading()` is set to `false` for the field collection we land on line 166 in
https://github.com/pimcore/pimcore/blob/e64b91426a24b60e70e6b2b56a3a065b9dc4ba80/models/DataObject/Concrete/Dao.php#L156-L171

From there we go to 
https://github.com/pimcore/pimcore/blob/e64b91426a24b60e70e6b2b56a3a065b9dc4ba80/models/DataObject/ClassDefinition/Data/Fieldcollections.php#L322

and end in
https://github.com/pimcore/pimcore/blob/e64b91426a24b60e70e6b2b56a3a065b9dc4ba80/models/DataObject/Fieldcollection/Dao.php#L78-L129

Here all fields of the field collection are loaded but as all relational fields are lazy loaded
https://github.com/pimcore/pimcore/blob/e64b91426a24b60e70e6b2b56a3a065b9dc4ba80/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php#L78-L81

the data for the relational fields inside the non-lazy field collection does not get loaded yet, see
https://github.com/pimcore/pimcore/blob/e64b91426a24b60e70e6b2b56a3a065b9dc4ba80/models/DataObject/Fieldcollection/Dao.php#L92-L97

We then access the relational field's getter method inside the field collection which looks like this:
```php
public function getMaterials () {
        $container = $this;
        $fd = $this->getDefinition()->getFieldDefinition("materials");
        $data = $fd->preGetData($container);
        if ($data instanceof \Pimcore\Model\DataObject\Data\EncryptedField) {
                    return $data->getPlain();
        }
         return $data;
}
```

The data is fetched in `$data = $fd->preGetData($container);`, see
https://github.com/pimcore/pimcore/blob/e64b91426a24b60e70e6b2b56a3a065b9dc4ba80/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php#L577-L601

And there the problem arises: As `$this->getLazyLoading()` returns `false` because we disabled lazy-loading for the field collection, the data to be returned from the getter method comes directly from the loaded object property. And at this point this only contains non-lazy fields.

This PR addresses this problem by only lazy-loading relational fields within field collections if also the field collection gets non-lazy loaded. And on the other hand it includes non-lazy-loaded fields in the data cache entry when the field collection itself is not lazy-loaded.
