### PR TITLE
[Kernel] Remove ini_set() without effect of "PCRE recursion limit"

### DIFF
--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -416,9 +416,6 @@ abstract class Kernel extends SymfonyKernel
         // set internal character encoding to UTF-8
         mb_internal_encoding('UTF-8');
 
-        // this is for simple_dom_html
-        ini_set('pcre.recursion-limit', 100000);
-
         // zlib.output_compression conflicts with while (@ob_end_flush()) ;
         // see also: https://github.com/pimcore/pimcore/issues/291
         if (ini_get('zlib.output_compression')) {


### PR DESCRIPTION
The current call to ini_set() has no effect, as:
* Typo in ini identifier "pcre.recursion-limit" (dash instead of underscore)
* Bundled library simple_dom_html has been removed


