### PR TITLE
Deprecate unused `Kernel::getRootDir()`

### DIFF
--- a/bundles/InstallBundle/InstallerKernel.php
+++ b/bundles/InstallBundle/InstallerKernel.php
@@ -55,14 +55,6 @@ class InstallerKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    public function getRootDir()
-    {
-        return $this->projectRoot . '/var/installer';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getLogDir()
     {
         return $this->projectRoot . '/var/log';
@@ -73,7 +65,7 @@ class InstallerKernel extends Kernel
      */
     public function getCacheDir()
     {
-        return $this->getRootDir() . '/cache';
+        return $this->projectRoot . '/var/installer/cache';
     }
 
     /**

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -67,6 +67,17 @@ abstract class Kernel extends SymfonyKernel
      * @var BundleCollection
      */
     private $bundleCollection;
+    
+    public function getRootDir()
+    {
+        trigger_deprecation(
+            'pimcore/pimcore',
+            '10.3',
+            'Kernel::getRootDir() is deprecated and will be removed in Pimcore 11. Use Kernel::getProjectDir() instead.',
+        );
+
+        return PIMCORE_PROJECT_ROOT;
+    }
 
     /**
      * {@inheritdoc}

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -67,7 +67,9 @@ abstract class Kernel extends SymfonyKernel
      * @var BundleCollection
      */
     private $bundleCollection;
-    
+    /**
+     * @deprecated
+     */
     public function getRootDir()
     {
         trigger_deprecation(

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -71,14 +71,6 @@ abstract class Kernel extends SymfonyKernel
     /**
      * {@inheritdoc}
      */
-    public function getRootDir()
-    {
-        return PIMCORE_PROJECT_ROOT;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getProjectDir()
     {
         return PIMCORE_PROJECT_ROOT;


### PR DESCRIPTION
`KernelInterface::getRootDir()` was deprecated in Symfony 4.2 and has been removed in Symfony 5.0.

This method is not used in Symfony and Pimcore anymore and could be deleted.

*Note:* should we deprecate this method instead, in case someone calls it somewhere?