### PR TITLE
Website settings in multi site environment are not fetched correctly

### DIFF
--- a/models/WebsiteSetting/Dao.php
+++ b/models/WebsiteSetting/Dao.php
@@ -62,7 +62,7 @@ class Dao extends Model\Dao\PhpArrayTable
             if ($name && $row['name'] != $name) {
                 $return = false;
             }
-            if ($row['siteId'] && $siteId && $row['siteId'] != $siteId) {
+            if ($row['siteId'] && $row['siteId'] != $siteId) {
                 $return = false;
             }
 


### PR DESCRIPTION
In my case a custom website setting "contactFormEmailRecipient" is set for main site and a sub site. For the sub site the according domain is selected in website settings.
The `$data` array holds two results and later, for the sub site `$data[0]` is taken. This is not correct. With this fix, `$data` holds only one result and everything is fine.

Bug fix: 6.9

