### PR TITLE
[Document] Areablock: hide/show button lacks status #10596

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
@@ -287,17 +287,32 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.area_abstra
         //visibility buttons
         visibilityButtons = this.visibilityButtons[element.key];
         if (typeof visibilityButtons === 'undefined') {
+            var elementIcon = "pimcore_material_icon_preview";
+            if (element.dataset.hidden == "true") {
+                elementIcon = "pimcore_icon_white_hide";
+            }
             visibilityDiv = Ext.get(element).query('.pimcore_block_visibility[data-name="' + this.name + '"]')[0];
             this.visibilityButtons[element.key] = new Ext.Button({
                 cls: "pimcore_block_button_visibility",
-                iconCls: "pimcore_icon_white_hide",
+                iconCls: elementIcon,
                 enableToggle: true,
                 pressed: (element.dataset.hidden == "true"),
                 toggleHandler: function (element, el) {
                     Ext.get(element).toggleCls('pimcore_area_hidden');
+                    if (el.btnIconEl.dom.classList.contains('pimcore_icon_white_hide')) {
+                        Ext.get(el.btnIconEl.dom).removeCls('pimcore_icon_white_hide');
+                        Ext.get(el.btnIconEl.dom).addCls('pimcore_material_icon_preview');
+                    } else {
+                        Ext.get(el.btnIconEl.dom).removeCls('pimcore_material_icon_preview');
+                        Ext.get(el.btnIconEl.dom).addCls('pimcore_icon_white_hide');
+                    }
                 }.bind(this, element)
             });
             this.visibilityButtons[element.key].render(visibilityDiv);
+            new Ext.tip.ToolTip({
+                target: this.visibilityButtons[element.key],
+                html: t("show_hide_areablock")
+            });
             if(element.dataset.hidden == "true") {
                 Ext.get(element).addCls('pimcore_area_hidden');
             }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #10596

## Additional info 
I also added tooltip with translation key to describe what hide/show button does
