### PR TITLE
[Fixed]Error:"Getting Array to string conversion" on installation in Windows platform

### DIFF
--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -171,6 +171,10 @@ class Composer
         $command = array_merge($command, $cmd);
 
         //$event->getIO()->write('Run command: ' . implode(' ', $command), false);
+        
+        if (substr(php_uname(), 0, 7) == "Windows") {
+            $command = implode(' ', $command);
+        }
 
         $process = new Process($command, null, null, null, $timeout);
         $process->run(function ($type, $buffer) use ($event, $writeBuffer) {


### PR DESCRIPTION
Related to PR: #9725

Steps to reproduce:
1. Run "COMPOSER_MEMORY_LIMIT=-1 composer create-project pimcore/skeleton my-project" cmd

Error:
Script Pimcore\Composer::clearCache handling the pimcore-scripts event terminated with an exception
[ErrorException]
Array to string conversion