### PR TITLE
Fix Multiselect getVersionPreview array_map argument order

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -345,9 +345,9 @@ class Multiselect extends Data implements
     public function getVersionPreview($data, $object = null, $params = [])
     {
         if (is_array($data)) {
-            return implode(',', array_map($data, function ($v) {
+            return implode(',', array_map(function ($v) {
                 return htmlspecialchars($v, ENT_QUOTES, 'UTF-8');
-            }));
+            }, $data));
         }
 
         return null;


### PR DESCRIPTION
Bug reproducable by adding a Multiselect field to any dataobject, filling this field and then searching globally (admin mode) for this object. The error looks something like:

```
array_map(): Argument #1 ($callback) must be a valid callback, array must have exactly two members
Server threw exception - could not perform action. Please reload the admin interface and try again.
```