### PR TITLE
Support endroid/qr-code 4

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -15,6 +15,8 @@
 
 namespace Pimcore\Bundle\AdminBundle\Controller\Admin\Document;
 
+use Endroid\QrCode\Builder\Builder;
+use Endroid\QrCode\Writer\PngWriter;
 use Pimcore\Controller\Traits\ElementEditLockHelperTrait;
 use Pimcore\Document\Editable\Block\BlockStateStack;
 use Pimcore\Document\Editable\EditmodeEditableDefinitionCollector;
@@ -392,19 +394,19 @@ class PageController extends DocumentControllerBase
 
         $url = $request->getScheme() . '://' . $request->getHttpHost() . $page->getFullPath();
 
-        $code = new \Endroid\QrCode\QrCode;
-        $code->setWriterByName('png');
-        $code->setText($url);
-        $code->setSize(500);
+        $result = Builder::create()
+            ->writer(new PngWriter())
+            ->data($url)
+            ->size($request->query->get('download') ? 4000 : 500)
+            ->build();
 
         $tmpFile = PIMCORE_PRIVATE_VAR . '/qr-code-' . uniqid() . '.png';
-        $code->writeFile($tmpFile);
+        $result->saveToFile($tmpFile);
 
         $response = new BinaryFileResponse($tmpFile);
         $response->headers->set('Content-Type', 'image/png');
 
         if ($request->query->get('download')) {
-            $code->setSize(4000);
             $response->setContentDisposition('attachment', 'qrcode-preview.png');
         }
 

--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -15,6 +15,8 @@
 
 namespace Pimcore\Bundle\AdminBundle\Controller\Admin;
 
+use Endroid\QrCode\Builder\Builder;
+use Endroid\QrCode\Writer\PngWriter;
 use Pimcore\Bundle\AdminBundle\Controller\AdminController;
 use Pimcore\Bundle\AdminBundle\HttpFoundation\JsonResponse;
 use Pimcore\Config;
@@ -843,17 +845,16 @@ class UserController extends AdminController implements KernelControllerEventInt
 
         $url = $twoFactor->getQRContent($proxyUser);
 
-        $code = new \Endroid\QrCode\QrCode;
-        $code->setWriterByName('png');
-        $code->setText($url);
-        $code->setSize(200);
+        $result = Builder::create()
+            ->writer(new PngWriter())
+            ->data($url)
+            ->size(200)
+            ->build();
 
         $qrCodeFile = PIMCORE_PRIVATE_VAR . '/qr-code-' . uniqid() . '.png';
-        $code->writeFile($qrCodeFile);
+        $result->saveToFile($qrCodeFile);
 
-        $response = new BinaryFileResponse($qrCodeFile);
-
-        return $response;
+        return new BinaryFileResponse($qrCodeFile);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     "doctrine/inflector": "^1.4.0 || ^2.0.0",
     "symfony/doctrine-messenger": "^5.2.0",
     "egulias/email-validator": "^3.0.0",
-    "endroid/qr-code": "^3.4.4 || ^4",
+    "endroid/qr-code": "^4",
     "friendsofsymfony/jsrouting-bundle": "^2.6",
     "geoip2/geoip2": "^2.9",
     "google/apiclient": "^2.10",

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     "doctrine/inflector": "^1.4.0 || ^2.0.0",
     "symfony/doctrine-messenger": "^5.2.0",
     "egulias/email-validator": "^3.0.0",
-    "endroid/qr-code": "^3.4.4",
+    "endroid/qr-code": "^3.4.4 || ^4",
     "friendsofsymfony/jsrouting-bundle": "^2.6",
     "geoip2/geoip2": "^2.9",
     "google/apiclient": "^2.10",

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -5,6 +5,9 @@
 - [Core] composer.json: `symfony/symfony` package requirement has been replaced by `symfony/*` individual bundles. **Note for Bundles**: if you are using `symfony/symfony` dependency, it will now conflict with package `pimcore/pimcore`. Please move your bundle requirements to Symfony individual component packages.
 - [[Ecommerce][TrackingManager] event name in method `trackCheckoutComplete()` changed from `checkout` to `purchase` for `GoogleTagManager` implementation](https://github.com/pimcore/pimcore/pull/9366/files)
 - [Glossary] `pimcoreglossary()` tag has been deprecated in favor of `pimcore_glossary` Twig filter and will be removed in Pimcore 11.
+- Bumped `google/apiclient` to 2.10 version - Use proper namespaces for API references
+- Bumped `endroid/qr-code` to 4 version
+
 ## 10.0.0
 
 ### System Requirements
@@ -39,7 +42,7 @@
 
 - `Pimcore\Model\Tool\Tracking\Event` has been removed.
 - `Pimcore\Tool\Archive` has been removed.
-- The object query table will now consider the fallback language. If you want to keep the old behavior set `pimcore.objects.ignore_localized_query_fallback` in your configuration.  
+- The object query table will now consider the fallback language. If you want to keep the old behavior set `pimcore.objects.ignore_localized_query_fallback` in your configuration.
 - Removed QR Codes.
 - Remove Linfo Integration.
 - [Ecommerce][IndexService] Removed FactFinder integration.
@@ -73,20 +76,20 @@
 - Removed `Pimcore\Model\Element\Reference\Placeholder` class.
 - Removed `pimcore.routing.defaults`. Use `pimcore.documents.default_controller` instead.
 - Removed `\Pimcore\Tool::getRoutingDefaults()`, `PageSnippet::$module|$action|get/setAction()|get/setModule()`, `DocType::$module|$action|get/setAction()|get/setModule()`, `Staticroute::$module|$action|get/setAction()|get/setModule()`.
-- Removed `\Pimcore\Tool::getValidCacheKey/()`, use `preg_replace('/[^a-zA-Z0-9]/', '_', $key)` instead. 
+- Removed `\Pimcore\Tool::getValidCacheKey/()`, use `preg_replace('/[^a-zA-Z0-9]/', '_', $key)` instead.
 - Removed `\Pimcore\Tool::isValidPath/()`, use `\Pimcore\Model\Element\Service::isValidPath()` instead.
-- Deprecated `\Pimcore\Model\Element\Service::getSaveCopyName()`, use `getSafeCopyName()` instead. 
+- Deprecated `\Pimcore\Model\Element\Service::getSaveCopyName()`, use `getSafeCopyName()` instead.
 - Using dynamic modules, controllers and actions in static routes (e.g. `%controller`) does not work anymore.
 - Removed `\Pimcore\Controller\Config\ConfigNormalizer`.
 - Removed `pimcore_action()` Twig extension. Use Twig `render()` instead.
 - Removed `\Pimcore\Console\Log\Formatter\ConsoleColorFormatter`
-- Removed `\Pimcore\Console\CliTrait`, use `php_sapi_name() === 'cli'` instead.  
+- Removed `\Pimcore\Console\CliTrait`, use `php_sapi_name() === 'cli'` instead.
 - Removed `\Pimcore\Console\Dumper`, use Symfony's `VarDumper` instead.
 - Removed `\Pimcore\Google\Webmastertools`, use `\Pimcore\Config::getReportConfig()->get('webmastertools'')` instead.
 - Removed `\Pimcore\Helper\JsonFormatter`, use `json_encode($data, JSON_PRETTY_PRINT)` instead.
 - Removed `\Pimcore\Log\Handler\Mail`, there's no replacement for this internal class.
 - Removed `\Pimcore\File::isIncludeable()` method, there's no replacement.
-- Removed `\Pimcore\DataObject\GridColumnConfig\AbstractConfigElement` just implement `\Pimcore\DataObject\GridColumnConfig\ConfigElementInterface` instead.   
+- Removed `\Pimcore\DataObject\GridColumnConfig\AbstractConfigElement` just implement `\Pimcore\DataObject\GridColumnConfig\ConfigElementInterface` instead.
 - [Documents] Renderlet Editable: removed `action` & `bundle` config. Specify controller reference, e.g. `App\Controller\FooController::myAction`
 - Bumped `codeception/codeception` to "^4.1.12".
 - Pimcore Bundle Migrations: Extending the functionality of `DoctrineMigrationsBundle` is not any longer possible the way we did it in the past. Therefore we're switching to standard Doctrine migrations, this means also that migration sets are not supported anymore and that the available migrations have to be configured manually or by using flex.
@@ -155,9 +158,9 @@
 - Replaced `Ramsey/Uuid` with `Symfony/Uuid`.
 - Matomo Integration has been removed.
 - `Pimcore\Tool\Console::exec()` method has been removed. Use Symfony\Component\Process\Process instead.
-- `\Pimcore\Tool\Console::getOptions()` method has been removed.   
-- `\Pimcore\Tool\Console::getOptionString()` method has been removed.   
-- `\Pimcore\Tool\Console::checkCliExecution()` method has been removed.   
+- `\Pimcore\Tool\Console::getOptions()` method has been removed.
+- `\Pimcore\Tool\Console::getOptionString()` method has been removed.
+- `\Pimcore\Tool\Console::checkCliExecution()` method has been removed.
 - `Pimcore\Twig\Extension\Templating\Navigation::buildNavigation()` method has been removed.
 - `Pimcore\Tool\Mime` class has been removed. Use `Symfony\Component\Mime\MimeTypes` instead.
 - [Documents] Areabricks: location changed from `Areas` to `areas` with BC layer.
@@ -176,7 +179,7 @@
 - `\Pimcore\Model\DataObject\Listing::getPaginatorAdapter` has been removed, use `knplabs/knp-paginator-bundle` instead.
 - `\Pimcore\Google\Cse::getPaginatorAdapter` has been removed, use `knplabs/knp-paginator-bundle` instead.
 - `\Pimcore\Helper\RobotsTxt` has been removed
-- `\Pimcore\Tool\Frontend::getSiteKey()` method has been removed.  
+- `\Pimcore\Tool\Frontend::getSiteKey()` method has been removed.
 - `\Pimcore\Model\User::getUsername()` has been removed, use `User::getName()` instead.
 - `\Pimcore\Cache\Runtime::get('pimcore_editmode')` isn't supported anymore, use `EditmodeResolver` service instead.
 - [Documents] `Editable::factory()` was removed, use `EditableLoader` service instead.
@@ -263,10 +266,10 @@
   - Removed configuration node `worker_mode` in `index_service` configuration
 - [Ecommerce] Moved method `getIdColumnType` from `MysqlConfigInterface` to `ConfigInterface`. Since it was and still is
   implemented in `AbstractConfig` this should not have any consequences.
-- [Ecommerce] Timestamp of CartItems is now in mirco seconds (existing data will be migrated).  
+- [Ecommerce] Timestamp of CartItems is now in mirco seconds (existing data will be migrated).
 - [Ecommerce][PricingManager] Added two new interfaces `ProductActionInterface` and `CartActionInterface`. All actions
   need to implement either of it - otherwise they will not be considered anymore in price calculation.
-- [Web2Print] 
+- [Web2Print]
    - Removed `PdfReactor8`, use `PdfReactor` instead.
    - Removed PDFreactor version selection in web2print settings, since most current PDFreactor client lib
      should be backwards compatible to older versions.
@@ -312,8 +315,8 @@
       $mail->to(new \Symfony\Component\Mime\Address($emailAddress, $name));
       ...
     ```
-- [Email & Newsletter] `\Pimcore\Mail::setEnableLayoutOnRendering/getEnableLayoutOnRendering()` methods have been removed, with Twig they are just not necessary anymore. 
-- [Email & Newsletter] `\Pimcore\Mail::isValidEmailAddress()` method has been removed, use `EmailValidator` instead.  
+- [Email & Newsletter] `\Pimcore\Mail::setEnableLayoutOnRendering/getEnableLayoutOnRendering()` methods have been removed, with Twig they are just not necessary anymore.
+- [Email & Newsletter] `\Pimcore\Mail::isValidEmailAddress()` method has been removed, use `EmailValidator` instead.
 - [Security] BruteforceProtectionHandler & BruteforceProtectionListener has been made final and marked as internal.
 - [JWTCookieSaveHandler] `Pimcore\Targeting\Storage\Cookie\JWT\Decoder` has been removed in favor of `Lcobucci\JWT\Encoding\JoseDecoder`.
 - `simple_html_dom` library has been removed. Use `Symfony\Component\DomCrawler\Crawler` instead.
@@ -328,4 +331,3 @@
 - Removed deprecated `marshal()` and `unmarshal()` methods from object data-types.
 - `DynamicTextLabelInterface::renderLayoutText()` must handle nullable object param.
 - [AdminBundle] Marked classes and controllers as @internal/final - please see all changes here: https://github.com/pimcore/pimcore/pull/8453/files & https://github.com/pimcore/pimcore/pull/8988/files
-- Bumped `google/apiclient` to 2.10 version - Use proper namespaces for API references


### PR DESCRIPTION
I use endroid/qr-code-bundle and I get deprecation notices in V3. V4 has PHP 8 support and fixed this notices.