### PR TITLE
function is not available in document

### DIFF
--- a/doc/Development_Documentation/20_Extending_Pimcore/17_Custom_Persistent_Models.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/17_Custom_Persistent_Models.md
@@ -173,6 +173,39 @@ class Dao extends AbstractDao {
         $this->assignVariablesToModel($data);
     }
 
+    public function assignVariablesToModel($data){
+        $vars = get_object_vars($this->model);
+ 
+        $buffer = [];
+ 
+        $validColumns = $this->getValidTableColumns($this->tableName);
+ 
+        if(count($vars))
+            foreach ($vars as $k => $v) {
+ 
+                if(!in_array($k, $validColumns))
+                    continue;
+ 
+                $getter = "set" . $this->camelize($k);
+ 
+                if(!is_callable([$this->model, $getter]))
+                    continue;
+ 
+                     $value = $this->model->$getter($data[$k]);
+ 
+                if(is_bool($value))
+                    $value = (int)$value;
+ 
+                $buffer[$k] = $value;
+            }
+            
+    }
+
+    public function camelize($input, $separator = '_')
+    {
+        return str_replace($separator, '', ucwords($input, $separator));
+    }
+    
     /**
      * save vote
      */


### PR DESCRIPTION
function assignVariablesToModel is called in model file. but not define anywhere.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

