### PR TITLE
Avoid var_dump-ing exceptions

### DIFF
--- a/lib/Log/ApplicationLogger.php
+++ b/lib/Log/ApplicationLogger.php
@@ -399,17 +399,30 @@ class ApplicationLogger implements LoggerInterface
         ], $context));
     }
 
-    private static function createExceptionFileObject(\Throwable $exceptionObject)
+    private static function exceptionToString(\Throwable $exceptionObject, bool $includeStackTrace, bool $includePrevious = false): string
     {
-        //workaround to prevent "nesting level to deep" errors when used var_export()
-        ob_start();
-        var_dump($exceptionObject);
-        $dataDump = ob_get_clean();
+        $data = [
+            $exceptionObject->getMessage(),
+            "File: " . $exceptionObject->getFile(),
+            "Line: " . $exceptionObject->getLine(),
+            "Code: " . $exceptionObject->getCode(),
+        ];
 
-        if (!$dataDump) {
-            $dataDump = $exceptionObject->getMessage();
+        if ($includeStackTrace) {
+            $data[] = "Trace: " . $exceptionObject->getTraceAsString();
         }
 
-        return new FileObject($dataDump);
+        if ($includePrevious) {
+            $data[] = "Previous: " . self::exceptionToString($exceptionObject->getPrevious(), true);
+        }
+
+        $exceptionString =  implode(", ", $data);
+        return $exceptionString;
+    }
+    
+    private static function createExceptionFileObject(\Throwable $exceptionObject)
+    {
+        $data = self::exceptionToString($exceptionObject, true, true);
+        return new FileObject($data);
     }
 }

--- a/lib/Log/ApplicationLogger.php
+++ b/lib/Log/ApplicationLogger.php
@@ -412,7 +412,7 @@ class ApplicationLogger implements LoggerInterface
             $data[] = "Trace: " . $exceptionObject->getTraceAsString();
         }
 
-        if ($includePrevious) {
+        if ($includePrevious && $exceptionObject->getPrevious()) {
             $data[] = "Previous: " . self::exceptionToString($exceptionObject->getPrevious(), true);
         }
 

--- a/lib/Log/ApplicationLogger.php
+++ b/lib/Log/ApplicationLogger.php
@@ -413,7 +413,7 @@ class ApplicationLogger implements LoggerInterface
         }
 
         if ($includePrevious && $exceptionObject->getPrevious()) {
-            $data[] = "Previous: " . self::exceptionToString($exceptionObject->getPrevious(), true);
+            $data[] = "Previous: " . self::exceptionToString($exceptionObject->getPrevious(), $includeStackTrace);
         }
 
         $exceptionString =  implode(", ", $data);

--- a/lib/Log/ApplicationLogger.php
+++ b/lib/Log/ApplicationLogger.php
@@ -409,15 +409,14 @@ class ApplicationLogger implements LoggerInterface
         ];
 
         if ($includeStackTrace) {
-            $data[] = "Trace: " . $exceptionObject->getTraceAsString();
+            $data[] = "Trace:\n" . $exceptionObject->getTraceAsString();
         }
 
         if ($includePrevious && $exceptionObject->getPrevious()) {
-            $data[] = "Previous: " . self::exceptionToString($exceptionObject->getPrevious(), $includeStackTrace);
+            $data[] = "\nPrevious:\n" . self::exceptionToString($exceptionObject->getPrevious(), $includeStackTrace);
         }
 
-        $exceptionString =  implode(", ", $data);
-        return $exceptionString;
+        return implode("\n", $data);
     }
     
     private static function createExceptionFileObject(\Throwable $exceptionObject)


### PR DESCRIPTION
For long stack traces and nested previous exceptions the `var_dump()` of an exception object may fail with error `mmap() failed: [12] Cannot allocate memory`, which is especially fatal because the `logException()` method is generally called inside a ´catch` block.

This PR suggests to just print a string message including the stacktrace of the exceptions and not doing a `var_dump()`. 

What do you think about the idea? 
What about the suggested formatting, should we better use JSONs for the FileObjects format?