### PR TITLE
[Cache] Use pimcore.cache.pool as default cache.app

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Compiler/CacheFallbackPass.php
+++ b/bundles/CoreBundle/DependencyInjection/Compiler/CacheFallbackPass.php
@@ -35,10 +35,9 @@ final class CacheFallbackPass implements CompilerPassInterface
         }
 
         // set default cache.app to Pimcore default cache, if not configured differently
-        if($appCache = $container->findDefinition('cache.app')) {
-            if($appCache instanceof ChildDefinition && $appCache->getParent() === 'cache.adapter.filesystem') {
-                $container->setAlias('cache.app', 'pimcore.cache.pool.app');
-            }
+        $appCache = $container->findDefinition('cache.app');
+        if($appCache instanceof ChildDefinition && $appCache->getParent() === 'cache.adapter.filesystem') {
+            $container->setAlias('cache.app', 'pimcore.cache.pool.app');
         }
     }
 }

--- a/bundles/CoreBundle/DependencyInjection/Compiler/CacheFallbackPass.php
+++ b/bundles/CoreBundle/DependencyInjection/Compiler/CacheFallbackPass.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -31,6 +32,13 @@ final class CacheFallbackPass implements CompilerPassInterface
         if (!$container->hasDefinition('pimcore.cache.pool')) {
             $alias = new Alias('pimcore.cache.adapter.pdo_tag_aware', true);
             $container->setAlias('pimcore.cache.pool', $alias);
+        }
+
+        // set default cache.app to Pimcore default cache, if not configured differently
+        if($appCache = $container->findDefinition('cache.app')) {
+            if($appCache instanceof ChildDefinition && $appCache->getParent() === 'cache.adapter.filesystem') {
+                $container->setAlias('cache.app', 'pimcore.cache.pool.app');
+            }
         }
     }
 }

--- a/bundles/CoreBundle/Resources/config/cache.yml
+++ b/bundles/CoreBundle/Resources/config/cache.yml
@@ -43,6 +43,12 @@ services:
         calls:
             - [setLogger, ['@logger']]
 
+    pimcore.cache.pool.app:
+        class: Symfony\Component\Cache\Adapter\ProxyAdapter
+        arguments:
+            - '@pimcore.cache.pool'
+            - 'app'
+
     #
     # PIMCORE CACHE
     #


### PR DESCRIPTION
For improved performance and in preparation of having the possibility to use `messenger:stop-workers` in distributed environments. 