### PR TITLE
[DRAFT] Update to dbal 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "doctrine/annotations": "^1.6.0",
     "doctrine/collections": "^1.5.0",
     "doctrine/persistence": "^2.1.0",
-    "doctrine/dbal": "^2.11.0",
+    "doctrine/dbal": "^3.1.3",
     "doctrine/doctrine-bundle": "^2.2.1",
     "doctrine/doctrine-migrations-bundle": "^3.0.1",
     "doctrine/inflector": "^1.4.0 || ^2.0.0",

--- a/lib/Db/Connection.php
+++ b/lib/Db/Connection.php
@@ -15,6 +15,8 @@
 
 namespace Pimcore\Db;
 
+use Doctrine\DBAL\Result;
+
 class Connection extends \Doctrine\DBAL\Connection implements ConnectionInterface
 {
     use PimcoreExtensionsTrait;

--- a/lib/Db/ConnectionInterface.php
+++ b/lib/Db/ConnectionInterface.php
@@ -17,14 +17,13 @@ namespace Pimcore\Db;
 
 use Doctrine\DBAL\Cache\CacheException;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
-use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Exception as DriverException;
-use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Result;
 use Pimcore\Model\Element\ValidationException;
 
-interface ConnectionInterface extends Connection
+interface ConnectionInterface
 {
     /**
      * @param string $query
@@ -32,11 +31,16 @@ interface ConnectionInterface extends Connection
      * @param array $types
      * @param QueryCacheProfile|null $qcp
      *
-     * @return ResultStatement
+     * @return Result
      *
      * @throws DBALException
      */
-    public function executeQuery($query, array $params = [], $types = [], QueryCacheProfile $qcp = null);
+    public function executeQuery(
+        string $sql,
+        array $params = [],
+        $types = [],
+        ?QueryCacheProfile $qcp = null
+    ): Result;
 
     /**
      * @param string $query
@@ -47,7 +51,7 @@ interface ConnectionInterface extends Connection
      *
      * @throws DBALException
      */
-    public function executeUpdate($query, array $params = [], array $types = []);
+    public function executeUpdate(string $sql, array $params = [], array $types = []): int;
 
     /**
      * @param string $query
@@ -55,26 +59,26 @@ interface ConnectionInterface extends Connection
      * @param array $types
      * @param QueryCacheProfile $qcp
      *
-     * @return ResultStatement
+     * @return Result
      *
      * @throws CacheException
      */
-    public function executeCacheQuery($query, $params, $types, QueryCacheProfile $qcp);
+    public function executeCacheQuery($sql, $params, $types, QueryCacheProfile $qcp): Result;
 
     /**
-     * @param string $tableExpression
+     * @param string $table
      * @param array $data
-     * @param array $identifier
+     * @param array $criteria
      * @param array $types
      *
      * @return int
      *
      * @throws DBALException
      */
-    public function update($tableExpression, array $data, array $identifier, array $types = []);
+    public function update($table, array $data, array $criteria, array $types = []);
 
     /**
-     * @param string $tableExpression
+     * @param string $table
      * @param array $data
      * @param array $types
      *
@@ -82,7 +86,7 @@ interface ConnectionInterface extends Connection
      *
      * @throws DBALException
      */
-    public function insert($tableExpression, array $data, array $types = []);
+    public function insert($table, array $data, array $types = []);
 
     /**
      * @param string $table

--- a/lib/Db/PimcoreExtensionsTrait.php
+++ b/lib/Db/PimcoreExtensionsTrait.php
@@ -263,7 +263,7 @@ trait PimcoreExtensionsTrait
      * @param array|scalar $params
      * @param array $types
      *
-     * @return array<string, mixed>|false False is returned if no rows are found.
+     * @return mixed
      *
      * @throws DBALException
      */
@@ -428,7 +428,7 @@ trait PimcoreExtensionsTrait
      *
      * @return string The quoted identifier and alias.
      */
-    public function quoteColumnAs($ident, $alias)
+    public function quoteColumnAs($ident, $alias = null)
     {
         return $this->_quoteIdentifierAs($ident, $alias);
     }
@@ -456,7 +456,7 @@ trait PimcoreExtensionsTrait
      *
      * @return string The quoted identifier and alias.
      */
-    protected function _quoteIdentifierAs(string $ident, ?string $alias = null, bool $auto = false, string $as = ' AS '): string
+    protected function _quoteIdentifierAs($ident, $alias = null, $auto = false, $as = ' AS ')
     {
         if (is_string($ident)) {
             $ident = explode('.', $ident);
@@ -489,7 +489,7 @@ trait PimcoreExtensionsTrait
      *
      * @return string The quoted identifier and alias.
      */
-    protected function _quoteIdentifier(string $value, bool $auto = false): string
+    protected function _quoteIdentifier($value, $auto = false)
     {
         if ($auto === false) {
             $q = '`';


### PR DESCRIPTION
https://github.com/pimcore/pimcore/issues/5361
https://github.com/pimcore/pimcore/issues/10613

@brusch @dvesh3 It is a BC break on multiple occasions here:
1. `Doctrine\DBAL\Connection` does not implement `Doctrine\DBAL\Driver\Connection` and has a different signature
2. `public function query(...$params)` changed to `public function query(string $sql): Result`
