### PR TITLE
[DataObject] Added mandatory check for ExternalImage data type

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -840,7 +840,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             }
 
             if ($allowUpdate) {
-                if ($request->get('filename') != $asset->getFilename() and !$asset->isAllowed('rename')) {
+                if ($request->get('filename') != $asset->getFilename() && !$asset->isAllowed('rename')) {
                     unset($updateData['filename']);
                     Logger::debug('prevented renaming asset because of missing permissions ');
                 }

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1303,7 +1303,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                         $relations = $object->getRelationData($fd->getOwnerFieldName(), false, $remoteClass->getId());
                         $toAdd = $this->detectAddedRemoteOwnerRelations($relations, $value);
                         $toDelete = $this->detectDeletedRemoteOwnerRelations($relations, $value);
-                        if (count($toAdd) > 0 or count($toDelete) > 0) {
+                        if (count($toAdd) > 0 || count($toDelete) > 0) {
                             $this->processRemoteOwnerRelations($object, $toDelete, $toAdd, $fd->getOwnerFieldName());
                         }
                     } else {

--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -177,7 +177,7 @@ class SearchController extends AdminController
             }
         }
 
-        if (is_array($types) and !empty($types[0])) {
+        if (is_array($types) && !empty($types[0])) {
             $conditionTypeParts = [];
             foreach ($types as $type) {
                 $conditionTypeParts[] = $db->quote($type);
@@ -188,7 +188,7 @@ class SearchController extends AdminController
             $conditionParts[] = '( maintype IN (' . implode(',', $conditionTypeParts) . ') )';
         }
 
-        if (is_array($subtypes) and !empty($subtypes[0])) {
+        if (is_array($subtypes) && !empty($subtypes[0])) {
             $conditionSubtypeParts = [];
             foreach ($subtypes as $subtype) {
                 $conditionSubtypeParts[] = $db->quote($subtype);
@@ -196,7 +196,7 @@ class SearchController extends AdminController
             $conditionParts[] = '( type IN (' . implode(',', $conditionSubtypeParts) . ') )';
         }
 
-        if (is_array($classnames) and !empty($classnames[0])) {
+        if (is_array($classnames) && !empty($classnames[0])) {
             if (in_array('folder', $subtypes)) {
                 $classnames[] = 'folder';
             }

--- a/bundles/AdminBundle/GDPR/DataProvider/DataObjects.php
+++ b/bundles/AdminBundle/GDPR/DataProvider/DataObjects.php
@@ -176,7 +176,7 @@ class DataObjects extends Elements implements DataProviderInterface
             }
         }
 
-        if (is_array($classnames) and !empty($classnames[0])) {
+        if (is_array($classnames) && !empty($classnames[0])) {
             $conditionClassnameParts = [];
             foreach ($classnames as $classname) {
                 $conditionClassnameParts[] = $db->quote($classname);

--- a/bundles/CoreBundle/Command/SearchBackendReindexCommand.php
+++ b/bundles/CoreBundle/Command/SearchBackendReindexCommand.php
@@ -82,7 +82,7 @@ class SearchBackendReindexCommand extends AbstractCommand
                         }
 
                         $searchEntry = Search\Backend\Data::getForElement($element);
-                        if ($searchEntry instanceof Search\Backend\Data and $searchEntry->getId() instanceof Search\Backend\Data\Id) {
+                        if ($searchEntry instanceof Search\Backend\Data && $searchEntry->getId() instanceof Search\Backend\Data\Id) {
                             $searchEntry->setDataFromElement($element);
                         } else {
                             $searchEntry = new Search\Backend\Data($element);

--- a/bundles/CoreBundle/EventListener/SearchBackendListener.php
+++ b/bundles/CoreBundle/EventListener/SearchBackendListener.php
@@ -74,7 +74,7 @@ class SearchBackendListener implements EventSubscriberInterface
     {
         $element = $e->getElement();
         $searchEntry = Data::getForElement($element);
-        if ($searchEntry instanceof Data and $searchEntry->getId() instanceof Data\Id) {
+        if ($searchEntry instanceof Data && $searchEntry->getId() instanceof Data\Id) {
             $searchEntry->setDataFromElement($element);
             $searchEntry->save();
         } else {

--- a/lib/Model/Listing/Dao/AbstractDao.php
+++ b/lib/Model/Listing/Dao/AbstractDao.php
@@ -85,7 +85,7 @@ abstract class AbstractDao extends Model\Dao\AbstractDao
      */
     protected function getOffsetLimit()
     {
-        if ($limit = $this->model->getLimit() and $offset = $this->model->getOffset()) {
+        if ($limit = $this->model->getLimit() && $offset = $this->model->getOffset()) {
             return ' LIMIT ' . $offset . ',' . $limit;
         }
 

--- a/lib/Navigation/Builder.php
+++ b/lib/Navigation/Builder.php
@@ -309,7 +309,7 @@ class Builder
                 continue;
             }
 
-            if (($child instanceof Document\Folder or $child instanceof Document\Page or $child instanceof Document\Link) and $child->getProperty('navigation_name')) {
+            if (($child instanceof Document\Folder || $child instanceof Document\Page || $child instanceof Document\Link) && $child->getProperty('navigation_name')) {
                 $path = $child->getFullPath();
                 if ($child instanceof Document\Link) {
                     $path = $child->getHref();

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -130,14 +130,14 @@ class Authentication
 
         $user = User::getByName($username);
         if (self::isValidUser($user)) {
-            if ($adminRequired and !$user->isAdmin()) {
+            if ($adminRequired && !$user->isAdmin()) {
                 return null;
             }
 
             $timeZone = date_default_timezone_get();
             date_default_timezone_set('UTC');
 
-            if ($timestamp > time() or $timestamp < (time() - (60 * 60 * 24))) {
+            if ($timestamp > time() || $timestamp < (time() - (60 * 60 * 24))) {
                 return null;
             }
             date_default_timezone_set($timeZone);

--- a/models/Asset/Dao.php
+++ b/models/Asset/Dao.php
@@ -354,7 +354,7 @@ class Dao extends Model\Element\Dao
      */
     public function getChildAmount($user = null)
     {
-        if ($user and !$user->isAdmin()) {
+        if ($user && !$user->isAdmin()) {
             $userIds = $user->getRoles();
             $userIds[] = $user->getId();
 

--- a/models/Asset/Folder.php
+++ b/models/Asset/Folder.php
@@ -54,7 +54,7 @@ class Folder extends Model\Asset
     public function setChildren($children)
     {
         $this->children = $children;
-        if (is_array($children) and count($children) > 0) {
+        if (is_array($children) && count($children) > 0) {
             $this->hasChildren = true;
         } else {
             $this->hasChildren = false;

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -350,7 +350,7 @@ class Dao extends Model\Element\Dao
             $query .= sprintf(' AND o_type IN (\'%s\')', implode("','", $objectTypes));
         }
 
-        if ($user and !$user->isAdmin()) {
+        if ($user && !$user->isAdmin()) {
             $userIds = $user->getRoles();
             $userIds[] = $user->getId();
 

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -111,7 +111,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
             }
 
             return $return;
-        } elseif (is_array($data) and count($data) === 0) {
+        } elseif (is_array($data) && count($data) === 0) {
             //give empty array if data was not null
             return [];
         } else {
@@ -395,7 +395,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if (!$omitMandatoryCheck and $this->getMandatory() and empty($data)) {
+        if (!$omitMandatoryCheck && $this->getMandatory() && empty($data)) {
             throw new Element\ValidationException('Empty mandatory field [ ' . $this->getName() . ' ]');
         }
 

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -104,7 +104,7 @@ class AdvancedManyToManyRelation extends ManyToManyRelation implements IdRewrite
             }
 
             return $return;
-        } elseif (is_array($data) and count($data) === 0) {
+        } elseif (is_array($data) && count($data) === 0) {
             //give empty array if data was not null
             return [];
         } else {
@@ -487,7 +487,7 @@ class AdvancedManyToManyRelation extends ManyToManyRelation implements IdRewrite
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if (!$omitMandatoryCheck and $this->getMandatory() and empty($data)) {
+        if (!$omitMandatoryCheck && $this->getMandatory() && empty($data)) {
             throw new Element\ValidationException('Empty mandatory field [ ' . $this->getName() . ' ]');
         }
 

--- a/models/DataObject/ClassDefinition/Data/Checkbox.php
+++ b/models/DataObject/ClassDefinition/Data/Checkbox.php
@@ -180,7 +180,7 @@ class Checkbox extends Data implements ResourcePersistenceAwareInterface, QueryR
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if (!$omitMandatoryCheck and $this->getMandatory() and $data === null) {
+        if (!$omitMandatoryCheck && $this->getMandatory() && $data === null) {
             throw new Model\Element\ValidationException('Empty mandatory field [ ' . $this->getName() . ' ]');
         }
 

--- a/models/DataObject/ClassDefinition/Data/Consent.php
+++ b/models/DataObject/ClassDefinition/Data/Consent.php
@@ -293,7 +293,7 @@ class Consent extends Data implements ResourcePersistenceAwareInterface, QueryRe
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if (!$omitMandatoryCheck and $this->getMandatory() and $data === null) {
+        if (!$omitMandatoryCheck && $this->getMandatory() && $data === null) {
             throw new Model\Element\ValidationException('Empty mandatory field [ ' . $this->getName() . ' ]');
         }
 

--- a/models/DataObject/ClassDefinition/Data/ExternalImage.php
+++ b/models/DataObject/ClassDefinition/Data/ExternalImage.php
@@ -311,7 +311,6 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
             throw new Model\Element\ValidationException('[ ' . $this->getName() . " ] should not be empty!");
         }
 
-        parent::checkValidity($data, $omitMandatoryCheck);
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/ExternalImage.php
+++ b/models/DataObject/ClassDefinition/Data/ExternalImage.php
@@ -300,6 +300,22 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
 
     /**
      * @param DataObject\Data\ExternalImage|null $data
+     * @param bool $omitMandatoryCheck
+     * @param array $params
+     *
+     * @throws Element\ValidationException
+     */
+    public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
+    {
+        if ($this->getMandatory() && !$omitMandatoryCheck && !$this->isEmpty($data)) {
+            throw new Model\Element\ValidationException('[ ' . $this->getName() . " ] should not be empty!");
+        }
+
+        parent::checkValidity($data, $omitMandatoryCheck);
+    }
+
+    /**
+     * @param DataObject\Data\ExternalImage|null $data
      *
      * @return bool
      */

--- a/models/DataObject/ClassDefinition/Data/ExternalImage.php
+++ b/models/DataObject/ClassDefinition/Data/ExternalImage.php
@@ -310,7 +310,6 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
         if ($this->getMandatory() && !$omitMandatoryCheck && !$this->isEmpty($data)) {
             throw new Model\Element\ValidationException('Empty mandatory field [ ' . $this->getName() . ' ]');
         }
-
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/ExternalImage.php
+++ b/models/DataObject/ClassDefinition/Data/ExternalImage.php
@@ -308,7 +308,7 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
         if ($this->getMandatory() && !$omitMandatoryCheck && !$this->isEmpty($data)) {
-            throw new Model\Element\ValidationException('[ ' . $this->getName() . " ] should not be empty!");
+            throw new Model\Element\ValidationException('Empty mandatory field [ ' . $this->getName() . ' ]');
         }
 
     }

--- a/models/DataObject/ClassDefinition/Data/ExternalImage.php
+++ b/models/DataObject/ClassDefinition/Data/ExternalImage.php
@@ -303,7 +303,7 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
      * @param bool $omitMandatoryCheck
      * @param array $params
      *
-     * @throws Element\ValidationException
+     * @throws Model\Element\ValidationException
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {

--- a/models/DataObject/ClassDefinition/Data/Hotspotimage.php
+++ b/models/DataObject/ClassDefinition/Data/Hotspotimage.php
@@ -499,7 +499,7 @@ class Hotspotimage extends Data implements ResourcePersistenceAwareInterface, Qu
     {
         if ($data instanceof DataObject\Data\Hotspotimage && $data->getImage()) {
             $id = $data->getImage()->getId();
-            if (array_key_exists('asset', $idMapping) and array_key_exists($id, $idMapping['asset'])) {
+            if (array_key_exists('asset', $idMapping) && array_key_exists($id, $idMapping['asset'])) {
                 $data->setImage(Asset::getById($idMapping['asset'][$id]));
 
                 // reset hotspot, marker & crop
@@ -536,21 +536,21 @@ class Hotspotimage extends Data implements ResourcePersistenceAwareInterface, Qu
                         //rewrite objects
                         if ($dataEntry['type'] == 'object' && $dataEntry['value']) {
                             $id = $dataEntry['value']->getId();
-                            if (array_key_exists('object', $idMapping) and array_key_exists($id, $idMapping['object'])) {
+                            if (array_key_exists('object', $idMapping) && array_key_exists($id, $idMapping['object'])) {
                                 $dataEntry['value'] = DataObject::getById($idMapping['object'][$id]);
                             }
                         }
                         //rewrite assets
                         if ($dataEntry['type'] == 'asset' && $dataEntry['value']) {
                             $id = $dataEntry['value']->getId();
-                            if (array_key_exists('asset', $idMapping) and array_key_exists($id, $idMapping['asset'])) {
+                            if (array_key_exists('asset', $idMapping) && array_key_exists($id, $idMapping['asset'])) {
                                 $dataEntry['value'] = Asset::getById($idMapping['asset'][$id]);
                             }
                         }
                         //rewrite documents
                         if ($dataEntry['type'] == 'document' && $dataEntry['value']) {
                             $id = $dataEntry['value']->getId();
-                            if (array_key_exists('document', $idMapping) and array_key_exists($id, $idMapping['document'])) {
+                            if (array_key_exists('document', $idMapping) && array_key_exists($id, $idMapping['document'])) {
                                 $dataEntry['value'] = Document::getById($idMapping['document'][$id]);
                             }
                         }

--- a/models/DataObject/ClassDefinition/Data/Image.php
+++ b/models/DataObject/ClassDefinition/Data/Image.php
@@ -282,7 +282,7 @@ class Image extends Data implements ResourcePersistenceAwareInterface, QueryReso
     {
         $data = $this->getDataFromObjectParam($container, $params);
         if ($data instanceof Asset\Image) {
-            if (array_key_exists('asset', $idMapping) and array_key_exists($data->getId(), $idMapping['asset'])) {
+            if (array_key_exists('asset', $idMapping) && array_key_exists($data->getId(), $idMapping['asset'])) {
                 return Asset::getById($idMapping['asset'][$data->getId()]);
             }
         }

--- a/models/DataObject/ClassDefinition/Data/ImageGallery.php
+++ b/models/DataObject/ClassDefinition/Data/ImageGallery.php
@@ -488,6 +488,22 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
 
     /**
      * @param DataObject\Data\ImageGallery|null $data
+     * @param bool $omitMandatoryCheck
+     * @param array $params
+     *
+     * @throws Element\ValidationException
+     */
+    public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
+    {
+        if ($this->getMandatory() && !$omitMandatoryCheck && ($data === null || empty($data->getItems()) || $data->getItems()[0]->getImage() === null)) {
+            throw new Model\Element\ValidationException('[ ' . $this->getName() . " ] At least 1 image should be uploaded!");
+        }
+
+        parent::checkValidity($data, $omitMandatoryCheck);
+    }
+
+    /**
+     * @param DataObject\Data\ImageGallery|null $data
      *
      * @return bool
      */

--- a/models/DataObject/ClassDefinition/Data/ImageGallery.php
+++ b/models/DataObject/ClassDefinition/Data/ImageGallery.php
@@ -496,7 +496,7 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
         if ($this->getMandatory() && !$omitMandatoryCheck && ($data === null || empty($data->getItems()) || $data->getItems()[0]->getImage() === null)) {
-            throw new Model\Element\ValidationException('[ ' . $this->getName() . " ] At least 1 image should be uploaded!");
+            throw new Model\Element\ValidationException('[ ' . $this->getName() . ' ] At least 1 image should be uploaded!');
         }
 
         parent::checkValidity($data, $omitMandatoryCheck);

--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -254,7 +254,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
     {
         $dependencies = [];
 
-        if ($data instanceof DataObject\Data\Link and $data->getInternal()) {
+        if ($data instanceof DataObject\Data\Link && $data->getInternal()) {
             if ((int)$data->getInternal() > 0) {
                 if ($data->getInternalType() == 'document') {
                     if ($doc = Document::getById($data->getInternal())) {
@@ -285,7 +285,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
      */
     public function getCacheTags($data, array $tags = [])
     {
-        if ($data instanceof DataObject\Data\Link and $data->getInternal()) {
+        if ($data instanceof DataObject\Data\Link && $data->getInternal()) {
             if ((int)$data->getInternal() > 0) {
                 if ($data->getInternalType() == 'document') {
                     if ($doc = Document::getById($data->getInternal())) {
@@ -372,7 +372,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
             $id = $data->getInternal();
             $type = $data->getInternalType();
 
-            if (array_key_exists($type, $idMapping) and array_key_exists($id, $idMapping[$type])) {
+            if (array_key_exists($type, $idMapping) && array_key_exists($id, $idMapping[$type])) {
                 $data->setInternal($idMapping[$type][$id]);
             }
         }

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -142,7 +142,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
             }
 
             return $return;
-        } elseif (is_array($data) and count($data) === 0) {
+        } elseif (is_array($data) && count($data) === 0) {
             //give empty array if data was not null
             return [];
         } else {
@@ -365,7 +365,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if (!$omitMandatoryCheck and $this->getMandatory() and empty($data)) {
+        if (!$omitMandatoryCheck && $this->getMandatory() && empty($data)) {
             throw new Element\ValidationException('Empty mandatory field [ '.$this->getName().' ]');
         }
 
@@ -378,7 +378,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
                 }
 
                 $allowClass = $this->allowObjectRelation($o);
-                if (!$allowClass or !($o instanceof DataObject\Concrete)) {
+                if (!$allowClass || !($o instanceof DataObject\Concrete)) {
                     if (!$allowClass && $o instanceof DataObject\Concrete) {
                         $id = $o->getId();
                     } else {
@@ -465,7 +465,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
             $data = $container->getObjectVar($this->getName());
         }
 
-        if (DataObject::doHideUnpublished() and is_array($data)) {
+        if (DataObject::doHideUnpublished() && is_array($data)) {
             $publishedList = [];
             foreach ($data as $listElement) {
                 if (Element\Service::isPublished($listElement)) {

--- a/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
@@ -257,7 +257,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
             }
 
             return $return;
-        } elseif (is_array($data) and count($data) === 0) {
+        } elseif (is_array($data) && count($data) === 0) {
             //give empty array if data was not null
             return [];
         } else {
@@ -504,7 +504,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if (!$omitMandatoryCheck and $this->getMandatory() and empty($data)) {
+        if (!$omitMandatoryCheck && $this->getMandatory() && empty($data)) {
             throw new Element\ValidationException('Empty mandatory field [ ' . $this->getName() . ' ]');
         }
 
@@ -614,7 +614,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
             $data = $container->getObjectVar($this->getName());
         }
 
-        if (DataObject::doHideUnpublished() and is_array($data)) {
+        if (DataObject::doHideUnpublished() && is_array($data)) {
             $publishedList = [];
             foreach ($data as $listElement) {
                 if (Element\Service::isPublished($listElement)) {

--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -393,7 +393,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if (!$omitMandatoryCheck and $this->getMandatory() and empty($data)) {
+        if (!$omitMandatoryCheck && $this->getMandatory() && empty($data)) {
             throw new Element\ValidationException('Empty mandatory field [ '.$this->getName().' ]');
         }
 

--- a/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -358,11 +358,11 @@ class Multiselect extends Data implements
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if (!$omitMandatoryCheck and $this->getMandatory() and empty($data)) {
+        if (!$omitMandatoryCheck && $this->getMandatory() && empty($data)) {
             throw new Model\Element\ValidationException('Empty mandatory field [ '.$this->getName().' ]');
         }
 
-        if (!is_array($data) and !empty($data)) {
+        if (!is_array($data) && !empty($data)) {
             throw new Model\Element\ValidationException('Invalid multiselect data');
         }
     }

--- a/models/DataObject/ClassDefinition/Data/Relations/AllowDocumentRelationTrait.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AllowDocumentRelationTrait.php
@@ -43,7 +43,7 @@ trait AllowDocumentRelationTrait
         $allowed = true;
         if (!$this->getDocumentsAllowed()) {
             $allowed = false;
-        } elseif ($this->getDocumentsAllowed() and is_array($allowedDocumentTypes) and count($allowedDocumentTypes) > 0) {
+        } elseif ($this->getDocumentsAllowed() && is_array($allowedDocumentTypes) && count($allowedDocumentTypes) > 0) {
             //check for allowed asset types
             $allowedTypes = [];
             foreach ($allowedDocumentTypes as $t) {

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -161,14 +161,14 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
         //TODO
-        if (!$omitMandatoryCheck and $this->getMandatory() and empty($data)) {
+        if (!$omitMandatoryCheck && $this->getMandatory() && empty($data)) {
             throw new Model\Element\ValidationException('Empty mandatory field [ '.$this->getName().' ]');
         }
 
         if (is_array($data)) {
             foreach ($data as $o) {
                 $allowClass = $this->allowObjectRelation($o);
-                if (!$allowClass or !($o instanceof DataObject\Concrete)) {
+                if (!$allowClass || !($o instanceof DataObject\Concrete)) {
                     throw new Model\Element\ValidationException('Invalid non owner object relation to object ['.$o->getId().']', null, null);
                 }
             }

--- a/models/DataObject/ClassDefinition/Data/Slider.php
+++ b/models/DataObject/ClassDefinition/Data/Slider.php
@@ -368,11 +368,11 @@ class Slider extends Data implements ResourcePersistenceAwareInterface, QueryRes
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if (!$omitMandatoryCheck and $this->getMandatory() and $data === null) {
+        if (!$omitMandatoryCheck && $this->getMandatory() && $data === null) {
             throw new Model\Element\ValidationException('Empty mandatory field [ '.$this->getName().' ] '.(string)$data);
         }
 
-        if (!empty($data) and !is_numeric($data)) {
+        if (!empty($data) && !is_numeric($data)) {
             throw new Model\Element\ValidationException('invalid slider data');
         }
     }

--- a/models/DataObject/ClassDefinition/Data/StructuredTable.php
+++ b/models/DataObject/ClassDefinition/Data/StructuredTable.php
@@ -389,7 +389,7 @@ class StructuredTable extends Data implements ResourcePersistenceAwareInterface,
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if (!$omitMandatoryCheck and $this->getMandatory()) {
+        if (!$omitMandatoryCheck && $this->getMandatory()) {
             $empty = true;
             if (!empty($data)) {
                 $dataArray = $data->getData();
@@ -406,7 +406,7 @@ class StructuredTable extends Data implements ResourcePersistenceAwareInterface,
             }
         }
 
-        if (!empty($data) and !$data instanceof DataObject\Data\StructuredTable) {
+        if (!empty($data) && !$data instanceof DataObject\Data\StructuredTable) {
             throw new Model\Element\ValidationException('invalid table data');
         }
     }

--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -506,11 +506,11 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if (!$omitMandatoryCheck and $this->getMandatory() and empty($data)) {
+        if (!$omitMandatoryCheck && $this->getMandatory() && empty($data)) {
             throw new Model\Element\ValidationException('Empty mandatory field [ '.$this->getName().' ]');
         }
 
-        if (!empty($data) and !is_array($data)) {
+        if (!empty($data) && !is_array($data)) {
             throw new Model\Element\ValidationException('Invalid table data');
         }
     }

--- a/models/DataObject/ClassDefinition/Data/TargetGroup.php
+++ b/models/DataObject/ClassDefinition/Data/TargetGroup.php
@@ -102,7 +102,7 @@ class TargetGroup extends Model\DataObject\ClassDefinition\Data\Select
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if (!$omitMandatoryCheck and $this->getMandatory() and empty($data)) {
+        if (!$omitMandatoryCheck && $this->getMandatory() && empty($data)) {
             throw new Model\Element\ValidationException('Empty mandatory field [ '.$this->getName().' ]');
         }
 

--- a/models/DataObject/ClassDefinition/Data/User.php
+++ b/models/DataObject/ClassDefinition/Data/User.php
@@ -108,13 +108,13 @@ class User extends Model\DataObject\ClassDefinition\Data\Select
         $users = $list->load();
 
         $options = [];
-        if (is_array($users) and count($users) > 0) {
+        if (is_array($users) && count($users) > 0) {
             foreach ($users as $user) {
                 if ($user instanceof Model\User) {
                     $value = $user->getName();
                     $first = $user->getFirstname();
                     $last = $user->getLastname();
-                    if (!empty($first) or !empty($last)) {
+                    if (!empty($first) || !empty($last)) {
                         $value .= ' (' . $first . ' ' . $last . ')';
                     }
                     $options[] = [
@@ -132,7 +132,7 @@ class User extends Model\DataObject\ClassDefinition\Data\Select
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if (!$omitMandatoryCheck and $this->getMandatory() and empty($data)) {
+        if (!$omitMandatoryCheck && $this->getMandatory() && empty($data)) {
             throw new Model\Element\ValidationException('Empty mandatory field [ '.$this->getName().' ]');
         }
 

--- a/models/DataObject/ClassDefinition/Data/Video.php
+++ b/models/DataObject/ClassDefinition/Data/Video.php
@@ -450,13 +450,13 @@ class Video extends Data implements ResourcePersistenceAwareInterface, QueryReso
         $data = $this->getDataFromObjectParam($container, $params);
 
         if ($data && $data->getData() instanceof Asset) {
-            if (array_key_exists('asset', $idMapping) and array_key_exists($data->getData()->getId(), $idMapping['asset'])) {
+            if (array_key_exists('asset', $idMapping) && array_key_exists($data->getData()->getId(), $idMapping['asset'])) {
                 $data->setData(Asset::getById($idMapping['asset'][$data->getData()->getId()]));
             }
         }
 
         if ($data && $data->getPoster() instanceof Asset) {
-            if (array_key_exists('asset', $idMapping) and array_key_exists($data->getPoster()->getId(), $idMapping['asset'])) {
+            if (array_key_exists('asset', $idMapping) && array_key_exists($data->getPoster()->getId(), $idMapping['asset'])) {
                 $data->setPoster(Asset::getById($idMapping['asset'][$data->getPoster()->getId()]));
             }
         }

--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -305,7 +305,7 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if (!$omitMandatoryCheck and $this->getMandatory() and empty($data)) {
+        if (!$omitMandatoryCheck && $this->getMandatory() && empty($data)) {
             throw new Element\ValidationException('Empty mandatory field [ '.$this->getName().' ]');
         }
         $dependencies = Text::getDependenciesOfWysiwygText($data);

--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -131,7 +131,7 @@ class Dao extends Model\DataObject\AbstractObject\Dao
 
             ORDER BY `index` ASC", $params);
 
-        if (is_array($relations) and count($relations) > 0) {
+        if (is_array($relations) && count($relations) > 0) {
             return $relations;
         } else {
             return [];

--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -414,7 +414,7 @@ class Dao extends Model\Dao\AbstractDao
             AND r.type='document'
             ORDER BY `index` ASC", $params);
 
-        if (is_array($relations) and count($relations) > 0) {
+        if (is_array($relations) && count($relations) > 0) {
             return $relations;
         } else {
             return [];

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -95,7 +95,7 @@ class Service extends Model\Element\Service
                     }
                 }
             }
-            if (is_array($dataKeys) and count($dataKeys) > 0) {
+            if (is_array($dataKeys) && count($dataKeys) > 0) {
                 $classesToCheck[$class->getName()] = $dataKeys;
             }
         }
@@ -1044,7 +1044,7 @@ class Service extends Model\Element\Service
      */
     public static function extractFieldDefinitions($layout, $targetClass, $targetList, $insideDataType)
     {
-        if ($insideDataType && $layout instanceof ClassDefinition\Data and !is_a($layout, $targetClass)) {
+        if ($insideDataType && $layout instanceof ClassDefinition\Data && !is_a($layout, $targetClass)) {
             $targetList[$layout->getName()] = $layout;
         }
 

--- a/models/Document/Dao.php
+++ b/models/Document/Dao.php
@@ -359,7 +359,7 @@ class Dao extends Model\Element\Dao
      */
     public function getChildAmount($user = null)
     {
-        if ($user and !$user->isAdmin()) {
+        if ($user && !$user->isAdmin()) {
             $userIds = $user->getRoles();
             $userIds[] = $user->getId();
 

--- a/models/Document/Editable/Dao.php
+++ b/models/Document/Editable/Dao.php
@@ -28,7 +28,7 @@ class Dao extends Model\Dao\AbstractDao
     {
         $data = $this->model->getDataForResource();
 
-        if (is_array($data) or is_object($data)) {
+        if (is_array($data) || is_object($data)) {
             $data = \Pimcore\Tool\Serialize::serialize($data);
         }
 

--- a/models/Document/Editable/Image.php
+++ b/models/Document/Editable/Image.php
@@ -755,7 +755,7 @@ class Image extends Model\Document\Editable
      */
     public function rewriteIds($idMapping)
     {
-        if (array_key_exists('asset', $idMapping) and array_key_exists($this->getId(), $idMapping['asset'])) {
+        if (array_key_exists('asset', $idMapping) && array_key_exists($this->getId(), $idMapping['asset'])) {
             $this->setId($idMapping['asset'][$this->getId()]);
 
             // reset marker & hotspot information

--- a/models/Document/Editable/Renderlet.php
+++ b/models/Document/Editable/Renderlet.php
@@ -393,7 +393,7 @@ class Renderlet extends Model\Document\Editable
     public function rewriteIds($idMapping)
     {
         $type = (string) $this->type;
-        if ($type && array_key_exists($this->type, $idMapping) and array_key_exists($this->getId(), $idMapping[$this->type])) {
+        if ($type && array_key_exists($this->type, $idMapping) && array_key_exists($this->getId(), $idMapping[$this->type])) {
             $this->setId($idMapping[$this->type][$this->getId()]);
             $this->setO(null);
         }

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -1023,7 +1023,7 @@ class Video extends Model\Document\Editable
      */
     public function rewriteIds($idMapping)
     {
-        if ($this->type == 'asset' && array_key_exists('asset', $idMapping) and array_key_exists($this->getId(), $idMapping['asset'])) {
+        if ($this->type == 'asset' && array_key_exists('asset', $idMapping) && array_key_exists($this->getId(), $idMapping['asset'])) {
             $this->setId($idMapping['asset'][$this->getId()]);
         }
     }

--- a/models/Document/Hardlink.php
+++ b/models/Document/Hardlink.php
@@ -92,7 +92,7 @@ class Hardlink extends Document
         $tags = parent::getCacheTags($tags);
 
         if ($this->getSourceDocument()) {
-            if ($this->getSourceDocument()->getId() != $this->getId() and !array_key_exists($this->getSourceDocument()->getCacheTag(), $tags)) {
+            if ($this->getSourceDocument()->getId() != $this->getId() && !array_key_exists($this->getSourceDocument()->getCacheTag(), $tags)) {
                 $tags = $this->getSourceDocument()->getCacheTags($tags);
             }
         }

--- a/models/Document/Link.php
+++ b/models/Document/Link.php
@@ -118,7 +118,7 @@ class Link extends Model\Document
 
         if ($this->getLinktype() === 'internal') {
             if ($this->getObject() instanceof Document || $this->getObject() instanceof Asset) {
-                if ($this->getObject()->getId() != $this->getId() and !array_key_exists($this->getObject()->getCacheTag(), $tags)) {
+                if ($this->getObject()->getId() != $this->getId() && !array_key_exists($this->getObject()->getCacheTag(), $tags)) {
                     $tags = $this->getObject()->getCacheTags($tags);
                 }
             }

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -132,7 +132,7 @@ abstract class PageSnippet extends Model\Document
         $this->getEditables();
         $this->getDao()->deleteAllEditables();
 
-        if (is_array($this->getEditables()) and count($this->getEditables()) > 0) {
+        if (is_array($this->getEditables()) && count($this->getEditables()) > 0) {
             foreach ($this->getEditables() as $name => $editable) {
                 if (!$editable->getInherited()) {
                     $editable->setDao(null);

--- a/models/Element/Sanitycheck.php
+++ b/models/Element/Sanitycheck.php
@@ -99,7 +99,7 @@ final class Sanitycheck extends Model\AbstractModel
     {
         $sanityCheck = new Sanitycheck();
         $sanityCheck->getDao()->getNext();
-        if ($sanityCheck->getId() and $sanityCheck->getType()) {
+        if ($sanityCheck->getId() && $sanityCheck->getType()) {
             return $sanityCheck;
         } else {
             return null;

--- a/models/Translation.php
+++ b/models/Translation.php
@@ -452,7 +452,7 @@ final class Translation extends AbstractModel
             }
 
             //process translations
-            if (is_array($data) and count($data) > 1) {
+            if (is_array($data) && count($data) > 1) {
                 $keys = $data[0];
                 // remove wrong quotes in some export/import constellations
                 $keys = array_map(function ($value) {

--- a/models/User/UserRole/Folder.php
+++ b/models/User/UserRole/Folder.php
@@ -76,7 +76,7 @@ class Folder extends Model\User\AbstractUser
     public function setChildren($children)
     {
         $this->children = $children;
-        if (is_array($children) and count($children) > 0) {
+        if (is_array($children) && count($children) > 0) {
             $this->hasChilds = true;
         } else {
             $this->hasChilds = false;

--- a/models/Version.php
+++ b/models/Version.php
@@ -193,7 +193,7 @@ final class Version extends AbstractModel
 
         $data = $this->getData();
         // if necessary convert the data to save it to filesystem
-        if (is_object($data) or is_array($data)) {
+        if (is_object($data) || is_array($data)) {
 
             // this is because of lazy loaded element inside documents and objects (eg: relational data-types, fieldcollections, ...)
             $fromRuntime = null;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Actually if we have a mandatory field with `ExternalImage` data type, the mandatory check will be skipped:

![Bildschirmfoto 2021-09-07 um 12 21 27](https://user-images.githubusercontent.com/12817320/132328958-a3089164-dea7-44f8-b89a-2f15a397f340.png)


## Additional info  

