### PR TITLE
Object field name to title value fixer

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
@@ -114,7 +114,11 @@ pimcore.object.classes.data.data = Class.create({
                         // autofill title field if untouched and empty
                         var title = el.ownerCt.getComponent("title");
                         if (title["_autooverwrite"] === true) {
-                            el.ownerCt.getComponent("title").setValue(el.getValue());
+                            let fixedTitle = '';
+                            for (let i = 0; i < el.getValue().length; i++) {
+                                fixedTitle += i === 0 ? el.getValue()[i].toUpperCase() : el.getValue()[i] === el.getValue()[i].toUpperCase() ? ' ' + el.getValue()[i] : el.getValue()[i];
+                            }
+                            el.ownerCt.getComponent("title").setValue(fixedTitle);
                         }
                     }
                 }


### PR DESCRIPTION
## Changes in this pull request  
Just a small helper to convert the name of an object field from "objectFieldName" to "Object Field Name" for the field "title"

## Additional info  
To test, create a field in any object definition, and write something camelCase to the name field.

