### PR TITLE
Backport: Fix new phpstan error

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -1164,9 +1164,7 @@ class ClassificationstoreController extends AdminController implements KernelCon
                 }
             }
 
-            if ($keyCriteria) {
-                $conditionParts[] = $keyCriteria;
-            }
+            $conditionParts[] = $keyCriteria;
         }
 
         $start = 0;

--- a/bundles/AdminBundle/Controller/Admin/EmailController.php
+++ b/bundles/AdminBundle/Controller/Admin/EmailController.php
@@ -168,7 +168,9 @@ class EmailController extends AdminController
     {
         if (!empty($data['objectClass'])) {
             $class = '\\' . ltrim($data['objectClass'], '\\');
-            if (!empty($data['objectId']) && is_subclass_of($class, ElementInterface::class)) {
+            $reflection = new \ReflectionClass($class);
+
+            if (!empty($data['objectId']) && $reflection->implementsInterface(ElementInterface::class)) {
                 $obj = $class::getById($data['objectId']);
                 if (is_null($obj)) {
                     $data['objectPath'] = '';
@@ -177,7 +179,7 @@ class EmailController extends AdminController
                 }
                 //check for classmapping
                 if (stristr($class, '\\Pimcore\\Model') === false) {
-                    $niceClassName = '\\' . ltrim(get_parent_class($class), '\\');
+                    $niceClassName = '\\' . ltrim($reflection->getParentClass()->getName(), '\\');
                 } else {
                     $niceClassName = $class;
                 }
@@ -525,7 +527,9 @@ class EmailController extends AdminController
         $data = null;
         if ($params['data']['type'] === 'object') {
             $class = '\\' . ltrim($params['data']['objectClass'], '\\');
-            if (!empty($params['data']['objectId']) && is_subclass_of($class, ElementInterface::class)) {
+            $reflection = new \ReflectionClass($class);
+
+            if (!empty($params['data']['objectId']) && $reflection->implementsInterface(ElementInterface::class)) {
                 $obj = $class::getById($params['data']['objectId']);
                 if (!is_null($obj)) {
                     $data = $obj;

--- a/models/DataObject/ClassDefinition/Data/Numeric.php
+++ b/models/DataObject/ClassDefinition/Data/Numeric.php
@@ -94,14 +94,14 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     /**
      * @internal
      *
-     * @var float
+     * @var float|null
      */
     public $minValue;
 
     /**
      * @internal
      *
-     * @var float
+     * @var float|null
      */
     public $maxValue;
 
@@ -215,7 +215,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     }
 
     /**
-     * @param float $maxValue
+     * @param float|null $maxValue
      */
     public function setMaxValue($maxValue)
     {
@@ -223,7 +223,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getMaxValue()
     {
@@ -231,7 +231,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     }
 
     /**
-     * @param float $minValue
+     * @param float|null $minValue
      */
     public function setMinValue($minValue)
     {
@@ -239,7 +239,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getMinValue()
     {
@@ -521,11 +521,11 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
                 throw new Model\Element\ValidationException('Value in field [ '.$this->getName().' ] is not an integer');
             }
 
-            if (strlen($this->getMinValue()) && $this->getMinValue() > $data) {
+            if ($this->getMinValue() !== null && $this->getMinValue() > $data) {
                 throw new Model\Element\ValidationException('Value in field [ '.$this->getName().' ] is not at least ' . $this->getMinValue());
             }
 
-            if (strlen($this->getMaxValue()) && $data > $this->getMaxValue()) {
+            if ($this->getMaxValue() !== null && $data > $this->getMaxValue()) {
                 throw new Model\Element\ValidationException('Value in field [ '.$this->getName().' ] is bigger than ' . $this->getMaxValue());
             }
 

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -57,7 +57,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
     /**
      * @internal
      *
-     * @var float
+     * @var float|null
      */
     public $defaultValue;
 
@@ -164,12 +164,14 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
     }
 
     /**
-     * @param int $defaultValue
+     * @param float|null $defaultValue
      */
     public function setDefaultValue($defaultValue)
     {
-        if (strlen((string)$defaultValue) > 0) {
-            $this->defaultValue = $defaultValue;
+        if ($defaultValue !== null) {
+            $this->defaultValue = (float) $defaultValue;
+        } else {
+            $this->defaultValue = null;
         }
     }
 

--- a/models/DataObject/Classificationstore/KeyConfig/Listing/Dao.php
+++ b/models/DataObject/Classificationstore/KeyConfig/Listing/Dao.php
@@ -81,10 +81,6 @@ class Dao extends Model\Listing\Dao\AbstractDao
             $condition = $condition . ' AND (' . $cond . ')';
         }
 
-        if ($condition) {
-            return ' WHERE ' . $condition . ' ';
-        }
-
-        return '';
+        return ' WHERE ' . $condition . ' ';
     }
 }

--- a/models/Staticroute.php
+++ b/models/Staticroute.php
@@ -385,7 +385,7 @@ final class Staticroute extends AbstractModel
     }
 
     /**
-     * @param int|array $siteId
+     * @param string|array $siteId
      *
      * @return $this
      */


### PR DESCRIPTION
Backport #9770

PhpStan released a new version: https://github.com/phpstan/phpstan/releases/tag/0.12.93

The errors are fixed only in 10.x because the symfony 5.4 check also use the dev version of PhpStan.