### PR TITLE
[Assets] Custom download - rasterize svg in defined file format

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -1176,6 +1176,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
             $thumbnailConfig->setQuality($config['quality']);
             $thumbnailConfig->setFormat($config['format']);
+            $thumbnailConfig->setRasterizeSVG(true);
 
             if ($thumbnailConfig->getFormat() == 'JPEG') {
                 $thumbnailConfig->setPreserveMetaData(true);


### PR DESCRIPTION
## Changes in this pull request  
Issue: Requesting a Download of any SVG Asset as JPEG or PNG will not work and give you a normal SVG Download 

## Additional info  

