### PR TITLE
Data import improve logs

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/log/admin.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/log/admin.js
@@ -193,6 +193,7 @@ pimcore.log.admin = Class.create({
                     flex: 220,
                     sortable: true,
                     renderer: function (s) {
+                        meta.tdAttr='data-qtip="'+s+'"';
                         return Ext.util.Format.htmlEncode(s);
                     }
                 },{


### PR DESCRIPTION
Adding tooltip about the Datarow values.

Instead of clicking the open to see the row values, users can just hover to the messages to get information

Related to this [improvement](https://github.com/pimcore/data-importer/issues/111)