### PR TITLE
Throw exception when executable cannot be found and this is cached

### DIFF
--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -64,6 +64,9 @@ final class Console
     public static function getExecutable($name, $throwException = false)
     {
         if (isset(self::$executableCache[$name])) {
+            if(!self::$executableCache[$name] && $throwException) {
+                throw new \Exception("No '$name' executable found, please install the application or add it to the PATH (in system settings or to your PATH environment variable");
+            }
             return self::$executableCache[$name];
         }
 


### PR DESCRIPTION
Steps to reproduce bug:
```php
try {
  \Pimcore\Tool\Console::getExecutable('non-existing-app', true);
  echo 'Found'.PHP_EOL;
} catch(\Exception $e) {
  echo 'Not found'.PHP_EOL;
}

try {
  \Pimcore\Tool\Console::getExecutable('non-existing-app', true);
  echo 'Found'.PHP_EOL;
} catch(\Exception $e) {
  echo 'Not found'.PHP_EOL;
}
```

This outputs 
```
Not found
Found
```

The reason is that in the first call the not found binary gets cached in https://github.com/pimcore/pimcore/blob/54b10266f3ca5982a41b0cfdc53a12e03e42ca05/lib/Tool/Console.php#L135

And then in the second call we go here:
https://github.com/pimcore/pimcore/blob/54b10266f3ca5982a41b0cfdc53a12e03e42ca05/lib/Tool/Console.php#L66-L68
And there the `false` gets returned.
With this PR an exception gets thrown.