### PR TITLE
[Symfony] Session - do not use deprecated features

### DIFF
--- a/bundles/CoreBundle/Resources/config/services.yaml
+++ b/bundles/CoreBundle/Resources/config/services.yaml
@@ -10,10 +10,10 @@ services:
     session:
         public: true
         class: Symfony\Component\HttpFoundation\Session\Session
-        arguments: [ '@session.storage', '@session.namespacedattributebag', '@session.flash_bag' ]
+        arguments:
+            $storage: '@session.storage'
+            $flashes: '@session.flash_bag'
 
-    session.namespacedattributebag:
-        class: Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag
 
     # Sessions need to be configured (e.g. adding custom attribute bags) before they are started. The configurator handles
     # a collection of configurator instances which can be added via addConfigurator or by using the pimcore.session.configurator

--- a/bundles/EcommerceFrameworkBundle/CartManager/SessionCart.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/SessionCart.php
@@ -44,7 +44,7 @@ class SessionCart extends AbstractCart implements CartInterface
     protected static function getSessionBag(): AttributeBagInterface
     {
         /** @var AttributeBagInterface $sessionBag */
-        $sessionBag = \Pimcore::getContainer()->get('session')->getBag(SessionConfigurator::ATTRIBUTE_BAG_CART);
+        $sessionBag = \Pimcore::getContainer()->get('request_stack')->getSession()->getBag(SessionConfigurator::ATTRIBUTE_BAG_CART);
 
         if (empty($sessionBag->get('carts'))) {
             $sessionBag->set('carts', []);

--- a/bundles/EcommerceFrameworkBundle/EventListener/Frontend/TrackingCodeFlashMessageListener.php
+++ b/bundles/EcommerceFrameworkBundle/EventListener/Frontend/TrackingCodeFlashMessageListener.php
@@ -21,8 +21,8 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Tracking\TrackingManager;
 use Pimcore\Http\Request\Resolver\PimcoreContextResolver;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -37,18 +37,18 @@ class TrackingCodeFlashMessageListener implements EventSubscriberInterface
     const FLASH_MESSAGE_BAG_KEY = 'ecommerceframework_trackingcode_flashmessagelistener';
 
     /**
-     * @var SessionInterface
+     * @var RequestStack
      */
-    protected $session;
+    protected RequestStack $requestStack;
 
     /**
      * @var TrackingManager
      */
     protected $trackingManger;
 
-    public function __construct(SessionInterface $session, TrackingManager $trackingManager)
+    public function __construct(RequestStack $requestStack, TrackingManager $trackingManager)
     {
-        $this->session = $session;
+        $this->requestStack = $requestStack;
         $this->trackingManger = $trackingManager;
     }
 
@@ -74,8 +74,9 @@ class TrackingCodeFlashMessageListener implements EventSubscriberInterface
 
         // Check FlashBag cookie exists to avoid autostart session by accessing the FlashBag.
         $flashBagCookie = (bool)$request->cookies->get(self::FLASH_MESSAGE_BAG_KEY, false);
-        if ($flashBagCookie && $this->session instanceof Session) {
-            $trackedCodes = $this->session->getFlashBag()->get(self::FLASH_MESSAGE_BAG_KEY);
+        $session = $this->requestStack->getSession();
+        if ($flashBagCookie && $session instanceof Session) {
+            $trackedCodes = $session->getFlashBag()->get(self::FLASH_MESSAGE_BAG_KEY);
 
             if (is_array($trackedCodes) && count($trackedCodes)) {
                 foreach ($this->trackingManger->getTrackers() as $tracker) {
@@ -96,15 +97,16 @@ class TrackingCodeFlashMessageListener implements EventSubscriberInterface
     {
         $response = $event->getResponse();
         $request = $event->getRequest();
+        $session = $this->requestStack->getSession();
 
         /**
          * If tracking codes are forwarded as FlashMessage, then set a cookie which is checked in subsequent request for successful handshake
          * else clear cookie, if set and FlashBag is already processed.
          */
         if (
-            $this->session instanceof Session &&
-            $this->session->isStarted() &&
-            $this->session->getFlashBag()->has(self::FLASH_MESSAGE_BAG_KEY)
+            $session instanceof Session &&
+            $session->isStarted() &&
+            $session->getFlashBag()->has(self::FLASH_MESSAGE_BAG_KEY)
         ) {
             $response->headers->setCookie(new Cookie(self::FLASH_MESSAGE_BAG_KEY, true));
             $response->headers->set('X-Pimcore-Output-Cache-Disable-Reason', 'Tracking Codes Passed', true);

--- a/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
@@ -48,6 +48,10 @@ class PricingManager implements PricingManagerInterface
     protected $actionMapping = [];
 
     /**
+     * TODO: use RequestStack to get session
+     *
+     * @deprecated will be removed in Pimcore 11
+     *
      * @var SessionInterface
      */
     protected $session;

--- a/bundles/EcommerceFrameworkBundle/SessionEnvironment.php
+++ b/bundles/EcommerceFrameworkBundle/SessionEnvironment.php
@@ -37,6 +37,10 @@ class SessionEnvironment extends Environment implements EnvironmentInterface
     const SESSION_KEY_CHECKOUT_TENANT = 'currentcheckouttenant';
 
     /**
+     * TODO: use RequestStack to get session
+     *
+     * @deprecated will be removed in Pimcore 11
+     *
      * @var SessionInterface
      */
     protected $session;

--- a/bundles/EcommerceFrameworkBundle/Tools/SessionConfigurator.php
+++ b/bundles/EcommerceFrameworkBundle/Tools/SessionConfigurator.php
@@ -16,7 +16,7 @@
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\Tools;
 
 use Pimcore\Session\SessionConfiguratorInterface;
-use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class SessionConfigurator implements SessionConfiguratorInterface
@@ -50,7 +50,7 @@ class SessionConfigurator implements SessionConfiguratorInterface
         $bagNames = $this->getBagNames();
 
         foreach ($bagNames as $bagName) {
-            $bag = new NamespacedAttributeBag('_' . $bagName);
+            $bag = new AttributeBag('_' . $bagName);
             $bag->setName($bagName);
 
             $session->registerBag($bag);

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
     "symfony/filesystem": "^5.2.0",
     "symfony/finder": "^5.2.0",
     "symfony/form": "^5.2.0",
-    "symfony/framework-bundle": "^5.2.0",
+    "symfony/framework-bundle": "^5.3.0",
     "symfony/http-client": "^5.2.0",
     "symfony/http-foundation": "^5.3.0",
     "symfony/http-kernel": "^5.2.0",

--- a/doc/Development_Documentation/10_E-Commerce_Framework/13_Checkout_Manager/07_Integrating_Payment.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/13_Checkout_Manager/07_Integrating_Payment.md
@@ -59,7 +59,7 @@ A client side handling could look like as follows:
 /**
  * @Route("/checkout-payment-response", name="shop-checkout-payment-response")
  */
-public function paymentResponseAction(Request $request, Factory $factory, SessionInterface $session) {
+public function paymentResponseAction(Request $request, Factory $factory, RequestStack $requestStack) {
      
     // ... do some stuff, and get $cart
      
@@ -77,7 +77,7 @@ public function paymentResponseAction(Request $request, Factory $factory, Sessio
         // $paymentStatus = $payment->executeDebit();
         // $orderAgent = Factory::getInstance()->getOrderManager()->createOrderAgent($order);
         // $orderAgent->updatePayment($paymentStatus);
- 
+        $session = $requestStack->getSession();
         $session->set("last_order_id", $order->getId());
         $goto = $this->generateUrl('shop-checkout-completed');
          

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/35_Working_with_Sessions.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/35_Working_with_Sessions.md
@@ -14,7 +14,7 @@ or application.
 namespace TestBundle\Session\Configurator;
  
 use Pimcore\Session\SessionConfiguratorInterface;
-use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
  
 class SessionCartConfigurator implements SessionConfiguratorInterface
@@ -24,7 +24,7 @@ class SessionCartConfigurator implements SessionConfiguratorInterface
      */
     public function configure(SessionInterface $session)
     {
-        $bag = new NamespacedAttributeBag('_session_cart');
+        $bag = new AttributeBag('_session_cart');
         $bag->setName('session_cart');
  
         $session->registerBag($bag);
@@ -46,7 +46,7 @@ services:
 if ($request->hasSession()) {
     $session = $request->getSession();
      
-    /** @var NamespacedAttributeBag $bag */
+    /** @var AttributeBag $bag */
     $bag = $session->getBag('session_cart');
     $bag->set('foo', 1);
 }

--- a/lib/Targeting/Session/SessionConfigurator.php
+++ b/lib/Targeting/Session/SessionConfigurator.php
@@ -23,7 +23,7 @@ use Pimcore\Event\FullPageCacheEvents;
 use Pimcore\Session\SessionConfiguratorInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
-use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class SessionConfigurator implements SessionConfiguratorInterface, EventSubscriberInterface
@@ -42,10 +42,10 @@ class SessionConfigurator implements SessionConfiguratorInterface, EventSubscrib
 
     public function configure(SessionInterface $session)
     {
-        $sessionBag = new NamespacedAttributeBag('_' . self::TARGETING_BAG_SESSION);
+        $sessionBag = new AttributeBag('_' . self::TARGETING_BAG_SESSION);
         $sessionBag->setName(self::TARGETING_BAG_SESSION);
 
-        $visitorBag = new NamespacedAttributeBag('_' . self::TARGETING_BAG_VISITOR);
+        $visitorBag = new AttributeBag('_' . self::TARGETING_BAG_VISITOR);
         $visitorBag->setName(self::TARGETING_BAG_VISITOR);
 
         $session->registerBag($sessionBag);

--- a/lib/Targeting/Storage/SessionStorage.php
+++ b/lib/Targeting/Storage/SessionStorage.php
@@ -20,7 +20,7 @@ namespace Pimcore\Targeting\Storage;
 use Pimcore\Targeting\Model\VisitorInfo;
 use Pimcore\Targeting\Session\SessionConfigurator;
 use Pimcore\Targeting\Storage\Traits\TimestampsTrait;
-use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 
 class SessionStorage implements TargetingStorageInterface
 {
@@ -152,7 +152,7 @@ class SessionStorage implements TargetingStorageInterface
      *
      * @throws \Exception
      *
-     * @return null|NamespacedAttributeBag
+     * @return null|AttributeBag
      */
     private function getSessionBag(VisitorInfo $visitorInfo, string $scope, bool $checkPreviousSession = false)
     {
@@ -186,7 +186,7 @@ class SessionStorage implements TargetingStorageInterface
                 ));
         }
 
-        if ($bag instanceof NamespacedAttributeBag) {
+        if ($bag instanceof AttributeBag) {
             return $bag;
         }
 
@@ -194,7 +194,7 @@ class SessionStorage implements TargetingStorageInterface
     }
 
     private function updateTimestamps(
-        NamespacedAttributeBag $bag,
+        AttributeBag $bag,
         \DateTimeInterface $createdAt = null,
         \DateTimeInterface $updatedAt = null
     ) {

--- a/tests/Model/Document/DocumentTest.php
+++ b/tests/Model/Document/DocumentTest.php
@@ -267,6 +267,7 @@ class DocumentTest extends ModelTestCase
 
         $document->setEditable($input);
 
+        $this->buildSession();
         ElementService::saveElementToSession($document);
         $loadedDocument = Service::getElementFromSession('document', $document->getId());
 

--- a/tests/_support/Test/EcommerceTestCase.php
+++ b/tests/_support/Test/EcommerceTestCase.php
@@ -33,8 +33,6 @@ abstract class EcommerceTestCase extends TestCase
     private $environment;
 
     /**
-     * @deprecated will be removed in Pimcore 11
-     *
      * @var SessionInterface
      */
     private $session;
@@ -50,19 +48,15 @@ abstract class EcommerceTestCase extends TestCase
 
     protected function buildSession(): SessionInterface
     {
-        $session = \Pimcore::getContainer()->get('request_stack')->getSession();
-
-        if (null === $session) {
-            $session = new Session(new MockArraySessionStorage());
+        if (null === $this->session) {
+            $this->session = new Session(new MockArraySessionStorage());
 
             $configurator = new SessionConfigurator();
-            $configurator->configure($session);
+            $configurator->configure($this->session);
 
-            $session->getBag(SessionConfigurator::ATTRIBUTE_BAG_CART)->set('carts', []);
+            $this->session->getBag(SessionConfigurator::ATTRIBUTE_BAG_CART)->set('carts', []);
         }
 
-        $this->session = $session;
-
-        return $session;
+        return $this->session;
     }
 }

--- a/tests/_support/Test/EcommerceTestCase.php
+++ b/tests/_support/Test/EcommerceTestCase.php
@@ -56,7 +56,7 @@ abstract class EcommerceTestCase extends TestCase
             $session = new Session(new MockArraySessionStorage());
 
             $configurator = new SessionConfigurator();
-            $configurator->configure($this->session);
+            $configurator->configure($session);
 
             $session->getBag(SessionConfigurator::ATTRIBUTE_BAG_CART)->set('carts', []);
         }

--- a/tests/_support/Test/EcommerceTestCase.php
+++ b/tests/_support/Test/EcommerceTestCase.php
@@ -33,6 +33,8 @@ abstract class EcommerceTestCase extends TestCase
     private $environment;
 
     /**
+     * @deprecated will be removed in Pimcore 11
+     *
      * @var SessionInterface
      */
     private $session;
@@ -48,15 +50,19 @@ abstract class EcommerceTestCase extends TestCase
 
     protected function buildSession(): SessionInterface
     {
-        if (null === $this->session) {
-            $this->session = new Session(new MockArraySessionStorage());
+        $session = \Pimcore::getContainer()->get('request_stack')->getSession();
+
+        if (null === $session) {
+            $session = new Session(new MockArraySessionStorage());
 
             $configurator = new SessionConfigurator();
             $configurator->configure($this->session);
 
-            $this->session->getBag(SessionConfigurator::ATTRIBUTE_BAG_CART)->set('carts', []);
+            $session->getBag(SessionConfigurator::ATTRIBUTE_BAG_CART)->set('carts', []);
         }
 
-        return $this->session;
+        $this->session = $session;
+
+        return $session;
     }
 }

--- a/tests/_support/Test/ModelTestCase.php
+++ b/tests/_support/Test/ModelTestCase.php
@@ -17,12 +17,22 @@ namespace Pimcore\Tests\Test;
 
 use Pimcore\Tests\Helper\DataType\Calculator;
 use Pimcore\Tests\ModelTester;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 /**
  * @property ModelTester $tester
  */
 abstract class ModelTestCase extends TestCase
 {
+
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
     /**
      * {@inheritdoc}
      */
@@ -50,5 +60,22 @@ abstract class ModelTestCase extends TestCase
     protected function needsDb()
     {
         return true;
+    }
+
+    protected function buildSession(): SessionInterface
+    {
+        if (null === $this->session) {
+            $this->session = new Session(new MockArraySessionStorage());
+
+            $requestStack = \Pimcore::getContainer()->get('request_stack');
+            if (!$request = $requestStack->getCurrentRequest()) {
+                $request = new Request();
+                $requestStack->push($request);
+            }
+
+            $request->setSession($this->session);
+        }
+
+        return $this->session;
     }
 }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #10345

## Additional info  

- Avoid using Session service by calling `RequestStack::getSession` 
- `NamespacedAttributeBag` usages have been replaced with `AttributeBag`