### PR TITLE
Add info about lower_case_table_names setting

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
@@ -46,4 +46,11 @@ init-connect='SET NAMES utf8mb4'
 lower_case_table_names=1
 ```
 
-Setting `lower_case_table_names=1` makes sure that tables for Pimcore classes are created in lower case even though their class names contain capital letters.
+Setting `lower_case_table_names=1` makes sure that tables for Pimcore classes are created in lower case even though their class names contain capital letters. Starting with MySQL 8, you can no longer set the `lower_case_table_names` option after the data directory has been initialized. If the directory was already initialized with a different `lower_case_table_names` setting, MySQL will fail to start (`Different lower_case_table_names settings for server and data dictionary`). To fix this, place the `pimcore.cnf` file in the config directory, remove the MySQL data directory and run `mysqld --initialize`. This will delete all databases, so backup the existing databases with `mysqldump` before deleting the data directory.
+
+```bash
+rm -rf /var/lib/mysql
+mkdir /var/lib/mysql
+chown mysql:mysql /var/lib/mysql
+mysqld --initialize
+```


### PR DESCRIPTION
The linked [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_lower_case_table_names) explains the limitations when setting `lower_case_table_names` but using `debconf-set-selections` didn't work for me ([and some other folks](https://bugs.mysql.com/bug.php?id=90695)), so I added a workaround to the docs.

