### PR TITLE
[Shared Translations] Show all languages for admin users

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
@@ -399,11 +399,13 @@ pimcore.settings.user.user.settings = Class.create({
                         this.typesSet.hide();
                         this.permissionsSet.hide();
                         this.userPanel.workspaces.disable();
+                        this.websiteTranslationSettings.getPanel().hide();
                     } else {
                         this.roleField.show();
                         this.typesSet.show();
                         this.permissionsSet.show();
                         this.userPanel.workspaces.enable();
+                        this.websiteTranslationSettings.getPanel().show();
                     }
                 }.bind(this)
             });

--- a/models/User.php
+++ b/models/User.php
@@ -704,16 +704,13 @@ final class User extends User\UserRole
     public function getAllowedLanguagesForEditingWebsiteTranslations()
     {
         $mergedWebsiteTranslationLanguagesEdit = $this->getMergedWebsiteTranslationLanguagesEdit();
-        if (empty($mergedWebsiteTranslationLanguagesEdit)) {
+        if (empty($mergedWebsiteTranslationLanguagesEdit) || $this->isAdmin()) {
             $mergedWebsiteTranslationLanguagesView = $this->getMergedWebsiteTranslationLanguagesView();
             if (empty($mergedWebsiteTranslationLanguagesView)) {
                 return Tool::getValidLanguages();
-            } else {
-                return $mergedWebsiteTranslationLanguagesEdit;
             }
-        } else {
-            return $mergedWebsiteTranslationLanguagesEdit;
         }
+        return $mergedWebsiteTranslationLanguagesEdit;
     }
 
     /**
@@ -746,11 +743,10 @@ final class User extends User\UserRole
     public function getAllowedLanguagesForViewingWebsiteTranslations()
     {
         $mergedWebsiteTranslationLanguagesView = $this->getMergedWebsiteTranslationLanguagesView();
-        if (empty($mergedWebsiteTranslationLanguagesView)) {
+        if (empty($mergedWebsiteTranslationLanguagesView) || $this->isAdmin()) {
             return Tool::getValidLanguages();
-        } else {
-            return $mergedWebsiteTranslationLanguagesView;
         }
+        return $mergedWebsiteTranslationLanguagesView;
     }
 
     /**


### PR DESCRIPTION
Steps to reproduce:
1. Ensure in `Settings > Localization` there is only `English` 
2. Create admin user and enable checkbox for viewing and editing shared translation for `English`
3. In `Settings > Localization` add `German`
4. After reload go to shared translations
5. You will see that current user will only see english (as configured)
6. When you now go to user settings the panel for languages to be shown in shared translations is not displayed due to https://github.com/pimcore/pimcore/blob/7edef74976d037e913a6ea7d2c497a566d62db57/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js#L557-L559

As the panel is not shown for admin users, there is no way to allow the newly added language `german` - only if the `admin` checkbox is removed and the user tab gets reloaded, the language panel will appear again.

This PR does 2 things:
- immediately show and hide language panel when the admin checkbox gets enabled or disabled (so that it works the same as when the user tab gets closed and reopened again)
- admin users can see and edit all languages in shared translations