### PR TITLE
[Docs] SettingsStore: Fix wrong param order

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/42_Settings_Store.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/42_Settings_Store.md
@@ -1,30 +1,30 @@
 # Settings Store
 
-The settings store is a simple key value store and allows to persist any kind of settings into the 
+The settings store is a simple key value store and allows to persist any kind of settings into the
 Pimcore database via API. There is no user interface for the Settings Store available. Compared to the
-`TmpStore` the settings do not have an expiry date and will not be cleaned up. 
+`TmpStore` the settings do not have an expiry date and will not be cleaned up.
 
 Sample use cases for settings store are:
 - Persist if a bundle is installed.
-- Runtime settings of a bundle. 
-- ... 
+- Runtime settings of a bundle.
+- ...
 
-The stored settings can be namespaced/grouped with a `scope` attribute and can be of following scalar data 
-types: 
+The stored settings can be namespaced/grouped with a `scope` attribute and can be of following scalar data
+types:
 - `string`
 - `bool`
 - `int`
 - `float`
 
-We highly recommend to use the `scope` attribute when using the settings store for a bundle (e.g. the bundles name), 
-while you can omit it when using the settings store for your app. 
+We highly recommend to use the `scope` attribute when using the settings store for a bundle (e.g. the bundles name),
+while you can omit it when using the settings store for your app.
 
 ### Sample Usage
 
-```php 
+```php
 
-// store or update setting
-SettingsStore::set('my-setting-id', 'this is some setting value', 'bundle-settings-1', 'string');
+// store or update setting (id, data, type, scope)
+SettingsStore::set('my-setting-id', 'this is some setting value', 'string', 'bundle-settings-1');
 
 // load setting by id
 $setting = SettingsStore::get('my-setting-id');


### PR DESCRIPTION
The order of the set method params are `id, data, type, scope` and not `id, data, scope, type`