### PR TITLE
Force id to be string to show the currently active Roles for a User

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
@@ -296,7 +296,10 @@ pimcore.settings.user.user.settings = Class.create({
         });
 
         var rolesStore = Ext.create('Ext.data.ArrayStore', {
-            fields: ["id", "name"],
+            fields: [
+                { type: "string", name: "id" },
+                "name"
+            ],
             data: this.data.roles
         });
 


### PR DESCRIPTION
## Bugfix: Active Roles of existing Users not shown

When editing Users, the Roles they are in are not shown as selected. This is due to the fact, that the ExtJS
MultiSelect Box uses Strings to determine which entries to select, but the ArrayStore contains integers as the id. 

## How to Reproduce

Create some Roles and a User. Assign some Roles to this User. Save it. Close the User Tab!
Reopen the User-Tab: The current Roles are not shown selected in the List, but they should be.
