### PR TITLE
[Cache] consider none-string values

### DIFF
--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -591,11 +591,25 @@ class CoreCacheHandler implements LoggerAwareInterface
         if ($result) {
             $this->logger->debug('Added entry {key} to cache', ['key' => $item->getKey()]);
         } else {
+            
+             $itemData = $item->get();
+            if (!is_string($itemData)) {
+                try {
+                    $itemData = serialize($itemData);
+                } catch (\Throwable) {
+                    $itemSizeText = "unknown";
+                }
+            }
+
+            if (!$itemSizeText) {
+                $itemSizeText = formatBytes(mb_strlen((string)$itemData));
+            }
+            
             $this->logger->error(
                 'Failed to add entry {key} to cache. Item size was {itemSize}',
                 [
                     'key' => $item->getKey(),
-                    'itemSize' => formatBytes(mb_strlen(!is_string($item->get()) ? serialize($item->get()) : $item->get())),
+                    'itemSize' => $itemSizeText,
                 ]
             );
         }

--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -592,17 +592,16 @@ class CoreCacheHandler implements LoggerAwareInterface
             $this->logger->debug('Added entry {key} to cache', ['key' => $item->getKey()]);
         } else {
             
-             $itemData = $item->get();
-            if (!is_string($itemData)) {
+            $itemData = $item->get();
+            if (is_string($itemData)) {
+                $itemSizeText = formatBytes(mb_strlen($itemData));
+            } else {
                 try {
                     $itemData = serialize($itemData);
+                    $itemSizeText = formatBytes(mb_strlen($itemData));
                 } catch (\Throwable) {
                     $itemSizeText = "unknown";
                 }
-            }
-
-            if (!$itemSizeText) {
-                $itemSizeText = formatBytes(mb_strlen((string)$itemData));
             }
             
             $this->logger->error(

--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -595,7 +595,7 @@ class CoreCacheHandler implements LoggerAwareInterface
                 'Failed to add entry {key} to cache. Item size was {itemSize}',
                 [
                     'key' => $item->getKey(),
-                    'itemSize' => formatBytes(strlen($item->get())),
+                    'itemSize' => formatBytes(mb_strlen(!is_string($item->get()) ? serialize($item->get()) : $item->get())),
                 ]
             );
         }


### PR DESCRIPTION
If the cache write fails and the value is not a string, the error log will result in an error itself during item size calculation.
This PR serializes values other than strings for size calculation and also considers multibyte characters in string length calculation.