### PR TITLE
[Messenger] Create custom messenger bus for pimcore core

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/NewsletterController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/NewsletterController.php
@@ -350,7 +350,7 @@ class NewsletterController extends DocumentControllerBase
      *
      * @throws Exception
      */
-    public function sendAction(Request $request, MessageBusInterface $messageBus): JsonResponse
+    public function sendAction(Request $request, MessageBusInterface $messengerBusPimcoreCore): JsonResponse
     {
         /** @var Document\Newsletter $document */
         $document = Document\Newsletter::getById($request->get('id'));
@@ -370,7 +370,7 @@ class NewsletterController extends DocumentControllerBase
             'progress' => 0,
         ], 'newsletter');
 
-        $messageBus->dispatch(
+        $messengerBusPimcoreCore->dispatch(
             new Pimcore\Messenger\SendNewsletterMessage($document->getTmpStoreId(), \Pimcore\Tool::getHostUrl())
         );
 

--- a/bundles/CoreBundle/DependencyInjection/Compiler/MessageBusPublicPass.php
+++ b/bundles/CoreBundle/DependencyInjection/Compiler/MessageBusPublicPass.php
@@ -19,7 +19,6 @@ namespace Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * @internal
@@ -28,6 +27,6 @@ final class MessageBusPublicPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        $container->getAlias(MessageBusInterface::class)->setPublic(true);
+        $container->getDefinition('messenger.bus.pimcore-core')->setPublic(true);
     }
 }

--- a/bundles/CoreBundle/EventListener/SearchBackendListener.php
+++ b/bundles/CoreBundle/EventListener/SearchBackendListener.php
@@ -31,7 +31,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 class SearchBackendListener implements EventSubscriberInterface
 {
     public function __construct(
-        private MessageBusInterface $messageBus
+        private MessageBusInterface $messengerBusPimcoreCore
     ) {
     }
 
@@ -61,7 +61,7 @@ class SearchBackendListener implements EventSubscriberInterface
     public function onPostAddElement(ElementEventInterface $e)
     {
         $element = $e->getElement();
-        $this->messageBus->dispatch(
+        $this->messengerBusPimcoreCore->dispatch(
             new SearchBackendMessage(Service::getElementType($element), $element->getId())
         );
     }
@@ -83,7 +83,7 @@ class SearchBackendListener implements EventSubscriberInterface
     public function onPostUpdateElement(ElementEventInterface $e)
     {
         $element = $e->getElement();
-        $this->messageBus->dispatch(
+        $this->messengerBusPimcoreCore->dispatch(
             new SearchBackendMessage(Service::getElementType($element), $element->getId())
         );
     }

--- a/bundles/CoreBundle/Resources/config/maintenance.yaml
+++ b/bundles/CoreBundle/Resources/config/maintenance.yaml
@@ -8,7 +8,7 @@ services:
             - 'maintenance.pid'
             - '@logger'
             - '@Symfony\Component\Lock\LockFactory'
-            - '@Symfony\Component\Messenger\MessageBusInterface'
+            - '@messenger.bus.pimcore-core'
 
     Pimcore\Maintenance\Tasks\ScheduledTasksTask:
         arguments:

--- a/bundles/CoreBundle/Resources/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yaml
@@ -43,6 +43,10 @@ framework:
             'Pimcore\Messenger\VersionDeleteMessage': pimcore_core
             'Pimcore\Messenger\OptimizeImageMessage': pimcore_core
             'Pimcore\Messenger\MaintenanceTaskMessage': pimcore_maintenance
+        default_bus: messenger.bus.portal-engine
+        buses:
+            messenger.bus.pimcore-core:
+
 # Twig Configuration
 twig:
     debug:            "%kernel.debug%"

--- a/bundles/CoreBundle/Resources/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yaml
@@ -43,7 +43,7 @@ framework:
             'Pimcore\Messenger\VersionDeleteMessage': pimcore_core
             'Pimcore\Messenger\OptimizeImageMessage': pimcore_core
             'Pimcore\Messenger\MaintenanceTaskMessage': pimcore_maintenance
-        default_bus: messenger.bus.portal-engine
+        default_bus: messenger.bus.pimcore-core
         buses:
             messenger.bus.pimcore-core:
 

--- a/lib/Maintenance/Executor.php
+++ b/lib/Maintenance/Executor.php
@@ -50,7 +50,7 @@ final class Executor implements ExecutorInterface
         string $pidFileName,
         LoggerInterface $logger,
         LockFactory $lockFactory,
-        private MessageBusInterface $messageBus
+        private MessageBusInterface $messengerBusPimcoreCore
     ) {
         $this->pidFileName = $pidFileName;
         $this->logger = $logger;
@@ -114,7 +114,7 @@ final class Executor implements ExecutorInterface
                 continue;
             }
 
-            $this->messageBus->dispatch(
+            $this->messengerBusPimcoreCore->dispatch(
                 new MaintenanceTaskMessage($name, $force)
             );
         }

--- a/lib/Web2Print/Processor.php
+++ b/lib/Web2Print/Processor.php
@@ -82,7 +82,7 @@ abstract class Processor
         $disableBackgroundExecution = $config['disableBackgroundExecution'] ?? false;
 
         if (!$disableBackgroundExecution) {
-            \Pimcore::getContainer()->get(MessageBusInterface::class)->dispatch(
+            \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
                 new GenerateWeb2PrintPdfMessage($jobConfig->documentId)
             );
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1064,7 +1064,7 @@ class Asset extends Element\AbstractElement
             }
 
             // Dispatch Symfony Message Bus to delete versions
-            \Pimcore::getContainer()->get(MessageBusInterface::class)->dispatch(
+            \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
                 new VersionDeleteMessage(Service::getElementType($this), $this->getId())
             );
 
@@ -2097,7 +2097,7 @@ class Asset extends Element\AbstractElement
      */
     protected function addToUpdateTaskQueue(): void
     {
-        \Pimcore::getContainer()->get(MessageBusInterface::class)->dispatch(
+        \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
             new AssetUpdateTasksMessage($this->getId())
         );
     }

--- a/models/Asset/Image/Thumbnail/Config/Dao.php
+++ b/models/Asset/Image/Thumbnail/Config/Dao.php
@@ -155,7 +155,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
     {
         $enabled = \Pimcore::getContainer()->getParameter('pimcore.config')['assets']['image']['thumbnails']['auto_clear_temp_files'];
         if ($enabled) {
-            \Pimcore::getContainer()->get(MessageBusInterface::class)->dispatch(
+            \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
                 new CleanupThumbnailsMessage('image', $this->model->getName())
             );
         }

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -403,7 +403,7 @@ class Processor
                 $generated = true;
 
                 if ($optimizeContent) {
-                    \Pimcore::getContainer()->get(MessageBusInterface::class)->dispatch(
+                    \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
                       new OptimizeImageMessage($storagePath)
                     );
                 }

--- a/models/Asset/Video/Thumbnail/Config/Dao.php
+++ b/models/Asset/Video/Thumbnail/Config/Dao.php
@@ -106,7 +106,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
     {
         $enabled = \Pimcore::getContainer()->getParameter('pimcore.config')['assets']['video']['thumbnails']['auto_clear_temp_files'];
         if ($enabled) {
-            \Pimcore::getContainer()->get(MessageBusInterface::class)->dispatch(
+            \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
                 new CleanupThumbnailsMessage('video', $this->model->getName())
             );
         }

--- a/models/Asset/Video/Thumbnail/Processor.php
+++ b/models/Asset/Video/Thumbnail/Processor.php
@@ -178,7 +178,7 @@ class Processor
 
         $instance->save();
 
-        \Pimcore::getContainer()->get(MessageBusInterface::class)->dispatch(
+        \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
             new VideoConvertMessage($instance->getProcessId())
         );
 

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -218,7 +218,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
     protected function doDelete()
     {
         // Dispatch Symfony Message Bus to delete versions
-        \Pimcore::getContainer()->get(MessageBusInterface::class)->dispatch(
+        \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
             new VersionDeleteMessage(Model\Element\Service::getElementType($this), $this->getId())
         );
 

--- a/models/Dependency/Dao.php
+++ b/models/Dependency/Dao.php
@@ -79,7 +79,7 @@ class Dao extends Model\Dao\AbstractDao
             $data = $this->db->fetchAll('SELECT `sourceid`, `sourcetype` FROM dependencies WHERE targetid = ? AND targettype = ?', [$id, $type]);
             if (is_array($data)) {
                 foreach ($data as $row) {
-                    \Pimcore::getContainer()->get(MessageBusInterface::class)->dispatch(
+                    \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
                         new SanityCheckMessage($row['sourcetype'], $row['sourceid'])
                     );
                 }

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -225,7 +225,7 @@ abstract class PageSnippet extends Model\Document
     protected function doDelete()
     {
         // Dispatch Symfony Message Bus to delete versions
-        \Pimcore::getContainer()->get(MessageBusInterface::class)->dispatch(
+        \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
             new VersionDeleteMessage(Service::getElementType($this), $this->getId())
         );
 


### PR DESCRIPTION
Bundles could create their own messenger buses (and they might be defined it as default automatically) thus Pimcore core and maintenance messages then use the bundles buses. 

To be more robust: Pimcore now defines its own bus and does not rely on the default bus anymore.
