### PR TITLE
[Data objects] Trigger preObjectSave and postObjectSave JS events for data object folders

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/folder.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/folder.js
@@ -343,6 +343,22 @@ pimcore.object.folder = Class.create(pimcore.object.abstract, {
 
         this.tab.mask();
 
+        try {
+            pimcore.plugin.broker.fireEvent('preSaveObject', this, 'object');
+        } catch (e) {
+            if (e instanceof pimcore.error.ValidationException) {
+                this.tab.unmask();
+                pimcore.helpers.showPrettyError('object', t("error"), t("saving_failed"), e.message);
+                return false;
+            }
+
+            if (e instanceof pimcore.error.ActionCancelledException) {
+                this.tab.unmask();
+                pimcore.helpers.showNotification(t("Info"), 'Object folder not saved: ' + e.message, 'info');
+                return false;
+            }
+        }
+
         Ext.Ajax.request({
             url: Routing.generate('pimcore_admin_dataobject_dataobject_savefolder', {task: task}),
             method: "PUT",
@@ -353,6 +369,8 @@ pimcore.object.folder = Class.create(pimcore.object.abstract, {
                     if (rdata && rdata.success) {
                         pimcore.helpers.showNotification(t("success"), t("saved_successfully"), "success");
                         this.resetChanges();
+
+                        pimcore.plugin.broker.fireEvent("postSaveObject", this);
                     }
                     else {
                         pimcore.helpers.showNotification(t("error"), t("saving_failed"),


### PR DESCRIPTION
While for asset and document folders the JS events `preAssetSave` and `preDocumentSave` get triggered, this is not the case for data object folders. 

With this PR `preObjectSave` and `postObjectSave` get triggered when saving a data object folder.