### PR TITLE
Memorized asset issue

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/asset.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/asset.js
@@ -32,7 +32,7 @@ pimcore.asset.asset = Class.create(pimcore.element.abstract, {
         try {
             this.data = Ext.decode(response.responseText);
 
-            if (!this.data.success && this.options && this.options.ignoreNotFoundError) {
+            if (this.data.success === false && this.options && this.options.ignoreNotFoundError) {
                 return;
             }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/asset.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/asset.js
@@ -32,6 +32,10 @@ pimcore.asset.asset = Class.create(pimcore.element.abstract, {
         try {
             this.data = Ext.decode(response.responseText);
 
+            if (!this.data.success && this.options && this.options.ignoreNotFoundError) {
+                return;
+            }
+
             if (typeof this.data.editlock == "object") {
                 pimcore.helpers.lockManager(this.id, "asset", this.type, this.data);
                 throw "asset is locked";


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6142086/130077226-459ad70b-d7c7-4383-b275-4fd2a124b3b6.png)

Scenario:
- get the asset tab get memorized in the local storage 
- delete the asset by using a different browser
- reload the backend ui

There will be an endless round of requests because
- the item does not exist
- success is false but the response flag never gets respected
- item type is different so it will start the next cycle

