### PR TITLE
Restore group icon

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
@@ -703,6 +703,7 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.area_abstra
                 if(groups[g].length > 0) {
                     groupMenu = {
                         text: t(groups[g]),
+                        iconCls: "pimcore_icon_area",
                         hideOnClick: false,
                         menu: []
                     };


### PR DESCRIPTION
Restore missing areablock group icon

Removed here: https://github.com/pimcore/pimcore/commit/f03438780701177e667f4171d6327103e281af21