### PR TITLE
Fix version display when an object stored in an older version does no…

### DIFF
--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -457,7 +457,7 @@ class AdvancedManyToManyRelation extends ManyToManyRelation implements IdRewrite
         if (is_array($data) && count($data) > 0) {
             foreach ($data as $metaObject) {
                 $o = $metaObject->getElement();
-                $item = Element\Service::getElementType($o) . ' ' . $o->getRealFullPath();
+                $item = $o ? Element\Service::getElementType($o) . ' ' . $o->getRealFullPath() : 'WARNING: ' . $metaObject->getElementType() . ' (' . $metaObject->getElementId() . ') WAS DELETED !!!';
 
                 if (count($metaObject->getData())) {
                     $subItems = [];


### PR DESCRIPTION
Fix: When trying to display a version that contains reference to an object that is already deleted, it fails to display the version 