### PR TITLE
[Feature]: Add pimcoreEditableAdded javascript event

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
@@ -848,12 +848,15 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.area_abstra
                 },
                 success: function (response) {
                     let res = Ext.decode(response.responseText);
+                    let element;
+
                     if(!this.elements.length) {
-                        Ext.get(this.id).setHtml(res['htmlCode']);
+                        element = Ext.get(this.id).setHtml(res['htmlCode']);
+                        element = element.down('.pimcore_block_entry');
                     } else if (this.elements[index-1]) {
-                        Ext.get(this.elements[index-1]).insertHtml('afterEnd', res['htmlCode'], true);
+                        element = Ext.get(this.elements[index-1]).insertHtml('afterEnd', res['htmlCode'], true);
                     } else if (this.elements[index]) {
-                        Ext.get(this.elements[index]).insertHtml('beforeBegin', res['htmlCode'], true);
+                        element = Ext.get(this.elements[index]).insertHtml('beforeBegin', res['htmlCode'], true);
                     }
 
                     res['editableDefinitions'].forEach(editableDef => {
@@ -862,6 +865,9 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.area_abstra
 
                     this.refresh();
 
+                    if (element && element.dom) {
+                        element.dom.dispatchEvent(new Event('pimcoreEditableAdded', { bubbles: true }));
+                    }
                 }.bind(this)
             });
         }

--- a/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/02_Bricks.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/02_Bricks.md
@@ -507,6 +507,27 @@ class Iframe extends AbstractTemplateAreabrick
 }
 ```
 
+## JavaScript editmode handling
+
+To run your own JavaScript code when a brick gets added to a document in editmode, you can listen to the `pimcoreEditableAdded` event:
+
+```js
+const initializeBricks = (bricks) => {
+  // Put your custom JS code here
+  console.log(bricks);
+};
+
+const brickClass = '.example-brick';
+
+// Runs on DOM ready
+initializeBricks(document.querySelectorAll(brickClass));
+
+// Runs on editable added
+document.addEventListener('pimcoreEditableAdded', (event) => {
+  initializeBricks(event.target.querySelectorAll(brickClass));
+});
+```
+
 ## Examples
 
 You can find many examples in the [demo package](https://github.com/pimcore/demo/tree/10.x/src/Document/Areabrick).


### PR DESCRIPTION
## Changes in this pull request  

Adds a javascript event "pimcoreEditableAdded" after an editable was added.

## Additional info  

This feature adds a possibility to run js-brick-logic in editmode without needing to set needsReload to true in bricks.
