### PR TITLE
[Data Object][BlockElement] Improve block data type memory usage

### DIFF
--- a/models/DataObject/Data/BlockElement.php
+++ b/models/DataObject/Data/BlockElement.php
@@ -139,9 +139,14 @@ class BlockElement extends AbstractModel implements OwnerAwareFieldInterface, Ca
                 function ($currentValue) {
                     if ($currentValue instanceof ElementDescriptor) {
                         $cacheKey = $currentValue->getCacheKey();
-                        if (Runtime::isRegistered($cacheKey)) {
-                            // we don't want the copy from the runtime but cache is fine
-                            Runtime::getInstance()->offsetUnset($cacheKey);
+                        $cacheKeyRenewed = $cacheKey . '_blockElementRenewed';
+
+                        if(!Runtime::isRegistered($cacheKeyRenewed)) {
+                            if (Runtime::isRegistered($cacheKey)) {
+                                // we don't want the copy from the runtime but cache is fine
+                                Runtime::getInstance()->offsetUnset($cacheKey);
+                            }
+                            Runtime::save(true, $cacheKeyRenewed);
                         }
 
                         $renewedElement = Service::getElementById($currentValue->getType(), $currentValue->getId());


### PR DESCRIPTION
Currently the object where a block element is used is loaded once from the cache for each block element within the object. So if we have for example 50 block elements within an object it will be loaded 51 times when you open it for example in the Pimcore backend. This could lead to serious memory problems.

This PR avoids this and the object will be loaded twice only instead of 51 times in the example above.