### PR TITLE
Fix: Unable to edit/save a document when it contains an empty property of type document/object

### DIFF
--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -304,6 +304,10 @@ class Service extends Model\Element\Service
      */
     public static function pathExists($path, $type = null)
     {
+        if (!$path) {
+            return false;
+        }
+
         $path = Element\Service::correctPath($path);
 
         try {

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -377,6 +377,10 @@ abstract class AbstractObject extends Model\Element\AbstractElement
      */
     public static function getByPath($path, $force = false)
     {
+        if (!$path) {
+            return null;
+        }
+
         $path = Model\Element\Service::correctPath($path);
 
         try {

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -903,6 +903,10 @@ class Service extends Model\Element\Service
      */
     public static function pathExists($path, $type = null)
     {
+        if (!$path) {
+            return false;
+        }
+
         $path = Element\Service::correctPath($path);
 
         try {

--- a/models/Document.php
+++ b/models/Document.php
@@ -227,6 +227,10 @@ class Document extends Element\AbstractElement
      */
     public static function getByPath($path, $force = false)
     {
+        if (!$path) {
+            return null;
+        }
+
         $path = Element\Service::correctPath($path);
 
         $cacheKey = self::getPathCacheKey($path);

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -348,6 +348,10 @@ class Service extends Model\Element\Service
      */
     public static function pathExists($path, $type = null)
     {
+        if (!$path) {
+            return false;
+        }
+
         $path = Element\Service::correctPath($path);
 
         try {


### PR DESCRIPTION
Resolves https://github.com/pimcore/pimcore/issues/11136

I had the problem also with object. Asset already have this if statement.

![image](https://user-images.githubusercontent.com/998558/148518167-7b7e92de-bd6f-46d6-9391-361f70c9cf34.png)
