### PR TITLE
[Data Objects] Exacter typehints for data object class getter / setter methods

### DIFF
--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -1040,7 +1040,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
      */
     public function getPhpdocInputType(): ?string
     {
-        return '\\Pimcore\\Model\\DataObject\\Data\\ObjectMetadata[]';
+        return '\\'.DataObject\Data\ObjectMetadata::class.'[]';
     }
 
     /**
@@ -1048,6 +1048,6 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
      */
     public function getPhpdocReturnType(): ?string
     {
-        return '\\Pimcore\\Model\\DataObject\\Data\\ObjectMetadata[]';
+        return '\\'.DataObject\Data\ObjectMetadata::class.'[]';
     }
 }

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -1064,7 +1064,7 @@ class AdvancedManyToManyRelation extends ManyToManyRelation implements IdRewrite
      */
     public function getPhpdocInputType(): ?string
     {
-        return '\\Pimcore\\Model\\DataObject\\Data\\ElementMetadata[]';
+        return '\\'.DataObject\Data\ElementMetadata::class.'[]';
     }
 
     /**
@@ -1072,6 +1072,6 @@ class AdvancedManyToManyRelation extends ManyToManyRelation implements IdRewrite
      */
     public function getPhpdocReturnType(): ?string
     {
-        return '\\Pimcore\\Model\\DataObject\\Data\\ElementMetadata[]';
+        return '\\'.DataObject\Data\ElementMetadata::class.'[]';
     }
 }

--- a/models/DataObject/ClassDefinition/Data/Geopolygon.php
+++ b/models/DataObject/ClassDefinition/Data/Geopolygon.php
@@ -306,7 +306,7 @@ class Geopolygon extends AbstractGeo implements ResourcePersistenceAwareInterfac
      */
     public function getPhpdocInputType(): ?string
     {
-        return 'array|null';
+        return '\\'.DataObject\Data\GeoCoordinates::class.'[]|null';
     }
 
     /**
@@ -314,7 +314,7 @@ class Geopolygon extends AbstractGeo implements ResourcePersistenceAwareInterfac
      */
     public function getPhpdocReturnType(): ?string
     {
-        return 'array|null';
+        return '\\'.DataObject\Data\GeoCoordinates::class.'[]|null';
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Geopolyline.php
+++ b/models/DataObject/ClassDefinition/Data/Geopolyline.php
@@ -311,7 +311,7 @@ class Geopolyline extends AbstractGeo implements
      */
     public function getPhpdocInputType(): ?string
     {
-        return 'array|null';
+        return '\\'.DataObject\Data\GeoCoordinates::class.'[]|null';
     }
 
     /**
@@ -319,7 +319,7 @@ class Geopolyline extends AbstractGeo implements
      */
     public function getPhpdocReturnType(): ?string
     {
-        return 'array|null';
+        return '\\'.DataObject\Data\GeoCoordinates::class.'[]|null';
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -675,7 +675,7 @@ class Multiselect extends Data implements
      */
     public function getPhpdocInputType(): ?string
     {
-        return 'array|null';
+        return 'string[]|null';
     }
 
     /**
@@ -683,7 +683,7 @@ class Multiselect extends Data implements
      */
     public function getPhpdocReturnType(): ?string
     {
-        return 'array|null';
+        return 'string[]|null';
     }
 
     /**


### PR DESCRIPTION
Replaces hard-coded class FQNs with `::class`.
Replaces `array` by more specific type plus `[]` appendix.

If we need a migration which regenerated data object classes, jsut give me a note. But as no behaviour is changed, imho this is not necessary.