### PR TITLE
[Monolog] Do not log cache & doctrine logs

### DIFF
--- a/bundles/CoreBundle/Resources/config/pimcore/dev.yaml
+++ b/bundles/CoreBundle/Resources/config/pimcore/dev.yaml
@@ -20,7 +20,7 @@ monolog:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
-            channels: ["!event"]
+            channels: ['!event', '!doctrine', '!cache']
         console:
             type: console
             process_psr_3_messages: false


### PR DESCRIPTION
## Changes in this pull request  
doctrine logs keep flooding `dev.log` file when messenger supervisor is running.

## Additional info  

