### PR TITLE
[Elements] Show in tree does not work when using HTML special characters in element key

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -680,6 +680,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         $tmpAsset = [
             'id' => $asset->getId(),
+            'key' => $element->getKey(),
             'text' => htmlspecialchars($asset->getFilename()),
             'type' => $asset->getType(),
             'path' => $asset->getRealFullPath(),

--- a/bundles/AdminBundle/Controller/Traits/DocumentTreeConfigTrait.php
+++ b/bundles/AdminBundle/Controller/Traits/DocumentTreeConfigTrait.php
@@ -46,6 +46,7 @@ trait DocumentTreeConfigTrait
 
         $tmpDocument = [
             'id' => $childDocument->getId(),
+            'key' => $childDocument->getKey(),
             'idx' => (int)$childDocument->getIndex(),
             'text' => $childDocument->getKey(),
             'type' => $childDocument->getType(),

--- a/bundles/AdminBundle/Resources/public/js/pimcore/treenodelocator.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/treenodelocator.js
@@ -464,19 +464,19 @@ pimcore.treenodelocator = function()
          * Returns the direction (-1/+1/0) for elements sorted by key.
          */
         getDirectionForElementsSortedByKey: function (elementKey, elementType, firstElementChild, lastElementChild) {
-            if(elementType === 'asset' && lastElementChild && lastElementChild.data.type === 'folder') {
+            if(elementType === 'asset' && lastElementChild && lastElementChild.get('type') === 'folder') {
                 return 1;
             }
 
-            if(elementType === 'folder' && firstElementChild && firstElementChild.data.type === 'asset') {
+            if(elementType === 'folder' && firstElementChild && firstElementChild.get('type') === 'asset') {
                 return -1;
             }
 
-            if (firstElementChild && elementKey.toUpperCase() < firstElementChild.data.text.toUpperCase()) {
+            if (firstElementChild && elementKey.toUpperCase() < firstElementChild.get('key').toUpperCase()) {
                 return -1;
             }
 
-            if (lastElementChild && elementKey.toUpperCase() > lastElementChild.data.text.toUpperCase()) {
+            if (lastElementChild && elementKey.toUpperCase() > lastElementChild.get('key').toUpperCase()) {
                 return 1;
             }
 

--- a/lib/Image/Optimizer/AbstractCommandOptimizer.php
+++ b/lib/Image/Optimizer/AbstractCommandOptimizer.php
@@ -33,7 +33,6 @@ abstract class AbstractCommandOptimizer implements OptimizerInterface
 
             Console::addLowProcessPriority($command);
             $process = new Process($command);
-            $process->setTimeout(null);
             $process->run();
 
             if (file_exists($output) && filesize($output) > 0) {

--- a/lib/Image/Optimizer/AbstractCommandOptimizer.php
+++ b/lib/Image/Optimizer/AbstractCommandOptimizer.php
@@ -33,6 +33,7 @@ abstract class AbstractCommandOptimizer implements OptimizerInterface
 
             Console::addLowProcessPriority($command);
             $process = new Process($command);
+            $process->setTimeout(null);
             $process->run();
 
             if (file_exists($output) && filesize($output) > 0) {


### PR DESCRIPTION
Steps to reproduce:
1. Create data object named `Sneaker "test"` in a folder
2. Copy and paste this object 30 times until you get a pagination in the data object tree
3. Open the object on page 2 (should be named `Sneaker "test"_copy_9`
4. Reload data object tree or navigate to page 1 in the folder
4. Click `Show in tree` button

Object does not get found.

The reason is that in https://github.com/pimcore/pimcore/blob/bdba843682564b55292ae2c2ae724186d82db0d8/bundles/AdminBundle/Resources/public/js/pimcore/treenodelocator.js#L475-L481 the `text` of the tree item gets used. This gets filled in https://github.com/pimcore/pimcore/blob/bdba843682564b55292ae2c2ae724186d82db0d8/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php#L267

This `htmlspecialchars()` causes that in above JS function `getDirectionForElementsSortedByKey`
`elementKey.toUpperCase() = 'SNEAKER "TEST"_COPY_9"'`
`firstElementChild.data.text.toUpperCase() = 'SNEAKER &quot;TEST&quot;_COPY_9"'`

Because of this the comparison goes wrong and the pagination returns `-1` and thus does not go to page 2.

With this PR the real element key gets used for comparison.

Also resolves #6526