### PR TITLE
Bugfix: add UTF-8 support to Input regex validation

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Input.php
+++ b/models/DataObject/ClassDefinition/Data/Input.php
@@ -304,7 +304,7 @@ class Input extends Data implements
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
         if (!$omitMandatoryCheck && $this->getRegex() && strlen($data) > 0) {
-            if (!preg_match('#' . $this->getRegex() . '#', $data)) {
+            if (!preg_match('#' . $this->getRegex() . '#u', $data)) {
                 throw new Model\Element\ValidationException('Value in field [ ' . $this->getName() . " ] doesn't match input validation '" . $this->getRegex() . "'");
             }
         }


### PR DESCRIPTION
Regex validation in dataobjects currently does not support UTF-8, making unicode regex validation impossible.
Added 'u' modifier to checkValidity method to resolve.

Steps to reproduce:

- Add regex validation to Dataobject field with Unicode (Example "a-zA-Z\x{00C0}\-\x{024F}0-9" to support diacritics)
- Attempting to save object should result in the following exception: Exception: ErrorException: Warning: preg_match(): Compilation failed: character code point value in \x{} or \o{} is too large

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

