### PR TITLE
Add foreign keys to data object tables

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20211018104331.php
+++ b/bundles/CoreBundle/Migrations/Version20211018104331.php
@@ -45,6 +45,9 @@ final class Version20211018104331 extends AbstractMigration
 
                 $fkName = 'fk_'.$table.'__'.$objectIdColumn;
                 if (!$tableSchema->hasForeignKey($fkName)) {
+                    if($tableSchema->getColumn($objectIdColumn)->getCustomSchemaOption('unsigned') === false) {
+                        $tableSchema->changeColumn($objectIdColumn, ['unsigned' => true]);
+                    }
                     $tableSchema->addForeignKeyConstraint('objects', [$objectIdColumn], ['o_id'], ['ON DELETE CASCADE'], $fkName);
                 }
             }

--- a/bundles/CoreBundle/Migrations/Version20211018104331.php
+++ b/bundles/CoreBundle/Migrations/Version20211018104331.php
@@ -46,7 +46,8 @@ final class Version20211018104331 extends AbstractMigration
 
                 $fkName = AbstractDao::getForeignKeyName($table, $objectIdColumn);
                 if (!$tableSchema->hasForeignKey($fkName)) {
-                    if($tableSchema->getColumn($objectIdColumn)->getCustomSchemaOption('unsigned') === false) {
+                    $column = $tableSchema->getColumn($objectIdColumn);
+                    if(!$column->hasCustomSchemaOption('unsigned') || $column->getCustomSchemaOption('unsigned') === false) {
                         $tableSchema->changeColumn($objectIdColumn, ['unsigned' => true]);
                     }
 

--- a/bundles/CoreBundle/Migrations/Version20211018104331.php
+++ b/bundles/CoreBundle/Migrations/Version20211018104331.php
@@ -20,6 +20,7 @@ namespace Pimcore\Bundle\CoreBundle\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Model\Dao\AbstractDao;
 use Pimcore\Model\DataObject;
 
 final class Version20211018104331 extends AbstractMigration
@@ -43,11 +44,12 @@ final class Version20211018104331 extends AbstractMigration
                     continue;
                 }
 
-                $fkName = 'fk_'.$table.'__'.$objectIdColumn;
+                $fkName = AbstractDao::getForeignKeyName($table, $objectIdColumn);
                 if (!$tableSchema->hasForeignKey($fkName)) {
                     if($tableSchema->getColumn($objectIdColumn)->getCustomSchemaOption('unsigned') === false) {
                         $tableSchema->changeColumn($objectIdColumn, ['unsigned' => true]);
                     }
+
                     $tableSchema->addForeignKeyConstraint('objects', [$objectIdColumn], ['o_id'], ['ON DELETE CASCADE'], $fkName);
                 }
             }

--- a/bundles/CoreBundle/Migrations/Version20211018104331.php
+++ b/bundles/CoreBundle/Migrations/Version20211018104331.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Model\DataObject;
+
+final class Version20211018104331 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $list = new DataObject\ClassDefinition\Listing();
+
+        foreach ($list as $class) {
+            $foreignKeys = $this->getForeignKeys($class);
+
+            foreach($foreignKeys as $table => $objectIdColumn) {
+                try {
+                    $tableSchema = $schema->getTable($table);
+                } catch(SchemaException $e) {
+                    continue;
+                }
+
+                $fkName = 'fk_'.$table.'__'.$objectIdColumn;
+                if (!$tableSchema->hasForeignKey($fkName)) {
+                    $tableSchema->addForeignKeyConstraint('objects', [$objectIdColumn], ['o_id'], ['ON DELETE CASCADE'], $fkName);
+                }
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $list = new DataObject\ClassDefinition\Listing();
+
+        foreach ($list as $class) {
+            $foreignKeys = $this->getForeignKeys($class);
+
+            foreach ($foreignKeys as $table => $objectIdColumn) {
+                try {
+                    $tableSchema = $schema->getTable($table);
+                } catch (SchemaException $e) {
+                    continue;
+                }
+
+                $fkName = 'fk_'.$table.'__'.$objectIdColumn;
+                if ($tableSchema->hasForeignKey($fkName)) {
+                    $tableSchema->removeForeignKey($fkName);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param DataObject\ClassDefinition $class
+     * @return string[]
+     */
+    private function getForeignKeys(DataObject\ClassDefinition $class): array
+    {
+        $foreignKeys = [
+            'object_query_'.$class->getId() => 'oo_id',
+            'object_store_'.$class->getId() => 'oo_id',
+            'object_relations_'.$class->getId() => 'src_id',
+            'object_classificationstore_groups_'.$class->getId() => 'o_id',
+            'object_classificationstore_data_'.$class->getId() => 'o_id',
+            'object_metadata_'.$class->getId() => 'o_id',
+            'object_localized_data_'.$class->getId() => 'ooo_id'
+        ];
+
+        $brickList = new DataObject\Objectbrick\Definition\Listing();
+        foreach ($brickList as $brickDefinition) {
+            $foreignKeys['object_brick_query_'.$brickDefinition->getKey().'_'.$class->getId()] = 'o_id';
+            $foreignKeys['object_brick_localized_'.$brickDefinition->getKey().'_'.$class->getId()] = 'ooo_id';
+        }
+
+        $fieldCollectionList = new DataObject\FieldCollection\Definition\Listing();
+        foreach ($fieldCollectionList as $fieldCollectionDefinition) {
+            $foreignKeys['object_collection_'.$fieldCollectionDefinition->getKey().'_'.$class->getId()] = 'o_id';
+            $foreignKeys['object_collection_'.$fieldCollectionDefinition->getKey().'_localized_'.$class->getId()] = 'ooo_id';
+        }
+        return $foreignKeys;
+    }
+}

--- a/bundles/CoreBundle/Migrations/Version20211018104331.php
+++ b/bundles/CoreBundle/Migrations/Version20211018104331.php
@@ -51,7 +51,7 @@ final class Version20211018104331 extends AbstractMigration
                         $tableSchema->changeColumn($objectIdColumn, ['unsigned' => true]);
                     }
 
-                    $tableSchema->addForeignKeyConstraint('objects', [$objectIdColumn], ['o_id'], ['ON DELETE CASCADE'], $fkName);
+                    $tableSchema->addForeignKeyConstraint('objects', [$objectIdColumn], ['o_id'], ['onDelete' => 'CASCADE'], $fkName);
                 }
             }
         }

--- a/bundles/CoreBundle/Migrations/Version20211018104331.php
+++ b/bundles/CoreBundle/Migrations/Version20211018104331.php
@@ -90,13 +90,13 @@ final class Version20211018104331 extends AbstractMigration
         ];
 
         $brickList = new DataObject\Objectbrick\Definition\Listing();
-        foreach ($brickList as $brickDefinition) {
+        foreach ($brickList->load() as $brickDefinition) {
             $foreignKeys['object_brick_query_'.$brickDefinition->getKey().'_'.$class->getId()] = 'o_id';
             $foreignKeys['object_brick_localized_'.$brickDefinition->getKey().'_'.$class->getId()] = 'ooo_id';
         }
 
         $fieldCollectionList = new DataObject\FieldCollection\Definition\Listing();
-        foreach ($fieldCollectionList as $fieldCollectionDefinition) {
+        foreach ($fieldCollectionList->load() as $fieldCollectionDefinition) {
             $foreignKeys['object_collection_'.$fieldCollectionDefinition->getKey().'_'.$class->getId()] = 'o_id';
             $foreignKeys['object_collection_'.$fieldCollectionDefinition->getKey().'_localized_'.$class->getId()] = 'ooo_id';
         }

--- a/bundles/CoreBundle/Migrations/Version20211018104331.php
+++ b/bundles/CoreBundle/Migrations/Version20211018104331.php
@@ -71,7 +71,7 @@ final class Version20211018104331 extends AbstractMigration
                     continue;
                 }
 
-                $fkName = 'fk_'.$table.'__'.$objectIdColumn;
+                $fkName = AbstractDao::getForeignKeyName($table, $objectIdColumn);
                 if ($tableSchema->hasForeignKey($fkName)) {
                     $tableSchema->removeForeignKey($fkName);
                 }

--- a/bundles/CoreBundle/Migrations/Version20211018104331.php
+++ b/bundles/CoreBundle/Migrations/Version20211018104331.php
@@ -95,7 +95,7 @@ final class Version20211018104331 extends AbstractMigration
             $foreignKeys['object_brick_localized_'.$brickDefinition->getKey().'_'.$class->getId()] = 'ooo_id';
         }
 
-        $fieldCollectionList = new DataObject\FieldCollection\Definition\Listing();
+        $fieldCollectionList = new DataObject\Fieldcollection\Definition\Listing();
         foreach ($fieldCollectionList->load() as $fieldCollectionDefinition) {
             $foreignKeys['object_collection_'.$fieldCollectionDefinition->getKey().'_'.$class->getId()] = 'o_id';
             $foreignKeys['object_collection_'.$fieldCollectionDefinition->getKey().'_localized_'.$class->getId()] = 'ooo_id';

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -941,7 +941,7 @@ DEFAULT CHARSET=utf8mb4;
 DROP TABLE IF EXISTS `object_url_slugs`;
 CREATE TABLE `object_url_slugs` (
       `objectId` INT(11) NOT NULL DEFAULT '0',
-	    `classId` VARCHAR(50) NOT NULL DEFAULT '0',
+      `classId` VARCHAR(50) NOT NULL DEFAULT '0',
       `fieldname` VARCHAR(70) NOT NULL DEFAULT '0',
       `index` INT(11) UNSIGNED NOT NULL DEFAULT '0',
       `ownertype` ENUM('object','fieldcollection','localizedfield','objectbrick') NOT NULL DEFAULT 'object',
@@ -958,7 +958,8 @@ CREATE TABLE `object_url_slugs` (
       INDEX `ownertype` (`ownertype`),
       INDEX `ownername` (`ownername`),
       INDEX `slug` (`slug`),
-      INDEX `siteId` (`siteId`)
+      INDEX `siteId` (`siteId`),
+      CONSTRAINT `fk_object_url_slugs__objectId` FOREIGN KEY (`objectId`) REFERENCES objects (`o_id`) ON DELETE CASCADE
 ) DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 
 DROP TABLE IF EXISTS `webdav_locks`;

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -940,7 +940,7 @@ DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `object_url_slugs`;
 CREATE TABLE `object_url_slugs` (
-      `objectId` INT(11) NOT NULL DEFAULT '0',
+      `objectId` INT(11) UNSIGNED NOT NULL DEFAULT '0',
       `classId` VARCHAR(50) NOT NULL DEFAULT '0',
       `fieldname` VARCHAR(70) NOT NULL DEFAULT '0',
       `index` INT(11) UNSIGNED NOT NULL DEFAULT '0',

--- a/lib/Model/Dao/AbstractDao.php
+++ b/lib/Model/Dao/AbstractDao.php
@@ -95,4 +95,13 @@ abstract class AbstractDao implements DaoInterface
         }
         Cache::clearTags(['system', 'resource']);
     }
+
+    public static function getForeignKeyName($table, $column) {
+        $fkName = 'fk_'.$table.'__'.$column;
+        if (strlen($fkName) > 64) {
+            $fkName = 'fk_'.md5($fkName);
+        }
+
+        return $fkName;
+    }
 }

--- a/lib/Model/Dao/AbstractDao.php
+++ b/lib/Model/Dao/AbstractDao.php
@@ -99,7 +99,7 @@ abstract class AbstractDao implements DaoInterface
     public static function getForeignKeyName($table, $column) {
         $fkName = 'fk_'.$table.'__'.$column;
         if (strlen($fkName) > 64) {
-            $fkName = 'fk_'.md5($fkName);
+            $fkName = substr($fkName, 0, 55) . '_' . hash('crc32', $fkName);
         }
 
         return $fkName;

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -131,7 +131,7 @@ class Dao extends Model\Dao\AbstractDao
 			  `oo_classId` varchar(50) default '" . $this->model->getId() . "',
 			  `oo_className` varchar(255) default '" . $this->model->getName() . "',
 			  PRIMARY KEY  (`oo_id`),
-			  CONSTRAINT `fk_".$objectTable."__oo_id` FOREIGN KEY (`oo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
+			  CONSTRAINT `".self::getForeignKeyName($objectTable, 'oo_id')."` FOREIGN KEY (`oo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
 			) DEFAULT CHARSET=utf8mb4;");
 
         // update default value of classname columns
@@ -140,7 +140,7 @@ class Dao extends Model\Dao\AbstractDao
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $objectDatastoreTable . "` (
 			  `oo_id` int(11) UNSIGNED NOT NULL default '0',
 			  PRIMARY KEY  (`oo_id`),
-			  CONSTRAINT `fk_".$objectDatastoreTable."__oo_id` FOREIGN KEY (`oo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
+			  CONSTRAINT `".self::getForeignKeyName($objectDatastoreTable, 'oo_id')."` FOREIGN KEY (`oo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
 			) DEFAULT CHARSET=utf8mb4;");
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $objectDatastoreTableRelation . "` (
@@ -155,7 +155,7 @@ class Dao extends Model\Dao\AbstractDao
               `position` varchar(70) NOT NULL DEFAULT '0',
               INDEX `forward_lookup` (`src_id`, `ownertype`, `ownername`, `position`),
               INDEX `reverse_lookup` (`dest_id`, `type`),
-			  CONSTRAINT `fk_" .$objectDatastoreTableRelation."__src_id` FOREIGN KEY (`src_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
+			  CONSTRAINT `".self::getForeignKeyName($objectDatastoreTableRelation, 'src_id')."` FOREIGN KEY (`src_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
         ) DEFAULT CHARSET=utf8mb4;");
 
         $this->handleEncryption($this->model, [$objectTable, $objectDatastoreTable, $objectDatastoreTableRelation]);

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -131,7 +131,7 @@ class Dao extends Model\Dao\AbstractDao
 			  `oo_classId` varchar(50) default '" . $this->model->getId() . "',
 			  `oo_className` varchar(255) default '" . $this->model->getName() . "',
 			  PRIMARY KEY  (`oo_id`),
-			  CONSTRAINT `fk_query_".$this->model->getId()."__oo_id` FOREIGN KEY (`oo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE ON UPDATE CASCADE
+			  CONSTRAINT `fk_".$objectTable."__oo_id` FOREIGN KEY (`oo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
 			) DEFAULT CHARSET=utf8mb4;");
 
         // update default value of classname columns
@@ -140,7 +140,7 @@ class Dao extends Model\Dao\AbstractDao
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $objectDatastoreTable . "` (
 			  `oo_id` int(11) UNSIGNED NOT NULL default '0',
 			  PRIMARY KEY  (`oo_id`),
-			  CONSTRAINT `fk_store_".$this->model->getId()."__oo_id` FOREIGN KEY (`oo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE ON UPDATE CASCADE
+			  CONSTRAINT `fk_".$objectDatastoreTable."__oo_id` FOREIGN KEY (`oo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
 			) DEFAULT CHARSET=utf8mb4;");
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $objectDatastoreTableRelation . "` (
@@ -155,7 +155,7 @@ class Dao extends Model\Dao\AbstractDao
               `position` varchar(70) NOT NULL DEFAULT '0',
               INDEX `forward_lookup` (`src_id`, `ownertype`, `ownername`, `position`),
               INDEX `reverse_lookup` (`dest_id`, `type`),
-			  CONSTRAINT `fk_relations_" . $this->model->getId()."__src_id` FOREIGN KEY (`src_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE ON UPDATE CASCADE
+			  CONSTRAINT `fk_" .$objectDatastoreTableRelation."__src_id` FOREIGN KEY (`src_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
         ) DEFAULT CHARSET=utf8mb4;");
 
         $this->handleEncryption($this->model, [$objectTable, $objectDatastoreTable, $objectDatastoreTableRelation]);

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -137,15 +137,15 @@ class Dao extends Model\Dao\AbstractDao
         $this->db->query('ALTER TABLE `' . $objectTable . "` ALTER COLUMN `oo_className` SET DEFAULT '" . $this->model->getName() . "';");
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $objectDatastoreTable . "` (
-			  `oo_id` int(11) NOT NULL default '0',
+			  `oo_id` int(11) UNSIGNED NOT NULL default '0',
 			  PRIMARY KEY  (`oo_id`),
 			  CONSTRAINT `fk_".$this->model->getId()."__oo_id` FOREIGN KEY (`oo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE ON UPDATE CASCADE
 			) DEFAULT CHARSET=utf8mb4;");
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $objectDatastoreTableRelation . "` (
               `id` BIGINT(20) NOT NULL PRIMARY KEY  AUTO_INCREMENT,
-              `src_id` int(11) NOT NULL DEFAULT '0',
-              `dest_id` int(11) NOT NULL DEFAULT '0',
+              `src_id` int(11) UNSIGNED NOT NULL DEFAULT '0',
+              `dest_id` int(11) UNSIGNED NOT NULL DEFAULT '0',
               `type` varchar(50) NOT NULL DEFAULT '',
               `fieldname` varchar(70) NOT NULL DEFAULT '0',
               `index` int(11) unsigned NOT NULL DEFAULT '0',

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -127,10 +127,11 @@ class Dao extends Model\Dao\AbstractDao
         $protectedDatastoreColumns = ['oo_id'];
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $objectTable . "` (
-			  `oo_id` int(11) NOT NULL default '0',
+			  `oo_id` int(11) UNSIGNED NOT NULL default '0',
 			  `oo_classId` varchar(50) default '" . $this->model->getId() . "',
 			  `oo_className` varchar(255) default '" . $this->model->getName() . "',
-			  PRIMARY KEY  (`oo_id`)
+			  PRIMARY KEY  (`oo_id`),
+			  CONSTRAINT `fk_query_".$this->model->getId()."__oo_id` FOREIGN KEY (`oo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE ON UPDATE CASCADE
 			) DEFAULT CHARSET=utf8mb4;");
 
         // update default value of classname columns
@@ -139,7 +140,7 @@ class Dao extends Model\Dao\AbstractDao
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $objectDatastoreTable . "` (
 			  `oo_id` int(11) UNSIGNED NOT NULL default '0',
 			  PRIMARY KEY  (`oo_id`),
-			  CONSTRAINT `fk_".$this->model->getId()."__oo_id` FOREIGN KEY (`oo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE ON UPDATE CASCADE
+			  CONSTRAINT `fk_store_".$this->model->getId()."__oo_id` FOREIGN KEY (`oo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE ON UPDATE CASCADE
 			) DEFAULT CHARSET=utf8mb4;");
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $objectDatastoreTableRelation . "` (

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -138,7 +138,8 @@ class Dao extends Model\Dao\AbstractDao
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $objectDatastoreTable . "` (
 			  `oo_id` int(11) NOT NULL default '0',
-			  PRIMARY KEY  (`oo_id`)
+			  PRIMARY KEY  (`oo_id`),
+			  CONSTRAINT `fk_".$this->model->getId()."__oo_id` FOREIGN KEY (`oo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE ON UPDATE CASCADE
 			) DEFAULT CHARSET=utf8mb4;");
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $objectDatastoreTableRelation . "` (
@@ -152,7 +153,8 @@ class Dao extends Model\Dao\AbstractDao
               `ownername` varchar(70) NOT NULL DEFAULT '',
               `position` varchar(70) NOT NULL DEFAULT '0',
               INDEX `forward_lookup` (`src_id`, `ownertype`, `ownername`, `position`),
-              INDEX `reverse_lookup` (`dest_id`, `type`)
+              INDEX `reverse_lookup` (`dest_id`, `type`),
+			  CONSTRAINT `fk_relations_" . $this->model->getId()."__src_id` FOREIGN KEY (`src_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE ON UPDATE CASCADE
         ) DEFAULT CHARSET=utf8mb4;");
 
         $this->handleEncryption($this->model, [$objectTable, $objectDatastoreTable, $objectDatastoreTableRelation]);

--- a/models/DataObject/Classificationstore/Dao.php
+++ b/models/DataObject/Classificationstore/Dao.php
@@ -237,7 +237,7 @@ class Dao extends Model\Dao\AbstractDao
             `groupId` BIGINT(20) NOT NULL,
             `fieldname` VARCHAR(70) NOT NULL,
             PRIMARY KEY (`o_id`, `fieldname`, `groupId`),
-            CONSTRAINT `fk_'.$groupsTable.'__o_id` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
+            CONSTRAINT `'.self::getForeignKeyName($groupsTable, 'o_id').'` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
         ) DEFAULT CHARSET=utf8mb4;');
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $dataTable . '` (
@@ -253,7 +253,7 @@ class Dao extends Model\Dao\AbstractDao
             PRIMARY KEY (`o_id`, `fieldname`, `groupId`, `keyId`, `language`)
             INDEX `keyId` (`keyId`),
             INDEX `language` (`language`),
-            CONSTRAINT `fk_'.$dataTable.'__o_id` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
+            CONSTRAINT `'.self::getForeignKeyName($dataTable, 'o_id').'` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
         ) DEFAULT CHARSET=utf8mb4;');
 
         $this->tableDefinitions = null;

--- a/models/DataObject/Classificationstore/Dao.php
+++ b/models/DataObject/Classificationstore/Dao.php
@@ -250,7 +250,7 @@ class Dao extends Model\Dao\AbstractDao
             `fieldname` VARCHAR(70) NOT NULL,
             `language` VARCHAR(10) NOT NULL,
             `type` VARCHAR(50) NULL,
-            PRIMARY KEY (`o_id`, `fieldname`, `groupId`, `keyId`, `language`)
+            PRIMARY KEY (`o_id`, `fieldname`, `groupId`, `keyId`, `language`),
             INDEX `keyId` (`keyId`),
             INDEX `language` (`language`),
             CONSTRAINT `'.self::getForeignKeyName($dataTable, 'o_id').'` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE

--- a/models/DataObject/Classificationstore/Dao.php
+++ b/models/DataObject/Classificationstore/Dao.php
@@ -236,7 +236,8 @@ class Dao extends Model\Dao\AbstractDao
             `o_id` BIGINT(20) NOT NULL,
             `groupId` BIGINT(20) NOT NULL,
             `fieldname` VARCHAR(70) NOT NULL,
-            PRIMARY KEY (`o_id`, `fieldname`, `groupId`)
+            PRIMARY KEY (`o_id`, `fieldname`, `groupId`),
+            CONSTRAINT `fk_'.$groupsTable.'__o_id` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
         ) DEFAULT CHARSET=utf8mb4;');
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $dataTable . '` (
@@ -249,9 +250,10 @@ class Dao extends Model\Dao\AbstractDao
             `fieldname` VARCHAR(70) NOT NULL,
             `language` VARCHAR(10) NOT NULL,
             `type` VARCHAR(50) NULL,
-            PRIMARY KEY (`o_id`, `fieldname`, `groupId`, `keyId`, `language`),
+            PRIMARY KEY (`o_id`, `fieldname`, `groupId`, `keyId`, `language`)
             INDEX `keyId` (`keyId`),
-            INDEX `language` (`language`)
+            INDEX `language` (`language`),
+            CONSTRAINT `fk_'.$dataTable.'__o_id` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
         ) DEFAULT CHARSET=utf8mb4;');
 
         $this->tableDefinitions = null;

--- a/models/DataObject/Classificationstore/Dao.php
+++ b/models/DataObject/Classificationstore/Dao.php
@@ -233,7 +233,7 @@ class Dao extends Model\Dao\AbstractDao
         $dataTable = $this->getDataTableName();
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $groupsTable . '` (
-            `o_id` BIGINT(20) NOT NULL,
+            `o_id` INT(11) UNSIGNED NOT NULL,
             `groupId` BIGINT(20) NOT NULL,
             `fieldname` VARCHAR(70) NOT NULL,
             PRIMARY KEY (`o_id`, `fieldname`, `groupId`),
@@ -241,7 +241,7 @@ class Dao extends Model\Dao\AbstractDao
         ) DEFAULT CHARSET=utf8mb4;');
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $dataTable . '` (
-            `o_id` BIGINT(20) NOT NULL,
+            `o_id` INT(11) UNSIGNED NOT NULL,
             `collectionId` BIGINT(20) NULL,
             `groupId` BIGINT(20) NOT NULL,
             `keyId` BIGINT(20) NOT NULL,

--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -419,6 +419,15 @@ class Dao extends Model\DataObject\AbstractObject\Dao
      */
     public function delete()
     {
+        // delete fields which have their own delete algorithm
+        if ($this->model->getClass()) {
+            foreach ($this->model->getClass()->getFieldDefinitions() as $fd) {
+                if ($fd instanceof CustomResourcePersistingInterface) {
+                    $fd->delete($this->model);
+                }
+            }
+        }
+
         parent::delete();
     }
 }

--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -419,19 +419,6 @@ class Dao extends Model\DataObject\AbstractObject\Dao
      */
     public function delete()
     {
-        $this->db->delete('object_query_' . $this->model->getClassId(), ['oo_id' => $this->model->getId()]);
-        $this->db->delete('object_store_' . $this->model->getClassId(), ['oo_id' => $this->model->getId()]);
-        $this->db->delete('object_relations_' . $this->model->getClassId(), ['src_id' => $this->model->getId()]);
-
-        // delete fields which have their own delete algorithm
-        if ($this->model->getClass()) {
-            foreach ($this->model->getClass()->getFieldDefinitions() as $fd) {
-                if ($fd instanceof CustomResourcePersistingInterface) {
-                    $fd->delete($this->model);
-                }
-            }
-        }
-
         parent::delete();
     }
 }

--- a/models/DataObject/Data/ObjectMetadata/Dao.php
+++ b/models/DataObject/Data/ObjectMetadata/Dao.php
@@ -127,14 +127,15 @@ class Dao extends Model\Dao\AbstractDao
               `ownername` VARCHAR(70) NOT NULL DEFAULT '',
               `position` VARCHAR(70) NOT NULL DEFAULT '0',
               `index` int(11) unsigned NOT NULL DEFAULT '0',
-              PRIMARY KEY (`o_id`, `dest_id`, `type`, `fieldname`, `column`, `ownertype`, `ownername`, `position`, `index`),
+              PRIMARY KEY (`o_id`, `dest_id`, `type`, `fieldname`, `column`, `ownertype`, `ownername`, `position`, `index`)
               INDEX `dest_id` (`dest_id`),
               INDEX `fieldname` (`fieldname`),
               INDEX `column` (`column`),
               INDEX `ownertype` (`ownertype`),
               INDEX `ownername` (`ownername`),
               INDEX `position` (`position`),
-              INDEX `index` (`index`)
+              INDEX `index` (`index`),
+              CONSTRAINT `fk_".$table."__o_id` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
 		) DEFAULT CHARSET=utf8mb4;");
 
         $this->handleEncryption($class, [$table]);

--- a/models/DataObject/Data/ObjectMetadata/Dao.php
+++ b/models/DataObject/Data/ObjectMetadata/Dao.php
@@ -117,7 +117,7 @@ class Dao extends Model\Dao\AbstractDao
         $table = 'object_metadata_' . $classId;
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $table . "` (
-              `o_id` int(11) NOT NULL default '0',
+              `o_id` int(11) UNSIGNED NOT NULL default '0',
               `dest_id` int(11) NOT NULL default '0',
 	          `type` VARCHAR(50) NOT NULL DEFAULT '',
               `fieldname` varchar(71) NOT NULL,

--- a/models/DataObject/Data/ObjectMetadata/Dao.php
+++ b/models/DataObject/Data/ObjectMetadata/Dao.php
@@ -127,7 +127,7 @@ class Dao extends Model\Dao\AbstractDao
               `ownername` VARCHAR(70) NOT NULL DEFAULT '',
               `position` VARCHAR(70) NOT NULL DEFAULT '0',
               `index` int(11) unsigned NOT NULL DEFAULT '0',
-              PRIMARY KEY (`o_id`, `dest_id`, `type`, `fieldname`, `column`, `ownertype`, `ownername`, `position`, `index`)
+              PRIMARY KEY (`o_id`, `dest_id`, `type`, `fieldname`, `column`, `ownertype`, `ownername`, `position`, `index`),
               INDEX `dest_id` (`dest_id`),
               INDEX `fieldname` (`fieldname`),
               INDEX `column` (`column`),

--- a/models/DataObject/Data/ObjectMetadata/Dao.php
+++ b/models/DataObject/Data/ObjectMetadata/Dao.php
@@ -135,7 +135,7 @@ class Dao extends Model\Dao\AbstractDao
               INDEX `ownername` (`ownername`),
               INDEX `position` (`position`),
               INDEX `index` (`index`),
-              CONSTRAINT `fk_".$table."__o_id` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
+              CONSTRAINT `".self::getForeignKeyName($table, 'o_id')."` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
 		) DEFAULT CHARSET=utf8mb4;");
 
         $this->handleEncryption($class, [$table]);

--- a/models/DataObject/Fieldcollection/Definition/Dao.php
+++ b/models/DataObject/Fieldcollection/Definition/Dao.php
@@ -72,7 +72,7 @@ class Dao extends Model\Dao\AbstractDao
 		  `o_id` int(11) NOT NULL default '0',
 		  `index` int(11) default '0',
           `fieldname` varchar(190) default '',
-          PRIMARY KEY (`o_id`,`index`,`fieldname`(190))
+          PRIMARY KEY (`o_id`,`index`,`fieldname`(190)),
           INDEX `index` (`index`),
           INDEX `fieldname` (`fieldname`),
           CONSTRAINT `fk_".$table."__o_id` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE

--- a/models/DataObject/Fieldcollection/Definition/Dao.php
+++ b/models/DataObject/Fieldcollection/Definition/Dao.php
@@ -72,9 +72,10 @@ class Dao extends Model\Dao\AbstractDao
 		  `o_id` int(11) NOT NULL default '0',
 		  `index` int(11) default '0',
           `fieldname` varchar(190) default '',
-          PRIMARY KEY (`o_id`,`index`,`fieldname`(190)),
+          PRIMARY KEY (`o_id`,`index`,`fieldname`(190))
           INDEX `index` (`index`),
-          INDEX `fieldname` (`fieldname`)
+          INDEX `fieldname` (`fieldname`),
+          CONSTRAINT `fk_".$table."__o_id` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
 		) DEFAULT CHARSET=utf8mb4;");
 
         $existingColumns = $this->getValidTableColumns($table, false); // no caching of table definition

--- a/models/DataObject/Fieldcollection/Definition/Dao.php
+++ b/models/DataObject/Fieldcollection/Definition/Dao.php
@@ -75,7 +75,7 @@ class Dao extends Model\Dao\AbstractDao
           PRIMARY KEY (`o_id`,`index`,`fieldname`(190)),
           INDEX `index` (`index`),
           INDEX `fieldname` (`fieldname`),
-          CONSTRAINT `fk_".$table."__o_id` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
+          CONSTRAINT `".self::getForeignKeyName($table, 'o_id')."` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
 		) DEFAULT CHARSET=utf8mb4;");
 
         $existingColumns = $this->getValidTableColumns($table, false); // no caching of table definition

--- a/models/DataObject/Fieldcollection/Definition/Dao.php
+++ b/models/DataObject/Fieldcollection/Definition/Dao.php
@@ -69,7 +69,7 @@ class Dao extends Model\Dao\AbstractDao
         $table = $this->getTableName($class);
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $table . "` (
-		  `o_id` int(11) NOT NULL default '0',
+		  `o_id` int(11) UNSIGNED NOT NULL default '0',
 		  `index` int(11) default '0',
           `fieldname` varchar(190) default '',
           PRIMARY KEY (`o_id`,`index`,`fieldname`(190)),

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -797,7 +797,7 @@ QUERY;
               `index` INT(11) NOT NULL DEFAULT '0',
               `fieldname` VARCHAR(190) NOT NULL DEFAULT '',
               `language` varchar(10) NOT NULL DEFAULT '',
-              PRIMARY KEY (`ooo_id`, `language`, `index`, `fieldname`)
+              PRIMARY KEY (`ooo_id`, `language`, `index`, `fieldname`),
               INDEX `index` (`index`),
               INDEX `fieldname` (`fieldname`),
               INDEX `language` (`language`),
@@ -809,7 +809,7 @@ QUERY;
                 'CREATE TABLE IF NOT EXISTS `'.$table."` (
               `ooo_id` int(11) UNSIGNED NOT NULL default '0',
               `language` varchar(10) NOT NULL DEFAULT '',
-              PRIMARY KEY (`ooo_id`,`language`)
+              PRIMARY KEY (`ooo_id`,`language`),
               INDEX `language` (`language`),
               CONSTRAINT `".self::getForeignKeyName($table, 'ooo_id')."` FOREIGN KEY (`ooo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
             ) DEFAULT CHARSET=utf8mb4;"
@@ -875,7 +875,7 @@ QUERY;
                     'CREATE TABLE IF NOT EXISTS `'.$queryTable."` (
                       `ooo_id` int(11) UNSIGNED NOT NULL default '0',
                       `language` varchar(10) NOT NULL DEFAULT '',
-                      PRIMARY KEY (`ooo_id`,`language`)
+                      PRIMARY KEY (`ooo_id`,`language`),
                       INDEX `language` (`language`),
                       CONSTRAINT `".self::getForeignKeyName($queryTable, 'ooo_id')."` FOREIGN KEY (`ooo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
                     ) DEFAULT CHARSET=utf8mb4;"

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -793,7 +793,7 @@ QUERY;
         if (isset($context['containerType']) && ($context['containerType'] === 'fieldcollection' || $context['containerType'] === 'objectbrick')) {
             $this->db->query(
                 'CREATE TABLE IF NOT EXISTS `'.$table."` (
-              `ooo_id` int(11) NOT NULL default '0',
+              `ooo_id` int(11) UNSIGNED NOT NULL default '0',
               `index` INT(11) NOT NULL DEFAULT '0',
               `fieldname` VARCHAR(190) NOT NULL DEFAULT '',
               `language` varchar(10) NOT NULL DEFAULT '',
@@ -807,7 +807,7 @@ QUERY;
         } else {
             $this->db->query(
                 'CREATE TABLE IF NOT EXISTS `'.$table."` (
-              `ooo_id` int(11) NOT NULL default '0',
+              `ooo_id` int(11) UNSIGNED NOT NULL default '0',
               `language` varchar(10) NOT NULL DEFAULT '',
               PRIMARY KEY (`ooo_id`,`language`)
               INDEX `language` (`language`),
@@ -873,7 +873,7 @@ QUERY;
 
                 $this->db->query(
                     'CREATE TABLE IF NOT EXISTS `'.$queryTable."` (
-                      `ooo_id` int(11) NOT NULL default '0',
+                      `ooo_id` int(11) UNSIGNED NOT NULL default '0',
                       `language` varchar(10) NOT NULL DEFAULT '',
                       PRIMARY KEY (`ooo_id`,`language`)
                       INDEX `language` (`language`),

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -544,7 +544,7 @@ class Dao extends Model\Dao\AbstractDao
             $dirtyLanguageCondition = ' AND position IN('.implode(',', $languageList).')';
         }
 
-        if ($container instanceof DataObject\Objectbrick\Definition || $container instanceof DataObject\Fieldcollection\Definition) {
+        if ($container instanceof DataObject\Fieldcollection\Definition) {
             $objectId = $object->getId();
             $index = $context['index'] ?? null;
             $containerName = $context['fieldname'];
@@ -559,14 +559,12 @@ class Dao extends Model\Dao\AbstractDao
                 ).$dirtyLanguageCondition;
 
             $this->db->deleteWhere('object_relations_'.$object->getClassId(), $sql);
-            if ($container instanceof DataObject\Fieldcollection\Definition) {
-                return true;
-            }
-        } else {
-            $sql = 'ownertype = "localizedfield" AND ownername = "localizedfield" and src_id = '.$this->model->getObject(
-                )->getId().$dirtyLanguageCondition;
-            $this->db->deleteWhere('object_relations_'.$this->model->getObject()->getClassId(), $sql);
+
+            return true;
         }
+
+        $sql = 'ownertype = "localizedfield" AND ownername = "localizedfield" and src_id = '.$this->model->getObject()->getId().$dirtyLanguageCondition;
+        $this->db->deleteWhere('object_relations_'.$this->model->getObject()->getClassId(), $sql);
 
         return false;
     }
@@ -799,10 +797,11 @@ QUERY;
               `index` INT(11) NOT NULL DEFAULT '0',
               `fieldname` VARCHAR(190) NOT NULL DEFAULT '',
               `language` varchar(10) NOT NULL DEFAULT '',
-              PRIMARY KEY (`ooo_id`, `language`, `index`, `fieldname`),
+              PRIMARY KEY (`ooo_id`, `language`, `index`, `fieldname`)
               INDEX `index` (`index`),
               INDEX `fieldname` (`fieldname`),
-              INDEX `language` (`language`)
+              INDEX `language` (`language`),
+              CONSTRAINT `fk_".$table."__ooo_id` FOREIGN KEY (`ooo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
             ) DEFAULT CHARSET=utf8mb4;"
             );
         } else {
@@ -810,8 +809,9 @@ QUERY;
                 'CREATE TABLE IF NOT EXISTS `'.$table."` (
               `ooo_id` int(11) NOT NULL default '0',
               `language` varchar(10) NOT NULL DEFAULT '',
-              PRIMARY KEY (`ooo_id`,`language`),
-              INDEX `language` (`language`)
+              PRIMARY KEY (`ooo_id`,`language`)
+              INDEX `language` (`language`),
+              CONSTRAINT `fk_".$table."__ooo_id` FOREIGN KEY (`ooo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
             ) DEFAULT CHARSET=utf8mb4;"
             );
         }
@@ -875,8 +875,9 @@ QUERY;
                     'CREATE TABLE IF NOT EXISTS `'.$queryTable."` (
                       `ooo_id` int(11) NOT NULL default '0',
                       `language` varchar(10) NOT NULL DEFAULT '',
-                      PRIMARY KEY (`ooo_id`,`language`),
-                      INDEX `language` (`language`)
+                      PRIMARY KEY (`ooo_id`,`language`)
+                      INDEX `language` (`language`),
+                      CONSTRAINT `fk_".$queryTable."__ooo_id` FOREIGN KEY (`ooo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
                     ) DEFAULT CHARSET=utf8mb4;"
                 );
 

--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -801,7 +801,7 @@ QUERY;
               INDEX `index` (`index`),
               INDEX `fieldname` (`fieldname`),
               INDEX `language` (`language`),
-              CONSTRAINT `fk_".$table."__ooo_id` FOREIGN KEY (`ooo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
+              CONSTRAINT `".self::getForeignKeyName($table, 'ooo_id')."` FOREIGN KEY (`ooo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
             ) DEFAULT CHARSET=utf8mb4;"
             );
         } else {
@@ -811,7 +811,7 @@ QUERY;
               `language` varchar(10) NOT NULL DEFAULT '',
               PRIMARY KEY (`ooo_id`,`language`)
               INDEX `language` (`language`),
-              CONSTRAINT `fk_".$table."__ooo_id` FOREIGN KEY (`ooo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
+              CONSTRAINT `".self::getForeignKeyName($table, 'ooo_id')."` FOREIGN KEY (`ooo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
             ) DEFAULT CHARSET=utf8mb4;"
             );
         }
@@ -877,7 +877,7 @@ QUERY;
                       `language` varchar(10) NOT NULL DEFAULT '',
                       PRIMARY KEY (`ooo_id`,`language`)
                       INDEX `language` (`language`),
-                      CONSTRAINT `fk_".$queryTable."__ooo_id` FOREIGN KEY (`ooo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
+                      CONSTRAINT `".self::getForeignKeyName($queryTable, 'ooo_id')."` FOREIGN KEY (`ooo_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
                     ) DEFAULT CHARSET=utf8mb4;"
                 );
 

--- a/models/DataObject/Objectbrick/Definition/Dao.php
+++ b/models/DataObject/Objectbrick/Definition/Dao.php
@@ -66,7 +66,7 @@ class Dao extends Model\DataObject\Fieldcollection\Definition\Dao
           PRIMARY KEY (`o_id`,`fieldname`)
           INDEX `o_id` (`o_id`),
           INDEX `fieldname` (`fieldname`),
-          CONSTRAINT `fk_'.$tableStore.'__o_id` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
+          CONSTRAINT `".self::getForeignKeyName($tableStore, 'o_id')."` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
 		) DEFAULT CHARSET=utf8mb4;");
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $tableQuery . "` (
@@ -75,7 +75,7 @@ class Dao extends Model\DataObject\Fieldcollection\Definition\Dao
           PRIMARY KEY (`o_id`,`fieldname`),
           INDEX `o_id` (`o_id`),
           INDEX `fieldname` (`fieldname`),
-          CONSTRAINT `fk_'.$tableQuery.'__o_id` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
+          CONSTRAINT `".self::getForeignKeyName($tableQuery, 'o_id')."` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
 		) DEFAULT CHARSET=utf8mb4;");
 
         $existingColumnsStore = $this->getValidTableColumns($tableStore, false); // no caching of table definition

--- a/models/DataObject/Objectbrick/Definition/Dao.php
+++ b/models/DataObject/Objectbrick/Definition/Dao.php
@@ -63,9 +63,10 @@ class Dao extends Model\DataObject\Fieldcollection\Definition\Dao
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $tableStore . "` (
 		  `o_id` int(11) NOT NULL default '0',
           `fieldname` varchar(190) default '',
-          PRIMARY KEY (`o_id`,`fieldname`),
+          PRIMARY KEY (`o_id`,`fieldname`)
           INDEX `o_id` (`o_id`),
-          INDEX `fieldname` (`fieldname`)
+          INDEX `fieldname` (`fieldname`),
+          CONSTRAINT `fk_'.$tableStore.'__o_id` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
 		) DEFAULT CHARSET=utf8mb4;");
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $tableQuery . "` (
@@ -73,7 +74,8 @@ class Dao extends Model\DataObject\Fieldcollection\Definition\Dao
           `fieldname` varchar(190) default '',
           PRIMARY KEY (`o_id`,`fieldname`),
           INDEX `o_id` (`o_id`),
-          INDEX `fieldname` (`fieldname`)
+          INDEX `fieldname` (`fieldname`),
+          CONSTRAINT `fk_'.$tableQuery.'__o_id` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE
 		) DEFAULT CHARSET=utf8mb4;");
 
         $existingColumnsStore = $this->getValidTableColumns($tableStore, false); // no caching of table definition

--- a/models/DataObject/Objectbrick/Definition/Dao.php
+++ b/models/DataObject/Objectbrick/Definition/Dao.php
@@ -61,7 +61,7 @@ class Dao extends Model\DataObject\Fieldcollection\Definition\Dao
         $tableQuery = $this->getTableName($class, true);
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $tableStore . "` (
-		  `o_id` int(11) NOT NULL default '0',
+		  `o_id` int(11) UNSIGNED NOT NULL default '0',
           `fieldname` varchar(190) default '',
           PRIMARY KEY (`o_id`,`fieldname`)
           INDEX `o_id` (`o_id`),
@@ -70,7 +70,7 @@ class Dao extends Model\DataObject\Fieldcollection\Definition\Dao
 		) DEFAULT CHARSET=utf8mb4;");
 
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $tableQuery . "` (
-		  `o_id` int(11) NOT NULL default '0',
+		  `o_id` int(11) UNSIGNED NOT NULL default '0',
           `fieldname` varchar(190) default '',
           PRIMARY KEY (`o_id`,`fieldname`),
           INDEX `o_id` (`o_id`),

--- a/models/DataObject/Objectbrick/Definition/Dao.php
+++ b/models/DataObject/Objectbrick/Definition/Dao.php
@@ -63,7 +63,7 @@ class Dao extends Model\DataObject\Fieldcollection\Definition\Dao
         $this->db->query('CREATE TABLE IF NOT EXISTS `' . $tableStore . "` (
 		  `o_id` int(11) UNSIGNED NOT NULL default '0',
           `fieldname` varchar(190) default '',
-          PRIMARY KEY (`o_id`,`fieldname`)
+          PRIMARY KEY (`o_id`,`fieldname`),
           INDEX `o_id` (`o_id`),
           INDEX `fieldname` (`fieldname`),
           CONSTRAINT `".self::getForeignKeyName($tableStore, 'o_id')."` FOREIGN KEY (`o_id`) REFERENCES objects (`o_id`) ON DELETE CASCADE


### PR DESCRIPTION
From time to time we have the problem that there is an item in the `object_store_*` table but not in `objects`. As there is a unique data field it is then neither possible to create a new item with the same value, nor to find the existing one (because of INNER JOINS on the `objects` table. I do not know the reason, perhaps there is a transaction missing somewhere but anyway, it would be cleaner if the data which belongs together would be explicitly connected with a foreign key. Then such situations could not occur anymore, no matter how one of the datasets belonging to the same object got removed / not created.