### PR TITLE
Configuration improvements - Filter out duplicate keys

### DIFF
--- a/lib/Config/LocationAwareConfigRepository.php
+++ b/lib/Config/LocationAwareConfigRepository.php
@@ -291,10 +291,10 @@ class LocationAwareConfigRepository
      */
     public function fetchAllKeys(): array
     {
-        return array_merge(
+        return array_unique(array_merge(
             SettingsStore::getIdsByScope($this->settingsStoreScope),
             array_keys($this->containerConfig),
             $this->legacyConfigFile ? array_keys($this->getLegacyStore()->fetchAll()) : [],
-        );
+        ));
     }
 }


### PR DESCRIPTION
Otherwise configurations could be listed twice in e.g. the get tree action.

related: https://github.com/pimcore/pimcore/issues/9330