### PR TITLE
[Composer] Migrations: make is-installed check more strict

### DIFF
--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -90,7 +90,10 @@ class Composer
         try {
             $process = static::executeCommand($event, $consoleDir,
                 ['internal:migration-helpers', '--is-installed'], 30, false);
-            $isInstalled = (bool) trim($process->getOutput());
+
+            if($process->getExitCode() === 0 && trim($process->getOutput()) === '1') {
+                $isInstalled = true;
+            }
         } catch (\Throwable $e) {
             // noting to do
         }


### PR DESCRIPTION
Do not run migrations in case some other output as the expected is returned. 
This is important in case some warnings or other errors are printed. 