### PR TITLE
[Predefined Asset metadata] default action for "Add predefined definitions" button not working as expected

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/Controller/Admin/SettingsController.php
@@ -238,7 +238,7 @@ class SettingsController extends AdminController
         $list = Metadata\Predefined\Listing::getByTargetType($type, [$subType]);
         $result = [];
         foreach ($list as $item) {
-            if ($group === null || $group === $item->getGroup()) {
+            if ((empty($group) && empty($item->getGroup())) || $group === $item->getGroup()) {
                 $item->expand();
                 $result[] = $item->getObjectVars();
             }

--- a/bundles/AdminBundle/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/Controller/Admin/SettingsController.php
@@ -238,7 +238,8 @@ class SettingsController extends AdminController
         $list = Metadata\Predefined\Listing::getByTargetType($type, [$subType]);
         $result = [];
         foreach ($list as $item) {
-            if ((empty($group) && empty($item->getGroup())) || $group === $item->getGroup()) {
+            $itemGroup = $item->getGroup() ?? "";
+            if ($group === "default" || $group === $itemGroup) {
                 $item->expand();
                 $result[] = $item->getObjectVars();
             }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/metadata/grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/metadata/grid.js
@@ -290,7 +290,7 @@ pimcore.asset.metadata.grid = Class.create({
                 tbarItems.push(
                     new Ext.SplitButton({
                         text: t('add_predefined_metadata_definitions'),
-                        handler: this.handleAddPredefinedDefinitions.bind(this, null),
+                        handler: this.handleAddPredefinedDefinitions.bind(this, "default"),
                         menu: new Ext.menu.Menu({
                             items: predefinedMetadataGroups
                         }),


### PR DESCRIPTION
Right now, if you directly click on the button no metadata definitions are added. 
#9019 mentions that all metadata defintions should be added in this case.