### PR TITLE
[Admin Translations] Translations keys should be wrapped with + sign if translated value is missing

### DIFF
--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -220,7 +220,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
 
                             //wrap non-translated keys with "+", if debug admin translations is enabled
                             if  ($debugAdminTranslations) {
-                                $translationKey = '+' . $translationKey . '+';
+                                $translationTerm = '+' . $translationTerm. '+';
                             }
                         }
 

--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -204,6 +204,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
                 $list = new Translation\Listing();
                 $list->setDomain($domain);
 
+                $debugAdminTranslations = \Pimcore\Config::getSystemConfiguration('general')['debug_admin_translations'] ?? false;
                 $list->setCondition('language = ?', [$locale]);
                 $translations = $list->loadRaw();
 
@@ -216,6 +217,11 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
 
                         if (empty($translationTerm)) {
                             $translationTerm = $translationKey;
+
+                            //wrap non-translated keys with "+", if debug admin translations is enabled
+                            if  ($debugAdminTranslations) {
+                                $translationKey = '+' . $translationKey . '+';
+                            }
                         }
 
                         if (empty($translation['type']) || $translation['type'] === 'simple') {


### PR DESCRIPTION
## Changes in this pull request  
Resolves #9482

## Additional info  
and debug is enabled