### PR TITLE
[Image thumbnails] Support absolute URLs in getHtml()

### DIFF
--- a/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
+++ b/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
@@ -94,7 +94,8 @@ You can configure the generated markup with the following options:
 | `imgCallback`                  | callable | A callable to modify the attributes for the generated `<img>` tag. There 1 argument passed, the array of attributes.  |
 | `disableImgTag`                | bool     | Set to `true` to not include the `<img>` fallback tag in the generated `<picture>` tag.   |
 | `useDataSrc`                   | bool     | Set to `true` to use `data-src(set)` attributes instead of `src(set)`.   |
-
+| `absoluteUrl`                  | bool     | Set to `true` to use absolute URLs.   |
+| `absoluteUrlProtocol`          | string   | Protocol to be used for absolute URLs, e.g. "https"   |
 
 
 ## Usage Examples

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -219,7 +219,6 @@ final class Thumbnail
     {
         $srcSetValues = [];
         $sourceTagAttributes = [];
-        $thumb = null;
 
         foreach ([1, 2] as $highRes) {
             $thumbConfigRes = clone $thumbConfig;
@@ -227,8 +226,13 @@ final class Thumbnail
             $thumbConfigRes->setHighResolution($highRes);
             $thumb = $image->getThumbnail($thumbConfigRes, true);
 
+            $thumbPath = $thumb->getPath(true);
+            if (!empty($options['absoluteUrl'])) {
+                $thumbPath = Tool::getHostUrl($options['absoluteUrlProtocol'] ?? null).$thumbPath;
+            }
+
             $descriptor = $highRes . 'x';
-            $srcSetValues[] = $this->addCacheBuster($thumb . ' ' . $descriptor, $options, $image);
+            $srcSetValues[] = $this->addCacheBuster($thumbPath . ' ' . $descriptor, $options, $image);
 
             if ($this->useOriginalFile($this->asset->getFilename()) && $this->getConfig()->isSvgTargetFormatPossible()) {
                 break;
@@ -352,6 +356,10 @@ final class Thumbnail
         } else {
             $path = $this->getPath(true);
             $attributes['src'] = $this->addCacheBuster($path, $options, $image);
+        }
+
+        if(!empty($options['absoluteUrl'])) {
+            $attributes['src'] = Tool::getHostUrl($options['absoluteUrlProtocol'] ?? null).$attributes['src'];
         }
 
         if (!isset($options['disableWidthHeightAttributes'])) {


### PR DESCRIPTION
This PR adds support for absoute URLs in `Asset\Image\Thumbnail::getHTML()`.

Usage:
```php
$asset = \Pimcore\Model\Asset\Image::getById(16);
var_dump($asset->getThumbnail('test')->getHtml(['absoluteUrl' => true]));
```
This outputs:
```html
<picture >
	<source srcset="http://example.org/image-thumb__16__test/Bildschirmfoto 2021-10-07 um 12.16.51.webp 1x, http://example.org/image-thumb__16__test/Bildschirmfoto 2021-10-07 um 12.16.51@2x.webp 2x" type="image/webp" />
	<source srcset="http://example.org/image-thumb__16__test/Bildschirmfoto 2021-10-07 um 12.16.51.png 1x, http://example.org/image-thumb__16__test/Bildschirmfoto 2021-10-07 um 12.16.51@2x.png 2x" type="image/png" />
	<img src="http://example.org/image-thumb__16__test/Bildschirmfoto 2021-10-07 um 12.16.51.png" width="2618" height="198" alt="" loading="lazy" />
</picture>
```

The default protocol is defined in https://github.com/pimcore/pimcore/blob/777984e9d301bc1df1dbbe2cdbda04d27e74b750/lib/Tool.php#L433
Imho nowadays we should change this to `https`. Especially when doing exports from CLI there is no Symfony request object which the real protocol could be retrieved from. Alternatively a configuration like for the main domain in `System Settings > Website` would also work.
Because of the current approach, this PR implements to set the protcol to be used via `absoluteUrlProtocol`
```php
var_dump($asset->getThumbnail('test')->getHtml(['absoluteUrl' => true, 'absoluteUrlProtocol' => 'https']));
```