### PR TITLE
[Ecommerce] Fix executeTransactionalQuery

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ProductCentricBatchProcessingWorker.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ProductCentricBatchProcessingWorker.php
@@ -433,8 +433,8 @@ abstract class ProductCentricBatchProcessingWorker extends AbstractWorker implem
      */
     protected function executeTransactionalQuery(\Closure $fn, int $maxTries = 3, float $sleep = .5)
     {
-        $this->db->beginTransaction();
         for ($i = 1; $i <= $maxTries; $i++) {
+            $this->db->beginTransaction();
             try {
                 $fn();
 


### PR DESCRIPTION
This PR fixes the `There is no active transaction.` error on second/third try of `executeTransactionalQuery()` in `ProductCentricBatchProcessingWorker.php`.

![image](https://user-images.githubusercontent.com/9052094/127989025-f7d432c0-e516-4b25-b25d-a8bda38df22c.png)

`beginTransaction` opens a transaction, and either `rollback `or `commit `closes it, meaning there is no active transaction on second/third try.