### PR TITLE
Add index to application_logs.maintenanceChecked

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20211209131141.php
+++ b/bundles/CoreBundle/Migrations/Version20211209131141.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Log\Handler\ApplicationLoggerDb;
+
+/**
+ * @internal
+ */
+class Version20211209131141 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable(ApplicationLoggerDb::TABLE_NAME);
+        if (!$table->hasIndex('maintenanceChecked')) {
+            $table->addIndex(['maintenanceChecked'], 'maintenanceChecked');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable(ApplicationLoggerDb::TABLE_NAME);
+        if ($table->hasIndex('maintenanceChecked')) {
+            $table->dropIndex('maintenanceChecked');
+        }
+    }
+}

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -19,7 +19,8 @@ CREATE TABLE `application_logs` (
   KEY `component` (`component`),
   KEY `timestamp` (`timestamp`),
   KEY `relatedobject` (`relatedobject`),
-  KEY `priority` (`priority`)
+  KEY `priority` (`priority`),
+  KEY `maintenanceChecked` (`maintenanceChecked`)
 ) DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `assets`;

--- a/lib/Maintenance/Tasks/LogMailMaintenanceTask.php
+++ b/lib/Maintenance/Tasks/LogMailMaintenanceTask.php
@@ -96,6 +96,6 @@ class LogMailMaintenanceTask implements TaskInterface
         // flag them as checked, regardless if email notifications are enabled or not
         // otherwise, when activating email notifications, you'll receive all log-messages from the past and not
         // since the point when you enabled the notifications
-        $db->query('UPDATE '.ApplicationLoggerDb::TABLE_NAME.' set maintenanceChecked = 1');
+        $db->query('UPDATE '.ApplicationLoggerDb::TABLE_NAME.' set maintenanceChecked = 1 WHERE maintenanceChecked!=1');
     }
 }

--- a/lib/Maintenance/Tasks/LogMailMaintenanceTask.php
+++ b/lib/Maintenance/Tasks/LogMailMaintenanceTask.php
@@ -96,6 +96,6 @@ class LogMailMaintenanceTask implements TaskInterface
         // flag them as checked, regardless if email notifications are enabled or not
         // otherwise, when activating email notifications, you'll receive all log-messages from the past and not
         // since the point when you enabled the notifications
-        $db->query('UPDATE '.ApplicationLoggerDb::TABLE_NAME.' set maintenanceChecked = 1 WHERE maintenanceChecked!=1');
+        $db->query('UPDATE '.ApplicationLoggerDb::TABLE_NAME.' set maintenanceChecked = 1 WHERE maintenanceChecked != 1');
     }
 }


### PR DESCRIPTION
Currently the maintenance job executes
https://github.com/pimcore/pimcore/blob/daca0c72f8df1a9059ac0dcdb4fedcb0137ffc3c/lib/Maintenance/Tasks/LogMailMaintenanceTask.php#L99

When there are several thousand rows in this table than this is a really heavy operation. This PR adds an index to the column `maintenanceChecked` and uses this to filter the results for the update.

Without this PR:
<img width="690" alt="Bildschirmfoto 2021-12-09 um 13 10 06" src="https://user-images.githubusercontent.com/8749138/145395189-eeeeda76-7cc6-42c3-82f7-f87443047859.png">

With this PR it does not even appear in `Show Processlist`.
In this case there are 300000 rows in `application_logs`.