### PR TITLE
Check if $o exists before call method_exists

### DIFF
--- a/lib/DataObject/GridColumnConfig/Operator/AnyGetter.php
+++ b/lib/DataObject/GridColumnConfig/Operator/AnyGetter.php
@@ -137,20 +137,24 @@ final class AnyGetter extends AbstractOperator
                     if (is_array($value)) {
                         $subValues = [];
                         foreach ($value as $o) {
-                            if ($this->attribute && method_exists($o, $getter)) {
-                                $subValues[] = $o->$getter($this->getParam1());
-                            } elseif ($this->attribute && method_exists($o, $fallbackGetter)) {
-                                $subValues[] = $o->$fallbackGetter($this->getParam1());
+                            if($o) {
+                                if ($this->attribute && method_exists($o, $getter)) {
+                                    $subValues[] = $o->$getter($this->getParam1());
+                                } elseif ($this->attribute && method_exists($o, $fallbackGetter)) {
+                                    $subValues[] = $o->$fallbackGetter($this->getParam1());
+                                }
                             }
                         }
                         $resultElementValue = $subValues;
                     }
                 } else {
                     $o = $value;
-                    if ($this->attribute && method_exists($o, $getter)) {
-                        $resultElementValue = $o->$getter($this->getParam1());
-                    } elseif ($this->attribute && method_exists($o, $fallbackGetter)) {
-                        $resultElementValue = $o->$fallbackGetter($this->getParam1());
+                    if($o) {
+                        if ($this->attribute && method_exists($o, $getter)) {
+                            $resultElementValue = $o->$getter($this->getParam1());
+                        } elseif ($this->attribute && method_exists($o, $fallbackGetter)) {
+                            $resultElementValue = $o->$fallbackGetter($this->getParam1());
+                        }
                     }
                 }
                 $resultElements[] = $resultElementValue;


### PR DESCRIPTION
otherwise u will get the error, if $o is not set
"method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given"

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

