### PR TITLE
Get website settings in multi site environment

### DIFF
--- a/models/WebsiteSetting/Dao.php
+++ b/models/WebsiteSetting/Dao.php
@@ -58,7 +58,7 @@ class Dao extends Model\Dao\AbstractDao
         if ($name != null) {
             $this->model->setName($name);
         }
-        $data = $this->db->fetchRow("SELECT * FROM website_settings WHERE name = ? AND (siteId IS NULL OR siteId = '' OR siteId = ?) AND  (language IS NULL OR language = '' OR language = ?) ORDER BY siteId,language DESC", [$this->model->getName(), $siteId, $language]);
+        $data = $this->db->fetchRow("SELECT * FROM website_settings WHERE name = ? AND (siteId IS NULL OR siteId = '' OR siteId = ?) AND  (language IS NULL OR language = '' OR language = ?) ORDER BY language, siteId DESC", [$this->model->getName(), $siteId, $language]);
 
         if (!empty($data['id'])) {
             $this->assignVariablesToModel($data);


### PR DESCRIPTION
Website settings are not selected correctly (using WebsiteSetting::getByName()) when $siteID parameter is given and $language parameter ist not given.
Changing the "ORDER BY" order fixed it for me. (Redone PR #11107)
