### PR TITLE
Fix has children detection

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -697,7 +697,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             ],
         ];
 
-        $hasChildren = (bool)$asset->getChildAmount($this->getAdminUser());
+        $hasChildren = $asset->getDao()->hasChildren($this->getAdminUser());
 
         // set type specific settings
         if ($asset instanceof Asset\Folder) {

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -278,7 +278,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             $allowedTypes[] = DataObject::OBJECT_TYPE_VARIANT;
         }
 
-        $hasChildren = (bool)$child->getChildAmount($allowedTypes, $this->getAdminUser());
+        $hasChildren = $child->getDao()->hasChildren($allowedTypes, null, $this->getAdminUser());
 
         $tmpObject['allowDrop'] = false;
         $tmpObject['leaf'] = !$hasChildren;

--- a/bundles/AdminBundle/Controller/Traits/DocumentTreeConfigTrait.php
+++ b/bundles/AdminBundle/Controller/Traits/DocumentTreeConfigTrait.php
@@ -69,7 +69,7 @@ trait DocumentTreeConfigTrait
             ],
         ];
 
-        $hasChildren = (bool)$childDocument->getChildAmount(Admin::getCurrentUser());
+        $hasChildren = $childDocument->getDao()->hasChildren(null, Admin::getCurrentUser());
 
         // add icon
         $tmpDocument['expandable'] = $hasChildren;


### PR DESCRIPTION
After this PR was merged: https://github.com/pimcore/pimcore/pull/10842/files some ajax calls for non admin users may take about 30 seconds (for example: `/admin/object/tree-get-childs-by-id`) and if it overflows the `max_execution_time` limit it is aborted, that happens because it counts all the objects and that is not efficient. 
<img width="1500" alt="Screenshot 2021-12-15 at 12 34 58" src="https://user-images.githubusercontent.com/6807023/146172084-75cb1721-c8a5-4005-974c-488e807b0c60.png">

Also there is a discrepancy from `hasChildren` and `getChildAmount` methods, taking in account that `getChildAmount` method checks the user, but  `hasChildren` doesn't do this, there can be situations when `getChildAmount` returns 0, but `hasChildren` returns true, which is confusing.