### PR TITLE
Trigger fallback language

### DIFF
--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -283,7 +283,6 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
             $translated = $this->translator->trans($normalizedId, $parameters, $domain, $locale);
         }
 
-        $lookForFallback = empty($translated);
         if ($normalizedId != $translated && $translated) {
             return $translated;
         } elseif ($normalizedId == $translated) {
@@ -329,7 +328,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
         }
 
         // now check for custom fallback locales, only for shared translations
-        if ($lookForFallback && $domain == 'messages') {
+        if (($normalizedId == $translated) && $domain == 'messages') {
             foreach (Tool::getFallbackLanguagesFor($locale) as $fallbackLanguage) {
                 $this->lazyInitialize($domain, $fallbackLanguage);
                 $catalogue = $this->getCatalogue($fallbackLanguage);


### PR DESCRIPTION
A fallback language for a parent language is never triggered because `$lookForFallback = empty($translated)` always returns false in function `Pimcore\Translation\Translator::checkForEmptyTranslation`. 

This is because the value for argument `$translated` in `checkForEmptyTranslation` always is equal to the `$id` if no translation is found, see these functions:
- function Pimcore\Translation\Translator::trans
- function Symfony\Component\Translation::get

## Changes in this pull request  
Trigger the fallback language if `$normalizedId` and `$translated` are equal (this assumes no translation was found).