### PR TITLE
Temp. files for QR codes should be stored in /var/tmp instead of /tmp…

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -397,7 +397,7 @@ class PageController extends DocumentControllerBase
         $code->setText($url);
         $code->setSize(500);
 
-        $tmpFile = PIMCORE_PRIVATE_VAR . '/qr-code-' . uniqid() . '.png';
+        $tmpFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/qr-code-' . uniqid() . '.png';
         $code->writeFile($tmpFile);
 
         $response = new BinaryFileResponse($tmpFile);

--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -848,7 +848,7 @@ class UserController extends AdminController implements KernelControllerEventInt
         $code->setText($url);
         $code->setSize(200);
 
-        $qrCodeFile = PIMCORE_PRIVATE_VAR . '/qr-code-' . uniqid() . '.png';
+        $qrCodeFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/qr-code-' . uniqid() . '.png';
         $code->writeFile($qrCodeFile);
 
         $response = new BinaryFileResponse($qrCodeFile);


### PR DESCRIPTION
fixes #9742

