### PR TITLE
Follow-Up PR#7177: Add Pimcore JS events to enable virtual data folder integration 

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/folder.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/folder.js
@@ -47,10 +47,14 @@ pimcore.object.folder = Class.create(pimcore.object.abstract, {
 
 
     getData: function () {
+
+        var eventData =  {requestParams: {id: this.id}};
+        pimcore.plugin.broker.fireEvent("preGetObjectFolder", eventData);
+
         var options = this.options || {};
         Ext.Ajax.request({
             url: Routing.generate('pimcore_admin_dataobject_dataobject_getfolder'),
-            params: {id: this.id},
+            params: eventData.requestParams,
             ignoreErrors: options.ignoreNotFoundError,
             success: this.getDataComplete.bind(this),
             failure: function() {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/folder/search.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/folder/search.js
@@ -223,10 +223,13 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
             language: this.gridLanguage,
         });
 
+        var eventData =  {requestParams: {classId: this.classId, folderId: this.object.id}};
+        pimcore.plugin.broker.fireEvent("preCreateObjectGrid", eventData);
+
         var gridHelper = new pimcore.object.helpers.grid(
             klass.data.text,
             fields,
-            Routing.generate('pimcore_admin_dataobject_dataobject_gridproxy', {classId: this.classId, folderId: this.object.id}),
+            Routing.generate('pimcore_admin_dataobject_dataobject_gridproxy', eventData.requestParams),
             baseParams,
             false
         );

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
@@ -182,6 +182,11 @@ pimcore.object.tree = Class.create({
             },
             "itemmouseleave": function () {
                 pimcore.helpers.treeToolTipHide();
+            },
+            "beforeload": function (store, operation, options) {
+                // add the parent path as an additional diagnostic parameter
+                // can be used by bundles that work with dynamic children nodes
+                store.proxy.setExtraParam('parentPath', operation.node.data.path)
             }
         };
 
@@ -191,6 +196,13 @@ pimcore.object.tree = Class.create({
     onTreeNodeClick: function (tree, record, item, index, event, eOpts ) {
         if (event.ctrlKey === false && event.shiftKey === false && event.altKey === false) {
             try {
+
+                var eventData =  {record: record, preventDefault: false};
+                pimcore.plugin.broker.fireEvent("prepareOnObjectTreeNodeClick", eventData);
+                if (eventData.preventDefault) {
+                    return;
+                }
+
                 if (record.data.permissions.view) {
                     pimcore.helpers.openObject(record.data.id, record.data.type);
                 }

--- a/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/06_Plugin_Backend_UI.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/06_Plugin_Backend_UI.md
@@ -113,6 +113,9 @@ corresponding method to the javascript plugin class.
 | prepareDocumentTreeContextMenu       | before context menu is opened, menu, tree and document record are passed as parameters                          |          |
 | prepareClassLayoutContextMenu        | before context menu is opened, allowedTypes array is passed as parameters                                       |          |
 | prepareOnRowContextmenu              | before context menu is opened object folder grid, menu, folder class and object record are passed as parameters |          |
+| prepareOnObjectTreeNodeClick         | before the data object is opened, after a tree node has been clicked. The node item is passed as parameter.     |          | 
+| preGetObjectFolder                   | before the data object grid folder configuration is loaded from the server. request configuration is passed.    |          |
+| preCreateObjectGrid                  | before the data object grid items are loaded from the server. request configuration are passed.                 |          |
 
 Uninstall is called after plugin has been uninstalled - this hook can be used to remove plugin features from the UI 
 after uninstall.


### PR DESCRIPTION
This is a follow-up Pull-Request for the PR https://github.com/pimcore/pimcore/pull/7177  from @andreas-gruenwald :

## Feature Request 

We are working on a bundle that allows developers to integrate folders and objects as part of a virtual data object tree.

The idea is very similar to the AlternateObjectTrees bundle, but the implementation

focuses more on the developer perspective,
and the UI integration into Pimcore's tree structure is more tightly.
Preview:

![image](https://user-images.githubusercontent.com/93317522/139231485-383b072f-90ab-408a-bac4-db932c0c29d4.png)

## Changes in this pull request  

In order to support the integration for data object trees and the children grid view, this PR adds additional JS events that make the core more flexible.

We tried to keep the changes as minimalistic as possible.

## Additional info  

Original Contributer: @andreas-gruenwald 
