### PR TITLE
[Perspective] Omit "not allowed perspective"-warning with &perspective=

### DIFF
--- a/bundles/AdminBundle/EventListener/UserPerspectiveListener.php
+++ b/bundles/AdminBundle/EventListener/UserPerspectiveListener.php
@@ -87,7 +87,7 @@ class UserPerspectiveListener implements EventSubscriberInterface, LoggerAwareIn
             if ($requestedPerspective !== $user->getActivePerspective()) {
                 $existingPerspectives = array_keys(\Pimcore\Perspective\Config::get()->toArray());
                 if (!in_array($requestedPerspective, $existingPerspectives)) {
-                    $this->logger->warning('Requested perspective {perspective} for {user} is not does not exist.', [
+                    $this->logger->warning('Requested perspective {perspective} for {user} does not exist.', [
                         'user' => $user->getName(),
                         'perspective' => $requestedPerspective,
                     ]);
@@ -105,7 +105,7 @@ class UserPerspectiveListener implements EventSubscriberInterface, LoggerAwareIn
                 ? $user->getActivePerspective()
                 : $user->getFirstAllowedPerspective();
 
-            if (null !== $previouslyRequested) {
+            if ($previouslyRequested) {
                 $this->logger->warning('User {user} is not allowed requested perspective {requestedPerspective}. Falling back to {perspective}.', [
                     'user' => $user->getName(),
                     'requestedPerspective' => $previouslyRequested,


### PR DESCRIPTION
On the default installation every time reloading the admin UI with the default GET-parameter "&perspective=", a WARNING "User pimcore is not allowed requested perspective ." is logged. But as seen a few lines above, this is not stated as a request for a new perspective. "Perspective for user {user} was not requested." as debug log makes sense here which is logged after this change.

Additionally fixed wording in a warning.