### PR TITLE
Error message when trying to save a data object with empty mandatory fields

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -835,6 +835,7 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
 
         if ($subItems) {
             $messages = array_map(function (Model\Element\ValidationException $validationException) {
+                $validationException->addContext($this->getName());
                 return $validationException->getMessage();
             }, $subItems);
 


### PR DESCRIPTION
resolves #10339 