### PR TITLE
update detailAction (timeline)

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Controller/AdminOrderController.php
+++ b/bundles/EcommerceFrameworkBundle/Controller/AdminOrderController.php
@@ -348,13 +348,13 @@ class AdminOrderController extends AdminController implements KernelControllerEv
 
             // add
             $arrTimeline[$group][] = [
-                'icon' => $arrIcons[$note->getTitle()],
-                'context' => $arrContext[$note->getTitle()] ?: 'default',
+                'icon' => $arrIcons[$note->getTitle()] ?? '',
+                'context' => $arrContext[$note->getTitle()] ?? 'default',
                 'type' => $note->getTitle(),
                 'date' => $formatter->formatDateTime($date->setTimestamp($note->getDate()), IntlFormatter::DATETIME_MEDIUM),
                 'avatar' => $avatar,
                 'user' => $user ? $user->getName() : null,
-                'message' => $note->getData()['message']['data'],
+                'message' => $note->getData()['message']['data'] ?? '',
                 'title' => $title ?: $note->getTitle(),
                 'quantity' => $quantity,
             ];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,11 +36,6 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/CartManager/CartPriceModificator/Shipping.php
 
 		-
-			message: "#^Ternary operator condition is always true\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/Controller/AdminOrderController.php
-
-		-
 			message: "#^Instanceof between Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\CoreExtensions\\\\ClassDefinition\\\\IndexFieldSelection\\|null and Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\CoreExtensions\\\\ObjectData\\\\IndexFieldSelection will always evaluate to false\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelection.php


### PR DESCRIPTION
Changed three lines to use the null coalescing operator (??) - the ternary operator (?) throws an error if the key is not found (ie., when the title is different that the options provided). Could use isset() instead.

To reproduce error, add a note with a title other than those defined in $arrIcons and $arrContext

<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `10.x`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  
