### PR TITLE
[Encrypted field] Explain how to set up encryption key for field type "encrypted field"

### DIFF
--- a/models/DataObject/ClassDefinition/Data/EncryptedField.php
+++ b/models/DataObject/ClassDefinition/Data/EncryptedField.php
@@ -126,7 +126,7 @@ class EncryptedField extends Data implements ResourcePersistenceAwareInterface, 
             try {
                 $key = Key::loadFromAsciiSafeString($key);
             } catch (\Exception $e) {
-                throw new \Exception('could not load key');
+                throw new \Exception('Could not find config "pimcore.encryption.secret". Please run "vendor/bin/generate-defuse-key" from command line and add the result to config/config.yaml');
             }
             // store it in raw binary mode to preserve space
             if (method_exists($this->delegate, 'marshalBeforeEncryption')) {


### PR DESCRIPTION
When you first try to save a data object with an encrypted field, you will get an error message "could not load key". This is not very helpful. This PR changes it by giving instructions how to set up encrytion secret.

Actually it would be much more convenient if we could just set the config `pimcore.encryption.secret` on Pimcore installation. What do you think? And in which file? We could put it in `config/config.yaml` by reading and writing it with Symfony Yaml. WDYT?