### PR TITLE
[BUG] getByTargetType for custom metadata not working

### DIFF
--- a/models/Metadata/Predefined/Listing.php
+++ b/models/Metadata/Predefined/Listing.php
@@ -74,7 +74,7 @@ class Listing extends \Pimcore\Model\Listing\JsonListing
 
         if (is_array($subTypes)) {
             return array_filter($list->load(), function ($item) use ($subTypes) {
-                if (empty($item->getTargetSubtype)) {
+                if (empty($item->getTargetSubtype())) {
                     return true;
                 }
 
@@ -86,7 +86,7 @@ class Listing extends \Pimcore\Model\Listing\JsonListing
             });
         }
 
-        return null;
+        return $list->load();
     }
 
     /**


### PR DESCRIPTION
When there is no subTypes parameter given the method returns null and this results in an error message in the grid config dialog box.