### PR TITLE
fix: shift timezone on date field

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/IndexController.php
+++ b/bundles/AdminBundle/Controller/Admin/IndexController.php
@@ -234,6 +234,7 @@ class IndexController extends AdminController implements KernelResponseEventInte
             'asset_hide_edit' => (bool)$config['assets']['hide_edit_image'],
             'main_domain' => $config['general']['domain'],
             'timezone' => $config['general']['timezone'],
+            'timezone_offset' => (int)date('Z'),
             'tile_layer_url_template' => $config['maps']['tile_layer_url_template'],
             'geocoding_url_template' => $config['maps']['geocoding_url_template'],
             'reverse_geocoding_url_template' => $config['maps']['reverse_geocoding_url_template'],

--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/metadata/tags/date.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/metadata/tags/date.js
@@ -23,7 +23,7 @@ pimcore.asset.metadata.tags.date = Class.create(pimcore.asset.metadata.tags.abst
         if (typeof data !== "undefined" && data !== null) {
             this.data = data;
         } else if (fieldConfig.useCurrentDate) {
-            this.data = (new Date().getTime()) / 1000;
+            this.data = pimcore.helpers.date.convertBrowserToServerTimestamp(new Date());
         }
 
         this.fieldConfig = fieldConfig;
@@ -39,10 +39,7 @@ pimcore.asset.metadata.tags.date = Class.create(pimcore.asset.metadata.tags.abst
             filter: this.getGridColumnFilter(field),
             renderer:function (key, value, metaData, record) {
                 if (value) {
-                    var timestamp = intval(value) * 1000;
-                    var date = new Date(timestamp);
-
-                    return Ext.Date.format(date, "Y-m-d");
+                    return Ext.Date.format(pimcore.helpers.date.convertServerToBrowserDate(value), "Y-m-d");
                 }
                 return "";
             }.bind(this, field.key)
@@ -69,8 +66,7 @@ pimcore.asset.metadata.tags.date = Class.create(pimcore.asset.metadata.tags.abst
         date.width += date.labelWidth;
 
         if (this.data) {
-            var tmpDate = new Date(intval(this.data) * 1000);
-            date.value = tmpDate;
+            date.value = pimcore.helpers.date.convertServerToBrowserDate(this.data);
         }
 
         this.component = new Ext.form.DateField(date);
@@ -79,7 +75,7 @@ pimcore.asset.metadata.tags.date = Class.create(pimcore.asset.metadata.tags.abst
 
     getValue:function () {
         if (this.component.getValue()) {
-            return this.component.getValue().getTime() / 1000;
+            return pimcore.helpers.date.convertBrowserToServerTimestamp(this.component.getValue());
         }
         return false;
     },
@@ -100,8 +96,7 @@ pimcore.asset.metadata.tags.date = Class.create(pimcore.asset.metadata.tags.abst
 
     convertPredefinedGridData: function(v, r) {
         if (v && !(v instanceof Date)) {
-            var d = new Date(intval(v) * 1000);
-            return d;
+            return pimcore.helpers.date.convertServerToBrowserDate(v);
         }
         return v;
     },
@@ -109,7 +104,7 @@ pimcore.asset.metadata.tags.date = Class.create(pimcore.asset.metadata.tags.abst
     getGridCellRenderer: function(value, metaData, record, rowIndex, colIndex, store) {
         if (value) {
             if(!(value instanceof Date)) {
-                value = new Date(value * 1000);
+                value = pimcore.helpers.date.convertServerToBrowserDate(value);
             }
             return Ext.Date.format(value, "Y-m-d");
         }
@@ -119,7 +114,7 @@ pimcore.asset.metadata.tags.date = Class.create(pimcore.asset.metadata.tags.abst
     marshal: function(value) {
         // value used for submission
         if (value) {
-            value = value.valueOf() / 1000;
+            value = pimcore.helpers.date.convertBrowserToServerTimestamp(value);
         }
 
         return value;
@@ -128,7 +123,7 @@ pimcore.asset.metadata.tags.date = Class.create(pimcore.asset.metadata.tags.abst
     unmarshal: function(value) {
         // process received and transform it to grid value
         if (value) {
-            value = new Date(intval(value) * 1000);
+            value = pimcore.helpers.date.convertServerToBrowserDate(value);
         }
 
         return value;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/date.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/date.js
@@ -19,11 +19,7 @@ pimcore.document.editables.date = Class.create(pimcore.document.editable, {
         this.name = name;
         this.config = this.parseConfig(config);
         this.config.name = id + "_editable";
-
-        this.data = null;
-        if(data) {
-            this.data = new Date(intval(data) * 1000);
-        }
+        this.data = data;
     },
 
     render: function () {
@@ -35,7 +31,7 @@ pimcore.document.editables.date = Class.create(pimcore.document.editable, {
         }
 
         if(this.data) {
-            this.config.value = this.data;
+            this.config.value = pimcore.helpers.date.convertServerToBrowserDate(this.data);
         }
 
         this.element = new Ext.form.DateField(this.config);
@@ -48,9 +44,9 @@ pimcore.document.editables.date = Class.create(pimcore.document.editable, {
 
     getValue: function () {
         if(this.element) {
-            return this.element.getValue();
+            return pimcore.helpers.date.convertBrowserToServerTimestamp(this.element.getValue());
         } else if (this.data) {
-            return Ext.Date.format(this.data, "Y-m-d\\TH:i:s");
+            return this.data;
         }
     },
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers/date.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers/date.js
@@ -1,0 +1,84 @@
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+// some global helper functions
+pimcore.registerNS("pimcore.helpers.date.x");
+
+/**
+ * @param {Date} [date]
+ * @return {int}
+ */
+pimcore.helpers.date.getOffsetToServer = function (date) {
+    if (!date) {
+        date = new Date();
+    }
+    return pimcore.settings.timezone_offset + (date.getTimezoneOffset() * 60);
+}
+
+
+/**
+ * @param {int} timestamp
+ * @return {int}
+ */
+pimcore.helpers.date.shiftTimestampFromServerToLocalTimezone = function (timestamp) {
+    return timestamp + pimcore.helpers.date.getOffsetToServer();
+}
+
+/**
+ * @param {int} timestamp
+ * @return {int}
+ */
+pimcore.helpers.date.shiftTimestampFromLocalToServerTimezone = function (timestamp) {
+    return timestamp - pimcore.helpers.date.getOffsetToServer();
+}
+
+/**
+ * @param {int|string|null} timestamp
+ * @param {boolean} [shiftTimezone=true] Shift timezone from Pimcore server to local browser?
+ * @return {Date|null}
+ */
+pimcore.helpers.date.convertServerToBrowserDate = function (timestamp, shiftTimezone) {
+    if (timestamp === null || timestamp === undefined) {
+        return null;
+    }
+
+    timestamp = intval(timestamp);
+    if (shiftTimezone !== false) {
+        timestamp = pimcore.helpers.date.shiftTimestampFromServerToLocalTimezone(timestamp);
+    }
+    return new Date(timestamp * 1000);
+}
+
+/**
+ *
+ * @param {Date|int|null} date
+ * @param {boolean} [shiftTimezone=true] Shift timezone from local browser server to Pimcore server?
+ * @return {int|null}
+ */
+pimcore.helpers.date.convertBrowserToServerTimestamp = function (date, shiftTimezone) {
+    if (date === null || date === undefined) {
+        return null;
+    }
+
+    var timestamp = date;
+    if (typeof date.getTime === 'function') {
+        timestamp = date.getTime();
+    }
+    timestamp /= 1000;
+
+    if (shiftTimezone !== false) {
+        timestamp = pimcore.helpers.date.shiftTimestampFromLocalToServerTimezone(timestamp);
+    }
+
+    return timestamp;
+}

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/date.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/date.js
@@ -73,7 +73,7 @@ pimcore.object.classes.data.date = Class.create(pimcore.object.classes.data.data
             if (typeof datax.defaultValue === 'object') {
                 tmpDate = datax.defaultValue;
             } else {
-                tmpDate = new Date(datax.defaultValue * 1000);
+                tmpDate = pimcore.helpers.date.convertServerToBrowserDate(datax.defaultValue);
             }
 
             defaultDateConfig.value = tmpDate;
@@ -151,6 +151,9 @@ pimcore.object.classes.data.date = Class.create(pimcore.object.classes.data.data
     applyData: function ($super) {
         $super();
         this.datax.queryColumnType = this.datax.columnType;
+        if (this.datax.defaultValue) {
+            this.datax.defaultValue = pimcore.helpers.date.convertBrowserToServerTimestamp(this.datax.defaultValue);
+        }
     },
 
     applySpecialData: function (source) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/date.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/date.js
@@ -27,7 +27,7 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
         if ((typeof this.data === "undefined" || this.data === null) && this.fieldConfig.defaultValue) {
             this.defaultValue = this.fieldConfig.defaultValue;
         } else if ((typeof this.data === "undefined" || this.data === null) && this.fieldConfig.useCurrentDate) {
-            this.defaultValue = (new Date().getTime()) / 1000;
+            this.defaultValue = pimcore.helpers.date.convertBrowserToServerTimestamp(new Date());
         }
 
         if(this.defaultValue) {
@@ -47,8 +47,7 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
                 }
 
                 if (value) {
-                    var timestamp = intval(value) * 1000;
-                    var date = new Date(timestamp);
+                    var date = pimcore.helpers.date.convertServerToBrowserDate(value);
 
                     return Ext.Date.format(date, "Y-m-d");
                 }
@@ -83,8 +82,7 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
         }
 
         if (this.data) {
-            var tmpDate = new Date(intval(this.data) * 1000);
-            date.value = tmpDate;
+            date.value = pimcore.helpers.date.convertServerToBrowserDate(this.data);
         }
 
         this.component = new Ext.form.DateField(date);
@@ -101,18 +99,13 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
 
     getValue:function () {
         if (this.component.getValue()) {
-            let value = this.component.getValue();
-            if (value && typeof value.getTime == "function") {
-                return value.getTime();
-            } else {
-                return value;
-            }
+            return pimcore.helpers.date.convertBrowserToServerTimestamp(this.component.getValue());
         }
         return false;
     },
 
     getCellEditValue: function () {
-        return this.getValue() / 1000;
+        return this.getValue();
     },
 
     getName:function () {

--- a/bundles/AdminBundle/Resources/views/Admin/Index/index.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/Index/index.html.twig
@@ -220,6 +220,7 @@
     "pimcore/error.js",
 
     "pimcore/treenodelocator.js",
+    "pimcore/helpers/date.js",
     "pimcore/helpers/generic-grid.js",
     "pimcore/helpers/quantityValue.js",
     "pimcore/overrides.js",

--- a/models/DataObject/ClassDefinition/Data/Date.php
+++ b/models/DataObject/ClassDefinition/Data/Date.php
@@ -179,7 +179,7 @@ class Date extends Data implements ResourcePersistenceAwareInterface, QueryResou
     public function getDataFromEditmode($data, $object = null, $params = [])
     {
         if (is_numeric($data)) {
-            return $this->getDateFromTimestamp($data / 1000);
+            return $this->getDateFromTimestamp($data);
         }
 
         return null;
@@ -194,10 +194,6 @@ class Date extends Data implements ResourcePersistenceAwareInterface, QueryResou
      */
     public function getDataFromGridEditor($data, $object = null, $params = [])
     {
-        if ($data) {
-            $data = $data * 1000;
-        }
-
         return $this->getDataFromEditmode($data, $object, $params);
     }
 

--- a/models/Document/Editable/Date.php
+++ b/models/Document/Editable/Date.php
@@ -74,6 +74,10 @@ class Date extends Model\Document\Editable
      */
     public function frontend()
     {
+        if (!$this->date instanceof \DateTimeInterface) {
+            return '';
+        }
+
         $format = null;
 
         if (isset($this->config['outputFormat']) && $this->config['outputFormat']) {
@@ -81,12 +85,10 @@ class Date extends Model\Document\Editable
         } elseif (isset($this->config['format']) && $this->config['format']) {
             $format = $this->config['format'];
         } else {
-            $format = 'Y-m-d\TH:i:sO'; // ISO8601
+            return $this->date->toIso8601String();
         }
 
-        if ($this->date instanceof \DateTimeInterface) {
-            return $this->date->formatLocalized($format);
-        }
+        return $this->date->formatLocalized($format);
     }
 
     /**
@@ -118,9 +120,8 @@ class Date extends Model\Document\Editable
      */
     public function setDataFromEditmode($data)
     {
-        if (strlen($data) > 5) {
-            $timestamp = strtotime($data);
-            $this->setDateFromTimestamp($timestamp);
+        if (is_numeric($data)) {
+            $this->setDateFromTimestamp((int)$data);
         }
 
         return $this;

--- a/tests/_support/Helper/Document/TestDataHelper.php
+++ b/tests/_support/Helper/Document/TestDataHelper.php
@@ -441,7 +441,7 @@ class TestDataHelper extends AbstractTestDataHelper
         $editable = new Date();
         $editable->setName($field);
         $dateStr = '2021-02-1' . ($seed % 10);
-        $editable->setDataFromEditmode($dateStr);
+        $editable->setDataFromEditmode(strtotime($dateStr));
         $page->setEditable($editable);
     }
 


### PR DESCRIPTION
This PR fixes a bug same as https://github.com/pimcore/pimcore/issues/5183 but for the Date field instead of the Datetime field. I gave prio to the Date field as that one was even more obscure. I do want to build an improvement on the Datetime field as well though, based on a similar approach.

Possible BC-BREAK 1: If you have a custom field type extending \Pimcore\Model\DataObject\ClassDefinition\Data\Date, then the change in getDataFromEditmode / getDataFromGridEditor might cause issues. I've changed it to consequently use the normal timestamp. The getDataFromEditmode method was the only PHP method using the Javascript millisecond format

Possible BC-BREAK 2: If you have a custom editable type extending \Pimcore\Model\Document\Editable\Date, then the change in setDataFromEditmode might cause issues. I've changed it to consequently use a timestamp (trough the entire system).

--- 

Error: Depending on the timezone of the browser and the timezone of the
Pimcore server the stored date may be either correct, one day earlier or
one day later than the date entered by the user.

Caused by: The date is selected in the browser using the user's timezone
and sent to the server as timestamp. For example if the user is in CEST
and selects "2021-08-03" then the timestamp for "2021-08-03 00:00:00
CEST" is sent to the server. But if the server is configured to use the
New York timezone, it converts that timestamp to "2021-08-02 18:00:00
EDT" and thus stores "2021-08-02" (if DATE MySQL column is used).
Similar issues occurs for the TIMESTAMP MySQL column.

Resolved by: Shifting timezone on the entered date when receiving data
from or sending data to Pimcore.

