### PR TITLE
Fix admin user not seeing all languages inside Shared translations

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -745,6 +745,10 @@ final class User extends User\UserRole
      */
     public function getAllowedLanguagesForViewingWebsiteTranslations()
     {
+        if ($this->isAdmin()) {
+            return Tool::getValidLanguages();
+        }
+
         $mergedWebsiteTranslationLanguagesView = $this->getMergedWebsiteTranslationLanguagesView();
         if (empty($mergedWebsiteTranslationLanguagesView)) {
             return Tool::getValidLanguages();


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  

There is a bug when admin is not able to see all languages in shared translations
Steps to reproduce

1. Add at least 2 languages to System Settings
2. Create new user role and inside Shared translations settings for that role uncheck at least one of the languages
3. Create new user and assign newly created role from step 2.
4. Now that user can become an admin in future, so edit user and Check that he is admin
5. Login as user from step 2. Go to Shared Translations and this user won't be able to see the language that is unchecked from step 2. 

Expected behavior: Admin should always see all languages in shared translations no matter his previous role.  



