### PR TITLE
Option to allow free input in select editable

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/select.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/select.js
@@ -37,7 +37,7 @@ pimcore.document.editables.select = Class.create(pimcore.document.editable, {
 
         config.name = id + "_editable";
         config.triggerAction = 'all';
-        config.editable = false;
+        config.editable = config.editable ? config.editable : false;
         config.value = data;
 
         this.config = config;

--- a/doc/Development_Documentation/03_Documents/01_Editables/30_Select.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/30_Select.md
@@ -14,6 +14,7 @@ The select editable generates select-box component in Editmode.
 | `class`  | string  | A CSS class that is added to the surrounding container of this element in editmode |
 | `defaultValue`  | string   | A default value for the available options. Note: This value needs to be saved before calling getData() or use setDataFromResource().                          |
 | `required` | boolean  | (default: false) set to true to make field value required for publish    |
+| `editable` | boolean  | (default: false) set to true to allow custom option   |
 
 ## Methods
 


### PR DESCRIPTION
It would be usefull if we allow free input inside select editable by passing new option 'editable' when creating select editable