### PR TITLE
[DOCS] Prevent upgrading errors

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5/01_Update_from_5.x_to_5.4_or_above.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/01_Within_V5/01_Update_from_5.x_to_5.4_or_above.md
@@ -77,6 +77,10 @@ Replace the `scripts` and `autoload` sections in your `composer.json` with the f
       "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
     ]
   },
+  "conflict": {
+    "monolog/monolog": ">=2",
+    "symfony/monolog-bundle": "3.6.0"
+  },
 ```
 
 ## 4. Install Pimcore as Composer dependency 
@@ -126,7 +130,7 @@ php manual-migration.php 100
 
 Additionally we have to update to files in the project manually, use the following commands: 
 ```
-wget https://raw.githubusercontent.com/pimcore/skeleton/master/bin/console -O bin/console
+wget https://raw.githubusercontent.com/pimcore/skeleton/v1.3.0/bin/console -O bin/console
 chmod 0755 bin/console
 wget https://raw.githubusercontent.com/pimcore/skeleton/41b065b663e675a941586abcac705220c0404756/web/app.php -O web/app.php
 wget https://raw.githubusercontent.com/pimcore/demo-basic/master/app/AppKernel.php -O app/AppKernel.php


### PR DESCRIPTION
Add conflict with monolog bundle to prevent upgrading errors because of incompability with monolog
Do not use bin/console from master as it's version 10.x and does not fit the 5.x environment

## Changes in this pull request  
docs only
