### PR TITLE
Handle errors from preSave doing sanity checks for getOptions

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -1080,10 +1080,10 @@ class TranslationController extends AdminController
                     libxml_clear_errors();
                     $html = $doc->saveHTML();
 
-                    $bodyStart = strpos($html, '<body>') + 6;
+                    $bodyStart = strpos($html, '<body>');
                     $bodyEnd = strpos($html, '</body>');
                     if ($bodyStart && $bodyEnd) {
-                        $html = substr($html, $bodyStart, $bodyEnd - $bodyStart);
+                        $html = substr($html, $bodyStart + 6, $bodyEnd - $bodyStart);
                     }
 
                     $output .= $html;

--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -524,7 +524,7 @@ class SearchController extends AdminController
 
         for ($i = $count; $i >= 0; $i--) {
             $shortPath = '/' . implode('/', array_unique($parts));
-            if (strlen($shortPath) <= 50 || $i === 0) {
+            if (strlen($shortPath) <= 50 || $i == 0) {
                 break;
             }
             array_splice($parts, $i - 1, 1, '…');

--- a/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -707,7 +707,13 @@ class Multiselect extends Data implements
             $context = [];
             $context['fieldname'] = $this->getName();
 
-            $options = $optionsProvider->getOptions($context, $this);
+            try{
+                $options = $optionsProvider->getOptions($context, $this);
+            }
+            catch (\Exception $e){
+                // error from getOptions => no values => no comma => no problems
+                $options = null;
+            }
         } else {
             $options = $this->getOptions();
         }


### PR DESCRIPTION
in case an error occurs, we don't have options, so therefore no sanity check (finding commas in values) is needed

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #9991

## Additional info  
The method _preSave_ in the Multiselect only has 1 responsibility => check for commas in the value fields. Therefore, whenever an error occurs (e.g. when creating classes and their listings) there is no need to check for commas afterwards since we don't have values (for any reason). For a clean approach the _$options_ is set to null to not trigger the following _if_ statement

So a simple try catch does the trick here.
