### PR TITLE
[Data Objects] Add checkValidity() for field type "image"

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Image.php
+++ b/models/DataObject/ClassDefinition/Data/Image.php
@@ -158,9 +158,20 @@ class Image extends Data implements ResourcePersistenceAwareInterface, QueryReso
         return null;
     }
 
+    /**
+     * @param mixed $data
+     * @param false $omitMandatoryCheck
+     * @param array $params
+     * @return bool
+     */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        return $data === null || $data instanceof Asset\Image;
+        if (!$omitMandatoryCheck && $this->getMandatory() && !$data instanceof Asset\Image) {
+            throw new Model\Element\ValidationException('Empty mandatory field [ '.$this->getName().' ]');
+        }
+        if($data !== null && !$data instanceof Asset\Image) {
+            throw new Element\ValidationException('Invalid data in field `'.$this->getName().'`');
+        }
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Image.php
+++ b/models/DataObject/ClassDefinition/Data/Image.php
@@ -158,6 +158,11 @@ class Image extends Data implements ResourcePersistenceAwareInterface, QueryReso
         return null;
     }
 
+    public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
+    {
+        return $data === null || $data instanceof Asset\Image;
+    }
+
     /**
      * @param int $data
      * @param null|Model\DataObject\Concrete $object

--- a/models/DataObject/ClassDefinition/Data/Image.php
+++ b/models/DataObject/ClassDefinition/Data/Image.php
@@ -160,7 +160,7 @@ class Image extends Data implements ResourcePersistenceAwareInterface, QueryReso
 
     /**
      * @param mixed $data
-     * @param false $omitMandatoryCheck
+     * @param bool $omitMandatoryCheck
      * @param array $params
      *
      * @throws Element\ValidationException

--- a/models/DataObject/ClassDefinition/Data/Image.php
+++ b/models/DataObject/ClassDefinition/Data/Image.php
@@ -162,12 +162,13 @@ class Image extends Data implements ResourcePersistenceAwareInterface, QueryReso
      * @param mixed $data
      * @param false $omitMandatoryCheck
      * @param array $params
-     * @return bool
+     *
+     * @throws Element\ValidationException
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
         if (!$omitMandatoryCheck && $this->getMandatory() && !$data instanceof Asset\Image) {
-            throw new Model\Element\ValidationException('Empty mandatory field [ '.$this->getName().' ]');
+            throw new Element\ValidationException('Empty mandatory field [ '.$this->getName().' ]');
         }
         if($data !== null && !$data instanceof Asset\Image) {
             throw new Element\ValidationException('Invalid data in field `'.$this->getName().'`');


### PR DESCRIPTION
Currently there is no error when doing this:
```php
$object = new \Pimcore\Model\dataObject\Product();
$object->setImage('123'); // image is a field of type "image"
$object->save();
```

With this PR you will get a `ValidationException`.