### PR TITLE
Fix PhpDoc: getByField methods can return null

### DIFF
--- a/.github/ci/files/var/classes/DataObject/FilterDefinition.php
+++ b/.github/ci/files/var/classes/DataObject/FilterDefinition.php
@@ -30,17 +30,17 @@ use Pimcore\Model\DataObject\PreGetValueHookInterface;
 
 /**
 * @method static \Pimcore\Model\DataObject\FilterDefinition\Listing getList()
-* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition getByPageLimit($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition getByDefaultOrderByInheritance($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition getByOrderByAsc($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition getByOrderByDesc($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition getByAjaxReload($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition getByInfiniteScroll($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition getByLimitOnFirstLoad($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition getByConditionsInheritance($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition getByFiltersInheritance($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition getByCrossSellingCategory($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition getBySimilarityFieldsInheritance($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition|null getByPageLimit($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition|null getByDefaultOrderByInheritance($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition|null getByOrderByAsc($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition|null getByOrderByDesc($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition|null getByAjaxReload($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition|null getByInfiniteScroll($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition|null getByLimitOnFirstLoad($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition|null getByConditionsInheritance($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition|null getByFiltersInheritance($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition|null getByCrossSellingCategory($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\FilterDefinition\Listing|\Pimcore\Model\DataObject\FilterDefinition|null getBySimilarityFieldsInheritance($value, $limit = 0, $offset = 0)
 */
 
 class FilterDefinition extends \Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractFilterDefinition
@@ -82,7 +82,7 @@ public function getPageLimit(): ?float
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("pageLimit");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -93,7 +93,7 @@ public function getPageLimit(): ?float
 		try {
 			return $this->getValueFromParent("pageLimit");
 		} catch (InheritanceParentNotFoundException $e) {
-			// no data from parent available, continue ... 
+			// no data from parent available, continue ...
 		}
 	}
 
@@ -126,7 +126,7 @@ public function getDefaultOrderByInheritance(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("defaultOrderByInheritance");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -137,7 +137,7 @@ public function getDefaultOrderByInheritance(): ?string
 		try {
 			return $this->getValueFromParent("defaultOrderByInheritance");
 		} catch (InheritanceParentNotFoundException $e) {
-			// no data from parent available, continue ... 
+			// no data from parent available, continue ...
 		}
 	}
 
@@ -167,7 +167,7 @@ public function getDefaultOrderBy()
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("defaultOrderBy");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -201,7 +201,7 @@ public function getOrderByAsc(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("orderByAsc");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -212,7 +212,7 @@ public function getOrderByAsc(): ?string
 		try {
 			return $this->getValueFromParent("orderByAsc");
 		} catch (InheritanceParentNotFoundException $e) {
-			// no data from parent available, continue ... 
+			// no data from parent available, continue ...
 		}
 	}
 
@@ -243,7 +243,7 @@ public function getOrderByDesc(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("orderByDesc");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -254,7 +254,7 @@ public function getOrderByDesc(): ?string
 		try {
 			return $this->getValueFromParent("orderByDesc");
 		} catch (InheritanceParentNotFoundException $e) {
-			// no data from parent available, continue ... 
+			// no data from parent available, continue ...
 		}
 	}
 
@@ -285,7 +285,7 @@ public function getAjaxReload(): ?bool
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("ajaxReload");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -296,7 +296,7 @@ public function getAjaxReload(): ?bool
 		try {
 			return $this->getValueFromParent("ajaxReload");
 		} catch (InheritanceParentNotFoundException $e) {
-			// no data from parent available, continue ... 
+			// no data from parent available, continue ...
 		}
 	}
 
@@ -327,7 +327,7 @@ public function getInfiniteScroll(): ?bool
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("infiniteScroll");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -338,7 +338,7 @@ public function getInfiniteScroll(): ?bool
 		try {
 			return $this->getValueFromParent("infiniteScroll");
 		} catch (InheritanceParentNotFoundException $e) {
-			// no data from parent available, continue ... 
+			// no data from parent available, continue ...
 		}
 	}
 
@@ -369,7 +369,7 @@ public function getLimitOnFirstLoad(): ?float
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("limitOnFirstLoad");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -380,7 +380,7 @@ public function getLimitOnFirstLoad(): ?float
 		try {
 			return $this->getValueFromParent("limitOnFirstLoad");
 		} catch (InheritanceParentNotFoundException $e) {
-			// no data from parent available, continue ... 
+			// no data from parent available, continue ...
 		}
 	}
 
@@ -413,7 +413,7 @@ public function getConditionsInheritance(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("conditionsInheritance");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -424,7 +424,7 @@ public function getConditionsInheritance(): ?string
 		try {
 			return $this->getValueFromParent("conditionsInheritance");
 		} catch (InheritanceParentNotFoundException $e) {
-			// no data from parent available, continue ... 
+			// no data from parent available, continue ...
 		}
 	}
 
@@ -454,7 +454,7 @@ public function getConditions()
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("conditions");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -488,7 +488,7 @@ public function getFiltersInheritance(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("filtersInheritance");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -499,7 +499,7 @@ public function getFiltersInheritance(): ?string
 		try {
 			return $this->getValueFromParent("filtersInheritance");
 		} catch (InheritanceParentNotFoundException $e) {
-			// no data from parent available, continue ... 
+			// no data from parent available, continue ...
 		}
 	}
 
@@ -529,7 +529,7 @@ public function getFilters()
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("filters");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -563,7 +563,7 @@ public function getCrossSellingCategory(): ?\Pimcore\Model\Element\AbstractEleme
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("crossSellingCategory");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -576,7 +576,7 @@ public function getCrossSellingCategory(): ?\Pimcore\Model\Element\AbstractEleme
 		try {
 			return $this->getValueFromParent("crossSellingCategory");
 		} catch (InheritanceParentNotFoundException $e) {
-			// no data from parent available, continue ... 
+			// no data from parent available, continue ...
 		}
 	}
 
@@ -620,7 +620,7 @@ public function getSimilarityFieldsInheritance(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("similarityFieldsInheritance");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -631,7 +631,7 @@ public function getSimilarityFieldsInheritance(): ?string
 		try {
 			return $this->getValueFromParent("similarityFieldsInheritance");
 		} catch (InheritanceParentNotFoundException $e) {
-			// no data from parent available, continue ... 
+			// no data from parent available, continue ...
 		}
 	}
 
@@ -661,7 +661,7 @@ public function getSimilarityFields()
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("similarityFields");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}

--- a/.github/ci/files/var/classes/DataObject/OnlineShopOrder.php
+++ b/.github/ci/files/var/classes/DataObject/OnlineShopOrder.php
@@ -53,39 +53,39 @@ use Pimcore\Model\DataObject\PreGetValueHookInterface;
 
 /**
 * @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing getList()
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByOrdernumber($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByOrderState($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByOrderdate($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByItems($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByComment($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByCustomerOrderData($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByVoucherTokens($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByGiftItems($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getBySubTotalNetPrice($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getBySubTotalPrice($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByTotalNetPrice($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByTotalPrice($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByCurrency($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByCartId($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getBySuccessorOrder($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByCartHash($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByCustomer($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByCustomerFirstname($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByCustomerLastname($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByCustomerCompany($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByCustomerStreet($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByCustomerZip($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByCustomerCity($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByCustomerCountry($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByCustomerEmail($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByDeliveryFirstname($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByDeliveryLastname($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByDeliveryCompany($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByDeliveryStreet($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByDeliveryZip($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByDeliveryCity($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByDeliveryCountry($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder getByPaymentReference($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByOrdernumber($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByOrderState($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByOrderdate($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByItems($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByComment($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByCustomerOrderData($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByVoucherTokens($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByGiftItems($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getBySubTotalNetPrice($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getBySubTotalPrice($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByTotalNetPrice($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByTotalPrice($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByCurrency($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByCartId($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getBySuccessorOrder($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByCartHash($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByCustomer($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByCustomerFirstname($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByCustomerLastname($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByCustomerCompany($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByCustomerStreet($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByCustomerZip($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByCustomerCity($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByCustomerCountry($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByCustomerEmail($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByDeliveryFirstname($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByDeliveryLastname($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByDeliveryCompany($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByDeliveryStreet($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByDeliveryZip($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByDeliveryCity($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByDeliveryCountry($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrder\Listing|\Pimcore\Model\DataObject\OnlineShopOrder|null getByPaymentReference($value, $limit = 0, $offset = 0)
 */
 
 class OnlineShopOrder extends \Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractOrder
@@ -150,7 +150,7 @@ public function getOrdernumber(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("ordernumber");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -184,7 +184,7 @@ public function getOrderState(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("orderState");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -218,7 +218,7 @@ public function getOrderdate(): ?\Carbon\Carbon
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("orderdate");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -252,7 +252,7 @@ public function getItems(): array
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("items");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -298,7 +298,7 @@ public function getComment(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("comment");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -332,7 +332,7 @@ public function getCustomerOrderData(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("customerOrderData");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -366,7 +366,7 @@ public function getVoucherTokens(): array
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("voucherTokens");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -412,7 +412,7 @@ public function getGiftItems(): array
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("giftItems");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -457,7 +457,7 @@ public function getPriceModifications()
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("priceModifications");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -491,7 +491,7 @@ public function getSubTotalNetPrice(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("subTotalNetPrice");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -527,7 +527,7 @@ public function getSubTotalPrice(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("subTotalPrice");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -563,7 +563,7 @@ public function getTotalNetPrice(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("totalNetPrice");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -599,7 +599,7 @@ public function getTotalPrice(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("totalPrice");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -635,7 +635,7 @@ public function getTaxInfo(): array
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("taxInfo");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -669,7 +669,7 @@ public function getCurrency(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("currency");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -703,7 +703,7 @@ public function getCartId(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("cartId");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -737,7 +737,7 @@ public function getSuccessorOrder(): ?\Pimcore\Model\Element\AbstractElement
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("successorOrder");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -783,7 +783,7 @@ public function getCartHash(): ?int
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("cartHash");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -819,7 +819,7 @@ public function getCustomer(): ?\Pimcore\Model\Element\AbstractElement
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("customer");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -865,7 +865,7 @@ public function getCustomerFirstname(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("customerFirstname");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -899,7 +899,7 @@ public function getCustomerLastname(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("customerLastname");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -933,7 +933,7 @@ public function getCustomerCompany(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("customerCompany");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -967,7 +967,7 @@ public function getCustomerStreet(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("customerStreet");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -1001,7 +1001,7 @@ public function getCustomerZip(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("customerZip");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -1035,7 +1035,7 @@ public function getCustomerCity(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("customerCity");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -1069,7 +1069,7 @@ public function getCustomerCountry(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("customerCountry");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -1103,7 +1103,7 @@ public function getCustomerEmail(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("customerEmail");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -1137,7 +1137,7 @@ public function getDeliveryFirstname(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("deliveryFirstname");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -1171,7 +1171,7 @@ public function getDeliveryLastname(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("deliveryLastname");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -1205,7 +1205,7 @@ public function getDeliveryCompany(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("deliveryCompany");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -1239,7 +1239,7 @@ public function getDeliveryStreet(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("deliveryStreet");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -1273,7 +1273,7 @@ public function getDeliveryZip(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("deliveryZip");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -1307,7 +1307,7 @@ public function getDeliveryCity(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("deliveryCity");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -1341,7 +1341,7 @@ public function getDeliveryCountry(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("deliveryCountry");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -1373,8 +1373,8 @@ public function setDeliveryCountry(?string $deliveryCountry)
 public function getPaymentProvider(): ?\Pimcore\Model\DataObject\Objectbrick
 {
 	$data = $this->paymentProvider;
-	if (!$data) { 
-		if (\Pimcore\Tool::classExists("\\Pimcore\\Model\\DataObject\\OnlineShopOrder\\PaymentProvider")) { 
+	if (!$data) {
+		if (\Pimcore\Tool::classExists("\\Pimcore\\Model\\DataObject\\OnlineShopOrder\\PaymentProvider")) {
 			$data = new \Pimcore\Model\DataObject\OnlineShopOrder\PaymentProvider($this, "paymentProvider");
 			$this->paymentProvider = $data;
 		} else {
@@ -1383,7 +1383,7 @@ public function getPaymentProvider(): ?\Pimcore\Model\DataObject\Objectbrick
 	}
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("paymentProvider");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -1412,7 +1412,7 @@ public function getPaymentInfo()
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("paymentInfo");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -1446,7 +1446,7 @@ public function getPaymentReference(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("paymentReference");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -1478,8 +1478,8 @@ public function setPaymentReference(?string $paymentReference)
 public function getCustomized(): ?\Pimcore\Model\DataObject\Objectbrick
 {
 	$data = $this->customized;
-	if (!$data) { 
-		if (\Pimcore\Tool::classExists("\\Pimcore\\Model\\DataObject\\OnlineShopOrder\\Customized")) { 
+	if (!$data) {
+		if (\Pimcore\Tool::classExists("\\Pimcore\\Model\\DataObject\\OnlineShopOrder\\Customized")) {
 			$data = new \Pimcore\Model\DataObject\OnlineShopOrder\Customized($this, "customized");
 			$this->customized = $data;
 		} else {
@@ -1488,7 +1488,7 @@ public function getCustomized(): ?\Pimcore\Model\DataObject\Objectbrick
 	}
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("customized");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}

--- a/.github/ci/files/var/classes/DataObject/OnlineShopOrderItem.php
+++ b/.github/ci/files/var/classes/DataObject/OnlineShopOrderItem.php
@@ -27,15 +27,15 @@ use Pimcore\Model\DataObject\PreGetValueHookInterface;
 
 /**
 * @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing getList()
-* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem getByOrderState($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem getByProduct($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem getByProductNumber($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem getByProductName($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem getByAmount($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem getByTotalNetPrice($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem getByTotalPrice($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem getByComment($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem getBySubItems($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem|null getByOrderState($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem|null getByProduct($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem|null getByProductNumber($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem|null getByProductName($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem|null getByAmount($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem|null getByTotalNetPrice($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem|null getByTotalPrice($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem|null getByComment($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopOrderItem\Listing|\Pimcore\Model\DataObject\OnlineShopOrderItem|null getBySubItems($value, $limit = 0, $offset = 0)
 */
 
 class OnlineShopOrderItem extends \Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractOrderItem
@@ -74,7 +74,7 @@ public function getOrderState(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("orderState");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -108,7 +108,7 @@ public function getProduct(): ?\Pimcore\Model\Element\AbstractElement
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("product");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -154,7 +154,7 @@ public function getProductNumber(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("productNumber");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -188,7 +188,7 @@ public function getProductName(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("productName");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -222,7 +222,7 @@ public function getAmount(): ?float
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("amount");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -258,7 +258,7 @@ public function getTotalNetPrice(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("totalNetPrice");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -294,7 +294,7 @@ public function getTotalPrice(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("totalPrice");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -330,7 +330,7 @@ public function getTaxInfo(): array
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("taxInfo");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -363,7 +363,7 @@ public function getPricingRules()
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("pricingRules");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -397,7 +397,7 @@ public function getComment(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("comment");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -431,7 +431,7 @@ public function getSubItems(): array
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("subItems");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -475,8 +475,8 @@ public function setSubItems(?array $subItems)
 public function getCustomized(): ?\Pimcore\Model\DataObject\Objectbrick
 {
 	$data = $this->customized;
-	if (!$data) { 
-		if (\Pimcore\Tool::classExists("\\Pimcore\\Model\\DataObject\\OnlineShopOrderItem\\Customized")) { 
+	if (!$data) {
+		if (\Pimcore\Tool::classExists("\\Pimcore\\Model\\DataObject\\OnlineShopOrderItem\\Customized")) {
 			$data = new \Pimcore\Model\DataObject\OnlineShopOrderItem\Customized($this, "customized");
 			$this->customized = $data;
 		} else {
@@ -485,7 +485,7 @@ public function getCustomized(): ?\Pimcore\Model\DataObject\Objectbrick
 	}
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("customized");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}

--- a/.github/ci/files/var/classes/DataObject/OnlineShopTaxClass.php
+++ b/.github/ci/files/var/classes/DataObject/OnlineShopTaxClass.php
@@ -17,7 +17,7 @@ use Pimcore\Model\DataObject\PreGetValueHookInterface;
 
 /**
 * @method static \Pimcore\Model\DataObject\OnlineShopTaxClass\Listing getList()
-* @method static \Pimcore\Model\DataObject\OnlineShopTaxClass\Listing|\Pimcore\Model\DataObject\OnlineShopTaxClass getByTaxEntryCombinationType($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopTaxClass\Listing|\Pimcore\Model\DataObject\OnlineShopTaxClass|null getByTaxEntryCombinationType($value, $limit = 0, $offset = 0)
 */
 
 class OnlineShopTaxClass extends Concrete
@@ -46,7 +46,7 @@ public function getTaxEntryCombinationType(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("taxEntryCombinationType");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -79,7 +79,7 @@ public function getTaxEntries()
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("taxEntries");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}

--- a/.github/ci/files/var/classes/DataObject/OnlineShopVoucherSeries.php
+++ b/.github/ci/files/var/classes/DataObject/OnlineShopVoucherSeries.php
@@ -17,7 +17,7 @@ use Pimcore\Model\DataObject\PreGetValueHookInterface;
 
 /**
 * @method static \Pimcore\Model\DataObject\OnlineShopVoucherSeries\Listing getList()
-* @method static \Pimcore\Model\DataObject\OnlineShopVoucherSeries\Listing|\Pimcore\Model\DataObject\OnlineShopVoucherSeries getByName($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopVoucherSeries\Listing|\Pimcore\Model\DataObject\OnlineShopVoucherSeries|null getByName($value, $limit = 0, $offset = 0)
 */
 
 class OnlineShopVoucherSeries extends \Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractVoucherSeries
@@ -46,7 +46,7 @@ public function getName(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("name");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -79,7 +79,7 @@ public function getTokenSettings()
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("tokenSettings");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}

--- a/.github/ci/files/var/classes/DataObject/OnlineShopVoucherToken.php
+++ b/.github/ci/files/var/classes/DataObject/OnlineShopVoucherToken.php
@@ -18,9 +18,9 @@ use Pimcore\Model\DataObject\PreGetValueHookInterface;
 
 /**
 * @method static \Pimcore\Model\DataObject\OnlineShopVoucherToken\Listing getList()
-* @method static \Pimcore\Model\DataObject\OnlineShopVoucherToken\Listing|\Pimcore\Model\DataObject\OnlineShopVoucherToken getByTokenId($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopVoucherToken\Listing|\Pimcore\Model\DataObject\OnlineShopVoucherToken getByToken($value, $limit = 0, $offset = 0)
-* @method static \Pimcore\Model\DataObject\OnlineShopVoucherToken\Listing|\Pimcore\Model\DataObject\OnlineShopVoucherToken getByVoucherSeries($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopVoucherToken\Listing|\Pimcore\Model\DataObject\OnlineShopVoucherToken|null getByTokenId($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopVoucherToken\Listing|\Pimcore\Model\DataObject\OnlineShopVoucherToken|null getByToken($value, $limit = 0, $offset = 0)
+* @method static \Pimcore\Model\DataObject\OnlineShopVoucherToken\Listing|\Pimcore\Model\DataObject\OnlineShopVoucherToken|null getByVoucherSeries($value, $limit = 0, $offset = 0)
 */
 
 class OnlineShopVoucherToken extends Concrete
@@ -50,7 +50,7 @@ public function getTokenId(): ?float
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("tokenId");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -86,7 +86,7 @@ public function getToken(): ?string
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("token");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}
@@ -120,7 +120,7 @@ public function getVoucherSeries(): ?\Pimcore\Model\Element\AbstractElement
 {
 	if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {
 		$preValue = $this->preGetValue("voucherSeries");
-		if ($preValue !== null) { 
+		if ($preValue !== null) {
 			return $preValue;
 		}
 	}

--- a/bundles/CoreBundle/Migrations/Version20210901130000.php
+++ b/bundles/CoreBundle/Migrations/Version20210901130000.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Model\DataObject\ClassDefinition\Listing;
+
+final class Version20210901130000 extends AbstractMigration
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getDescription(): string
+    {
+        return 'Updates class definition files';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->regenerateClasses();
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->regenerateClasses();
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private function regenerateClasses()
+    {
+        $listing = new Listing();
+        foreach ($listing->getClasses() as $class) {
+            $this->write(sprintf('Saving php files for class: %s', $class->getName()));
+            $class->generateClassFiles(false);
+        }
+    }
+}

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -509,7 +509,7 @@ final class ClassDefinition extends Model\AbstractModel
                             $this->getName()
                         ).'\Listing|\\Pimcore\\Model\\DataObject\\'.ucfirst(
                             $this->getName()
-                        ).' getBy'.ucfirst(
+                        ).'|null getBy'.ucfirst(
                             $def->getName()
                         ).'($field, $value, $locale = null, $limit = 0, $offset = 0, $objectTypes = null)'."\n";
 
@@ -518,7 +518,7 @@ final class ClassDefinition extends Model\AbstractModel
                                 $this->getName()
                             ).'\Listing|\\Pimcore\\Model\\DataObject\\'.ucfirst(
                                 $this->getName()
-                            ).' getBy'.ucfirst(
+                            ).'|null getBy'.ucfirst(
                                 $localizedFieldDefinition->getName()
                             ).'($value, $locale = null, $limit = 0, $offset = 0, $objectTypes = null)'."\n";
                     }
@@ -527,7 +527,7 @@ final class ClassDefinition extends Model\AbstractModel
                             $this->getName()
                         ).'\Listing|\\Pimcore\\Model\\DataObject\\'.ucfirst(
                             $this->getName()
-                        ).' getBy'.ucfirst($def->getName()).'($value, $limit = 0, $offset = 0, $objectTypes = null)'."\n";
+                        ).'|null getBy'.ucfirst($def->getName()).'($value, $limit = 0, $offset = 0, $objectTypes = null)'."\n";
                 }
             }
         }

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -594,7 +594,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
     {
         $code = "\t" . 'if ($this instanceof PreGetValueHookInterface && !\Pimcore::inAdmin()) {' . "\n";
         $code .= "\t\t" . '$preValue = $this->preGetValue("' . $key . '");' . "\n";
-        $code .= "\t\t" . 'if ($preValue !== null) { ' . "\n";
+        $code .= "\t\t" . 'if ($preValue !== null) {' . "\n";
         $code .= "\t\t\t" . 'return $preValue;' . "\n";
         $code .= "\t\t" . '}' . "\n";
         $code .= "\t" . '}' . "\n\n";
@@ -641,7 +641,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
             $code .= "\t\t" . 'try {' . "\n";
             $code .= "\t\t\t" . 'return $this->getValueFromParent("' . $key . '");' . "\n";
             $code .= "\t\t" . '} catch (InheritanceParentNotFoundException $e) {' . "\n";
-            $code .= "\t\t\t" . '// no data from parent available, continue ... ' . "\n";
+            $code .= "\t\t\t" . '// no data from parent available, continue ...' . "\n";
             $code .= "\t\t" . '}' . "\n";
             $code .= "\t" . '}' . "\n\n";
         }
@@ -783,7 +783,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
             $code .= "\t\t" . 'try {' . "\n";
             $code .= "\t\t\t" . 'return $this->getValueFromParent("' . $key . '");' . "\n";
             $code .= "\t\t" . '} catch (InheritanceParentNotFoundException $e) {' . "\n";
-            $code .= "\t\t\t" . '// no data from parent available, continue ... ' . "\n";
+            $code .= "\t\t\t" . '// no data from parent available, continue ...' . "\n";
             $code .= "\t\t" . '}' . "\n";
             $code .= "\t" . '}' . "\n";
         }

--- a/models/DataObject/ClassDefinition/Data/Objectbricks.php
+++ b/models/DataObject/ClassDefinition/Data/Objectbricks.php
@@ -558,9 +558,9 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
         $code .= '{' . "\n";
 
         $code .= "\t" . '$data = $this->' . $key . ";\n";
-        $code .= "\t" . 'if (!$data) { ' . "\n";
+        $code .= "\t" . 'if (!$data) {' . "\n";
 
-        $code .= "\t\t" . 'if (\Pimcore\Tool::classExists("' . str_replace('\\', '\\\\', $classname) . '")) { ' . "\n";
+        $code .= "\t\t" . 'if (\Pimcore\Tool::classExists("' . str_replace('\\', '\\\\', $classname) . '")) {' . "\n";
         $code .= "\t\t\t" . '$data = new ' . $classname . '($this, "' . $key . '");' . "\n";
         $code .= "\t\t\t" . '$this->' . $key . ' = $data;' . "\n";
         $code .= "\t\t" . '} else {' . "\n";

--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -701,7 +701,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
             $code .= "\t\t" . 'try {' . "\n";
             $code .= "\t\t\t" . 'return $this->getValueFromParent("' . $key . '");' . "\n";
             $code .= "\t\t" . '} catch (InheritanceParentNotFoundException $e) {' . "\n";
-            $code .= "\t\t\t" . '// no data from parent available, continue ... ' . "\n";
+            $code .= "\t\t\t" . '// no data from parent available, continue ...' . "\n";
             $code .= "\t\t" . '}' . "\n";
             $code .= "\t" . '}' . "\n\n";
         }
@@ -749,7 +749,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
             $code .= "\t\t" . 'try {' . "\n";
             $code .= "\t\t\t" . 'return $this->getValueFromParent("' . $key . '");' . "\n";
             $code .= "\t\t" . '} catch (InheritanceParentNotFoundException $e) {' . "\n";
-            $code .= "\t\t\t" . '// no data from parent available, continue ... ' . "\n";
+            $code .= "\t\t\t" . '// no data from parent available, continue ...' . "\n";
             $code .= "\t\t" . '}' . "\n";
             $code .= "\t" . '}' . "\n";
         }

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -595,7 +595,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
                         $cd .= "\t\t\t\t" . '}' . "\n";
                         $cd .= "\t\t\t" . "}\n";
                         $cd .= "\t\t" . '} catch (InheritanceParentNotFoundException $e) {' . "\n";
-                        $cd .= "\t\t\t" . '// no data from parent available, continue ... ' . "\n";
+                        $cd .= "\t\t\t" . '// no data from parent available, continue ...' . "\n";
                         $cd .= "\t\t" . '}' . "\n";
                         $cd .= "\t" . "}\n";
                     }


### PR DESCRIPTION
`$test = DataObject\Test::getByTest('Test', null, 1)` can return null.
PhpDoc is wrong and PhpStan not happy if I use it in an if :)