### PR TITLE
[DataObject] Fixed ImageGallery mandatory check

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ImageGallery.php
+++ b/models/DataObject/ClassDefinition/Data/ImageGallery.php
@@ -488,6 +488,22 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
 
     /**
      * @param DataObject\Data\ImageGallery|null $data
+     * @param bool $omitMandatoryCheck
+     * @param array $params
+     *
+     * @throws Element\ValidationException
+     */
+    public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
+    {
+        if ($this->getMandatory() && !$omitMandatoryCheck && ($data === null || empty($data->getItems()) || $data->getItems()[0]->getImage() === null)) {
+            throw new Model\Element\ValidationException('[ ' . $this->getName() . " ] At least 1 image should be uploaded!");
+        }
+
+        parent::checkValidity($data, $omitMandatoryCheck);
+    }
+
+    /**
+     * @param DataObject\Data\ImageGallery|null $data
      *
      * @return bool
      */


### PR DESCRIPTION
Replaces #10260 - added `getMandatory()`  check (only validate if field is marked as mandatory), cleaned up commit history & rebased on `10.1`.  (kudos to @MyZik). 

Resolves #10255
Resolves #10260