### PR TITLE
[Assets] Set remote stream results in 0-byte file

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/asset.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/asset.js
@@ -29,9 +29,14 @@ pimcore.asset.asset = Class.create(pimcore.element.abstract, {
     },
 
     getDataComplete: function (response) {
-
         try {
             this.data = Ext.decode(response.responseText);
+
+            if(this.type !== this.data.type) {
+                pimcore.helpers.closeAsset(this.id);
+                pimcore.helpers.openAsset(this.id, this.data.type);
+                return;
+            }
 
             if (typeof this.data.editlock == "object") {
                 pimcore.helpers.lockManager(this.id, "asset", this.type, this.data);

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1302,7 +1302,7 @@ class Asset extends Element\AbstractElement
 
             if (!$isRewindable) {
                 $tempFile = $this->getTemporaryFile();
-                $dest = fopen($tempFile, 'w+', false, File::getContext());
+                $dest = fopen($tempFile, 'rb', false, File::getContext());
                 $this->stream = $dest;
             }
         } elseif (is_null($stream)) {


### PR DESCRIPTION
Currently there is a bug when calling `Asset::setStream()` with remote streams:
https://github.com/pimcore/pimcore/blob/1953ecc0f32d188fe23cda447710eee3508c021d/models/Asset.php#L1299-L1303

There the `getTemporaryFile()` method creates a local temporary file but then it is tried to open this temporary file with file mode `w+` which "Opens for writing; place the file pointer at the beginning of the file and **truncate the file to zero length**."
For this reason the resulting file has 0 bytes after calling `Asset::save()`.

The JS file fix is because the current behavior of "unknown" asset type is irritating: When you have a Pimcore asset whose filesystem file has 0 byte, Pimcore opens the asset as type `unknown`. When you then later have fixed the error in the import (or whatever created the 0-byte-asset), you will have the correct filesystem file. But when you click reload in the Pimcore backend, it still uses type unknown because in 
https://github.com/pimcore/pimcore/blob/35946764dbf331546ea776f1a1122d727e32adf3/bundles/AdminBundle/Resources/public/js/pimcore/asset/asset.js#L437-L446
the currently loaded asset type gets reused. And so you can reload as often as you want, you will never see the correct asset view (e.g. with asset type "image"). Not even reloading the whole Pimcore backend helps because the asset type is also part of the local storage key. The only way to get the correct view in such a case is to close the asset and then open it again.
This PR changes this by reloading the asset with the correct asset type when the `get-data-by-id` AJAX call returns a different asset type than it was previously assumed.
