### PR TITLE
Fix: Predefined Properties doesn't respect ctype

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -40,6 +40,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -742,12 +743,17 @@ class DocumentController extends ElementControllerBase implements KernelControll
      *
      * @param Request $request
      *
+     * @throws BadRequestHttpException If type is invalid
+     *
      * @return JsonResponse
      */
     public function getDocTypesAction(Request $request)
     {
         $list = new Document\DocType\Listing();
-        if (($type = $request->get('type')) && Document\Service::isValidType($type)) {
+        if ($type = $request->get('type')) {
+            if (!Document\Service::isValidType($type)) {
+                throw new BadRequestHttpException('Invalid type: ' . $type);
+            }
             $list->setFilter(function (Document\DocType $docType) use ($type) {
                 return $docType->getType() === $type;
             });

--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
@@ -747,19 +747,11 @@ class DocumentController extends ElementControllerBase implements KernelControll
     public function getDocTypesAction(Request $request)
     {
         $list = new Document\DocType\Listing();
-        if ($request->get('type')) {
-            $type = $request->get('type');
-            if (Document\Service::isValidType($type)) {
-                $list->setFilter(function ($row) use ($type) {
-                    if ($row['type'] == $type) {
-                        return true;
-                    }
-
-                    return false;
-                });
-            }
+        if (($type = $request->get('type')) && Document\Service::isValidType($type)) {
+            $list->setFilter(function (Document\DocType $docType) use ($type) {
+                return $docType->getType() === $type;
+            });
         }
-        $list->load();
 
         $docTypes = [];
         foreach ($list->getDocTypes() as $type) {

--- a/bundles/AdminBundle/Controller/Admin/ElementController.php
+++ b/bundles/AdminBundle/Controller/Admin/ElementController.php
@@ -786,17 +786,14 @@ class ElementController extends AdminController
         $type = $request->get('elementType');
         $allowedTypes = ['asset', 'document', 'object'];
 
-        if (in_array($type, $allowedTypes)) {
+        if (in_array($type, $allowedTypes, true)) {
             $list = new Model\Property\Predefined\Listing();
-            $list->setFilter(function ($row) use ($type) {
-                if (is_array($row['ctype'])) {
-                    $row['ctype'] = implode(',', $row['ctype']);
-                }
-                if (strpos($row['ctype'], $type) !== false) {
-                    return true;
+            $list->setFilter(function (Model\Property\Predefined $predefined) use ($type) {
+                if (!str_contains($predefined->getCtype(), $type)) {
+                    return false;
                 }
 
-                return false;
+                return true;
             });
 
             $list->load();

--- a/bundles/AdminBundle/Controller/Admin/ElementController.php
+++ b/bundles/AdminBundle/Controller/Admin/ElementController.php
@@ -796,8 +796,6 @@ class ElementController extends AdminController
                 return true;
             });
 
-            $list->load();
-
             foreach ($list->getProperties() as $type) {
                 $properties[] = $type->getObjectVars();
             }

--- a/bundles/AdminBundle/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/Controller/Admin/SettingsController.php
@@ -215,9 +215,9 @@ class SettingsController extends AdminController
 
             if ($request->get('filter')) {
                 $filter = $request->get('filter');
-                $list->setFilter(function ($row) use ($filter) {
-                    foreach ($row as $value) {
-                        if (strpos($value, $filter) !== false) {
+                $list->setFilter(function (Metadata\Predefined $predefined) use ($filter) {
+                    foreach ($predefined->getObjectVars() as $value) {
+                        if (stripos($value, $filter) !== false) {
                             return true;
                         }
                     }
@@ -335,13 +335,13 @@ class SettingsController extends AdminController
 
             if ($request->get('filter')) {
                 $filter = $request->get('filter');
-                $list->setFilter(function ($row) use ($filter) {
-                    foreach ($row as $value) {
+                $list->setFilter(function (Property\Predefined $predefined) use ($filter) {
+                    foreach ($predefined->getObjectVars() as $value) {
                         if ($value) {
                             $cellValues = is_array($value) ? $value : [$value];
 
                             foreach ($cellValues as $cellValue) {
-                                if (strpos($cellValue, $filter) !== false) {
+                                if (stripos($cellValue, $filter) !== false) {
                                     return true;
                                 }
                             }
@@ -887,13 +887,12 @@ class SettingsController extends AdminController
 
             if ($request->get('filter')) {
                 $filter = $request->get('filter');
-                $list->setFilter(function ($staticRoute) use ($filter) {
-                    $vars = $staticRoute->getObjectVars();
-                    foreach ($vars as $value) {
-                        if (! is_scalar($value)) {
+                $list->setFilter(function (Staticroute $staticRoute) use ($filter) {
+                    foreach ($staticRoute->getObjectVars() as $value) {
+                        if (!is_scalar($value)) {
                             continue;
                         }
-                        if (strpos((string)$value, $filter) !== false) {
+                        if (stripos((string)$value, $filter) !== false) {
                             return true;
                         }
                     }
@@ -1217,21 +1216,18 @@ class SettingsController extends AdminController
     /**
      * @Route("/thumbnail-downloadable", name="pimcore_admin_settings_thumbnaildownloadable", methods={"GET"})
      *
-     * @param Request $request
-     *
      * @return JsonResponse
      */
-    public function thumbnailDownloadableAction(Request $request)
+    public function thumbnailDownloadableAction()
     {
         $thumbnails = [];
 
         $list = new Asset\Image\Thumbnail\Config\Listing();
-        $list->setFilter(function (array $config) {
-            return array_key_exists('downloadable', $config) ? $config['downloadable'] : false;
+        $list->setFilter(function (Asset\Image\Thumbnail\Config $config) {
+            return $config->isDownloadable();
         });
         $items = $list->getThumbnails();
 
-        /** @var Asset\Image\Thumbnail\Config $item */
         foreach ($items as $item) {
             $thumbnails[] = [
                 'id' => $item->getName(),

--- a/bundles/AdminBundle/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/Controller/Admin/SettingsController.php
@@ -210,11 +210,9 @@ class SettingsController extends AdminController
             }
         } else {
             // get list of types
-
             $list = new Metadata\Predefined\Listing();
 
-            if ($request->get('filter')) {
-                $filter = $request->get('filter');
+            if ($filter = $request->get('filter')) {
                 $list->setFilter(function (Metadata\Predefined $predefined) use ($filter) {
                     foreach ($predefined->getObjectVars() as $value) {
                         if (stripos($value, $filter) !== false) {
@@ -226,15 +224,11 @@ class SettingsController extends AdminController
                 });
             }
 
-            $list->load();
-
             $properties = [];
-            if (is_array($list->getDefinitions())) {
-                foreach ($list->getDefinitions() as $metadata) {
-                    $data = $metadata->getObjectVars();
-                    $data['writeable'] = $metadata->isWriteable();
-                    $properties[] = $data;
-                }
+            foreach ($list->getDefinitions() as $metadata) {
+                $data = $metadata->getObjectVars();
+                $data['writeable'] = $metadata->isWriteable();
+                $properties[] = $data;
             }
 
             return $this->adminJson(['data' => $properties, 'success' => true, 'total' => $list->getTotalCount()]);
@@ -333,8 +327,7 @@ class SettingsController extends AdminController
             // get list of types
             $list = new Property\Predefined\Listing();
 
-            if ($request->get('filter')) {
-                $filter = $request->get('filter');
+            if ($filter = $request->get('filter')) {
                 $list->setFilter(function (Property\Predefined $predefined) use ($filter) {
                     foreach ($predefined->getObjectVars() as $value) {
                         if ($value) {
@@ -352,15 +345,11 @@ class SettingsController extends AdminController
                 });
             }
 
-            $list->load();
-
             $properties = [];
-            if (is_array($list->getProperties())) {
-                foreach ($list->getProperties() as $property) {
-                    $data = $property->getObjectVars();
-                    $data['writeable'] = $property->isWriteable();
-                    $properties[] = $data;
-                }
+            foreach ($list->getProperties() as $property) {
+                $data = $property->getObjectVars();
+                $data['writeable'] = $property->isWriteable();
+                $properties[] = $data;
             }
 
             return $this->adminJson(['data' => $properties, 'success' => true, 'total' => $list->getTotalCount()]);
@@ -885,8 +874,7 @@ class SettingsController extends AdminController
 
             $list = new Staticroute\Listing();
 
-            if ($request->get('filter')) {
-                $filter = $request->get('filter');
+            if ($filter = $request->get('filter')) {
                 $list->setFilter(function (Staticroute $staticRoute) use ($filter) {
                     foreach ($staticRoute->getObjectVars() as $value) {
                         if (!is_scalar($value)) {
@@ -901,10 +889,7 @@ class SettingsController extends AdminController
                 });
             }
 
-            $list->load();
-
             $routes = [];
-            /** @var Staticroute $routeFromList */
             foreach ($list->getRoutes() as $routeFromList) {
                 $route = $routeFromList->getObjectVars();
                 $route['writeable'] = $routeFromList->isWriteable();
@@ -1156,22 +1141,18 @@ class SettingsController extends AdminController
     /**
      * @Route("/thumbnail-tree", name="pimcore_admin_settings_thumbnailtree", methods={"GET", "POST"})
      *
-     * @param Request $request
-     *
      * @return JsonResponse
      */
-    public function thumbnailTreeAction(Request $request)
+    public function thumbnailTreeAction()
     {
         $this->checkPermission('thumbnails');
 
         $thumbnails = [];
 
         $list = new Asset\Image\Thumbnail\Config\Listing();
-        $items = $list->getThumbnails();
 
         $groups = [];
-        /** @var Asset\Image\Thumbnail\Config $item */
-        foreach ($items as $item) {
+        foreach ($list->getThumbnails() as $item) {
             if ($item->getGroup()) {
                 if (empty($groups[$item->getGroup()])) {
                     $groups[$item->getGroup()] = [
@@ -1226,9 +1207,8 @@ class SettingsController extends AdminController
         $list->setFilter(function (Asset\Image\Thumbnail\Config $config) {
             return $config->isDownloadable();
         });
-        $items = $list->getThumbnails();
 
-        foreach ($items as $item) {
+        foreach ($list->getThumbnails() as $item) {
             $thumbnails[] = [
                 'id' => $item->getName(),
                 'text' => $item->getName(),
@@ -1387,22 +1367,18 @@ class SettingsController extends AdminController
     /**
      * @Route("/video-thumbnail-tree", name="pimcore_admin_settings_videothumbnailtree", methods={"GET", "POST"})
      *
-     * @param Request $request
-     *
      * @return JsonResponse
      */
-    public function videoThumbnailTreeAction(Request $request)
+    public function videoThumbnailTreeAction()
     {
         $this->checkPermission('thumbnails');
 
         $thumbnails = [];
 
         $list = new Asset\Video\Thumbnail\Config\Listing();
-        $items = $list->getThumbnails();
 
         $groups = [];
-        /** @var Asset\Video\Thumbnail\Config $item */
-        foreach ($items as $item) {
+        foreach ($list->getThumbnails() as $item) {
             if ($item->getGroup()) {
                 if (!$groups[$item->getGroup()]) {
                     $groups[$item->getGroup()] = [

--- a/lib/Model/Listing/JsonListing.php
+++ b/lib/Model/Listing/JsonListing.php
@@ -20,17 +20,17 @@ use Pimcore\Model\AbstractModel;
 abstract class JsonListing extends AbstractModel
 {
     /**
-     * @var mixed
+     * @var callable|null
      */
     protected $filter;
 
     /**
-     * @var mixed
+     * @var callable|null
      */
     protected $order;
 
     /**
-     * @return mixed
+     * @return callable|null
      */
     public function getFilter()
     {
@@ -38,7 +38,7 @@ abstract class JsonListing extends AbstractModel
     }
 
     /**
-     * @param mixed $filter
+     * @param callable|null $filter
      */
     public function setFilter($filter)
     {
@@ -46,7 +46,7 @@ abstract class JsonListing extends AbstractModel
     }
 
     /**
-     * @return mixed
+     * @return callable|null
      */
     public function getOrder()
     {
@@ -54,7 +54,7 @@ abstract class JsonListing extends AbstractModel
     }
 
     /**
-     * @param mixed $order
+     * @param callable|null $order
      */
     public function setOrder($order)
     {

--- a/models/Asset/Image/Thumbnail/Config/Listing/Dao.php
+++ b/models/Asset/Image/Thumbnail/Config/Listing/Dao.php
@@ -34,6 +34,12 @@ class Dao extends Config\Dao
         foreach ($this->loadIdList() as $name) {
             $configs[] = Config::getByName($name);
         }
+        if ($this->model->getFilter()) {
+            $configs = array_filter($configs, $this->model->getFilter());
+        }
+        if ($this->model->getOrder()) {
+            usort($configs, $this->model->getOrder());
+        }
 
         $this->model->setThumbnails($configs);
 
@@ -45,6 +51,6 @@ class Dao extends Config\Dao
      */
     public function getTotalCount()
     {
-        return count($this->loadIdList());
+        return count($this->loadList());
     }
 }

--- a/models/Document/DocType/Listing/Dao.php
+++ b/models/Document/DocType/Listing/Dao.php
@@ -33,6 +33,12 @@ class Dao extends Model\Document\DocType\Dao
         foreach ($this->loadIdList() as $id) {
             $docTypes[] = Model\Document\DocType::getById($id);
         }
+        if ($this->model->getFilter()) {
+            $docTypes = array_filter($docTypes, $this->model->getFilter());
+        }
+        if ($this->model->getOrder()) {
+            usort($docTypes, $this->model->getOrder());
+        }
 
         $this->model->setDocTypes($docTypes);
 
@@ -44,8 +50,6 @@ class Dao extends Model\Document\DocType\Dao
      */
     public function getTotalCount()
     {
-        $amount = count($this->loadIdList());
-
-        return $amount;
+        return count($this->loadList());
     }
 }

--- a/models/Metadata/Predefined/Listing/Dao.php
+++ b/models/Metadata/Predefined/Listing/Dao.php
@@ -36,6 +36,12 @@ class Dao extends Model\Metadata\Predefined\Dao
         foreach ($this->loadIdList() as $id) {
             $properties[] = Model\Metadata\Predefined::getById($id);
         }
+        if ($this->model->getFilter()) {
+            $properties = array_filter($properties, $this->model->getFilter());
+        }
+        if ($this->model->getOrder()) {
+            usort($properties, $this->model->getOrder());
+        }
 
         $this->model->setDefinitions($properties);
 

--- a/models/Property/Predefined/Listing/Dao.php
+++ b/models/Property/Predefined/Listing/Dao.php
@@ -38,6 +38,21 @@ class Dao extends Model\Property\Predefined\Dao
             $properties[] = Model\Property\Predefined::getById($id);
         }
 
+        if (is_callable($filter = $this->model->getFilter())) {
+            $filteredData = [];
+            foreach ($properties as $row) {
+                if ($filter($row)) {
+                    $filteredData[] = $row;
+                }
+            }
+
+            $properties = $filteredData;
+        }
+
+        if (is_callable($order = $this->model->getOrder())) {
+            usort($properties, $order);
+        }
+
         $this->model->setProperties($properties);
 
         return $properties;

--- a/models/Property/Predefined/Listing/Dao.php
+++ b/models/Property/Predefined/Listing/Dao.php
@@ -37,20 +37,11 @@ class Dao extends Model\Property\Predefined\Dao
         foreach ($this->loadIdList() as $id) {
             $properties[] = Model\Property\Predefined::getById($id);
         }
-
-        if (is_callable($filter = $this->model->getFilter())) {
-            $filteredData = [];
-            foreach ($properties as $row) {
-                if ($filter($row)) {
-                    $filteredData[] = $row;
-                }
-            }
-
-            $properties = $filteredData;
+        if ($this->model->getFilter()) {
+            $properties = array_filter($properties, $this->model->getFilter());
         }
-
-        if (is_callable($order = $this->model->getOrder())) {
-            usort($properties, $order);
+        if ($this->model->getOrder()) {
+            usort($properties, $this->model->getOrder());
         }
 
         $this->model->setProperties($properties);

--- a/models/Staticroute/Listing/Dao.php
+++ b/models/Staticroute/Listing/Dao.php
@@ -50,8 +50,6 @@ class Dao extends Model\Staticroute\Dao
      */
     public function getTotalCount()
     {
-        $amount = count($this->loadIdList());
-
-        return $amount;
+        return count($this->loadList());
     }
 }


### PR DESCRIPTION
## Steps to reproduce

1. Add an predefined property with ctype Asset
2. Go to an document
3. Go to settings tab
3. Property is available

## Edit: Fix also other listings

- Search in Settings - Predefined Properties
- Search in Settings - Predefined Asset Metadata
- Image Config - downloadable property
- Predefined Document Type - ComboBox doesn't respect type
