### PR TITLE
[Data object grid] Fix JS error: Reload tree after deleting objects via grid

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/folder/search.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/folder/search.js
@@ -466,9 +466,10 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
                         "id": ids,
                         "success": function () {
                             this.getStore().reload();
-                            var tree = pimcore.globalmanager.get("layout_object_tree");
-                            var treePanel = tree.tree;
-                            tree.refresh(treePanel.getRootNode());
+                            var tree = pimcore.globalmanager.get("layout_object_tree").tree;
+                            tree.getStore().load({
+                                node: tree.getRootNode()
+                            });
                         }.bind(this)
                     };
                     pimcore.elementservice.deleteElement(options);


### PR DESCRIPTION
Steps to reproduce:
1. Create at least 2 data objects
2. Open grid which shows those 2 objects
3. Select both, right-click, click "Delete"

JS error occurs. This PR fixes this.