### PR TITLE
Fix `preg_match()` usage in condition

### DIFF
--- a/lib/Navigation/Container.php
+++ b/lib/Navigation/Container.php
@@ -325,7 +325,7 @@ class Container implements \RecursiveIterator, \Countable
                         // Use regex?
                         if (true === $useRegex) {
                             foreach ($item as $item2) {
-                                if (0 !== preg_match($value, $item2)) {
+                                if (preg_match($value, $item2)) {
                                     return $page;
                                 }
                             }
@@ -337,7 +337,7 @@ class Container implements \RecursiveIterator, \Countable
                     } else {
                         // Use regex?
                         if (true === $useRegex) {
-                            if (0 !== preg_match($value, $item)) {
+                            if (preg_match($value, $item)) {
                                 return $page;
                             }
                         } else {
@@ -393,7 +393,7 @@ class Container implements \RecursiveIterator, \Countable
                         // Use regex?
                         if (true === $useRegex) {
                             foreach ($item as $item2) {
-                                if (0 !== preg_match($value, $item2)) {
+                                if (preg_match($value, $item2)) {
                                     $found[] = $page;
                                 }
                             }
@@ -405,7 +405,7 @@ class Container implements \RecursiveIterator, \Countable
                     } else {
                         // Use regex?
                         if (true === $useRegex) {
-                            if (0 !== preg_match($value, $item)) {
+                            if (preg_match($value, $item)) {
                                 $found[] = $page;
                             }
                         } else {
@@ -421,7 +421,7 @@ class Container implements \RecursiveIterator, \Countable
 
             // Use regex?
             if (true === $useRegex) {
-                if (0 !== preg_match($value, $pageProperty)) {
+                if (preg_match($value, $pageProperty)) {
                     $found[] = $page;
                 }
             } else {


### PR DESCRIPTION
`preg_match()` returns `0` when there's no match and `false` on error (see [the docs](https://www.php.net/manual/en/function.preg-match.php#refsect1-function.preg-match-returnvalues)), so checking `!== 0` is dangerous because the condition is true when there's a match *or* an error.