### PR TITLE
[Installation] Check for mysql version >= 8

### DIFF
--- a/lib/Tool/Requirements.php
+++ b/lib/Tool/Requirements.php
@@ -77,7 +77,7 @@ final class Requirements
         // MySQL version
         $checks[] = new Check(
             [
-                'name' => 'InnoDB Support',
+                'name' => 'MySQL version >= 8.0',
                 'state' => version_compare($db->fetchOne('SELECT VERSION()'), 8, '>=')
             ]
         );

--- a/lib/Tool/Requirements.php
+++ b/lib/Tool/Requirements.php
@@ -74,6 +74,14 @@ final class Requirements
     {
         $checks = [];
 
+        // MySQL version
+        $checks[] = new Check(
+            [
+                'name' => 'InnoDB Support',
+                'state' => version_compare($db->fetchOne('SELECT VERSION()'), 8, '>=')
+            ]
+        );
+
         // storage engines
         $engines = $db->fetchCol('SHOW ENGINES;');
 


### PR DESCRIPTION
Currently during installation MySQL version does not get checked. While everything works fine during installation, later it causes fatal errors with constructs like https://github.com/pimcore/pimcore/blob/015a594d171e1deea7cd0f6c9a0f252371c335b1/models/DataObject/Concrete/Dao/InheritanceHelper.php#L282-L296