### PR TITLE
Variant classificationstore fields are not marked as inherited unless one field is set

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -684,6 +684,12 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
             if ($fielddefinition->isEmpty($fieldData) && !empty($parent)) {
                 $this->getDataForField($parent, $key, $fielddefinition, $objectFromVersion, $level + 1);
+                // exception for classification store. if there are no items then it is empty by definition.
+                // consequence is that we have to preserve the metadata information
+                // see https://github.com/pimcore/pimcore/issues/9329
+                if ($fielddefinition instanceof DataObject\ClassDefinition\Data\Classificationstore && $level == 0) {
+                    $this->objectData[$key]['metaData'] = $value['metaData'] ?? [];
+                }
             } else {
                 $isInheritedValue = $isInheritedValue || ($level != 0);
                 $this->metaData[$key]['objectid'] = $object->getId();


### PR DESCRIPTION
resolves #9329
