### PR TITLE
Pass editmode as attribute to document render events

### DIFF
--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -28,6 +28,7 @@ use Pimcore\Templating\Renderer\ActionRenderer;
 use Pimcore\Twig\Extension\Templating\Placeholder\ContainerService;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Pimcore\Http\Request\Resolver\EditmodeResolver;
 
 class DocumentRenderer implements DocumentRendererInterface
 {

--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -111,8 +111,14 @@ class DocumentRenderer implements DocumentRendererInterface
      */
     public function render(Document\PageSnippet $document, array $attributes = [], array $query = [], array $options = []): string
     {
+        $eventAttributes = array_filter(
+            $attributes,
+            fn($key) => in_array($key, [EditmodeResolver::ATTRIBUTE_EDITMODE]),
+            ARRAY_FILTER_USE_KEY
+        );
+        
         $this->eventDispatcher->dispatch(
-            new DocumentEvent($document),
+            new DocumentEvent($document, $eventAttributes),
             DocumentEvents::RENDERER_PRE_RENDER
         );
 
@@ -147,7 +153,7 @@ class DocumentRenderer implements DocumentRendererInterface
         $this->localeService->setLocale($tempLocale);
 
         $this->eventDispatcher->dispatch(
-            new DocumentEvent($document),
+            new DocumentEvent($document, $eventAttributes),
             DocumentEvents::RENDERER_POST_RENDER
         );
 

--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -112,14 +112,8 @@ class DocumentRenderer implements DocumentRendererInterface
      */
     public function render(Document\PageSnippet $document, array $attributes = [], array $query = [], array $options = []): string
     {
-        $eventAttributes = array_filter(
-            $attributes,
-            fn($key) => in_array($key, [EditmodeResolver::ATTRIBUTE_EDITMODE]),
-            ARRAY_FILTER_USE_KEY
-        );
-        
         $this->eventDispatcher->dispatch(
-            new DocumentEvent($document, $eventAttributes),
+            new DocumentEvent($document, $attributes),
             DocumentEvents::RENDERER_PRE_RENDER
         );
 
@@ -154,7 +148,7 @@ class DocumentRenderer implements DocumentRendererInterface
         $this->localeService->setLocale($tempLocale);
 
         $this->eventDispatcher->dispatch(
-            new DocumentEvent($document, $eventAttributes),
+            new DocumentEvent($document, $attributes),
             DocumentEvents::RENDERER_POST_RENDER
         );
 

--- a/lib/Document/Renderer/DocumentRenderer.php
+++ b/lib/Document/Renderer/DocumentRenderer.php
@@ -28,7 +28,6 @@ use Pimcore\Templating\Renderer\ActionRenderer;
 use Pimcore\Twig\Extension\Templating\Placeholder\ContainerService;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
-use Pimcore\Http\Request\Resolver\EditmodeResolver;
 
 class DocumentRenderer implements DocumentRendererInterface
 {


### PR DESCRIPTION
# Enhancement

Pass editmode as attribute to document render events.

This is especially useful, because documents get now rendered in `Pimcore\Document\Editable\EditableUsageResolver` while saving a document in the pimcore backend and in this context data object inheritance is disabled and the EditmodeResolve will not recognize that the editmode is active. If you depend on data object inheritance during the rendering process the saving process will fail. 

Passing the editmode attribute to the render event enables developers to enable inheritance during redering in editmode on document save.

__
As an alternative Pimcore could set the data object inheritance to the same setting as during the frontend rendering process by default.