### PR TITLE
disable the output-cache if the client sends an authorization header

### DIFF
--- a/bundles/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
@@ -168,6 +168,13 @@ class FullPageCacheListener
         $requestUri = $request->getRequestUri();
         $excludePatterns = [];
 
+        // disable the output-cache if the client sends an authorization header
+        if ($request->headers->has('authorization')) {
+            $this->disable('authorization header in use');
+
+            return;
+        }
+
         // only enable GET method
         if (!$request->isMethodCacheable()) {
             $this->disable();


### PR DESCRIPTION
pimcore 10 enables the full page cache for `GET` requests by default in the `prod`-environment. It disables the cache automatically when a session is in use; however, if the application identifies it's users using an authorization-header, the full page cache is still enabled.

## Changes in this pull request  

disables the output-cache if the client sends an authorization header.

Resolves #10610

