### PR TITLE
Full Page Cache Priority Optimization

### DIFF
--- a/bundles/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
@@ -255,13 +255,6 @@ class FullPageCacheListener
             }
         }
 
-        // check if targeting matched anything and disable cache
-        if ($this->disabledByTargeting()) {
-            $this->disable('Targeting matched rules/target groups');
-
-            return;
-        }
-
         $deviceDetector = Tool\DeviceDetector::getInstance();
         $device = $deviceDetector->getDevice();
         $deviceDetector->setWasUsed(false);
@@ -344,6 +337,13 @@ class FullPageCacheListener
 
         if (!$this->responseCanBeCached($response)) {
             $this->disable('Response can\'t be cached');
+        }
+
+        // check if targeting matched anything and disable cache
+        if ($this->disabledByTargeting()) {
+            $this->disable('Targeting matched rules/target groups');
+
+            return;
         }
 
         if ($this->enabled && $this->sessionStatus->isDisabledBySession($request)) {

--- a/bundles/CoreBundle/Resources/config/event_listeners.yaml
+++ b/bundles/CoreBundle/Resources/config/event_listeners.yaml
@@ -129,7 +129,7 @@ services:
     Pimcore\Bundle\CoreBundle\EventListener\Frontend\FullPageCacheListener:
         public: true
         tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 6 }
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 610 }
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: -120 }
             - { name: kernel.event_listener, event: kernel.response, method: stopPropagationCheck, priority: 100 }
 


### PR DESCRIPTION
Resolves #9782

The full page cache should have a higher priority than many other listeners, e.g. sessions, targeting, ... 