### PR TITLE
[DataObjects][Folders] Fix "Warning: undefined array key"

### DIFF
--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1205,7 +1205,7 @@ class Service extends Model\Element\Service
             if (is_array($allowedLayoutIds)) {
                 foreach ($allowedLayoutIds as $allowedLayoutId) {
                     if ($allowedLayoutId) {
-                        if (!$layoutDefinitions[$allowedLayoutId]) {
+                        if (!isset($layoutDefinitions[$allowedLayoutId]) || !$layoutDefinitions[$allowedLayoutId]) {
                             $customLayout = ClassDefinition\CustomLayout::getById($allowedLayoutId);
                             if (!$customLayout) {
                                 continue;


### PR DESCRIPTION
## Changes in this pull request  

When a user has a custom layout set for a specific DataObject workspace, after opening the folder associated to that workspace a "Warning: Undefined array key {customLayoutId}" is thrown.

Steps to reproduce:

1. Set APP_ENV=dev
2. Create a user, grant him the "Objects" permission and add a DataObject workspace with all permissions checked and a custom layout set
3. Login as that user
4. Open the folder associated to the workspace you just created. A warning will be thrown.


This PR fixes this problem.