### PR TITLE
Fix dashboard illegal chars

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
@@ -86,7 +86,6 @@ pimcore.layout.toolbar = Class.create({
                                 text: data[i],
                                 iconCls: "pimcore_nav_icon_dashboards",
                                 handler: function (key) {
-                                    key = key.replace(/\s/g, '_');
                                     try {
                                         pimcore.globalmanager.get("layout_portal_" + key).activate();
                                     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
@@ -86,6 +86,7 @@ pimcore.layout.toolbar = Class.create({
                                 text: data[i],
                                 iconCls: "pimcore_nav_icon_dashboards",
                                 handler: function (key) {
+                                    key = key.replace(/\s/g, '_');
                                     try {
                                         pimcore.globalmanager.get("layout_portal_" + key).activate();
                                     }
@@ -101,7 +102,7 @@ pimcore.layout.toolbar = Class.create({
                             text: t("add"),
                             iconCls: "pimcore_nav_icon_add",
                             handler: function () {
-                                Ext.MessageBox.prompt(' ', t('enter_the_name_of_the_new_item'),
+                                var prompt = Ext.MessageBox.prompt(' ', t('enter_the_name_of_the_new_item'),
                                     function (button, value, object) {
                                         if (button == "ok") {
                                             Ext.Ajax.request({
@@ -138,6 +139,9 @@ pimcore.layout.toolbar = Class.create({
                                         }
                                     }
                                 );
+                                prompt.textField.on('keyUp', function(el){
+                                    el.setValue(el.getValue().replace(/\W/g, ''));
+                                }, this);
                             }.bind(this)
                         });
                     }.bind(this)


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves issue with illegal charset when creating dashboards. Illegal chars lead to non-functional dashboards (you cannot open them anymore).

=> **I consider this as draft, the solution is simple, but might confuse users since chars recently entered might disappear**

## Reproduce error
Create a dashboard with an identifier containing special chars like ?&%$, etc. or spaces.

