### PR TITLE
[Improvement] Creating system thumbnails for grid view (like treepreview thumbnails) to improve performance

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -1308,6 +1308,10 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             $thumbnailConfig = Asset\Image\Thumbnail\Config::getPreviewConfig();
         }
 
+        if ($request->get('frame')) {
+            $thumbnailConfig = Asset\Image\Thumbnail\Config::getGridConfig((bool)$request->get('hdpi'));
+        }
+
         $cropPercent = $request->get('cropPercent');
         if ($cropPercent && filter_var($cropPercent, FILTER_VALIDATE_BOOLEAN)) {
             $thumbnailConfig->addItemAt(0, 'cropPercent', [

--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -228,8 +228,10 @@ class ThumbnailsImageCommand extends AbstractCommand
                 }
 
                 $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig();
+                $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getGridConfig();
             } elseif (!$input->getOption('thumbnails')) {
                 $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig();
+                $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getGridConfig();
             }
         }
 

--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -35,6 +35,11 @@ final class Config extends Model\AbstractModel
     protected const PREVIEW_THUMBNAIL_NAME = 'pimcore-system-treepreview';
 
     /**
+     * @internal
+     */
+    protected const GRID_THUMBNAIL_NAME = 'pimcore-system-grid';
+
+    /**
      * format of array:
      * array(
      array(
@@ -292,6 +297,43 @@ final class Config extends Model\AbstractModel
         }
 
         $thumbnail->setHighResolution(2);
+
+        return $thumbnail;
+    }
+
+    /**
+     * @internal
+     *
+     * @param bool $hdpi
+     *
+     * @return Config
+     */
+    public static function getGridConfig($hdpi = false)
+    {
+        $customPreviewImageThumbnail = \Pimcore::getContainer()->getParameter('pimcore.config')['assets']['preview_image_thumbnail'];
+        $thumbnail = null;
+
+        if ($customPreviewImageThumbnail) {
+            $thumbnail = self::getByName($customPreviewImageThumbnail);
+        }
+
+        if (!$thumbnail) {
+            $thumbnail = new self();
+            $thumbnail->setName(self::GRID_THUMBNAIL_NAME);
+            $thumbnail->addItem('scaleByWidth', [
+                'width' => 88,
+            ]);
+            $thumbnail->addItem('setBackgroundImage', [
+                'path' => '/bundles/pimcoreadmin/img/tree-preview-transparent-background.png',
+                'mode' => 'asTexture',
+            ]);
+            $thumbnail->setQuality(60);
+            $thumbnail->setFormat('PJPEG');
+        }
+
+        if ($hdpi) {
+            $thumbnail->setHighResolution(2);
+        }
 
         return $thumbnail;
     }


### PR DESCRIPTION
  
## Changes in this pull request  
In order to improve performance in projects with many images to show in data objects grid view, we added a new system thumbnail type (like trepreview thumbnails) that the command pimcore:thumbnails:image -s now can create, instead of let Pimcore doing the (auto) thumbnails on demand.