### PR TITLE
Fix: document as pimcore_build_nav param not possible anymore

### DIFF
--- a/lib/Twig/Extension/NavigationExtension.php
+++ b/lib/Twig/Extension/NavigationExtension.php
@@ -17,9 +17,6 @@ declare(strict_types=1);
 
 namespace Pimcore\Twig\Extension;
 
-use Pimcore\Model\Document;
-use Pimcore\Navigation\Container;
-use Pimcore\Navigation\Renderer\RendererInterface;
 use Pimcore\Twig\Extension\Templating\Navigation;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
@@ -45,61 +42,11 @@ class NavigationExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('pimcore_build_nav', [$this, 'buildNavigation']),
-            new TwigFunction('pimcore_render_nav', [$this, 'render'], [
+            new TwigFunction('pimcore_build_nav', [$this->navigationExtension, 'build']),
+            new TwigFunction('pimcore_render_nav', [$this->navigationExtension, 'render'], [
                 'is_safe' => ['html'],
             ]),
-            new TwigFunction('pimcore_nav_renderer', [$this, 'getRenderer']),
+            new TwigFunction('pimcore_nav_renderer', [$this->navigationExtension, 'getRenderer']),
         ];
-    }
-
-    /**
-     * This is essentially the same as the build() method on the
-     * Navigation helper, but without a pageCallback as it does not make
-     * sense in Twig context. If you need a more customized navigation
-     * with a callback, build the navigation externally, pass it to the
-     * view and just call render through the extension.
-     *
-     * @param array $params config array
-     *
-     * @return Container
-     *
-     * @throws \Exception
-     */
-    public function buildNavigation(
-        $params = []
-    ): Container {
-        return $this->navigationExtension->build($params);
-    }
-
-    /**
-     * Loads a renderer instance
-     *
-     * @param string $alias
-     *
-     * @return RendererInterface
-     */
-    public function getRenderer(string $alias): RendererInterface
-    {
-        return $this->navigationExtension->getRenderer($alias);
-    }
-
-    /**
-     * Renders a navigation with the given renderer
-     *
-     * @param Container $container
-     * @param string $rendererName
-     * @param string|null $renderMethod     Optional render method to use (e.g. menu -> renderMenu)
-     * @param array<int, mixed> $rendererArguments      Option arguments to pass to the render method after the container
-     *
-     * @return string
-     */
-    public function render(
-        Container $container,
-        string $rendererName = 'menu',
-        string $renderMethod = null,
-        ...$rendererArguments
-    ) {
-        return call_user_func_array([$this->navigationExtension, 'render'], func_get_args());
     }
 }

--- a/lib/Twig/Extension/NavigationExtension.php
+++ b/lib/Twig/Extension/NavigationExtension.php
@@ -60,14 +60,14 @@ class NavigationExtension extends AbstractExtension
      * with a callback, build the navigation externally, pass it to the
      * view and just call render through the extension.
      *
-     * @param mixed $params config array or active document (legacy mode)
+     * @param array $params config array
      *
      * @return Container
      *
      * @throws \Exception
      */
     public function buildNavigation(
-        $params = null
+        $params = []
     ): Container {
         return $this->navigationExtension->build($params);
     }


### PR DESCRIPTION
Get following error after update to Pimcore X:

`ContainerPcgwqDE\Navigation_62d2b4b::build(): Argument #1 ($params) must be of type array, Pimcore\Model\Document\Page given, called in /var/www/html/vendor/pimcore/pimcore/lib/Twig/Extension/NavigationExtension.php on line 72`