### PR TITLE
Fixed ExtJS resize frame on Valid Units in Quantity Values (#9864)

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/inputQuantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/inputQuantityValue.js
@@ -82,7 +82,7 @@ pimcore.object.classes.data.inputQuantityValue = Class.create(pimcore.object.cla
                 xtype: 'multiselect',
                 queryDelay: 0,
                 triggerAction: 'all',
-                resizable: true,
+                resizable: false,
                 width: 600,
                 fieldLabel: t("valid_quantityValue_units"),
                 typeAhead: true,


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #9864
