### PR TITLE
Fixed CSS issue in Firefox: drop target icon is misplaced

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/admin.css
+++ b/bundles/AdminBundle/Resources/public/css/admin.css
@@ -1205,6 +1205,7 @@ span.warning {
 }
 
 .pimcore_droptarget_display div {
+    width: 100%;
     min-height: 30px;
     padding: 5px 10px 4px;
     margin-top: 0;


### PR DESCRIPTION
fixes #9682