### PR TITLE
PHP CLI executable not found when open_basedir is used

### DIFF
--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -18,6 +18,7 @@ namespace Pimcore\Tool;
 use Pimcore\Config;
 use Pimcore\Logger;
 use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
 final class Console
@@ -178,7 +179,16 @@ final class Console
      */
     public static function getPhpCli()
     {
-        return self::getExecutable('php', true);
+        try {
+            return self::getExecutable('php', true);
+        } catch(\Exception $e) {
+            $phpFinder = new PhpExecutableFinder();
+            $phpPath = $phpFinder->find(true);
+            if (!$phpPath) {
+                throw $e;
+            }
+            return $phpPath;
+        }
     }
 
     /**


### PR DESCRIPTION
Since Pimcore 6.9 Symfony's `ExecutableFinder` is used to find CLI executables. But when you use open_basedir, the `ExecutableFinder` only searches for the requested application within the allowed open_basedir directories - even if you have the path for the requested application in your `PATH` environment variable, see https://github.com/symfony/symfony/blob/dd8c1dd9bac12563dcd962c9fd7e7ad1af9120b5/src/Symfony/Component/Process/ExecutableFinder.php#L51-L64

I am not an expert if this is correct but @fabpot says so in https://github.com/symfony/symfony/pull/1042#issuecomment-1221687
Actually imho the PHP docs say about `open_basedir`:
> Limit the files that can be accessed by PHP to the specified directory-tree, including the file itself.
> When a script tries to access the filesystem, for example using include, or fopen(), the location of the file is checked. When the file is outside the specified directory-tree, PHP will refuse to access it.

We actually do not want to access the file with PHP but to get the path of the binary and then execute it. I think this is the difference between `open_ basedir` and `PATH`.
I have also posted this at https://github.com/symfony/symfony/issues/41006#issuecomment-971318325

Until Pimcore 6.8 we used `which` to find the executable (which uses the configured PATH and does not care about any PHP settings), see https://github.com/pimcore/pimcore/blob/01ae62571cb2d738cc9b166dad7b0622ab5cbc1d/lib/Tool/Console.php#L112
But let's dicuss this `open_basedir` problem at Symfony... 

Back to Pimcore: Symfony offers a special `PhpExecutableFinder`. This does not care about open_basedir and accesses the PHP constant `PHP_BINARY` which is better then trying to find the executable in directories. Because it is some kind of strange when we have a PHP application which tells us that it cannot find the PHP binary. For this reason this PR uses the `PhpExecutableFinder` as fallback for `Console::getPhpCli()`.