### PR TITLE
Bug fix: Fixed faulty classification store active groups filtering 

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/previewVersion.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/DataObject/DataObject/previewVersion.html.twig
@@ -114,7 +114,7 @@
                     {% set languages = validLanguages|merge(languages) %}
                 {% endif %}
 
-                {% for activeGroupId, enabled in activeGroups|filter(activeGroupId => activeGroups[activeGroupId] is not empty) %}
+                {% for activeGroupId, enabled in activeGroups|filter((enabled, activeGroupId) => activeGroups[activeGroupId] is not empty) %}
                     {% set groupDefinition = pimcore_object_classificationstore_group(activeGroupId) %}
                     {% if groupDefinition is not empty %}
                         {% set keyGroupRelations = groupDefinition.getRelations() %}

--- a/bundles/AdminBundle/Resources/views/SearchAdmin/Search/Quicksearch/object.html.twig
+++ b/bundles/AdminBundle/Resources/views/SearchAdmin/Search/Quicksearch/object.html.twig
@@ -40,7 +40,7 @@
                         {% set languages = validLanguages|merge(languages) %}
                     {% endif %}
 
-                    {% for activeGroupId, enabled in activeGroups|filter(activeGroupId => activeGroups[activeGroupId] is not empty) %}
+                    {% for activeGroupId, enabled in activeGroups|filter((enabled, activeGroupId) => activeGroups[activeGroupId] is not empty) %}
                         {% set groupDefinition = pimcore_object_classificationstore_group(activeGroupId) %}
                         {% if groupDefinition is not empty %}
                             {% set keyGroupRelations = groupDefinition.getRelations() %}


### PR DESCRIPTION
## Changes in this pull request
Resolves #10661

## Additional info
Since active groups are stored with group ID in key and whether it's enabled or not as the value, we need to filter on the key and not the value.