### PR TITLE
Crisp SVG preview

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/image.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/image.js
@@ -438,8 +438,11 @@ pimcore.asset.image = Class.create(pimcore.asset.asset, {
                     this.initPreviewImage();
                     var area = this.displayPanel.getEl().down('img');
                     if(area) {
+                        area.setStyle('min-width', "200px");
+                        area.setStyle('min-height', "200px");
                         area.setStyle('max-width', (width - 340) + "px");
                         area.setStyle('max-height', (height - 40) + "px");
+                        area.setStyle('object-fit', "contain");
                     }
                 }
             }.bind(this));

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -159,7 +159,7 @@ final class Thumbnail
 
         if ($this->asset && empty($this->pathReference)) {
             // if no correct thumbnail config is given use the original image as thumbnail
-            if (!$this->config) {
+            if (!$this->config || ($this->asset->getMimeType('xml+svg') && !$this->config->isRasterizeSVG())) {
                 $this->pathReference = [
                     'type' => 'asset',
                     'src' => $this->asset->getRealFullPath(),

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -159,7 +159,7 @@ final class Thumbnail
 
         if ($this->asset && empty($this->pathReference)) {
             // if no correct thumbnail config is given use the original image as thumbnail
-            if (!$this->config || ($this->asset->getMimeType('xml+svg') && !$this->config->isRasterizeSVG())) {
+            if (!$this->config || ($this->asset->getMimeType() == 'image/svg+xml' && !$this->config->isRasterizeSVG())) {
                 $this->pathReference = [
                     'type' => 'asset',
                     'src' => $this->asset->getRealFullPath(),


### PR DESCRIPTION
Another take on PRs #10253 and #10254

## Changes in this pull request  
Resolves #10086

## Additional info  

When working with small svgs, current thumbnail generation blurs them, because they are rasterized even when they shouldn't (tree preview generates checkered background).

This PR takes on account the rasterizeSVG setting. Minimum dimensions 200x200 shouldn't be an issue, since tree preview generates scale by 400px width when thumbnail is used.

Two example images: One with Pimconaut (large svg) and a simple user icon (small svg).

<img width="960" alt="Näyttökuva 2021-9-9 kello 13 45 53" src="https://user-images.githubusercontent.com/47414813/132674143-731fae06-bcfa-483d-a287-2110a22602f7.png">
<img width="960" alt="Näyttökuva 2021-9-9 kello 13 48 41" src="https://user-images.githubusercontent.com/47414813/132674155-e460ab69-c3f9-4f11-9362-e1499d93ed32.png">
