### PR TITLE
Fix Warning: Undefined array key "sort"

### DIFF
--- a/lib/Helper/Dashboard.php
+++ b/lib/Helper/Dashboard.php
@@ -85,8 +85,8 @@ final class Dashboard
 
             if (empty($this->dashboards)) {
                 $perspectiveCfg = \Pimcore\Perspective\Config::getRuntimePerspective();
-                $dasboardCfg = $perspectiveCfg['dashboards'] ?? [];
-                $this->dashboards = $dasboardCfg['predefined'] ?? [];
+                $dashboardCfg = $perspectiveCfg['dashboards'] ?? [];
+                $this->dashboards = $dashboardCfg['predefined'] ?? [];
             }
         }
 
@@ -163,8 +163,8 @@ final class Dashboard
     public function getDisabledPortlets()
     {
         $perspectiveCfg = \Pimcore\Perspective\Config::getRuntimePerspective($this->user);
-        $dasboardCfg = $perspectiveCfg['dashboards'] ?? [];
+        $dashboardCfg = $perspectiveCfg['dashboards'] ?? [];
 
-        return $dasboardCfg['disabledPortlets'] ?? [];
+        return $dashboardCfg['disabledPortlets'] ?? [];
     }
 }

--- a/lib/Perspective/Config.php
+++ b/lib/Perspective/Config.php
@@ -335,8 +335,8 @@ final class Config
         }
 
         usort($result, static function ($treeA, $treeB) {
-            $a = $treeA['sort'] ?: 0;
-            $b = $treeB['sort'] ?: 0;
+            $a = $treeA['sort'] ?? 0;
+            $b = $treeB['sort'] ?? 0;
 
             return $a <=> $b;
         });


### PR DESCRIPTION
If the sort setting is missing.
For example:
```
pimcore:
    perspectives:
        definitions:
            default:
                elementTree:
                    -
                        type: documents
                        position: left
                    -
                        type: assets
                        position: left
                        sort: 1
                    -
                        type: objects
                        position: left
                        sort: 2
                iconCls: pimcore_nav_icon_perspective
```