### PR TITLE
[DataObject] Added mandatory check for ExternalImage data type

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ExternalImage.php
+++ b/models/DataObject/ClassDefinition/Data/ExternalImage.php
@@ -307,7 +307,7 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if ($this->getMandatory() && !$omitMandatoryCheck && !$this->isEmpty($data)) {
+        if ($this->getMandatory() && !$omitMandatoryCheck && $this->isEmpty($data)) {
             throw new Model\Element\ValidationException('Empty mandatory field [ ' . $this->getName() . ' ]');
         }
     }

--- a/models/DataObject/ClassDefinition/Data/ExternalImage.php
+++ b/models/DataObject/ClassDefinition/Data/ExternalImage.php
@@ -300,6 +300,20 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
 
     /**
      * @param DataObject\Data\ExternalImage|null $data
+     * @param bool $omitMandatoryCheck
+     * @param array $params
+     *
+     * @throws Model\Element\ValidationException
+     */
+    public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
+    {
+        if ($this->getMandatory() && !$omitMandatoryCheck && !$this->isEmpty($data)) {
+            throw new Model\Element\ValidationException('Empty mandatory field [ ' . $this->getName() . ' ]');
+        }
+    }
+
+    /**
+     * @param DataObject\Data\ExternalImage|null $data
      *
      * @return bool
      */


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Actually if we have a mandatory field with `ExternalImage` data type, the mandatory check will be skipped:

![Bildschirmfoto 2021-09-07 um 12 21 27](https://user-images.githubusercontent.com/12817320/132328958-a3089164-dea7-44f8-b89a-2f15a397f340.png)


## Additional info  

Rebase of https://github.com/pimcore/pimcore/pull/10266
@brusch 