### PR TITLE
[Upgrade docs] Change autoload config or AppBundle classes' namespaces

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
@@ -58,11 +58,11 @@ Add `"AppBundle\\": ["src/"],` to the `autoload` block,
       "App\\": ["src/"],
       "AppBundle\\": ["src/"],
       "Pimcore\\Model\\DataObject\\": "var/classes/DataObject",
-      "Pimcore\\Model\\Object\\": "var/classes/Object",
       ... some other items maybe
     }
   },
 ```
+(Alternatively you can change the namespaces of all classes under app/ folder to `App\...` which had `AppBundle\...` before.)
 
 ### File / Folder changes
 - Move configs from `app/config/*.yml` to `config/*.yaml`

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
@@ -45,13 +45,26 @@ doctrine:
 ```
  
 ### Cleanup your composer.json
-```
+```sh
 composer remove --no-update wikimedia/composer-merge-plugin doctrine/migrations php-http/guzzle6-adapter
 composer require --no-update php-http/guzzle7-adapter:^0.1.1
+```
 Update composer.json as per [skeleton](https://github.com/pimcore/skeleton/blob/10.x/composer.json)
+
+Add `"AppBundle\\": ["src/"],` to the `autoload` block, 
+```json
+"autoload": {
+    "psr-4": {
+      "App\\": ["src/"],
+      "AppBundle\\": ["src/"],
+      "Pimcore\\Model\\DataObject\\": "var/classes/DataObject",
+      "Pimcore\\Model\\Object\\": "var/classes/Object",
+      ... some other items maybe
+    }
+  },
 ```
 
-Important changes:
+### File / Folder changes
 - Move configs from `app/config/*.yml` to `config/*.yaml`
 - Move templates from `app/Resources/views` to `templates` and bundles templates from `app/Resources/XYZBundle/views` to `templates/bundles/XYZBundle`
 - Move `app/AppKernel.php` to `src/Kernel.php` and edit it to have `namespace App;` and class name `Kernel`

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
@@ -51,7 +51,7 @@ composer require --no-update php-http/guzzle7-adapter:^0.1.1
 ```
 Update composer.json as per [skeleton](https://github.com/pimcore/skeleton/blob/10.x/composer.json)
 
-Add `"AppBundle\\": ["src/"],` to the `autoload` block, 
+Add `"AppBundle\\": ["src/"],` to the `autoload` block, if you would like to keep using AppBundle instead of App.
 ```json
 "autoload": {
     "psr-4": {


### PR DESCRIPTION
When neither autoload config nor AppBundle class namespaces are changed, the classes will still have namespace `AppBundle\...` but autoloading in https://github.com/pimcore/skeleton/blob/f15d0229b63b75a6e2ba2408210fddf48b9c1989/composer.json#L23 is only configured for namespace `App\...` - and so the classes will not get found.