### PR TITLE
Fix admin translation export

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -261,7 +261,7 @@ class TranslationController extends AdminController
         foreach ($translations as $t) {
             $tempRow = [];
             foreach ($columns as $key) {
-                $value = array_key_exists($key, $t) ? $t[$key] : null;
+                $value = $t[$key] ?? null;
                 //clean value of evil stuff such as " and linebreaks
                 if (is_string($value)) {
                     $value = Tool\Text::removeLineBreaks($value);

--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -261,7 +261,7 @@ class TranslationController extends AdminController
         foreach ($translations as $t) {
             $tempRow = [];
             foreach ($columns as $key) {
-                $value = $t[$key];
+                $value = array_key_exists($key, $t) ? $t[$key] : null;
                 //clean value of evil stuff such as " and linebreaks
                 if (is_string($value)) {
                     $value = Tool\Text::removeLineBreaks($value);


### PR DESCRIPTION
When exporting Admin translations with keys which doesn't have any translations, an exception is raised.
Checking if key exist inside translation array (and if not return null) fix the problem.