### PR TITLE
Fix unserialize for versions generated in pimcore6

### DIFF
--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -81,9 +81,9 @@ final class Localizedfield extends Model\AbstractModel implements
     /**
      * @internal
      *
-     * @var array
+     * @var array|null
      */
-    protected array $context = [];
+    protected ?array $context = [];
 
     /**
      * @internal
@@ -717,15 +717,15 @@ final class Localizedfield extends Model\AbstractModel implements
      */
     public function getContext(): array
     {
-        return $this->context;
+        return $this->context ?? [];
     }
 
     /**
-     * @param array $context
+     * @param array|null $context
      */
-    public function setContext(array $context): void
+    public function setContext(?array $context): void
     {
-        $this->context = $context;
+        $this->context = $context ?? [];
     }
 
     /**


### PR DESCRIPTION
Fix unserialize for versions generated in pimcore6: Cannot assign null to property Pimcore\Model\DataObject\Localizedfield:: of type array
<img width="802" alt="Screenshot 2021-11-12 at 15 39 50" src="https://user-images.githubusercontent.com/6807023/141476184-e4f733f4-1d00-479f-9488-36cc1dc19765.png">
y
