### PR TITLE
Fixes Key/name labels on Properties

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/properties.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/properties.js
@@ -260,7 +260,7 @@ pimcore.element.properties = Class.create({
                         sortable: true
                     },
                     {
-                        text: t("name"),
+                        text: t("key"),
                         dataIndex: 'name',
                         getEditor: function() {
                             return new Ext.form.TextField({


### PR DESCRIPTION
Fixes a mismatch where currently what is called "Name" on the element is actually the "Key" of the property:

![image](https://user-images.githubusercontent.com/279826/133981975-48b2e9aa-168d-4fd6-91cd-d0ff5b56e539.png)

I could make a follow-up patch to also add the actual "Name" column on the element as well.