### PR TITLE
[Thumbnails] Low-quality placeholder are not shown anymore

### DIFF
--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -243,7 +243,7 @@ final class Thumbnail
 
         if (isset($options['previewDataUri'])) {
             $sourceTagAttributes['data-srcset'] = $sourceTagAttributes['srcset'];
-            $sourceTagAttributes['srcset'] = 'data:,1w';
+            unset($sourceTagAttributes['srcset']);
         }
 
         $sourceTagAttributes['type'] = $thumb->getMimeType();


### PR DESCRIPTION
Reverts #8818
The problem with this fix is that the preview image in <src> is not displayed anymore with this fix
