### PR TITLE
Headless Chrome settings not read

### DIFF
--- a/lib/Web2Print/Processor/HeadlessChrome.php
+++ b/lib/Web2Print/Processor/HeadlessChrome.php
@@ -36,7 +36,7 @@ class HeadlessChrome extends Processor
     protected function buildPdf(Document\PrintAbstract $document, $config)
     {
         $web2printConfig = Config::getWeb2PrintConfig();
-        $web2printConfig = $web2printConfig['headlessChromeSettings'];
+        $web2printConfig = $web2printConfig->get('headlessChromeSettings');
         $web2printConfig = json_decode($web2printConfig, true);
 
         $params = ['document' => $document];


### PR DESCRIPTION
Headless Chrome settings are not read correctly from Config object. I think the right way to do this stuff is to use the getter!?

