### PR TITLE
[Symfony 6] Fix return value of normalizer

### DIFF
--- a/bundles/AdminBundle/Serializer/Normalizer/ReferenceLoopNormalizer.php
+++ b/bundles/AdminBundle/Serializer/Normalizer/ReferenceLoopNormalizer.php
@@ -29,7 +29,26 @@ class ReferenceLoopNormalizer implements NormalizerInterface
      */
     public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
-        return Serialize::removeReferenceLoops($object);
+        $object = Serialize::removeReferenceLoops($object);
+
+        if($object instanceof \JsonSerializable) {
+            return $object->jsonSerialize();
+        }
+
+        if(is_object($object)) {
+
+            $propCollection = get_object_vars($object);
+
+            $array = [];
+            foreach ($propCollection as $name => $propValue) {
+                $array[$name] = $propValue;
+            }
+
+            return $array;
+
+        }
+
+        return $object;
     }
 
     /**

--- a/lib/Tool/Serialize.php
+++ b/lib/Tool/Serialize.php
@@ -66,9 +66,9 @@ final class Serialize
      *
      * @param mixed $data
      *
-     * @return string
+     * @return mixed
      */
-    public static function removeReferenceLoops($data)
+    public static function removeReferenceLoops($data): mixed
     {
         self::$loopFilterProcessedObjects = []; // reset
 


### PR DESCRIPTION
followup of #10846

it is possible, that return value of `Serialize::removeReferenceLoops($object);` is an object ... thus not matching the return type declaration. 

E.g. when doing something like 
```php
    public function configurationGetAction(Request $request)
    {
        $configuration = Dao::getByName($request->get('name'));

        return $this->adminJson($configuration);
    }
```

there might be more elegant solutions to that? 