### PR TITLE
Greater lock TTL for parallel commands

### DIFF
--- a/lib/Console/Traits/Parallelization.php
+++ b/lib/Console/Traits/Parallelization.php
@@ -120,7 +120,7 @@ trait Parallelization
      */
     private function lock($name = null, $blocking = false)
     {
-        $this->lock = \Pimcore::getContainer()->get(LockFactory::class)->createLock($name ?: $this->getName());
+        $this->lock = \Pimcore::getContainer()->get(LockFactory::class)->createLock($name ?: $this->getName(), 86400);
 
         if (!$this->lock->acquire($blocking)) {
             $this->lock = null;


### PR DESCRIPTION
By default all locks currently use the PDOStore, see https://github.com/pimcore/pimcore/blob/eed98a084d6e8852788cbbcaf8f2b67fe60a1ba6/bundles/CoreBundle/Resources/config/services.yml#L226-L229

This store supports TTL and the default TTL is 300 seconds: https://github.com/symfony/lock/blob/69902b2719376c83712c83a265ed5469b1e7c92d/LockFactory.php#L56

For parallel commands which use the `Parallelization` trait currently the default TTL is used (no second argument given for TTL):
https://github.com/pimcore/pimcore/blob/eed98a084d6e8852788cbbcaf8f2b67fe60a1ba6/lib/Console/Traits/Parallelization.php#L137

This leads to multiple parallel processes if the command execution needs longer than 300 seconds. Depending on how long the first process needs, this can stack up until the server goes down.
This PR changes the TTL to 1 day, in analogy to https://github.com/pimcore/pimcore/blob/eed98a084d6e8852788cbbcaf8f2b67fe60a1ba6/lib/Maintenance/Executor.php#L86

PS: I would prefer using a lock store which does not care about TTL like FlockStore but this may be discussed elsewhere.