### PR TITLE
[Data Objects] Advanced relations must not be dirty directly after loading

### DIFF
--- a/models/DataObject/Data/ElementMetadata.php
+++ b/models/DataObject/Data/ElementMetadata.php
@@ -86,7 +86,7 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
      */
     public function __call($name, $arguments)
     {
-        if (substr($name, 0, 3) == 'get') {
+        if (str_starts_with($name, 'get')) {
             $key = substr($name, 3, strlen($name) - 3);
             $idx = array_searchi($key, $this->columns);
 
@@ -99,8 +99,8 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
             throw new \Exception("Requested data $key not available");
         }
 
-        if (substr($name, 0, 3) == 'set') {
-            $key = substr($name, 3, strlen($name) - 3);
+        if (str_starts_with($name, 'set')) {
+            $key = substr($name, 3);
             $idx = array_searchi($key, $this->columns);
 
             if ($idx !== false) {

--- a/models/DataObject/Data/ElementMetadata.php
+++ b/models/DataObject/Data/ElementMetadata.php
@@ -141,7 +141,9 @@ class ElementMetadata extends Model\AbstractModel implements DataObject\OwnerAwa
      */
     public function load(DataObject\Concrete $source, $destinationId, $fieldname, $ownertype, $ownername, $position, $index, $destinationType)
     {
-        return $this->getDao()->load($source, $destinationId, $fieldname, $ownertype, $ownername, $position, $index, $destinationType);
+        $return = $this->getDao()->load($source, $destinationId, $fieldname, $ownertype, $ownername, $position, $index, $destinationType);
+        $this->markMeDirty(false);
+        return $return;
     }
 
     /**

--- a/models/DataObject/Data/ObjectMetadata.php
+++ b/models/DataObject/Data/ObjectMetadata.php
@@ -143,7 +143,10 @@ class ObjectMetadata extends Model\AbstractModel implements DataObject\OwnerAwar
      */
     public function load(DataObject\Concrete $source, $destinationId, $fieldname, $ownertype, $ownername, $position, $index)
     {
-        return $this->getDao()->load($source, $destinationId, $fieldname, $ownertype, $ownername, $position, $index);
+        $return = $this->getDao()->load($source, $destinationId, $fieldname, $ownertype, $ownername, $position, $index);
+        $this->markMeDirty(false);
+
+        return $return;
     }
 
     /**

--- a/models/DataObject/Traits/OwnerAwareFieldTrait.php
+++ b/models/DataObject/Traits/OwnerAwareFieldTrait.php
@@ -107,13 +107,13 @@ trait OwnerAwareFieldTrait
     /**
      * @internal
      */
-    protected function markMeDirty()
+    protected function markMeDirty($dirty = true)
     {
         if ($this->_owner && $this->_owner instanceof DirtyIndicatorInterface) {
-            $this->_owner->markFieldDirty($this->_fieldname, true);
+            $this->_owner->markFieldDirty($this->_fieldname, $dirty);
         }
         if ($this->_language && $this->_owner instanceof Localizedfield) {
-            $this->_owner->markLanguageAsDirty($this->_language);
+            $this->_owner->markLanguageAsDirty($this->_language, $dirty);
         }
     }
 }

--- a/tests/Model/LazyLoading/AdvancedManyToManyObjectRelationTest.php
+++ b/tests/Model/LazyLoading/AdvancedManyToManyObjectRelationTest.php
@@ -98,7 +98,7 @@ class AdvancedManyToManyObjectRelationTest extends AbstractLazyLoadingTest
         $object = LazyLoading::getByPath('/lazy1');
         $this->assertFalse($object->isFieldDirty('advancedObjects'), 'Advanced relation must not be dirty directly after loading');
 
-        $object->setAdvancedObjects()[0]->setMetadataUpper('some-other-metadata');
+        $object->getAdvancedObjects()[0]->setMetadataUpper('some-other-metadata');
         $this->assertTrue($object->isFieldDirty('advancedObjects'), 'Advanced relation must be dirty after changing a metadata field');
     }
 

--- a/tests/Model/LazyLoading/AdvancedManyToManyObjectRelationTest.php
+++ b/tests/Model/LazyLoading/AdvancedManyToManyObjectRelationTest.php
@@ -55,6 +55,7 @@ class AdvancedManyToManyObjectRelationTest extends AbstractLazyLoadingTest
         $object = $this->createDataObject();
         $object->setAdvancedObjects($this->loadMetadataRelations('advancedObjects', 'metadataUpper'));
         $object->save();
+
         $parentId = $object->getId();
         $childId = $this->createChildDataObject($object)->getId();
 
@@ -81,6 +82,24 @@ class AdvancedManyToManyObjectRelationTest extends AbstractLazyLoadingTest
             //serialize data object and check for (not) wanted content in serialized string
             $this->checkSerialization($object, $messagePrefix);
         }
+    }
+
+    public function testDirty()
+    {
+        $object = $this->createDataObject();
+
+        $relatedObjects = $this->loadMetadataRelations('advancedObjects', 'metadataUpper');
+
+        $object->setAdvancedObjects($relatedObjects);
+        $object->save();
+        $this->assertFalse($object->isDirty('advancedObjects'), 'Advanced relation must not be dirty after saving');
+
+        Cache\Runtime::clear();
+        $object = LazyLoading::getByPath('/lazy1');
+        $this->assertFalse($object->isDirty('advancedObjects'), 'Advanced relation must not be dirty directly after loading');
+
+        $relatedObjects[0]->setMetadataUpper('some-other-metadata');
+        $this->assertTrue($object->isDirty('advancedObjects'), 'Advanced relation must be dirty after changing a metadata field');
     }
 
     public function testLocalizedClassAttributes()

--- a/tests/Model/LazyLoading/AdvancedManyToManyObjectRelationTest.php
+++ b/tests/Model/LazyLoading/AdvancedManyToManyObjectRelationTest.php
@@ -84,7 +84,7 @@ class AdvancedManyToManyObjectRelationTest extends AbstractLazyLoadingTest
         }
     }
 
-    public function testDirty()
+    public function testDirtyFlag()
     {
         $object = $this->createDataObject();
 
@@ -98,7 +98,7 @@ class AdvancedManyToManyObjectRelationTest extends AbstractLazyLoadingTest
         $object = LazyLoading::getByPath('/lazy1');
         $this->assertFalse($object->isFieldDirty('advancedObjects'), 'Advanced relation must not be dirty directly after loading');
 
-        $relatedObjects[0]->setMetadataUpper('some-other-metadata');
+        $object->setAdvancedObjects()[0]->setMetadataUpper('some-other-metadata');
         $this->assertTrue($object->isFieldDirty('advancedObjects'), 'Advanced relation must be dirty after changing a metadata field');
     }
 

--- a/tests/Model/LazyLoading/AdvancedManyToManyObjectRelationTest.php
+++ b/tests/Model/LazyLoading/AdvancedManyToManyObjectRelationTest.php
@@ -92,14 +92,14 @@ class AdvancedManyToManyObjectRelationTest extends AbstractLazyLoadingTest
 
         $object->setAdvancedObjects($relatedObjects);
         $object->save();
-        $this->assertFalse($object->isDirty('advancedObjects'), 'Advanced relation must not be dirty after saving');
+        $this->assertFalse($object->isFieldDirty('advancedObjects'), 'Advanced relation must not be dirty after saving');
 
         Cache\Runtime::clear();
         $object = LazyLoading::getByPath('/lazy1');
-        $this->assertFalse($object->isDirty('advancedObjects'), 'Advanced relation must not be dirty directly after loading');
+        $this->assertFalse($object->isFieldDirty('advancedObjects'), 'Advanced relation must not be dirty directly after loading');
 
         $relatedObjects[0]->setMetadataUpper('some-other-metadata');
-        $this->assertTrue($object->isDirty('advancedObjects'), 'Advanced relation must be dirty after changing a metadata field');
+        $this->assertTrue($object->isFieldDirty('advancedObjects'), 'Advanced relation must be dirty after changing a metadata field');
     }
 
     public function testLocalizedClassAttributes()


### PR DESCRIPTION
Steps to reproduce bug:
1. Create class `ABC` with advanced many-to-many object relation named `relation`, allowed class is the class itself (for simplicity)
2. Create object `a` in `/`, save and publish
3. Create object `b` in `/`, assign `a` in field `relation`, save and publish
4. Create the following script:
```php
$object = \Pimcore\Model\DataObject\ABC::getByPath('/b');
$object->getRelation();
var_dump($object->isFieldDirty('relation'));
```
This will result in `true`

The reason is that when loading the advanced relation, the setter methods get used: https://github.com/pimcore/pimcore/blob/7efe8331d012641a6aca0e500bd280e0363d01bf/models/DataObject/Data/ObjectMetadata/Dao.php#L96

And those setter methods trigger `$this->markMeDirty()`, see for example https://github.com/pimcore/pimcore/blob/7efe8331d012641a6aca0e500bd280e0363d01bf/models/DataObject/Data/ObjectMetadata.php#L157
But of course the `ObjectMetadata` objects have to set the field dirty when they get called from the application after loading, so they are correct there.

This PR resets the dirty state after loading the data from the Dao.