### PR TITLE
[Select field] Support stdclass in select options

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -201,6 +201,7 @@ class Select extends Data implements
         if (is_array($options)) {
             $this->options = [];
             foreach ($options as $option) {
+                $option = (array)$option;
                 if (!array_key_exists('key', $option) || !array_key_exists('value', $option)) {
                     throw new InvalidArgumentException('Please provide select options as associative array with fields "key" and "value"');
                 }


### PR DESCRIPTION
Follow-up of #10250

As some points in code use `json_decode()` without second parameter so that JSON objects get decoded to assosicative arrays, select field options for classification store select fields can end up as array of `stdclass` objects, e.g. in https://github.com/pimcore/pimcore/blob/606484e4708bb6d6d2080d8b90152451164c67c5/bundles/AdminBundle/Helper/GridHelperService.php#L110

This PR supports stdclass notation for `setOptions()`