### PR TITLE
[Data objects] Better aggregation of validation exception messages for nested fields with > 2 levels

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -1124,10 +1124,13 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
                 }
 
                 if ($validationExceptions) {
-                    $aggregatedExceptions = new Model\Element\ValidationException($validationExceptions[0]->getMessage());
-                    $aggregatedExceptions->setSubItems($validationExceptions);
-
-                    throw $aggregatedExceptions;
+                    $errors = [];
+                    /** @var \Exception $e */
+                    foreach ($validationExceptions as $e) {
+                        $errors[] = $e->getAggregatedMessage();
+                    }
+                    $message = implode(' / ', $errors);
+                    throw new Model\Element\ValidationException($message);
                 }
             }
         }

--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -1116,18 +1116,18 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
                             }
 
                             $fd->checkValidity($data, false, $params);
-                        } catch (Model\Element\ValidationException $ve) {
-                            $ve->addContext($this->getName() . '-' . $idx);
-                            $validationExceptions[] = $ve;
+                        } catch (Model\Element\ValidationException $e) {
+                            $exceptionClass = get_class($e);
+
+                            $newException = new $exceptionClass($e->getMessage().' fieldname='.$fd->getName(), $e->getCode(), $e->getPrevious());
+                            $subItems = $e->getSubItems();
+                            array_unshift($subItems, $e);
+                            $newException->setSubItems($subItems);
+                            $newException->addContext($this->getName().'-'.$idx);
+
+                            throw $newException;
                         }
                     }
-                }
-
-                if ($validationExceptions) {
-                    $aggregatedExceptions = new Model\Element\ValidationException();
-                    $aggregatedExceptions->setSubItems($validationExceptions);
-
-                    throw $aggregatedExceptions;
                 }
             }
         }

--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -1116,18 +1116,18 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
                             }
 
                             $fd->checkValidity($data, false, $params);
-                        } catch (Model\Element\ValidationException $e) {
-                            $exceptionClass = get_class($e);
-
-                            $newException = new $exceptionClass($e->getMessage().' fieldname='.$fd->getName(), $e->getCode(), $e->getPrevious());
-                            $subItems = $e->getSubItems();
-                            array_unshift($subItems, $e);
-                            $newException->setSubItems($subItems);
-                            $newException->addContext($this->getName().'-'.$idx);
-
-                            throw $newException;
+                        } catch (Model\Element\ValidationException $ve) {
+                            $ve->addContext($this->getName() . '-' . $idx);
+                            $validationExceptions[] = $ve;
                         }
                     }
+                }
+
+                if ($validationExceptions) {
+                    $aggregatedExceptions = new Model\Element\ValidationException($validationExceptions[0]->getMessage());
+                    $aggregatedExceptions->setSubItems($validationExceptions);
+
+                    throw $aggregatedExceptions;
                 }
             }
         }

--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -1125,7 +1125,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
 
                 if ($validationExceptions) {
                     $errors = [];
-                    /** @var \Exception $e */
+                    /** @var Element\ValidationException $e */
                     foreach ($validationExceptions as $e) {
                         $errors[] = $e->getAggregatedMessage();
                     }

--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -459,10 +459,13 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
             }
 
             if ($validationExceptions) {
-                $aggregatedExceptions = new Model\Element\ValidationException();
-                $aggregatedExceptions->setSubItems($validationExceptions);
-
-                throw $aggregatedExceptions;
+                $errors = [];
+                /** @var Model\Element\ValidationException $e */
+                foreach ($validationExceptions as $e) {
+                    $errors[] = $e->getAggregatedMessage();
+                }
+                $message = implode(' / ', $errors);
+                throw new Model\Element\ValidationException($message);
             }
         }
     }

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -1004,7 +1004,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
         }
 
         if (count($validationExceptions) > 0) {
-            $aggregatedExceptions = new Model\Element\ValidationException();
+            $aggregatedExceptions = new Model\Element\ValidationException($validationExceptions[0]->getMessage());
             $aggregatedExceptions->setSubItems($validationExceptions);
 
             throw $aggregatedExceptions;

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -1005,7 +1005,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
 
         if (count($validationExceptions) > 0) {
             $errors = [];
-            /** @var \Exception $e */
+            /** @var Element\ValidationException $e */
             foreach ($validationExceptions as $e) {
                 $errors[] = $e->getAggregatedMessage();
             }

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -956,7 +956,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
                                 $fd->checkValidity(null, false, $params);
                             }
                         } catch (\Exception $e) {
-                            if ($fd->supportsInheritance() && $fd->isEmpty($dataForValidityCheck[$language][$fd->getName()]) && $data->getObject()->getClass()->getAllowInherit()) {
+                            if ($data->getObject()->getClass()->getAllowInherit()) {
                                 //try again with parent data when inheritance is activated
                                 try {
                                     $getInheritedValues = DataObject::doGetInheritedValues();

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -1004,10 +1004,13 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
         }
 
         if (count($validationExceptions) > 0) {
-            $aggregatedExceptions = new Model\Element\ValidationException($validationExceptions[0]->getMessage());
-            $aggregatedExceptions->setSubItems($validationExceptions);
-
-            throw $aggregatedExceptions;
+            $errors = [];
+            /** @var \Exception $e */
+            foreach ($validationExceptions as $e) {
+                $errors[] = $e->getAggregatedMessage();
+            }
+            $message = implode(' / ', $errors);
+            throw new Model\Element\ValidationException($message);
         }
     }
 

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -956,7 +956,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
                                 $fd->checkValidity(null, false, $params);
                             }
                         } catch (\Exception $e) {
-                            if ($data->getObject()->getClass()->getAllowInherit()) {
+                            if ($fd->supportsInheritance() && $fd->isEmpty($dataForValidityCheck[$language][$fd->getName()]) && $data->getObject()->getClass()->getAllowInherit()) {
                                 //try again with parent data when inheritance is activated
                                 try {
                                     $getInheritedValues = DataObject::doGetInheritedValues();

--- a/models/DataObject/ClassDefinition/Data/Objectbricks.php
+++ b/models/DataObject/ClassDefinition/Data/Objectbricks.php
@@ -633,10 +633,13 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
             }
 
             if ($validationExceptions) {
-                $aggregatedExceptions = new Model\Element\ValidationException('invalid brick ' . $this->getName());
-                $aggregatedExceptions->setSubItems($validationExceptions);
-
-                throw $aggregatedExceptions;
+                $errors = [];
+                /** @var Model\Element\ValidationException $e */
+                foreach ($validationExceptions as $e) {
+                    $errors[] = $e->getAggregatedMessage();
+                }
+                $message = implode(' / ', $errors);
+                throw new Model\Element\ValidationException('invalid brick ' . $this->getName().': '.$message);
             }
         }
     }

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -170,7 +170,8 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
         if ($validationExceptions) {
             $message = 'Validation failed: ';
             $errors = [];
-            /** @var \Exception $e */
+
+            /** @var Model\Element\ValidationException $e */
             foreach ($validationExceptions as $e) {
                 $errors[] = $e->getAggregatedMessage();
             }

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -172,35 +172,10 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
             $errors = [];
             /** @var \Exception $e */
             foreach ($validationExceptions as $e) {
-                $msg = $e->getMessage();
-
-                if ($e instanceof Model\Element\ValidationException) {
-                    $subItems = $e->getSubItems();
-                    if (is_array($subItems) && count($subItems)) {
-                        $msg .= ' (';
-                        $subItemParts = [];
-                        /** @var \Exception $subItem */
-                        foreach ($subItems as $subItem) {
-                            $subItemMessage = $subItem->getMessage();
-                            if ($subItem instanceof Model\Element\ValidationException) {
-                                $contextStack = $subItem->getContextStack();
-                                if ($contextStack) {
-                                    $subItemMessage .= '[ ' . $contextStack[0] . ' ]';
-                                }
-                            }
-                            $subItemParts[] = $subItemMessage;
-                        }
-                        $msg .= implode(', ', $subItemParts);
-                        $msg .= ')';
-                    }
-                }
-                $errors[] = $msg;
+                $errors[] = $e->getAggregatedMessage();
             }
             $message .= implode(' / ', $errors);
-            $aggregatedExceptions = new Model\Element\ValidationException($message);
-            $aggregatedExceptions->setSubItems($validationExceptions);
-
-            throw $aggregatedExceptions;
+            throw new Model\Element\ValidationException($message);
         }
 
         $isDirtyDetectionDisabled = self::isDirtyDetectionDisabled();

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -132,7 +132,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
                     try {
                         $fd->checkValidity($value, $omitMandatoryCheck, $params);
                     } catch (\Exception $e) {
-                        if ($this->getClass()->getAllowInherit()) {
+                        if ($fd->supportsInheritance() && $fd->isEmpty($value) && $this->getClass()->getAllowInherit()) {
                             //try again with parent data when inheritance is activated
                             try {
                                 $getInheritedValues = DataObject::doGetInheritedValues();

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -132,7 +132,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
                     try {
                         $fd->checkValidity($value, $omitMandatoryCheck, $params);
                     } catch (\Exception $e) {
-                        if ($fd->supportsInheritance() && $fd->isEmpty($value) && $this->getClass()->getAllowInherit()) {
+                        if ($this->getClass()->getAllowInherit()) {
                             //try again with parent data when inheritance is activated
                             try {
                                 $getInheritedValues = DataObject::doGetInheritedValues();

--- a/models/Element/ValidationException.php
+++ b/models/Element/ValidationException.php
@@ -75,6 +75,10 @@ class ValidationException extends \Exception
 
     public function getAggregatedMessage() {
         $msg = $this->getMessage();
+        $contextStack = $this->getContextStack();
+        if ($contextStack) {
+            $msg .= '[ '.$contextStack[0].' ]';
+        }
 
         $subItems = $this->getSubItems();
         if (count($subItems) > 0) {

--- a/models/Element/ValidationException.php
+++ b/models/Element/ValidationException.php
@@ -34,7 +34,7 @@ class ValidationException extends \Exception
     }
 
     /**
-     * @param \Exception $subItems
+     * @param \Exception[] $subItems
      */
     public function setSubItems(array $subItems = [])
     {

--- a/models/Element/ValidationException.php
+++ b/models/Element/ValidationException.php
@@ -73,7 +73,8 @@ class ValidationException extends \Exception
         return $result;
     }
 
-    public function getAggregatedMessage() {
+    public function getAggregatedMessage(): string
+    {
         $msg = $this->getMessage();
         $contextStack = $this->getContextStack();
         if ($contextStack) {

--- a/models/Element/ValidationException.php
+++ b/models/Element/ValidationException.php
@@ -22,11 +22,11 @@ class ValidationException extends \Exception
      */
     protected $contextStack = [];
 
-    /** @var array */
+    /** @var \Exception[] */
     protected $subItems = [];
 
     /**
-     * @return array
+     * @return \Exception[]
      */
     public function getSubItems()
     {
@@ -34,7 +34,7 @@ class ValidationException extends \Exception
     }
 
     /**
-     * @param array $subItems
+     * @param \Exception $subItems
      */
     public function setSubItems(array $subItems = [])
     {
@@ -71,5 +71,32 @@ class ValidationException extends \Exception
         }
 
         return $result;
+    }
+
+    public function getAggregatedMessage() {
+        $msg = $this->getMessage();
+
+        $subItems = $this->getSubItems();
+        if (count($subItems) > 0) {
+            $msg .= ' (';
+            $subItemParts = [];
+
+            foreach ($subItems as $subItem) {
+                if ($subItem instanceof self) {
+                    $subItemMessage = $subItem->getAggregatedMessage();
+                    $contextStack = $subItem->getContextStack();
+                    if ($contextStack) {
+                        $subItemMessage .= '[ '.$contextStack[0].' ]';
+                    }
+                } else {
+                    $subItemMessage = $subItem->getMessage();
+                }
+                $subItemParts[] = $subItemMessage;
+            }
+            $msg .= implode(', ', $subItemParts);
+            $msg .= ')';
+        }
+
+        return $msg;
     }
 }


### PR DESCRIPTION
Steps to reproduce:
1. Create data object class `Product`
2. Create data object class `Test` like this:
<img width="320" alt="Bildschirmfoto 2021-10-07 um 18 10 31" src="https://user-images.githubusercontent.com/8749138/136423149-b1824857-4494-4fa2-bd7c-40619baa7884.png">
For the many to one relation allow class `Test`

3. Create object of class `Product`
4. Create object of class `Test`
5. Create the following PHP script:
```php
<?php
$object = \Pimcore\Model\DataObject\Test::getById(2); // or whatever id the just created object of class Test has
$object->setPublished(true);
$data = [
    "relation" => new \Pimcore\Model\DataObject\Data\BlockElement('relation', 'manyToOneRelation', \Pimcore\Model\DataObject\Product::getById(1)), // or whatever id the just created object of class Product has
];

$object->setBlock([$data], 'en'); 
$object->save();
```

Without this PR you will get the following error:
```
[Pimcore\Model\Element\ValidationException]                                             
  Validation failed:  fieldname=localizedfields ( fieldname=block[ localizedfields-de ]) 
```
This does not say anything about which error actually occured - only that it is a validation exception and where it happened.

With this PR, you will get the error:
```
[Pimcore\Model\Element\ValidationException]                                                                                                                          
  Validation failed: Invalid data in field `relation` [type: manyToOneRelation][ block-0 ] fieldname=block[ localizedfields-de ] fieldname=localizedfields
```
This `Invalid data in field 'relation'` is the actual error which occured for adding an object of the wrong class in https://github.com/pimcore/pimcore/blob/d54aaae8d294f9e7d91fa0a8ed899335d389bfb9/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php#L418

This lack of information about the actual error caused a lot of headaches in repairing the `BlockTest` in #10087

The reason why currently som errors are swallowed away, is that in https://github.com/pimcore/pimcore/blob/b6512cb45e06a5058ee7a2ffd0214ca2a905213e/models/DataObject/Concrete.php#L172-L204 only 2 levels of validation exceptions are taken into account while in above example there are 3 levels: relation -> block -> localized fields.