### PR TITLE
[DataObject] Added isEmpty to QuanitiyValue data types

### DIFF
--- a/models/DataObject/ClassDefinition/Data/InputQuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/InputQuantityValue.php
@@ -189,5 +189,4 @@ class InputQuantityValue extends QuantityValue
 
         return null;
     }
-
 }

--- a/models/DataObject/ClassDefinition/Data/InputQuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/InputQuantityValue.php
@@ -189,4 +189,16 @@ class InputQuantityValue extends QuantityValue
 
         return null;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEmpty($data)
+    {
+        if($data instanceof Model\DataObject\Data\QuantityValue) {
+            return empty($data->getValue()) && empty($data->getUnitId());
+        }
+
+        return parent::isEmpty($data);
+    }
 }

--- a/models/DataObject/ClassDefinition/Data/InputQuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/InputQuantityValue.php
@@ -190,15 +190,4 @@ class InputQuantityValue extends QuantityValue
         return null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isEmpty($data)
-    {
-        if($data instanceof Model\DataObject\Data\QuantityValue) {
-            return empty($data->getValue()) && empty($data->getUnitId());
-        }
-
-        return parent::isEmpty($data);
-    }
 }

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -661,4 +661,16 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
 
         return null;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEmpty($data)
+    {
+        if($data instanceof Model\DataObject\Data\QuantityValue) {
+            return empty($data->getValue()) && empty($data->getUnitId());
+        }
+
+        return parent::isEmpty($data);
+    }
 }


### PR DESCRIPTION
The thing is, that loading a data object with an empty quantity value data attributes results in different data depending if it is loaded from database or if it is loaded from a version. 

loaded from database --> null
loaded from version --> quantity value object with null values in it

this is because when saving a data object (from pimcore backend) with an empty quality value attribute, the data object has a quantity value object with null values in it ... and this is then serialized when saving the version. 
when loading from database, there is a check for null values and only if values are not null, a quantity value object is returned. 

this results in for example in https://github.com/pimcore/pimcore/issues/7627 --> inheritance does not work properly for unpublished data objects with quantity value attributes. 

this PR fixes is by adding `isEmpty` methods that consider empty quantiy value objects
not sure, if we can fix it already during saving time without major refactorings. 

there also might other data types to be checked?