### PR TITLE
Avoid overlapping toolbar buttons with notifications

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -571,7 +571,7 @@ pimcore.helpers.showNotification = function (title, text, type, detailText, hide
             maxWidth: 350,
             closeable: true,
             align: "br",
-            anchor: Ext.get(tabContainer),
+            anchor: Ext.get(tabsBody),
             paddingX: 5,
             paddingY: paddingY
         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -550,6 +550,18 @@ pimcore.helpers.showNotification = function (title, text, type, detailText, hide
         });
         errWin.show();
     } else {
+        // Avoid overlapping any footer toolbar buttons
+        // Find current active tab to find its footer if there is one
+        let paddingY = 10;
+        let tabsBody = document.getElementById('pimcore_panel_tabs-body');
+        let activeTab = tabsBody.querySelector(':scope > [aria-expanded="true"]');
+        if (activeTab) {
+            let footerToolbar = activeTab.querySelector(':scope .x-toolbar-footer');
+            if (footerToolbar) {
+                paddingY += footerToolbar.scrollHeight;
+            }
+        }
+
         var notification = Ext.create('Ext.window.Toast', {
             iconCls: 'pimcore_icon_' + type,
             title: title,
@@ -558,7 +570,10 @@ pimcore.helpers.showNotification = function (title, text, type, detailText, hide
             width: 'auto',
             maxWidth: 350,
             closeable: true,
-            align: "br"
+            align: "br",
+            anchor: Ext.get(tabContainer),
+            paddingX: 5,
+            paddingY: paddingY
         });
         notification.show(document);
     }


### PR DESCRIPTION
<!--

## IMPORTANT CHANGE REGARDING THE TARGET BRANCH FOR YOUR PR! 
Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` -> target branch `10.x`
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves a small annoyance that the notification window would often overlap the footer toolbar, this would be like a pebble in ones shoe when trying to edit multiple items quickly. Also moves it horizontally a few pixels for nicer alignment.

## Additional info  

Works with repeating notifications as well.

No toolbar:
![image](https://user-images.githubusercontent.com/279826/124428540-22cd8480-dd6d-11eb-9ec4-14f353ad200d.png)

With toolbar:
![image](https://user-images.githubusercontent.com/279826/124428668-4b557e80-dd6d-11eb-8b85-9c31dde07130.png)
