### PR TITLE
Don't add the same page multiple times in `Pimcore\Navigation\Container::findAllBy()`

### DIFF
--- a/lib/Navigation/Container.php
+++ b/lib/Navigation/Container.php
@@ -395,11 +395,13 @@ class Container implements \RecursiveIterator, \Countable
                             foreach ($item as $item2) {
                                 if (preg_match($value, $item2)) {
                                     $found[] = $page;
+                                    break 2;
                                 }
                             }
                         } else {
                             if (in_array($value, $item)) {
                                 $found[] = $page;
+                                break;
                             }
                         }
                     } else {
@@ -407,10 +409,12 @@ class Container implements \RecursiveIterator, \Countable
                         if (true === $useRegex) {
                             if (preg_match($value, $item)) {
                                 $found[] = $page;
+                                break;
                             }
                         } else {
                             if ($item == $value) {
                                 $found[] = $page;
+                                break;
                             }
                         }
                     }


### PR DESCRIPTION
If the page property is an array, and we iterate over it, we should skip the rest when we find a match. Otherwise, the same page may be added twice to the result array.