### PR TITLE
changed old method name to current

### DIFF
--- a/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/02_Bricks.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/02_Bricks.md
@@ -223,7 +223,7 @@ reasons, but a couple of methods could be useful when implementing your own bric
 
 | Method                  | Description                                      |
 |-------------------------|--------------------------------------------------|
-| `$info->getTag()`       | Returns the tag rendering the brick              |
+| `$info->getEditable()`       | Returns the editable rendering the brick              |
 | `$info->getDocument()`  | Retrieve the document   |
 | `$info->getDocumentElement($name)` | Retrieve the editable tag from document   |
 | `$info->getRequest()`   | Returns the current request                      |


### PR DESCRIPTION
The Info object still had getTag(), which was replaced by getEditable().

Not sure if the line below needs a wording change.