### PR TITLE
ListCommand: Fix array_combine error

### DIFF
--- a/bundles/CoreBundle/Command/Bundle/ListCommand.php
+++ b/bundles/CoreBundle/Command/Bundle/ListCommand.php
@@ -84,7 +84,6 @@ class ListCommand extends AbstractBundleCommand
                 $row[] = false;
                 $row[] = false;
                 $row[] = false;
-                $row[] = false;
                 $row[] = 0;
             }
 


### PR DESCRIPTION
Fix error when I call the command with --json option and one bundle is not enabled:
```
php bin/console pimcore:bundle:list --json

In ListCommand.php line 96:
                                                                               
  array_combine(): Argument #1 ($keys) and argument #2 ($values) must have th  
  e same number of elements                                                    
                                                                               

pimcore:bundle:list [-f|--fully-qualified-classnames] [--json]

Failed to execute command php bin/console pimcore:bundle:list --json: exit status 255
```