### PR TITLE
Cannot assign Pimcore\Model\Element\ElementDescriptor to property Pimcore \Model\DataObject\Objectbrick::$object

### DIFF
--- a/models/DataObject/Objectbrick.php
+++ b/models/DataObject/Objectbrick.php
@@ -47,7 +47,7 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
      *
      * @var Model\DataObject\Concrete|null
      */
-    protected ?Concrete $object = null;
+    protected $object = null;
 
     /**
      * @internal

--- a/models/DataObject/Objectbrick/Data/AbstractData.php
+++ b/models/DataObject/Objectbrick/Data/AbstractData.php
@@ -54,7 +54,7 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
     /**
      * @var Concrete|null
      */
-    protected ?Concrete $object = null;
+    protected $object = null;
 
     /**
      * @var int|null


### PR DESCRIPTION
see #10239

Hi @blankse , this seems to be somehow related to the phpstan 4 level changes (https://github.com/pimcore/pimcore/pull/8684) and I am really not sure how we should tackle this in the ideal world. 

Please understand this change as a discussion point.

So what happens is that while deepcopying the related object gets condensed (i.e. transformed into a ElementDescriptor) and DeepCopy afterwards does this reflection thing 

```
        // Copy the property
        $property->setValue($object, $this->recursiveCopy($propertyValue));
```

which of course does not work because the $object is not a Concrete anymore.