### PR TITLE
Set Layout properties to internal

### DIFF
--- a/models/DataObject/ClassDefinition/Layout.php
+++ b/models/DataObject/ClassDefinition/Layout.php
@@ -23,66 +23,92 @@ class Layout
     use Model\DataObject\ClassDefinition\Helper\VarExport, Element\ChildsCompatibilityTrait;
 
     /**
+     * @internal
+     *
      * @var string
      */
     public $name;
 
     /**
+     * @internal
+     *
      * @var string
      */
     public $type;
 
     /**
+     * @internal
+     *
      * @var string
      */
     public $region;
 
     /**
+     * @internal
+     *
      * @var string
      */
     public $title;
 
     /**
+     * @internal
+     *
      * @var string|int
      */
     public $width = 0;
 
     /**
+     * @internal
+     *
      * @var string|int
      */
     public $height = 0;
 
     /**
+     * @internal
+     *
      * @var bool
      */
     public $collapsible = false;
 
     /**
+     * @internal
+     *
      * @var bool
      */
     public $collapsed = false;
 
     /**
+     * @internal
+     *
      * @var string
      */
     public $bodyStyle;
 
     /**
+     * @internal
+     *
      * @var string
      */
     public $datatype = 'layout';
 
     /**
+     * @internal
+     *
      * @var array
      */
     public $permissions;
 
     /**
+     * @internal
+     *
      * @var array
      */
     public $childs = [];
 
     /**
+     * @internal
+     *
      * @var bool
      */
     public $locked = false;
@@ -316,7 +342,7 @@ class Layout
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getDatatype()
     {
@@ -324,7 +350,7 @@ class Layout
     }
 
     /**
-     * @param mixed $datatype
+     * @param string $datatype
      *
      * @return $this
      */

--- a/models/DataObject/ClassDefinition/Layout/Accordion.php
+++ b/models/DataObject/ClassDefinition/Layout/Accordion.php
@@ -22,11 +22,15 @@ class Accordion extends Model\DataObject\ClassDefinition\Layout
     /**
      * Static type of this element
      *
+     * @internal
+     *
      * @var string
      */
     public $fieldtype = 'accordion';
 
     /**
+     * @internal
+     *
      * @var bool
      */
     public $border = false;

--- a/models/DataObject/ClassDefinition/Layout/Button.php
+++ b/models/DataObject/ClassDefinition/Layout/Button.php
@@ -22,21 +22,29 @@ class Button extends Model\DataObject\ClassDefinition\Layout
     /**
      * Static type of this element
      *
+     * @internal
+     *
      * @var string
      */
     public $fieldtype = 'button';
 
     /**
+     * @internal
+     *
      * @var string
      */
     public $handler;
 
     /**
+     * @internal
+     *
      * @var string
      */
     public $text;
 
     /**
+     * @internal
+     *
      * @var string
      */
     public $icon;

--- a/models/DataObject/ClassDefinition/Layout/Fieldcontainer.php
+++ b/models/DataObject/ClassDefinition/Layout/Fieldcontainer.php
@@ -25,16 +25,22 @@ class Fieldcontainer extends Model\DataObject\ClassDefinition\Layout
     /**
      * Static type of this element
      *
+     * @internal
+     *
      * @var string
      */
     public $fieldtype = 'fieldcontainer';
 
     /**
+     * @internal
+     *
      * @var string
      */
     public $layout = 'hbox';
 
     /**
+     * @internal
+     *
      * @var string
      */
     public $fieldLabel;

--- a/models/DataObject/ClassDefinition/Layout/Fieldset.php
+++ b/models/DataObject/ClassDefinition/Layout/Fieldset.php
@@ -25,6 +25,8 @@ class Fieldset extends Model\DataObject\ClassDefinition\Layout
     /**
      * Static type of this element
      *
+     * @internal
+     *
      * @var string
      */
     public $fieldtype = 'fieldset';

--- a/models/DataObject/ClassDefinition/Layout/Iframe.php
+++ b/models/DataObject/ClassDefinition/Layout/Iframe.php
@@ -24,14 +24,24 @@ class Iframe extends Model\DataObject\ClassDefinition\Layout implements LayoutDe
     /**
      * Static type of this element
      *
+     * @internal
+     *
      * @var string
      */
     public $fieldtype = 'iframe';
 
-    /** @var string */
+    /**
+     * @internal
+     *
+     * @var string
+     */
     public $iframeUrl;
 
-    /** @var string */
+    /**
+     * @internal
+     *
+     * @var string
+     */
     public $renderingData;
 
     /**

--- a/models/DataObject/ClassDefinition/Layout/Panel.php
+++ b/models/DataObject/ClassDefinition/Layout/Panel.php
@@ -27,16 +27,22 @@ class Panel extends Model\DataObject\ClassDefinition\Layout
     /**
      * Static type of this element
      *
+     * @internal
+     *
      * @var string
      */
     public $fieldtype = 'panel';
 
     /**
+     * @internal
+     *
      * @var string
      */
     public $layout;
 
     /**
+     * @internal
+     *
      * @var bool
      */
     public $border = false;

--- a/models/DataObject/ClassDefinition/Layout/Region.php
+++ b/models/DataObject/ClassDefinition/Layout/Region.php
@@ -25,6 +25,8 @@ class Region extends Model\DataObject\ClassDefinition\Layout
     /**
      * Static type of this element
      *
+     * @internal
+     *
      * @var string
      */
     public $fieldtype = 'region';

--- a/models/DataObject/ClassDefinition/Layout/Tabpanel.php
+++ b/models/DataObject/ClassDefinition/Layout/Tabpanel.php
@@ -22,16 +22,22 @@ class Tabpanel extends Model\DataObject\ClassDefinition\Layout
     /**
      * Static type of this element
      *
+     * @internal
+     *
      * @var string
      */
     public $fieldtype = 'tabpanel';
 
     /**
+     * @internal
+     *
      * @var bool
      */
     public $border = false;
 
     /**
+     * @internal
+     *
      * @var string|null
      */
     public $tabPosition = 'top';
@@ -61,7 +67,7 @@ class Tabpanel extends Model\DataObject\ClassDefinition\Layout
     }
 
     /**
-     * @param string $tabPosition|null
+     * @param string|null $tabPosition
      */
     public function setTabPosition($tabPosition): void
     {

--- a/models/DataObject/ClassDefinition/Layout/Text.php
+++ b/models/DataObject/ClassDefinition/Layout/Text.php
@@ -23,26 +23,36 @@ class Text extends Model\DataObject\ClassDefinition\Layout implements Model\Data
     /**
      * Static type of this element
      *
+     * @internal
+     *
      * @var string
      */
     public $fieldtype = 'text';
 
     /**
+     * @internal
+     *
      * @var string
      */
     public $html = '';
 
     /**
+     * @internal
+     *
      * @var string
      */
     public $renderingClass;
 
     /**
+     * @internal
+     *
      * @var string
      */
     public $renderingData;
 
     /**
+     * @internal
+     *
      * @var bool
      */
     public $border = false;


### PR DESCRIPTION
Splitting from https://github.com/pimcore/pimcore/pull/10824

I think these attributes should be internal. It should be used the getter and setter. There are only public to send it to JavaScript.