### PR TITLE
using reference to edit cmd variable

### DIFF
--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -364,7 +364,7 @@ final class Console
      *
      * @return void
      */
-    public static function addLowProcessPriority(&$cmd): void
+    public static function addLowProcessPriority(&$cmd)
     {
         $nice = (string) self::getExecutable('nice');
         if ($nice) {

--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -364,7 +364,7 @@ final class Console
      *
      * @return void
      */
-    public static function addLowProcessPriority(&$cmd)
+    public static function addLowProcessPriority(&$cmd): void
     {
         $nice = (string) self::getExecutable('nice');
         if ($nice) {

--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -364,7 +364,7 @@ final class Console
      *
      * @return array|string
      */
-    public static function addLowProcessPriority($cmd)
+    public static function addLowProcessPriority(&$cmd)
     {
         $nice = (string) self::getExecutable('nice');
         if ($nice) {

--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -362,9 +362,9 @@ final class Console
      *
      * @param array|string $cmd
      *
-     * @return array|string
+     * @return void
      */
-    public static function addLowProcessPriority(&$cmd)
+    public static function addLowProcessPriority(&$cmd): void
     {
         $nice = (string) self::getExecutable('nice');
         if ($nice) {
@@ -374,7 +374,5 @@ final class Console
                 array_unshift($cmd, $nice, '-n 19');
             }
         }
-
-        return $cmd;
     }
 }

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -109,7 +109,9 @@ class Image extends Model\Asset
             $imageWidth = $thumbnail->getWidth();
             $imageHeight = $thumbnail->getHeight();
 
-            $process = new Process(Console::addLowProcessPriority([$facedetectBin, $image]));
+            $command = [$facedetectBin, $image];
+            Console::addLowProcessPriority($command);
+            $process = new Process($command);
             $process->run();
             $result = $process->getOutput();
             if (strpos($result, "\n")) {


### PR DESCRIPTION
all of the calls of this function do not overwrite the variable, they all look like:

Console::addLowProcessPriority($command);
instead of:
$command = Console::addLowProcessPriority($command);

without & nothing will happen

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

