### PR TITLE
[Data Object] Values of options provider for (multi) select data-type are strings

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multiselect.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multiselect.js
@@ -98,7 +98,7 @@ pimcore.object.tags.multiselect = Class.create(pimcore.object.tags.abstract, {
                 if(label.indexOf('<') >= 0) {
                     label = replace_html_event_attributes(strip_tags(label, "div,span,b,strong,em,i,small,sup,sub2"));
                 }
-                storeData.push({id: value, text: label});
+                storeData.push({id: value.toString(), text: label});
             }
         }
 


### PR DESCRIPTION
If custom provider provides an integer as value, the List-View of the multiselect field won't show selected items after reload.
Tags-View works, so I'm assuming a handling "Ext.ux.form.MultiSelect" vs. "Ext.form.field.Tag". 