### PR TITLE
[Classification Store] Add static getById methods

### DIFF
--- a/models/DataObject/Classificationstore/CollectionGroupRelation.php
+++ b/models/DataObject/Classificationstore/CollectionGroupRelation.php
@@ -61,8 +61,8 @@ final class CollectionGroupRelation extends Model\AbstractModel
     }
 
     /**
-     * @param int|null $colId
      * @param int|null $groupId
+     * @param int|null $colId
      *
      * @return self|null
      */

--- a/models/DataObject/Classificationstore/CollectionGroupRelation.php
+++ b/models/DataObject/Classificationstore/CollectionGroupRelation.php
@@ -66,7 +66,7 @@ final class CollectionGroupRelation extends Model\AbstractModel
      *
      * @return self|null
      */
-    public static function getByColAndGroupId($colId = null, $groupId = null)
+    public static function getByGroupAndColId($groupId = null, $colId = null)
     {
         try {
             $config = new self();

--- a/models/DataObject/Classificationstore/CollectionGroupRelation.php
+++ b/models/DataObject/Classificationstore/CollectionGroupRelation.php
@@ -63,6 +63,8 @@ final class CollectionGroupRelation extends Model\AbstractModel
     /**
      * @param int|null $colId
      * @param int|null $groupId
+     *
+     * @return self|null
      */
     public static function getById($colId = null, $groupId = null)
     {

--- a/models/DataObject/Classificationstore/CollectionGroupRelation.php
+++ b/models/DataObject/Classificationstore/CollectionGroupRelation.php
@@ -64,7 +64,7 @@ final class CollectionGroupRelation extends Model\AbstractModel
      * @param int|null $colId
      * @param int|null $groupId
      */
-    public function getById($colId = null, $groupId = null)
+    public static function getById($colId = null, $groupId = null)
     {
         try {
             $config = new self();

--- a/models/DataObject/Classificationstore/CollectionGroupRelation.php
+++ b/models/DataObject/Classificationstore/CollectionGroupRelation.php
@@ -61,6 +61,22 @@ final class CollectionGroupRelation extends Model\AbstractModel
     }
 
     /**
+     * @param int|null $colId
+     * @param int|null $groupId
+     */
+    public function getById($colId = null, $groupId = null)
+    {
+        try {
+            $config = new self();
+            $config->getDao()->getById((int)$colId, (int)$groupId);
+
+            return $config;
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    /**
      * @return int
      */
     public function getGroupId()

--- a/models/DataObject/Classificationstore/CollectionGroupRelation.php
+++ b/models/DataObject/Classificationstore/CollectionGroupRelation.php
@@ -64,7 +64,7 @@ final class CollectionGroupRelation extends Model\AbstractModel
      * @param int|null $colId
      * @param int|null $groupId
      */
-    public static function getById($colId = null, $groupId = null)
+    public static function getByColAndGroupId($colId = null, $groupId = null)
     {
         try {
             $config = new self();

--- a/models/DataObject/Classificationstore/CollectionGroupRelation/Dao.php
+++ b/models/DataObject/Classificationstore/CollectionGroupRelation/Dao.php
@@ -41,7 +41,7 @@ class Dao extends Model\Dao\AbstractDao
         }
 
         $data = $this->db->fetchRow('SELECT * FROM ' . self::TABLE_NAME_RELATIONS
-            . ',' . Model\DataObject\Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS. ' WHERE colId = ? AND groupId = `?', $this->model->getColId(), $this->model->getGroupId());
+            . ',' . Model\DataObject\Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS. ' WHERE colId = ? AND groupId = `?', [$this->model->getColId(), $this->model->getGroupId()]);
 
         $this->assignVariablesToModel($data);
     }

--- a/models/DataObject/Classificationstore/KeyGroupRelation.php
+++ b/models/DataObject/Classificationstore/KeyGroupRelation.php
@@ -86,22 +86,6 @@ final class KeyGroupRelation extends Model\AbstractModel
     }
 
     /**
-     * @param int|null $keyId
-     * @param int|null $groupId
-     */
-    public static function getById($keyId = null, $groupId = null)
-    {
-        try {
-            $config = new self();
-            $config->getDao()->getById((int)$keyId, (int)$groupId);
-
-            return $config;
-        } catch (\Exception $e) {
-            return null;
-        }
-    }
-
-    /**
      * @return int
      */
     public function getGroupId()
@@ -253,14 +237,13 @@ final class KeyGroupRelation extends Model\AbstractModel
      */
     public static function getByGroupAndKeyId($groupId, $keyId)
     {
-        $relation = new KeyGroupRelation\Listing();
-        $relation->setCondition('groupId = ' . $relation->quote($groupId) . ' and keyId = ' . $relation->quote($keyId));
-        $relation->setLimit(1);
-        $relation = $relation->load();
-        if ($relation) {
-            return $relation[0];
-        }
+        try {
+            $relation = new self();
+            $relation->getDao()->getById((int)$keyId, (int)$groupId);
 
-        return null;
+            return $relation;
+        } catch (\Exception $e) {
+            return null;
+        }
     }
 }

--- a/models/DataObject/Classificationstore/KeyGroupRelation.php
+++ b/models/DataObject/Classificationstore/KeyGroupRelation.php
@@ -89,7 +89,7 @@ final class KeyGroupRelation extends Model\AbstractModel
      * @param int|null $keyId
      * @param int|null $groupId
      */
-    public function getById($keyId = null, $groupId = null)
+    public static function getById($keyId = null, $groupId = null)
     {
         try {
             $config = new self();

--- a/models/DataObject/Classificationstore/KeyGroupRelation.php
+++ b/models/DataObject/Classificationstore/KeyGroupRelation.php
@@ -86,6 +86,22 @@ final class KeyGroupRelation extends Model\AbstractModel
     }
 
     /**
+     * @param int|null $keyId
+     * @param int|null $groupId
+     */
+    public function getById($keyId = null, $groupId = null)
+    {
+        try {
+            $config = new self();
+            $config->getDao()->getById((int)$keyId, (int)$groupId);
+
+            return $config;
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    /**
      * @return int
      */
     public function getGroupId()


### PR DESCRIPTION
Add `getById` methods for `CollectionGroupRelation` and `KeyGroupRelation` - similar to all the other classification store classes like https://github.com/pimcore/pimcore/blob/7edef74976d037e913a6ea7d2c497a566d62db57/models/DataObject/Classificationstore/CollectionConfig.php#L66-L76