### PR TITLE
[Docs] Update 09_Adding_Document_Editables.md

### DIFF
--- a/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/09_Adding_Document_Editables.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/09_Adding_Document_Editables.md
@@ -92,5 +92,5 @@ Register event listener:
 services:
   App\EventListener\PimcoreAdminListener:
     tags:
-      - { name: kernel.event_listener, event: pimcore.bundle_manager.paths.js, method: addJSFiles }
+      - { name: kernel.event_listener, event: pimcore.bundle_manager.paths.editmode_js, method: addJSFiles }
 ```


### PR DESCRIPTION
Documentation for event listener is using incorrect event for an editable. Should use "pimcore.bundle_manager.paths.editmode_js" to only be loaded in editmode, after all other editables.

Same change applies for CSS using "editmode_css"

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

