### PR TITLE
[DataObject] ClassesRebuildCommand - Fix error: Argument #1 ($key) must be of type string, null given

### DIFF
--- a/lib/Model/DataObject/ClassDefinition/ClassDefinitionManager.php
+++ b/lib/Model/DataObject/ClassDefinition/ClassDefinitionManager.php
@@ -41,10 +41,11 @@ class ClassDefinitionManager
 
             $cls = new ClassDefinition();
             $cls->setId($id);
-            $definitionFile = $cls->getDefinitionFile($name);
+            $cls->setName($name);
+            $definitionFile = $cls->getDefinitionFile();
 
             if (!file_exists($definitionFile)) {
-                $deleted[] = [$name, $id];
+                $deleted[] = [$name, $id, self::DELETED];
 
                 //ClassDefinition doesn't exist anymore, therefore we delete it
                 $cls->delete();


### PR DESCRIPTION
## Changes in this pull request  
Resolves #9759

## Additional info  

