### PR TITLE
Fix empty Hotspots and Markers in Image-Editable

### DIFF
--- a/models/Element/Data/MarkerHotspotItem.php
+++ b/models/Element/Data/MarkerHotspotItem.php
@@ -25,17 +25,17 @@ class MarkerHotspotItem implements \ArrayAccess
     /**
      * @var string
      */
-    protected $name = '';
+    public $name = '';
 
     /**
      * @var string
      */
-    protected $type = '';
+    public $type = '';
 
     /**
      * @var mixed
      */
-    protected $value;
+    public $value;
 
     /**
      * @param array $data


### PR DESCRIPTION
Fix empty Hotspots and Markers in Image-Editable:

How to reproduce:
- create Image-Editable and fill it with an image
- set marker or hotspot on image and fill it with data (doesn't matter which)
- save the document and reload
- data will now be gone in the markers/hotspots (but is still saved in DB)
- if the document is saved again, all de data will be overwritten and thus deleted


## Changes in this pull request  
Change protected vars back do public

## Additional info  
object2array() - helper function casts the data to Json and back to assoc-array, but only public data will be converted.

