### PR TITLE
Allow Concrete::__callStatic() to retrieve variants in getters

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20210702102100.php
+++ b/bundles/CoreBundle/Migrations/Version20210702102100.php
@@ -46,7 +46,7 @@ final class Version20210702102100 extends AbstractMigration
     /**
      * @throws \Exception
      */
-    private function rebuildClassesCommand()
+    private function regenerateClasses()
     {
         $listing = new Listing();
         foreach ($listing->getClasses() as $class) {

--- a/bundles/CoreBundle/Migrations/Version20210702102100.php
+++ b/bundles/CoreBundle/Migrations/Version20210702102100.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Tool\Console;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+final class Version20210608094532 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Updates class definition files';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->rebuildClassesCommand();
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->rebuildClassesCommand();
+    }
+
+    /**
+     * @throws \Exception|ProcessFailedException
+     */
+    private function rebuildClassesCommand()
+    {
+        $cmd = [
+            Console::getPhpCli(),
+            'bin/console',
+            'pimcore:deployment:classes-rebuild',
+            '--create-classes',
+        ];
+
+        $process = new Process($cmd);
+        $process->setWorkingDirectory(PIMCORE_PROJECT_ROOT);
+        $process->mustRun();
+
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+
+        if ($process->getOutput())  {
+            $this->write($process->getOutput());
+        }
+    }
+}

--- a/bundles/CoreBundle/Migrations/Version20210702102100.php
+++ b/bundles/CoreBundle/Migrations/Version20210702102100.php
@@ -35,7 +35,7 @@ final class Version20210702102100 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->rebuildClassesCommand();
+        $this->regenerateClasses();
     }
 
     public function down(Schema $schema): void

--- a/bundles/CoreBundle/Migrations/Version20210702102100.php
+++ b/bundles/CoreBundle/Migrations/Version20210702102100.php
@@ -23,7 +23,7 @@ use Pimcore\Model\DataObject\ClassDefinition\Listing;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
-final class Version20210608094532 extends AbstractMigration
+final class Version20210702102100 extends AbstractMigration
 {
     /**
      * {@inheritDoc}

--- a/bundles/CoreBundle/Migrations/Version20210702102100.php
+++ b/bundles/CoreBundle/Migrations/Version20210702102100.php
@@ -19,12 +19,15 @@ namespace Pimcore\Bundle\CoreBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
-use Pimcore\Tool\Console;
+use Pimcore\Model\DataObject\ClassDefinition\Listing;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
 final class Version20210608094532 extends AbstractMigration
 {
+    /**
+     * {@inheritDoc}
+     */
     public function getDescription(): string
     {
         return 'Updates class definition files';
@@ -41,27 +44,14 @@ final class Version20210608094532 extends AbstractMigration
     }
 
     /**
-     * @throws \Exception|ProcessFailedException
+     * @throws \Exception
      */
     private function rebuildClassesCommand()
     {
-        $cmd = [
-            Console::getPhpCli(),
-            'bin/console',
-            'pimcore:deployment:classes-rebuild',
-            '--create-classes',
-        ];
-
-        $process = new Process($cmd);
-        $process->setWorkingDirectory(PIMCORE_PROJECT_ROOT);
-        $process->mustRun();
-
-        if (!$process->isSuccessful()) {
-            throw new ProcessFailedException($process);
-        }
-
-        if ($process->getOutput())  {
-            $this->write($process->getOutput());
+        $listing = new Listing();
+        foreach ($listing->getClasses() as $class) {
+            $this->write(sprintf('Saving php files for class: %s', $class->getName()));
+            $class->generateClassFiles(false);
         }
     }
 }

--- a/bundles/CoreBundle/Migrations/Version20210702102100.php
+++ b/bundles/CoreBundle/Migrations/Version20210702102100.php
@@ -40,7 +40,7 @@ final class Version20210702102100 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->rebuildClassesCommand();
+        $this->regenerateClasses();
     }
 
     /**

--- a/doc/Development_Documentation/05_Objects/03_Working_with_PHP_API.md
+++ b/doc/Development_Documentation/05_Objects/03_Working_with_PHP_API.md
@@ -206,8 +206,17 @@ This is especially useful to get an object matching a foreign key, or get a list
 ```php
 $result = DataObject\ClassName::getByMyfieldname($value, ['limit' => $limit, 'offset' => $offset]);
 
+// or object variants matching a value
+$result = DataObject\ClassName::getByMyfieldname($value, ['limit' => $limit, 'offset' => $offset, 'objectTypes' => [DataObject::OBJECT_TYPE_VARIANT]]);
+
 // or for localized fields
 $result = DataObject\ClassName::getByMyfieldname($value, ['locale' => $locale, 'limit' => $limit, 'offset' => $offset]);
+
+// or object variants matching a value in localized fields
+$result = DataObject\ClassName::getByMyfieldname($value, ['locale' => $locale, 'limit' => $limit, 'offset' => $offset, 'objectTypes' => [DataObject::OBJECT_TYPE_VARIANT]]);
+
+// or object variants and objects matching a value in localized fields
+$result = DataObject\ClassName::getByMyfieldname($value, ['locale' => $locale, 'limit' => $limit, 'offset' => $offset, 'objectTypes' => [DataObject::OBJECT_TYPE_VARIANT, DataObject::OBJECT_TYPE_OBJECT]]);
 ```
 If you set no limit, a list object containing all matching objects are returned. If the limit is set to 1
 the first matching object is returned directly (without listing). Only published objects are return.

--- a/doc/Development_Documentation/05_Objects/03_Working_with_PHP_API.md
+++ b/doc/Development_Documentation/05_Objects/03_Working_with_PHP_API.md
@@ -1,8 +1,8 @@
 # Working with Objects via PHP API
 
-Pimcore provides an object orientated PHP API to work with Objects. There are several generic functionalities 
+Pimcore provides an object orientated PHP API to work with Objects. There are several generic functionalities
 provided by Pimcore and for each Pimcore object class Pimcore generates corresponding PHP classes for working
-with these objects via a comfortable PHP API and take full advantage of a IDE (e.g. code completion etc.). 
+with these objects via a comfortable PHP API and take full advantage of an IDE (e.g. code completion etc.).
 
 ## CRUD Operations
 The following code snippet indicates how to access, create and modify an object programmatically:
@@ -41,6 +41,8 @@ $object = DataObject::getById(235);
 // or obtain an object by path
 $object = DataObject::getByPath("/path/to/the/object");
 
+// or get variants matching a value (default is to only fetch objects)
+$city = DataObject\Product::getByColor('purple', 1, 0, [Product::OBJECT_TYPE_VARIANT]);
 
 //updating and saving objects
 $myObject->setName("My Name");
@@ -58,19 +60,19 @@ $city->delete();
 <a name="objectsListing">&nbsp;</a>
 
 ## Object Listings
-Once data is available in a structured manner, it can not only be accessed more conveniently but also be filtered, 
-sorted, grouped and displayed intuitively by the use of an object listing. Moreover, data can be exported very easily 
+Once data is available in a structured manner, it can not only be accessed more conveniently but also be filtered,
+sorted, grouped and displayed intuitively by the use of an object listing. Moreover, data can be exported very easily
 not only programmatically but also through the Pimcore object csv export.
 
-Object listings are a simple way to retrieve objects from Pimcore while being able to filter and sort data along that 
+Object listings are a simple way to retrieve objects from Pimcore while being able to filter and sort data along that
 process. Object listings also come with a built-in paginator that simplifies the display of results in a paged manner.
 
-When working with object listings, user defined routes come in handy while implementing a object detail views. 
-User defined routes allow directing requests to certain detail pages, even though the request does not portray the path 
-of a document, but matches a certain route. For more information have a look at 
+When working with object listings, user defined routes come in handy while implementing object detail views.
+User defined routes allow directing requests to certain detail pages, even though the request does not portray the path
+of a document, but matches a certain route. For more information have a look at
 [URLs based on Custom Routes](../02_MVC/04_Routing_and_URLs/02_Custom_Routes.md).
 
-An object listing class is created automatically for each class defined in Pimcore. Objects for the class `Myobject` 
+An object listing class is created automatically for each class defined in Pimcore. Objects for the class `Myobject`
 are retrieved through a listing as in the following example:
 
 ```php
@@ -146,7 +148,7 @@ $items->setOrderKey("(SELECT id FROM sometable GROUP BY someField)", false);
 ```
 
 ### Using prepared statement placeholders and variables
-The syntax is similar to that from the Zend Framework described 
+The syntax is similar to that from the Zend Framework described
 [here](http://framework.zend.com/manual/en/zend.db.adapter.html#zend.db.adapter.select.fetchall).
 
 ```php
@@ -185,9 +187,9 @@ $entries->setCondition("name LIKE :name", ["name" => "%term%"]); // name is a fi
 ```
 
 ##### Disable Localized Fields in listings
-Sometimes you don't want to have localized data on the listings (condition & order by). For this particular case you 
-can disable localized fields on your listing (the objects in the list will still include the localized fields). 
-Conditions and order by statements on localized fields are then not possible anymore. 
+Sometimes you don't want to have localized data on the listings (condition & order by). For this particular case you
+can disable localized fields on your listing (the objects in the list will still include the localized fields).
+Conditions and order by statements on localized fields are then not possible anymore.
 
 ```php
 <?php
@@ -205,9 +207,9 @@ This is especially useful to get an object matching a foreign key, or get a list
 $result = DataObject\ClassName::getByMyfieldname($value, ['limit' => $limit, 'offset' => $offset]);
 
 // or for localized fields
-$result = DataObject\ClassName::getByMyfieldname($value, ['locale' => locale, 'limit' => $limit, 'offset' => $offset]);
+$result = DataObject\ClassName::getByMyfieldname($value, ['locale' => $locale, 'limit' => $limit, 'offset' => $offset]);
 ```
-If you set no limit, a list object containing all matching objects is returned. If the limit is set to 1 
+If you set no limit, a list object containing all matching objects are returned. If the limit is set to 1
 the first matching object is returned directly (without listing). Only published objects are return.
 
 Alternatively you can pass an array as second parameter which will be applied to the object listing.
@@ -292,8 +294,7 @@ $country = DataObject\Country::getByName("Austria", "en", 1);
 
 
 ### Get an Object List including unpublished Objects
-Normally object lists only give published objects. This can be changed by setting a lists `unpublished` property to 
-`true`.
+Normally object lists only give published objects. This can be changed by setting a lists `unpublished` property to `true`.
 
 ```php
 <?php
@@ -321,7 +322,7 @@ You can switch globally the behaviour (it will bypass `setUnpublished` setting),
 ```
 
 ### Filter Objects by attributes from Field Collections
-To filter objects by attributes from field collections, you can use following syntax 
+To filter objects by attributes from field collections, you can use following syntax
 (Both code snippets result in the same object listing).
 
 ```php
@@ -343,22 +344,22 @@ $list = \Pimcore\Model\DataObject\Collectiontest::getList([
 ]);
 ```
 
-You can add field collections to an listing object by specifying the type of the field collection and optionally the 
+You can add field collections to a listing object by specifying the type of the field collection and optionally the
 fieldname. The fieldname is the fieldname of the field collection in the class definition of the current object.
-Once field collections are added to an object listing, you can access attributes of field collections in the condition 
-of the object listing. The syntax is as shown in the examples above `FIELDCOLLECTIONTYPE~FIELDNAME.ATTRIBUTE_OF_FIELDCOLLECTION`, 
+Once field collections are added to an object listing, you can access attributes of field collections in the condition
+of the object listing. The syntax is as shown in the examples above `FIELDCOLLECTIONTYPE~FIELDNAME.ATTRIBUTE_OF_FIELDCOLLECTION`,
 or if you have not specified a fieldname `FIELDCOLLECTION.ATTRIBUTE_OF_FIELDCOLLECTION`.
 
 The object listing of this example only delivers objects of the type Collectiontest, which have
-* an Fieldcollection of the type `MyCollection` and the value `testinput` in the attribute `myinput` and
-* an Fieldcollection in the field `collection` of the type `MyCollection` and the value `hugo` in the attribute `myinput`. 
+* a Fieldcollection of the type `MyCollection` and the value `testinput` in the attribute `myinput` and
+* a Fieldcollection in the field `collection` of the type `MyCollection` and the value `hugo` in the attribute `myinput`.
 
 
 <a name="zendPaginatorListing">&nbsp;</a>
 
 ### Working with Knp\Component\Pager\Paginator
 
-##### Action 
+##### Action
 ```php
 public function testAction( Request $request, \Knp\Component\Pager\PaginatorInterface $paginator)
 {
@@ -378,6 +379,7 @@ public function testAction( Request $request, \Knp\Component\Pager\PaginatorInte
     ]);
 }
 ```
+
 ##### View
 ```twig
 {% for item in paginator %}
@@ -430,10 +432,9 @@ public function testAction( Request $request, \Knp\Component\Pager\PaginatorInte
 
 ### Access and modify internal object list query
 
-It is possible to access and modify the internal query from every object listing. The internal query is based 
+It is possible to access and modify the internal query from every object listing. The internal query is based
 on `\Doctrine\DBAL\Query\QueryBuilder`.
 ```php
-
 <?php
 // get all news with ratings that is stored in a not Pimcore related table
  

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -504,7 +504,7 @@ final class ClassDefinition extends Model\AbstractModel
                             $this->getName()
                         ).' getBy'.ucfirst(
                             $def->getName()
-                        ).'($field, $value, $locale = null, $limit = 0, $offset = 0)'."\n";
+                        ).'($field, $value, $locale = null, $limit = 0, $offset = 0, $objectTypes = null)'."\n";
 
                     foreach ($def->getFieldDefinitions() as $localizedFieldDefinition) {
                         $cd .= '* @method static \\Pimcore\\Model\\DataObject\\'.ucfirst(
@@ -513,14 +513,14 @@ final class ClassDefinition extends Model\AbstractModel
                                 $this->getName()
                             ).' getBy'.ucfirst(
                                 $localizedFieldDefinition->getName()
-                            ).'($value, $locale = null, $limit = 0, $offset = 0)'."\n";
+                            ).'($value, $locale = null, $limit = 0, $offset = 0, $objectTypes = null)'."\n";
                     }
                 } elseif ($def->isFilterable()) {
                     $cd .= '* @method static \\Pimcore\\Model\\DataObject\\'.ucfirst(
                             $this->getName()
                         ).'\Listing|\\Pimcore\\Model\\DataObject\\'.ucfirst(
                             $this->getName()
-                        ).' getBy'.ucfirst($def->getName()).'($value, $limit = 0, $offset = 0)'."\n";
+                        ).' getBy'.ucfirst($def->getName()).'($value, $limit = 0, $offset = 0, $objectTypes = null)'."\n";
                 }
             }
         }

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -683,9 +683,9 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
             }
 
             if ($field instanceof Model\DataObject\ClassDefinition\Data\Localizedfields) {
-                $arguments = array_pad($arguments, 5, 0);
+                $arguments = array_pad($arguments, 6, 0);
 
-                [$localizedPropertyName, $value, $locale, $limit, $offset] = $arguments;
+                [$localizedPropertyName, $value, $locale, $limit, $offset, $objectTypes] = $arguments;
 
                 $localizedField = $field->getFieldDefinition($localizedPropertyName);
 
@@ -708,8 +708,8 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
                     $listConfig['locale'] = $locale;
                 }
             } else {
-                $arguments = array_pad($arguments, 3, 0);
-                [$value, $limit, $offset] = $arguments;
+                $arguments = array_pad($arguments, 4, 0);
+                [$value, $limit, $offset, $objectTypes] = $arguments;
 
                 if (!$field instanceof AbstractRelations) {
                     $defaultCondition = $realPropertyName . ' = ' . Db::get()->quote($value) . ' ';
@@ -733,6 +733,17 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
             }
 
             $list = static::getList($listConfig);
+
+            // Check if variants, in addition to objects, to be fetched
+            if (!empty($objectTypes)) {
+                if (\array_diff($objectTypes, [static::OBJECT_TYPE_VARIANT, static::OBJECT_TYPE_OBJECT])) {
+                    Logger::error('Class: DataObject\\Concrete => Unsupported object type in array ' . implode(',', $objectTypes));
+
+                    throw new \Exception('Unsupported object type in array [' . implode(',', $objectTypes) . '] in class DataObject\\Concrete');
+                }
+
+                $list->setObjectTypes($objectTypes);
+            }
 
             if ($field instanceof AbstractRelations && $field->isFilterable()) {
                 $list = $field->addListingFilter($list, $value);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #9457

## Additional info  

Only tested on 6.9.6 so far, but should probably work on 10.x as well :)