### PR TITLE
fix: check if fieldcollection has localized fields

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -126,6 +126,9 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
                     foreach ($collectionDef->getFieldDefinitions() as $fd) {
                         if (!$fd instanceof CalculatedValue) {
                             $value = $item->{'get' . $fd->getName()}();
+                            if ($fd instanceof Localizedfields) {
+                                $params['fieldcollection'] = $item->getFieldname();
+                            }
                             $collectionData[$fd->getName()] = $fd->getDataForEditmode($value, $object, $params);
                         }
                     }

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -271,6 +271,11 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
                         if (method_exists($parent, 'getLocalizedFields')) {
                             $parentData = $parent->getLocalizedFields();
                         }
+                        // if we have a fieldcollection within a localized field, this ends in naming collision
+                        // as default the fieldcollections supports no inheritance we just return "null"
+                        if (isset($params['fieldcollection'])) {
+                            $parentData = null;
+                        }
                     }
                     if ($parentData) {
                         $parentResult = $this->doGetDataForEditMode(


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves a bugfix if having a FieldCollection within a LocalizedField with the same name than a LocalizedField in the object itself wich having also the FieldCollection included

## Additional info  
The FieldCollections itself doesn't support inerhitance out of the box and must still be done with custom code.

With this change this is still possible to support custom inheritance but also then it never should inherit a single LocalizedField (e.g. one language) instead it should be inherited only all languages of a FieldCollection - LocalizedField
