### PR TITLE
[Assets] Display image at natural size, if smaller than max dimensions

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/image.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/image.js
@@ -438,8 +438,11 @@ pimcore.asset.image = Class.create(pimcore.asset.asset, {
                     this.initPreviewImage();
                     var area = this.displayPanel.getEl().down('img');
                     if(area) {
+                        area.setStyle('width', this.data.imageInfo.dimensions.width + "px");
+                        area.setStyle('height', this.data.imageInfo.dimensions.height + "px");
                         area.setStyle('max-width', (width - 340) + "px");
                         area.setStyle('max-height', (height - 40) + "px");
+                        area.setStyle('object-fit', 'contain');
                     }
                 }
             }.bind(this));


### PR DESCRIPTION
Normal images work fine with current styling (defining max-width and max-height), but when .svg file is previewed, it is not shown due to lack of definition of width and height.

This PR defines those based on image dimensions while keeping maximum dimensions. Object fit is added so that image contains its aspect ratio.

