### PR TITLE
Fix Error: "var/config/reports.php doesn't exist"

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20210630062445.php
+++ b/bundles/CoreBundle/Migrations/Version20210630062445.php
@@ -33,6 +33,11 @@ final class Version20210630062445 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $file = Config::locateConfigFile('reports.php');
+
+        if (!file_exists($file)) {
+            return;
+        }
+        
         $config = Config::getConfigInstance($file);
         $config = $config->toArray();
 


### PR DESCRIPTION
Error in migration Version20210630062445:
```
[error] Migration Pimcore\Bundle\CoreBundle\Migrations\Version20210630062445 failed during Execution. Error: "/var/www/html/var/config/reports.php doesn't exist"

In Config.php line 922:
                                                      
  /var/www/html/var/config/reports.php doesn't exist  
```