### PR TITLE
Fix Predefined getByKey and getByName methods

### DIFF
--- a/models/Metadata/Predefined/Dao.php
+++ b/models/Metadata/Predefined/Dao.php
@@ -72,6 +72,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
     public function getByNameAndLanguage($name = null, $language = null)
     {
         $list = new Listing();
+        /** @var Model\Metadata\Predefined[] $definitions */
         $definitions = array_values(array_filter($list->getDefinitions(), function ($item) use ($name, $language) {
             $return = true;
             if ($name && $item->getName() != $name) {
@@ -85,7 +86,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
         }));
 
         if (count($definitions) && $definitions[0]->getId()) {
-            $this->assignVariablesToModel($definitions[0]);
+            $this->assignVariablesToModel($definitions[0]->getObjectVars());
         } else {
             throw new Model\Exception\NotFoundException(sprintf('Predefined metadata config with name "%s" and language %s does not exist.', $name, $language));
         }

--- a/models/Property/Predefined.php
+++ b/models/Property/Predefined.php
@@ -119,7 +119,7 @@ final class Predefined extends Model\AbstractModel
                 $property = new self();
                 $property->getDao()->getByKey($key);
                 \Pimcore\Cache\Runtime::set($cacheKey, $property);
-            } catch (\Exception $e) {
+            } catch (Model\Exception\NotFoundException $e) {
                 return null;
             }
         }

--- a/models/Property/Predefined/Dao.php
+++ b/models/Property/Predefined/Dao.php
@@ -69,7 +69,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
     /**
      * @param string|null $key
      *
-     * @throws \Exception
+     * @throws Model\Exception\NotFoundException
      */
     public function getByKey($key = null)
     {
@@ -79,15 +79,19 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
         $key = $this->model->getKey();
 
         $list = new Listing();
+        /** @var Model\Property\Predefined[] $properties */
         $properties = array_values(array_filter($list->getProperties(), function ($item) use ($key) {
             return $item->getKey() == $key;
         }
         ));
 
         if (count($properties) && $properties[0]->getId()) {
-            $this->assignVariablesToModel($properties[0]);
+            $this->assignVariablesToModel($properties[0]->getObjectVars());
         } else {
-            throw new \Exception('Route with name: ' . $this->model->getName() . ' does not exist');
+            throw new Model\Exception\NotFoundException(sprintf(
+                'Predefined property with key "%s" does not exist.',
+                $this->model->getKey()
+            ));
         }
     }
 


### PR DESCRIPTION
This methods doesn't work anymore because assignVariablesToModel needs an array and not an object.