### PR TITLE
[Element] Performance optimization for getting cache tags of elements

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -279,7 +279,8 @@ final class Config implements \ArrayAccess
                     }
 
                     if ($s instanceof Model\Element\ElementInterface) {
-                        $cacheTags = $s->getCacheTags($cacheTags);
+                        $elementCacheKey = $s->getCacheTag();
+                        $cacheTags[$elementCacheKey] = $elementCacheKey;
                     }
 
                     if (isset($s)) {

--- a/lib/Tool/Text.php
+++ b/lib/Tool/Text.php
@@ -231,13 +231,10 @@ class Text
                 $id = $idMatches[0];
                 $type = $typeMatches[0];
 
-                $element = Element\Service::getElementById($type, $id);
-
-                if ($id && $type && $element instanceof Element\ElementInterface) {
+                if ($id && $type) {
                     $elements[] = [
                         'id' => $id,
                         'type' => $type,
-                        'element' => $element,
                     ];
                 }
             }
@@ -284,9 +281,9 @@ class Text
         if (!empty($text)) {
             $elements = self::getElementsInWysiwyg($text);
             foreach ($elements as $element) {
-                $el = $element['element'];
-                if (!array_key_exists($el->getCacheTag(), $tags)) {
-                    $tags = $el->getCacheTags($tags);
+                $tag = Element\Service::getElementCacheTag($element['type'], $element['id']);
+                if (!isset($tags[$tag])) {
+                    $tags[$tag] = $tag;
                 }
             }
         }

--- a/lib/Tool/Text.php
+++ b/lib/Tool/Text.php
@@ -282,9 +282,7 @@ class Text
             $elements = self::getElementsInWysiwyg($text);
             foreach ($elements as $element) {
                 $tag = Element\Service::getElementCacheTag($element['type'], $element['id']);
-                if (!isset($tags[$tag])) {
-                    $tags[$tag] = $tag;
-                }
+                $tags[$tag] = $tag;
             }
         }
 

--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -288,9 +288,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
         if ($data instanceof DataObject\Data\Link && $data->getInternal()) {
             if ((int)$data->getInternal() > 0) {
                 $tag = Element\Service::getElementCacheTag($data->getInternalType(), $data->getInternal());
-                if (!isset($tags[$tag])) {
-                    $tags[$tag] = $tag;
-                }
+                $tags[$tag] = $tag;
             }
         }
 

--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -287,18 +287,9 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
     {
         if ($data instanceof DataObject\Data\Link && $data->getInternal()) {
             if ((int)$data->getInternal() > 0) {
-                if ($data->getInternalType() == 'document') {
-                    if ($doc = Document::getById($data->getInternal())) {
-                        if (!array_key_exists($doc->getCacheTag(), $tags)) {
-                            $tags = $doc->getCacheTags($tags);
-                        }
-                    }
-                } elseif ($data->getInternalType() == 'asset') {
-                    if ($asset = Asset::getById($data->getInternal())) {
-                        if (!array_key_exists($asset->getCacheTag(), $tags)) {
-                            $tags = $asset->getCacheTags($tags);
-                        }
-                    }
+                $tag = Element\Service::getElementCacheTag($data->getInternalType(), $data->getInternal());
+                if (!isset($tags[$tag])) {
+                    $tags[$tag] = $tag;
                 }
             }
         }

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -126,8 +126,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
     public function getCacheTag()
     {
         $elementType = Service::getElementType($this);
-
-        return $elementType . '_' . $this->getId();
+        return Service::getElementCacheTag($elementType, $this->getId());
     }
 
     /**
@@ -140,8 +139,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
     protected static function getCacheKey($id): string
     {
         $elementType = Service::getElementTypeByClassName(static::class);
-
-        return $elementType . '_' . $id;
+        return Service::getElementCacheTag($elementType, $id);
     }
 
     /**

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -1564,4 +1564,15 @@ class Service extends Model\AbstractModel
 
         return $rowData;
     }
+
+    /**
+     * @internal
+     * @param string $type
+     * @param int|string $id
+     * @return string
+     */
+    public static function getElementCacheTag(string $type, $id): string
+    {
+        return $type . '_' . $id;
+    }
 }


### PR DESCRIPTION
This optimization saves a lot of memory and database queries. 
This is especially useful if you have many links in your documents/objects. 