### PR TITLE
Assets: Clicking on image in preview grid does not open image

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/folder.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/folder.js
@@ -81,7 +81,7 @@ pimcore.asset.folder = Class.create(pimcore.asset.asset, {
 
         var tpl = new Ext.XTemplate(
             '<tpl for=".">',
-            '<div class="thumb-wrap">',
+            '<div class="thumb-wrap" id="{type}_{id}" data-idpath="{idPath}">',
             '<img class="thumb" src="{url}" loading="lazy">',
             '<span class="filename" title="{filename}">{filenameDisplay}</span></div>',
             '</tpl>',
@@ -99,7 +99,7 @@ pimcore.asset.folder = Class.create(pimcore.asset.asset, {
                 store: this.store,
                 autoScroll: true,
                 tpl: tpl,
-                itemSelector: 'td.thumb-item',
+                itemSelector: '.thumb-wrap',
                 emptyText: ' ',
                 listeners: {
                     "itemclick": function (view, record, item, index, e, eOpts ) {


### PR DESCRIPTION
fixes #10357 
regression of #10271