### PR TITLE
[Mail settings check] check for debug mail addresses only in debug mode

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/IndexController.php
+++ b/bundles/AdminBundle/Controller/Admin/IndexController.php
@@ -357,7 +357,7 @@ class IndexController extends AdminController implements KernelResponseEventInte
         //mail settings
         $mailIncomplete = false;
         if (isset($config['email'])) {
-            if (empty($config['email']['debug']['email_addresses'])) {
+            if (\Pimcore::inDebugMode() && empty($config['email']['debug']['email_addresses'])) {
                 $mailIncomplete = true;
             }
             if (empty($config['email']['sender']['email'])) {


### PR DESCRIPTION
don't show notification for missing debug e-mail addresses in production environment anymore. 