### PR TITLE
[Select field] Throw exception when manually creating options with wrong parameter structure

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -201,6 +201,7 @@ class Select extends Data implements
         if(is_array($options)) {
             $this->options = [];
             foreach ($options as $option) {
+                $option = (array)$option; // support stdclass option
                 if (!array_key_exists('key', $option) || !array_key_exists('value', $option)) {
                     throw new InvalidArgumentException('Please provide select options as associative array with fields "key" and "value"');
                 }

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Model\DataObject\ClassDefinition\Data;
 
+use InvalidArgumentException;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
@@ -195,9 +196,16 @@ class Select extends Data implements
      *
      * @return $this
      */
-    public function setOptions($options)
+    public function setOptions(array $options)
     {
-        $this->options = $options;
+        $this->options = [];
+        foreach($options as $option) {
+            if(!array_key_exists('key', $option) || !array_key_exists('value', $option)) {
+                throw new InvalidArgumentException('Please provide select options as associative array with fields "key" and "value"');
+            }
+
+            $this->options[] = $options;
+        }
 
         return $this;
     }

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -201,12 +201,11 @@ class Select extends Data implements
         if(is_array($options)) {
             $this->options = [];
             foreach ($options as $option) {
-                $option = (array)$option; // support stdclass option
                 if (!array_key_exists('key', $option) || !array_key_exists('value', $option)) {
                     throw new InvalidArgumentException('Please provide select options as associative array with fields "key" and "value", '.json_encode($option));
                 }
 
-                $this->options[] = $options;
+                $this->options[] = $option;
             }
         } else {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -196,7 +196,7 @@ class Select extends Data implements
      *
      * @return $this
      */
-    public function setOptions(array $options = null)
+    public function setOptions(?array $options = [])
     {
         $this->options = [];
         foreach($options as $option) {

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -196,7 +196,7 @@ class Select extends Data implements
      *
      * @return $this
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options = null)
     {
         $this->options = [];
         foreach($options as $option) {

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -202,7 +202,7 @@ class Select extends Data implements
             $this->options = [];
             foreach ($options as $option) {
                 if (!array_key_exists('key', $option) || !array_key_exists('value', $option)) {
-                    throw new InvalidArgumentException('Please provide select options as associative array with fields "key" and "value", '.json_encode($option));
+                    throw new InvalidArgumentException('Please provide select options as associative array with fields "key" and "value"');
                 }
 
                 $this->options[] = $option;

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -203,7 +203,7 @@ class Select extends Data implements
             foreach ($options as $option) {
                 $option = (array)$option; // support stdclass option
                 if (!array_key_exists('key', $option) || !array_key_exists('value', $option)) {
-                    throw new InvalidArgumentException('Please provide select options as associative array with fields "key" and "value"');
+                    throw new InvalidArgumentException('Please provide select options as associative array with fields "key" and "value", '.json_encode($option));
                 }
 
                 $this->options[] = $options;

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -198,8 +198,8 @@ class Select extends Data implements
      */
     public function setOptions(?array $options)
     {
-        $this->options = [];
         if(is_array($options)) {
+            $this->options = [];
             foreach ($options as $option) {
                 if (!array_key_exists('key', $option) || !array_key_exists('value', $option)) {
                     throw new InvalidArgumentException('Please provide select options as associative array with fields "key" and "value"');
@@ -207,6 +207,8 @@ class Select extends Data implements
 
                 $this->options[] = $options;
             }
+        } else {
+            $this->options = null;
         }
 
         return $this;

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -192,7 +192,7 @@ class Select extends Data implements
     }
 
     /**
-     * @param array $options
+     * @param array|null $options
      *
      * @return $this
      */

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -196,15 +196,17 @@ class Select extends Data implements
      *
      * @return $this
      */
-    public function setOptions(?array $options = [])
+    public function setOptions(?array $options)
     {
         $this->options = [];
-        foreach($options as $option) {
-            if(!array_key_exists('key', $option) || !array_key_exists('value', $option)) {
-                throw new InvalidArgumentException('Please provide select options as associative array with fields "key" and "value"');
-            }
+        if(is_array($options)) {
+            foreach ($options as $option) {
+                if (!array_key_exists('key', $option) || !array_key_exists('value', $option)) {
+                    throw new InvalidArgumentException('Please provide select options as associative array with fields "key" and "value"');
+                }
 
-            $this->options[] = $options;
+                $this->options[] = $options;
+            }
         }
 
         return $this;


### PR DESCRIPTION
Steps to reproduce problem:
1. Create class `Test`
2. Create select field `test`
3. Run the following script:
```php
<?php
$class = \Pimcore\Model\DataObject\ClassDefinition::getByName('Test');
$field = $class->getFieldDefinition('test');
$field->setOptions([['label 1', 'value 1']]);
$class->save();
```
You will get no error and in field configuration everything will look fine:
<img width="705" alt="Bildschirmfoto 2021-09-06 um 15 41 28" src="https://user-images.githubusercontent.com/8749138/132226784-9350ce89-da5d-4034-8484-7ae7dcae99d6.png">

Yet when you look at the available options in the dropdown you will notice that something is wrong:
<img width="421" alt="Bildschirmfoto 2021-09-06 um 15 40 55" src="https://user-images.githubusercontent.com/8749138/132226227-7fe0f3a3-9817-4d53-a03c-f5753d634aab.png">

We first thought that something about translations is wrong but actually the cause is
`$field->setOptions([['label 1', 'value 1']]);`
which is wrong, it actually has to be
`$field->setOptions([['key' => 'label 1', 'value' => 'value 1']]);`
But it took us some time to notice that. With this PR an exception gets thrown when `setOptions()` gets called with wrong parameter structure.

PS: I am not sure if we have to allow for `null` here but as it was possible before, I kept this behaviour.