### PR TITLE
Element Router with string name

### DIFF
--- a/lib/Routing/Element/Router.php
+++ b/lib/Routing/Element/Router.php
@@ -73,7 +73,7 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
     /**
      * {@inheritdoc}
      */
-    public function supports($name)
+    public function supports(string $name)
     {
         return $name === 'pimcore_element';
     }

--- a/lib/Routing/Element/Router.php
+++ b/lib/Routing/Element/Router.php
@@ -73,7 +73,7 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
     /**
      * {@inheritdoc}
      */
-    public function supports(string $name)
+    public function supports($name)
     {
         return $name === 'pimcore_element';
     }

--- a/lib/Routing/Staticroute/Router.php
+++ b/lib/Routing/Staticroute/Router.php
@@ -135,7 +135,7 @@ final class Router implements RouterInterface, RequestMatcherInterface, Versatil
     /**
      * {@inheritdoc}
      */
-    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH)
+    public function generate(string $name, array $parameters = [], int $referenceType = self::ABSOLUTE_PATH)
     {
         // when using $name = false we don't use the default route (happens when $name = null / ZF default behavior)
         // but just the query string generation using the given parameters

--- a/lib/Routing/Staticroute/Router.php
+++ b/lib/Routing/Staticroute/Router.php
@@ -137,15 +137,6 @@ final class Router implements RouterInterface, RequestMatcherInterface, Versatil
      */
     public function generate(string $name, array $parameters = [], int $referenceType = self::ABSOLUTE_PATH)
     {
-        // when using $name = false we don't use the default route (happens when $name = null / ZF default behavior)
-        // but just the query string generation using the given parameters
-        // eg. $this->url(["foo" => "bar"], false) => /?foo=bar
-        if ($name === null) {
-            if (Staticroute::getCurrentRoute() instanceof Staticroute) {
-                $name = Staticroute::getCurrentRoute()->getName();
-            }
-        }
-
         // ABSOLUTE_URL = http://example.com
         // NETWORK_PATH = //example.com
         $needsHostname = self::ABSOLUTE_URL === $referenceType || self::NETWORK_PATH === $referenceType;
@@ -216,8 +207,10 @@ final class Router implements RouterInterface, RequestMatcherInterface, Versatil
             return $url;
         }
 
-        throw new RouteNotFoundException(sprintf('Could not generate URL for route %s as the static route wasn\'t found',
-            $name));
+        throw new RouteNotFoundException(sprintf(
+            'Could not generate URL for route %s as the static route wasn\'t found',
+            $name
+        ));
     }
 
     /**


### PR DESCRIPTION
It is not possible to set an route with an object as name. We must use a string and give the object as parameter.

Before:
`{{ url(document) }}`
`{{ url(object) }}`

After:
`{{ url('pimcore_element', {'element': document}) }}`
`{{ url('pimcore_element', {'element': object}) }}`