### PR TITLE
[Bug] Moved downloading image to local file system after deferred check

### DIFF
--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -163,7 +163,7 @@ class Processor
 
         $fileExtension = $format;
         if ($format == 'original') {
-            $fileExtension = \Pimcore\File::getFileExtension($fileSystemPath);
+            $fileExtension = $fileExt;
         } elseif ($format === 'pjpeg' || $format === 'jpeg') {
             $fileExtension = 'jpg';
         }

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -109,15 +109,7 @@ class Processor
             ];
         }
 
-        if (!$fileSystemPath && $asset instanceof Asset) {
-            $fileSystemPath = $asset->getLocalFile();
-        }
-
-        if (is_resource($fileSystemPath)) {
-            $fileSystemPath = self::getLocalFileFromStream($fileSystemPath);
-        }
-
-        $fileExt = File::getFileExtension(basename($fileSystemPath));
+        $fileExt = File::getFileExtension($asset->getFilename());
 
         // simple detection for source type if SOURCE is selected
         if ($format == 'source' || empty($format)) {
@@ -200,6 +192,14 @@ class Processor
         }
 
         // all checks on the file system should be below the deferred part for performance reasons (remote file systems)
+        if (!$fileSystemPath && $asset instanceof Asset) {
+            $fileSystemPath = $asset->getLocalFile();
+        }
+
+        if (is_resource($fileSystemPath)) {
+            $fileSystemPath = self::getLocalFileFromStream($fileSystemPath);
+        }
+        
         if (!file_exists($fileSystemPath)) {
             throw new \Exception(sprintf('Source file %s does not exist!', $fileSystemPath));
         }


### PR DESCRIPTION
## Changes in this pull request  

When generating deferred thumbnails, the asset was always downloaded to the `PIMCORE_SYSTEM_TEMP_DIRECTORY` because `$asset->getLocalPath()` was called before generating the deferred thumbnail path

The only reason I could find is that the file extension was needed to get the proper format. I have changed this to getting the extension from the asset filename, which should always be the same, right?


