### PR TITLE
[Admin] Documents - Editable rendering js error handling

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/manager.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/manager.js
@@ -42,6 +42,10 @@ pimcore.document.editables.manager = Class.create({
 
         if (!definition.inDialogBox) {
             if (typeof editable['render'] === 'function') {
+                let editableElement = Ext.get(editable.id);
+                if (editableElement === null) {
+                    return;
+                }
                 editable.render();
             }
             editable.setInherited(inherited);


### PR DESCRIPTION

## Changes in this pull request  
If editable rendering fails on server-side then manager should not try to render it in editmode:

![image](https://user-images.githubusercontent.com/5137917/136565483-789ddb5f-1461-48ac-8f71-6b1cf6dc90ab.png)

## Additional info  

