### PR TITLE
Elements expand icon issue with user permissions

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -697,11 +697,13 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             ],
         ];
 
+        $hasChildren = (bool)$asset->getChildAmount($this->getAdminUser());
+
         // set type specific settings
         if ($asset instanceof Asset\Folder) {
             $tmpAsset['leaf'] = false;
-            $tmpAsset['expanded'] = !$asset->hasChildren();
-            $tmpAsset['loaded'] = !$asset->hasChildren();
+            $tmpAsset['expanded'] = !$hasChildren;
+            $tmpAsset['loaded'] = !$hasChildren;
             $tmpAsset['permissions']['create'] = $asset->isAllowed('create');
             $tmpAsset['thumbnail'] = $this->getThumbnailUrl($asset);
         } else {

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -278,12 +278,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             $allowedTypes[] = DataObject::OBJECT_TYPE_VARIANT;
         }
 
-        $hasChildren = $child->hasChildren($allowedTypes);
+        $hasChildren = (bool)$child->getChildAmount($allowedTypes, $this->getAdminUser());
 
-        $tmpObject['isTarget'] = false;
         $tmpObject['allowDrop'] = false;
-        $tmpObject['allowChildren'] = false;
-
         $tmpObject['leaf'] = !$hasChildren;
 
         $tmpObject['isTarget'] = true;

--- a/bundles/AdminBundle/Controller/Traits/DocumentTreeConfigTrait.php
+++ b/bundles/AdminBundle/Controller/Traits/DocumentTreeConfigTrait.php
@@ -19,6 +19,7 @@ use Pimcore\Config;
 use Pimcore\Event\Admin\ElementAdminStyleEvent;
 use Pimcore\Model\Document;
 use Pimcore\Model\Site;
+use Pimcore\Tool\Admin;
 use Pimcore\Tool\Frontend;
 
 /**
@@ -68,14 +69,16 @@ trait DocumentTreeConfigTrait
             ],
         ];
 
+        $hasChildren = (bool)$childDocument->getChildAmount(Admin::getCurrentUser());
+
         // add icon
-        $tmpDocument['expandable'] = $childDocument->hasChildren();
-        $tmpDocument['loaded'] = !$childDocument->hasChildren();
+        $tmpDocument['expandable'] = $hasChildren;
+        $tmpDocument['loaded'] = !$hasChildren;
 
         // set type specific settings
         if ($childDocument->getType() == 'page') {
             $tmpDocument['leaf'] = false;
-            $tmpDocument['expanded'] = !$childDocument->hasChildren();
+            $tmpDocument['expanded'] = !$hasChildren;
 
             // test for a site
             if ($site = Site::getByRootId($childDocument->getId())) {
@@ -84,7 +87,7 @@ trait DocumentTreeConfigTrait
             }
         } elseif ($childDocument->getType() == 'folder' || $childDocument->getType() == 'link' || $childDocument->getType() == 'hardlink') {
             $tmpDocument['leaf'] = false;
-            $tmpDocument['expanded'] = !$childDocument->hasChildren();
+            $tmpDocument['expanded'] = !$hasChildren;
         } elseif (method_exists($childDocument, 'getTreeNodeConfig')) {
             $tmp = $childDocument->getTreeNodeConfig();
             $tmpDocument = array_merge($tmpDocument, $tmp);


### PR DESCRIPTION
If we define objects like this 
![Screenshot from 2021-11-16 14-00-10](https://user-images.githubusercontent.com/35298078/142059454-781b91c5-dd09-4af9-a14e-dbf5b024d712.png)

and then define workspaces for user like this
![Screenshot from 2021-11-16 14-00-55](https://user-images.githubusercontent.com/35298078/142059486-db7db15b-5176-4f4c-bb47-e37a612bc6f4.png)

When that user opens object tree he will see expand icon (+ plus icon) even though he doesn't have permission to see neither child objects, after click on plus icon the icon will disappear.

![Screenshot from 2021-11-16 14-03-42](https://user-images.githubusercontent.com/35298078/142059951-64901ad5-cc40-44f2-8347-c26a344d8a1e.png)

![Screenshot from 2021-11-16 14-03-50](https://user-images.githubusercontent.com/35298078/142059979-f44d88a6-c790-4565-b1f6-219c057c3494.png)

Same thing happens to documents and assets too.

Issue is caused because hasChildren method doesn't check user permissions. So fix for this can be if we use different method but maybe checking for user permissions needs to be added to hasChildren method.



