### PR TITLE
fixed speed - better to split into 2 queries then use OR condition

### DIFF
--- a/models/DataObject/Fieldcollection/Dao.php
+++ b/models/DataObject/Fieldcollection/Dao.php
@@ -248,11 +248,13 @@ class Dao extends Model\Dao\AbstractDao
         }
 
         $where = "(ownertype = 'fieldcollection' AND " . $this->db->quoteInto('ownername = ?', $this->model->getFieldname())
-            . ' AND ' . $this->db->quoteInto('src_id = ?', $object->getId()) . ')'
-            . ' OR ' . $whereLocalizedFields;
+            . ' AND ' . $this->db->quoteInto('src_id = ?', $object->getId()) . ')';
 
         // empty relation table
         $this->db->deleteWhere('object_relations_' . $object->getClassId(), $where);
+
+        // better to split into 2 queries then use OR condition (on big tables has to go through all rows so its killing index)
+        $this->db->deleteWhere('object_relations_' . $object->getClassId(), $whereLocalizedFields);
 
         return ['saveFieldcollectionRelations' => true, 'saveLocalizedRelations' => true];
     }

--- a/models/DataObject/Fieldcollection/Dao.php
+++ b/models/DataObject/Fieldcollection/Dao.php
@@ -252,8 +252,6 @@ class Dao extends Model\Dao\AbstractDao
 
         // empty relation table
         $this->db->deleteWhere('object_relations_' . $object->getClassId(), $where);
-
-        // better to split into 2 queries then use OR condition (on big tables has to go through all rows so its killing index)
         $this->db->deleteWhere('object_relations_' . $object->getClassId(), $whereLocalizedFields);
 
         return ['saveFieldcollectionRelations' => true, 'saveLocalizedRelations' => true];


### PR DESCRIPTION
## Changes in this pull request  
When working with fieldcollections and having a lot of objects of the same type the `save()` gets kinda slow, because big tables has to go through all rows so its killing the index.

