### PR TITLE
[Grid Operator Required By] Use database index

### DIFF
--- a/lib/DataObject/GridColumnConfig/Operator/RequiredBy.php
+++ b/lib/DataObject/GridColumnConfig/Operator/RequiredBy.php
@@ -68,13 +68,13 @@ final class RequiredBy extends AbstractOperator
         }
 
         if ($this->getOnlyCount()) {
-            $query = 'select count(*) from dependencies where targetid = ' . $element->getId() . $typeCondition;
-            $count = $db->fetchOne($query);
+            $query = 'select count(*) from dependencies where targettype = ? AND targetid = ?'. $typeCondition;
+            $count = $db->fetchOne($query, [Service::getElementType($element), $element->getId()]);
             $result->value = $count;
         } else {
             $resultList = [];
-            $query = 'select * from dependencies where targetid = ' . $element->getId() . $typeCondition;
-            $dependencies = $db->fetchAll($query);
+            $query = 'select * from dependencies where targettype = ? AND targetid = ' . $element->getId() . $typeCondition;
+            $dependencies = $db->fetchAll($query, [Service::getElementType($element), $element->getId()]);
             foreach ($dependencies as $dependency) {
                 $sourceType = $dependency['sourcetype'];
                 $sourceId = $dependency['sourceid'];


### PR DESCRIPTION
The `dependencies` table has an index on `sourcetype`, `sourceid`, `targettype`, `targetid`:
https://github.com/pimcore/pimcore/blob/f348932931e7ff08f3128ed58491fde3cc9849a2/bundles/InstallBundle/Resources/install.sql#L92

MySQL can only use the index when the fields in the condition are a prefix of the index columns:

> If the table has a multiple-column index, any leftmost prefix of the index can be used by the optimizer to look up rows` https://dev.mysql.com/doc/refman/8.0/en/multiple-column-indexes.html

For this reason in the current implementation no index is used which results in very low query performance when you have some more datasets in this table.

EXPLAIN comparison:
Without this PR:

id | select_type | table | partitions | type | possible_keys | key | key_len | ref | rows | filtered | Extra
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | SIMPLE | dependencies | NULL | index | NULL | targettype_targetid | 5 | NULL | 23701675 | 10.00 | Using where; Using index

With this PR:

id | select_type | table | partitions | type | possible_keys | key | key_len | ref | rows | filtered | Extra
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | SIMPLE | dependencies | NULL | ref | targettype_targetid | targettype_targetid | 5 | const,const | 1 | 100.00 | Using index

Look at the column `rows`.
Execution times are multiple seconds without index and some milliseconds with index.

PS: And as a side effect of course you might get wrong results when not requesting the `targettype` because there might be multiple elements with the same `targetid` but meaning different element types (document, objects, assets).