### PR TITLE
Fix deprecation warnings

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Compiler/WorkflowPass.php
+++ b/bundles/CoreBundle/DependencyInjection/Compiler/WorkflowPass.php
@@ -214,7 +214,7 @@ final class WorkflowPass implements CompilerPassInterface
             // Enable the AuditTrail
             if ($workflowConfig['audit_trail']['enabled']) {
                 $listener = new Definition(Workflow\EventListener\AuditTrailListener::class);
-                $listener->setPrivate(true);
+                $listener->setPublic(false);
                 $listener->addTag('monolog.logger', ['channel' => 'workflow']);
                 $listener->addTag(
                     'kernel.event_listener',
@@ -234,7 +234,7 @@ final class WorkflowPass implements CompilerPassInterface
 
             // Add Guard Listener
             $guard = new Definition(Workflow\EventListener\GuardListener::class);
-            $guard->setPrivate(true);
+            $guard->setPublic(false);
             $configuration = [];
             foreach ($workflowConfig['transitions'] as $transitionName => $config) {
                 if (!isset($config['guard'])) {

--- a/bundles/CoreBundle/Resources/config/services.yml
+++ b/bundles/CoreBundle/Resources/config/services.yml
@@ -46,7 +46,10 @@ services:
             - !abstract  Provider-shared Key
             - '@security.encoder_factory'
             - '%security.authentication.hide_user_not_found%'
-        deprecated: 'The "%service_id%" service is deprecated, use the new authenticator system instead.'
+        deprecated:
+            message: 'The "%service_id%" service is deprecated, use the new authenticator system instead.'
+            package: pimcore/pimcore
+            version: 10.0.4
 
     pimcore.security.validator.user_password:
         class: Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator

--- a/bundles/CoreBundle/Resources/config/templating.yml
+++ b/bundles/CoreBundle/Resources/config/templating.yml
@@ -21,7 +21,10 @@ services:
 
     Pimcore\Templating\Renderer\TagRenderer:
         alias: Pimcore\Templating\Renderer\EditableRenderer
-        deprecated: 'The "%alias_id%" service is deprecated. Use "Pimcore\Templating\Renderer\EditableRenderer" instead'
+        deprecated:
+            message: 'The "%alias_id%" service is deprecated. Use "Pimcore\Templating\Renderer\EditableRenderer" instead'
+            package: pimcore/pimcore
+            version: 6.8
 
     # NAVIGATION
 


### PR DESCRIPTION
```
Since symfony/dependency-injection 5.1: Not setting the attribute "package" of the "deprecated" option in "/var/www/html/vendor/pimcore/pimcore/bundles/CoreBundle/DependencyInjection/../Resources/config/services.yml" is deprecated.

Since symfony/dependency-injection 5.1: Not setting the attribute "version" of the "deprecated" option in "/var/www/html/vendor/pimcore/pimcore/bundles/CoreBundle/DependencyInjection/../Resources/config/services.yml" is deprecated.

Since symfony/dependency-injection 5.1: Not setting the attribute "package" of the "deprecated" option in "/var/www/html/vendor/pimcore/pimcore/bundles/CoreBundle/DependencyInjection/../Resources/config/templating.yml" is deprecated.

Since symfony/dependency-injection 5.1: Not setting the attribute "version" of the "deprecated" option in "/var/www/html/vendor/pimcore/pimcore/bundles/CoreBundle/DependencyInjection/../Resources/config/templating.yml" is deprecated.

Since symfony/dependency-injection 5.2: The "Symfony\Component\DependencyInjection\Definition::setPrivate()" method is deprecated, use "setPublic()" instead.
```