### PR TITLE
Update `codeception/module-symfony`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -167,7 +167,7 @@
   "require-dev": {
     "cache/integration-tests": "dev-master",
     "codeception/codeception": "^4.1.12",
-    "codeception/module-symfony": "^2.0.0",
+    "codeception/module-symfony": "^2.0.2",
     "codeception/phpunit-wrapper": "^9",
     "phpstan/phpstan": "^0.12.85",
     "phpstan/phpstan-symfony": "^0.12.32",

--- a/composer.json
+++ b/composer.json
@@ -167,7 +167,7 @@
   "require-dev": {
     "cache/integration-tests": "dev-master",
     "codeception/codeception": "^4.1.12",
-    "codeception/module-symfony": "^1.6.0",
+    "codeception/module-symfony": "^2.0.0",
     "codeception/phpunit-wrapper": "^9",
     "phpstan/phpstan": "^0.12.85",
     "phpstan/phpstan-symfony": "^0.12.32",


### PR DESCRIPTION
There are no **b**reaking **c**hanges between version 1.x and version 2.x if you were already using Symfony 4.4 or higher, so it should be safe to upgrade.

See https://github.com/Codeception/module-symfony/releases .