### PR TITLE
[Data objects] Do not use admin mode when reloading object as admin user

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -531,9 +531,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 $objectData['validLayouts'] = [];
 
                 foreach ($validLayouts as $validLayout) {
-                    if ($validLayout->getId() != $currentLayoutId) {
-                        $objectData['validLayouts'][] = ['id' => $validLayout->getId(), 'name' => $validLayout->getName()];
-                    }
+                    $objectData['validLayouts'][] = ['id' => $validLayout->getId(), 'name' => $validLayout->getName()];
                 }
 
                 $user = Tool\Admin::getCurrentUser();
@@ -542,12 +540,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                     $layout = DataObject\Service::getSuperLayoutDefinition($object);
                     $objectData['layout'] = $layout;
                 } elseif (!empty($currentLayoutId)) {
-                    // check if user has sufficient rights
-                    if (is_array($validLayouts) && isset($validLayouts[$currentLayoutId])) {
-                        $objectData['layout'] = $validLayouts[$currentLayoutId]->getLayoutDefinitions();
-                    } else {
-                        $currentLayoutId = 0;
-                    }
+                    $objectData['layout'] = $validLayouts[$currentLayoutId]->getLayoutDefinitions();
                 }
 
                 $objectData['currentLayoutId'] = $currentLayoutId;

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -492,7 +492,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
             $this->addAdminStyle($object, ElementAdminStyleEvent::CONTEXT_EDITOR, $objectData['general']);
 
-            $currentLayoutId = $request->get('layoutId', 0);
+            $currentLayoutId = $request->get('layoutId', null);
 
             $validLayouts = DataObject\Service::getValidLayouts($object);
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -523,11 +523,14 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                     }
                 }
             }
+
             if (!empty($validLayouts)) {
-                $objectData['validLayouts'] = [ ];
+                $objectData['validLayouts'] = [];
 
                 foreach ($validLayouts as $validLayout) {
-                    $objectData['validLayouts'][] = ['id' => $validLayout->getId(), 'name' => $validLayout->getName()];
+                    if((string)$validLayout->getId() !== "0") {
+                        $objectData['validLayouts'][] = ['id' => $validLayout->getId(), 'name' => $validLayout->getName()];
+                    }
                 }
 
                 $user = Tool\Admin::getCurrentUser();

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -492,7 +492,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
             $this->addAdminStyle($object, ElementAdminStyleEvent::CONTEXT_EDITOR, $objectData['general']);
 
-            $currentLayoutId = $request->get('layoutId', null);
+            $currentLayoutId = $request->get('layoutId', 0);
 
             $validLayouts = DataObject\Service::getValidLayouts($object);
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -492,7 +492,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
             $this->addAdminStyle($object, ElementAdminStyleEvent::CONTEXT_EDITOR, $objectData['general']);
 
-            $currentLayoutId = $request->get('layoutId', null);
+            $currentLayoutId = $request->get('layoutId', 0);
 
             $validLayouts = DataObject\Service::getValidLayouts($object);
 
@@ -504,8 +504,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                     $ok = true;
                 }
             }
-            if (!$ok && count($validLayouts) > 0) {
-                $currentLayoutId = reset($validLayouts)->getId();
+
+            if (!$ok) {
+                $currentLayoutId = null;
             }
 
             //master layout has id 0 so we check for is_null()
@@ -520,6 +521,10 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                         }
                     }
                 }
+            }
+
+            if ($currentLayoutId === null && count($validLayouts) > 0) {
+                $currentLayoutId = reset($validLayouts)->getId();
             }
 
             if (!empty($validLayouts)) {

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -499,15 +499,13 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             //Fallback if $currentLayoutId is not set or empty string
             //Uses first valid layout instead of admin layout when empty
             $ok = false;
-            foreach ($validLayouts as $key => $layout) {
-                if ($currentLayoutId == $layout->getId()) {
+            foreach ($validLayouts as $layout) {
+                if ($currentLayoutId !== null && $currentLayoutId == $layout->getId()) {
                     $ok = true;
                 }
             }
-            if (!$ok) {
-                if (count($validLayouts) > 0) {
-                    $currentLayoutId = reset($validLayouts)->getId();
-                }
+            if (!$ok && count($validLayouts) > 0) {
+                $currentLayoutId = reset($validLayouts)->getId();
             }
 
             //master layout has id 0 so we check for is_null()
@@ -528,7 +526,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 $objectData['validLayouts'] = [];
 
                 foreach ($validLayouts as $validLayout) {
-                    if((string)$validLayout->getId() !== "0") {
+                    if($validLayout->getId() != $currentLayoutId) {
                         $objectData['validLayouts'][] = ['id' => $validLayout->getId(), 'name' => $validLayout->getName()];
                     }
                 }

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -500,7 +500,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             //Uses first valid layout instead of admin layout when empty
             $ok = false;
             foreach ($validLayouts as $layout) {
-                if ($currentLayoutId !== null && $currentLayoutId == $layout->getId()) {
+                if ($currentLayoutId == $layout->getId()) {
                     $ok = true;
                 }
             }
@@ -510,8 +510,8 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             }
 
             //master layout has id 0 so we check for is_null()
-            if ((is_null($currentLayoutId) || !strlen($currentLayoutId)) && !empty($validLayouts)) {
-                if (count($validLayouts) == 1) {
+            if ($currentLayoutId === null && !empty($validLayouts)) {
+                if (count($validLayouts) === 1) {
                     $firstLayout = reset($validLayouts);
                     $currentLayoutId = $firstLayout->getId();
                 } else {

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -543,7 +543,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                     $objectData['layout'] = $layout;
                 } elseif (!empty($currentLayoutId)) {
                     // check if user has sufficient rights
-                    if (is_array($validLayouts) && $validLayouts[$currentLayoutId]) {
+                    if (is_array($validLayouts) && isset($validLayouts[$currentLayoutId])) {
                         $objectData['layout'] = $validLayouts[$currentLayoutId]->getLayoutDefinitions();
                     } else {
                         $currentLayoutId = 0;

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -531,19 +531,12 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 $objectData['validLayouts'] = [];
 
                 foreach ($validLayouts as $validLayout) {
-                    if($validLayout->getId() != $currentLayoutId) {
+                    if ($validLayout->getId() != $currentLayoutId) {
                         $objectData['validLayouts'][] = ['id' => $validLayout->getId(), 'name' => $validLayout->getName()];
                     }
                 }
 
                 $user = Tool\Admin::getCurrentUser();
-
-                if (!is_null($currentLayoutId)) {
-                    if ($currentLayoutId == '0' && !$user->isAdmin()) {
-                        $first = reset($validLayouts);
-                        $currentLayoutId = $first->getId();
-                    }
-                }
 
                 if ($currentLayoutId == -1 && $user->isAdmin()) {
                     $layout = DataObject\Service::getSuperLayoutDefinition($object);
@@ -551,10 +544,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 } elseif (!empty($currentLayoutId)) {
                     // check if user has sufficient rights
                     if (is_array($validLayouts) && $validLayouts[$currentLayoutId]) {
-                        $customLayout = DataObject\ClassDefinition\CustomLayout::getById($currentLayoutId);
-
-                        $customLayoutDefinition = $customLayout->getLayoutDefinitions();
-                        $objectData['layout'] = $customLayoutDefinition;
+                        $objectData['layout'] = $validLayouts[$currentLayoutId]->getLayoutDefinitions();
                     } else {
                         $currentLayoutId = 0;
                     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
@@ -459,7 +459,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                 })
             };
 
-            if (this.data["validLayouts"] && this.data.validLayouts.length > 1) {
+            if (this.data["validLayouts"] && this.data.validLayouts.length >= 1) {
                 reloadConfig.xtype = "splitbutton";
 
                 var menu = [];

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
@@ -52,7 +52,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
 
     getData: function () {
         var params = {id: this.id};
-        if (this.options !== undefined && this.options.layoutId !== null) {
+        if (this.options !== undefined) {
             params.layoutId = this.options.layoutId;
         }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
@@ -52,7 +52,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
 
     getData: function () {
         var params = {id: this.id};
-        if (this.options !== undefined) {
+        if (this.options !== undefined && this.options.layoutId !== null) {
             params.layoutId = this.options.layoutId;
         }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
@@ -84,12 +84,10 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
         this.layoutDefinitions = bricksData.layoutDefinitions;
 
         this.component.insert(0, this.getControls());
-        if (this.data.length > 0) {
-            for (var i = 0; i < this.data.length; i++) {
-                if (this.data[i] != null) {
-                    this.preventDelete[this.data[i].type] = this.data[i].inherited;
-                    this.addBlockElement(i, this.data[i].type, this.data[i], true, this.data[i].title, false);
-                }
+        for (var i = 0; i < this.data.length; i++) {
+            if (this.data[i] != null) {
+                this.preventDelete[this.data[i].type] = this.data[i].inherited;
+                this.addBlockElement(i, this.data[i].type, this.data[i], true, this.data[i].title, false);
             }
         }
 

--- a/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
+++ b/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
@@ -183,19 +183,16 @@ class WorkflowManagementListener implements EventSubscriberInterface
                             //load the new layout into the object container
                             $validLayouts = DataObject\Service::getValidLayouts($element);
 
-                            //check that the layout id is valid before trying to load
-                            if (!empty($validLayouts)) {
-                                // check user permissions again
-                                if ($validLayouts[$workflowLayoutId]) {
-                                    $customLayout = ClassDefinition\CustomLayout::getById($workflowLayoutId);
-                                    $customLayoutDefinition = $customLayout->getLayoutDefinitions();
-                                    DataObject\Service::enrichLayoutDefinition(
-                                        $customLayoutDefinition,
-                                        $e->getArgument('object')
-                                    );
-                                    $data['layout'] = $customLayoutDefinition;
-                                    $data['currentLayoutId'] = $workflowLayoutId;
-                                }
+                            // check user permissions again
+                            if (isset($validLayouts[$workflowLayoutId])) {
+                                $customLayout = ClassDefinition\CustomLayout::getById($workflowLayoutId);
+                                $customLayoutDefinition = $customLayout->getLayoutDefinitions();
+                                DataObject\Service::enrichLayoutDefinition(
+                                    $customLayoutDefinition,
+                                    $e->getArgument('object')
+                                );
+                                $data['layout'] = $customLayoutDefinition;
+                                $data['currentLayoutId'] = $workflowLayoutId;
                             }
                         }
                     }

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -979,7 +979,7 @@ class Service extends Model\Element\Service
     /**
      * @param Concrete $object
      *
-     * @return array
+     * @return DataObject\ClassDefinition\CustomLayout[]
      */
     public static function getValidLayouts(Concrete $object)
     {

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -994,18 +994,18 @@ class Service extends Model\Element\Service
             $isMasterAllowed = true;
         }
 
-        if ($isMasterAllowed) {
-            $master = new ClassDefinition\CustomLayout();
-            $master->setId(0);
-            $master->setName('Master');
-            $resultList[0] = $master;
-        }
-
         if ($user->getAdmin()) {
             $superLayout = new ClassDefinition\CustomLayout();
             $superLayout->setId(-1);
             $superLayout->setName('Master (Admin Mode)');
             $resultList[-1] = $superLayout;
+        }
+
+        if ($isMasterAllowed) {
+            $master = new ClassDefinition\CustomLayout();
+            $master->setId(0);
+            $master->setName('Master');
+            $resultList[0] = $master;
         }
 
         $classId = $object->getClassId();

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -994,18 +994,18 @@ class Service extends Model\Element\Service
             $isMasterAllowed = true;
         }
 
-        if ($user->getAdmin()) {
-            $superLayout = new ClassDefinition\CustomLayout();
-            $superLayout->setId(-1);
-            $superLayout->setName('Master (Admin Mode)');
-            $resultList[-1] = $superLayout;
-        }
-
         if ($isMasterAllowed) {
             $master = new ClassDefinition\CustomLayout();
             $master->setId(0);
             $master->setName('Master');
             $resultList[0] = $master;
+        }
+
+        if ($user->getAdmin()) {
+            $superLayout = new ClassDefinition\CustomLayout();
+            $superLayout->setId(-1);
+            $superLayout->setName('Master (Admin Mode)');
+            $resultList[-1] = $superLayout;
         }
 
         $classId = $object->getClassId();


### PR DESCRIPTION
Steps to reproduce bug:
1. Log in as admin user
1. Create class with input field `abc`, enable `Not editable`
2. Create object of this class
3. You see that field `abc` is not editable -> this is correct
4. Click `Reload` button
5. Field `abc` is editable -> this is wrong

The reason is that the object gets automatically reloaded in admin mode, although the default reload button was clicked. 
This PR fixes this behaviour:
- with default reload button readonly fields are not editable
- with reload split button item `Reload (Admin mode)` readonly fields are editable