### PR TITLE
Bug disableWidthHeightAttributes fixed

### DIFF
--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -353,13 +353,15 @@ final class Thumbnail
             $path = $this->getPath(true);
             $attributes['src'] = $this->addCacheBuster($path, $options, $image);
         }
+        
+        if (!isset($options['disableWidthHeightAttributes'])) {
+            if ($this->getWidth()) {
+                $attributes['width'] = $this->getWidth();
+            }
 
-        if ($this->getWidth()) {
-            $attributes['width'] = $this->getWidth();
-        }
-
-        if ($this->getHeight()) {
-            $attributes['height'] = $this->getHeight();
+            if ($this->getHeight()) {
+                $attributes['height'] = $this->getHeight();
+            }
         }
 
         $altText = $attributes['alt'] ?? '';


### PR DESCRIPTION
https://pimcore.com/docs/pimcore/current/Development_Documentation/Assets/Working_with_Thumbnails/Image_Thumbnails.html#page_Generating-HTML-for-Thumbnails
The disableWidthHeightAttributes has no effect, but should remove width="" and height="" on image tag
