### PR TITLE
No edit button for empty EditableDialogBoxConfiguration

### DIFF
--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -452,7 +452,11 @@ class Areablock extends Model\Document\Editable implements BlockInterface
         $brick = $areabrickManager->getBrick($this->indices[$this->current]['type']);
         if ($this->getEditmode() && $brick instanceof EditableDialogBoxInterface) {
             $dialogConfig = $brick->getEditableDialogBoxConfiguration($this, $info);
-            $dialogConfig->setId('dialogBox-' . $this->getName() . '-' . $this->indices[$this->current]['key']);
+            if( $dialogConfig->getItems()) {
+                $dialogConfig->setId('dialogBox-' . $this->getName() . '-' . $this->indices[$this->current]['key']);
+            } else {
+                $dialogConfig = null;
+            }
         }
 
         $attr = HtmlUtils::assembleAttributeString($attributes);


### PR DESCRIPTION
## Changes in this pull request  
This change will have the areablock check that the EditableDialogBoxConfiguration contains items prior to creating the edit button. This will avoid showing an empty dialog box window.

Resolves #7671

## Additional info  
Another way to solve this would be a change in the signature of getEditableDialogBoxConfiguration to allow the return of null, but that would cause a BC break.
