### PR TITLE
Fix: labelWidth must be an integer

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/classificationstore.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/classificationstore.js
@@ -54,7 +54,7 @@ pimcore.object.classes.data.classificationstore = Class.create(pimcore.object.cl
         this.specificPanel.removeAll();
 
         this.specificPanel.add({
-            xtype: "textfield",
+            xtype: "numberfield",
             name: "labelWidth",
             fieldLabel: t("label_width"),
             value: this.datax.labelWidth

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/localizedfields.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/localizedfields.js
@@ -172,7 +172,7 @@ pimcore.object.classes.data.localizedfields = Class.create(pimcore.object.classe
             bodyStyle: "padding: 10px;",
             items: [
                 {
-                    xtype: "textfield",
+                    xtype: "numberfield",
                     name: "labelWidth",
                     fieldLabel: t("label_width"),
                     value: this.datax.labelWidth

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/structuredTable.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/structuredTable.js
@@ -81,7 +81,7 @@ pimcore.object.classes.data.structuredTable = Class.create(pimcore.object.classe
                 value: t('height_explanation')
             },
             {
-                xtype: "textfield",
+                xtype: "numberfield",
                 fieldLabel: t("label_width"),
                 name: "labelWidth",
                 value: this.datax.labelWidth

--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -95,7 +95,7 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
     /**
      * @internal
      *
-     * @var string|int
+     * @var int
      */
     public $labelWidth = 0;
 
@@ -917,18 +917,15 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
     }
 
     /**
-     * @param string|int $labelWidth
+     * @param int $labelWidth
      */
     public function setLabelWidth($labelWidth)
     {
-        if (is_numeric($labelWidth)) {
-            $labelWidth = (int)$labelWidth;
-        }
-        $this->labelWidth = $labelWidth;
+        $this->labelWidth = (int)$labelWidth;
     }
 
     /**
-     * @return string|int
+     * @return int
      */
     public function getLabelWidth()
     {

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -1247,7 +1247,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
      */
     public function setLabelWidth($labelWidth)
     {
-        $this->labelWidth = $labelWidth;
+        $this->labelWidth = (int)$labelWidth;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/StructuredTable.php
+++ b/models/DataObject/ClassDefinition/Data/StructuredTable.php
@@ -51,7 +51,7 @@ class StructuredTable extends Data implements ResourcePersistenceAwareInterface,
     /**
      * @internal
      *
-     * @var string|int
+     * @var int
      */
     public $labelWidth = 0;
 
@@ -123,7 +123,7 @@ class StructuredTable extends Data implements ResourcePersistenceAwareInterface,
     }
 
     /**
-     * @return string|int
+     * @return int
      */
     public function getLabelWidth()
     {
@@ -131,16 +131,13 @@ class StructuredTable extends Data implements ResourcePersistenceAwareInterface,
     }
 
     /**
-     * @param string|int $labelWidth
+     * @param int $labelWidth
      *
      * @return $this
      */
     public function setLabelWidth($labelWidth)
     {
-        if (is_numeric($labelWidth)) {
-            $labelWidth = (int)$labelWidth;
-        }
-        $this->labelWidth = $labelWidth;
+        $this->labelWidth = (int)$labelWidth;
 
         return $this;
     }

--- a/models/DataObject/ClassDefinition/Layout/Traits/LabelTrait.php
+++ b/models/DataObject/ClassDefinition/Layout/Traits/LabelTrait.php
@@ -25,7 +25,7 @@ trait LabelTrait
      *
      * @internal
      *
-     * @var string|int
+     * @var int
      */
     public $labelWidth = 100;
 
@@ -37,23 +37,19 @@ trait LabelTrait
     public $labelAlign = 'left';
 
     /**
-     * @param string|int $labelWidth
+     * @param int $labelWidth
      *
      * @return $this
      */
     public function setLabelWidth($labelWidth)
     {
-        if (is_numeric($labelWidth)) {
-            $labelWidth = (int)$labelWidth;
-        }
-
-        $this->labelWidth = $labelWidth;
+        $this->labelWidth = (int)$labelWidth;
 
         return $this;
     }
 
     /**
-     * @return string|int
+     * @return int
      */
     public function getLabelWidth()
     {


### PR DESCRIPTION
## Changes in this pull request  
Resolves #9761

## Additional info  
ExtJS doesn't support labelWidth in percent. Must be an integer.
See: https://docs.sencha.com/extjs/7.4.0/classic/Ext.form.field.Text.html

> labelWidth : Number 
> The width of the fieldLabel in pixels. Only applicable if labelAlign is set to "left" or "right".

Open discussion: https://forum.sencha.com/forum/showthread.php?339242-How-to-specify-labelWidth-in-percentage
