### PR TITLE
Re-added \Pimcore\Console\Traits\Parallelization::getConsolePath() - …

### DIFF
--- a/lib/Console/Traits/Parallelization.php
+++ b/lib/Console/Traits/Parallelization.php
@@ -155,4 +155,12 @@ trait Parallelization
             $this->lock = null;
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConsolePath(): string
+    {
+        return PIMCORE_PROJECT_ROOT . '/bin/console';
+    }
 }


### PR DESCRIPTION
…was accidentally removed in #8922

Issue is that parallelization doesn't work anymore, when running outside the project root. 
