### PR TITLE
[DataObjects] Remove @internal from getRelationData()

### DIFF
--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -552,8 +552,6 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
     /**
      * get object relation data as array for a specific field
      *
-     * @internal
-     *
      * @param string $fieldName
      * @param bool $forOwner
      * @param string $remoteClassId


### PR DESCRIPTION
The docs mention `getRelationData()` as best practice to get data from Reverse Object Relation Datatype fields, so it should NOT be an internal method.

See https://pimcore.com/docs/pimcore/10.3/Development_Documentation/Objects/Object_Classes/Data_Types/Reverse_Object_Relation_Type.html#page_Working-with-PHP-API