### PR TITLE
[Messenger] fix queue names for messenger transports

### DIFF
--- a/bundles/CoreBundle/Resources/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yaml
@@ -30,8 +30,14 @@ framework:
             pimcore_newsletter: native://default
     messenger:
         transports:
-            pimcore_core: "doctrine://default"
-            pimcore_maintenance: "doctrine://default"
+            pimcore_core:
+                dsn: "doctrine://default"
+                options:
+                    queue_name: pimcore_core
+            pimcore_maintenance:
+                dsn: "doctrine://default"
+                options:
+                    queue_name: pimcore_maintenance
         routing:
             'Pimcore\Messenger\SendNewsletterMessage': pimcore_core
             'Pimcore\Messenger\VideoConvertMessage': pimcore_core

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 ## 10.3.0
+- **Important notice**: [Symfony Messenger] Pimcore Core & Maintenance messages are now routed to different queues instead of default. It is
+  required to run command `bin/console messenger:consume pimcore_core pimcore_maintenance` before the upgrade, so that
+  the messages on default queue gets consumed.
 - [Documents] Introduced additional interfaces for editable methods `getDataEditmode()`, `rewriteIds()` & `load()`. Existing `method_exists` calls are deprecated and will be removed in Pimcore 11.
 
 ## 10.2.0


### PR DESCRIPTION
defines queue names for messenger transports ... 

otherwise `bin/console messenger:consume pimcore_core` would also handle `pimcore_maintenance` messages