### PR TITLE
Don't return Document from runtime cache when `$force` parameter is true in `Document::getByPath()`

### DIFF
--- a/models/Document.php
+++ b/models/Document.php
@@ -224,8 +224,6 @@ class Document extends Element\AbstractElement
             return \Pimcore\Cache\Runtime::get($cacheKey);
         }
 
-        $doc = null;
-
         try {
             $helperDoc = new Document();
             $helperDoc->getDao()->getByPath($path);

--- a/models/Document.php
+++ b/models/Document.php
@@ -220,7 +220,7 @@ class Document extends Element\AbstractElement
 
         $cacheKey = 'document_path_' . md5($path);
 
-        if (\Pimcore\Cache\Runtime::isRegistered($cacheKey)) {
+        if (!$force && \Pimcore\Cache\Runtime::isRegistered($cacheKey)) {
             return \Pimcore\Cache\Runtime::get($cacheKey);
         }
 


### PR DESCRIPTION
When calling `Document::getByPath('/some/path/', true)`, I'd expect a fresh document loaded from the DB. But as the method has a cache, a cached instance is returned.

## Changes in this pull request  

When the `$force` parameter is `true`, the cache is skipped and the document gets loaded from the DB.