### PR TITLE
Remove unused variable

### DIFF
--- a/lib/Document/Editable/EditableHandler.php
+++ b/lib/Document/Editable/EditableHandler.php
@@ -365,8 +365,6 @@ class EditableHandler implements LoggerAwareInterface
                 $bundleName = substr($bundleName, 0, -6);
             }
 
-            $templateReference = '';
-
             foreach (['areas', 'Areas'] as $folderName) {
                 $templateReference = sprintf(
                     '@%s/%s/%s/%s.%s',


### PR DESCRIPTION
`$templateReference` is immediately overridden in line 371 and thus always set.