### PR TITLE
Do not initialize db schema in constructor.

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Tools/Installer.php
+++ b/bundles/EcommerceFrameworkBundle/Tools/Installer.php
@@ -413,15 +413,9 @@ class Installer extends AbstractInstaller
 
     /**
      * @return Schema
-     * @throws \Exception
      */
     protected function getSchema(): Schema
     {
-        if ($this->db instanceof Connection) {
-            $this->schema ??= $this->db->getSchemaManager()->createSchema();
-            return $this->schema;
-        } else {
-            throw new \Exception('Cannot create schema.');
-        }
+        return $this->schema ??= $this->db->getSchemaManager()->createSchema();
     }
 }

--- a/bundles/EcommerceFrameworkBundle/Tools/Installer.php
+++ b/bundles/EcommerceFrameworkBundle/Tools/Installer.php
@@ -415,7 +415,7 @@ class Installer extends AbstractInstaller
     /**
      * @return Schema
      */
-    public function getSchema() : Schema {
+    public function getSchema() : ?Schema {
         if ($this->db instanceof Connection && is_null($this->schema)) {
             $this->schema = $this->db->getSchemaManager()->createSchema();
         }

--- a/bundles/EcommerceFrameworkBundle/Tools/Installer.php
+++ b/bundles/EcommerceFrameworkBundle/Tools/Installer.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\Tools;
 
 use Doctrine\DBAL\Schema\Schema;
 use Pimcore\Db\ConnectionInterface;
+use Doctrine\DBAL\Connection;
 use Pimcore\Extension\Bundle\Installer\AbstractInstaller;
 use Pimcore\Extension\Bundle\Installer\Exception\InstallationException;
 use Pimcore\Model\DataObject\ClassDefinition;
@@ -412,9 +413,15 @@ class Installer extends AbstractInstaller
 
     /**
      * @return Schema
+     * @throws \Exception
      */
     protected function getSchema(): Schema
     {
-        return $this->schema ??= $this->db->getSchemaManager()->createSchema();
+        if ($this->db instanceof Connection) {
+            $this->schema ??= $this->db->getSchemaManager()->createSchema();
+            return $this->schema;
+        } else {
+            throw new \Exception('Cannot create schema.');
+        }
     }
 }

--- a/bundles/EcommerceFrameworkBundle/Tools/Installer.php
+++ b/bundles/EcommerceFrameworkBundle/Tools/Installer.php
@@ -163,10 +163,7 @@ class Installer extends AbstractInstaller
         $this->installSourcesPath = __DIR__ . '/../Resources/install';
         $this->bundle = $bundle;
         $this->db = $connection;
-        if ($this->db instanceof Connection) {
-            $this->schema = $this->db->getSchemaManager()->createSchema();
-        }
-
+        $this->schema = null;
         parent::__construct();
     }
 
@@ -348,7 +345,7 @@ class Installer extends AbstractInstaller
     private function installTables()
     {
         foreach ($this->tablesToInstall as $name => $statement) {
-            if ($this->schema->hasTable($name)) {
+            if ($this->getSchema()->hasTable($name)) {
                 $this->output->write(sprintf(
                     '     <comment>WARNING:</comment> Skipping table "%s" as it already exists',
                     $name
@@ -364,7 +361,7 @@ class Installer extends AbstractInstaller
     private function uninstallTables()
     {
         foreach (array_keys($this->tablesToInstall) as $table) {
-            if (!$this->schema->hasTable($table)) {
+            if (!$this->getSchema()->hasTable($table)) {
                 $this->output->write(sprintf(
                     '     <comment>WARNING:</comment> Not dropping table "%s" as it doesn\'t exist',
                     $table
@@ -373,7 +370,7 @@ class Installer extends AbstractInstaller
                 continue;
             }
 
-            $this->schema->dropTable($table);
+            $this->getSchema()->dropTable($table);
         }
     }
 
@@ -413,5 +410,15 @@ class Installer extends AbstractInstaller
     public function needsReloadAfterInstall()
     {
         return true;
+    }
+
+    /**
+     * @return Schema
+     */
+    public function getSchema() : Schema {
+        if ($this->db instanceof Connection && is_null($this->schema)) {
+            $this->schema = $this->db->getSchemaManager()->createSchema();
+        }
+        return $this->schema;
     }
 }

--- a/bundles/EcommerceFrameworkBundle/Tools/Installer.php
+++ b/bundles/EcommerceFrameworkBundle/Tools/Installer.php
@@ -413,12 +413,8 @@ class Installer extends AbstractInstaller
     /**
      * @return Schema
      */
-    public function getSchema(): Schema
+    protected function getSchema(): Schema
     {
-        if (!$this->schema) {
-            $this->schema = $this->db->getSchemaManager()->createSchema();
-        }
-        
-        return $this->schema;
+        return $this->schema ??= $this->db->getSchemaManager()->createSchema();
     }
 }

--- a/bundles/EcommerceFrameworkBundle/Tools/Installer.php
+++ b/bundles/EcommerceFrameworkBundle/Tools/Installer.php
@@ -416,7 +416,7 @@ class Installer extends AbstractInstaller
      * @return Schema
      */
     public function getSchema() : Schema {
-        if (is_null($this->schema)) {
+        if (!$this->schema) {
             $this->schema = $this->db->getSchemaManager()->createSchema();
         }
         return $this->schema;

--- a/bundles/EcommerceFrameworkBundle/Tools/Installer.php
+++ b/bundles/EcommerceFrameworkBundle/Tools/Installer.php
@@ -15,7 +15,6 @@
 
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\Tools;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Schema;
 use Pimcore\Db\ConnectionInterface;
 use Pimcore\Extension\Bundle\Installer\AbstractInstaller;
@@ -152,7 +151,7 @@ class Installer extends AbstractInstaller
     protected $db;
 
     /**
-     * @var Schema
+     * @var Schema|null
      */
     protected $schema;
 
@@ -163,7 +162,6 @@ class Installer extends AbstractInstaller
         $this->installSourcesPath = __DIR__ . '/../Resources/install';
         $this->bundle = $bundle;
         $this->db = $connection;
-        $this->schema = null;
         parent::__construct();
     }
 
@@ -415,10 +413,12 @@ class Installer extends AbstractInstaller
     /**
      * @return Schema
      */
-    public function getSchema() : Schema {
+    public function getSchema(): Schema
+    {
         if (!$this->schema) {
             $this->schema = $this->db->getSchemaManager()->createSchema();
         }
+        
         return $this->schema;
     }
 }

--- a/bundles/EcommerceFrameworkBundle/Tools/Installer.php
+++ b/bundles/EcommerceFrameworkBundle/Tools/Installer.php
@@ -415,8 +415,8 @@ class Installer extends AbstractInstaller
     /**
      * @return Schema
      */
-    public function getSchema() : ?Schema {
-        if ($this->db instanceof Connection && is_null($this->schema)) {
+    public function getSchema() : Schema {
+        if (is_null($this->schema)) {
             $this->schema = $this->db->getSchemaManager()->createSchema();
         }
         return $this->schema;

--- a/lib/Db/ConnectionInterface.php
+++ b/lib/Db/ConnectionInterface.php
@@ -297,9 +297,4 @@ interface ConnectionInterface extends Connection
      * @return \PDO
      */
     public function getWrappedConnection();
-    
-    /**
-     * @return \Doctrine\DBAL\Schema\AbstractSchemaManager
-     */
-    public function getSchemaManager();
 }

--- a/lib/Db/ConnectionInterface.php
+++ b/lib/Db/ConnectionInterface.php
@@ -297,4 +297,9 @@ interface ConnectionInterface extends Connection
      * @return \PDO
      */
     public function getWrappedConnection();
+    
+    /**
+     * @return \Doctrine\DBAL\Schema\AbstractSchemaManager
+     */
+    public function getSchemaManager();
 }

--- a/lib/Db/ConnectionInterface.php
+++ b/lib/Db/ConnectionInterface.php
@@ -24,6 +24,9 @@ use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Pimcore\Model\Element\ValidationException;
 
+/**
+ * @method \Doctrine\DBAL\Schema\AbstractSchemaManager getSchemaManager()
+ */
 interface ConnectionInterface extends Connection
 {
     /**


### PR DESCRIPTION
When the ecommerce bundle is activated, on the /admin page additional 1.8000 - 4.000 db schema queries are executed:

![image](https://user-images.githubusercontent.com/16687355/144396165-79d956f8-6aa6-49b5-a179-4c6a7ab84224.png)

In Microsoft Aure (Azure DB for Maria DB 10.4) this results in a TTFB between betwen 15 and 30 seconds.

## Changes in this pull request  
Do not execute ``$this->db->getSchemaManager()->createSchema();`` in the constructor of the Ecommerce framework bundle installer. Instead, initialize it lazy when needed.

