### PR TITLE
Fix handling of temporary files and streams from storage

### DIFF
--- a/lib/Helper/TemporaryFileHelperTrait.php
+++ b/lib/Helper/TemporaryFileHelperTrait.php
@@ -33,7 +33,7 @@ trait TemporaryFileHelperTrait
      */
     protected static function getLocalFileFromStream($stream): string
     {
-        if (!stream_is_local($stream) || stream_get_meta_data($stream)['uri'] == 'php://temp') {
+        if (!stream_is_local($stream) || stream_get_meta_data($stream)['uri'] === 'php://temp') {
             $stream = self::getTemporaryFileFromStream($stream);
         }
 

--- a/lib/Helper/TemporaryFileHelperTrait.php
+++ b/lib/Helper/TemporaryFileHelperTrait.php
@@ -33,7 +33,7 @@ trait TemporaryFileHelperTrait
      */
     protected static function getLocalFileFromStream($stream): string
     {
-        if (!stream_is_local($stream)) {
+        if (!stream_is_local($stream) || stream_get_meta_data($stream)['uri'] == 'php://temp') {
             $stream = self::getTemporaryFileFromStream($stream);
         }
 

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -391,7 +391,9 @@ class Processor
                 $image->save($tmpFsPath, $format, $config->getQuality());
                 $stream = fopen($tmpFsPath, 'rb');
                 $storage->writeStream($storagePath, $stream);
-                fclose($stream);
+                if(is_resource($stream)) {
+                    fclose($stream);
+                }
                 unlink($tmpFsPath);
 
                 $generated = true;


### PR DESCRIPTION
### Expected behavior

You are able to use the GoogleCloudStorage Adapter for Flysystem (https://github.com/thephpleague/flysystem-google-cloud-storage) with pimcore. Assets and Thumbnails shoudl be correctly stored and retrieved from GoogleCloudStorage.

### Actual behavior

Exceptions get thrown wehn generating thumbnails for a just uploaded image, because Thumbnail Processor can't access the images data stream.

### Steps to reproduce

-  Configure your pimcore instance to use GoogleCloudStorage Adapter for Flysystem (https://github.com/thephpleague/flysystem-google-cloud-storage), at least for asset storage.
- Try to upload an image asset
- You get an error message 
`Uncaught PHP Exception TypeError: "Pimcore\Model\Asset\Image\Thumbnail::getLocalFileFromStream(): Return value must be of type string, null returned" at /var/www/html/vendor/pimcore/pimcore/lib/Helper/TemporaryFileHelperTrait.php line 45`


### Additional Notes
The underlying Google libraries use php://temp as a streaming vehicle. When pimcore tries to access the data as a file, this fails (https://github.com/pimcore/pimcore/blob/10.x/models/Asset/Image/Thumbnail/Processor.php#L203)

I adapted TemporaryFileHelperTrait to detect if the stream is a php://temp stream, so that pimcore would create a temporary file out of the data, too.

Also, GoogleCloudStorage Adapter or the underlying Google library seams to close a stream after writing to a bucket. So I introduced a check to only close the stream if it wasn't already closed. Without this change, the following exception would be thrown:
```
Source file php://temp does not exist! in /var/www/html/vendor/pimcore/pimcore/models/Asset/Image/Thumbnail/Processor.php:204
Stack trace:
0 /var/www/html/vendor/pimcore/pimcore/models/Asset/Image/Thumbnail.php(170): Pimcore\Model\Asset\Image\Thumbnail\Processor::process()
1 /var/www/html/vendor/pimcore/pimcore/models/Asset/Thumbnail/ImageThumbnailTrait.php(113): Pimcore\Model\Asset\Image\Thumbnail->generate()
2 /var/www/html/vendor/pimcore/pimcore/models/Asset/Image/Thumbnail.php(110): Pimcore\Model\Asset\Image\Thumbnail->getPathReference()
3 /var/www/html/vendor/pimcore/pimcore/models/Asset/Thumbnail/ImageThumbnailTrait.php(319): Pimcore\Model\Asset\Image\Thumbnail->getStream()
4 /var/www/html/vendor/pimcore/pimcore/models/Asset/Image.php(152): Pimcore\Model\Asset\Image\Thumbnail->getLocalFile()
5 /var/www/html/vendor/pimcore/pimcore/models/Asset/Image.php(100): Pimcore\Model\Asset\Image->detectFaces()
6 /var/www/html/vendor/pimcore/pimcore/models/Asset.php(735): Pimcore\Model\Asset\Image->postPersistData()
7 /var/www/html/vendor/pimcore/pimcore/models/Asset/Image.php(79): Pimcore\Model\Asset->update()
8 /var/www/html/vendor/pimcore/pimcore/models/Asset.php(534): Pimcore\Model\Asset\Image->update()
9 /var/www/html/src/Verivox/HeraclesTestsBundle/MigrationHelper/AssetTrait.php(39): Pimcore\Model\Asset->save()