### PR TITLE
Remove unnecessary `iterator_to_array()` call in `Pimcore\Navigation\Container::addPages()`

### DIFF
--- a/lib/Navigation/Container.php
+++ b/lib/Navigation/Container.php
@@ -155,6 +155,7 @@ class Container implements \RecursiveIterator, \Countable
      */
     public function addPages($pages)
     {
+        // @phpstan-ignore-next-line this should be checked via parameter type in Pimcore 11
         if (!$pages instanceof self && !is_array($pages)) {
             throw new \Exception('Invalid argument: $pages must be an array or an instance of ' . self::class);
         }

--- a/lib/Navigation/Container.php
+++ b/lib/Navigation/Container.php
@@ -155,12 +155,8 @@ class Container implements \RecursiveIterator, \Countable
      */
     public function addPages($pages)
     {
-        if ($pages instanceof self) {
-            $pages = iterator_to_array($pages);
-        }
-
-        if (!is_array($pages)) {
-            throw new \Exception('Invalid argument: $pages must be an array  or an instance of Container');
+        if (!$pages instanceof self && !is_array($pages)) {
+            throw new \Exception('Invalid argument: $pages must be an array or an instance of ' . self::class);
         }
 
         foreach ($pages as $page) {


### PR DESCRIPTION
Calling `iterator_to_array()` shouldn't be necessary, if the only thing we do is iterating over it.