### PR TITLE
[Documents] Fix adding Blank documents without DocType

### DIFF
--- a/models/Document/DocType/Dao.php
+++ b/models/Document/DocType/Dao.php
@@ -48,10 +48,11 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
      */
     public function getById($id = null)
     {
-        if ($id != null) {
-            $this->model->setId($id);
+        if (empty($id)) {
+            return null;
         }
 
+        $this->model->setId($id);
         $data = $this->getDataByName($this->model->getId());
 
         if ($data && $id != null) {


### PR DESCRIPTION
## Changes in this pull request  
follow-up to #10162

## Additional info  
Fixes error on adding blank documents in admin:
```php
Pimcore\Model\Dao\PimcoreLocationAwareConfigDao::getDataByName(): Argument #1 ($id) must be of type string, null given, called in /var/www/html/dev/pimcore/pimcore/models/Document/DocType/Dao.php on line 55
```
