### PR TITLE
Feature: quicksearch, load list on search, data on hover

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
@@ -928,7 +928,7 @@ Ext.onReady(function () {
                             success: function (response) {
                                 var result = Ext.decode(response.responseText);
 
-                                record.set('preview', result.preview);
+                                record.preview = result.preview;
                                 Ext.get('pimcore_quicksearch_preview').setHtml(result.preview);
                             },
                             failure: function () {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
@@ -917,12 +917,34 @@ Ext.onReady(function () {
             listeners: {
                 "highlightitem": function (view, node, opts) {
                     var record = quicksearchStore.getAt(node.dataset.recordindex);
-                    var previewHtml = record.get('preview');
-                    if(!previewHtml) {
-                        previewHtml = '<div class="no_preview">' + t('preview_not_available') + '</div>';
-                    }
+                    if (!record.get('preview')) {
+                        Ext.Ajax.request({
+                            url: Routing.generate('pimcore_admin_searchadmin_search_quicksearch_by_id'),
+                            method: 'GET',
+                            params: {
+                                "id": record.get('id'),
+                                "type": record.get('type')
+                            },
+                            success: function (response) {
+                                var result = Ext.decode(response.responseText);
 
-                    Ext.get('pimcore_quicksearch_preview').setHtml(previewHtml);
+                                record.set('preview', result.preview);
+                                Ext.get('pimcore_quicksearch_preview').setHtml(result.preview);
+                            },
+                            failure: function () {
+                                var previewHtml = '<div class="no_preview">' + t('preview_not_available') + '</div>';
+
+                                Ext.get('pimcore_quicksearch_preview').setHtml(previewHtml);
+                            }
+                        });
+                    } else {
+                        var previewHtml = record.get('preview');
+                        if(!previewHtml) {
+                            previewHtml = '<div class="no_preview">' + t('preview_not_available') + '</div>';
+                        }
+
+                        Ext.get('pimcore_quicksearch_preview').setHtml(previewHtml);
+                    }
                 }
             }
         },

--- a/bundles/AdminBundle/Resources/views/SearchAdmin/Search/Quicksearch/object.html.twig
+++ b/bundles/AdminBundle/Resources/views/SearchAdmin/Search/Quicksearch/object.html.twig
@@ -1,9 +1,13 @@
 {% set fields = element.getClass().getFieldDefinitions() %}
+{% set paddingTop = 20 %}
 
-<div class="small-icon {{ iconCls }}"></div>
+{% if iconCls is defined and iconCls != '' %}
+    <div class="small-icon {{ iconCls }}"></div>
+    {% set paddingTop = paddingTop + 50 %}
+{% endif %}
 {% include '@PimcoreAdmin/SearchAdmin/Search/Quicksearch/info-table.html.twig' with {'element': element, 'cls': 'no-opacity'} %}
 
-<table class="data-table" style="top: 70px;">
+<table class="data-table" style="top: {{ paddingTop }}px">
     {% set c = 0 %}
     {% set break = false %}
     {% for fieldName, definition in fields|slice(0,30) %}


### PR DESCRIPTION
Splitted loading of a list and data objects data loading.  Initial request size is now 10-15kb instead of 400 on demo project. After that on first hover is send request to get data object data and every that request is also around 10kb in size. 
Resolves #11216