### PR TITLE
Fix set stream for asset model

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1350,7 +1350,7 @@ class Asset extends Element\AbstractElement
             $isRewindable = @rewind($this->stream);
 
             if (!$isRewindable) {
-                $tempFile = $this->getTemporaryFile();
+                $tempFile = $this->getLocalFileFromStream($this->stream);
                 $dest = fopen($tempFile, 'rb', false, File::getContext());
                 $this->stream = $dest;
             }


### PR DESCRIPTION
when an asset is renamed, or a new version is uploaded, display for old versions is broken:
<img width="1160" alt="Screenshot 2021-12-02 at 16 54 14" src="https://user-images.githubusercontent.com/6807023/144446011-52ea3b42-7f2c-4b28-915d-b8ce2bfda903.png">

That happens because If stream is not rewindable it goes to:
`public function getTemporaryFile(bool $keep = false)
    {
        return self::getTemporaryFileFromStream($this->getStream(), $keep);
    }`

then, in `$this->getStream()` because stream is not rewindable, it is set to null and created from: `$this->stream = Storage::get('asset')->readStream($this->getRealFullPath());` 
This way stream is created from asset real full path stored in version (it is possible that it does not exist any more, or the file  is different from the file it was in version) and not from `$version->getBinaryFileStream()` as it should be
