### PR TITLE
[Assets] Close stream when saving

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -759,7 +759,7 @@ class Asset extends Element\AbstractElement
 
                 $storage->move($tempFilePath, $path);
 
-                $this->stream = null; // set stream to null, so that the source stream isn't used anymore after saving
+                $this->closeStream(); // set stream to null, so that the source stream isn't used anymore after saving
 
                 $mimeType = $storage->mimeType($path);
                 $this->setMimeType($mimeType);


### PR DESCRIPTION
Currently in https://github.com/pimcore/pimcore/blob/1141aeab72f0f6e08ac5e8a0ec9012d69c7ae2bf/models/Asset.php#L761 `$this->stream` gets set to `null` but the stream is still open.

Consequently https://github.com/pimcore/pimcore/blob/1141aeab72f0f6e08ac5e8a0ec9012d69c7ae2bf/models/Asset.php#L832 does not have an effect because of https://github.com/pimcore/pimcore/blob/1141aeab72f0f6e08ac5e8a0ec9012d69c7ae2bf/models/Asset.php#L1369 (`$this->stream` is `null` here, so the opened file handle does not get closed)
When you are working with a lot of assets and the streams are left open, you will get `failed to open stream: Too many open files in ...` errors.

This PR really closes the stream when saving the asset.