### PR TITLE
[UI] Only generate @2x/hdpi previews

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -156,7 +156,6 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             $previewUrl = $this->generateUrl('pimcore_admin_asset_getimagethumbnail', [
                 'id' => $asset->getId(),
                 'treepreview' => true,
-                'hdpi' => true,
                 '_dc' => time(),
             ]);
 
@@ -708,7 +707,6 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         if ($asset->getType() == 'image') {
             try {
                 $tmpAsset['thumbnail'] = $this->getThumbnailUrl($asset);
-                $tmpAsset['thumbnailHdpi'] = $this->getThumbnailUrl($asset, true);
 
                 // we need the dimensions for the wysiwyg editors, so that they can resize the image immediately
                 if ($asset->getCustomSetting('imageWidth') && $asset->getCustomSetting('imageHeight')) {
@@ -722,7 +720,6 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             try {
                 if (\Pimcore\Video::isAvailable()) {
                     $tmpAsset['thumbnail'] = $this->getThumbnailUrl($asset);
-                    $tmpAsset['thumbnailHdpi'] = $this->getThumbnailUrl($asset, true);
                 }
             } catch (\Exception $e) {
                 Logger::debug('Cannot get dimensions of video, seems to be broken.');
@@ -732,7 +729,6 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                 // add the PDF check here, otherwise the preview layer in admin is shown without content
                 if (\Pimcore\Document::isAvailable() && \Pimcore\Document::isFileTypeSupported($asset->getFilename())) {
                     $tmpAsset['thumbnail'] = $this->getThumbnailUrl($asset);
-                    $tmpAsset['thumbnailHdpi'] = $this->getThumbnailUrl($asset, true);
                 }
             } catch (\Exception $e) {
                 Logger::debug('Cannot get dimensions of video, seems to be broken.');
@@ -752,25 +748,16 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
     /**
      * @param Asset $asset
-     * @param bool $hdpi
-     * @param bool $grid
      *
      * @return null|string
      */
-    protected function getThumbnailUrl(Asset $asset, $hdpi = false, $grid = false)
+    protected function getThumbnailUrl(Asset $asset)
     {
         $params = [
             'id' => $asset->getId(),
             'treepreview' => true,
+            '_dc' => $asset->getModificationDate()
         ];
-
-        if ($hdpi) {
-            $params['hdpi'] = true;
-        }
-
-        if ($grid) {
-            $params['grid'] = true;
-        }
 
         if ($asset instanceof Asset\Image) {
             return $this->generateUrl('pimcore_admin_asset_getimagethumbnail', $params);
@@ -1306,7 +1293,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }
 
         if ($request->get('treepreview')) {
-            $thumbnailConfig = Asset\Image\Thumbnail\Config::getPreviewConfig((bool)$request->get('hdpi'));
+            $thumbnailConfig = Asset\Image\Thumbnail\Config::getPreviewConfig();
         }
 
         $cropPercent = $request->get('cropPercent');
@@ -1361,7 +1348,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                     throw $this->createAccessDeniedException('not allowed to view thumbnail');
                 }
 
-                $stream = $folder->getPreviewImage((bool)$request->get('hdpi'));
+                $stream = $folder->getPreviewImage();
                 if (!$stream) {
                     $response = new BinaryFileResponse(PIMCORE_PATH . '/bundles/AdminBundle/Resources/public/img/blank.png');
                 } else {
@@ -1409,7 +1396,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $thumbnail = array_merge($request->request->all(), $request->query->all());
 
         if ($request->get('treepreview')) {
-            $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig((bool)$request->get('hdpi'));
+            $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig();
         }
 
         $time = null;
@@ -1475,7 +1462,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }
 
         if ($request->get('treepreview')) {
-            $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig((bool)$request->get('hdpi'));
+            $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig();
         }
 
         $page = 1;
@@ -1787,7 +1774,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                         'type' => $asset->getType(),
                         'filename' => $asset->getFilename(),
                         'filenameDisplay' => htmlspecialchars($filenameDisplay),
-                        'url' => $this->getThumbnailUrl($asset, true, true),
+                        'url' => $this->getThumbnailUrl($asset),
                         'idPath' => $data['idPath'] = Element\Service::getIdPath($asset),
                     ];
                 }

--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -290,7 +290,9 @@ class PageController extends DocumentControllerBase
     {
         $document = Document\Page::getById($request->get('id'));
         if ($document instanceof Document\Page) {
-            return new BinaryFileResponse($document->getPreviewImageFilesystemPath((bool) $request->get('hdpi')), 200, ['Content-Type' => 'image/jpg']);
+            return new BinaryFileResponse($document->getPreviewImageFilesystemPath(), 200, [
+                'Content-Type' => 'image/jpg'
+            ]);
         }
 
         throw $this->createNotFoundException('Page not found');

--- a/bundles/AdminBundle/Controller/Traits/DocumentTreeConfigTrait.php
+++ b/bundles/AdminBundle/Controller/Traits/DocumentTreeConfigTrait.php
@@ -97,11 +97,6 @@ trait DocumentTreeConfigTrait
             // only if the thumbnail exists and isn't out of time
             if (file_exists($thumbnailFile) && filemtime($thumbnailFile) > ($childDocument->getModificationDate() - 20)) {
                 $tmpDocument['thumbnail'] = $this->generateUrl('pimcore_admin_page_display_preview_image', ['id' => $childDocument->getId()]);
-                $thumbnailFileHdpi = $childDocument->getPreviewImageFilesystemPath(true);
-                if (file_exists($thumbnailFileHdpi)) {
-                    $tmpDocument['thumbnailHdpi'] = $this->generateUrl('pimcore_admin_page_display_preview_image',
-                        ['id' => $childDocument->getId(), 'hdpi' => true]);
-                }
             }
         }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1152,14 +1152,8 @@ pimcore.helpers.treeNodeThumbnailPreview = function (treeView, record, item, ind
 
         var thumbnail = record.data["thumbnail"];
         if (thumbnail) {
-            var srcset = thumbnail + ' 1x';
-            var thumbnailHdpi = record.data["thumbnailHdpi"];
-            if(thumbnailHdpi) {
-                    srcset += ', ' + thumbnailHdpi + " 2x";
-            }
-
             imageHtml = '<div class="thumb"><img src="' + uriPrefix + thumbnail
-                + '" onload="this.parentNode.className += \' complete\';" srcset="' + srcset + '" /></div>';
+                + '" onload="this.parentNode.className += \' complete\';" /></div>';
         }
 
         if (imageHtml) {
@@ -1207,6 +1201,7 @@ pimcore.helpers.treeNodeThumbnailPreview = function (treeView, record, item, ind
                 'body { margin:0; padding: 0; } ' +
                 '.thumb { border: 1px solid #999; background: url(' + uriPrefix + '/bundles/pimcoreadmin/img/flat-color-icons/hourglass.svg) no-repeat center center; background-size: 20px 20px; box-sizing: border-box; min-height: 300px; } ' +
                 '.complete { border:none; border-radius: 0; background:none; max-width: 100%; }' +
+                '.complete img { max-width: 100%; }' +
                 '/* firefox fix: remove loading/broken image icon */ @-moz-document url-prefix() { img:-moz-loading { visibility: hidden; } img:-moz-broken { -moz-force-broken-image-icon: 0;}} ' +
                 '</style>' +
                 imageHtml;

--- a/bundles/AdminBundle/Resources/views/SearchAdmin/Search/Quicksearch/asset.html.twig
+++ b/bundles/AdminBundle/Resources/views/SearchAdmin/Search/Quicksearch/asset.html.twig
@@ -1,6 +1,6 @@
 {# @var $element \Pimcore\Model\Asset\Image|\Pimcore\Model\Asset\Document|\Pimcore\Model\Asset\Video #}
 {% set previewImage = null %}
-{% set params = { 'id': element.id, 'treepreview': true, 'hdpi': true } %}
+{% set params = { 'id': element.id, 'treepreview': true } %}
 
 {% if element is instanceof('\\Pimcore\\Model\\Asset\\Image') %}
     {% set previewImage = path('pimcore_admin_asset_getimagethumbnail', params) %}

--- a/bundles/AdminBundle/Resources/views/SearchAdmin/Search/Quicksearch/document.html.twig
+++ b/bundles/AdminBundle/Resources/views/SearchAdmin/Search/Quicksearch/document.html.twig
@@ -1,9 +1,9 @@
 {# @var $element \Pimcore\Model\Document\Page #}
 {% set previewImage = null %}
 {% if element is instanceof('\\Pimcore\\Model\\Document\\Page') and config['documents']['generate_preview'] == true %}
-    {% set thumbnailFileHdpi = element.getPreviewImageFilesystemPath(true) %}
-    {% if pimcore_file_exists(thumbnailFileHdpi) %}
-        {% set previewImage = path('pimcore_admin_page_display_preview_image', {'id': element.id, 'hdpi': true }) %}
+    {% set thumbnailFile = element.getPreviewImageFilesystemPath() %}
+    {% if pimcore_file_exists(thumbnailFile) %}
+        {% set previewImage = path('pimcore_admin_page_display_preview_image', {'id': element.id }) %}
     {% endif %}
 {% endif %}
 

--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -212,17 +212,10 @@ class ThumbnailsImageCommand extends AbstractCommand
                     $thumbnailsToGenerate = [];
                 }
 
-                $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig(false);
+                $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig();
 
-                if (!$input->getOption('skip-high-res')) {
-                    $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig(true);
-                }
             } elseif (!$input->getOption('thumbnails')) {
-                $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig(false);
-
-                if (!$input->getOption('skip-high-res')) {
-                    $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig(true);
-                }
+                $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig();
             }
         }
 

--- a/models/Asset/Folder.php
+++ b/models/Asset/Folder.php
@@ -98,24 +98,21 @@ class Folder extends Model\Asset
 
     /**
      * @internal
-     *
-     * @param bool $hdpi
-     *
      * @return resource|null
      *
      * @throws \Doctrine\DBAL\Exception
      * @throws \League\Flysystem\FilesystemException
      */
-    public function getPreviewImage(bool $hdpi = false)
+    public function getPreviewImage()
     {
         $storage = Storage::get('thumbnail');
         $cacheFilePath = sprintf('%s/image-thumb__%s__-folder-preview%s.jpg',
             rtrim($this->getRealFullPath(), '/'),
             $this->getId(),
-            ($hdpi ? '-hdpi' : '')
+            '-hdpi'
         );
 
-        $tileThumbnailConfig = Asset\Image\Thumbnail\Config::getPreviewConfig($hdpi);
+        $tileThumbnailConfig = Asset\Image\Thumbnail\Config::getPreviewConfig();
 
         $limit = 42;
         $db = \Pimcore\Db::get();

--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -264,12 +264,9 @@ final class Config extends Model\AbstractModel
 
     /**
      * @internal
-     *
-     * @param bool $hdpi
-     *
      * @return Config
      */
-    public static function getPreviewConfig($hdpi = false)
+    public static function getPreviewConfig()
     {
         $customPreviewImageThumbnail = \Pimcore::getContainer()->getParameter('pimcore.config')['assets']['preview_image_thumbnail'];
         $thumbnail = null;
@@ -292,9 +289,7 @@ final class Config extends Model\AbstractModel
             $thumbnail->setFormat('PJPEG');
         }
 
-        if ($hdpi) {
-            $thumbnail->setHighResolution(2);
-        }
+        $thumbnail->setHighResolution(2);
 
         return $thumbnail;
     }

--- a/models/Document/Page.php
+++ b/models/Document/Page.php
@@ -272,17 +272,10 @@ class Page extends TargetingDocument
     }
 
     /**
-     * @param bool $hdpi
-     *
      * @return string
      */
-    public function getPreviewImageFilesystemPath($hdpi = false)
+    public function getPreviewImageFilesystemPath()
     {
-        $suffix = '';
-        if ($hdpi) {
-            $suffix = '@2x';
-        }
-
-        return PIMCORE_SYSTEM_TEMP_DIRECTORY . '/document-page-previews/document-page-screenshot-' . $this->getId() . $suffix . '.jpg';
+        return PIMCORE_SYSTEM_TEMP_DIRECTORY . '/document-page-previews/document-page-screenshot-' . $this->getId() . '@2x.jpg';
     }
 }

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -626,22 +626,13 @@ class Service extends Model\Element\Service
         $tmpFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/screenshot_tmp_' . $doc->getId() . '.png';
         $file = $doc->getPreviewImageFilesystemPath();
 
-        $dir = dirname($file);
-        if (!is_dir($dir)) {
-            File::mkdir($dir);
-        }
+        File::mkdir(dirname($file));
 
         if (\Pimcore\Image\HtmlToImage::convert($url, $tmpFile)) {
             $im = \Pimcore\Image::getInstance();
             $im->load($tmpFile);
-            $im->scaleByWidth(400);
-            $im->save($file, 'jpeg', 85);
-
-            // HDPi version
-            $im = \Pimcore\Image::getInstance();
-            $im->load($tmpFile);
             $im->scaleByWidth(800);
-            $im->save($doc->getPreviewImageFilesystemPath(true), 'jpeg', 85);
+            $im->save($file, 'jpeg', 85);
 
             unlink($tmpFile);
 


### PR DESCRIPTION
- save storage
- generating preview on update is more efficient (only standard resolution was generated before, ...) 