### PR TITLE
Check if file is SVG when generating thumbnail

### DIFF
--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -158,8 +158,9 @@ final class Thumbnail
         $generated = false;
 
         if ($this->asset && empty($this->pathReference)) {
-            // if no correct thumbnail config is given use the original image as thumbnail
-            if (!$this->config) {
+            $isSvg = $this->asset->getMimetype() == 'image/svg+xml' ? true : false;
+            // if no correct thumbnail config is given or image is svg use the original image as thumbnail
+            if (!$this->config || $isSvg) {
                 $this->pathReference = [
                     'type' => 'asset',
                     'src' => $this->asset->getRealFullPath(),


### PR DESCRIPTION
## Changes in this pull request  
Resolves #10252

## Additional info  

Adds check in thumbnail generation whether the image asset is .svg. If it is, it returns the asset file itself without modifications.
