### PR TITLE
[DataObject] don't increase the version count when versioning is disabled

### DIFF
--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -117,11 +117,11 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
      */
     protected function update($isUpdate = null, $params = [])
     {
-        $fieldDefintions = $this->getClass()->getFieldDefinitions();
+        $fieldDefinitions = $this->getClass()->getFieldDefinitions();
 
         $validationExceptions = [];
 
-        foreach ($fieldDefintions as $fd) {
+        foreach ($fieldDefinitions as $fd) {
             try {
                 $getter = 'get' . ucfirst($fd->getName());
 

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -49,7 +49,9 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
      */
     protected function updateModificationInfos()
     {
-        $this->setVersionCount($this->getDao()->getVersionCountForUpdate() + 1);
+        if (Model\Version::isEnabled() === true) {
+            $this->setVersionCount($this->getDao()->getVersionCountForUpdate() + 1);
+        }
 
         if ($this->getVersionCount() > 4200000000) {
             $this->setVersionCount(1);

--- a/models/Version.php
+++ b/models/Version.php
@@ -168,14 +168,6 @@ final class Version extends AbstractModel
     /**
      * @return bool
      */
-    public static function isDisabled(): bool
-    {
-        return (self::$disabled === true);
-    }
-
-    /**
-     * @return bool
-     */
     public static function isEnabled(): bool
     {
         return (self::$disabled === false);

--- a/models/Version.php
+++ b/models/Version.php
@@ -166,6 +166,22 @@ final class Version extends AbstractModel
     }
 
     /**
+     * @return bool
+     */
+    public static function isDisabled(): bool
+    {
+        return (self::$disabled === true);
+    }
+
+    /**
+     * @return bool
+     */
+    public static function isEnabled(): bool
+    {
+        return (self::$disabled === false);
+    }
+
+    /**
      * @throws \Exception
      */
     public function save()

--- a/models/Version.php
+++ b/models/Version.php
@@ -170,7 +170,7 @@ final class Version extends AbstractModel
      */
     public static function isEnabled(): bool
     {
-        return (self::$disabled === false);
+        return !self::$disabled;
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
I noticed that the version count was increased, even with versioning disabled. the small fix/check honors such setting now:
```
if (Model\Version::$disabled === false) {
    $this->setVersionCount($this->getDao()->getVersionCountForUpdate() + 1);
}
```

## Additional info  
fixed one minor typo too

