### PR TITLE
Fix DocumentFallbackListener::$fallbackDocument must not be accessed before initialization

### DIFF
--- a/bundles/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
@@ -49,7 +49,7 @@ class DocumentFallbackListener implements EventSubscriberInterface
     /**
      * @var Document|null
      */
-    private ?Document $fallbackDocument;
+    private ?Document $fallbackDocument = null;
 
     public function __construct(
         protected RequestStack $requestStack,


### PR DESCRIPTION
Partly reverted https://github.com/pimcore/pimcore/pull/9912 as it causes the following error on login:

![image](https://user-images.githubusercontent.com/6142086/128017787-2092aa68-80b6-441c-9d17-5cea64f46e44.png)

@Blackbam Could you please recheck this whenever you find some time? Thx!