### PR TITLE
Fixes incorrect default value casting in QuantityValues

### DIFF
--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -167,7 +167,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
      */
     public function setDefaultValue($defaultValue)
     {
-        if (!empty($this->defaultValue)) {
+        if (!empty($defaultValue)) {
             $this->defaultValue = (float) $defaultValue;
         } else {
             $this->defaultValue = null;

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -155,7 +155,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
      */
     public function getDefaultValue()
     {
-        if ($this->defaultValue !== null) {
+        if (!empty($this->defaultValue)) {
             return (float) $this->defaultValue;
         }
 
@@ -167,7 +167,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
      */
     public function setDefaultValue($defaultValue)
     {
-        if ($defaultValue !== null) {
+        if (!empty($this->defaultValue)) {
             $this->defaultValue = (float) $defaultValue;
         } else {
             $this->defaultValue = null;


### PR DESCRIPTION
Resolves #10754

When `defaultValue` was for example an empty string it would be cast to `0.0` causing discrepancy between what was shown in the admin UI and other locations. This PR resolves the issue.