### PR TITLE
LoginController: fix behavior of /login/csrf-token for logged in users

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/LoginController.php
+++ b/bundles/AdminBundle/Controller/Admin/LoginController.php
@@ -131,7 +131,9 @@ class LoginController extends AdminController implements BruteforceProtectedCont
      */
     public function csrfTokenAction(Request $request, CsrfProtectionHandler $csrfProtection)
     {
-        $csrfProtection->regenerateCsrfToken();
+        if(!$this->getAdminUser()) {
+            $csrfProtection->regenerateCsrfToken();
+        }
 
         return $this->json([
            'csrfToken' => $csrfProtection->getCsrfToken(),


### PR DESCRIPTION
Follow up of #6849

Scenario: 
You have 2 tabs with the Pimcore login page open, 
then you login on one of the tabs, but not on the second tab. 
The CSRF token get's then still refreshed on the tab with the remaining login page and that breaks the CSRF check of the tab with the admin interface. 