### PR TITLE
[eCommerceFramework] Fixed token filtering in VoucherSeries details tab

### DIFF
--- a/bundles/EcommerceFrameworkBundle/VoucherService/Token/Listing.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/Token/Listing.php
@@ -67,7 +67,7 @@ class Listing extends \Pimcore\Model\Listing\AbstractListing implements Paginate
                 $this->addConditionParam('length = ?', $filter['length']);
             }
 
-            if (isset($filter['creation_from']) && $filter['creation_from'] !== '') {
+            if (!empty($filter['creation_from'])) {
                 $this->addConditionParam("DATE(timestamp) >= STR_TO_DATE(?,'%Y-%m-%d')", $filter['creation_from']);
             }
 

--- a/bundles/EcommerceFrameworkBundle/VoucherService/Token/Listing.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/Token/Listing.php
@@ -67,11 +67,11 @@ class Listing extends \Pimcore\Model\Listing\AbstractListing implements Paginate
                 $this->addConditionParam('length = ?', $filter['length']);
             }
 
-            if (isset($filter['creation_from'])) {
+            if (isset($filter['creation_from']) && $filter['creation_from'] !== '') {
                 $this->addConditionParam("DATE(timestamp) >= STR_TO_DATE(?,'%Y-%m-%d')", $filter['creation_from']);
             }
 
-            if (isset($filter['creation_to'])) {
+            if (isset($filter['creation_to']) && $filter['creation_to'] !== '') {
                 $this->addConditionParam("DATE(timestamp) <= STR_TO_DATE(?,'%Y-%m-%d')", $filter['creation_to']);
             }
 

--- a/bundles/EcommerceFrameworkBundle/VoucherService/Token/Listing.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/Token/Listing.php
@@ -71,7 +71,7 @@ class Listing extends \Pimcore\Model\Listing\AbstractListing implements Paginate
                 $this->addConditionParam("DATE(timestamp) >= STR_TO_DATE(?,'%Y-%m-%d')", $filter['creation_from']);
             }
 
-            if (isset($filter['creation_to']) && $filter['creation_to'] !== '') {
+            if (!empty($filter['creation_to'])) {
                 $this->addConditionParam("DATE(timestamp) <= STR_TO_DATE(?,'%Y-%m-%d')", $filter['creation_to']);
             }
 


### PR DESCRIPTION
If you try to filter for tokens in the details tab on a OnlineShopVoucherSeries, you won't get any results unless you provide from- and to-dates.
This bug was introduced with https://github.com/pimcore/pimcore/pull/7482/commits/72e61b1024fefe2dde370e0136fec078cc7d66ac and is fixed with this patch
