### PR TITLE
`bin/console list` throws error when symfony/maker-bundle is installed

### DIFF
--- a/lib/Console/Application.php
+++ b/lib/Console/Application.php
@@ -104,9 +104,9 @@ final class Application extends \Symfony\Bundle\FrameworkBundle\Console\Applicat
 
     public function add(Command $command)
     {
-        $definition = $command->getDefinition();
-
         if ($command instanceof DoctrineCommand) {
+            $definition = $command->getDefinition();
+
             // add filter option
             $definition->addOption(new InputOption(
                 'prefix',


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
The maker-bundle throws an exception on running `bin/console list`:

```
In MakerCommand.php line 120:
                               
  Application cannot be null.  
```

Steps to reproduce:
 1. Install Pimcore 10.x (tested with 10.0.9 and 10.1.0)
 2. Add MakerBundle `composer require symfony/maker-bundle`
 3. Activate MakerBundle (add `\Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true]` to `config/bundles.php`)
 4. run `bin/console list`

I could fix this with the changes I made in this PR.

`$definition` is only needed when the command is an Instance of DoctrineCommand, therefore i think it is okay to load it after we checked the objecttype.

