### PR TITLE
[UI] Fixed 1px white line at the top of main tabs on certain display scalings

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/admin.css
+++ b/bundles/AdminBundle/Resources/public/css/admin.css
@@ -1416,7 +1416,8 @@ span.warning {
 
 #pimcore_panel_tabs > .x-panel-bodyWrap > .x-panel-body > .x-tabpanel-child {
     border-color: #393C3F;
-    border-top-width: 3px;
+    border-top-width: 2px;
+    background: #393C3F;
 }
 
 #pimcore_panel_tabs > .x-panel-bodyWrap > .x-tab-bar .x-tab-close-btn {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/142037/141100261-b9f77d28-24db-4a70-bfda-72d8c7ef98f9.png)


Just happens on certain scalings (for me when using 150%). 