### PR TITLE
Increase colour contrast on locked elements in tree

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/admin.css
+++ b/bundles/AdminBundle/Resources/public/css/admin.css
@@ -262,7 +262,7 @@
 
 
 .pimcore_treenode_lockOwner .x-tree-node-text  {
-    color: #0091f8 !important;
+    color: #1d60c4 !important;
 }
 
 .pimcore_treenode_hide_plus_button .x-tree-expander {

--- a/bundles/AdminBundle/Resources/public/css/admin.css
+++ b/bundles/AdminBundle/Resources/public/css/admin.css
@@ -257,7 +257,7 @@
 }
 
 .pimcore_treenode_locked .x-tree-node-text {
-    color: #3b72c0 !important;
+    color: #3b5c8a !important;
 }
 
 


### PR DESCRIPTION
## Changes in this pull request  

I have alwayt thought the contrast was a bit low. Is this ok?

Lock colour changes (updated on top):
![image](https://user-images.githubusercontent.com/279826/123923841-a9f3b480-d989-11eb-926c-f81506f6582f.png)

Inherited Lock colour changes (updated on top):
![image](https://user-images.githubusercontent.com/279826/123929505-2937b700-d98f-11eb-81d5-efc563cf3a76.png)
