### PR TITLE
[Admin] Grids & lists: use loading=lazy on all <img> tags

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/admin.css
+++ b/bundles/AdminBundle/Resources/public/css/admin.css
@@ -509,30 +509,32 @@
     font-size: 11px;
 }
 
-.asset_folder_preview .thumb{
-    width: 250px;
-    height: 250px;
-}
-
-.asset_folder_preview .thumb td {
-    width: 250px;
-    height: 250px;
-}
-
 .asset_folder_preview .thumb-wrap{
     float: left;
+    width: 250px;
+    height: 250px;
     margin: 4px;
     margin-right: 0;
     padding: 5px;
     background: #ececec;
     cursor: pointer;
+    position: relative;
+    overflow: hidden;
 }
 
-.asset_folder_preview .thumb-wrap span{
+.asset_folder_preview .thumb{
+    width: 250px;
+    max-height: 220px;
+}
+
+.asset_folder_preview .filename {
     display: block;
     overflow: hidden;
     text-align: center;
     width: 250px;
+    position: absolute;
+    bottom: 3px;
+    left: 0;
 }
 
 .asset_folder_preview .x-view-over{

--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/folder.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/folder.js
@@ -82,10 +82,7 @@ pimcore.asset.folder = Class.create(pimcore.asset.asset, {
         var tpl = new Ext.XTemplate(
             '<tpl for=".">',
             '<div class="thumb-wrap">',
-            '<div class="thumb"><table cellspacing="0" cellpadding="0" border="0"><tr><td class="thumb-item" align="center" '
-                + 'valign="middle" style="background: url({url}) center center no-repeat; ' +
-                'background-size: contain;" id="{type}_{id}" data-idpath="{idPath}">'
-                + '</td></tr></table></div>',
+            '<img class="thumb" src="{url}" loading="lazy">',
             '<span class="filename" title="{filename}">{filenameDisplay}</span></div>',
             '</tpl>',
             '<div class="x-clear"></div>'

--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/helpers/grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/helpers/grid.js
@@ -199,11 +199,7 @@ pimcore.asset.helpers.grid = Class.create({
                         locked: this.getColumnLock(field),
                         renderer: function (value) {
                             if (value) {
-                                return '<div class="thumb-wrap">',
-                                '<div class="thumb"><table cellspacing="0" cellpadding="0" border="0"><tr><td class="thumb-item" align="center" '
-                                + 'valign="middle" style="background: url(' + value + ') center center no-repeat; ' +
-                                'background-size: contain; width: 200px; height: 100px; cursor: default !important;">'
-                                + '</td></tr></table></div></div>';
+                                return '<img style="max-width: 200px; max-height: 100px;" src="' + value + '" loading="lazy">';
                             }
                         }.bind(this)
                     });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/externalImage.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/externalImage.js
@@ -39,7 +39,7 @@ pimcore.object.tags.externalImage = Class.create(pimcore.object.tags.abstract, {
                 }
 
                 if (value) {
-                    return '<img style="max-width:88px;max-height:88px" src="' + value  + '" />';
+                    return '<img style="max-width:88px;max-height:88px" src="' + value  + '" loading="lazy" />';
                 }
             }.bind(this, field.key)};
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
@@ -71,7 +71,7 @@ pimcore.object.tags.hotspotimage = Class.create(pimcore.object.tags.image, {
                         params['height'] = 20;
                         params['frame'] = true;
 
-                        return '<img src="' + Routing.generate('pimcore_admin_asset_getimagethumbnail', params)  + '" />';
+                        return '<img src="' + Routing.generate('pimcore_admin_asset_getimagethumbnail', params)  + '" loading="lazy" />';
                     } else {
                         params['width'] = 88;
                         params['height'] = 88;
@@ -84,7 +84,7 @@ pimcore.object.tags.hotspotimage = Class.create(pimcore.object.tags.image, {
                             url = Ext.String.urlAppend(url, cropParams);
                         }
 
-                        url = '<img src="' + url + '" style="width:88px; height:88px;" />';
+                        url = '<img src="' + url + '" style="width:88px; height:88px;" loading="lazy" />';
                         return url;
                     }
                 }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/image.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/image.js
@@ -49,7 +49,7 @@ pimcore.object.tags.image = Class.create(pimcore.object.tags.abstract, {
                             frame: true
                         };
                         var path = Routing.generate('pimcore_admin_asset_getimagethumbnail', params);
-                        return '<img src="'+path+'" />';
+                        return '<img src="'+path+'" loading="lazy" />';
                     }
 
                     var params = {
@@ -61,7 +61,7 @@ pimcore.object.tags.image = Class.create(pimcore.object.tags.abstract, {
 
                     var path = Routing.generate('pimcore_admin_asset_getimagethumbnail', params);
 
-                    return '<img src="'+path+'" style="width:88px; height:88px;"  />';
+                    return '<img src="'+path+'" style="width:88px; height:88px;" loading="lazy" />';
                 }
             }.bind(this, field.key)
         };

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/imagegallery.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/imagegallery.js
@@ -63,7 +63,7 @@ pimcore.object.tags.imageGallery = Class.create(pimcore.object.tags.abstract, {
                             params = Ext.merge(params, item.crop);
                         }
                         var url = Routing.generate(route, params);
-                        var tag = '<img style="padding-left: 3px" src="'+url+'">';
+                        var tag = '<img style="padding-left: 3px" src="'+url+'" loading="lazy">';
 
                         content += tag;
                     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/video.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/video.js
@@ -47,7 +47,7 @@ pimcore.object.tags.video = Class.create(pimcore.object.tags.abstract, {
                         height: 88,
                         frame: true
                     });
-                    return '<img src="' + path + '" />';
+                    return '<img src="' + path + '" loading="lazy" />';
                 }
             }.bind(this, field.key)
         };


### PR DESCRIPTION
### Use-case: 
Asset folder with hundreds of images in it. Open the folder in the admin ui and select "all" for "items on page". 
The browser will start loading thumbnails for all items in the list. That can massively overload the server, especially if the thumbnails need to be generated first. 

![image](https://user-images.githubusercontent.com/142037/132472287-5eb37958-a1fa-4f38-aa73-fc6eed779dc2.png)

