### PR TITLE
Fix insertOrUpdate on tables without primary keys

### DIFF
--- a/lib/Db/PimcoreExtensionsTrait.php
+++ b/lib/Db/PimcoreExtensionsTrait.php
@@ -343,7 +343,7 @@ trait PimcoreExtensionsTrait
     public function insertOrUpdate($table, array $data)
     {
         // get the field name of the primary key
-        $fieldsPrimaryKey = self::$tablePrimaryKeyCache[$table] ??= (array) $this->getSchemaManager()->listTableDetails($table)->getPrimaryKeyColumns();
+        $fieldsPrimaryKey = self::$tablePrimaryKeyCache[$table] ??= $this->getPrimaryKeyColumns($table);
 
         // extract and quote col names from the array keys
         $i = 0;
@@ -610,5 +610,19 @@ trait PimcoreExtensionsTrait
     public function escapeLike(string $like): string
     {
         return str_replace(['_', '%'], ['\\_', '\\%'], $like);
+    }
+
+    /**
+     * @param string $table
+     *
+     * @return string[]
+     */
+    private function getPrimaryKeyColumns(string $table): array
+    {
+        try {
+            return $this->getSchemaManager()->listTableDetails($table)->getPrimaryKeyColumns();
+        } catch (DBALException) {
+            return [];
+        }
     }
 }


### PR DESCRIPTION
Since https://github.com/pimcore/pimcore/pull/11159 the insertOrUpdate method throws an exception if the table has no primary key. See tests in customer-data-framework:

```
1) ActivityTest: Track activity
 Test  tests/Model/Activity/ActivityTest.php:testTrackActivity

  [Doctrine\DBAL\Exception] Table plugin_cmf_deletions has no primary key.  

/home/runner/work/customer-data-framework/customer-data-framework/vendor/doctrine/dbal/lib/Doctrine/DBAL/Schema/Table.php:743
/home/runner/work/customer-data-framework/customer-data-framework/vendor/pimcore/pimcore/lib/Db/PimcoreExtensionsTrait.php:348
/home/runner/work/customer-data-framework/customer-data-framework/src/CustomerSaveManager/DefaultCustomerSaveManager.php:282
/home/runner/work/customer-data-framework/customer-data-framework/src/CustomerSaveManager/DefaultCustomerSaveManager.php:236
/home/runner/work/customer-data-framework/customer-data-framework/src/Event/PimcoreObjectEventListener.php:135
/home/runner/work/customer-data-framework/customer-data-framework/vendor/symfony/event-dispatcher/Debug/WrappedListener.php:117
/home/runner/work/customer-data-framework/customer-data-framework/vendor/symfony/event-dispatcher/EventDispatcher.php:230
/home/runner/work/customer-data-framework/customer-data-framework/vendor/symfony/event-dispatcher/EventDispatcher.php:59
/home/runner/work/customer-data-framework/customer-data-framework/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:154
/home/runner/work/customer-data-framework/customer-data-framework/vendor/pimcore/pimcore/models/DataObject/AbstractObject.php:660
/home/runner/work/customer-data-framework/customer-data-framework/vendor/pimcore/pimcore/tests/_support/Util/TestHelper.php:834
/home/runner/work/customer-data-framework/customer-data-framework/vendor/pimcore/pimcore/tests/_support/Util/TestHelper.php:796
/home/runner/work/customer-data-framework/customer-data-framework/tests/Model/Activity/ActivityTest.php:21
/home/runner/work/customer-data-framework/customer-data-framework/vendor/phpunit/phpunit/src/Framework/TestCase.php:1197
/home/runner/work/customer-data-framework/customer-data-framework/vendor/phpunit/phpunit/src/Framework/TestResult.php:726
/home/runner/work/customer-data-framework/customer-data-framework/vendor/phpunit/phpunit/src/Framework/TestCase.php:903
/home/runner/work/customer-data-framework/customer-data-framework/vendor/phpunit/phpunit/src/Framework/TestSuite.php:678
/home/runner/work/customer-data-framework/customer-data-framework/vendor/codeception/phpunit-wrapper/src/Runner.php:117
/home/runner/work/customer-data-framework/customer-data-framework/vendor/codeception/codeception/src/Codeception/SuiteManager.php:161
/home/runner/work/customer-data-framework/customer-data-framework/vendor/codeception/codeception/src/Codeception/Codecept.php:208
/home/runner/work/customer-data-framework/customer-data-framework/vendor/codeception/codeception/src/Codeception/Codecept.php:162
/home/runner/work/customer-data-framework/customer-data-framework/vendor/codeception/codeception/src/Codeception/Command/Run.php:544
/home/runner/work/customer-data-framework/customer-data-framework/vendor/codeception/codeception/src/Codeception/Command/Run.php:408
/home/runner/work/customer-data-framework/customer-data-framework/vendor/symfony/console/Command/Command.php:298
/home/runner/work/customer-data-framework/customer-data-framework/vendor/symfony/console/Application.php:1005
/home/runner/work/customer-data-framework/customer-data-framework/vendor/symfony/console/Application.php:299
/home/runner/work/customer-data-framework/customer-data-framework/vendor/symfony/console/Application.php:171
/home/runner/work/customer-data-framework/customer-data-framework/vendor/codeception/codeception/src/Codeception/Application.php:117
/home/runner/work/customer-data-framework/customer-data-framework/vendor/codeception/codeception/app.php:46
/home/runner/work/customer-data-framework/customer-data-framework/vendor/codeception/codeception/app.php:47
/home/runner/work/customer-data-framework/customer-data-framework/vendor/codeception/codeception/codecept:7
/home/runner/work/customer-data-framework/customer-data-framework/vendor/bin/codecept:107
```