### PR TITLE
Changing "Sort children by" on folder that contains folder breaks

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1184,7 +1184,12 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     private function updateLatestVersionIndex($objectId, $newIndex)
     {
         $object = DataObject\Concrete::getById($objectId);
-        if ($object && $latestVersion = $object->getLatestVersion()) {
+
+        if (
+            $object &&
+            $object->getType() != 'folder' &&
+            $latestVersion = $object->getLatestVersion()
+        ) {
             // don't renew references (which means loading the target elements)
             // Not needed as we just save a new version with the updated index
             $object = $latestVersion->loadData(false);

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1187,7 +1187,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
         if (
             $object &&
-            $object->getType() != 'folder' &&
+            $object->getType() != DataObject::OBJECT_TYPE_FOLDER &&
             $latestVersion = $object->getLatestVersion()
         ) {
             // don't renew references (which means loading the target elements)


### PR DESCRIPTION
Changing "Sort children by" on folder that contains folder breaks causing this error

"Message: Call to undefined method getLatestVersion in class Pimcore\Model\DataObject\Folder"
