### PR TITLE
[Assets] Add dialog to overwrite assets on upload

### DIFF
--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -958,5 +958,10 @@
     "clear_relation_filter": "Clear active relation filter",
     "apply_filter": "Apply filter",
     "config_not_writeable": "Not writable, this can have several reasons. For details please have a look into the docs.",
-    "sites": "Sites"
+    "sites": "Sites",
+    "file_exists": "File already exists",
+    "asset_upload_want_to_overwrite": "Do you want to overwrite file %s?",
+    "asset_upload_overwrite": "Overwrite",
+    "asset_upload_keep_both": "Keep both files",
+    "asset_upload_overwrite_all": "Overwrite all"
 }


### PR DESCRIPTION
In case of a file path collision when uploading an asset file currently the new file gets uploaded with `_1` suffix (or `_2`, `_3` etc.).
With this PR in such a case this dialog opens:
<img width="530" alt="Bildschirmfoto 2021-12-14 um 16 05 46" src="https://user-images.githubusercontent.com/8749138/146024661-f5ea35e9-1c49-4cd2-bfe7-a0c89f9176eb.png">

The buttons explained:
- *Overwrite*: Use the uploaded file as data for the already existing asset
- *Keep both files*: Upload new file with suffix (current behaviour)
- *Overwrite all*: When uploading multiple files at once, all existing files will get overwritten. Files which did not exist before, are created as usual.
- *Close window*: Abort upload -> No files will be changed

Resolves #6893