### PR TITLE
[Admin] Grids - Replace cellEditing with RowEditing

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
@@ -61,12 +61,13 @@ pimcore.object.quantityValue.unitsettings = Class.create({
 
 
     getRowEditor: function () {
+        let fields = [{
+            name: 'id',
+            type: 'string'
+        }, 'abbreviation', 'longname', 'group', 'baseunit', 'factor', 'conversionOffset', 'reference', 'converter'];
 
         var baseUnitStore = Ext.create('Ext.data.JsonStore', {
-            fields: [{
-                name: 'id',
-                type: 'string'
-            }, 'abbreviation', 'longname', 'group', 'baseunit', 'factor', 'conversionOffset', 'reference', 'converter'],
+            fields: fields,
             proxy: {
                 type: 'ajax',
                 async: true,
@@ -165,6 +166,7 @@ pimcore.object.quantityValue.unitsettings = Class.create({
                 },
                 pageSize: itemsPerPage
             },
+            fields: fields,
             remoteSort: true,
             remoteFilter: true,
             autoSync: true,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
@@ -257,10 +257,7 @@ pimcore.object.quantityValue.unitsettings = Class.create({
                                 this.rowEditing.completeEdit();
                                 let recs = this.grid.store.insert(0, [u]);
 
-                                this.rowEditing.startEditByPosition({
-                                    row: 0,
-                                    column: 0
-                                });
+                                this.rowEditing.startEdit(0,0);
 
                             }.bind(this)
                         });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
@@ -210,7 +210,7 @@ pimcore.object.quantityValue.unitsettings = Class.create({
                     {
                         text: t('delete'),
                         handler: this.onDelete.bind(this),
-                        iconCls: "pimcore_icon_delete"
+                        iconCls: "pimcore_icon_minus"
                     },
                     '-',
                     {
@@ -255,7 +255,7 @@ pimcore.object.quantityValue.unitsettings = Class.create({
                                     id: value
                                 };
                                 this.rowEditing.completeEdit();
-                                let recs = this.grid.store.insert(0, [u]);
+                                this.grid.store.insert(0, [u]);
 
                                 this.rowEditing.startEdit(0,0);
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
@@ -183,15 +183,16 @@ pimcore.object.quantityValue.unitsettings = Class.create({
 
         this.pagingtoolbar = pimcore.helpers.grid.buildDefaultPagingToolbar(this.store, {pageSize: itemsPerPage});
 
-        this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {
-            clicksToEdit: 1
+        this.rowEditing = Ext.create('Ext.grid.plugin.RowEditing', {
+            clicksToEdit: 1,
+            clicksToMoveEditor: 1,
         });
 
         this.grid = new Ext.grid.GridPanel({
             frame: false,
             autoScroll: true,
             store: this.store,
-            plugins: ['pimcore.gridfilters', this.cellEditing],
+            plugins: ['pimcore.gridfilters', this.rowEditing],
             columnLines: true,
             stripeRows: true,
             columns : typesColumns,
@@ -253,10 +254,10 @@ pimcore.object.quantityValue.unitsettings = Class.create({
                                 var u = {
                                     id: value
                                 };
-                                this.cellEditing.completeEdit();
+                                this.rowEditing.completeEdit();
                                 let recs = this.grid.store.insert(0, [u]);
 
-                                this.cellEditing.startEditByPosition({
+                                this.rowEditing.startEditByPosition({
                                     row: 0,
                                     column: 0
                                 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/docTypes.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/docTypes.js
@@ -191,7 +191,7 @@ pimcore.settings.document.doctypes = Class.create({
                 renderer: function (d) {
                     if (d !== undefined) {
                         var date = new Date(d * 1000);
-                        return Ext.date.format(date, "Y-m-d H:i:s");
+                        return Ext.Date.format(date, "Y-m-d H:i:s");
                     } else {
                         return "";
                     }
@@ -207,7 +207,7 @@ pimcore.settings.document.doctypes = Class.create({
                 renderer: function (d) {
                     if (d !== undefined) {
                         var date = new Date(d * 1000);
-                        return Ext.date.format(date, "Y-m-d H:i:s");
+                        return Ext.Date.format(date, "Y-m-d H:i:s");
                     } else {
                         return "";
                     }
@@ -252,8 +252,10 @@ pimcore.settings.document.doctypes = Class.create({
         ];
 
 
-        this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {
+        this.rowEditing = Ext.create('Ext.grid.plugin.RowEditing', {
             clicksToEdit: 1,
+            clicksToMoveEditor: 1,
+
             listeners: {
                 validateedit: function (editor, context, eOpts) {
                     if (!context.record.data.writeable) {
@@ -281,7 +283,7 @@ pimcore.settings.document.doctypes = Class.create({
             stripeRows: true,
             selModel: Ext.create('Ext.selection.RowModel', {}),
             plugins: [
-                this.cellEditing
+                this.rowEditing
             ],
             tbar: {
                 cls: 'pimcore_main_toolbar',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/docTypes.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/docTypes.js
@@ -255,12 +255,9 @@ pimcore.settings.document.doctypes = Class.create({
         this.rowEditing = Ext.create('Ext.grid.plugin.RowEditing', {
             clicksToEdit: 1,
             clicksToMoveEditor: 1,
-
             listeners: {
-                validateedit: function (editor, context, eOpts) {
+                beforeedit: function (editor, context, eOpts) {
                     if (!context.record.data.writeable) {
-                        editor.cancelEdit();
-                        pimcore.helpers.showNotification(t("info"), t("config_not_writeable"), "info");
                         return false;
                     }
                 }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/glossary.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/glossary.js
@@ -158,8 +158,9 @@ pimcore.settings.glossary = Class.create({
             }
         ];
 
-        this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {
-            clicksToEdit: 1
+        this.rowEditing = Ext.create('Ext.grid.plugin.RowEditing', {
+            clicksToEdit: 1,
+            clicksToMoveEditor: 1,
         });
 
         var toolbar = Ext.create('Ext.Toolbar', {
@@ -189,7 +190,7 @@ pimcore.settings.glossary = Class.create({
             },
             selModel: Ext.create('Ext.selection.RowModel', {}),
             plugins: [
-                this.cellEditing
+                this.rowEditing
             ],
 
             trackMouseOver: true,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/glossary.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/glossary.js
@@ -107,6 +107,7 @@ pimcore.settings.glossary = Class.create({
                 editor: {
                     xtype: 'textfield',
                     id: 'linkEditor',
+                    fieldCls: "input_drop_target",
                 },
                 tdCls: "pimcore_droptarget_input"
             },
@@ -169,14 +170,14 @@ pimcore.settings.glossary = Class.create({
             }
         ];
 
-        let dd = Ext.create('Ext.grid.plugin.RowEditing', {
+        this.rowEditing = Ext.create('Ext.grid.plugin.RowEditing', {
             clicksToEdit: 1,
             clicksToMoveEditor: 1,
             listeners: {
                 beforeedit: function(el, e, eOpts, i) {
                     var editorRow = el.editor.body;
                     editorRow.rowIdx = e.rowIdx;
-                    this.rowEditDropZone = new Ext.dd.DropZone(editorRow, {
+                    let dd = new Ext.dd.DropZone(editorRow, {
                         ddGroup: "element",
 
                         getTargetFromEvent: function(e) {
@@ -268,7 +269,7 @@ pimcore.settings.glossary = Class.create({
 
         for (var i = 0; i < rows.length; i++) {
 
-            var dd = new Ext.dd.DropZone(rows[i], {
+            let dd = new Ext.dd.DropZone(rows[i], {
                 ddGroup: "element",
 
                 getTargetFromEvent: function(e) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/glossary.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/glossary.js
@@ -86,7 +86,7 @@ pimcore.settings.glossary = Class.create({
         var casesensitiveCheck = new Ext.grid.column.Check({
             text: t("casesensitive"),
             dataIndex: "casesensitive",
-            width: 50,
+            flex: 55,
             editor: {
                 xtype: 'checkbox',
             }
@@ -95,7 +95,7 @@ pimcore.settings.glossary = Class.create({
         var exactmatchCheck = new Ext.grid.column.Check({
             text: t("exactmatch"),
             dataIndex: "exactmatch",
-            width: 50,
+            flex: 50,
             editor: {
                 xtype: 'checkbox',
             }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
@@ -90,17 +90,10 @@ pimcore.settings.properties.predefined = Class.create({
         var inheritableCheck = new Ext.grid.column.Check({
             text: t("inheritable"),
             dataIndex: "inheritable",
-            width: 50,
-            listeners: {
-                beforecheckchange: function (el, rowIndex, checked, record) {
-                    if(!record.data.writeable) {
-                        pimcore.helpers.showNotification(t("info"), t("config_not_writeable"), "info");
-                        return false;
-                    }
-
-                    return true;
-                }
-            }
+            editor: {
+                xtype: 'checkbox',
+            },
+            width: 50
         });
 
         var contentTypesStore = Ext.create('Ext.data.ArrayStore', {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
@@ -207,13 +207,12 @@ pimcore.settings.properties.predefined = Class.create({
 
         ];
 
-        this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {
+        this.rowEditing = Ext.create('Ext.grid.plugin.RowEditing', {
             clicksToEdit: 1,
+            clicksToMoveEditor: 1,
             listeners: {
-                validateedit: function (editor, context, eOpts) {
+                beforeedit: function (editor, context, eOpts) {
                     if (!context.record.data.writeable) {
-                        editor.cancelEdit();
-                        pimcore.helpers.showNotification(t("info"), t("config_not_writeable"), "info");
                         return false;
                     }
                 }
@@ -236,7 +235,7 @@ pimcore.settings.properties.predefined = Class.create({
             },
             selModel: Ext.create('Ext.selection.RowModel', {}),
             plugins: [
-                this.cellEditing
+                this.rowEditing
             ],
             tbar: {
                 cls: 'pimcore_main_toolbar',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
@@ -125,26 +125,37 @@ pimcore.settings.properties.predefined = Class.create({
                }
             },
             {text: t("key"), flex: 50, sortable: true, dataIndex: 'key', editor: new Ext.form.TextField({})},
-            {text: t("type"), flex: 50, sortable: true, dataIndex: 'type', editor: new Ext.form.ComboBox({
-                triggerAction: 'all',
-                editable: false,
-                store: ["text","document","asset","object","bool","select"]
+            {text: t("type"), flex: 50, sortable: true, dataIndex: 'type',
+                editor: new Ext.form.ComboBox({
+                    triggerAction: 'all',
+                    editable: false,
+                    store: ["text","document","asset","object","bool","select"]
 
             })},
             {text: t("value"), flex: 50, sortable: true, dataIndex: 'data', editor: new Ext.form.TextField({})},
-            {text: t("configuration"), flex: 50, sortable: false, dataIndex: 'config',
-                                                                editor: new Ext.form.TextField({})},
-            {
-                text: t("content_type"), flex: 50, sortable: true, dataIndex: 'ctype',
-                getEditor: function (fieldInfo) {
-                    return new pimcore.object.helpers.metadataMultiselectEditor({
-                        fieldInfo: fieldInfo
-                    });
-                }.bind(this, {value: "document;asset;object" })
-            }
-
-
-            ,
+            {text: t("configuration"), flex: 50, sortable: false, dataIndex: 'config', editor: new Ext.form.TextField({})},
+            {text: t("content_type"), flex: 50, sortable: true, dataIndex: 'ctype',
+                editor: new Ext.ux.form.MultiSelect({
+                    store: new Ext.data.ArrayStore({
+                        fields: ['key', {
+                            name: 'value',
+                            convert: function (v, r) {
+                                if (Array.isArray(v)) {
+                                    return v.join(";");
+                                }
+                                return v;
+                            }
+                        }],
+                        data: [
+                            ['document', 'document'],
+                            ['object', ['object']],
+                            ['asset', ['asset']]
+                        ],
+                    }),
+                    displayField: 'key',
+                    valueField: 'value',
+                }),
+            },
             inheritableCheck,
             {
                 xtype: 'actioncolumn',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/staticroutes.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/staticroutes.js
@@ -191,13 +191,12 @@ pimcore.settings.staticroutes = Class.create({
             }
         ];
 
-        this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {
+        this.rowEditing = Ext.create('Ext.grid.plugin.RowEditing', {
             clicksToEdit: 1,
+            clicksToMoveEditor: 1,
             listeners: {
-                validateedit: function (editor, context, eOpts) {
+                beforeedit: function (editor, context, eOpts) {
                     if (!context.record.data.writeable) {
-                        editor.cancelEdit();
-                        pimcore.helpers.showNotification(t("info"), t("config_not_writeable"), "info");
                         return false;
                     }
                 }
@@ -221,7 +220,7 @@ pimcore.settings.staticroutes = Class.create({
             },
             sm: Ext.create('Ext.selection.RowModel', {}),
             plugins: [
-                this.cellEditing
+                this.rowEditing
             ],
             tbar: {
                 cls: 'pimcore_main_toolbar',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/translations.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/translations.js
@@ -190,14 +190,13 @@ pimcore.settings.translations = Class.create({
             listeners: {
                 beforeedit: function(editor, e) {
                     let cm = this.grid.getColumnManager().getColumns();
-                    for (var i=0; i < cm.length; i++) {
-                        if (cm[i].dataIndex === 'data') {
-                            let editor = this.getCellEditor(e.record.get('type'));
+                    for (let i=0; i < cm.length; i++) {
+                        let columnId = cm[i].id;
+                        if (columnId.startsWith('translation_column_')) {
+                            let editor = this.getCellEditor(e.column.dataIndex.substring(1), e.record);
                             if (editor) {
-                                e.grid.columns[i].setEditor(editor);
+                                e.grid.getColumnManager().columns[i].setEditor(editor);
                             }
-
-                            break;
                         }
                     }
                 }.bind(this)

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/translations.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/translations.js
@@ -111,7 +111,7 @@ pimcore.settings.translations = Class.create({
                 sortable: true,
                 dataIndex: "_" + languages[i],
                 filter: 'string',
-                getEditor: this.getCellEditor.bind(this, languages[i]),
+                editor: new Ext.form.TextField({}),
                 renderer: function (text) {
                     if (text) {
                         return replace_html_event_attributes(strip_tags(text, 'div,span,b,strong,em,i,small,sup,sub,p'));
@@ -184,25 +184,23 @@ pimcore.settings.translations = Class.create({
 
         this.pagingtoolbar = pimcore.helpers.grid.buildDefaultPagingToolbar(this.store, {pageSize: itemsPerPage});
 
-        this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {
+        this.rowEditing = Ext.create('Ext.grid.plugin.RowEditing', {
             clicksToEdit: 1,
+            clicksToMoveEditor: 1,
             listeners: {
-                beforeedit: function(editor, context, eOpts) {
-                    editor.editors.each(function (e) {
-                        try {
-                            // complete edit, so the value is stored when hopping around with TAB
-                            e.completeEdit();
-                            if (in_array(context.field, this.languages)) {
-                                Ext.destroy(e);
+                beforeedit: function(editor, e) {
+                    let cm = this.grid.getColumnManager().getColumns();
+                    for (var i=0; i < cm.length; i++) {
+                        if (cm[i].dataIndex === 'data') {
+                            let editor = this.getCellEditor(e.record.get('type'));
+                            if (editor) {
+                                e.grid.columns[i].setEditor(editor);
                             }
-                        } catch (exception) {
-                            // garbage collector was faster
-                            // already destroyed
-                        }
-                    });
 
-                    editor.editors.clear();
-                }
+                            break;
+                        }
+                    }
+                }.bind(this)
             }
         });
 
@@ -266,7 +264,7 @@ pimcore.settings.translations = Class.create({
             selModel: Ext.create('Ext.selection.RowModel', {}),
             plugins: [
                 "pimcore.gridfilters",
-                this.cellEditing
+                this.rowEditing
             ],
             tbar: toolbar,
             viewConfig: {
@@ -320,10 +318,7 @@ pimcore.settings.translations = Class.create({
 
         var handler = function(rowIndex, cellIndex, mode) {
             record.set("editor", mode);
-            this.cellEditing.startEditByPosition({
-                row : rowIndex,
-                column: cellIndex
-            });
+            this.rowEditing.startEdit(rowIndex,cellIndex);
         };
 
         var menu = new Ext.menu.Menu();
@@ -458,16 +453,13 @@ pimcore.settings.translations = Class.create({
 
         Ext.MessageBox.prompt("", t("please_enter_the_new_name"), function (button, value) {
             if (button == "ok") {
-                this.cellEditing.cancelEdit();
+                this.rowEditing.cancelEdit();
 
                 this.grid.store.insert(0, {
                     key: value
                 });
 
-                this.cellEditing.startEditByPosition({
-                    row: 0,
-                    column: 2
-                });
+                this.rowEditing.startEdit(0, 2);
             }
         }.bind(this));
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/website.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/website.js
@@ -54,13 +54,11 @@ pimcore.settings.website = Class.create({
     },
 
     getRowEditor:function () {
-
-
         var itemsPerPage = pimcore.helpers.grid.getDefaultPageSize();
         var url = Routing.generate('pimcore_admin_settings_websitesettings');
 
         this.store = pimcore.helpers.grid.buildDefaultStore(
-            url, ["id", 'name','type', "data", 'siteId', 'creationDate', 'modificationDate'],
+            url, ['id', 'name', 'type', 'language', 'data', 'siteId', 'creationDate', 'modificationDate'],
             itemsPerPage
         );
 
@@ -93,83 +91,63 @@ pimcore.settings.website = Class.create({
 
         this.pagingtoolbar = pimcore.helpers.grid.buildDefaultPagingToolbar(this.store);
 
-        var languagestore = [["",t("none")]];
-        var websiteLanguages = pimcore.settings.websiteLanguages;
-        var selectContent = "";
-        for (var i=0; i<websiteLanguages.length; i++) {
+        this.languagestore = [["",t("none")]];
+        let websiteLanguages = pimcore.settings.websiteLanguages;
+        let selectContent = "";
+        for (let i=0; i<websiteLanguages.length; i++) {
             selectContent = pimcore.available_languages[websiteLanguages[i]] + " [" + websiteLanguages[i] + "]";
-            languagestore.push([websiteLanguages[i], selectContent]);
+            this.languagestore.push([websiteLanguages[i], selectContent]);
         }
-
-        var customLanguage = new Ext.form.ComboBox({
-            name: "language",
-            store: languagestore,
-            editable: false,
-            triggerAction: 'all',
-            mode: "local",
-            width: 150,
-            emptyText: t('language')
-        });
 
         var typesColumns = [
             {
                 text: t("type"),
                 dataIndex: 'type',
                 editable: false,
-                width: 40,
+                flex: 20,
                 renderer: this.getTypeRenderer.bind(this),
                 sortable: true
             },
             {
                 text: t("name"),
                 dataIndex: 'name',
-                width: 200,
+                flex: 100,
                 editable: true,
-                editor: new Ext.form.TextField({}),
-                sortable: true
+                sortable: true,
+                editor: new Ext.form.TextField({})
             },
             {
                 text: t('language'),
                 sortable: true,
                 dataIndex: "language",
-                getEditor: function() {
-                    return new Ext.form.ComboBox({
-                        name: "language",
-                        store: languagestore,
-                        editable: false,
-                        listConfig: {minWidth: 150},
-                        triggerAction: 'all',
-                        mode: "local"
-                    });
-                },
-                width: 80
+                editor: new Ext.form.ComboBox({
+                    store: this.languagestore,
+                    mode: "local",
+                    editable: false,
+                    triggerAction: "all"
+                }),
+                flex: 50
             },
             {
                 text: t("value"),
                 dataIndex: 'data',
-                flex: 10,
+                flex: 300,
                 editable: true,
                 renderer: this.getCellRenderer.bind(this),
-                listeners: {
-                    "mousedown": this.cellMousedown.bind(this)
-                }
             },
-            {text: t("site"), width: 250, sortable:true, dataIndex: "siteId",
-                getEditor: function() {
-                    return new Ext.form.ComboBox({
-                        store: pimcore.globalmanager.get("sites"),
-                        valueField: "id",
-                        displayField: "domain",
-                        editable: false,
-                        triggerAction: "all"
-                    });
-                },
+            {text: t("site"), flex: 100, sortable:true, dataIndex: "siteId",
+                editor: new Ext.form.ComboBox({
+                    store: pimcore.globalmanager.get("sites"),
+                    valueField: "id",
+                    displayField: "domain",
+                    editable: false,
+                    triggerAction: "all"
+                }),
                 renderer: function (siteId) {
                     var store = pimcore.globalmanager.get("sites");
                     var pos = store.findExact("id", siteId);
-                    if(pos >= 0) {
-                        var val = store.getAt(pos).get("domain");
-                        return val;
+                    if (pos >= 0) {
+                        return store.getAt(pos).get("domain");
                     }
                     return null;
                 }
@@ -224,7 +202,6 @@ pimcore.settings.website = Class.create({
         ];
 
 
-
         var propertyTypes = new Ext.data.SimpleStore({
             fields: ['id', 'name'],
             data: [
@@ -259,11 +236,11 @@ pimcore.settings.website = Class.create({
             clicksToEdit: 1,
             clicksToMoveEditor: 1,
             listeners: {
-                beforeedit: function(editor, e) {
+                beforeedit: function(el, e) {
                     let cm = this.grid.getColumnManager().getColumns();
                     for (let i=0; i < cm.length; i++) {
                         if (cm[i].dataIndex === 'data') {
-                            let editor = this.getCellEditor(e.record.get('type'));
+                            let editor = this.getCellEditor(e.record);
                             if (editor) {
                                 e.grid.columns[i].setEditor(editor);
                             }
@@ -271,7 +248,49 @@ pimcore.settings.website = Class.create({
                             break;
                         }
                     }
-                }.bind(this)
+
+                    var editorRow = el.editor.body;
+                    editorRow.rowIdx = e.rowIdx;
+                    // add dnd support
+                    var dd = new Ext.dd.DropZone(editorRow, {
+                        ddGroup: "element",
+
+                        getTargetFromEvent: function(e) {
+                            return this.getEl();
+                        },
+
+                        onNodeOver : function(elementType, node, dragZone, e, data ) {
+                            if (data.records.length == 1) {
+                                var record = data.records[0];
+                                var data = record.data;
+
+                                if (data.elementType == elementType) {
+                                    return Ext.dd.DropZone.prototype.dropAllowed;
+                                }
+                            }
+
+                            return Ext.dd.DropZone.prototype.dropNotAllowed;
+                        }.bind(this, e.record.get('type')),
+
+                        onNodeDrop : function(elementType, node, dragZone, e, data) {
+                            if (pimcore.helpers.dragAndDropValidateSingleItem(data)) {
+                                try {
+                                    var record = data.records[0];
+                                    var data = record.data;
+
+                                    if (data.elementType == elementType) {
+                                        Ext.getCmp('valueEditor').setValue(data.path);
+                                        return true;
+                                    }
+                                } catch (e) {
+                                    console.log(e);
+                                }
+                            }
+                            return false;
+                        }.bind(this, e.record.get('type'))
+                    });
+                }.bind(this),
+                delay: 1
             }
         });
 
@@ -339,31 +358,41 @@ pimcore.settings.website = Class.create({
         return '<div class="pimcore_icon_' + value + '" data-id="' + record.get("id") + '">&nbsp;</div>';
     },
 
-    getCellEditor: function (type) {
-        if (!type) {
-            return null;
-        }
+    getCellEditor: function (record) {
+        var data = record.data;
 
+        var type = data.type;
         var property;
 
         if (type === "text") {
             property = Ext.create('Ext.form.TextField');
         } else if (type == "textarea") {
             property = Ext.create('Ext.form.TextArea');
-        } else if (type == "document" || type == "asset" || type == "object" || type == "bool") {
-            //no editor needed here
+        } else if (type == "document" || type == "asset" || type == "object") {
+            property = {
+                xtype: 'textfield',
+                editable: false,
+                id: 'valueEditor',
+                fieldCls: "input_drop_target",
+                flex: 1,
+                value: data.data
+            }
         } else if (type == "date") {
             property = Ext.create('Ext.form.field.Date', {
                 format: "Y-m-d"
             });
-        } else if (type == "checkbox") {
-            //no editor needed here
+        } else if (type == "checkbox" || type == "bool") {
+            property =  {
+                xtype: 'checkbox',
+                flex: 1,
+            }
         } else if (type == "select") {
             var config = data.config;
             property =  Ext.create('Ext.form.ComboBox', {
                 triggerAction: 'all',
                 editable: false,
-                store: config.split(",")
+                store: config.split(","),
+                flex: 1,
             });
         }
 
@@ -452,24 +481,6 @@ pimcore.settings.website = Class.create({
         return Ext.util.Format.htmlEncode(value);
     },
 
-    cellMousedown: function (grid, cell, rowIndex, cellIndex, e) {
-
-        // this is used for the boolean field type
-
-        var store = this.store;
-        var record = store.getAt(rowIndex);
-        var data = record.data;
-        var type = data.type;
-
-        if (type == "bool") {
-
-            //this.rowEditing.editors.each(Ext.destroy, Ext);
-            //this.rowEditing.editors.clear();
-
-            record.set("data", !data.data);
-        }
-    },
-
     addSetFromUserDefined: function (customKey, customType) {
         if(in_array(customKey.getValue(), this.disallowedKeys)) {
             Ext.MessageBox.alert(t("error"), t("name_is_not_allowed"));
@@ -522,11 +533,14 @@ pimcore.settings.website = Class.create({
             value = "";
         }
 
-        store.add({
+        let res = store.add({
             name: key,
             data: value,
             type: type
         });
+
+        this.rowEditing.completeEdit();
+        this.rowEditing.startEdit(res[0], 1);
     }
 
 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/website.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/website.js
@@ -261,7 +261,7 @@ pimcore.settings.website = Class.create({
             listeners: {
                 beforeedit: function(editor, e) {
                     let cm = this.grid.getColumnManager().getColumns();
-                    for (var i=0; i < cm.length; i++) {
+                    for (let i=0; i < cm.length; i++) {
                         if (cm[i].dataIndex === 'data') {
                             let editor = this.getCellEditor(e.record.get('type'));
                             if (editor) {


### PR DESCRIPTION
## Changes in this pull request  
In Admin interface, adding and updating settings on grids is cumbersome with cell-editing plugin as each cell edit fires an update request, which sometimes breaks when multiple requests are fired in close intervals, so I would like to propose using RowEditing instead of CellEditing plugin.

With Row Editing plugin, only one request is fired when clicking on update or pressing Enter. 
![image](https://user-images.githubusercontent.com/5137917/137859929-354734ce-701c-4eee-9b0f-c1dc11dc2be2.png)



Grids covered:
 - Glossary
 - Unit settings
 - Document Types
 - Predefined Properties
 - Static Routes
 - Translations
 - Website Settings
 - Redirects