### PR TITLE
Fixed missing adapter config in pdfreactor

### DIFF
--- a/lib/Web2Print/Processor/PdfReactor.php
+++ b/lib/Web2Print/Processor/PdfReactor.php
@@ -94,7 +94,7 @@ class PdfReactor extends Processor
     {
         $pdfreactor = $this->getClient();
 
-        $customConfig = (array)$params['adapterConfig'];
+        $customConfig = (array)($params['adapterConfig'] ?? []);
         $reactorConfig = $this->getConfig((object)$customConfig);
 
         if (!array_keys($customConfig, 'addLinks')) {


### PR DESCRIPTION
fixing missing key `adapterConfig` error