### PR TITLE
Fix xliff export

### DIFF
--- a/lib/Translation/ExportService/Exporter/Xliff12Exporter.php
+++ b/lib/Translation/ExportService/Exporter/Xliff12Exporter.php
@@ -90,7 +90,7 @@ class Xliff12Exporter implements ExporterInterface
         $exportFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/' . $exportId . '.xliff';
         if (!is_file($exportFile)) {
             // create initial xml file structure
-            File::put($exportFile, '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL . '<xliff version="1.2"></xliff>');
+            File::put($exportFile, '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL . '<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2"></xliff>');
         }
 
         return $exportFile;


### PR DESCRIPTION
## Changes in this pull request  
### Adds missing namespace for xliff-Element
some tools need the correct namespace:
`xmlns="urn:oasis:names:tc:xliff:document:1.2"`
(see https://docs.oasis-open.org/xliff/v1.2/xliff-profile-html/xliff-profile-html-1.2-cd02.html#Structure_MappingAttributes)

### Encodes text via `htmlspecialchars()` instead of wrapping every text in CDATA sections
Some translation providers, like Across, don't support CDATA sections.
Also, the use of CDATA sections is not recommended (see https://docs.oasis-open.org/xliff/v1.2/xliff-profile-html/xliff-profile-html-1.2-cd02.html#General_CDATA).

### Properly encodes some special characters like `<` and `>`
Previously, when you used these characters as normal text in a wysiwyg-editable, they would be used as HTML instead of text after importing the translated xliff-file.

**For example:**
  > this is \<strong\>bold\</strong\> text

would be

  > this is <strong>bold</strong> text

after export, translation and import.
