### PR TITLE
Deadlock-preventing execution of all database write operations

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -434,9 +434,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             $newPath = $parent->getRealFullPath() . '/' . trim($dir, '/ ');
 
             $newParent = Asset\Service::createFolderByPath($newPath);
-            if ($newParent) {
-                $parentId = $newParent->getId();
-            }
+            $parentId = $newParent->getId();
         } elseif (!$request->get('parentId') && $parentPath) {
             $parent = Asset::getByPath($parentPath);
             if ($parent instanceof Asset\Folder) {

--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -433,23 +433,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
             $newPath = $parent->getRealFullPath() . '/' . trim($dir, '/ ');
 
-            $maxRetries = 5;
-            $newParent = null;
-            for ($retries = 0; $retries < $maxRetries; $retries++) {
-                try {
-                    $newParent = Asset\Service::createFolderByPath($newPath);
-
-                    break;
-                } catch (\Exception $e) {
-                    if ($retries < ($maxRetries - 1)) {
-                        $waitTime = rand(100000, 900000); // microseconds
-                        usleep($waitTime); // wait specified time until we restart the transaction
-                    } else {
-                        // if the transaction still fail after $maxRetries retries, we throw out the exception
-                        throw $e;
-                    }
-                }
-            }
+            $newParent = Asset\Service::createFolderByPath($newPath);
             if ($newParent) {
                 $parentId = $newParent->getId();
             }

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -569,7 +569,7 @@ class Asset extends Element\AbstractElement
             }
 
             $additionalTags = [];
-            if (isset($updatedChildren) && is_array($updatedChildren)) {
+            if (isset($updatedChildren)) {
                 foreach ($updatedChildren as $assetId) {
                     $tag = 'asset_' . $assetId;
                     $additionalTags[] = $tag;

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -569,7 +569,7 @@ class Asset extends Element\AbstractElement
             }
 
             $additionalTags = [];
-            if (isset($updatedChildren)) {
+            if (is_array($updatedChildren)) {
                 foreach ($updatedChildren as $assetId) {
                     $tag = 'asset_' . $assetId;
                     $additionalTags[] = $tag;

--- a/models/Document.php
+++ b/models/Document.php
@@ -441,7 +441,7 @@ class Document extends Element\AbstractElement
             }
 
             $additionalTags = [];
-            if (isset($updatedChildren) && is_array($updatedChildren)) {
+            if (isset($updatedChildren)) {
                 foreach ($updatedChildren as $documentId) {
                     $tag = 'document_' . $documentId;
                     $additionalTags[] = $tag;

--- a/models/Document.php
+++ b/models/Document.php
@@ -441,7 +441,7 @@ class Document extends Element\AbstractElement
             }
 
             $additionalTags = [];
-            if (isset($updatedChildren)) {
+            if (is_array($updatedChildren)) {
                 foreach ($updatedChildren as $documentId) {
                     $tag = 'document_' . $documentId;
                     $additionalTags[] = $tag;


### PR DESCRIPTION
Currently for example in https://github.com/pimcore/pimcore/blob/9a5b9adef0889af8fdade11ff3254ff80c47dd6a/models/DataObject/AbstractObject.php#L671-L748 we have an implementation which tries to prevent deadlocks but for example in https://github.com/pimcore/pimcore/blob/9a5b9adef0889af8fdade11ff3254ff80c47dd6a/models/Property/Dao.php#L56 we do not have such a logic which may cause errors like `SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction ...`. 
As MySQL already gives the hint to restart it, this PR implements deadlock-prevention for all database write operations.