### PR TITLE
Update Web2Print/Config - Config could be null

### DIFF
--- a/lib/Web2Print/Config.php
+++ b/lib/Web2Print/Config.php
@@ -91,7 +91,7 @@ final class Config
         $repository = self::getRepository();
 
         list($config, $dataSource) = $repository->loadConfigByKey(self::CONFIG_ID);
-        $config = new \Pimcore\Config\Config($config);
+        $config = new \Pimcore\Config\Config($config ?? []);
 
         return $config;
     }


### PR DESCRIPTION
$repository->loadConfigByKey can return null for config, but Config\Config expects an array