### PR TITLE
Fix issue with remaining tmp files created by getting metadata

### DIFF
--- a/models/Search/Backend/Data.php
+++ b/models/Search/Backend/Data.php
@@ -461,7 +461,9 @@ class Data extends \Pimcore\Model\AbstractModel
                 }
             } elseif ($element instanceof Asset\Image) {
                 try {
-                    $metaData = array_merge($element->getEXIFData(), $element->getIPTCData());
+                    $elementLocalPath = $element->getLocalFile();
+                    $metaData = array_merge($element->getEXIFData($elementLocalPath), $element->getIPTCData($elementLocalPath));
+                    unlink($elementLocalPath);
                     foreach ($metaData as $key => $value) {
                         if (is_array($value)) {
                             $this->data .= ' ' . $key . ' : ' . implode(' - ', $value);


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
Unlink tmp files after getting metadata info

## Additional info  

In Search Backend Data.php model, after setting data from element, methods "getEXIFData()" and "getIPTCData" is creating local files in tmp folder, but doesn't unlink them, so you can wake up with full storage.