### PR TITLE
decode quotation marks to make exact search working

### DIFF
--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -413,6 +413,7 @@ class SearchController extends AdminController
             $query = '';
         }
 
+        $query = str_replace('&quot;', '"', $query);
         $query = str_replace('%', '*', $query);
         $query = str_replace('@', '#', $query);
         $query = preg_replace("@([^ ])\-@", '$1 ', $query);


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
ensure we have double quote (") character on search query to make Boolean Full-Text Searches "exact search" working, as now quote is encoded (&quot;)

## Additional info  

https://dev.mysql.com/doc/refman/5.6/en/fulltext-boolean.html