### PR TITLE
Fix new phpstan error with Symfony 5.4-dev

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -1179,9 +1179,7 @@ class ClassificationstoreController extends AdminController implements KernelCon
                 }
             }
 
-            if ($keyCriteria) {
-                $conditionParts[] = $keyCriteria;
-            }
+            $conditionParts[] = $keyCriteria;
         }
 
         $start = 0;

--- a/bundles/AdminBundle/Controller/Admin/EmailController.php
+++ b/bundles/AdminBundle/Controller/Admin/EmailController.php
@@ -168,7 +168,9 @@ class EmailController extends AdminController
     {
         if (!empty($data['objectClass'])) {
             $class = '\\' . ltrim($data['objectClass'], '\\');
-            if (!empty($data['objectId']) && is_subclass_of($class, ElementInterface::class)) {
+            $reflection = new \ReflectionClass($class);
+
+            if (!empty($data['objectId']) && $reflection->implementsInterface(ElementInterface::class)) {
                 $obj = $class::getById($data['objectId']);
                 if (is_null($obj)) {
                     $data['objectPath'] = '';
@@ -177,7 +179,7 @@ class EmailController extends AdminController
                 }
                 //check for classmapping
                 if (stristr($class, '\\Pimcore\\Model') === false) {
-                    $niceClassName = '\\' . ltrim(get_parent_class($class), '\\');
+                    $niceClassName = '\\' . ltrim($reflection->getParentClass()->getName(), '\\');
                 } else {
                     $niceClassName = $class;
                 }
@@ -525,7 +527,9 @@ class EmailController extends AdminController
         $data = null;
         if ($params['data']['type'] === 'object') {
             $class = '\\' . ltrim($params['data']['objectClass'], '\\');
-            if (!empty($params['data']['objectId']) && is_subclass_of($class, ElementInterface::class)) {
+            $reflection = new \ReflectionClass($class);
+
+            if (!empty($params['data']['objectId']) && $reflection->implementsInterface(ElementInterface::class)) {
                 $obj = $class::getById($params['data']['objectId']);
                 if (!is_null($obj)) {
                     $data = $obj;

--- a/models/DataObject/ClassDefinition/Data/Numeric.php
+++ b/models/DataObject/ClassDefinition/Data/Numeric.php
@@ -94,14 +94,14 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     /**
      * @internal
      *
-     * @var float
+     * @var float|null
      */
     public $minValue;
 
     /**
      * @internal
      *
-     * @var float
+     * @var float|null
      */
     public $maxValue;
 
@@ -215,7 +215,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     }
 
     /**
-     * @param float $maxValue
+     * @param float|null $maxValue
      */
     public function setMaxValue($maxValue)
     {
@@ -223,7 +223,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getMaxValue()
     {
@@ -231,7 +231,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     }
 
     /**
-     * @param float $minValue
+     * @param float|null $minValue
      */
     public function setMinValue($minValue)
     {
@@ -239,7 +239,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getMinValue()
     {
@@ -521,11 +521,11 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
                 throw new Model\Element\ValidationException('Value in field [ '.$this->getName().' ] is not an integer');
             }
 
-            if (strlen($this->getMinValue()) && $this->getMinValue() > $data) {
+            if ($this->getMinValue() !== null && $this->getMinValue() > $data) {
                 throw new Model\Element\ValidationException('Value in field [ '.$this->getName().' ] is not at least ' . $this->getMinValue());
             }
 
-            if (strlen($this->getMaxValue()) && $data > $this->getMaxValue()) {
+            if ($this->getMaxValue() !== null && $data > $this->getMaxValue()) {
                 throw new Model\Element\ValidationException('Value in field [ '.$this->getName().' ] is bigger than ' . $this->getMaxValue());
             }
 

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -57,7 +57,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
     /**
      * @internal
      *
-     * @var float
+     * @var float|null
      */
     public $defaultValue;
 
@@ -154,23 +154,17 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
     /**
      * @return float|null
      */
-    public function getDefaultValue()
+    public function getDefaultValue(): ?float
     {
-        if ($this->defaultValue !== null) {
-            return (float) $this->defaultValue;
-        }
-
-        return null;
+        return $this->defaultValue;
     }
 
     /**
-     * @param int $defaultValue
+     * @param float|null $defaultValue
      */
-    public function setDefaultValue($defaultValue)
+    public function setDefaultValue(?float $defaultValue): void
     {
-        if (strlen((string)$defaultValue) > 0) {
-            $this->defaultValue = $defaultValue;
-        }
+        $this->defaultValue = $defaultValue;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -154,17 +154,25 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
     /**
      * @return float|null
      */
-    public function getDefaultValue(): ?float
+    public function getDefaultValue()
     {
-        return $this->defaultValue;
+        if ($this->defaultValue !== null) {
+            return (float) $this->defaultValue;
+        }
+
+        return null;
     }
 
     /**
      * @param float|null $defaultValue
      */
-    public function setDefaultValue(?float $defaultValue): void
+    public function setDefaultValue($defaultValue)
     {
-        $this->defaultValue = $defaultValue;
+        if ($defaultValue !== null) {
+            $this->defaultValue = (float) $defaultValue;
+        } else {
+            $this->defaultValue = null;
+        }
     }
 
     /**

--- a/models/DataObject/Classificationstore/KeyConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/KeyConfig/Listing/Dao.php
@@ -81,10 +81,6 @@ class Dao extends Model\Listing\Dao\AbstractDao
             $condition = $condition . ' AND (' . $cond . ')';
         }
 
-        if ($condition) {
-            return ' WHERE ' . $condition . ' ';
-        }
-
-        return '';
+        return ' WHERE ' . $condition . ' ';
     }
 }

--- a/models/Staticroute.php
+++ b/models/Staticroute.php
@@ -385,7 +385,7 @@ final class Staticroute extends AbstractModel
     }
 
     /**
-     * @param int|array $siteId
+     * @param string|array $siteId
      *
      * @return $this
      */


### PR DESCRIPTION
The current 10.x branch have PhpStan errors with Symfony 5.4.x-dev
```
------ ----------------------------------------------------------------------------------- 
  Line   bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php  
 ------ ----------------------------------------------------------------------------------- 
  1182   If condition is always true.                                                       
 ------ ----------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------- 
  Line   bundles/AdminBundle/Controller/Admin/EmailController.php             
 ------ --------------------------------------------------------------------- 
  171    Call to function is_subclass_of() with non-empty-string and          
         'Pimcore\\Model\\Element\\ElementInterface' will always evaluate to  
         false.                                                               
  171    Result of && is always false.                                        
  528    Call to function is_subclass_of() with non-empty-string and          
         'Pimcore\\Model\\Element\\ElementInterface' will always evaluate to  
         false.                                                               
  528    Result of && is always false.                                        
 ------ --------------------------------------------------------------------- 

 ------ ---------------------------------------------------- 
  Line   models/DataObject/ClassDefinition/Data/Numeric.php  
 ------ ---------------------------------------------------- 
  524    Left side of && is always false.                    
  528    Left side of && is always false.                    
 ------ ---------------------------------------------------- 

 ------ -------------------------------------------------------------------- 
  Line   models/DataObject/ClassDefinition/Data/QuantityValue.php            
 ------ -------------------------------------------------------------------- 
  171    Comparison operation ">" between int<1, max> and 0 is always true.  
 ------ -------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------- 
  Line   models/DataObject/Classificationstore/KeyConfig/Listing/Dao.php  
 ------ ----------------------------------------------------------------- 
  84     If condition is always true.                                     
  88     Unreachable statement - code above always terminates.            
 ------ ----------------------------------------------------------------- 

 ------ --------------------------------------------- 
  Line   models/Staticroute.php                       
 ------ --------------------------------------------- 
  398    Ternary operator condition is always false.  
 ------ --------------------------------------------- 
```