### PR TITLE
[Data objects: Check Validity] Check inherited value only if field supports inheritance and value is not empty

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -950,7 +950,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
                 foreach ($this->getFieldDefinitions() as $fd) {
                     try {
                         try {
-                            if (!isset($dataForValidityCheck[$language]) || !isset($dataForValidityCheck[$language][$fd->getName()])) {
+                            if (!isset($dataForValidityCheck[$language][$fd->getName()])) {
                                 $dataForValidityCheck[$language][$fd->getName()] = null;
                             }
                             $fd->checkValidity($dataForValidityCheck[$language][$fd->getName()], false, $params);

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -955,7 +955,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
                             }
                             $fd->checkValidity($dataForValidityCheck[$language][$fd->getName()], false, $params);
                         } catch (\Exception $e) {
-                            if ($fd->supportsInheritance() && $fd->isEmpty($dataForValidityCheck[$language][$fd->getName()]) && $data->getObject()->getClass()->getAllowInherit()) {
+                            if ($data->getObject()->getClass()->getAllowInherit() && $fd->supportsInheritance() && $fd->isEmpty($dataForValidityCheck[$language][$fd->getName()])) {
                                 //try again with parent data when inheritance is activated
                                 try {
                                     $getInheritedValues = DataObject::doGetInheritedValues();

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -950,11 +950,10 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
                 foreach ($this->getFieldDefinitions() as $fd) {
                     try {
                         try {
-                            if (isset($dataForValidityCheck[$language]) && isset($dataForValidityCheck[$language][$fd->getName()])) {
-                                $fd->checkValidity($dataForValidityCheck[$language][$fd->getName()], false, $params);
-                            } else {
-                                $fd->checkValidity(null, false, $params);
+                            if (!isset($dataForValidityCheck[$language]) || !isset($dataForValidityCheck[$language][$fd->getName()])) {
+                                $dataForValidityCheck[$language][$fd->getName()] = null;
                             }
+                            $fd->checkValidity($dataForValidityCheck[$language][$fd->getName()], false, $params);
                         } catch (\Exception $e) {
                             if ($fd->supportsInheritance() && $fd->isEmpty($dataForValidityCheck[$language][$fd->getName()]) && $data->getObject()->getClass()->getAllowInherit()) {
                                 //try again with parent data when inheritance is activated

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -956,7 +956,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
                                 $fd->checkValidity(null, false, $params);
                             }
                         } catch (\Exception $e) {
-                            if ($data->getObject()->getClass()->getAllowInherit()) {
+                            if ($fd->supportsInheritance() && $fd->isEmpty($dataForValidityCheck[$language][$fd->getName()]) && $data->getObject()->getClass()->getAllowInherit()) {
                                 //try again with parent data when inheritance is activated
                                 try {
                                     $getInheritedValues = DataObject::doGetInheritedValues();

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -134,7 +134,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
                     try {
                         $fd->checkValidity($value, $omitMandatoryCheck, $params);
                     } catch (\Exception $e) {
-                        if ($this->getClass()->getAllowInherit()) {
+                        if ($fd->supportsInheritance() && $fd->isEmpty($value) && $this->getClass()->getAllowInherit()) {
                             //try again with parent data when inheritance is activated
                             try {
                                 $getInheritedValues = DataObject::doGetInheritedValues();

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -134,7 +134,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
                     try {
                         $fd->checkValidity($value, $omitMandatoryCheck, $params);
                     } catch (\Exception $e) {
-                        if ($fd->supportsInheritance() && $fd->isEmpty($value) && $this->getClass()->getAllowInherit()) {
+                        if ($this->getClass()->getAllowInherit() && $fd->supportsInheritance() && $fd->isEmpty($value)) {
                             //try again with parent data when inheritance is activated
                             try {
                                 $getInheritedValues = DataObject::doGetInheritedValues();


### PR DESCRIPTION
In `checkValidity()` currently for all object and localized fields whenever the class supports inheritance and the object's value is not valid, then it is tried to get the value with inheritance. When the field does not support inheritance or when the value is not empty currently, we cannot expect that any other value be returned in this case with inheritance as without. This PR removes this extra try with inheritance if the field type does not support inheritance or the current value is not empty.