### PR TITLE
Update select.js

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/select.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/select.js
@@ -266,18 +266,19 @@ pimcore.object.tags.select = Class.create(pimcore.object.tags.abstract, {
             store: store,
             componentCls: this.getWrapperClassNames(),
             width: 250,
-            displayField: 'key',
-            valueField: 'value',
-            labelWidth: 100
-        };
-
-        if(hasHTMLContent) {
-            options.displayTpl = Ext.create('Ext.XTemplate',
+            tpl: Ext.create('Ext.XTemplate',
+                '<ul class="x-list-plain"><tpl for=".">',
+                '<li role="option" class="x-boundlist-item">{key}</li>',
+                '</tpl></ul>'
+            ),
+            displayTpl: Ext.create('Ext.XTemplate',
                 '<tpl for=".">',
                 '{[Ext.util.Format.stripTags(values.key)]}',
                 '</tpl>'
-            );
-        }
+            ),
+            valueField: 'value',
+            labelWidth: 100
+        };
 
         if (this.fieldConfig.labelWidth) {
             options.labelWidth = this.fieldConfig.labelWidth;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20427487/142765238-65a5d8d4-4a39-4fda-a030-d28612e4c87d.png)
![image](https://user-images.githubusercontent.com/20427487/142765244-40c1562b-ee06-48c8-987b-1d2d103323e9.png)

The selected value of a ComboBox breaks when the key is Html. It seems to be caused by the sencha Library, reproducible in the sencha sandbox as well.
The changes resolve the problem with using a template for the options ("tpl") and a template for the selected value/key ("displayTpl"), and the problem causing dispalyfield is gone.

![image](https://user-images.githubusercontent.com/20427487/142765392-b3d8317d-9bad-4057-93df-5b80e84fd961.png)