### PR TITLE
[ADMIN] Change the way, the admin index template is used

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/IndexController.php
+++ b/bundles/AdminBundle/Controller/Admin/IndexController.php
@@ -41,6 +41,7 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 
 /**
  * @internal
@@ -62,6 +63,7 @@ class IndexController extends AdminController implements KernelResponseEventInte
 
     /**
      * @Route("/", name="pimcore_admin_index", methods={"GET"})
+     * @Template(template="@PimcoreAdmin/Admin/Index/index.html.twig")
      *
      * @param Request $request
      * @param SiteConfigProvider $siteConfigProvider
@@ -111,7 +113,7 @@ class IndexController extends AdminController implements KernelResponseEventInte
         $this->eventDispatcher->dispatch($settingsEvent, AdminEvents::INDEX_ACTION_SETTINGS);
         $templateParams['settings'] = $settingsEvent->getSettings();
 
-        return $this->render('@PimcoreAdmin/Admin/Index/index.html.twig', $templateParams);
+        return $templateParams;
     }
 
     /**


### PR DESCRIPTION
Change from hardcoded template rendering to the Symfony way of doing things, so you can easily override the admin template if needed

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Remove hardcoded template reference to annotation

