### PR TITLE
Fix phpstan error in WorkflowController::submitWorkflowTransition()

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/WorkflowController.php
+++ b/bundles/AdminBundle/Controller/Admin/WorkflowController.php
@@ -147,7 +147,7 @@ class WorkflowController extends AdminController implements KernelControllerEven
 
             $reasons = array_map(function ($blockTransitionItem) {
                 return $blockTransitionItem->getMessage();
-            }, $blockTransitionList->getIterator()->getArrayCopy());
+            }, iterator_to_array($blockTransitionList->getIterator(), true));
 
             $data = [
                 'success' => false,


### PR DESCRIPTION
## Changes in this pull request  
Resolves
```
 ------ ---------------------------------------------------------------- 
  Line   bundles/AdminBundle/Controller/Admin/WorkflowController.php     
 ------ ---------------------------------------------------------------- 
  150    Call to an undefined method Traversable<mixed,                  
         Symfony\Component\Workflow\TransitionBlocker>::getArrayCopy().  
 ------ ---------------------------------------------------------------- 
```
## Additional info  
Affected from: Symfony 5.4.x-dev
