### PR TITLE
Update `.gitattributes` to save space and trees

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@
 
 bundles/AdminBundle/Resources/public/js/lib/* linguist-vendored
 
-# Exclude build/test files from archive
+# Exclude build/test files from archive to reduce ZIP size for composer dist download
 /.github export-ignore
 /doc export-ignore
 /tests export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,17 @@
 * -text
 
 bundles/AdminBundle/Resources/public/js/lib/* linguist-vendored
+
+# Exclude build/test files from archive
+/.github export-ignore
+/doc export-ignore
+/tests export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.markdownlint.json export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/CLA.md export-ignore
+/CONTRIBUTING.md export-ignore
+/codeception.dist.yml export-ignore
+/phpstan* export-ignore


### PR DESCRIPTION
## Changes in this pull request  
Resolves #10177

## Additional info  

Test this locally:

```bash
git checkout 10.1
git archive --format zip HEAD > archive-10.1.zip
ls -la archive-10.1.zip # 63MB
git checkout update-gitattributes
git archive --format zip HEAD > archive-update-gitattributes.zip
ls -la archive-update-gitattributes.zip # 29MB
```

The package downloaded by Composer every time Pimcore is required is 63MB. After applying this PR, the size decreases by 54% to 29MB.

By using `export-ignore` in a `.gitattributes` file, it is possible to dramatically reduce the file size of a Composer package download.

When Composer downloads a package, a zip/tar file is created using the `git archive` command. This behavior can be changed, but by default, Composer downloads an archive of the specified package. When using GitHub, GitLab, or BitBucket, Composer can directly download the zip file, and all those services will imitate a `git archive` command output to generate the downloadable archive.

The `git archive` command looks up for files matching an `export-ignore` rule, and if matched, it will exclude those files from the archive.

With `export-ignore` rules in the `.gitattributes` file, Composer packages can opt to exclude build files and test files (such as GitHub CI configuration file, tests and configuration files, documentation, etc.) when the package is downloaded by Composer.

All these excluded files will remain in the repository when it is cloned/forked, and are otherwise available to those who download the package source files; The `export-ignore` rule will exclude them in the zip file downloads, thus reducing the download size and time when the packages are consumed.

Link: https://php.watch/articles/composer-gitattributes