### PR TITLE
Add support for condition variable types when using the Note Listing

### DIFF
--- a/models/Element/Note/Listing/Dao.php
+++ b/models/Element/Note/Listing/Dao.php
@@ -31,7 +31,11 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function load()
     {
-        $notesData = $this->db->fetchCol('SELECT id FROM notes' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $notesData = $this->db->fetchCol(
+            'SELECT id FROM notes' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
+            $this->model->getConditionVariables(),
+            $this->model->getConditionVariableTypes()
+        );
 
         $notes = [];
         foreach ($notesData as $noteData) {
@@ -50,7 +54,11 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function loadIdList()
     {
-        $notesIds = $this->db->fetchCol('SELECT id FROM notes' . $this->getCondition() . $this->getGroupBy() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $notesIds = $this->db->fetchCol(
+            'SELECT id FROM notes' . $this->getCondition() . $this->getGroupBy() . $this->getOrder() . $this->getOffsetLimit(),
+            $this->model->getConditionVariables(),
+            $this->model->getConditionVariableTypes()
+        );
 
         return array_map('intval', $notesIds);
     }
@@ -61,7 +69,11 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount()
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM notes ' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int)$this->db->fetchOne(
+                'SELECT COUNT(*) FROM notes ' . $this->getCondition(),
+                $this->model->getConditionVariables(),
+                $this->model->getConditionVariableTypes()
+            );
         } catch (\Exception $e) {
             return 0;
         }


### PR DESCRIPTION
## Changes in this pull request  

Previously the Listing class for Notes did not take the condition variable types into account when building the query. This made it impossible to perform some advanced queries on the notes, such as using the `IN(?)` operator with an array of strings.

## Additional info  

Example
```
$notes->setCondition("type IN (?)", [['erp_import', 'workflow]]);
```

Without the `conditionVariableTypes` the array of strings is not processed correctly when preparing the query.