### PR TITLE
[Docs] Remove false statement about calling bin/console

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/11_Console_CLI.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/11_Console_CLI.md
@@ -77,7 +77,7 @@ class AwesomeCommand extends AbstractCommand
 Call `bin/console list` script from the command line to get a list of available commands. To call 
 a command, use `bin/console <subcommand>`.
 
-> Be sure to run the console with the PHP user to prevent writing permissions issues later, either by calling `php bin/console` or by switching to the appropriate user, for instance on Debian system `su -l www-data -s /bin/bash`.
+> Be sure to run the console with the PHP user to prevent writing permissions issues later by switching to the appropriate user, for instance on Debian system `su -l www-data -s /bin/bash`.
 
 ##### Examples:
 ```php


### PR DESCRIPTION
Explicitly executing `bin/console` w/ interpreter `php` makes no difference to implicit given interpreter in shebang `#!/usr/bin/env php` in regards to the effective user of the process.
