### PR TITLE
Non-parsable SQL query checking grid permissions

### DIFF
--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -548,7 +548,8 @@ class Dao extends Model\Element\Dao
                 return $firstPermission;
             }
 
-            $permissions = $this->db->fetchRow('SELECT ' . $queryType . ' FROM users_workspaces_object WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $user->getId() . ') DESC, `' . $type . '` DESC  LIMIT 1');
+            $orderByType = $type ? ', `' . $type . '` DESC' : '';
+            $permissions = $this->db->fetchRow('SELECT ' . $queryType . ' FROM users_workspaces_object WHERE cid IN (' . implode(',', $parentIds) . ') AND userId IN (' . implode(',', $userIds) . ') ORDER BY LENGTH(cpath) DESC, FIELD(userId, ' . $user->getId() . ') DESC' . $orderByType . ' LIMIT 1');
 
             return $permissions;
         } catch (\Exception $e) {


### PR DESCRIPTION
Doctrine\DBAL\Driver\PDO\Exception: SQLSTATE[42S22]:
Column not found: 1054 Unknown column '' in 'order clause'
Caused by permissions check without type for custom grid field definitions
https://github.com/pimcore/pimcore/blob/10.x/models/DataObject/Service.php#L1182
Fixed by adding the type order by section conditionally when a type is provided

**To reproduce**
Refresh the grid view in a data object folder when logged in with a user restricted (via roles) using workspaces.
The query doesn't appear to be causing an error in the interface, but I ran into it via a monitoring system.