### PR TITLE
Document-types remove int-cast and is_numeric-function

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -256,7 +256,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
                 $createValues['key'] = \Pimcore\Model\Element\Service::getValidKey($request->get('key'), 'document');
 
                 // check for a docType
-                $docType = Document\DocType::getById((int)$request->get('docTypeId'));
+                $docType = Document\DocType::getById($request->get('docTypeId'));
                 if ($docType) {
                     $createValues['template'] = $docType->getTemplate();
                     $createValues['controller'] = $docType->getController();

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
@@ -1395,10 +1395,6 @@ pimcore.document.tree = Class.create({
         var textKeyTitle;
         var textKeyMessage;
 
-        if(!is_numeric(docTypeId)) {
-            docTypeId = null; // avoid sending objects or functions to the controller
-        }
-
         if(type == "page") {
 
             textKeyTitle = t("add_page");


### PR DESCRIPTION
Document-types configurations are now yaml-files with a string ID

## Changes in this pull request  
Removes int-cast and is_numeric query of the "docTypeId" param for document-types
