### PR TITLE
[Maintenance] Log-rotate: do not rotate files created on the same day

### DIFF
--- a/lib/Maintenance/Tasks/LogCleanupTask.php
+++ b/lib/Maintenance/Tasks/LogCleanupTask.php
@@ -37,7 +37,8 @@ class LogCleanupTask implements TaskInterface
             if ($lastTimeItem) {
                 $lastTime = $lastTimeItem->getData();
             } else {
-                $lastTime = time() - 86400;
+                TmpStore::add($tmpStoreTimeId, time(), null, 86400 * 7);
+                continue;
             }
 
             if (file_exists($log) && date('Y-m-d', $lastTime) != date('Y-m-d')) {
@@ -45,12 +46,8 @@ class LogCleanupTask implements TaskInterface
                 $archiveFilename = preg_replace('/\.log$/', '', $log).'-archive-'.date('Y-m-d', $lastTime).'.log';
                 rename($log, $archiveFilename);
 
-                if ($lastTimeItem) {
-                    $lastTimeItem->setData(time());
-                    $lastTimeItem->update(86400 * 7);
-                } else {
-                    TmpStore::add($tmpStoreTimeId, time(), null, 86400 * 7);
-                }
+                $lastTimeItem->setData(time());
+                $lastTimeItem->update(86400 * 7);
             }
         }
 


### PR DESCRIPTION
Actual behavior: 
Log files created in `var/log` are instantly rotated by `LogCleanupTask`. This can cause e.g. issues für logs from video or document conversion. 

Expected behavior: 
Log files shouldn't be rotated when created on the same day. 