### PR TITLE
[Workflow] Fix issue when creating element, ni ID given, unable to sa…

### DIFF
--- a/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
+++ b/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
@@ -59,9 +59,9 @@ class WorkflowManagementListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            DataObjectEvents::PRE_ADD => 'onElementPreAdd',
-            DocumentEvents::PRE_ADD => 'onElementPreAdd',
-            AssetEvents::PRE_ADD => 'onElementPreAdd',
+            DataObjectEvents::POST_ADD => 'onElementPreAdd',
+            DocumentEvents::POST_ADD => 'onElementPreAdd',
+            AssetEvents::POST_ADD => 'onElementPreAdd',
 
             DataObjectEvents::POST_DELETE => 'onElementPostDelete',
             DocumentEvents::POST_DELETE => 'onElementPostDelete',

--- a/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
+++ b/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
@@ -59,9 +59,9 @@ class WorkflowManagementListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            DataObjectEvents::POST_ADD => 'onElementPreAdd',
-            DocumentEvents::POST_ADD => 'onElementPreAdd',
-            AssetEvents::POST_ADD => 'onElementPreAdd',
+            DataObjectEvents::POST_ADD => 'onElementPostAdd',
+            DocumentEvents::POST_ADD => 'onElementPostAdd',
+            AssetEvents::POST_ADD => 'onElementPostAdd',
 
             DataObjectEvents::POST_DELETE => 'onElementPostDelete',
             DocumentEvents::POST_DELETE => 'onElementPostDelete',
@@ -76,7 +76,7 @@ class WorkflowManagementListener implements EventSubscriberInterface
     /**
      * Set initial place if defined on element create.
      */
-    public function onElementPreAdd(ElementEventInterface $e): void
+    public function onElementPostAdd(ElementEventInterface $e): void
     {
         /** @var Asset|Document|ConcreteObject $element */
         $element = $e->getElement();


### PR DESCRIPTION
Not entirely sure where this issue comes from, but actually calling `getMarking()` here: 
https://github.com/pimcore/pimcore/blob/412486842a2485016f198f616b317740cc0f1226/bundles/CoreBundle/EventListener/WorkflowManagementListener.php#L94 

triggers a workflow save, which fails because there is no element ID yet. 
Moving the event listener to post add solves the issue. 

How to reproduce: 
- Create new asset folder in our demo instance
- Error 😉