### PR TITLE
FIX: invisible fields saved incorectly when fieldcollections swap places

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
@@ -102,7 +102,7 @@ pimcore.object.tags.fieldcollections = Class.create(pimcore.object.tags.abstract
 
     postSaveObject: function(object, task) {
 
-        if (object.id == this.object.id && task == "publish") {
+        if (object.id == this.object.id) {
             for (var itemIndex = 0; itemIndex < this.component.items.items.length; itemIndex++) {
                 var item = this.component.items.items[itemIndex];
                 item["pimcore_oIndex"] = itemIndex;


### PR DESCRIPTION
Problem was occurring when swapping 2 fieldcollections inside object swap places using arrows. Problem was only occurring if user saves(auto save is also causing this) and then publishes object.  Resolves #11201
