### PR TITLE
Fix: ObjectBrick with multiple Localized fields are broken after update to 6.9/10.0

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20210706090823.php
+++ b/bundles/CoreBundle/Migrations/Version20210706090823.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Model\DataObject;
+
+/**
+ * @internal
+ */
+final class Version20210706090823 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $list = new DataObject\ClassDefinition\Listing();
+        $list = $list->load();
+        foreach ($list as $class) {
+            $this->write(sprintf('Saving class: %s', $class->getName()));
+            $class->save();
+        }
+
+        $list = new DataObject\Objectbrick\Definition\Listing();
+        $list = $list->load();
+        foreach ($list as $brickDefinition) {
+            $this->write(sprintf('Saving object brick: %s', $brickDefinition->getKey()));
+            $brickDefinition->save();
+        }
+
+        $list = new DataObject\Fieldcollection\Definition\Listing();
+        $list = $list->load();
+        foreach ($list as $fc) {
+            $this->write(sprintf('Saving field collection: %s', $fc->getKey()));
+            $fc->save();
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->write(sprintf('Please restore your class definition files in %s and run bin/console pimcore:deployment:classes-rebuild manually.', PIMCORE_CLASS_DIRECTORY));
+    }
+}

--- a/bundles/CoreBundle/Migrations/Version20210706090823.php
+++ b/bundles/CoreBundle/Migrations/Version20210706090823.php
@@ -28,7 +28,7 @@ final class Version20210706090823 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return '';
+        return 'Rebuild class definitions to fix Objectbricks with multiple Localized fields';
     }
 
     public function up(Schema $schema): void

--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -700,6 +700,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
     public function setReferencedFields($referencedFields)
     {
         $this->referencedFields = $referencedFields;
+        $this->fieldDefinitionsCache = null;
     }
 
     /**
@@ -716,6 +717,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
     public function addReferencedField($field)
     {
         $this->referencedFields[] = $field;
+        $this->fieldDefinitionsCache = null;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -537,6 +537,7 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
     public function setReferencedFields($referencedFields)
     {
         $this->referencedFields = $referencedFields;
+        $this->fieldDefinitionsCache = null;
     }
 
     /**
@@ -553,6 +554,7 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
     public function addReferencedField($field)
     {
         $this->referencedFields[] = $field;
+        $this->fieldDefinitionsCache = null;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -475,6 +475,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
     public function setReferencedFields($referencedFields)
     {
         $this->referencedFields = $referencedFields;
+        $this->fieldDefinitionsCache = null;
     }
 
     /**
@@ -491,6 +492,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
     public function addReferencedField($field)
     {
         $this->referencedFields[] = $field;
+        $this->fieldDefinitionsCache = null;
     }
 
     /**


### PR DESCRIPTION
Resolve #9646 