### PR TITLE
[Layout][Toolbar] Fix UI throwing errors when a perspective has a space inside its name

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
@@ -34,7 +34,7 @@ pimcore.layout.toolbar = Class.create({
                         var itemCfg = {
                             text: t(perspective.name),
                             disabled: perspective.active,
-                            itemId: 'pimcore_menu_file_perspective_' + perspective.name.replace(/\s/g, '-'),
+                            itemId: 'pimcore_menu_file_perspective_' + perspective.name..replace(/[^a-z0-9\-_]/i, '-'),
                             handler: this.openPerspective.bind(this, perspective.name)
                         };
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
@@ -34,7 +34,7 @@ pimcore.layout.toolbar = Class.create({
                         var itemCfg = {
                             text: t(perspective.name),
                             disabled: perspective.active,
-                            itemId: 'pimcore_menu_file_perspective_' + perspective.name,
+                            itemId: 'pimcore_menu_file_perspective_' + perspective.name.replace(/\s/g, '-'),
                             handler: this.openPerspective.bind(this, perspective.name)
                         };
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
@@ -34,7 +34,7 @@ pimcore.layout.toolbar = Class.create({
                         var itemCfg = {
                             text: t(perspective.name),
                             disabled: perspective.active,
-                            itemId: 'pimcore_menu_file_perspective_' + perspective.name.replace(/[^a-z0-9\-_]/i, '-'),
+                            itemId: 'pimcore_menu_file_perspective_' + perspective.name.replace(/[^a-z0-9\-_]+/ig, '-'),
                             handler: this.openPerspective.bind(this, perspective.name)
                         };
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/layout/toolbar.js
@@ -34,7 +34,7 @@ pimcore.layout.toolbar = Class.create({
                         var itemCfg = {
                             text: t(perspective.name),
                             disabled: perspective.active,
-                            itemId: 'pimcore_menu_file_perspective_' + perspective.name..replace(/[^a-z0-9\-_]/i, '-'),
+                            itemId: 'pimcore_menu_file_perspective_' + perspective.name.replace(/[^a-z0-9\-_]/i, '-'),
                             handler: this.openPerspective.bind(this, perspective.name)
                         };
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #10632 

## Additional info
Issue solved by replacing any space inside the name with hyphens.