### PR TITLE
Don't execute "Git Mirror" workflow on forks

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -9,6 +9,7 @@ on:
 jobs:
     to_github:
         runs-on: ubuntu-18.04
+        if: github.repository_owner == 'pimcore'
         steps:
             - uses: actions/checkout@v1
             - uses: pixta-dev/repository-mirroring-action@v1

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     to_github:
         runs-on: ubuntu-18.04
-        if: github.repository_owner == 'pimcore'
+        if: ${{ github.repository == 'pimcore/pimcore' }}
         steps:
             - uses: actions/checkout@v1
             - uses: pixta-dev/repository-mirroring-action@v1


### PR DESCRIPTION
I get error emails from my fork. See: https://github.com/blankse/pimcore/actions