### PR TITLE
Add missing type check to the Document path cache

### DIFF
--- a/models/Document.php
+++ b/models/Document.php
@@ -232,7 +232,10 @@ class Document extends Element\AbstractElement
         $cacheKey = self::getPathCacheKey($path);
 
         if (!$force && \Pimcore\Cache\Runtime::isRegistered($cacheKey)) {
-            return \Pimcore\Cache\Runtime::get($cacheKey);
+            $document = \Pimcore\Cache\Runtime::get($cacheKey);
+            if ($document && static::typeMatch($document)) {
+                return $document;
+            }
         }
 
         try {


### PR DESCRIPTION
`Element::getById()` checks the type of the cached element before returning it.
`Document::getByPath()` should do this, too.