### PR TITLE
Make pimcore mail instantiation more robust

### DIFF
--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -139,8 +139,8 @@ class Mail extends Email
         if (is_array($headers)) {
             $options = $headers;
 
-            $headers = $options['headers'] instanceof Headers ? $options['headers'] : null;
-            $body = $options['body'] instanceof AbstractPart ? $options['body'] : null;
+            $headers = ($options['headers'] ?? null) instanceof Headers ? $options['headers'] : null;
+            $body = ($options['body'] ?? null) instanceof AbstractPart ? $options['body'] : null;
             parent::__construct($headers, $body);
 
             if ($options['subject'] ?? false) {


### PR DESCRIPTION
not providing `headers` and `body` key in first constructor parameter might result in undefined key error messages 