### PR TITLE
Add DefinitionWriteException and catch this in migrations

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20210107103923.php
+++ b/bundles/CoreBundle/Migrations/Version20210107103923.php
@@ -33,34 +33,33 @@ final class Version20210107103923 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $list = new DataObject\ClassDefinition\Listing();
-        foreach ($list->getClasses() as $class) {
-            $this->write(sprintf('Saving class: %s', $class->getName()));
-            try {
+        try {
+            $list = new DataObject\ClassDefinition\Listing();
+            foreach ($list->getClasses() as $class) {
+                $this->write(sprintf('Saving class: %s', $class->getName()));
                 $class->save();
-            } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
-                $this->write($e->getMessage());
             }
-        }
 
-        $list = new DataObject\Objectbrick\Definition\Listing();
-        foreach ($list->load() as $brickDefinition) {
-            $this->write(sprintf('Saving object brick: %s', $brickDefinition->getKey()));
-            try {
+            $list = new DataObject\Objectbrick\Definition\Listing();
+            foreach ($list->load() as $brickDefinition) {
+                $this->write(sprintf('Saving object brick: %s', $brickDefinition->getKey()));
                 $brickDefinition->save();
-            } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
-                $this->write($e->getMessage());
             }
-        }
 
-        $list = new DataObject\Fieldcollection\Definition\Listing();
-        foreach ($list->load() as $fc) {
-            $this->write(sprintf('Saving field collection: %s', $fc->getKey()));
-            try {
+            $list = new DataObject\Fieldcollection\Definition\Listing();
+            foreach ($list->load() as $fc) {
+                $this->write(sprintf('Saving field collection: %s', $fc->getKey()));
                 $fc->save();
-            } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
-                $this->write($e->getMessage());
             }
+        } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
+            $this->write(
+                'Could not write class definition file. Please set PIMCORE_CLASS_DEFINITION_WRITABLE env.' . "\n" .
+                sprintf(
+                    'If you already have migrate the definitions you can skip this migration via "php bin/console doctrine:migrations:version --add %s"',
+                    __CLASS__
+                )
+            );
+            throw $e;
         }
     }
 

--- a/bundles/CoreBundle/Migrations/Version20210107103923.php
+++ b/bundles/CoreBundle/Migrations/Version20210107103923.php
@@ -51,7 +51,7 @@ final class Version20210107103923 extends AbstractMigration
                 $this->write(sprintf('Saving field collection: %s', $fc->getKey()));
                 $fc->save();
             }
-        } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
+        } catch (DataObject\Exception\DefinitionWriteException $e) {
             $this->write(
                 'Could not write class definition file. Please set PIMCORE_CLASS_DEFINITION_WRITABLE env.' . "\n" .
                 sprintf(

--- a/bundles/CoreBundle/Migrations/Version20210107103923.php
+++ b/bundles/CoreBundle/Migrations/Version20210107103923.php
@@ -34,25 +34,33 @@ final class Version20210107103923 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $list = new DataObject\ClassDefinition\Listing();
-        $list = $list->load();
-
-        foreach ($list as $class) {
+        foreach ($list->getClasses() as $class) {
             $this->write(sprintf('Saving class: %s', $class->getName()));
-            $class->save();
+            try {
+                $class->save();
+            } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
+                $this->write($e->getMessage());
+            }
         }
 
         $list = new DataObject\Objectbrick\Definition\Listing();
-        $list = $list->load();
-        foreach ($list as $brickDefinition) {
+        foreach ($list->load() as $brickDefinition) {
             $this->write(sprintf('Saving object brick: %s', $brickDefinition->getKey()));
-            $brickDefinition->save();
+            try {
+                $brickDefinition->save();
+            } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
+                $this->write($e->getMessage());
+            }
         }
 
         $list = new DataObject\Fieldcollection\Definition\Listing();
-        $list = $list->load();
-        foreach ($list as $fc) {
+        foreach ($list->load() as $fc) {
             $this->write(sprintf('Saving field collection: %s', $fc->getKey()));
-            $fc->save();
+            try {
+                $fc->save();
+            } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
+                $this->write($e->getMessage());
+            }
         }
     }
 

--- a/bundles/CoreBundle/Migrations/Version20210706090823.php
+++ b/bundles/CoreBundle/Migrations/Version20210706090823.php
@@ -34,24 +34,33 @@ final class Version20210706090823 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $list = new DataObject\ClassDefinition\Listing();
-        $list = $list->load();
-        foreach ($list as $class) {
+        foreach ($list->getClasses() as $class) {
             $this->write(sprintf('Saving class: %s', $class->getName()));
-            $class->save();
+            try {
+                $class->save();
+            } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
+                $this->write($e->getMessage());
+            }
         }
 
         $list = new DataObject\Objectbrick\Definition\Listing();
-        $list = $list->load();
-        foreach ($list as $brickDefinition) {
+        foreach ($list->load() as $brickDefinition) {
             $this->write(sprintf('Saving object brick: %s', $brickDefinition->getKey()));
-            $brickDefinition->save();
+            try {
+                $brickDefinition->save();
+            } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
+                $this->write($e->getMessage());
+            }
         }
 
         $list = new DataObject\Fieldcollection\Definition\Listing();
-        $list = $list->load();
-        foreach ($list as $fc) {
+        foreach ($list->load() as $fc) {
             $this->write(sprintf('Saving field collection: %s', $fc->getKey()));
-            $fc->save();
+            try {
+                $fc->save();
+            } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
+                $this->write($e->getMessage());
+            }
         }
     }
 

--- a/bundles/CoreBundle/Migrations/Version20210706090823.php
+++ b/bundles/CoreBundle/Migrations/Version20210706090823.php
@@ -51,7 +51,7 @@ final class Version20210706090823 extends AbstractMigration
                 $this->write(sprintf('Saving field collection: %s', $fc->getKey()));
                 $fc->save();
             }
-        } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
+        } catch (DataObject\Exception\DefinitionWriteException $e) {
             $this->write(
                 'Could not write class definition file. Please set PIMCORE_CLASS_DEFINITION_WRITABLE env.' . "\n" .
                 sprintf(

--- a/bundles/CoreBundle/Migrations/Version20210706090823.php
+++ b/bundles/CoreBundle/Migrations/Version20210706090823.php
@@ -33,34 +33,33 @@ final class Version20210706090823 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $list = new DataObject\ClassDefinition\Listing();
-        foreach ($list->getClasses() as $class) {
-            $this->write(sprintf('Saving class: %s', $class->getName()));
-            try {
+        try {
+            $list = new DataObject\ClassDefinition\Listing();
+            foreach ($list->getClasses() as $class) {
+                $this->write(sprintf('Saving class: %s', $class->getName()));
                 $class->save();
-            } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
-                $this->write($e->getMessage());
             }
-        }
 
-        $list = new DataObject\Objectbrick\Definition\Listing();
-        foreach ($list->load() as $brickDefinition) {
-            $this->write(sprintf('Saving object brick: %s', $brickDefinition->getKey()));
-            try {
+            $list = new DataObject\Objectbrick\Definition\Listing();
+            foreach ($list->load() as $brickDefinition) {
+                $this->write(sprintf('Saving object brick: %s', $brickDefinition->getKey()));
                 $brickDefinition->save();
-            } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
-                $this->write($e->getMessage());
             }
-        }
 
-        $list = new DataObject\Fieldcollection\Definition\Listing();
-        foreach ($list->load() as $fc) {
-            $this->write(sprintf('Saving field collection: %s', $fc->getKey()));
-            try {
+            $list = new DataObject\Fieldcollection\Definition\Listing();
+            foreach ($list->load() as $fc) {
+                $this->write(sprintf('Saving field collection: %s', $fc->getKey()));
                 $fc->save();
-            } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
-                $this->write($e->getMessage());
             }
+        } catch (DataObject\ClassDefinition\Exception\WriteException $e) {
+            $this->write(
+                'Could not write class definition file. Please set PIMCORE_CLASS_DEFINITION_WRITABLE env.' . "\n" .
+                sprintf(
+                    'If you already have migrate the definitions you can skip this migration via "php bin/console doctrine:migrations:version --add %s"',
+                    __CLASS__
+                )
+            );
+            throw $e;
         }
     }
 

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -400,12 +400,12 @@ final class ClassDefinition extends Model\AbstractModel
      * @param bool $saveDefinitionFile
      *
      * @throws \Exception
-     * @throws DataObject\ClassDefinition\Exception\WriteException
+     * @throws DataObject\Exception\DefinitionWriteException
      */
     public function save($saveDefinitionFile = true)
     {
         if ($saveDefinitionFile && !$this->isWritable()) {
-            throw new DataObject\ClassDefinition\Exception\WriteException();
+            throw new DataObject\Exception\DefinitionWriteException();
         }
 
         $fieldDefinitions = $this->getFieldDefinitions();

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -400,11 +400,12 @@ final class ClassDefinition extends Model\AbstractModel
      * @param bool $saveDefinitionFile
      *
      * @throws \Exception
+     * @throws DataObject\ClassDefinition\Exception\WriteException
      */
     public function save($saveDefinitionFile = true)
     {
         if ($saveDefinitionFile && !$this->isWritable()) {
-            throw new \Exception(sprintf('Definitions in %s folder cannot be overwritten', PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY));
+            throw new DataObject\ClassDefinition\Exception\WriteException();
         }
 
         $fieldDefinitions = $this->getFieldDefinitions();

--- a/models/DataObject/ClassDefinition/CustomLayout.php
+++ b/models/DataObject/ClassDefinition/CustomLayout.php
@@ -187,11 +187,13 @@ class CustomLayout extends Model\AbstractModel
 
     /**
      * @param bool $saveDefinitionFile
+     *
+     * @throws DataObject\ClassDefinition\Exception\WriteException
      */
     public function save($saveDefinitionFile = true)
     {
         if ($saveDefinitionFile && !$this->isWritable()) {
-            throw new \Exception(sprintf('Definitions in %s folder cannot be overwritten', PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY));
+            throw new DataObject\ClassDefinition\Exception\WriteException();
         }
 
         $isUpdate = $this->exists();

--- a/models/DataObject/ClassDefinition/CustomLayout.php
+++ b/models/DataObject/ClassDefinition/CustomLayout.php
@@ -188,12 +188,12 @@ class CustomLayout extends Model\AbstractModel
     /**
      * @param bool $saveDefinitionFile
      *
-     * @throws DataObject\ClassDefinition\Exception\WriteException
+     * @throws DataObject\Exception\DefinitionWriteException
      */
     public function save($saveDefinitionFile = true)
     {
         if ($saveDefinitionFile && !$this->isWritable()) {
-            throw new DataObject\ClassDefinition\Exception\WriteException();
+            throw new DataObject\Exception\DefinitionWriteException();
         }
 
         $isUpdate = $this->exists();

--- a/models/DataObject/ClassDefinition/Exception/WriteException.php
+++ b/models/DataObject/ClassDefinition/Exception/WriteException.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Model\DataObject\ClassDefinition\Exception;
+
+class WriteException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct(sprintf('Definitions in %s folder cannot be overwritten', PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY));
+    }
+}

--- a/models/DataObject/Exception/DefinitionWriteException.php
+++ b/models/DataObject/Exception/DefinitionWriteException.php
@@ -13,9 +13,9 @@
  *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
-namespace Pimcore\Model\DataObject\ClassDefinition\Exception;
+namespace Pimcore\Model\DataObject\Exception;
 
-class WriteException extends \Exception
+class DefinitionWriteException extends \Exception
 {
     public function __construct()
     {

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -173,12 +173,12 @@ class Definition extends Model\AbstractModel
      * @param bool $generateDefinitionFile
      *
      * @throws \Exception
-     * @throws DataObject\ClassDefinition\Exception\WriteException
+     * @throws DataObject\Exception\DefinitionWriteException
      */
     protected function generateClassFiles($generateDefinitionFile = true)
     {
         if ($generateDefinitionFile && !$this->isWritable()) {
-            throw new DataObject\ClassDefinition\Exception\WriteException();
+            throw new DataObject\Exception\DefinitionWriteException();
         }
 
         $infoDocBlock = $this->getInfoDocBlock();

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -173,11 +173,12 @@ class Definition extends Model\AbstractModel
      * @param bool $generateDefinitionFile
      *
      * @throws \Exception
+     * @throws DataObject\ClassDefinition\Exception\WriteException
      */
     protected function generateClassFiles($generateDefinitionFile = true)
     {
         if ($generateDefinitionFile && !$this->isWritable()) {
-            throw new \Exception(sprintf('Definitions in %s folder cannot be overwritten', PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY));
+            throw new DataObject\ClassDefinition\Exception\WriteException();
         }
 
         $infoDocBlock = $this->getInfoDocBlock();

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -237,7 +237,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
     protected function generateClassFiles($generateDefinitionFile = true)
     {
         if ($generateDefinitionFile && !$this->isWritable()) {
-            throw new DataObject\ClassDefinition\Exception\WriteException();
+            throw new DataObject\Exception\DefinitionWriteException();
         }
 
         $definitionFile = $this->getDefinitionFile();

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -237,7 +237,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
     protected function generateClassFiles($generateDefinitionFile = true)
     {
         if ($generateDefinitionFile && !$this->isWritable()) {
-            throw new \Exception(sprintf('Definitions in %s folder cannot be overwritten', PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY));
+            throw new DataObject\ClassDefinition\Exception\WriteException();
         }
 
         $definitionFile = $this->getDefinitionFile();


### PR DESCRIPTION
If a class definition file is in the config/pimcore/classes folder it can't be saved. So the migrations failed. Should be catched and give the user a hint.