### PR TITLE
convertToWebPath can return null

### DIFF
--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -283,7 +283,7 @@ trait ImageThumbnailTrait
      *
      * @param array $pathReference
      *
-     * @return string
+     * @return string|null
      */
     protected function convertToWebPath(array $pathReference): ?string
     {

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -285,7 +285,7 @@ trait ImageThumbnailTrait
      *
      * @return string
      */
-    protected function convertToWebPath(array $pathReference): string
+    protected function convertToWebPath(array $pathReference): ?string
     {
         $type = $pathReference['type'] ?? null;
         $path = $pathReference['src'] ?? null;


### PR DESCRIPTION
This method can return null, which will result in a TypeError:

> Pimcore\Model\Asset\Video\ImageThumbnail::convertToWebPath(): Return value must be of type string, null returned

This commit fixes the type error.