### PR TITLE
Update LogMailMaintenanceTask.php

### DIFF
--- a/lib/Maintenance/Tasks/LogMailMaintenanceTask.php
+++ b/lib/Maintenance/Tasks/LogMailMaintenanceTask.php
@@ -86,7 +86,9 @@ class LogMailMaintenanceTask implements TaskInterface
                     $mail = new \Pimcore\Mail();
                     $mail->setIgnoreDebugMode(true);
                     $mail->html($html);
-                    $mail->addTo($receivers);
+                    foreach ($receivers as $receiver){
+                            $mail->addTo(new Address($receiver, $receiver));
+                    }
                     $mail->setSubject('Error Log '.\Pimcore\Tool::getHostUrl());
                     $mail->send();
                 }

--- a/lib/Maintenance/Tasks/LogMailMaintenanceTask.php
+++ b/lib/Maintenance/Tasks/LogMailMaintenanceTask.php
@@ -19,6 +19,7 @@ use Pimcore\Config;
 use Pimcore\Db;
 use Pimcore\Log\Handler\ApplicationLoggerDb;
 use Pimcore\Maintenance\TaskInterface;
+use Symfony\Component\Mime\Address;
 
 /**
  * @internal


### PR DESCRIPTION
This is currently not working because the array of receivers needs to be set as Address and assigned to addto for each entry
This Pull requests makes the mailing again usable
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

