### PR TITLE
Fix issue with missing indexName in ecommerce indexer configuration.

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
@@ -194,7 +194,7 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
     /** @inheritDoc */
     public function getFieldNameMapped($fieldName, $considerSubFieldNames = false)
     {
-        if ($this->fieldMapping[$fieldName]) {
+        if (isset($this->fieldMapping[$fieldName])) {
             return $this->fieldMapping[$fieldName];
         }
 
@@ -202,7 +202,7 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
         if ($considerSubFieldNames) {
             $fieldNameParts = $this->extractPossibleFirstSubFieldnameParts($fieldName);
             foreach ($fieldNameParts as $fieldNamePart) {
-                if ($this->fieldMapping[$fieldNamePart]) {
+                if (isset($this->fieldMapping[$fieldNamePart])) {
                     return $this->fieldMapping[$fieldNamePart] . str_replace($fieldNamePart, '', $fieldName);
                 }
             }

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
@@ -247,10 +247,10 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
      */
     public function getClientConfig($property = null)
     {
-        return $property
-            ? $this->clientConfig[$property]
-            : $this->clientConfig
-            ;
+        if ($property) {
+            return $this->clientConfig[$property] ?? null;
+        }
+        return $this->clientConfig;
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Config/ElasticSearch.php
@@ -250,6 +250,7 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
         if ($property) {
             return $this->clientConfig[$property] ?? null;
         }
+
         return $this->clientConfig;
     }
 


### PR DESCRIPTION
## Changes in this pull request  
Fix issue with missing indexName in ecommerce indexer configuration. If indexName ist not set, then the tenant name will be used. But currently a missing arrey index exception is thrown.

