### PR TITLE
[DataObjects] Fix Table data type does not use the table config

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/table.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/table.js
@@ -21,9 +21,8 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
 
         this.fieldConfig = fieldConfig;
 
-        if (!data) {
+        if (data.length < 1) {
             data = this.getInitialData();
-
         }
 
         this.data = data;


### PR DESCRIPTION
Resolves #10285

data is always array and when its empty on object creation if wouldn't pass and this.getInitialData() won't be called 
