### PR TITLE
Check if array is empty before imploding

### DIFF
--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -297,7 +297,10 @@ class GridHelperService
                                 ) . ' AND ' . $brickPrefix . 'fieldname = ' . $db->quote($brickFilterField) . ')';
                             $fieldConditions[] = $brickCondition;
                         }
-                        $conditionPartsFilters[] = '(' . implode(' OR ', $fieldConditions) . ')';
+                        
+                        if (!empty($fieldConditions)) {
+                            $conditionPartsFilters[] = '(' . implode(' OR ', $fieldConditions) . ')';
+                        }
                     } else {
                         $brickCondition = '(' . $brickField->getFilterCondition($filter['value'], $operator,
                                 ['brickPrefix' => $brickPrefix]) . ' AND ' . $brickPrefix . 'fieldname = ' . $db->quote($brickFilterField) . ')';


### PR DESCRIPTION
If  `$filter['value']` is an empty array (`[]`)n the `$conditionPartsFilters` will contain an invalid condition, causing an SQL exception.

Same check as for the following line -  just a different use case: 

https://github.com/pimcore/pimcore/blob/4888053a44f8847866ee1a5822a07626d99e3c1b/bundles/AdminBundle/Helper/GridHelperService.php#L316