### PR TITLE
Display faulty countrycodes in ECF backoffice display

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Resources/views/admin_order/detail.html.twig
+++ b/bundles/EcommerceFrameworkBundle/Resources/views/admin_order/detail.html.twig
@@ -279,7 +279,11 @@
                                     {{ order.getCustomerStreet() }}<br/>
                                     {{ order.getCustomerZip() ~ ' - ' ~ order.getCustomerCity() }}<br/>
                                     {% if(order.getCustomerCountry()) %}
-                                        {{ (regionArray[order.getCustomerCountry()])|upper }}<br/>
+                                        {%  if order.getCustomerCountry() in regionArray|keys %}
+                                            {{ (regionArray[order.getCustomerCountry()])|upper }}<br/>
+                                        {% else %}
+                                            {{ order.getCustomerCountry()|upper }}<br/>
+                                        {% endif %}                                        
                                     {% endif %}
 
                                     {% if order.getCustomer() and attribute(order.getCustomer(), 'email') is defined %}


### PR DESCRIPTION
If there's a country code stored in OnlineShopOrder/customerCountry that is not handled by https://github.com/umpirsky/country-list an exception is thrown on the Ecommerce Framework Back Office display page.

This PR fixes this.