### PR TITLE
[Improvement] Only show area EditableDialogBox dialog when it actually has items to edit

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -697,7 +697,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             ],
         ];
 
-        $hasChildren = (bool)$asset->getChildAmount($this->getAdminUser());
+        $hasChildren = $asset->getDao()->hasChildren($this->getAdminUser());
 
         // set type specific settings
         if ($asset instanceof Asset\Folder) {

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -1476,11 +1476,11 @@ class ClassificationstoreController extends AdminController implements KernelCon
         foreach ($list as $item) {
             $resultItem = [
                 'id' => $item->getId(),
-                'text' => $item->getName(),
+                'text' => htmlspecialchars($item->getName(), ENT_QUOTES),
                 'expandable' => false,
                 'leaf' => true,
                 'expanded' => true,
-                'description' => $item->getDescription(),
+                'description' => htmlspecialchars($item->getDescription(), ENT_QUOTES),
                 'iconCls' => 'pimcore_icon_classificationstore',
             ];
 
@@ -1488,7 +1488,7 @@ class ClassificationstoreController extends AdminController implements KernelCon
 
             if ($item->getDescription()) {
             }
-            $resultItem['qtip'] = $item->getDescription() ? $item->getDescription() : ' ';
+            $resultItem['qtip'] = $item->getDescription() ? htmlspecialchars($item->getDescription(), ENT_QUOTES) : ' ';
             $result[] = $resultItem;
         }
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -278,7 +278,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             $allowedTypes[] = DataObject::OBJECT_TYPE_VARIANT;
         }
 
-        $hasChildren = (bool)$child->getChildAmount($allowedTypes, $this->getAdminUser());
+        $hasChildren = $child->getDao()->hasChildren($allowedTypes, null, $this->getAdminUser());
 
         $tmpObject['allowDrop'] = false;
         $tmpObject['leaf'] = !$hasChildren;

--- a/bundles/AdminBundle/Controller/Traits/DocumentTreeConfigTrait.php
+++ b/bundles/AdminBundle/Controller/Traits/DocumentTreeConfigTrait.php
@@ -69,7 +69,7 @@ trait DocumentTreeConfigTrait
             ],
         ];
 
-        $hasChildren = (bool)$childDocument->getChildAmount(Admin::getCurrentUser());
+        $hasChildren = $childDocument->getDao()->hasChildren(null, Admin::getCurrentUser());
 
         // add icon
         $tmpDocument['expandable'] = $hasChildren;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers/generic-grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers/generic-grid.js
@@ -138,5 +138,5 @@ pimcore.helpers.grid.buildDefaultPagingToolbar = function (store, options) {
 };
 
 pimcore.helpers.grid.getTranslationColumnRenderer = function (value, metaData, record, rowIndex, colIndex, store) {
-    return t(value);
+    return Ext.util.Format.htmlEncode(t(value));
 };

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/input.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/input.js
@@ -113,7 +113,7 @@ pimcore.object.classes.data.input = Class.create(pimcore.object.classes.data.dat
                 var testString = testStringEl.getValue();
 
                 try {
-                    var regexp = new RegExp(regex);
+                    var regexp = new RegExp(regex, 'u');
                     if (regexp.test(testString)) {
                         testStringEl.addCls("class-editor-validation-success");
                         testStringEl.removeCls("class-editor-validation-error");

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classificationstore/collectionsPanel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classificationstore/collectionsPanel.js
@@ -116,8 +116,10 @@ pimcore.object.classificationstore.collectionsPanel = Class.create({
         });
 
         gridColumns.push({text: t("group_id"), flex: 60, sortable: true, dataIndex: 'groupId', filter: 'string'});
-        gridColumns.push({text: t("name"), flex: 200, sortable: true, dataIndex: 'groupName', filter: 'string'});
-        gridColumns.push({text: t("description"), flex: 200, sortable: true, dataIndex: 'groupDescription', filter: 'string'});
+        gridColumns.push({text: t("name"), flex: 200, sortable: true, dataIndex: 'groupName', filter: 'string',
+            renderer: Ext.util.Format.htmlEncode});
+        gridColumns.push({text: t("description"), flex: 200, sortable: true, dataIndex: 'groupDescription', filter: 'string',
+            renderer: Ext.util.Format.htmlEncode});
 
         gridColumns.push({text: t('sorter'), width: 150, sortable: true, dataIndex: 'sorter',
             tooltip: t("classificationstore_tooltip_sorter"),
@@ -264,8 +266,10 @@ pimcore.object.classificationstore.collectionsPanel = Class.create({
 
         //gridColumns.push({text: t("store"), flex: 60, sortable: true, dataIndex: 'storeId', filter: 'string'});
         gridColumns.push({text: "ID", flex: 60, sortable: true, dataIndex: 'id', filter: 'string'});
-        gridColumns.push({text: t("name"), flex: 200, sortable: true, dataIndex: 'name', editor: new Ext.form.TextField({}), filter: 'string'});
-        gridColumns.push({text: t("description"), flex: 300, sortable: true, dataIndex: 'description', editor: new Ext.form.TextField({}), filter: 'string'});
+        gridColumns.push({text: t("name"), flex: 200, sortable: true, dataIndex: 'name', editor: new Ext.form.TextField({}), filter: 'string',
+            renderer: Ext.util.Format.htmlEncode});
+        gridColumns.push({text: t("description"), flex: 300, sortable: true, dataIndex: 'description', editor: new Ext.form.TextField({}), filter: 'string',
+            renderer: Ext.util.Format.htmlEncode});
 
         var dateRenderer =  function(d) {
             if (d !== undefined) {
@@ -359,7 +363,7 @@ pimcore.object.classificationstore.collectionsPanel = Class.create({
                     if (selected.length > 0) {
                         var record = selected[0];
                         var collectionId = record.data.id;
-                        var collectionName = record.data.name;
+                        var collectionName = Ext.util.Format.htmlEncode(record.data.name);
 
                         this.collectionId = collectionId;
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classificationstore/groupsPanel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classificationstore/groupsPanel.js
@@ -119,8 +119,10 @@ pimcore.object.classificationstore.groupsPanel = Class.create({
 
 
         gridColumns.push({text: t("key_id"), flex: 60, sortable: true, dataIndex: 'keyId', filter: 'string'});
-        gridColumns.push({text: t("name"), flex: 200, sortable: true, dataIndex: 'keyName', filter: 'string'});
-        gridColumns.push({text: t("description"), flex: 200, sortable: true, dataIndex: 'keyDescription', filter: 'string'});
+        gridColumns.push({text: t("name"), flex: 200, sortable: true, dataIndex: 'keyName', filter: 'string',
+            renderer: Ext.util.Format.htmlEncode});
+        gridColumns.push({text: t("description"), flex: 200, sortable: true, dataIndex: 'keyDescription', filter: 'string',
+            renderer: Ext.util.Format.htmlEncode});
 
         gridColumns.push(mandatoryCheck);
         gridColumns.push({text: t('sorter'), width: 150, sortable: true, dataIndex: 'sorter',
@@ -269,8 +271,10 @@ pimcore.object.classificationstore.groupsPanel = Class.create({
         //gridColumns.push({text: t("store"), width: 60, sortable: true, dataIndex: 'storeId', filter: 'string'});
         gridColumns.push({text: "ID", width: 60, sortable: true, dataIndex: 'id', filter: 'string'});
         gridColumns.push({text: t("parent_id"), width: 160, sortable: true, dataIndex: 'parentId', hidden: true, editor: new Ext.form.TextField({})});
-        gridColumns.push({text: t("name"), flex: 200, sortable: true, dataIndex: 'name', editor: new Ext.form.TextField({}), filter: 'string'});
-        gridColumns.push({text: t("description"), flex: 300, sortable: true, dataIndex: 'description', editor: new Ext.form.TextField({}), filter: 'string'});
+        gridColumns.push({text: t("name"), flex: 200, sortable: true, dataIndex: 'name', editor: new Ext.form.TextField({}), filter: 'string',
+            renderer: Ext.util.Format.htmlEncode});
+        gridColumns.push({text: t("description"), flex: 300, sortable: true, dataIndex: 'description', editor: new Ext.form.TextField({}), filter: 'string',
+            renderer: Ext.util.Format.htmlEncode});
 
         var dateRenderer =  function(d) {
             if (d !== undefined) {
@@ -365,7 +369,7 @@ pimcore.object.classificationstore.groupsPanel = Class.create({
                     if (selected.length > 0) {
                         var record = selected[0];
                         var groupId = record.data.id;
-                        var groupName = record.data.name;
+                        var groupName = Ext.util.Format.htmlEncode(record.data.name);
 
                         this.groupId = groupId;
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classificationstore/propertiesPanel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classificationstore/propertiesPanel.js
@@ -125,13 +125,16 @@ pimcore.object.classificationstore.propertiespanel = Class.create({
                 sortable: true,
                 dataIndex: 'name',
                 filter: 'string',
-                editor: new Ext.form.TextField({})
+                editor: new Ext.form.TextField({}),
+                renderer: Ext.util.Format.htmlEncode
             }
 
         );
 
-        gridColumns.push({text: t("title"), width: 200, sortable: false, dataIndex: 'title',editor: new Ext.form.TextField({}), filter: 'string'});
-        gridColumns.push({text: t("description"), width: 300, sortable: true, dataIndex: 'description',editor: new Ext.form.TextField({}), filter: 'string'});
+        gridColumns.push({text: t("title"), width: 200, sortable: false, dataIndex: 'title',editor: new Ext.form.TextField({}), filter: 'string',
+            renderer: Ext.util.Format.htmlEncode});
+        gridColumns.push({text: t("description"), width: 300, sortable: true, dataIndex: 'description',editor: new Ext.form.TextField({}), filter: 'string',
+            renderer: Ext.util.Format.htmlEncode});
         gridColumns.push({text: t("definition"), width: 300, sortable: true, hidden: true, dataIndex: 'definition',editor: new Ext.form.TextField({})});
         gridColumns.push({text: t("type"), width: 150, sortable: true, dataIndex: 'type', filter: 'string',
             editor: new Ext.form.ComboBox({
@@ -285,7 +288,7 @@ pimcore.object.classificationstore.propertiespanel = Class.create({
         var definition = data.data.definition;
         if (definition) {
             definition = Ext.util.JSON.decode(definition);
-            definition.name = data.data.name;
+            definition.name = Ext.util.Format.htmlEncode(data.data.name);
         } else {
             definition = {
                 name: data.data.name

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classificationstore/storeTree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classificationstore/storeTree.js
@@ -166,8 +166,8 @@ pimcore.object.classificationstore.storeTree = Class.create({
                 "click": function() {
                     var data = {
                         id: record.data.id,
-                        name: record.data.text,
-                        description: record.data.description
+                        name: Ext.util.Format.htmlDecode(record.data.text),
+                        description: Ext.util.Format.htmlDecode(record.data.description)
                     }
                     var panel = new pimcore.object.classificationstore.storeConfiguration(data, this.applyConfig.bind(this));
                     panel.show();

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/input.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/input.js
@@ -96,7 +96,7 @@ pimcore.object.tags.input = Class.create(pimcore.object.tags.abstract, {
         }
 
         if(this.fieldConfig["regex"]) {
-            input.regex = new RegExp(this.fieldConfig.regex);
+            input.regex = new RegExp(this.fieldConfig.regex, 'u');
         }
 
         this.component = new Ext.form.TextField(input);

--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -123,7 +123,12 @@ class ThumbnailsImageCommand extends AbstractCommand
         $list->setCondition(implode(' AND ', $conditions));
 
         $assetIdsList = $list->loadIdList();
-        $thumbnailList = new Asset\Image\Thumbnail\Config\Listing();
+        $thumbnailList = [];
+        $thumbnailList[] = Asset\Image\Thumbnail\Config::getPreviewConfig();
+        if (!$input->getOption('system')) {
+            $thumbnailList = new Asset\Image\Thumbnail\Config\Listing();
+            $thumbnailList = $thumbnailList->getThumbnails();
+        }
 
         $allowedThumbs = [];
         if ($input->getOption('thumbnails')) {
@@ -132,7 +137,7 @@ class ThumbnailsImageCommand extends AbstractCommand
 
         $items = [];
         foreach ($assetIdsList as $assetId) {
-            foreach ($thumbnailList->getThumbnails() as $thumbnailConfig) {
+            foreach ($thumbnailList as $thumbnailConfig) {
                 $thumbName = $thumbnailConfig->getName();
                 if (empty($allowedThumbs) || in_array($thumbName, $allowedThumbs)) {
                     $items[] = $assetId . '~~~' . $thumbName;
@@ -220,16 +225,6 @@ class ThumbnailsImageCommand extends AbstractCommand
                     $avifConfig->setFormat('avif');
                     $thumbnailsToGenerate[] = $avifConfig;
                 }
-            }
-
-            if ($input->getOption('system')) {
-                if (!$input->getOption('thumbnails')) {
-                    $thumbnailsToGenerate = [];
-                }
-
-                $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig();
-            } elseif (!$input->getOption('thumbnails')) {
-                $thumbnailsToGenerate[] = Asset\Image\Thumbnail\Config::getPreviewConfig();
             }
         }
 

--- a/bundles/EcommerceFrameworkBundle/Model/DefaultMockup.php
+++ b/bundles/EcommerceFrameworkBundle/Model/DefaultMockup.php
@@ -16,8 +16,9 @@
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
 
 use Pimcore\Logger;
+use Pimcore\Model\DataObject;
 
-class DefaultMockup implements ProductInterface
+class DefaultMockup implements ProductInterface, LinkGeneratorAwareInterface
 {
     /** @var int */
     protected $id;
@@ -27,6 +28,12 @@ class DefaultMockup implements ProductInterface
 
     /** @var array */
     protected $relations;
+
+    /**
+     * contains link generators by class type (just for caching)
+     * @var array
+     */
+    protected static array $linkGenerators = [];
 
     public function __construct($id, $params, $relations)
     {
@@ -39,6 +46,13 @@ class DefaultMockup implements ProductInterface
                 $this->relations[$relation['fieldname']][] = ['id' => $relation['dest'], 'type' => $relation['type']];
             }
         }
+    }
+
+    public function getLinkGenerator(): ?DataObject\ClassDefinition\LinkGeneratorInterface {
+        if($classId = $this->params['o_classId'] ?? null){
+            return static::$linkGenerators[$classId] ??= DataObject\ClassDefinition::getById($classId)->getLinkGenerator();
+        }
+        return null;
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/Model/DefaultMockup.php
+++ b/bundles/EcommerceFrameworkBundle/Model/DefaultMockup.php
@@ -31,6 +31,7 @@ class DefaultMockup implements ProductInterface, LinkGeneratorAwareInterface
 
     /**
      * contains link generators by class type (just for caching)
+     *
      * @var array
      */
     protected static array $linkGenerators = [];
@@ -48,10 +49,12 @@ class DefaultMockup implements ProductInterface, LinkGeneratorAwareInterface
         }
     }
 
-    public function getLinkGenerator(): ?DataObject\ClassDefinition\LinkGeneratorInterface {
-        if($classId = $this->params['o_classId'] ?? null){
+    public function getLinkGenerator(): ?DataObject\ClassDefinition\LinkGeneratorInterface
+    {
+        if ($classId = $this->params['o_classId'] ?? null) {
             return static::$linkGenerators[$classId] ??= DataObject\ClassDefinition::getById($classId)->getLinkGenerator();
         }
+
         return null;
     }
 

--- a/bundles/EcommerceFrameworkBundle/Model/LinkGeneratorAwareInterface.php
+++ b/bundles/EcommerceFrameworkBundle/Model/LinkGeneratorAwareInterface.php
@@ -1,6 +1,20 @@
 <?php
 
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
+
 use Pimcore\Model\DataObject;
 
 /**
@@ -8,7 +22,6 @@ use Pimcore\Model\DataObject;
  */
 interface LinkGeneratorAwareInterface
 {
-
     /**
      * @return DataObject\ClassDefinition\LinkGeneratorInterface|null
      */

--- a/bundles/EcommerceFrameworkBundle/Model/LinkGeneratorAwareInterface.php
+++ b/bundles/EcommerceFrameworkBundle/Model/LinkGeneratorAwareInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
+use Pimcore\Model\DataObject;
+
+/**
+ * Interface LinkGeneratorAwareInterface
+ */
+interface LinkGeneratorAwareInterface
+{
+
+    /**
+     * @return DataObject\ClassDefinition\LinkGeneratorInterface|null
+     */
+    public function getLinkGenerator(): ?DataObject\ClassDefinition\LinkGeneratorInterface;
+}

--- a/bundles/EcommerceFrameworkBundle/PricingManager/Condition/DateRange.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Condition/DateRange.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Condition;
 
+use DateTimeZone;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\ConditionInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\EnvironmentInterface;
 
@@ -91,8 +92,8 @@ class DateRange implements DateRangeInterface
     {
         return json_encode([
             'type' => 'DateRange',
-            'starting' => $this->getStarting()->getTimestamp(),
-            'ending' => $this->getEnding()->getTimestamp(),
+            'starting' => $this->getStarting()->format('d.m.Y'),
+            'ending' => $this->getEnding()->format('d.m.Y'),
         ]);
     }
 
@@ -105,10 +106,10 @@ class DateRange implements DateRangeInterface
     {
         $json = json_decode($string);
 
-        $starting = \DateTime::createFromFormat('Y-m-d\TH:i:s', $json->starting);
+        $starting = \DateTime::createFromFormat('d.m.Y', $json->starting, new DateTimeZone('UTC'));
         $starting->setTime(0, 0, 0);
 
-        $ending = \DateTime::createFromFormat('Y-m-d\TH:i:s', $json->ending);
+        $ending = \DateTime::createFromFormat('d.m.Y', $json->ending, new DateTimeZone('UTC'));
         $ending->setTime(23, 59, 59);
 
         $this->setStarting($starting);

--- a/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/item.js
+++ b/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/item.js
@@ -368,6 +368,10 @@ pimcore.bundle.EcommerceFramework.pricing.config.item = Class.create({
                     {
                         condition[ item.name ] = item.getForm().getFieldValues();
                     }
+                    else if(item.xtype === 'datefield')
+                    {
+                        condition[ item.name ] = item.getSubmitValue();
+                    }
                     else
                     {
                         condition[ item.getName() ] = item.getValue();

--- a/bundles/EcommerceFrameworkBundle/Tools/Installer.php
+++ b/bundles/EcommerceFrameworkBundle/Tools/Installer.php
@@ -17,7 +17,6 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\Tools;
 
 use Doctrine\DBAL\Schema\Schema;
 use Pimcore\Db\ConnectionInterface;
-use Doctrine\DBAL\Connection;
 use Pimcore\Extension\Bundle\Installer\AbstractInstaller;
 use Pimcore\Extension\Bundle\Installer\Exception\InstallationException;
 use Pimcore\Model\DataObject\ClassDefinition;

--- a/bundles/EcommerceFrameworkBundle/Tools/Installer.php
+++ b/bundles/EcommerceFrameworkBundle/Tools/Installer.php
@@ -15,9 +15,9 @@
 
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\Tools;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Schema;
 use Pimcore\Db\ConnectionInterface;
+use Doctrine\DBAL\Connection;
 use Pimcore\Extension\Bundle\Installer\AbstractInstaller;
 use Pimcore\Extension\Bundle\Installer\Exception\InstallationException;
 use Pimcore\Model\DataObject\ClassDefinition;
@@ -152,7 +152,7 @@ class Installer extends AbstractInstaller
     protected $db;
 
     /**
-     * @var Schema
+     * @var Schema|null
      */
     protected $schema;
 
@@ -163,10 +163,6 @@ class Installer extends AbstractInstaller
         $this->installSourcesPath = __DIR__ . '/../Resources/install';
         $this->bundle = $bundle;
         $this->db = $connection;
-        if ($this->db instanceof Connection) {
-            $this->schema = $this->db->getSchemaManager()->createSchema();
-        }
-
         parent::__construct();
     }
 
@@ -348,7 +344,7 @@ class Installer extends AbstractInstaller
     private function installTables()
     {
         foreach ($this->tablesToInstall as $name => $statement) {
-            if ($this->schema->hasTable($name)) {
+            if ($this->getSchema()->hasTable($name)) {
                 $this->output->write(sprintf(
                     '     <comment>WARNING:</comment> Skipping table "%s" as it already exists',
                     $name
@@ -364,7 +360,7 @@ class Installer extends AbstractInstaller
     private function uninstallTables()
     {
         foreach (array_keys($this->tablesToInstall) as $table) {
-            if (!$this->schema->hasTable($table)) {
+            if (!$this->getSchema()->hasTable($table)) {
                 $this->output->write(sprintf(
                     '     <comment>WARNING:</comment> Not dropping table "%s" as it doesn\'t exist',
                     $table
@@ -373,7 +369,7 @@ class Installer extends AbstractInstaller
                 continue;
             }
 
-            $this->schema->dropTable($table);
+            $this->getSchema()->dropTable($table);
         }
     }
 
@@ -413,5 +409,13 @@ class Installer extends AbstractInstaller
     public function needsReloadAfterInstall()
     {
         return true;
+    }
+
+    /**
+     * @return Schema
+     */
+    protected function getSchema(): Schema
+    {
+        return $this->schema ??= $this->db->getSchemaManager()->createSchema();
     }
 }

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/30_Link_Generator.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/30_Link_Generator.md
@@ -41,6 +41,7 @@ use App\Website\Tool\Text;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\ProductInterface;
 use Pimcore\Model\DataObject\ClassDefinition\LinkGeneratorInterface;
 use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Bundle\EcommerceFrameworkBundle\Model\DefaultMockup;
 
 class ProductLinkGenerator extends AbstractProductLinkGenerator implements LinkGeneratorInterface
 {
@@ -90,6 +91,23 @@ class ProductLinkGenerator extends AbstractProductLinkGenerator implements LinkG
     }
 }
 ```
+
+Note: If you want to support mockups or arbitrary objects you can change the typehint to:
+```php
+    /**
+     * @param object $object
+     * @param array $params
+     *
+     * @return string
+     */
+    public function generate(object $object, array $params = []): string
+    {
+        //...
+    }
+```
+
+
+
 
 The link generator will receive the referenced object and additional data depending on the context.
 This would be the document (if embedded in a document), the object if embedded in an object including the tag or field definition as context.

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/09_Performance_Guide.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/09_Performance_Guide.md
@@ -174,20 +174,6 @@ to decide buffer pool size and update `my.cnf`:
     innodb_buffer_pool_size=5G # needs to be adjusted according to your data
 ```
 
-#### MySQL Query Cache
-MySQL server features a Query Cache. When enabled, the query cache stores SELECT statements together 
-with the retrieved record set in memory, then if another identical query is received, the server can 
- retrieve the results from the query cache rather than parsing and executing the same query again.
-
-- you can check if query cache is enabled with command `SHOW VARIABLES LIKE 'have_query_cache';`. 
-- In order to enable the query caching, update `my.cnf`:
-```ini
-[mysqld] 
-query_cache_type=1 
-query_cache_size = 10M 
-query_cache_limit=256K
-```
-
 - you can also use Mysql Tuning script for more optimizations [mysqltuner.pl](https://github.com/rackerhacker/MySQLTuner-perl)
 
 #### Benchmarks:

--- a/lib/Db/ConnectionInterface.php
+++ b/lib/Db/ConnectionInterface.php
@@ -24,6 +24,9 @@ use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Pimcore\Model\Element\ValidationException;
 
+/**
+ * @method \Doctrine\DBAL\Schema\AbstractSchemaManager getSchemaManager()
+ */
 interface ConnectionInterface extends Connection
 {
     /**

--- a/lib/Extension/Document/Areabrick/EditableDialogBoxConfiguration.php
+++ b/lib/Extension/Document/Areabrick/EditableDialogBoxConfiguration.php
@@ -154,6 +154,14 @@ class EditableDialogBoxConfiguration implements \JsonSerializable
         return $this;
     }
 
+    /**
+     * @return bool
+     */
+    public function isEmpty(): bool
+    {
+        return empty($this->items);
+    }
+
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Extension/Document/Areabrick/EditableDialogBoxConfiguration.php
+++ b/lib/Extension/Document/Areabrick/EditableDialogBoxConfiguration.php
@@ -154,14 +154,6 @@ class EditableDialogBoxConfiguration implements \JsonSerializable
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function isEmpty(): bool
-    {
-        return empty($this->items);
-    }
-
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Twig/Extension/Templating/PimcoreUrl.php
+++ b/lib/Twig/Extension/Templating/PimcoreUrl.php
@@ -99,18 +99,18 @@ class PimcoreUrl implements RuntimeExtensionInterface
             $name = $this->getCurrentRoute();
         }
 
-        $object = $parameters["object"] ?? null;
+        $object = $parameters['object'] ?? null;
         $linkGenerator = null;
 
-        if($object instanceof LinkGeneratorAwareInterface){ //e.g. Mockup
+        if ($object instanceof LinkGeneratorAwareInterface) { //e.g. Mockup
             $linkGenerator = $object->getLinkGenerator();
-        }elseif($object instanceof Concrete){
+        } elseif ($object instanceof Concrete) {
             $linkGenerator = $object->getClass()->getLinkGenerator();
         }
 
-        if($linkGenerator){
-            if(array_key_exists("object",$parameters)){
-                unset($parameters["object"]);
+        if ($linkGenerator) {
+            if (array_key_exists('object', $parameters)) {
+                unset($parameters['object']);
             }
             $path = $linkGenerator->generate($object, [
                 'route' => $name,

--- a/lib/Twig/Extension/Templating/PimcoreUrl.php
+++ b/lib/Twig/Extension/Templating/PimcoreUrl.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Twig\Extension\Templating;
 
+use Pimcore\Bundle\EcommerceFrameworkBundle\Model\LinkGeneratorAwareInterface;
 use Pimcore\Http\RequestHelper;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Twig\Extension\Templating\Traits\HelperCharsetTrait;
@@ -98,19 +99,27 @@ class PimcoreUrl implements RuntimeExtensionInterface
             $name = $this->getCurrentRoute();
         }
 
-        if (isset($parameters['object']) && $parameters['object'] instanceof Concrete) {
-            $object = $parameters['object'];
-            if ($linkGenerator = $object->getClass()->getLinkGenerator()) {
-                unset($parameters['object']);
-                $path = $linkGenerator->generate($object, [
-                    'route' => $name,
-                    'parameters' => $parameters,
-                    'context' => $this,
-                    'referenceType' => $referenceType,
-                ]);
+        $object = $parameters["object"] ?? null;
+        $linkGenerator = null;
 
-                return $path;
+        if($object instanceof LinkGeneratorAwareInterface){ //e.g. Mockup
+            $linkGenerator = $object->getLinkGenerator();
+        }elseif($object instanceof Concrete){
+            $linkGenerator = $object->getClass()->getLinkGenerator();
+        }
+
+        if($linkGenerator){
+            if(array_key_exists("object",$parameters)){
+                unset($parameters["object"]);
             }
+            $path = $linkGenerator->generate($object, [
+                'route' => $name,
+                'parameters' => $parameters,
+                'context' => $this,
+                'referenceType' => $referenceType,
+            ]);
+
+            return $path;
         }
 
         if ($name !== null) {

--- a/models/DataObject/ClassDefinition/Data/Input.php
+++ b/models/DataObject/ClassDefinition/Data/Input.php
@@ -304,7 +304,7 @@ class Input extends Data implements
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
         if (!$omitMandatoryCheck && $this->getRegex() && strlen($data) > 0) {
-            if (!preg_match('#' . $this->getRegex() . '#', $data)) {
+            if (!preg_match('#' . $this->getRegex() . '#u', $data)) {
                 throw new Model\Element\ValidationException('Value in field [ ' . $this->getName() . " ] doesn't match input validation '" . $this->getRegex() . "'");
             }
         }

--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -354,7 +354,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
     {
         $unserializedData = Serialize::unserialize((string) $data);
 
-        if ($data === null || $unserializedData === null) {
+        if ($data === null || empty($unserializedData)) {
             return [];
         }
 

--- a/models/DataObject/ClassDefinition/LinkGeneratorInterface.php
+++ b/models/DataObject/ClassDefinition/LinkGeneratorInterface.php
@@ -20,6 +20,12 @@ use Pimcore\Model\DataObject\Concrete;
 interface LinkGeneratorInterface
 {
     /**
+     *
+     * If you want to support mockups or arbitrary objects you can change the typehint to
+     * public function generate(object $object, array $params = []): string
+     *
+     * TODO: Change type of `$object` parameter to `object` in Pimcore 11
+     *
      * @param Concrete $object
      * @param array $params
      *

--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -398,7 +398,7 @@ class Service
     {
         $tableDefinition = $tableDefinitions[$table] ?? false;
         if ($tableDefinition) {
-            $colDefinition = $tableDefinition[$colName];
+            $colDefinition = $tableDefinition[$colName] ?? false;
             if ($colDefinition) {
                 if (!strlen($default) && strtolower($null) === 'null') {
                     $default = null;

--- a/models/Document.php
+++ b/models/Document.php
@@ -232,7 +232,10 @@ class Document extends Element\AbstractElement
         $cacheKey = self::getPathCacheKey($path);
 
         if (!$force && \Pimcore\Cache\Runtime::isRegistered($cacheKey)) {
-            return \Pimcore\Cache\Runtime::get($cacheKey);
+            $document = \Pimcore\Cache\Runtime::get($cacheKey);
+            if ($document && static::typeMatch($document)) {
+                return $document;
+            }
         }
 
         try {

--- a/models/Document.php
+++ b/models/Document.php
@@ -20,7 +20,6 @@ use Pimcore\Event\DocumentEvents;
 use Pimcore\Event\FrontendEvents;
 use Pimcore\Event\Model\DocumentEvent;
 use Pimcore\Logger;
-use Pimcore\Model\Document\Hardlink;
 use Pimcore\Model\Document\Hardlink\Wrapper\WrapperInterface;
 use Pimcore\Model\Document\Listing;
 use Pimcore\Model\Element\ElementInterface;
@@ -209,6 +208,18 @@ class Document extends Element\AbstractElement
     }
 
     /**
+     * @internal
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    protected static function getPathCacheKey(string $path): string
+    {
+        return 'document_path_' . md5($path);
+    }
+
+    /**
      * @param string $path
      * @param bool $force
      *
@@ -218,7 +229,7 @@ class Document extends Element\AbstractElement
     {
         $path = Element\Service::correctPath($path);
 
-        $cacheKey = 'document_path_' . md5($path);
+        $cacheKey = self::getPathCacheKey($path);
 
         if (!$force && \Pimcore\Cache\Runtime::isRegistered($cacheKey)) {
             return \Pimcore\Cache\Runtime::get($cacheKey);
@@ -420,10 +431,17 @@ class Document extends Element\AbstractElement
 
                     // if the old path is different from the new path, update all children
                     $updatedChildren = [];
-                    if ($oldPath && $oldPath != $this->getRealFullPath()) {
+                    if ($oldPath && $oldPath !== $newPath = $this->getRealFullPath()) {
                         $differentOldPath = $oldPath;
                         $this->getDao()->updateWorkspaces();
-                        $updatedChildren = $this->getDao()->updateChildPaths($oldPath);
+                        $updatedChildren = array_map(
+                            static function (array $doc) use ($oldPath, $newPath): array {
+                                $doc['oldPath'] = substr_replace($doc['path'], $oldPath, 0, strlen($newPath));
+
+                                return $doc;
+                            },
+                            $this->getDao()->updateChildPaths($oldPath),
+                        );
                     }
 
                     $this->commit();
@@ -453,12 +471,13 @@ class Document extends Element\AbstractElement
 
             $additionalTags = [];
             if (isset($updatedChildren) && is_array($updatedChildren)) {
-                foreach ($updatedChildren as $documentId) {
-                    $tag = 'document_' . $documentId;
+                foreach ($updatedChildren as $updatedDocument) {
+                    $tag = self::getCacheKey($updatedDocument['id']);
                     $additionalTags[] = $tag;
 
-                    // remove the child also from registry (internal cache) to avoid path inconsistencies during long running scripts, such as CLI
+                    // remove the child also from registry (internal cache) to avoid path inconsistencies during long-running scripts, such as CLI
                     \Pimcore\Cache\Runtime::set($tag, null);
+                    \Pimcore\Cache\Runtime::set(self::getPathCacheKey($updatedDocument['oldPath']), null);
                 }
             }
             $this->clearDependentCache($additionalTags);
@@ -825,6 +844,7 @@ class Document extends Element\AbstractElement
 
         //clear document from registry
         \Pimcore\Cache\Runtime::set(self::getCacheKey($this->getId()), null);
+        \Pimcore\Cache\Runtime::set(self::getPathCacheKey($this->getRealFullPath()), null);
 
         \Pimcore::getEventDispatcher()->dispatch(new DocumentEvent($this), DocumentEvents::POST_DELETE);
     }

--- a/models/Document.php
+++ b/models/Document.php
@@ -220,11 +220,9 @@ class Document extends Element\AbstractElement
 
         $cacheKey = 'document_path_' . md5($path);
 
-        if (\Pimcore\Cache\Runtime::isRegistered($cacheKey)) {
+        if (!$force && \Pimcore\Cache\Runtime::isRegistered($cacheKey)) {
             return \Pimcore\Cache\Runtime::get($cacheKey);
         }
-
-        $doc = null;
 
         try {
             $helperDoc = new Document();

--- a/models/Document/Dao.php
+++ b/models/Document/Dao.php
@@ -192,7 +192,7 @@ class Dao extends Model\Element\Dao
     public function updateChildPaths($oldPath)
     {
         //get documents to empty their cache
-        $documents = $this->db->fetchCol('SELECT id FROM documents WHERE path LIKE ?', $this->db->escapeLike($oldPath) . '%');
+        $documents = $this->db->fetchAll('SELECT id, CONCAT(path,`key`) AS path FROM documents WHERE path LIKE ?', [$this->db->escapeLike($oldPath) . '%']);
 
         $userId = '0';
         if ($user = \Pimcore\Tool\Admin::getCurrentUser()) {

--- a/models/Document/Editable/Area.php
+++ b/models/Document/Editable/Area.php
@@ -149,7 +149,7 @@ class Area extends Model\Document\Editable
             $dialogConfig->setId('dialogBox-' . $this->getName());
         }
 
-        if ($dialogConfig) {
+        if ($dialogConfig && !$dialogConfig->isEmpty()) {
             $attributes = $this->getEditmodeElementAttributes();
             $dialogAttributes = [
                 'data-dialog-id' => $dialogConfig->getId(),

--- a/models/Document/Editable/Area.php
+++ b/models/Document/Editable/Area.php
@@ -146,10 +146,14 @@ class Area extends Model\Document\Editable
         $info = $this->buildInfoObject();
         if ($this->getEditmode() && $brick instanceof EditableDialogBoxInterface) {
             $dialogConfig = $brick->getEditableDialogBoxConfiguration($this, $info);
-            $dialogConfig->setId('dialogBox-' . $this->getName());
+            if ($dialogConfig->getItems()) {
+                $dialogConfig->setId('dialogBox-' . $this->getName());
+            } else {
+                $dialogConfig = null;
+            }
         }
 
-        if ($dialogConfig && !$dialogConfig->isEmpty()) {
+        if ($dialogConfig) {
             $attributes = $this->getEditmodeElementAttributes();
             $dialogAttributes = [
                 'data-dialog-id' => $dialogConfig->getId(),


### PR DESCRIPTION
**Situation**
An area is used multiple times throughout different templates.

**Problem**
The area shall offer an EditableDialogBox in the one template, but must not have such in the other one.

**Solution**
The area checks if there are items to be edited. If so, the dialog is output.