### PR TITLE
Hide empty groups in the areablock menu

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
@@ -717,7 +717,9 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.area_abstra
                             }
                         }
                     }
-                    menu.push(groupMenu);
+                    if(groupMenu.menu.length) {
+                        menu.push(groupMenu);
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
For the Areablock editable only show group menus that contain areas

## Changes in this pull request  
Resolves #10957

## Additional info  
Sorry, had to recreate the PR because I did something wrong when trying to rebase to the 10.2 branch.
