### PR TITLE
[DataObjects] Do not load admin-mode master layout for Remembered tabs

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
@@ -52,7 +52,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
 
     getData: function () {
         var params = {id: this.id};
-        if (this.options !== undefined) {
+        if (this.options !== undefined && this.options.layoutId !== undefined) {
             params.layoutId = this.options.layoutId;
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #10424

## Additional info  

