### PR TITLE
[DataObject] User - Fix data of user fields empty again after reloading the data object

### DIFF
--- a/models/DataObject/ClassDefinition/Data/User.php
+++ b/models/DataObject/ClassDefinition/Data/User.php
@@ -173,6 +173,12 @@ class User extends Model\DataObject\ClassDefinition\Data\Select
         return array_keys($vars);
     }
 
+    public function __wakeup()
+    {
+        //loads select list options
+        $this->init();
+    }
+
     /**
      * @return $this
      */


### PR DESCRIPTION
## Changes in this pull request  
Resolves #9756

## Additional info  

When reloading object, customlayout -1(master) is passed to the controller, which then calls `getSuperLayoutDefinition` to get the super layout https://github.com/pimcore/pimcore/blob/10.x/models/DataObject/Service.php#L1070 and cleans up the option when serializing data here https://github.com/pimcore/pimcore/blob/10.x/models/DataObject/ClassDefinition/Data/User.php#L171