### PR TITLE
Remove superfluous `array_merge()` call

### DIFF
--- a/lib/Db/PimcoreExtensionsTrait.php
+++ b/lib/Db/PimcoreExtensionsTrait.php
@@ -366,8 +366,6 @@ trait PimcoreExtensionsTrait
             implode(', ', $set)
         );
 
-        $bind = array_merge($bind, $bind);
-
         return $this->executeUpdate($sql, $bind);
     }
 


### PR DESCRIPTION
`$bind` is an associative array, which means calling `$bind = array_merge($bind, $bind)` results in the exact same array and thus can be removed. See: https://3v4l.org/d47Wt