### PR TITLE
Provide a Tool\Sorter class and use it for array sorting functions as callback

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetHelperController.php
@@ -255,13 +255,7 @@ class AssetHelperController extends AdminController
                 }
             }
         }
-        usort($availableFields, function ($a, $b) {
-            if ($a['position'] == $b['position']) {
-                return 0;
-            }
-
-            return ($a['position'] < $b['position']) ? -1 : 1;
-        });
+        usort($availableFields, [Tool\Sorter::class, 'position']);
 
         $availableConfigs = $classId ? $this->getMyOwnGridColumnConfigs($userId, $classId, $searchType) : [];
         $sharedConfigs = $classId ? $this->getSharedGridColumnConfigs($this->getAdminUser(), $classId, $searchType) : [];

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -476,13 +476,7 @@ class DataObjectHelperController extends AdminController
                 }
             }
         }
-        usort($availableFields, function ($a, $b) {
-            if ($a['position'] == $b['position']) {
-                return 0;
-            }
-
-            return ($a['position'] < $b['position']) ? -1 : 1;
-        });
+        usort($availableFields, [Tool\Sorter::class, 'position']);
 
         $frontendLanguages = Tool\Admin::reorderWebsiteLanguages(\Pimcore\Tool\Admin::getCurrentUser(), $config['general']['valid_languages']);
         if ($frontendLanguages) {

--- a/bundles/AdminBundle/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/Controller/Admin/SettingsController.php
@@ -942,9 +942,7 @@ class SettingsController extends AdminController
             }
         }
 
-        usort($langs, function ($a, $b) {
-            return strcmp($a['display'], $b['display']);
-        });
+        usort($langs, [Tool\Sorter::class, 'display']);
 
         return $this->adminJson($langs);
     }

--- a/bundles/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
+++ b/bundles/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
@@ -28,6 +28,7 @@ use Pimcore\Extension\Document\Areabrick\AreabrickManagerInterface;
 use Pimcore\Logger;
 use Pimcore\Routing\RouteReferenceInterface;
 use Pimcore\Tool\AssetsInstaller;
+use Pimcore\Tool\Sorter;
 use SensioLabs\AnsiConverter\AnsiToHtmlConverter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
@@ -324,26 +325,7 @@ class ExtensionManagerController extends AdminController implements KernelContro
             });
         }
 
-        // show enabled/active first, then order by priority for
-        // bundles with the same enabled state
-        usort($results, function ($a, $b) {
-            if ($a['active'] && !$b['active']) {
-                return -1;
-            }
-
-            if (!$a['active'] && $b['active']) {
-                return 1;
-            }
-
-            if ($a['active'] === $b['active']) {
-                if ($a['priority'] === $b['priority']) {
-                    return 0;
-                }
-
-                // reverse sorty by priority -> higher comes first
-                return $a['priority'] < $b['priority'] ? 1 : -1;
-            }
-        });
+        usort($results, [Sorter::class, 'extensions']);
 
         return $results;
     }

--- a/bundles/AdminBundle/GDPR/DataProvider/Manager.php
+++ b/bundles/AdminBundle/GDPR/DataProvider/Manager.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\AdminBundle\GDPR\DataProvider;
 
 use Pimcore\DependencyInjection\CollectionServiceLocator;
+use Pimcore\Tool\Sorter;
 
 /**
  * @internal
@@ -52,9 +53,7 @@ class Manager
 
         $this->sortedServices = $this->services->all();
 
-        usort($this->sortedServices, function (DataProviderInterface $left, DataProviderInterface $right) {
-            return $left->getSortPriority() > $right->getSortPriority();
-        });
+        usort($this->sortedServices, [Sorter::class, 'sortPriority']);
 
         return $this->sortedServices;
     }

--- a/bundles/CoreBundle/Command/InternalUnicodeCldrLanguageTerritoryGeneratorCommand.php
+++ b/bundles/CoreBundle/Command/InternalUnicodeCldrLanguageTerritoryGeneratorCommand.php
@@ -18,6 +18,7 @@ namespace Pimcore\Bundle\CoreBundle\Command;
 use Pimcore\Console\AbstractCommand;
 use Pimcore\File;
 use Pimcore\Localization\LocaleServiceInterface;
+use Pimcore\Tool\Sorter;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -73,13 +74,7 @@ class InternalUnicodeCldrLanguageTerritoryGeneratorCommand extends AbstractComma
         $finalData = [];
 
         foreach ($languageRawData as $languageCode => $rawLanguage) {
-            usort($rawLanguage, function ($a, $b) {
-                if ($a['population'] == $b['population']) {
-                    return 0;
-                }
-
-                return ($a['population'] > $b['population']) ? -1 : 1;
-            });
+            usort($rawLanguage, [Sorter::class, 'population']);
 
             $finalData[$languageCode] = [];
             foreach ($rawLanguage as $territory) {

--- a/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -29,6 +29,7 @@ use Pimcore\Sitemap\EventListener\SitemapGeneratorListener;
 use Pimcore\Targeting\ActionHandler\DelegatingActionHandler;
 use Pimcore\Targeting\DataLoaderInterface;
 use Pimcore\Targeting\Storage\TargetingStorageInterface;
+use Pimcore\Tool\Sorter;
 use Pimcore\Translation\ExportDataExtractorService\DataExtractor\DataObjectDataExtractor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -393,13 +394,7 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
             $generators = $config['generators'];
         }
 
-        uasort($generators, function (array $a, array $b) {
-            if ($a['priority'] === $b['priority']) {
-                return 0;
-            }
-
-            return $a['priority'] < $b['priority'] ? 1 : -1;
-        });
+        uasort($generators, [Sorter::class, 'priority']);
 
         $mapping = [];
         foreach ($generators as $generatorName => $generatorConfig) {

--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -22,6 +22,7 @@ use Pimcore\Model\Element\ElementDumpStateInterface;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
 use Pimcore\Model\Version\SetDumpStateFilter;
+use Pimcore\Tool\Sorter;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
@@ -422,9 +423,7 @@ class CoreCacheHandler implements LoggerAwareInterface
     public function cleanupQueue(): void
     {
         // order by priority
-        uasort($this->saveQueue, function (CacheQueueItem $a, CacheQueueItem $b) {
-            return $b->getPriority() <=> $a->getPriority();
-        });
+        uasort($this->saveQueue, [Sorter::class, 'itemPriority']);
 
         // remove overrun
         array_splice($this->saveQueue, $this->maxWriteToCacheItems);

--- a/lib/HttpKernel/BundleCollection/BundleCollection.php
+++ b/lib/HttpKernel/BundleCollection/BundleCollection.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\HttpKernel\BundleCollection;
 
+use Pimcore\Tool\Sorter;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 class BundleCollection
@@ -97,13 +98,7 @@ class BundleCollection
             });
         }
 
-        usort($items, function (ItemInterface $a, ItemInterface $b) {
-            if ($a->getPriority() === $b->getPriority()) {
-                return 0;
-            }
-
-            return ($a->getPriority() > $b->getPriority()) ? -1 : 1;
-        });
+        usort($items, [Sorter::class, 'itemPriority']);
 
         return $items;
     }

--- a/lib/Image/Optimizer.php
+++ b/lib/Image/Optimizer.php
@@ -18,6 +18,7 @@ namespace Pimcore\Image;
 use Pimcore\Exception\ImageOptimizationFailedException;
 use Pimcore\File;
 use Pimcore\Image\Optimizer\OptimizerInterface;
+use Pimcore\Tool\Sorter;
 use Pimcore\Tool\Storage;
 
 class Optimizer implements ImageOptimizerInterface
@@ -54,13 +55,7 @@ class Optimizer implements ImageOptimizerInterface
         }
 
         // order by filesize
-        usort($optimizedImages, function ($a, $b) {
-            if ($a['filesize'] == $b['filesize']) {
-                return 0;
-            }
-
-            return ($a['filesize'] < $b['filesize']) ? -1 : 1;
-        });
+        usort($optimizedImages, [Sorter::class, 'filesize']);
 
         // first entry is the smallest -> use this one
         if (count($optimizedImages)) {

--- a/lib/Perspective/Config.php
+++ b/lib/Perspective/Config.php
@@ -334,12 +334,7 @@ final class Config
             }
         }
 
-        usort($result, static function ($treeA, $treeB) {
-            $a = $treeA['sort'] ?: 0;
-            $b = $treeB['sort'] ?: 0;
-
-            return $a <=> $b;
-        });
+        usort($result, [Tool\Sorter::class, 'sort']);
 
         return $result;
     }

--- a/lib/Targeting/Model/VisitorInfo.php
+++ b/lib/Targeting/Model/VisitorInfo.php
@@ -19,6 +19,7 @@ namespace Pimcore\Targeting\Model;
 
 use Pimcore\Model\Tool\Targeting\Rule;
 use Pimcore\Model\Tool\Targeting\TargetGroup;
+use Pimcore\Tool\Sorter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -193,16 +194,7 @@ class VisitorInfo implements \IteratorAggregate
         $assignments = array_values($this->targetGroupAssignments);
 
         // sort reverse (highest count first)
-        usort($assignments, function (TargetGroupAssignment $a, TargetGroupAssignment $b) {
-            $aCount = $a->getCount();
-            $bCount = $b->getCount();
-
-            if ($aCount === $bCount) {
-                return 0;
-            }
-
-            return $aCount < $bCount ? 1 : -1;
-        });
+        usort($assignments, [Sorter::class, 'count']);
 
         $this->sortedTargetGroupAssignments = $assignments;
 

--- a/lib/Tool/Sorter.php
+++ b/lib/Tool/Sorter.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Tool;
+
+use Pimcore\Bundle\AdminBundle\GDPR\DataProvider\DataProviderInterface;
+use Pimcore\Cache\Core\CacheQueueItem;
+use Pimcore\HttpKernel\BundleCollection\ItemInterface;
+use Pimcore\Model\Element\Tag;
+use Pimcore\Model\Staticroute;
+use Pimcore\Targeting\Model\TargetGroupAssignment;
+use Pimcore\Workflow\WorkflowConfig;
+
+/**
+ * Static callbacks for array sorting functions.
+ *
+ * @see https://www.php.net/manual/en/array.sorting.php
+ */
+class Sorter
+{
+    public static function date(array $a, array $b): int
+    {
+        return $a['date'] <=> $b['date'];
+    }
+
+    public static function index(array $a, array $b): int
+    {
+        return $a['index'] <=> $b['index'];
+    }
+
+    public static function name(array $a, array $b): int
+    {
+        return $a['name'] <=> $b['name'];
+    }
+
+    public static function population(array $a, array $b): int
+    {
+        return $a['population'] <=> $b['population'];
+    }
+
+    public static function position(array $a, array $b): int
+    {
+        return $a['position'] <=> $b['position'];
+    }
+
+    public static function priority(array $a, array $b): int
+    {
+        return $a['priority'] <=> $b['priority'];
+    }
+
+    public static function sortIndex(array $a, array $b): int
+    {
+        return $a['sortIndex'] <=> $b['sortIndex'];
+    }
+
+    public static function sort(array $a, array $b): int
+    {
+        $a = $a['sort'] ?: 0;
+        $b = $b['sort'] ?: 0;
+
+        return $a <=> $b;
+    }
+
+    /**
+     * show enabled/active first, then order by priority for bundles with the
+     * same enabled state. Uses reverse sort by priority -> higher comes first
+     *
+     * @param array $a
+     * @param array $b
+     */
+    public function extensions(array $a, array $b): int
+    {
+        if ($a['active'] && !$b['active']) {
+            return -1;
+        }
+
+        if (!$a['active'] && $b['active']) {
+            return 1;
+        }
+
+        return $b['priority'] <=> $a['priority'];
+    }
+
+    public static function siteId(Staticroute $a, Staticroute $b): int
+    {
+        return $a->getSiteId() <=> $b->getSiteId();
+    }
+
+    /**
+     * Order by key length, longer key have priority
+     * (%abcd prior %ab, so that %ab doesn't replace %ab in [%ab]cd)
+     * @param string|null $a
+     * @param string|null $b
+     */
+    public static function strlen(?string $a, ?string $b): int
+    {
+        return strlen($b) <=> strlen($a);
+    }
+
+    public static function cpath(array $a, array $b): int
+    {
+        return strcmp($a['cpath'], $b['cpath']);
+    }
+
+    public static function filesize(array $a, array $b): int
+    {
+        return strcmp($a['filesize'], $b['filesize']);
+    }
+
+    public static function display(array $a, array $b): int
+    {
+        return strcmp($a['display'], $b['display']);
+    }
+
+    public static function itemPriority(CacheQueueItem|ItemInterface|WorkflowConfig $a, CacheQueueItem|ItemInterface|WorkflowConfig $b): int
+    {
+        return $a->getPriority() <=> $b->getPriority();
+    }
+
+    public static function namePath(Tag $a, Tag $b): int
+    {
+        return strcmp($a->getNamePath(), $b->getNamePath());
+    }
+
+    public static function count(TargetGroupAssignment $a, TargetGroupAssignment $b): int
+    {
+        return $a->getCount() <=> $b->getCount();
+    }
+
+    /**
+     * @see DataProviderInterface::getSortPriority()
+     * Higher is sorted first so $b is to the left of $a in the comparison
+     *
+     * @param DataProviderInterface $a
+     * @param DataProviderInterface $b
+     */
+    public static function sortPriority(DataProviderInterface $a, DataProviderInterface $b): int
+    {
+        return $b->getSortPriority() <=> $a->getSortPriority();
+    }
+}

--- a/lib/Tool/Sorter.php
+++ b/lib/Tool/Sorter.php
@@ -108,7 +108,7 @@ class Sorter
      */
     public static function strlen(?string $a, ?string $b): int
     {
-        return strlen($b) <=> strlen($a);
+        return strlen($b ?? '') <=> strlen($a ?? '');
     }
 
     public static function cpath(array $a, array $b): int

--- a/lib/Tool/Sorter.php
+++ b/lib/Tool/Sorter.php
@@ -128,7 +128,7 @@ class Sorter
 
     public static function itemPriority(CacheQueueItem|ItemInterface|WorkflowConfig $a, CacheQueueItem|ItemInterface|WorkflowConfig $b): int
     {
-        return $a->getPriority() <=> $b->getPriority();
+        return $b->getPriority() <=> $a->getPriority();
     }
 
     public static function namePath(Tag $a, Tag $b): int

--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -22,6 +22,7 @@ use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Document\PageSnippet;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\ValidationException;
+use Pimcore\Tool\Sorter;
 use Pimcore\Workflow\EventSubscriber\ChangePublishedStateSubscriber;
 use Pimcore\Workflow\EventSubscriber\NotesSubscriber;
 use Pimcore\Workflow\MarkingStore\StateTableMarkingStore;
@@ -162,9 +163,7 @@ class Manager
     {
         $this->workflows[$workflowName] = new WorkflowConfig($workflowName, $options);
 
-        uasort($this->workflows, function (WorkflowConfig $a, WorkflowConfig $b) {
-            return $b->getPriority() <=> $a->getPriority();
-        });
+        uasort($this->workflows, [Sorter::class, 'itemPriority']);
     }
 
     /**

--- a/models/Asset/Dao.php
+++ b/models/Asset/Dao.php
@@ -21,6 +21,7 @@ use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Asset\MetaData\ClassDefinition\Data\Data;
 use Pimcore\Tool\Serialize;
+use Pimcore\Tool\Sorter;
 
 /**
  * @internal
@@ -224,9 +225,7 @@ class Dao extends Model\Element\Dao
         $propertiesRaw = $this->db->fetchAll('SELECT * FROM properties WHERE ((cid IN (' . implode(',', $parentIds) . ") AND inheritable = 1) OR cid = ? )  AND ctype='asset'", [$this->model->getId()]);
 
         // because this should be faster than mysql
-        usort($propertiesRaw, function ($left, $right) {
-            return strcmp($left['cpath'], $right['cpath']);
-        });
+        usort($propertiesRaw, [Sorter::class, 'cpath']);
 
         foreach ($propertiesRaw as $propertyRaw) {
             try {

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -19,6 +19,7 @@ use Pimcore\Db;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
+use Pimcore\Tool\Sorter;
 
 /**
  * @internal
@@ -242,9 +243,7 @@ class Dao extends Model\Element\Dao
         $propertiesRaw = $this->db->fetchAll('SELECT name, type, data, cid, inheritable, cpath FROM properties WHERE ((cid IN (' . implode(',', $parentIds) . ") AND inheritable = 1) OR cid = ? ) AND ctype='object'", [$this->model->getId()]);
 
         // because this should be faster than mysql
-        usort($propertiesRaw, function ($left, $right) {
-            return strcmp($left['cpath'], $right['cpath']);
-        });
+        usort($propertiesRaw, [Sorter::class, 'cpath']);
 
         foreach ($propertiesRaw as $propertyRaw) {
             try {

--- a/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
@@ -21,6 +21,7 @@ use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\ClassDefinition\Data\CustomResourcePersistingInterface;
 use Pimcore\Model\Element;
+use Pimcore\Tool\Sorter;
 
 abstract class AbstractRelations extends Data implements
     CustomResourcePersistingInterface,
@@ -165,13 +166,7 @@ abstract class AbstractRelations extends Data implements
 
         // using PHP sorting to order the relations, because "ORDER BY index ASC" in the queries above will cause a
         // filesort in MySQL which is extremely slow especially when there are millions of relations in the database
-        usort($relations, function ($a, $b) {
-            if ($a['index'] == $b['index']) {
-                return 0;
-            }
-
-            return ($a['index'] < $b['index']) ? -1 : 1;
-        });
+        usort($relations, [Sorter::class, 'index']);
 
         $data = $this->loadData($relations, $object, $params);
         if ($object instanceof Element\DirtyIndicatorInterface && $data['dirty']) {

--- a/models/Document/Dao.php
+++ b/models/Document/Dao.php
@@ -18,6 +18,7 @@ namespace Pimcore\Model\Document;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Tool\Serialize;
+use Pimcore\Tool\Sorter;
 
 /**
  * @internal
@@ -265,9 +266,7 @@ class Dao extends Model\Element\Dao
         }
 
         // because this should be faster than mysql
-        usort($propertiesRaw, function ($left, $right) {
-            return strcmp($left['cpath'], $right['cpath']);
-        });
+        usort($propertiesRaw, [Sorter::class, 'cpath']);
 
         foreach ($propertiesRaw as $propertyRaw) {
             try {

--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -620,22 +620,10 @@ class Areablock extends Model\Document\Editable implements BlockInterface
         }
 
         // sort with translated names
-        if (count($result['name'])) {
-            usort($result['name'], function ($a, $b) {
-                if ($a['name'] == $b['name']) {
-                    return 0;
-                }
-
-                return ($a['name'] < $b['name']) ? -1 : 1;
-            });
-        }
+        usort($result['name'], [Tool\Sorter::class, 'name']);
 
         // sort by allowed brick config order
-        if (count($result['index'])) {
-            usort($result['index'], function ($a, $b) {
-                return $a['sortIndex'] - $b['sortIndex'];
-            });
-        }
+        usort($result['index'], [Tool\Sorter::class, 'sortIndex']);
 
         $result = array_merge($result['index'], $result['name']);
 

--- a/models/Document/Editable/Scheduledblock.php
+++ b/models/Document/Editable/Scheduledblock.php
@@ -19,6 +19,7 @@ use Pimcore\Bundle\CoreBundle\EventListener\Frontend\FullPageCacheListener;
 use Pimcore\Document\Editable\Block\BlockName;
 use Pimcore\Http\Request\Resolver\OutputTimestampResolver;
 use Pimcore\Tool\HtmlUtils;
+use Pimcore\Tool\Sorter;
 
 /**
  * @method \Pimcore\Model\Document\Editable\Dao getDao()
@@ -47,13 +48,7 @@ class Scheduledblock extends Block implements BlockInterface
     {
         $this->indices = $data;
 
-        usort($this->indices, function ($left, $right) {
-            if ($left['date'] == $right['date']) {
-                return 0;
-            }
-
-            return ($left['date'] < $right['date']) ? -1 : 1;
-        });
+        usort($this->indices, [Sorter::class, 'date']);
 
         return $this;
     }

--- a/models/Element/Tag/Dao.php
+++ b/models/Element/Tag/Dao.php
@@ -17,6 +17,7 @@ namespace Pimcore\Model\Element\Tag;
 
 use Pimcore\Model;
 use Pimcore\Model\Element\Tag;
+use Pimcore\Tool\Sorter;
 
 /**
  * @internal
@@ -133,9 +134,7 @@ class Dao extends Model\Dao\AbstractDao
         }
 
         $tags = array_filter($tags);
-        @usort($tags, function ($left, $right) {
-            return strcmp($left->getNamePath(), $right->getNamePath());
-        });
+        @usort($tags, [Sorter::class, 'namePath']);
 
         return $tags;
     }

--- a/models/Staticroute.php
+++ b/models/Staticroute.php
@@ -17,6 +17,7 @@ namespace Pimcore\Model;
 
 use Pimcore\Event\FrontendEvents;
 use Pimcore\Model\Exception\NotFoundException;
+use Pimcore\Tool\Sorter;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -460,11 +461,7 @@ final class Staticroute extends AbstractModel
         $forbiddenCharacters = ['#', ':', '?'];
 
         // check for named variables
-        uksort($urlParams, function ($a, $b) {
-            // order by key length, longer key have priority
-            // (%abcd prior %ab, so that %ab doesn't replace %ab in [%ab]cd)
-            return strlen($b) - strlen($a);
-        });
+        uksort($urlParams, [Sorter::class, 'strlen']);
 
         $tmpReversePattern = $this->getReverse();
         foreach ($urlParams as $key => $param) {
@@ -485,11 +482,7 @@ final class Staticroute extends AbstractModel
         $urlEncodeEscapeCharacters = '~|urlen' . md5(microtime()) . 'code|~';
 
         // replace named variables
-        uksort($parametersInReversePattern, function ($a, $b) {
-            // order by key length, longer key have priority
-            // (%abcd prior %ab, so that %ab doesn't replace %ab in [%ab]cd)
-            return strlen($b) - strlen($a);
-        });
+        uksort($parametersInReversePattern, [Sorter::class, 'strlen']);
 
         foreach ($parametersInReversePattern as $key => $value) {
             $value = str_replace($forbiddenCharacters, '', $value);

--- a/models/Staticroute/Dao.php
+++ b/models/Staticroute/Dao.php
@@ -17,6 +17,7 @@ namespace Pimcore\Model\Staticroute;
 
 use Pimcore\Model;
 use Pimcore\Model\Exception\NotFoundException;
+use Pimcore\Tool\Sorter;
 use Symfony\Component\Uid\Uuid as Uid;
 
 /**
@@ -116,13 +117,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
             return false;
         });
 
-        usort($data, function (Model\Staticroute $a, Model\Staticroute $b) {
-            if ($a->getSiteId() == $b->getSiteId()) {
-                return 0;
-            }
-
-            return ($a->getSiteId() < $b->getSiteId()) ? 1 : -1;
-        });
+        usort($data, [Sorter::class, 'siteId']);
 
         if (count($data) && $data[0]->getId()) {
             $this->assignVariablesToModel($data[0]->getObjectVars());


### PR DESCRIPTION
This PR started as a "housekeeping" thing to make all the sorters as static functions and use the spaceship operator. But then I got the idea that perhaps all these could be collected into a single utility class because there were a lot of overlap (code re-use yay!).

I also noticed think this could be the starting point for a wider normalization of array shapes and serve as a reminder that every time a new array (or object) structure is introduced which is intended to be sorted by PHP its sortable attribute should conform to existing ones.

Thoughts?