### PR TITLE
[DataObject] Objectbricks - Fix mandatory field check for inherited values when parent brick doesn't exist

### DIFF
--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -527,7 +527,7 @@ final class Localizedfield extends Model\AbstractModel implements
                                 }
                             }
 
-                            if (method_exists($parentContainer, $method)) {
+                            if ($parentContainer && method_exists($parentContainer, $method)) {
                                 $localizedFields = $parentContainer->getLocalizedFields();
                                 if ($localizedFields instanceof Localizedfield) {
                                     if ($localizedFields->getObject()->getId() != $this->getObject()->getId()) {


### PR DESCRIPTION
## Changes in this pull request  
Resolves #10786

## Additional info  

