### PR TITLE
[Feature][Admin UI] Add data attribute with app environment to body element

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/Index/index.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/Index/index.html.twig
@@ -99,7 +99,7 @@
     <script src="{{ path('fos_js_routing_js', {'callback' : 'fos.Router.setData'}) }}"></script>
 </head>
 
-<body class="pimcore_version_10">
+<body class="pimcore_version_10" data-app-env="{{ app.environment }}">
 
 <div id="pimcore_loading">
     <div class="spinner">


### PR DESCRIPTION
This PR adds a data-attribute `data-app-env` to the body element, which value is the application environment name.

With this information the admin backend can be styled depending on the application environment, e.g. add a warning banner to (non) prod environments.

Example custom code: Style admin backend for non-prod environment differently, so immediately apparent to users that they're not working in the production environment:

```yaml
services:
    # Event subscribers
    App\EventSubscriber\:
        resource: '../src/EventSubscriber/*'
        tags: [ 'kernel.event_subscriber' ]
```

```php
<?php

namespace App\EventSubscriber;

class AdminAssetsSubscriber implements \Symfony\Component\EventDispatcher\EventSubscriberInterface
{
    public static function getSubscribedEvents()
    {
        return [
            \Pimcore\Event\BundleManagerEvents::CSS_PATHS => 'onCssPaths',
        ];
    }

    public function onCssPaths(\Pimcore\Event\BundleManager\PathsEvent $event)
    {
        $event->setPaths(array_merge($event->getPaths(), ['/css/env.css']));
    }
}
```

```css
body:not([data-app-env='prod']) #pimcore_body {
    background: repeating-linear-gradient(
        -45deg,
        #2e5c0d,
        #2e5c0d 5px,
        #0c0f12 30px,
        #0c0f12 10px
    );
}
```