### PR TITLE
fix: add UTF-8 support to javascript regex validation

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/input.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/input.js
@@ -113,7 +113,7 @@ pimcore.object.classes.data.input = Class.create(pimcore.object.classes.data.dat
                 var testString = testStringEl.getValue();
 
                 try {
-                    var regexp = new RegExp(regex);
+                    var regexp = new RegExp(regex, 'u');
                     if (regexp.test(testString)) {
                         testStringEl.addCls("class-editor-validation-success");
                         testStringEl.removeCls("class-editor-validation-error");

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/input.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/input.js
@@ -96,7 +96,7 @@ pimcore.object.tags.input = Class.create(pimcore.object.tags.abstract, {
         }
 
         if(this.fieldConfig["regex"]) {
-            input.regex = new RegExp(this.fieldConfig.regex);
+            input.regex = new RegExp(this.fieldConfig.regex, 'u');
         }
 
         this.component = new Ext.form.TextField(input);


### PR DESCRIPTION
add 'u' modifier to javascript input.js regex checks, removing validation error highlights with usage of \p{L} and similar
relates to #11033 

Without this fix:
![image](https://user-images.githubusercontent.com/60101908/146555216-14e29663-eb26-4ad2-a1c5-ad6258d0b64e.png)

With fix:
![image](https://user-images.githubusercontent.com/60101908/146555381-e471fb6a-e5d5-43ed-a59d-8f134f4b81de.png)

(Apologies Dvesh, I didn't test this case enough in my previous PR, should have been included in the mentioned PR)

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

