### PR TITLE
Ensure `$output` actually is `BufferedOutput` before calling `fetch()`

### DIFF
--- a/bundles/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
+++ b/bundles/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
@@ -487,9 +487,8 @@ class ExtensionManagerController extends AdminController implements KernelContro
 
         $installer = $this->bundleManager->getInstaller($bundle);
         if (null !== $installer) {
-            /** @var \Symfony\Component\Console\Output\BufferedOutput $output */
             $output = $installer->getOutput();
-            if (!empty($output)) {
+            if ($output instanceof BufferedOutput) {
                 $converter = new AnsiToHtmlConverter(null);
 
                 $converted = Encoding::fixUTF8($output->fetch());

--- a/bundles/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
+++ b/bundles/AdminBundle/Controller/ExtensionManager/ExtensionManagerController.php
@@ -29,6 +29,7 @@ use Pimcore\Logger;
 use Pimcore\Routing\RouteReferenceInterface;
 use Pimcore\Tool\AssetsInstaller;
 use SensioLabs\AnsiConverter\AnsiToHtmlConverter;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #10759 / #10763

## Additional info  
`InstallerInterface::getOutput()` allows to return any `OutputInterface`, but only `BufferedOutput` provides a `fetch()` method. 
