### PR TITLE
Sorting bug in classification store

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -1165,8 +1165,8 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
             }
 
             usort($this->activeGroupDefinitions, static function ($a, $b) use ($sorting) {
-                $s1 = $sorting[$a['id']] ?: 0;
-                $s2 = $sorting[$b['id']] ?: 0;
+                $s1 = $sorting[$a['id']] ?? 0;
+                $s2 = $sorting[$b['id']] ?? 0;
 
                 return $s1 <=> $s2;
             });


### PR DESCRIPTION
1.) Create classification store with 2 groups (e.g. a, b)
2.) Create an object and add group a, make sure inheritance is activated for this object
3.) Try to import a child object with data objects importer and add group b
4.) Import succeeds, but there will be an exception when you try to open the imported object

Found while testing pr pimcore/data-importer#148
