### PR TITLE
Updated documentation on the setting lower_case_table_names.

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/05_DB_Setup.md
@@ -1,9 +1,9 @@
-# Database Setup 
+# Database Setup
 
 Pimcore requires a standard MySQL database, the only thing you should assure is that the database uses `utf8mb4` as character set.  
 If you create a new database just set the character set to `utf8mb4`.
 
-> Note: You have to create the database manually before you can continue with the web-based installer, 
+> Note: You have to create the database manually before you can continue with the web-based installer,
 > which automatically creates the underlying database schema for Pimcore.
 
 ### Command to Create a new Database
@@ -23,7 +23,7 @@ GRANT ALL ON `project_database`.* TO 'project_user'@'localhost';
 ```
 ### Database Server Configuration (Optional)
 
-While setting up the MySQL Server you can enforce `utf8mb4` character set and [lower case table names](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_lower_case_table_names) by placing a `pimcore.cnf` file with the following contents into the server config directory (e.g. `/etc/mysql/conf.d/`). Refer to the server configuration manual applicable to your environment to determine the location of the server config directory.
+While setting up the MySQL Server you can enforce `utf8mb4` character set by placing a `pimcore.cnf` file with the following contents into the server config directory (e.g. `/etc/mysql/conf.d/`). Refer to the server configuration manual applicable to your environment to determine the location of the server config directory.
 
 ```ini
 # MySQL Server configuration for Pimcore.
@@ -43,10 +43,11 @@ default-character-set=utf8mb4
 character-set-server=utf8mb4
 collation-server=utf8mb4_unicode_ci
 init-connect='SET NAMES utf8mb4'
-lower_case_table_names=1
 ```
 
-Setting `lower_case_table_names=1` makes sure that tables for Pimcore classes are created in lower case even though their class names contain capital letters. Starting with MySQL 8, you can no longer set the `lower_case_table_names` option after the data directory has been initialized. If the directory was already initialized with a different `lower_case_table_names` setting, MySQL will fail to start (`Different lower_case_table_names settings for server and data dictionary`). To fix this, place the `pimcore.cnf` file in the config directory, remove the MySQL data directory and run `mysqld --initialize`. This will delete all databases, so backup the existing databases with `mysqldump` before deleting the data directory.
+Windows users:  
+For you it makes sense to set [lower case table names](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_lower_case_table_names).  
+Setting `lower_case_table_names=1` makes sure that tables for Pimcore classes are created in lower case even though their class names contain capital letters. This allows to avoid problems on case-insensitive filesystems, where Pimcore might, for example, try to create DataObject classes `product` and `PRODUCT`. Starting with MySQL 8, you can no longer set the `lower_case_table_names` option after the data directory has been initialized. If the directory was already initialized with a different `lower_case_table_names` setting, MySQL will fail to start (`Different lower_case_table_names settings for server and data dictionary`). To fix this, place the `pimcore.cnf` file in the config directory, remove the MySQL data directory and run `mysqld --initialize`. This will delete all databases, so backup the existing databases with `mysqldump` before deleting the data directory.
 
 ```bash
 rm -rf /var/lib/mysql


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #10427, #5824

## Additional info  
I think that it makes sense to use `lower_case_table_names` only on Windows, where both PHP and Mysql filenames are case-insensitive and it's actually possible to make mess with two DataObject classes with different letter cases. And this comment is worth adding to this documentation.
