### PR TITLE
[Data Objects] Responsible width for select option grid panel

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/multiselect.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/multiselect.js
@@ -129,7 +129,7 @@ pimcore.object.classes.data.multiselect = Class.create(pimcore.object.classes.da
                     renderer: function (value) {
                         return replace_html_event_attributes(strip_tags(value, 'div,span,b,strong,em,i,small,sup,sub'));
                     },
-                    width: 200
+                    flex: 1
                 },
                 {
                     text: t("value"),
@@ -138,7 +138,7 @@ pimcore.object.classes.data.multiselect = Class.create(pimcore.object.classes.da
                     editor: new Ext.form.TextField({
                         allowBlank: false
                     }),
-                    width: 200
+                    flex: 1
                 },
                 {
                     xtype: 'actioncolumn',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/select.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/select.js
@@ -128,7 +128,7 @@ pimcore.object.classes.data.select = Class.create(pimcore.object.classes.data.da
                     renderer: function (value) {
                         return replace_html_event_attributes(strip_tags(value, 'div,span,b,strong,em,i,small,sup,sub'));
                     },
-                    width: 200
+                    flex: 1
                 },
                 {
                     text: t("value"),
@@ -137,7 +137,7 @@ pimcore.object.classes.data.select = Class.create(pimcore.object.classes.data.da
                     editor: new Ext.form.TextField({
                         allowBlank: false
                     }),
-                    width: 200
+                    flex: 1
                 },
                 {
                     xtype: 'actioncolumn',


### PR DESCRIPTION
Use full available width for (multi-) select field options:

Before:
<img width="1073" alt="Bildschirmfoto 2021-08-18 um 16 13 05" src="https://user-images.githubusercontent.com/8749138/129914072-c48157b5-357c-4219-b348-e8b1dc24ce06.png">

After:
<img width="1070" alt="Bildschirmfoto 2021-08-18 um 16 12 28" src="https://user-images.githubusercontent.com/8749138/129914086-8b64f11a-e618-494e-bc7c-c0b5fdd51349.png">
