### PR TITLE
[Workflows] marking_store arguments are not compatible with Symfony 5.x anymore

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Compiler/WorkflowPass.php
+++ b/bundles/CoreBundle/DependencyInjection/Compiler/WorkflowPass.php
@@ -161,9 +161,18 @@ final class WorkflowPass implements CompilerPassInterface
                     $markingStoreDefinition->addArgument($places);
                 }
 
+                if($markingStoreType === 'single_state') {
+                    $markingStoreDefinition->addArgument(true);
+                }
+
+                if($markingStoreType === 'multiple_state') {
+                    $markingStoreDefinition->addArgument(false);
+                }
+
                 foreach ($workflowConfig['marking_store']['arguments'] ?? [] as $argument) {
                     $markingStoreDefinition->addArgument($argument);
                 }
+
             } elseif (!is_null($markingStoreService)) {
                 $markingStoreDefinition = new Reference($markingStoreService);
             }

--- a/bundles/CoreBundle/Resources/config/services_symfony_workflow.yml
+++ b/bundles/CoreBundle/Resources/config/services_symfony_workflow.yml
@@ -26,14 +26,6 @@ services:
             - ~
             - ~
 
-    workflow.marking_store.multiple_state:
-        class: Symfony\Component\Workflow\MarkingStore\MethodMarkingStore
-        abstract: true
-
-    workflow.marking_store.single_state:
-        class: Symfony\Component\Workflow\MarkingStore\MethodMarkingStore
-        abstract: true
-
     workflow.registry:
         class: Symfony\Component\Workflow\Registry
 

--- a/bundles/CoreBundle/Resources/config/services_workflow.yml
+++ b/bundles/CoreBundle/Resources/config/services_workflow.yml
@@ -19,6 +19,13 @@ services:
         class: Pimcore\Workflow\MarkingStore\StateTableMarkingStore
         abstract: true
 
+    workflow.marking_store.multiple_state:
+        class: Symfony\Component\Workflow\MarkingStore\MethodMarkingStore
+        abstract: true
+
+    workflow.marking_store.single_state:
+        class: Symfony\Component\Workflow\MarkingStore\MethodMarkingStore
+        abstract: true
 
     workflow.marking_store.data_object_splitted_state:
         class: Pimcore\Workflow\MarkingStore\DataObjectSplittedStateMarkingStore


### PR DESCRIPTION
fixed #9525

made old configuration work with Symfony 5 


see also followup https://github.com/pimcore/pimcore/issues/10093