### PR TITLE
Fix deprecation in league/csv

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/RedirectsController.php
+++ b/bundles/AdminBundle/Controller/Admin/RedirectsController.php
@@ -176,12 +176,11 @@ class RedirectsController extends AdminController
     /**
      * @Route("/csv-export", name="pimcore_admin_redirects_csvexport", methods={"GET"})
      *
-     * @param Request $request
      * @param Csv $csv
      *
      * @return Response
      */
-    public function csvExportAction(Request $request, Csv $csv)
+    public function csvExportAction(Csv $csv)
     {
         $this->checkPermission('redirects');
 
@@ -200,7 +199,7 @@ class RedirectsController extends AdminController
             'redirects.csv'
         ));
 
-        $response->setContent($writer->getContent());
+        $response->setContent($writer->toString());
 
         return $response;
     }

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     "guzzlehttp/guzzle": "^7.2",
     "http-interop/http-factory-guzzle": "^1.0.0",
     "lcobucci/jwt": "^4.0",
-    "league/csv": "^9.1",
+    "league/csv": "^9.7",
     "mjaschen/phpgeo": "^3.0",
     "mpratt/embera": "^2.0.14",
     "myclabs/deep-copy": "^1.7",


### PR DESCRIPTION
## Additional info  

league/csv add PHP 8 support in 9.6.2: https://github.com/thephpleague/csv/releases/tag/9.6.2
So it should bumped anyway.