### PR TITLE
Fix: skip CSRF check for all read methods

### DIFF
--- a/bundles/AdminBundle/EventListener/CsrfProtectionListener.php
+++ b/bundles/AdminBundle/EventListener/CsrfProtectionListener.php
@@ -71,7 +71,7 @@ class CsrfProtectionListener implements EventSubscriberInterface
 
         $this->csrfProtectionHandler->generateCsrfToken();
 
-        if ($request->getMethod() == Request::METHOD_GET) {
+        if ($request->isMethodCacheable()) {
             return;
         }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #10693

## Additional info  
The change in this PR uses the Symfony Request's native method to resolve whether the incoming request is a READ or a WRITE operation. On any READ operation, the CSRF token check is skipped.