### PR TITLE
[Image gallery] Only load image gallery items with an image / Remove gallery item when deleting image asset

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ImageGallery.php
+++ b/models/DataObject/ClassDefinition/Data/ImageGallery.php
@@ -278,7 +278,9 @@ class ImageGallery extends Data implements ResourcePersistenceAwareInterface, Qu
             ];
 
             $itemResult = $fd->getDataFromResource($itemData, $object, $params);
-            $resultItems[] = $itemResult;
+            if($itemResult instanceof DataObject\Data\Hotspotimage) {
+                $resultItems[] = $itemResult;
+            }
         }
 
         $imageGallery = new DataObject\Data\ImageGallery($resultItems);

--- a/tests/_support/Helper/DataType/TestDataHelper.php
+++ b/tests/_support/Helper/DataType/TestDataHelper.php
@@ -549,12 +549,12 @@ class TestDataHelper extends AbstractTestDataHelper
         /** @var DataObject\Data\Hotspotimage[] $items */
         $items = $value->getItems();
 
-        $this->assertNull($items[1]);
+        $this->assertCount(2, $items);
 
         $item0 = $items[0];
         $this->assertEquals($item0->getImage()->getFilename(), 'gal0.jpg');
 
-        $item2 = $items[2];
+        $item2 = $items[1];
         $this->assertEquals($item2->getImage()->getFilename(), 'gal2.jpg');
         $hotspots = $item2->getHotspots();
         $this->assertEquals('hotspot_2_' . $seed, $hotspots[0]['name']);


### PR DESCRIPTION
Steps to reproduce:
1. Create data object class with an image gallery
2. Upload an image to Pimcore assets
3. Create an object and assign the uploaded image to the gallery
4. Delete the image asset
5. Reload the object -> There is an empty placeholder in the image gallery

It is not possible to assign metadata to an image gallery item which has no image:
https://github.com/pimcore/pimcore/blob/4661359d9af40387ed5e7f14d00a81a7fb1979a0/models/DataObject/ClassDefinition/Data/ImageGallery.php#L268-L282
There the `getDataFromResource()` from `Hotspotimage` gets called and this returns `null` when the image cannot be loaded:
https://github.com/pimcore/pimcore/blob/4661359d9af40387ed5e7f14d00a81a7fb1979a0/models/DataObject/ClassDefinition/Data/Hotspotimage.php#L179-L180

So it does not make sense to load an image gallery item when the HotspotImage could not be loaded. This PR prevents loading such values as `null` and so preventing the empty image gallery item from being loaded.