### PR TITLE
[Image Thumbnails] Fix system image thumbnails generation when no thumbnails are configured

### DIFF
--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -118,7 +118,12 @@ class ThumbnailsImageCommand extends AbstractCommand
         $list->setCondition(implode(' AND ', $conditions));
 
         $assetIdsList = $list->loadIdList();
-        $thumbnailList = new Asset\Image\Thumbnail\Config\Listing();
+        $thumbnailList = [];
+        $thumbnailList[] = Asset\Image\Thumbnail\Config::getPreviewConfig();
+        if (!$input->getOption('system')) {
+            $thumbnailList = new Asset\Image\Thumbnail\Config\Listing();
+            $thumbnailList = $thumbnailList->getThumbnails();
+        }
 
         $allowedThumbs = [];
         if ($input->getOption('thumbnails')) {
@@ -127,7 +132,7 @@ class ThumbnailsImageCommand extends AbstractCommand
 
         $items = [];
         foreach ($assetIdsList as $assetId) {
-            foreach ($thumbnailList->getThumbnails() as $thumbnailConfig) {
+            foreach ($thumbnailList as $thumbnailConfig) {
                 $thumbName = $thumbnailConfig->getName();
                 if (empty($allowedThumbs) || in_array($thumbName, $allowedThumbs)) {
                     $items[] = $assetId . '~~~' . $thumbName;
@@ -209,16 +214,6 @@ class ThumbnailsImageCommand extends AbstractCommand
                     $webpConfig->setFormat('webp');
                     $thumbnailsToGenerate[] = $webpConfig;
                 }
-            }
-
-            if ($input->getOption('system')) {
-                if (!$input->getOption('thumbnails')) {
-                    $thumbnailsToGenerate = [];
-                }
-
-                $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig();
-            } elseif (!$input->getOption('thumbnails')) {
-                $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig();
             }
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves this bug: when no thumbnails are configured in Pimcore, it's not possible to generate system thumbnails.

## To reproduce

- Install Pimcore Skeleton
- Leave image thumbnails configuration empty (don't configure any thumbnail)
- Open a terminal and prompt the command to generate system thumbnails
`bin/console thumbnails:image -s`
- No thumbnails are generated

