### PR TITLE
[BUG] Admin Translations - Fix search domain for queries and handle $t == null

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -481,7 +481,9 @@ class TranslationController extends AdminController
                 //Reload translation to get complete data,
                 //if translation fetched based on the text not key
                 if ($searchString && !strpos($searchString, $t->getKey())) {
-                    $t = Translation::getByKey($t->getKey());
+                    if (!$t = Translation::getByKey($t->getKey(), $domain)) {
+                        continue;
+                    }
                 }
 
                 $translations[] = array_merge(


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Pass $domain to the model to query in the correct table and add handle to care for $t == null since this is a valid return value

## Reproduce
Open admin translations. Search for any string
=> error 500 => fix with _if($t = ...) { ... }_
After this query again and get no results even if the search string is present in the translation keys
=> pass $domain to _getByKey_ Method to search in the right table