### PR TITLE
[Fixed] Error: "Getting Array to string conversion" on installation

### DIFF
--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -172,7 +172,7 @@ class Composer
 
         //$event->getIO()->write('Run command: ' . implode(' ', $command), false);
 
-        $process = new Process($command, null, null, null, $timeout);
+        $process = new Process(implode(' ', $command), null, null, null, $timeout);
         $process->run(function ($type, $buffer) use ($event, $writeBuffer) {
             if ($writeBuffer) {
                 $event->getIO()->write($buffer, false);


### PR DESCRIPTION
**Steps to reproduce:**
1. Run "COMPOSER_MEMORY_LIMIT=-1 composer create-project pimcore/skeleton my-project" cmd

**Error:**
Script Pimcore\Composer::clearCache handling the pimcore-scripts event terminated with an exception
[ErrorException]
Array to string conversion



