### PR TITLE
Consistent method name getMimeType/setMimeType

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -1101,7 +1101,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         return new StreamedResponse(function () use ($stream) {
             fpassthru($stream);
         }, 200, [
-            'Content-Type' => $asset->getMimetype(),
+            'Content-Type' => $asset->getMimeType(),
             'Content-Disposition' => sprintf('attachment; filename="%s"', $asset->getFilename()),
             'Content-Length' => $asset->getFileSize(),
         ]);
@@ -1253,7 +1253,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $response = new StreamedResponse(function () use ($stream) {
             fpassthru($stream);
         }, 200, [
-            'Content-Type' => $image->getMimetype(),
+            'Content-Type' => $image->getMimeType(),
             'Access-Control-Allow-Origin' => '*',
         ]);
         $this->addThumbnailCacheHeaders($response);
@@ -1556,7 +1556,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     {
         $stream = null;
 
-        if ($asset->getMimetype() == 'application/pdf') {
+        if ($asset->getMimeType() == 'application/pdf') {
             $stream = $asset->getStream();
         }
 

--- a/bundles/AdminBundle/Resources/views/Admin/Asset/showVersionImage.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/Asset/showVersionImage.html.twig
@@ -59,7 +59,7 @@
                         </tr>
                         <tr>
                             <td>Mime Type</td>
-                            <td>{{ asset.getMimetype() }}</td>
+                            <td>{{ asset.getMimeType() }}</td>
                         </tr>
                         <tr>
                             <td>Dimensions</td>

--- a/bundles/AdminBundle/Resources/views/SearchAdmin/Search/Quicksearch/info-table.html.twig
+++ b/bundles/AdminBundle/Resources/views/SearchAdmin/Search/Quicksearch/info-table.html.twig
@@ -12,7 +12,7 @@
         {% if element is instanceof ('\\Pimcore\\Model\\Asset') %}
             <tr>
                 <th>{{ 'mimetype'|trans([],'admin') }}</th>
-                <td>{{ element.getMimetype() }}</td>
+                <td>{{ element.getMimeType() }}</td>
             </tr>
         {% endif %}
 

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/25_Email_Framework/01_Pimcore_Mail.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/25_Email_Framework/01_Pimcore_Mail.md
@@ -1,13 +1,13 @@
 # Pimcore Mail
 
-The `Pimcore\Mail` Class extends the [`Symfony\Component\Mime\Email`](https://symfony.com/doc/5.2/mailer.html#email-addresses) 
+The `Pimcore\Mail` Class extends the [`Symfony\Component\Mime\Email`](https://symfony.com/doc/5.2/mailer.html#email-addresses)
 Class and adds some features for the usage with Pimcore.
 
 If email settings are configured in your `config/config.yaml` then on initializing
 `Pimcore\Mail` object, these settings applied automatically. It is required to configure [email settings](./README.md#page_General-Information) prior to using Pimcore\Mail.
 
-The `Pimcore\Mail` Class automatically takes care of the nasty stuff (embedding CSS, 
-normalizing URLs and Twig expressions ...). Note that all CSS files are embedded 
+The `Pimcore\Mail` Class automatically takes care of the nasty stuff (embedding CSS,
+normalizing URLs and Twig expressions ...). Note that all CSS files are embedded
 to the html with a `<style>` tag because the image paths are also normalised.
 
 ## Useful Methods
@@ -28,23 +28,23 @@ to the html with a `<style>` tag because the image paths are also normalised.
 
 ```php
 $params = ['firstName' => 'Pim', 'lastName' => 'Core', 'product' => 73613];
- 
+
 //sending an email document (pimcore document)
 $mail = new \Pimcore\Mail();
 $mail->to('example@pimcore.org');
 $mail->setDocument('/email/myemaildocument');
 $mail->setParams($params);
 $mail->send();
- 
- 
+
+
 // sending a text-mail
- 
+
 $mail = new \Pimcore\Mail();
 $mail->to('example@pimcore.org');
 $mail->text("This is just plain text");
 $mail->send();
- 
-// Sending a rich text (HTML) email with Twig expressions 
+
+// Sending a rich text (HTML) email with Twig expressions
 $mail = new \Pimcore\Mail();
 $mail->to('example@pimcore.org');
 $mail->bcc("bcc@pimcore.org");
@@ -53,19 +53,19 @@ $mail->setParams([
 ]);
 $mail->html("<b>some</b> rich text: {{ myParam }}");
 $mail->send();
- 
+
 //adding an asset as attachment
 if($asset instanceof Asset) {
-   $mail->createAttachment($asset->getData(), $asset->getMimetype(), $asset->getFilename());
+   $mail->createAttachment($asset->getData(), $asset->getMimeType(), $asset->getFilename());
 }
 
 //Embedding Images
 $mail = new \Pimcore\Mail();
 $mail->to('example@pimcore.org');
 
-$mail->embed($asset->getData(), 'logo', $asset->getMimetype());
+$mail->embed($asset->getData(), 'logo', $asset->getMimeType());
 //or
-$mail->embedFromPath($asset->getFileSystemPath(), 'logo', $asset->getMimetype());
+$mail->embedFromPath($asset->getFileSystemPath(), 'logo', $asset->getMimeType());
 
 $mail->html("Embedded Image: <img src='cid:logo'>"); //image name(passed second argument in embed) as ref
 $mail->send();

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1553,7 +1553,7 @@ class Asset extends Element\AbstractElement
     /**
      * @return string
      */
-    public function getMimetype()
+    public function getMimeType()
     {
         return $this->mimetype;
     }

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -709,7 +709,7 @@ class Asset extends Element\AbstractElement
                 $this->stream = null; // set stream to null, so that the source stream isn't used anymore after saving
 
                 $mimeType = $storage->mimeType($path);
-                $this->setMimetype($mimeType);
+                $this->setMimeType($mimeType);
 
                 // set type
                 $type = self::getTypeFromMimeMapping($mimeType, $this->getFilename());
@@ -1563,7 +1563,7 @@ class Asset extends Element\AbstractElement
      *
      * @return $this
      */
-    public function setMimetype($mimetype)
+    public function setMimeType($mimetype)
     {
         $this->mimetype = $mimetype;
 

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -493,7 +493,7 @@ EOT;
     {
         $isAnimated = false;
 
-        switch ($this->getMimetype()) {
+        switch ($this->getMimeType()) {
             case 'image/gif':
                 $isAnimated = $this->isAnimatedGif();
 
@@ -518,7 +518,7 @@ EOT;
     {
         $isAnimated = false;
 
-        if ($this->getMimetype() == 'image/gif') {
+        if ($this->getMimeType() == 'image/gif') {
             $fileContent = $this->getData();
 
             /**
@@ -546,7 +546,7 @@ EOT;
     {
         $isAnimated = false;
 
-        if ($this->getMimetype() == 'image/png') {
+        if ($this->getMimeType() == 'image/png') {
             $fileContent = $this->getData();
 
             /**

--- a/models/Asset/WebDAV/File.php
+++ b/models/Asset/WebDAV/File.php
@@ -169,7 +169,7 @@ class File extends DAV\File
      */
     public function getContentType()
     {
-        return $this->asset->getMimetype();
+        return $this->asset->getMimeType();
     }
 
     /**


### PR DESCRIPTION
Asset\Image has getMimetype and Asset\Image\Thumbnail has getMimeType.

PHP method names are case-insensitive. So it shouldn't be a BC break.