### PR TITLE
Preventing unnecessary calls to transformation methods (especially fo…

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PIMCORE_PROJECT_ROOT="~/pimcore-rebase"

--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-PIMCORE_PROJECT_ROOT="~/pimcore-rebase"

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -299,7 +299,7 @@ class Processor
             // sorry for the goto/label - but in this case it makes life really easier and the code more readable
             prepareTransformations:
 
-            foreach ($transformations as $transformation) {
+            foreach ($transformations as &$transformation) {
                 if (!empty($transformation) && !$transformation['isApplied'] ?? true) {
                     $arguments = [];
 

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -368,11 +368,11 @@ class Processor
                     ksort($arguments);
                     if (!is_string($transformation['method']) && is_callable($transformation['method'])) {
                         $transformation['method']($image);
-                        $transformation['isApplied'] = true;
                     } elseif (method_exists($image, $transformation['method'])) {
                         call_user_func_array([$image, $transformation['method']], $arguments);
-                        $transformation['isApplied'] = true;
                     }
+
+                    $transformation['isApplied'] = true;
                 }
             }
         }

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -306,14 +306,6 @@ class Processor
                     if (is_string($transformation['method'])) {
                         $mapping = self::$argumentMapping[$transformation['method']];
 
-                        if (in_array($transformation['method'], ['cropPercent'])) {
-                            //avoid double cropping in case of $highResFactor re-calculation (goto prepareTransformations)
-                            if ($imageCropped) {
-                                continue;
-                            }
-                            $imageCropped = true;
-                        }
-
                         if (is_array($transformation['arguments'])) {
                             foreach ($transformation['arguments'] as $key => $value) {
                                 $position = array_search($key, $mapping);

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -300,7 +300,7 @@ class Processor
             prepareTransformations:
 
             foreach ($transformations as &$transformation) {
-                if (!empty($transformation) && (isset($transformation['isApplied']) && !$transformation['isApplied'])) {
+                if (!empty($transformation) && !isset($transformation['isApplied'])) {
                     $arguments = [];
 
                     if (is_string($transformation['method'])) {

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -300,7 +300,7 @@ class Processor
             prepareTransformations:
 
             foreach ($transformations as $transformation) {
-                if (!empty($transformation)) {
+                if (!empty($transformation) && !$transformation['isApplied'] ?? true) {
                     $arguments = [];
 
                     if (is_string($transformation['method'])) {
@@ -368,8 +368,10 @@ class Processor
                     ksort($arguments);
                     if (!is_string($transformation['method']) && is_callable($transformation['method'])) {
                         $transformation['method']($image);
+                        $transformation['isApplied'] = true;
                     } elseif (method_exists($image, $transformation['method'])) {
                         call_user_func_array([$image, $transformation['method']], $arguments);
+                        $transformation['isApplied'] = true;
                     }
                 }
             }

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -300,7 +300,7 @@ class Processor
             prepareTransformations:
 
             foreach ($transformations as &$transformation) {
-                if (!empty($transformation) && !$transformation['isApplied'] ?? true) {
+                if (!empty($transformation) && (isset($transformation['isApplied']) && !$transformation['isApplied'])) {
                     $arguments = [];
 
                     if (is_string($transformation['method'])) {


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Prevents image transformations to be called multiple times and do funny stuff to images.
Example: you have 2 transformations: 1 for rotation (from e.g. exif data) and 1 for highres manipulation.
The chain will apply the rotation and then the resizing for highres, then the _goto_ command will start from the beginning and then reapplying the rotation which will result in a wrong orientation.



