### PR TITLE
Class field rename save error

### DIFF
--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -398,7 +398,7 @@ class Service
     {
         $tableDefinition = $tableDefinitions[$table] ?? false;
         if ($tableDefinition) {
-            $colDefinition = $tableDefinition[$colName];
+            $colDefinition = $tableDefinition[$colName] ?? false;
             if ($colDefinition) {
                 if (!strlen($default) && strtolower($null) === 'null') {
                     $default = null;


### PR DESCRIPTION
When you create a class with a field named 'test' and then change field name to 'Test' and save this error appears

![Screenshot from 2021-12-17 12-34-55](https://user-images.githubusercontent.com/35298078/146539208-f065153d-4201-4111-99bd-2634b623788a.png)

I couldn't reproduce this error on demo projects, but it happened on every project I'm working on (10.1.4 and 10.2.6 versions)  and on fresh docker installation of skeleton version
