### PR TITLE
[Ecommerce] Fix Order list row count

### DIFF
--- a/bundles/EcommerceFrameworkBundle/OrderManager/AbstractOrderList.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/AbstractOrderList.php
@@ -134,7 +134,7 @@ abstract class AbstractOrderList implements OrderListInterface
             $conn = \Pimcore\Db::getConnection();
             $queryBuilder = $this->getQueryBuilder();
             $this->list = new \ArrayIterator($conn->fetchAll((string) $queryBuilder, $queryBuilder->getParameters(), $queryBuilder->getParameterTypes()));
-            $this->rowCount = (int)$conn->fetchCol('SELECT FOUND_ROWS() as "cnt"')[0];
+            $this->rowCount = $this->list->count();
         }
 
         return $this;


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/demo/issues/252 

## Additional info  
replace `SELECT FOUND_ROWS()` with `ArrayIterator::count()`
