### PR TITLE
IncludeRenderer and Snippet Editable cache should be kept with admin changes

### DIFF
--- a/models/Document/Editable/Snippet.php
+++ b/models/Document/Editable/Snippet.php
@@ -151,10 +151,12 @@ class Snippet extends Model\Document\Editable
         $content = $editableHandler->renderAction($this->snippet->getController(), $params);
 
         // write contents to the cache, if output-cache is enabled
-        if (isset($params['cache']) && $params['cache'] === true) {
+        if ($cacheConfig && !DeviceDetector::getInstance()->wasUsed()) {
+            $cacheTags = ['output_inline'];
+            $cacheTags[] = $cacheConfig['lifetime'] ? 'output_lifetime' : 'output';
+            Cache::save($content, $cacheKey, $cacheTags, $cacheConfig['lifetime']);
+        } elseif (isset($params['cache']) && $params['cache'] === true) {
             Cache::save($content, $cacheKey, ['output']);
-        } elseif ($cacheConfig && !DeviceDetector::getInstance()->wasUsed()) {
-            Cache::save($content, $cacheKey, ['output', 'output_inline'], $cacheConfig['lifetime']);
         }
 
         return $content;


### PR DESCRIPTION
Steps to reproduce

1. Enable Full Page Cache with lifetime
```
    full_page_cache:
        enabled: true
        lifetime: 3600
        exclude_patterns: ''
        exclude_cookie: ''
```
2. Open a page with embeded snippet (Cache for Main Request and Snippets are created)
3. Change a element (Cache with Tag "output" will be deleted)
4. Open a other page with the same embedded snippet
-> Snippet will be new created but should still kept because of lifetime setting