### PR TITLE
Support link generator for mockup objects

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Model/DefaultMockup.php
+++ b/bundles/EcommerceFrameworkBundle/Model/DefaultMockup.php
@@ -50,10 +50,7 @@ class DefaultMockup implements ProductInterface, LinkGeneratorAwareInterface
 
     public function getLinkGenerator(): ?DataObject\ClassDefinition\LinkGeneratorInterface {
         if($classId = $this->params['o_classId'] ?? null){
-            if(!array_key_exists($classId,static::$linkGenerators)){
-                static::$linkGenerators[$classId] = DataObject\ClassDefinition::getById($classId)->getLinkGenerator();
-            }
-            return static::$linkGenerators[$classId] ?? null;
+            return static::$linkGenerators[$classId] ??= DataObject\ClassDefinition::getById($classId)->getLinkGenerator();
         }
         return null;
     }

--- a/bundles/EcommerceFrameworkBundle/Model/DefaultMockup.php
+++ b/bundles/EcommerceFrameworkBundle/Model/DefaultMockup.php
@@ -16,8 +16,9 @@
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
 
 use Pimcore\Logger;
+use Pimcore\Model\DataObject;
 
-class DefaultMockup implements ProductInterface
+class DefaultMockup implements ProductInterface, LinkGeneratorAwareInterface
 {
     /** @var int */
     protected $id;
@@ -27,6 +28,12 @@ class DefaultMockup implements ProductInterface
 
     /** @var array */
     protected $relations;
+
+    /**
+     * contains link generators by class type (just for caching)
+     * @var array
+     */
+    protected static array $linkGenerators = [];
 
     public function __construct($id, $params, $relations)
     {
@@ -39,6 +46,16 @@ class DefaultMockup implements ProductInterface
                 $this->relations[$relation['fieldname']][] = ['id' => $relation['dest'], 'type' => $relation['type']];
             }
         }
+    }
+
+    public function getLinkGenerator(): ?DataObject\ClassDefinition\LinkGeneratorInterface {
+        if($classId = $this->params['o_classId'] ?? null){
+            if(!array_key_exists($classId,static::$linkGenerators)){
+                static::$linkGenerators[$classId] = DataObject\ClassDefinition::getById($classId)->getLinkGenerator();
+            }
+            return static::$linkGenerators[$classId] ?? null;
+        }
+        return null;
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/Model/LinkGeneratorAwareInterface.php
+++ b/bundles/EcommerceFrameworkBundle/Model/LinkGeneratorAwareInterface.php
@@ -4,7 +4,7 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
 use Pimcore\Model\DataObject;
 
 /**
- * Interface IndexableInterface
+ * Interface LinkGeneratorAwareInterface
  */
 interface LinkGeneratorAwareInterface
 {

--- a/bundles/EcommerceFrameworkBundle/Model/LinkGeneratorAwareInterface.php
+++ b/bundles/EcommerceFrameworkBundle/Model/LinkGeneratorAwareInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
+use Pimcore\Model\DataObject;
+
+/**
+ * Interface IndexableInterface
+ */
+interface LinkGeneratorAwareInterface
+{
+
+    /**
+     * @return DataObject\ClassDefinition\LinkGeneratorInterface|null
+     */
+    public function getLinkGenerator(): ?DataObject\ClassDefinition\LinkGeneratorInterface;
+}

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/30_Link_Generator.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/30_Link_Generator.md
@@ -41,6 +41,7 @@ use App\Website\Tool\Text;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\ProductInterface;
 use Pimcore\Model\DataObject\ClassDefinition\LinkGeneratorInterface;
 use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Bundle\EcommerceFrameworkBundle\Model\DefaultMockup;
 
 class ProductLinkGenerator extends AbstractProductLinkGenerator implements LinkGeneratorInterface
 {
@@ -90,6 +91,23 @@ class ProductLinkGenerator extends AbstractProductLinkGenerator implements LinkG
     }
 }
 ```
+
+Note: If you want to support mockups or arbitrary objects you can change the typehint to:
+```php
+    /**
+     * @param object $object
+     * @param array $params
+     *
+     * @return string
+     */
+    public function generate(object $object, array $params = []): string
+    {
+        //...
+    }
+```
+
+
+
 
 The link generator will receive the referenced object and additional data depending on the context.
 This would be the document (if embedded in a document), the object if embedded in an object including the tag or field definition as context.

--- a/lib/Twig/Extension/Templating/PimcoreUrl.php
+++ b/lib/Twig/Extension/Templating/PimcoreUrl.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Twig\Extension\Templating;
 
+use Pimcore\Bundle\EcommerceFrameworkBundle\Model\LinkGeneratorAwareInterface;
 use Pimcore\Http\RequestHelper;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Twig\Extension\Templating\Traits\HelperCharsetTrait;
@@ -98,19 +99,27 @@ class PimcoreUrl implements RuntimeExtensionInterface
             $name = $this->getCurrentRoute();
         }
 
-        if (isset($parameters['object']) && $parameters['object'] instanceof Concrete) {
-            $object = $parameters['object'];
-            if ($linkGenerator = $object->getClass()->getLinkGenerator()) {
-                unset($parameters['object']);
-                $path = $linkGenerator->generate($object, [
-                    'route' => $name,
-                    'parameters' => $parameters,
-                    'context' => $this,
-                    'referenceType' => $referenceType,
-                ]);
+        $object = $parameters["object"] ?? null;
+        $linkGenerator = null;
 
-                return $path;
+        if($object instanceof LinkGeneratorAwareInterface){ //e.g. Mockup
+            $linkGenerator = $object->getLinkGenerator();
+        }elseif($object instanceof Concrete){
+            $linkGenerator = $object->getClass()->getLinkGenerator();
+        }
+
+        if($linkGenerator){
+            if(array_key_exists("object",$parameters)){
+                unset($parameters["object"]);
             }
+            $path = $linkGenerator->generate($object, [
+                'route' => $name,
+                'parameters' => $parameters,
+                'context' => $this,
+                'referenceType' => $referenceType,
+            ]);
+
+            return $path;
         }
 
         if ($name !== null) {

--- a/models/DataObject/ClassDefinition/LinkGeneratorInterface.php
+++ b/models/DataObject/ClassDefinition/LinkGeneratorInterface.php
@@ -15,15 +15,16 @@
 
 namespace Pimcore\Model\DataObject\ClassDefinition;
 
+use Pimcore\Bundle\EcommerceFrameworkBundle\Model\DefaultMockup;
 use Pimcore\Model\DataObject\Concrete;
 
 interface LinkGeneratorInterface
 {
     /**
-     * @param Concrete $object
+     * @param Concrete|DefaultMockup $object
      * @param array $params
      *
      * @return string
      */
-    public function generate(Concrete $object, array $params = []): string;
+    public function generate(Concrete|DefaultMockup $object, array $params = []): string;
 }

--- a/models/DataObject/ClassDefinition/LinkGeneratorInterface.php
+++ b/models/DataObject/ClassDefinition/LinkGeneratorInterface.php
@@ -24,7 +24,7 @@ interface LinkGeneratorInterface
      * If you want to support mockups or arbitrary objects you can change the typehint to
      * public function generate(object $object, array $params = []): string
      *
-     * TODO: Change stypehint in Pimcore 11
+     * TODO: Change type of `$object` parameter to `object` in Pimcore 11
      *
      * @param Concrete $object
      * @param array $params

--- a/models/DataObject/ClassDefinition/LinkGeneratorInterface.php
+++ b/models/DataObject/ClassDefinition/LinkGeneratorInterface.php
@@ -24,7 +24,8 @@ interface LinkGeneratorInterface
      * If you want to support mockups or arbitrary objects you can change the typehint to
      * public function generate(object $object, array $params = []): string
      *
-     * Concrete $object
+     * TODO: Change stypehint in Pimcore 11
+     *
      * @param Concrete $object
      * @param array $params
      *

--- a/models/DataObject/ClassDefinition/LinkGeneratorInterface.php
+++ b/models/DataObject/ClassDefinition/LinkGeneratorInterface.php
@@ -15,16 +15,13 @@
 
 namespace Pimcore\Model\DataObject\ClassDefinition;
 
-use Pimcore\Bundle\EcommerceFrameworkBundle\Model\DefaultMockup;
-use Pimcore\Model\DataObject\Concrete;
-
 interface LinkGeneratorInterface
 {
     /**
-     * @param Concrete|DefaultMockup $object
+     * @param object $object
      * @param array $params
      *
      * @return string
      */
-    public function generate(Concrete|DefaultMockup $object, array $params = []): string;
+    public function generate(object $object, array $params = []): string;
 }

--- a/models/DataObject/ClassDefinition/LinkGeneratorInterface.php
+++ b/models/DataObject/ClassDefinition/LinkGeneratorInterface.php
@@ -15,13 +15,20 @@
 
 namespace Pimcore\Model\DataObject\ClassDefinition;
 
+use Pimcore\Model\DataObject\Concrete;
+
 interface LinkGeneratorInterface
 {
     /**
+     *
+     * If you want to support mockups or arbitrary objects you can change the typehint to
+     * public function generate(object $object, array $params = []): string
+     *
+     * Concrete $object
      * @param object $object
      * @param array $params
      *
      * @return string
      */
-    public function generate(object $object, array $params = []): string;
+    public function generate(Concrete $object, array $params = []): string;
 }

--- a/models/DataObject/ClassDefinition/LinkGeneratorInterface.php
+++ b/models/DataObject/ClassDefinition/LinkGeneratorInterface.php
@@ -25,7 +25,7 @@ interface LinkGeneratorInterface
      * public function generate(object $object, array $params = []): string
      *
      * Concrete $object
-     * @param object $object
+     * @param Concrete $object
      * @param array $params
      *
      * @return string


### PR DESCRIPTION
Currently it is not possible to use link generators for mockup objects. 
This leads to the problem, that in some places you can use {{ pimcore_url({'object': product}) }} because you have the orgininal object and in other cases {{ pimcore_url({'object': product}) }} won't work because you have a mockup object....

This PR adds support for Link generators with Mockup objects...


