### PR TITLE
Label Width: Remove wrong width explanation

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/localizedfields.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/localizedfields.js
@@ -179,11 +179,6 @@ pimcore.object.classes.data.localizedfields = Class.create(pimcore.object.classe
                     value: this.datax.labelWidth
                 },
                 {
-                    xtype: "displayfield",
-                    hideLabel: true,
-                    value: t('width_explanation')
-                },
-                {
                     xtype: "combo",
                     fieldLabel: t("label_align"),
                     name: "labelAlign",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/fieldcontainer.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/fieldcontainer.js
@@ -79,7 +79,7 @@ pimcore.object.classes.layout.fieldcontainer = Class.create(pimcore.object.class
                     value: this.datax.fieldLabel
                 },
                 {
-                    xtype: "textfield",
+                    xtype: "numberfield",
                     name: "labelWidth",
                     fieldLabel: t("label_width"),
                     value: this.datax.labelWidth

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/fieldcontainer.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/fieldcontainer.js
@@ -85,11 +85,6 @@ pimcore.object.classes.layout.fieldcontainer = Class.create(pimcore.object.class
                     value: this.datax.labelWidth
                 },
                 {
-                    xtype: "displayfield",
-                    hideLabel: true,
-                    value: t('width_explanation')
-                },
-                {
                     xtype: "combo",
                     fieldLabel: t("label_align"),
                     name: "labelAlign",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/fieldset.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/fieldset.js
@@ -55,11 +55,6 @@ pimcore.object.classes.layout.fieldset = Class.create(pimcore.object.classes.lay
                     value: this.datax.labelWidth
                 },
                 {
-                    xtype: "displayfield",
-                    hideLabel: true,
-                    value: t('width_explanation')
-                },
-                {
                     xtype: "combo",
                     fieldLabel: t("label_align"),
                     name: "labelAlign",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/fieldset.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/fieldset.js
@@ -49,7 +49,7 @@ pimcore.object.classes.layout.fieldset = Class.create(pimcore.object.classes.lay
             style: "margin: 10px 0 10px 0",
             items: [
                 {
-                    xtype: "textfield",
+                    xtype: "numberfield",
                     name: "labelWidth",
                     fieldLabel: t("label_width"),
                     value: this.datax.labelWidth

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/panel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/panel.js
@@ -75,7 +75,7 @@ pimcore.object.classes.layout.panel = Class.create(pimcore.object.classes.layout
                     checked: this.datax.border,
                 },
                 {
-                    xtype: "textfield",
+                    xtype: "numberfield",
                     name: "labelWidth",
                     fieldLabel: t("label_width"),
                     value: this.datax.labelWidth

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/panel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/panel.js
@@ -81,11 +81,6 @@ pimcore.object.classes.layout.panel = Class.create(pimcore.object.classes.layout
                     value: this.datax.labelWidth
                 },
                 {
-                    xtype: "displayfield",
-                    hideLabel: true,
-                    value: t('width_explanation')
-                },
-                {
                     xtype: "combo",
                     fieldLabel: t("label_align"),
                     name: "labelAlign",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
@@ -37,7 +37,7 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
             input.value = this.data.value;
         }
 
-        if (!isNaN(this.fieldConfig.width) && this.fieldConfig.width) {
+        if (this.fieldConfig.width) {
             input.width = this.fieldConfig.width;
         }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -175,10 +175,9 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
     getLayoutShow: function () {
 
         var href = {
-            fieldLabel: this.fieldConfig.title,
-            name: this.fieldConfig.name,
-            labelWidth: this.fieldConfig.labelWidth ? this.fieldConfig.labelWidth : 100
+            name: this.fieldConfig.name
         };
+        var labelWidth = this.fieldConfig.labelWidth ? this.fieldConfig.labelWidth : 100;
 
         if (this.data) {
             if (this.data.path) {
@@ -191,7 +190,6 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
         } else {
             href.width = 300;
         }
-        href.width = href.labelWidth + href.width;
         href.disabled = true;
 
         this.component = new Ext.form.TextField(href);
@@ -200,7 +198,9 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
             this.component.addCls("strikeThrough");
         }
 
-        this.composite = Ext.create('Ext.form.FieldContainer', {
+        var compositeCfg = {
+            fieldLabel: this.fieldConfig.title,
+            labelWidth: labelWidth,
             layout: 'hbox',
             items: [this.component, {
                 xtype: "button",
@@ -217,7 +217,13 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
                     this.requestNicePathData();
                 }.bind(this)
             }
-        });
+        };
+
+        if (this.fieldConfig.labelAlign) {
+            compositeCfg.labelAlign = this.fieldConfig.labelAlign;
+        }
+
+        this.composite = Ext.create('Ext.form.FieldContainer', compositeCfg);
 
         return this.composite;
 


### PR DESCRIPTION
Since https://github.com/pimcore/pimcore/pull/9780 this explanation is wrong. Can only be integer