### PR TITLE
[DataObjects] ClassDefinition::generateClassFiles() change visibility to public again and mark internal

### DIFF
--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -458,8 +458,10 @@ final class ClassDefinition extends Model\AbstractModel
      * @param bool $generateDefinitionFile
      *
      * @throws \Exception
+     *
+     * @internal
      */
-    private function generateClassFiles($generateDefinitionFile = true)
+    public function generateClassFiles($generateDefinitionFile = true)
     {
         $infoDocBlock = $this->getInfoDocBlock();
 


### PR DESCRIPTION
## Changes in this pull request  
`Classdefinition::generateClassFiles()` was introduced to allow migrations to regenerate class files instead of calling `save()`. please see https://github.com/pimcore/pimcore/pull/6047#discussion_r394424094

## Additional info  

