### PR TITLE
Hide empty groups in the areablock menu

### DIFF
--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -27,6 +27,8 @@ use Pimcore\Tool;
 /**
  * @method \Pimcore\Model\DataObject\Objectbrick\Definition\Dao getDao()
  * @method string getTableName(DataObject\ClassDefinition $class, $query)
+ * @method void createUpdateTable(DataObject\ClassDefinition $class)
+ * @method string getLocalizedTableName(DataObject\ClassDefinition $class, $query)
  */
 class Definition extends Model\DataObject\Fieldcollection\Definition
 {

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -131,7 +131,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
             if ($isLocalized) {
                 foreach ($validLanguages as $validLanguage) {
                     $tables[] = 'object_brick_localized_query_' . $key . '_' . $class->getId() . '_' . $validLanguage;
-                    $tables[] = 'object_brick_localized_' . $key . '_' . $class->getId() . '_' . $validLanguage;
+                    $tables[] = 'object_brick_localized_' . $key . '_' . $class->getId();
                 }
             }
         }

--- a/models/DataObject/Objectbrick/Definition/Dao.php
+++ b/models/DataObject/Objectbrick/Definition/Dao.php
@@ -31,6 +31,7 @@ class Dao extends Model\Dao\AbstractDao
      * @var array|null
      */
     protected $tableDefinitions = null;
+
     /**
      * @param DataObject\ClassDefinition $class
      * @param bool $query
@@ -61,6 +62,7 @@ class Dao extends Model\Dao\AbstractDao
             return 'object_brick_localized_' . $this->model->getKey() . '_' . $class->getId();
         }
     }
+
     /**
      * @param DataObject\ClassDefinition $class
      */

--- a/models/DataObject/Objectbrick/Definition/Dao.php
+++ b/models/DataObject/Objectbrick/Definition/Dao.php
@@ -23,8 +23,14 @@ use Pimcore\Model\DataObject;
  *
  * @property \Pimcore\Model\DataObject\Objectbrick\Definition $model
  */
-class Dao extends Model\DataObject\Fieldcollection\Definition\Dao
+class Dao extends Model\Dao\AbstractDao
 {
+    use DataObject\ClassDefinition\Helper\Dao;
+
+    /**
+     * @var array|null
+     */
+    protected $tableDefinitions = null;
     /**
      * @param DataObject\ClassDefinition $class
      * @param bool $query
@@ -40,6 +46,21 @@ class Dao extends Model\DataObject\Fieldcollection\Definition\Dao
         }
     }
 
+    /**
+     * @param DataObject\ClassDefinition $class
+     * @param bool $query
+     * @param string $language
+     *
+     * @return string
+     */
+    public function getLocalizedTableName(DataObject\ClassDefinition $class, $query = false, $language = 'en')
+    {
+        if ($query) {
+            return 'object_brick_localized_query_' . $this->model->getKey() . '_' . $class->getId() . '_' . $language;
+        } else {
+            return 'object_brick_localized_' . $this->model->getKey() . '_' . $class->getId();
+        }
+    }
     /**
      * @param DataObject\ClassDefinition $class
      */


### PR DESCRIPTION
For the Areablock editable only show group menus that contain areas

## Changes in this pull request  
Resolves #10957

## Additional info  

