### PR TITLE
Order assets by modificationDate to process new/updated assets earlier

### DIFF
--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -88,6 +88,10 @@ class ThumbnailsImageCommand extends AbstractCommand
     {
         $list = new Asset\Listing();
 
+        // Recently added or changed items are more likely to need thumbnails, start with those in case process is cut short
+        $list->setOrderKey('modificationDate');
+        $list->setOrder('DESC');
+
         $parentConditions = [];
 
         // get only images


### PR DESCRIPTION
The motivation for this change is where cron is being used to generate thumbnails and huge folders with many thumbnail configs will spend a lot of time just working through existing files on disk. If the command exits early for some reason this provides a greater possibility of having those thumbs generated.
