### PR TITLE
Make Version20210323082921 more resilient to NULL values

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20210323082921.php
+++ b/bundles/CoreBundle/Migrations/Version20210323082921.php
@@ -57,6 +57,11 @@ final class Version20210323082921 extends AbstractMigration
 
             foreach ($data as $row) {
                 if (!empty($row['id'])) {
+                    if ($row['language'] === null) {
+                        $row['language'] = '';
+                        $this->write("Language of setting id {$row['id']}: {$row['name']} for siteId {$row['siteId']} was NULL, converted to empty string");
+                    }
+
                     $db->insert('website_settings', $row);
                 }
             }


### PR DESCRIPTION
## Changes in this pull request  

Our `website-settings.php` had a lot of `null` values on languages, this helps alleviate fatal errors which would otherwise happen during migration.