### PR TITLE
[DataObject] [6.9] don't increase the version count when versioning is disabled

### DIFF
--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -109,11 +109,11 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
      */
     protected function update($isUpdate = null, $params = [])
     {
-        $fieldDefintions = $this->getClass()->getFieldDefinitions();
+        $fieldDefinitions = $this->getClass()->getFieldDefinitions();
 
         $validationExceptions = [];
 
-        foreach ($fieldDefintions as $fd) {
+        foreach ($fieldDefinitions as $fd) {
             try {
                 $getter = 'get' . ucfirst($fd->getName());
 

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -44,7 +44,9 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
      */
     protected function updateModificationInfos()
     {
-        $this->setVersionCount($this->getDao()->getVersionCountForUpdate() + 1);
+        if (Model\Version::$disabled === false) {
+            $this->setVersionCount($this->getDao()->getVersionCountForUpdate() + 1);
+        }
 
         if ($this->getVersionCount() > 4200000000) {
             $this->setVersionCount(1);


### PR DESCRIPTION
## Changes in this pull request  
see [PR-10733](https://github.com/pimcore/pimcore/pull/10733) for Pimcore 10.2.
We noticed the bug with Pimcore 6.9, which we are currently still using. But I fixed it for both versions, with two PRs

