### PR TITLE
Cache get has to apply the same conditions as cache set.

### DIFF
--- a/bundles/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/FullPageCacheListener.php
@@ -228,6 +228,12 @@ class FullPageCacheListener
                     }
                 }
 
+                if ($this->sessionStatus->isDisabledBySession($request)) {
+                    $this->disable('Session in use');
+
+                    return;
+                }
+                
                 // output-cache is always disabled when logged in at the admin ui
                 if (null !== $pimcoreUser = Tool\Authentication::authenticateSession($request)) {
                     $this->disable('backend user is logged in');


### PR DESCRIPTION
`FullPageCacheListener` skips storing the responses to the cache if a session is active - _BUT_ it does not check for an active Session when checking for a cached response.
This means as soon as someone without a session (anonymous) accessed a page the response will be available in the cache.
Now even if a user with a session accesses the site `FullPageCacheListener` will find a cached response because it completely ignores the Session when looking for a cached version and has no variance in the cache key either.

Fundamental rule for caching should be to apply the same rule set / cache key for setting and getting cache items.
This is currently violated by having the `$this->sessionStatus->isDisabledBySession($request)` check only present when setting the cache.