### PR TITLE
[BUG] PimcoreLocationAwareConfigDao: Runtime cache doesn´t cache datasource

### DIFF
--- a/lib/Model/Dao/PimcoreLocationAwareConfigDao.php
+++ b/lib/Model/Dao/PimcoreLocationAwareConfigDao.php
@@ -70,10 +70,12 @@ abstract class PimcoreLocationAwareConfigDao implements DaoInterface
 
         list($data, $this->dataSource) = $this->locationAwareConfigRepository->loadConfigByKey($id);
 
-        self::$cache[$this->settingsStoreScope][$id] = [
-            'datasource' => $this->dataSource,
-            'data' => $data,
-        ];
+        if($data) {
+            self::$cache[$this->settingsStoreScope][$id] = [
+                'datasource' => $this->dataSource,
+                'data' => $data,
+            ];
+        }
 
         return $data;
     }

--- a/lib/Model/Dao/PimcoreLocationAwareConfigDao.php
+++ b/lib/Model/Dao/PimcoreLocationAwareConfigDao.php
@@ -21,8 +21,6 @@ abstract class PimcoreLocationAwareConfigDao implements DaoInterface
 {
     use DaoTrait;
 
-    private const cacheKeyDataSource = 'datasource';
-
     private static array $cache = [];
 
     protected ?string $settingsStoreScope = null;
@@ -66,10 +64,10 @@ abstract class PimcoreLocationAwareConfigDao implements DaoInterface
         $this->id = $id;
 
         if (isset(self::$cache[$this->settingsStoreScope][$id]) &&
-            isset(self::$cache[$this->settingsStoreScope][$id][self::cacheKeyDataSource])) {
+            isset(self::$cache[$this->settingsStoreScope][$id]['datasource'])) {
 
-            $this->dataSource = self::$cache[$this->settingsStoreScope][$id][self::cacheKeyDataSource];
-            return self::$cache[$this->settingsStoreScope][$id];
+            $this->dataSource = self::$cache[$this->settingsStoreScope][$id]['datasource'];
+            return self::$cache[$this->settingsStoreScope][$id]['data'];
         }
 
         list($data, $this->dataSource) = $this->locationAwareConfigRepository->loadConfigByKey($id);

--- a/lib/Model/Dao/PimcoreLocationAwareConfigDao.php
+++ b/lib/Model/Dao/PimcoreLocationAwareConfigDao.php
@@ -21,6 +21,8 @@ abstract class PimcoreLocationAwareConfigDao implements DaoInterface
 {
     use DaoTrait;
 
+    private const cacheKeyDataSource = 'datasource';
+
     private static array $cache = [];
 
     protected ?string $settingsStoreScope = null;
@@ -63,13 +65,17 @@ abstract class PimcoreLocationAwareConfigDao implements DaoInterface
     {
         $this->id = $id;
 
-        if (isset(self::$cache[$this->settingsStoreScope][$id])) {
+        if (isset(self::$cache[$this->settingsStoreScope][$id]) &&
+            isset(self::$cache[$this->settingsStoreScope][$id][self::cacheKeyDataSource])) {
+
+            $this->dataSource = self::$cache[$this->settingsStoreScope][$id][self::cacheKeyDataSource];
             return self::$cache[$this->settingsStoreScope][$id];
         }
 
         list($data, $this->dataSource) = $this->locationAwareConfigRepository->loadConfigByKey($id);
 
         self::$cache[$this->settingsStoreScope][$id] = $data;
+        self::$cache[$this->settingsStoreScope][$id][self::cacheKeyDataSource] = $this->dataSource;
 
         return $data;
     }

--- a/lib/Model/Dao/PimcoreLocationAwareConfigDao.php
+++ b/lib/Model/Dao/PimcoreLocationAwareConfigDao.php
@@ -64,7 +64,6 @@ abstract class PimcoreLocationAwareConfigDao implements DaoInterface
         $this->id = $id;
 
         if (isset(self::$cache[$this->settingsStoreScope][$id]) &&
-            isset(self::$cache[$this->settingsStoreScope][$id]['datasource'])) {
 
             $this->dataSource = self::$cache[$this->settingsStoreScope][$id]['datasource'];
             return self::$cache[$this->settingsStoreScope][$id]['data'];

--- a/lib/Model/Dao/PimcoreLocationAwareConfigDao.php
+++ b/lib/Model/Dao/PimcoreLocationAwareConfigDao.php
@@ -63,15 +63,13 @@ abstract class PimcoreLocationAwareConfigDao implements DaoInterface
     {
         $this->id = $id;
 
-        if (isset(self::$cache[$this->settingsStoreScope][$id]) &&
-
+        if (isset(self::$cache[$this->settingsStoreScope][$id])) {
             $this->dataSource = self::$cache[$this->settingsStoreScope][$id]['datasource'];
             return self::$cache[$this->settingsStoreScope][$id]['data'];
         }
 
         list($data, $this->dataSource) = $this->locationAwareConfigRepository->loadConfigByKey($id);
 
-        self::$cache[$this->settingsStoreScope][$id] = $data;
         self::$cache[$this->settingsStoreScope][$id] = [
             'datasource' => $this->dataSource,
             'data' => $data,

--- a/lib/Model/Dao/PimcoreLocationAwareConfigDao.php
+++ b/lib/Model/Dao/PimcoreLocationAwareConfigDao.php
@@ -75,7 +75,10 @@ abstract class PimcoreLocationAwareConfigDao implements DaoInterface
         list($data, $this->dataSource) = $this->locationAwareConfigRepository->loadConfigByKey($id);
 
         self::$cache[$this->settingsStoreScope][$id] = $data;
-        self::$cache[$this->settingsStoreScope][$id][self::cacheKeyDataSource] = $this->dataSource;
+        self::$cache[$this->settingsStoreScope][$id] = [
+            'datasource' => $this->dataSource,
+            'data' => $data,
+        ];
 
         return $data;
     }

--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -208,10 +208,11 @@ final class Config extends Model\AbstractModel
 
         try {
             $thumbnail = \Pimcore\Cache\Runtime::get($cacheKey);
-            $thumbnail->setName($name);
             if (!$thumbnail) {
                 throw new \Exception('Thumbnail in registry is null');
             }
+
+            $thumbnail->setName($name);
         } catch (\Exception $e) {
             try {
                 $thumbnail = new self();


### PR DESCRIPTION
PimcoreLocationAwareConfigDao: Runtime cache doesn´t cache datasource, therefore datasource is null for all cached items. As a result "isWriteable" Method doesn´t work like intended.