### PR TITLE
[Bug] Fixed Warning: Undefined array key in $actions variable

### DIFF
--- a/lib/Targeting/EventListener/TargetingListener.php
+++ b/lib/Targeting/EventListener/TargetingListener.php
@@ -248,7 +248,7 @@ class TargetingListener implements EventSubscriberInterface
                 continue;
             }
 
-            if (!is_array($actions[$type])) {
+            if (array_key_exists($type,$actions) && !is_array($actions[$type])) {
                 $actions[$type] = [$action];
             } else {
                 $actions[$type][] = $action;

--- a/lib/Targeting/EventListener/TargetingListener.php
+++ b/lib/Targeting/EventListener/TargetingListener.php
@@ -248,7 +248,7 @@ class TargetingListener implements EventSubscriberInterface
                 continue;
             }
 
-            if (array_key_exists($type,$actions) && !is_array($actions[$type])) {
+            if (!isset($actions[$type])) {
                 $actions[$type] = [$action];
             } else {
                 $actions[$type][] = $action;


### PR DESCRIPTION


## Resolves 
Warning: Undefined array key "" in $actions variable

## Additional info  
Steps to reproduce

-   Enable debug mode
-   Create global targeting rule using action Code-Snippet
-   Check on the frontend side will get ' Warning: Undefined array key "codesnippet" '

![image](https://user-images.githubusercontent.com/30948231/147241512-8e647f3a-c122-4d62-b7a4-51c4cb2ca11d.png)



