### PR TITLE
Fix invisible field inside block element

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -363,7 +363,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
                         $items = $object->$blockGetter($language);
                         if (isset($items[$oIndex])) {
                             $item = $items[$oIndex][$elementName];
-                            $blockData = $item->getData();
+                            $blockData = $blockElement[$elementName] ?: $item->getData();
                             $resultElement[$elementName] = new DataObject\Data\BlockElement($elementName, $elementType, $blockData);
                         }
                     } else {
@@ -374,7 +374,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
                         }
                     }
                 } else {
-                    $elementData = $blockElement[$elementName];
+                    $elementData = $blockElement[$elementName] ?? null;
                     $blockData = $fd->getDataFromEditmode(
                         $elementData,
                         $object,


### PR DESCRIPTION
When env is set to DEV an error appears when trying to save an object that has block element with invisible field (test1 is invisible field)

![Screenshot from 2021-09-22 10-51-58](https://user-images.githubusercontent.com/35298078/134313539-812e67f1-f786-46a3-b8bd-425c4b78df16.png)

Also when you save an object that has invisible field inside block element using Master (admin mode) 
![Screenshot from 2021-09-22 10-57-16](https://user-images.githubusercontent.com/35298078/134314324-e9f7643b-aa42-40b1-8392-530037bd1859.png)
value inside invisible field wouldn't be updated.

