### PR TITLE
Error if you want left join a Asset Listing to assets_metadata table

### DIFF
--- a/models/Asset/Listing/Dao.php
+++ b/models/Asset/Listing/Dao.php
@@ -37,7 +37,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         $assets = [];
 
-        $queryBuilder = $this->getQueryBuilder(['id', 'type']);
+        $queryBuilder = $this->getQueryBuilder(['assets.id', 'assets.type']);
         $assetsData = $this->db->fetchAll((string) $queryBuilder, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         foreach ($assetsData as $assetData) {
@@ -75,7 +75,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function loadIdList()
     {
-        $queryBuilder = $this->getQueryBuilder(['id']);
+        $queryBuilder = $this->getQueryBuilder(['assets.id']);
         $assetIds = $this->db->fetchCol((string) $queryBuilder, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         return array_map('intval', $assetIds);

--- a/models/Document/Listing/Dao.php
+++ b/models/Document/Listing/Dao.php
@@ -37,7 +37,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function load()
     {
         $documents = [];
-        $select = $this->getQueryBuilder(['id', 'type']);
+        $select = $this->getQueryBuilder(['documents.id', 'documents.type']);
 
         $documentsData = $this->db->fetchAll((string) $select, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
@@ -76,7 +76,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function loadIdList()
     {
-        $queryBuilder = $this->getQueryBuilder(['id']);
+        $queryBuilder = $this->getQueryBuilder(['documents.id']);
         $documentIds = $this->db->fetchCol((string) $queryBuilder, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         return array_map('intval', $documentIds);
@@ -87,7 +87,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
      */
     public function loadIdPathList()
     {
-        $queryBuilder = $this->getQueryBuilder(['id', 'CONCAT(path,`key`) as path']);
+        $queryBuilder = $this->getQueryBuilder(['documents.id', 'CONCAT(documents.path, documents.key) as path']);
         $documentIds = $this->db->fetchAll((string) $queryBuilder, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         return $documentIds;


### PR DESCRIPTION
I get an error when I want to left join the Asset Listing to assets_metadata table. In 6.9 this works with the old QueryBuilder.

Example:

```
$listing = new Listing();
$listing->onCreateQueryBuilder(static function (QueryBuilder $select) {
    $select->leftJoin(
        'assets',
        'assets_metadata',
        'category',
        'assets.id = category.cid AND category.name = \'category\''
    );
});
$listing->setCondition('category.data = 456');
$assets = $listing->getData();
```

Error:
`SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'type' in field list is ambiguous").`