### PR TITLE
[System Requirements] Check for ImageMagick delegate LCMS

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/01_System_Requirements.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/01_System_Requirements.md
@@ -38,6 +38,7 @@ Both **mod_php** and **FCGI (FPM)** are supported.
 
 #### Recommended or Optional Modules & Extensions 
 - [imagick](http://php.net/imagick) (if not installed *gd* is used instead, but with less supported image types)
+  - LCMS delegate for Image Magick to prevent negative colors for CMYK images
 - [phpredis](https://github.com/phpredis/phpredis) (recommended cache backend adapter)
 - [graphviz](https://www.graphviz.org/) (for rendering workflow overview)
 - [mysqli](http://php.net/mysqli) (PDO although is still required for parameter mappings)

--- a/lib/Tool/Requirements.php
+++ b/lib/Tool/Requirements.php
@@ -19,6 +19,7 @@ use Pimcore\Db\ConnectionInterface;
 use Pimcore\File;
 use Pimcore\Image;
 use Pimcore\Tool\Requirements\Check;
+use Symfony\Component\Process\Process;
 
 /**
  * @internal
@@ -614,6 +615,16 @@ final class Requirements
             'link' => 'http://www.php.net/imagick',
             'state' => class_exists('Imagick') ? Check::STATE_OK : Check::STATE_WARNING,
         ]);
+
+        if(class_exists('Imagick')) {
+            $imageMagickLcmsDelegateInstalledProcess = Process::fromShellCommandline('convert -list configure | grep DELEGATES');
+            $imageMagickLcmsDelegateInstalledProcess->run();
+            $checks[] = new Check([
+                'name' => 'ImageMagick LCMS delegate',
+                'link' => 'https://talk.pimcore.org/t/cmyk-to-rgb-displaying-as-negative/908/17',
+                'state' => str_contains($imageMagickLcmsDelegateInstalledProcess->getOutput(), 'lcms') ? Check::STATE_OK : Check::STATE_WARNING,
+            ]);
+        }
 
         // APCu
         $checks[] = new Check([

--- a/lib/Tool/Requirements.php
+++ b/lib/Tool/Requirements.php
@@ -630,6 +630,7 @@ final class Requirements
                     $lcmsInstalled = true;
                     break;
                 }
+                $line = strtok($separator);
             }
 
             $checks[] = new Check([

--- a/lib/Tool/Requirements.php
+++ b/lib/Tool/Requirements.php
@@ -617,12 +617,25 @@ final class Requirements
         ]);
 
         if(class_exists('Imagick')) {
-            $imageMagickLcmsDelegateInstalledProcess = Process::fromShellCommandline('convert -list configure | grep DELEGATES');
+            $convertExecutablePath = \Pimcore\Tool\Console::getExecutable('convert');
+            $imageMagickLcmsDelegateInstalledProcess = Process::fromShellCommandline($convertExecutablePath.' -list configure');
             $imageMagickLcmsDelegateInstalledProcess->run();
+
+            $lcmsInstalled = false;
+            $separator = "\r\n";
+            $line = strtok($imageMagickLcmsDelegateInstalledProcess->getOutput(), $separator);
+
+            while ($line !== false) {
+                if(str_contains($line, 'DELEGATES') && str_contains($line, 'lcms')) {
+                    $lcmsInstalled = true;
+                    break;
+                }
+            }
+
             $checks[] = new Check([
                 'name' => 'ImageMagick LCMS delegate',
-                'link' => 'https://talk.pimcore.org/t/cmyk-to-rgb-displaying-as-negative/908/17',
-                'state' => str_contains($imageMagickLcmsDelegateInstalledProcess->getOutput(), 'lcms') ? Check::STATE_OK : Check::STATE_WARNING,
+                'link' => 'https://pimcore.com/docs/pimcore/current/Development_Documentation/Installation_and_Upgrade/System_Requirements.html#page_Recommended-or-Optional-Modules-Extensions',
+                'state' => $lcmsInstalled ? Check::STATE_OK : Check::STATE_WARNING,
             ]);
         }
 


### PR DESCRIPTION
As already described in #6790 there can be a problem with negative colors when generating thumbnails from CMYK images. As proposed in https://talk.pimcore.org/t/cmyk-to-rgb-displaying-as-negative/908/17 and https://www.php.net/manual/en/imagick.profileimage.php#114781 this is caused by ImageMagick missing the `lcms` delegate. This PR adds a check in the system requirements for this delegate.