### PR TITLE
[DataObjects] Fix localized calculated fields 

### DIFF
--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -279,7 +279,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
         $code .= 'public function get' . ucfirst($key) . ' ($language = null) {' . "\n";
         $code .= "\t" . 'if (!$language) {' . "\n";
         $code .= "\t\t" . 'try {' . "\n";
-        $code .= "\t\t\t" . '$locale = \Pimcore::getContainer()->get("pimcore.locale")->findLocale();'  . "\n";
+        $code .= "\t\t\t" . '$locale = \Pimcore::getContainer()->get("pimcore.locale")->getLocale();'  . "\n";
         $code .= "\t\t\t" . 'if (\Pimcore\Tool::isValidLanguage($locale)) {'  . "\n";
         $code .= "\t\t\t\t" . '$language = (string) $locale;'  . "\n";
         $code .= "\t\t\t" . '} else {'  . "\n";


### PR DESCRIPTION
# Bugfix

With this PR calculated fields in localized fields return the correct locale in cli context.

## Steps to reproduce
1. Create calculated field inside a localized field (this could be the name of a product for example)
![image](https://user-images.githubusercontent.com/9052094/125090908-2d22b200-e0d0-11eb-8e53-1bf1813d0b61.png)
 2. create command
 3. set locale to a none-default locale via `pimcore.locale` service
 4. calculated field will always return default locale