### PR TITLE
[DataObject] pre update validation exception event

### DIFF
--- a/lib/Event/DataObjectEvents.php
+++ b/lib/Event/DataObjectEvents.php
@@ -53,6 +53,18 @@ final class DataObjectEvents
 
     /**
      * Arguments:
+     *  - validationExceptions | ValidationException[] | Validation exceptions from field definition validation.
+     *  - message | string | Prefix before validation messages. Defaults to 'Validation failed: '.
+     *  - separator | string | Separator between validation messages. Defaults to ' / '.
+     *
+     * @Event("Pimcore\Event\Model\DataObjectEvent")
+     *
+     * @var string
+     */
+    const PRE_UPDATE_VALIDATION_EXCEPTION = 'pimcore.dataobject.preUpdateValidationException';
+
+    /**
+     * Arguments:
      *  - saveVersionOnly | is set if method saveVersion() was called instead of save()
      *  - oldPath | the old full path in case the path has changed
      *

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -167,15 +167,23 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
             }
         }
 
+        $preUpdateEvent = new DataObjectEvent($this, [
+            'validationExceptions' => $validationExceptions,
+            'message' => 'Validation failed: ',
+            'separator' => ' / ',
+        ]);
+        \Pimcore::getEventDispatcher()->dispatch($preUpdateEvent, DataObjectEvents::PRE_UPDATE_VALIDATION_EXCEPTION);
+        $validationExceptions = $preUpdateEvent->getArgument('validationExceptions');
+
         if ($validationExceptions) {
-            $message = 'Validation failed: ';
+            $message = $preUpdateEvent->getArgument('message');
             $errors = [];
 
             /** @var Model\Element\ValidationException $e */
             foreach ($validationExceptions as $e) {
                 $errors[] = $e->getAggregatedMessage();
             }
-            $message .= implode(' / ', $errors);
+            $message .= implode($preUpdateEvent->getArgument('separator'), $errors);
 
             throw new Model\Element\ValidationException($message);
         }


### PR DESCRIPTION
Dispatch an event before the validation exception is thrown.
Allow adding custom validation exceptions and manipulation of the output.

Without output changes.
```php
$customValidationExceptions = [
    new ValidationException('Custom field validation | This value is too long. It should have 20 characters or less.'),
];
$validationExceptions = array_merge(
    $event->getArgument('validationExceptions'),
    $customValidationExceptions
);
$event->setArgument('validationExceptions', $validationExceptions);
```
![Validation_before](https://user-images.githubusercontent.com/24292941/146389212-6b537102-4194-4a5d-b579-c29cb527b8e3.png)


With output changes.
```php
$event->setArgument('message', '');
$event->setArgument('separator', '<br>');
```
![Validation_after](https://user-images.githubusercontent.com/24292941/146389176-184e891e-b933-4f0a-b5a4-dbd4e2fda7f1.png)

