### PR TITLE
Parameter &?pimcore_nocache dosn't work

### DIFF
--- a/bundles/CoreBundle/Resources/config/cache.yaml
+++ b/bundles/CoreBundle/Resources/config/cache.yaml
@@ -15,6 +15,7 @@ services:
         class: Symfony\Component\Cache\Adapter\NullAdapter
 
     pimcore.cache.adapter.null_tag_aware:
+        public: true
         class: Symfony\Component\Cache\Adapter\TagAwareAdapter
         arguments: ['@pimcore.cache.adapter.null', null]
 


### PR DESCRIPTION
The Service has to be public because it is accessed in the Cache.php  file via the Container...