### PR TITLE
[Data object password field] Add new event for checking if password is already hashed

### DIFF
--- a/lib/Event/DataObjectEvents.php
+++ b/lib/Event/DataObjectEvents.php
@@ -132,6 +132,7 @@ final class DataObjectEvents
     /**
      * Arguments:
      *  - password | string | contains the current value of the password field
+     *  - alreadyHashed | bool | return variable which determines if the password is already hashed or not. If not it will get hashed when the object gets saved
      *
      * @Event("Pimcore\Event\Model\DataObjectEvent")
      *

--- a/lib/Event/DataObjectEvents.php
+++ b/lib/Event/DataObjectEvents.php
@@ -128,4 +128,14 @@ final class DataObjectEvents
      * @var string
      */
     const POST_CSV_ITEM_EXPORT = 'pimcore.dataobject.postCsvItemExport';
+
+    /**
+     * Arguments:
+     *  - password | string | contains the current value of the password field
+     *
+     * @Event("Pimcore\Event\Model\DataObjectEvent")
+     *
+     * @var string
+     */
+    const PASSWORD_ALREADY_HASHED_CHECK = 'pimcore.dataobject.passwordAlreadyHashed';
 }


### PR DESCRIPTION
In https://github.com/pimcore/pimcore/blob/b7cf6da36c28e59ff224b7807e35f630057e8bd0/models/DataObject/ClassDefinition/Data/Password.php#L197-L219 there are multiple ways to check if the currently set value in a password field is already a hash or not. But in some cases those mechanism are not enough. For example we currently want to migrate a Magento 1 application to Pimcore and want the logins to keep working. Magento 1 has a password hash like `07ae0810472e5bad57060ea3daca76b64fe48f7015779985961e5dea6ed5e3b5:ywD6JM5gEfI86shVQaafgeaWwzYGebU8`. Currently there is no way with the PHP API to get such a hash into a password field without getting it rehashed (which then of course makes the data unusable).
But even if we import the hash directly in the Pimcore database, as soon as we save the customer - even if the `setPassword()` method did not get executed, the rehashing will be done again - and again destroying the original hash.

I first thought that we could remove the hash recognition logic from `Password::getDataforResource()` and implement the `PreSetDataInterface` but this is not possible because the setter and thus the `preSetValue()` method of course get also loaded by Pimcore itself when it loads the object.

In the end the only solution I could think of was introducing a new event which can be used to check if a certain password is already a hash. 