### PR TITLE
Fix error if redirect is already deleted

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/RedirectsController.php
+++ b/bundles/AdminBundle/Controller/Admin/RedirectsController.php
@@ -53,17 +53,18 @@ class RedirectsController extends AdminController
         $this->checkPermission('redirects');
 
         if ($request->get('data')) {
-            if ($request->get('xaction') == 'destroy') {
+            if ($request->get('xaction') === 'destroy') {
                 $data = $this->decodeJson($request->get('data'));
 
                 $id = $data['id'] ?? null;
                 if ($id) {
                     $redirect = Redirect::getById($id);
-                    $redirect->delete();
+                    $redirect?->delete();
                 }
 
                 return $this->adminJson(['success' => true, 'data' => []]);
-            } elseif ($request->get('xaction') == 'update') {
+            }
+            if ($request->get('xaction') === 'update') {
                 $data = $this->decodeJson($request->get('data'));
 
                 // save redirect
@@ -91,7 +92,8 @@ class RedirectsController extends AdminController
                 }
 
                 return $this->adminJson(['data' => $redirect->getObjectVars(), 'success' => true]);
-            } elseif ($request->get('xaction') == 'create') {
+            }
+            if ($request->get('xaction') === 'create') {
                 $data = $this->decodeJson($request->get('data'));
                 unset($data['id']);
 

--- a/bundles/AdminBundle/Controller/Admin/RedirectsController.php
+++ b/bundles/AdminBundle/Controller/Admin/RedirectsController.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\AdminBundle\Controller\Admin;
 
 use Pimcore\Bundle\AdminBundle\Controller\AdminController;
+use Pimcore\Bundle\AdminBundle\Helper\QueryParams;
 use Pimcore\Bundle\AdminBundle\HttpFoundation\JsonResponse;
 use Pimcore\Logger;
 use Pimcore\Model\Document;
@@ -69,6 +70,10 @@ class RedirectsController extends AdminController
 
                 // save redirect
                 $redirect = Redirect::getById($data['id']);
+
+                if (!$redirect) {
+                    return $this->adminJson(['success' => false]);
+                }
 
                 if ($data['target']) {
                     if ($doc = Document::getByPath($data['target'])) {
@@ -130,7 +135,7 @@ class RedirectsController extends AdminController
             $list->setLimit($request->get('limit'));
             $list->setOffset($request->get('start'));
 
-            $sortingSettings = \Pimcore\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings(array_merge($request->request->all(), $request->query->all()));
+            $sortingSettings = QueryParams::extractSortingSettings(array_merge($request->request->all(), $request->query->all()));
             if ($sortingSettings['orderKey']) {
                 $list->setOrderKey($sortingSettings['orderKey']);
                 $list->setOrder($sortingSettings['order']);
@@ -236,11 +241,9 @@ class RedirectsController extends AdminController
     /**
      * @Route("/cleanup", name="pimcore_admin_redirects_cleanup", methods={"DELETE"})
      *
-     * @param Request $request
-     *
      * @return JsonResponse
      */
-    public function cleanupAction(Request $request)
+    public function cleanupAction()
     {
         $this->checkPermission('redirects');
 


### PR DESCRIPTION
Error occurs when double-clicking. Or if another user has already removed the redirect.

Remove:
```
Call to a member function delete() on null
```

Update:
```
Call to a member function setValues() on null
```