### PR TITLE
[Document Tree] - Correct check for variable localizedErrorDocumentsData

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
@@ -1618,7 +1618,7 @@ pimcore.document.tree = Class.create({
                     fieldLabel: t("error_page") + " (" + availableLanguages[language] + ")",
                     name: "errorDocument.localized." + language,
                     fieldCls: "input_drop_target",
-                    value: localizedErrorDocumentsData && localizedErrorDocumentsData[language] ? localizedErrorDocumentsData[language] : '',
+                    value: (localizedErrorDocumentsData && localizedErrorDocumentsData[language]) ? localizedErrorDocumentsData[language] : '',
                     labelWidth: 200,
                     width: 500,
                     xtype: "textfield",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
@@ -1618,7 +1618,7 @@ pimcore.document.tree = Class.create({
                     fieldLabel: t("error_page") + " (" + availableLanguages[language] + ")",
                     name: "errorDocument.localized." + language,
                     fieldCls: "input_drop_target",
-                    value: localizedErrorDocumentsData[language] ? localizedErrorDocumentsData[language] : '',
+                    value: localizedErrorDocumentsData && localizedErrorDocumentsData[language] ? localizedErrorDocumentsData[language] : '',
                     labelWidth: 200,
                     width: 500,
                     xtype: "textfield",


### PR DESCRIPTION
Corrected call to check wether or not the variable _localizedErrorDocumentsData_ is set. Else will run into errors and the _edit site_ menu won't open at all.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

