### PR TITLE
Classification store groups and keys sorting by groupId and keyId not working properly

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classificationstore/collectionsPanel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classificationstore/collectionsPanel.js
@@ -47,7 +47,7 @@ pimcore.object.classificationstore.collectionsPanel = Class.create({
         var readerFields = [];
         for (var i = 0; i < this.relationsFields.length; i++) {
             var columnConfig = {name: this.relationsFields[i]};
-            if (this.relationsFields[i] == "sorter") {
+            if (this.relationsFields[i] == "sorter" || this.relationsFields[i] == "groupId") {
                 columnConfig["type"] = "int";
             }
             readerFields.push(columnConfig);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classificationstore/groupsPanel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classificationstore/groupsPanel.js
@@ -45,7 +45,7 @@ pimcore.object.classificationstore.groupsPanel = Class.create({
         var readerFields = [];
         for (var i = 0; i < this.relationsFields.length; i++) {
             var columnConfig = {name: this.relationsFields[i], type: 'string'};
-            if (this.relationsFields[i] == "sorter") {
+            if (this.relationsFields[i] == "sorter" || this.relationsFields[i] == "keyId") {
                 columnConfig["type"] = "int";
             }
             readerFields.push(columnConfig);


### PR DESCRIPTION

Inside Classification Store tab on overview of all the groups inside a collection and all the keys inside the group sorting by groupId and KeyId  is not working properly after you add groups/keys and refresh page.

![Screenshot from 2021-11-03 14-59-19](https://user-images.githubusercontent.com/35298078/140082185-b278f8fd-811a-4356-bd59-815fec296ac1.png)

![Screenshot from 2021-11-03 14-59-11](https://user-images.githubusercontent.com/35298078/140082193-871e0678-7609-4619-b82d-7a69ef29fcab.png)


