### PR TITLE
#11144: adding cache invalidation for classification store KeyConfig

### DIFF
--- a/lib/Cache/RuntimeCacheTrait.php
+++ b/lib/Cache/RuntimeCacheTrait.php
@@ -1,12 +1,15 @@
 <?php
 /**
+ * Pimcore
  *
- * Created by PhpStorm.
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
  *
- * @date: 02.02.2022
- *
- * @author: Andreas Wroblewski <andreas.wroblewski@codafish.net>
- * @copyright: codafish><> GmbH, https://codafish.net
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
 namespace Pimcore\Cache;

--- a/lib/Cache/RuntimeCacheTrait.php
+++ b/lib/Cache/RuntimeCacheTrait.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ *
+ * Created by PhpStorm.
+ *
+ * @date: 02.02.2022
+ *
+ * @author: Andreas Wroblewski <andreas.wroblewski@codafish.net>
+ * @copyright: codafish><> GmbH, https://codafish.net
+ */
+
+namespace Pimcore\Cache;
+
+use Exception;
+use Pimcore\Cache;
+
+trait RuntimeCacheTrait
+{
+    /**
+     * @var bool
+     */
+    private static bool $cacheEnabled = false;
+
+    /**
+     * @param bool $cacheEnabled
+     */
+    public static function setCacheEnabled(bool $cacheEnabled): void
+    {
+        self::$cacheEnabled = $cacheEnabled;
+    }
+
+    /**
+     * @return bool
+     */
+    public static function getCacheEnabled(): bool
+    {
+        return self::$cacheEnabled;
+    }
+
+    /**
+     * Set cache item for a given cache key
+     *
+     * @param mixed $config
+     * @param string $cacheKey
+     */
+    private static function setCache(mixed $config, string $cacheKey): void
+    {
+        if (self::$cacheEnabled) {
+            Cache\Runtime::set($cacheKey, $config);
+        }
+
+        Cache::save($config, $cacheKey, [], null, 0, true);
+    }
+
+    /**
+     * Remove a cache item for a given cache key
+     *
+     * @param string $cacheKey
+     */
+    private static function removeCache(string $cacheKey): void
+    {
+        Cache::remove($cacheKey);
+        Cache\Runtime::set($cacheKey, null);
+    }
+
+    /**
+     * Get a cache item for a given cache key
+     *
+     * @param string $cacheKey
+     *
+     * @return mixed
+     *
+     * @throws Exception
+     */
+    private static function getCache(string $cacheKey): mixed
+    {
+        if (self::$cacheEnabled && Cache\Runtime::isRegistered($cacheKey) && $config = Cache\Runtime::get($cacheKey)) {
+            return $config;
+        }
+
+        return Cache::load($cacheKey);
+    }
+}

--- a/models/DataObject/Classificationstore/CollectionConfig.php
+++ b/models/DataObject/Classificationstore/CollectionConfig.php
@@ -25,10 +25,7 @@ use Pimcore\Model;
  */
 final class CollectionConfig extends Model\AbstractModel
 {
-    /**
-     * @var bool
-     */
-    public static $cacheEnabled = false;
+    use Cache\RuntimeCacheTrait;
 
     /**
      * @var int|null
@@ -129,22 +126,6 @@ final class CollectionConfig extends Model\AbstractModel
         $config->save();
 
         return $config;
-    }
-
-    /**
-     * @param bool $cacheEnabled
-     */
-    public static function setCacheEnabled($cacheEnabled)
-    {
-        self::$cacheEnabled = $cacheEnabled;
-    }
-
-    /**
-     * @return bool
-     */
-    public static function getCacheEnabled()
-    {
-        return self::$cacheEnabled;
     }
 
     /**
@@ -295,20 +276,6 @@ final class CollectionConfig extends Model\AbstractModel
     }
 
     /**
-     * Returns all group belonging to this collection
-     *
-     * @return CollectionGroupRelation[]
-     */
-    public function getRelations()
-    {
-        $list = new CollectionGroupRelation\Listing();
-        $list->setCondition('colId = ' . $this->id);
-        $list = $list->load();
-
-        return $list;
-    }
-
-    /**
      * @return int
      */
     public function getStoreId()
@@ -322,48 +289,6 @@ final class CollectionConfig extends Model\AbstractModel
     public function setStoreId($storeId)
     {
         $this->storeId = $storeId;
-    }
-
-    /**
-     * Set cache item for a given cache key
-     *
-     * @param CollectionConfig $config
-     * @param string $cacheKey
-     */
-    private static function setCache(CollectionConfig $config, string $cacheKey): void
-    {
-        if (self::$cacheEnabled) {
-            Cache\Runtime::set($cacheKey, $config);
-        }
-
-        Cache::save($config, $cacheKey, [], null, 0, true);
-    }
-
-    /**
-     * Remove a cache item for a given cache key
-     *
-     * @param string $cacheKey
-     */
-    private static function removeCache(string $cacheKey): void
-    {
-        Cache::remove($cacheKey);
-        Cache\Runtime::set($cacheKey, null);
-    }
-
-    /**
-     * Get a cache item for a given cache key
-     *
-     * @param string $cacheKey
-     *
-     * @return CollectionConfig|bool
-     */
-    private static function getCache(string $cacheKey): CollectionConfig|bool
-    {
-        if (self::$cacheEnabled && Cache\Runtime::isRegistered($cacheKey) && $config = Cache\Runtime::get($cacheKey)) {
-            return $config;
-        }
-
-        return Cache::load($cacheKey);
     }
 
     /**

--- a/models/DataObject/Classificationstore/GroupConfig.php
+++ b/models/DataObject/Classificationstore/GroupConfig.php
@@ -77,7 +77,7 @@ final class GroupConfig extends Model\AbstractModel
     public static function getById($id)
     {
         try {
-            $cacheKey = 'cs_groupconfig_' . $id;
+            $cacheKey = self::getCacheKey($id);
             if (Cache\Runtime::isRegistered($cacheKey)) {
                 $config = Cache\Runtime::get($cacheKey);
                 if ($config) {
@@ -218,7 +218,7 @@ final class GroupConfig extends Model\AbstractModel
     public function delete()
     {
         \Pimcore::getEventDispatcher()->dispatch(new GroupConfigEvent($this), DataObjectClassificationStoreEvents::GROUP_CONFIG_PRE_DELETE);
-        $cacheKey = 'cs_groupconfig_' . $this->getId();
+        $cacheKey =  self::getCacheKey($this->getId());
         Cache\Runtime::set($cacheKey, null);
         Cache::remove($cacheKey);
 
@@ -234,7 +234,7 @@ final class GroupConfig extends Model\AbstractModel
         $isUpdate = false;
 
         if ($this->getId()) {
-            $cacheKey = 'cs_groupconfig_' . $this->getId();
+            $cacheKey =  self::getCacheKey($this->getId());
             Cache\Runtime::set($cacheKey, null);
             Cache::remove($cacheKey);
 
@@ -323,5 +323,15 @@ final class GroupConfig extends Model\AbstractModel
     public function setStoreId($storeId)
     {
         $this->storeId = $storeId;
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return string
+     */
+    private static function getCacheKey(int $id): string
+    {
+        return 'cs_groupconfig_' . $id;
     }
 }

--- a/models/DataObject/Classificationstore/GroupConfig.php
+++ b/models/DataObject/Classificationstore/GroupConfig.php
@@ -26,10 +26,7 @@ use Pimcore\Model;
  */
 final class GroupConfig extends Model\AbstractModel
 {
-    /**
-     * @var bool
-     */
-    public static $cacheEnabled = false;
+    use Cache\RuntimeCacheTrait;
 
     /**
      * @var int|null
@@ -139,22 +136,6 @@ final class GroupConfig extends Model\AbstractModel
         $config->save();
 
         return $config;
-    }
-
-    /**
-     * @param bool $cacheEnabled
-     */
-    public static function setCacheEnabled($cacheEnabled)
-    {
-        self::$cacheEnabled = $cacheEnabled;
-    }
-
-    /**
-     * @return bool
-     */
-    public static function getCacheEnabled()
-    {
-        return self::$cacheEnabled;
     }
 
     /**
@@ -348,48 +329,6 @@ final class GroupConfig extends Model\AbstractModel
     public function setStoreId($storeId)
     {
         $this->storeId = $storeId;
-    }
-
-    /**
-     * Set cache item for a given cache key
-     *
-     * @param GroupConfig $config
-     * @param string $cacheKey
-     */
-    private static function setCache(GroupConfig $config, string $cacheKey): void
-    {
-        if (self::$cacheEnabled) {
-            Cache\Runtime::set($cacheKey, $config);
-        }
-
-        Cache::save($config, $cacheKey, [], null, 0, true);
-    }
-
-    /**
-     * Remove a cache item for a given cache key
-     *
-     * @param string $cacheKey
-     */
-    private static function removeCache(string $cacheKey): void
-    {
-        Cache::remove($cacheKey);
-        Cache\Runtime::set($cacheKey, null);
-    }
-
-    /**
-     * Get a cache item for a given cache key
-     *
-     * @param string $cacheKey
-     *
-     * @return GroupConfig|bool
-     */
-    private static function getCache(string $cacheKey): GroupConfig|bool
-    {
-        if (self::$cacheEnabled && Cache\Runtime::isRegistered($cacheKey) && $config = Cache\Runtime::get($cacheKey)) {
-            return $config;
-        }
-
-        return Cache::load($cacheKey);
     }
 
     /**

--- a/models/DataObject/Classificationstore/KeyConfig.php
+++ b/models/DataObject/Classificationstore/KeyConfig.php
@@ -102,7 +102,7 @@ final class KeyConfig extends Model\AbstractModel
                 return self::$cache[$id];
             }
 
-            $cacheKey = 'cs_keyconfig_' . $id;
+            $cacheKey = self::getCacheKey($id);
             $config = Cache::load($cacheKey);
             if ($config) {
                 return $config;
@@ -152,7 +152,7 @@ final class KeyConfig extends Model\AbstractModel
     public static function getByName($name, $storeId = 1)
     {
         try {
-            $cacheKey = 'cs_keyconfig_' . $storeId . '_' . md5($name);
+            $cacheKey = self::getCacheKey($storeId, $name);
 
             if (self::$cacheEnabled && Cache\Runtime::isRegistered($cacheKey)) {
                 $config = Cache\Runtime::get($cacheKey);
@@ -268,8 +268,8 @@ final class KeyConfig extends Model\AbstractModel
         \Pimcore::getEventDispatcher()->dispatch(new KeyConfigEvent($this), DataObjectClassificationStoreEvents::KEY_CONFIG_PRE_DELETE);
         if ($this->getId()) {
             unset(self::$cache[$this->getId()]);
-            $cacheKey = 'cs_keyconfig_' . $this->getId();
-            Cache::remove($cacheKey);
+            Cache::remove(self::getCacheKey($this->getId()));
+            Cache::remove(self::getCacheKey($this->getStoreId(), $this->getName()));
         }
         $this->getDao()->delete();
         \Pimcore::getEventDispatcher()->dispatch(new KeyConfigEvent($this), DataObjectClassificationStoreEvents::KEY_CONFIG_POST_DELETE);
@@ -293,8 +293,8 @@ final class KeyConfig extends Model\AbstractModel
 
         if ($this->getId()) {
             unset(self::$cache[$this->getId()]);
-            $cacheKey = 'cs_keyconfig_' . $this->getId();
-            Cache::remove($cacheKey);
+            Cache::remove(self::getCacheKey($this->getId()));
+            Cache::remove(self::getCacheKey($this->getStoreId(), $this->getName()));
 
             $isUpdate = true;
             \Pimcore::getEventDispatcher()->dispatch(new KeyConfigEvent($this), DataObjectClassificationStoreEvents::KEY_CONFIG_PRE_UPDATE);
@@ -421,5 +421,21 @@ final class KeyConfig extends Model\AbstractModel
     public function setStoreId($storeId)
     {
         $this->storeId = $storeId;
+    }
+
+    /**
+     * @param int $id
+     * @param string|null $name
+     *
+     * @return string
+     */
+    private static function getCacheKey(int $id, string $name = null): string
+    {
+        $cacheKey = 'cs_keyconfig_' . $id;
+        if ($name !== null) {
+            $cacheKey .=  '_' . md5($name);
+        }
+
+        return $cacheKey;
     }
 }

--- a/models/DataObject/Classificationstore/KeyConfig.php
+++ b/models/DataObject/Classificationstore/KeyConfig.php
@@ -441,7 +441,7 @@ final class KeyConfig extends Model\AbstractModel
      * Calculate cache key
      *
      * @param int $id
-     * @param string $name
+     * @param string|null $name
      *
      * @return string
      */

--- a/models/DataObject/Classificationstore/KeyConfig.php
+++ b/models/DataObject/Classificationstore/KeyConfig.php
@@ -26,17 +26,12 @@ use Pimcore\Model;
 final class KeyConfig extends Model\AbstractModel
 {
     /**
-     * @var array
-     */
-    public static $cache = [];
-
-    /**
      * @var bool
      */
     public static $cacheEnabled = false;
 
     /**
-     * @var int
+     * @var int|null
      */
     protected $id;
 
@@ -96,49 +91,23 @@ final class KeyConfig extends Model\AbstractModel
      */
     public static function getById($id)
     {
-        try {
-            $id = (int)$id;
-            if (self::$cacheEnabled && self::$cache[$id]) {
-                return self::$cache[$id];
-            }
+        $id = (int)$id;
+        $cacheKey = self::getCacheKey($id);
 
-            $cacheKey = self::getCacheKey($id);
-            $config = Cache::load($cacheKey);
-            if ($config) {
+        try {
+            if ($config = self::getCache($cacheKey)) {
                 return $config;
             }
 
             $config = new self();
             $config->getDao()->getById($id);
-            if (self::$cacheEnabled) {
-                self::$cache[$id] = $config;
-            }
 
-            Cache::save($config, $cacheKey, [], null, 0, true);
+            self::setCache($config, $cacheKey);
 
             return $config;
         } catch (Model\Exception\NotFoundException $e) {
             return null;
         }
-    }
-
-    /**
-     * @param bool $cacheEnabled
-     */
-    public static function setCacheEnabled($cacheEnabled)
-    {
-        self::$cacheEnabled = $cacheEnabled;
-        if (!$cacheEnabled) {
-            self::$cache = [];
-        }
-    }
-
-    /**
-     * @return bool
-     */
-    public static function getCacheEnabled()
-    {
-        return self::$cacheEnabled;
     }
 
     /**
@@ -151,18 +120,10 @@ final class KeyConfig extends Model\AbstractModel
      */
     public static function getByName($name, $storeId = 1)
     {
+        $cacheKey = self::getCacheKey($storeId, $name);
+
         try {
-            $cacheKey = self::getCacheKey($storeId, $name);
-
-            if (self::$cacheEnabled && Cache\Runtime::isRegistered($cacheKey)) {
-                $config = Cache\Runtime::get($cacheKey);
-                if ($config) {
-                    return $config;
-                }
-            }
-
-            $config = Cache::load($cacheKey);
-            if ($config) {
+            if ($config = self::getCache($cacheKey)) {
                 return $config;
             }
 
@@ -171,11 +132,7 @@ final class KeyConfig extends Model\AbstractModel
             $config->setStoreId($storeId ? $storeId : 1);
             $config->getDao()->getByName();
 
-            if (self::$cacheEnabled) {
-                Cache\Runtime::set($cacheKey, $config);
-            }
-
-            Cache::save($config, $cacheKey, [], null, 0, true);
+            self::setCache($config, $cacheKey);
 
             return $config;
         } catch (Model\Exception\NotFoundException $e) {
@@ -195,6 +152,22 @@ final class KeyConfig extends Model\AbstractModel
     }
 
     /**
+     * @param bool $cacheEnabled
+     */
+    public static function setCacheEnabled($cacheEnabled)
+    {
+        self::$cacheEnabled = $cacheEnabled;
+    }
+
+    /**
+     * @return bool
+     */
+    public static function getCacheEnabled()
+    {
+        return self::$cacheEnabled;
+    }
+
+    /**
      * @param int $id
      *
      * @return $this
@@ -207,7 +180,7 @@ final class KeyConfig extends Model\AbstractModel
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getId()
     {
@@ -235,7 +208,7 @@ final class KeyConfig extends Model\AbstractModel
     }
 
     /**
-     * Returns the key description.
+     * Returns the description.
      *
      * @return string
      */
@@ -245,7 +218,7 @@ final class KeyConfig extends Model\AbstractModel
     }
 
     /**
-     * Sets the key description
+     * Sets the description.
      *
      * @param string $description
      *
@@ -267,10 +240,10 @@ final class KeyConfig extends Model\AbstractModel
 
         \Pimcore::getEventDispatcher()->dispatch(new KeyConfigEvent($this), DataObjectClassificationStoreEvents::KEY_CONFIG_PRE_DELETE);
         if ($this->getId()) {
-            unset(self::$cache[$this->getId()]);
-            Cache::remove(self::getCacheKey($this->getId()));
-            Cache::remove(self::getCacheKey($this->getStoreId(), $this->getName()));
+            self::removeCache(self::getCacheKey($this->getId()));
+            self::removeCache(self::getCacheKey($this->getStoreId(), $this->getName()));
         }
+
         $this->getDao()->delete();
         \Pimcore::getEventDispatcher()->dispatch(new KeyConfigEvent($this), DataObjectClassificationStoreEvents::KEY_CONFIG_POST_DELETE);
     }
@@ -292,9 +265,8 @@ final class KeyConfig extends Model\AbstractModel
         }
 
         if ($this->getId()) {
-            unset(self::$cache[$this->getId()]);
-            Cache::remove(self::getCacheKey($this->getId()));
-            Cache::remove(self::getCacheKey($this->getStoreId(), $this->getName()));
+            self::removeCache(self::getCacheKey($this->getId()));
+            self::removeCache(self::getCacheKey($this->getStoreId(), $this->getName()));
 
             $isUpdate = true;
             \Pimcore::getEventDispatcher()->dispatch(new KeyConfigEvent($this), DataObjectClassificationStoreEvents::KEY_CONFIG_PRE_UPDATE);
@@ -424,8 +396,52 @@ final class KeyConfig extends Model\AbstractModel
     }
 
     /**
+     * Set cache item for a given cache key
+     *
+     * @param KeyConfig $config
+     * @param string $cacheKey
+     */
+    private static function setCache(KeyConfig $config, string $cacheKey): void
+    {
+        if (self::$cacheEnabled) {
+            Cache\Runtime::set($cacheKey, $config);
+        }
+
+        Cache::save($config, $cacheKey, [], null, 0, true);
+    }
+
+    /**
+     * Remove a cache item for a given cache key
+     *
+     * @param string $cacheKey
+     */
+    private static function removeCache(string $cacheKey): void
+    {
+        Cache::remove($cacheKey);
+        Cache\Runtime::set($cacheKey, null);
+    }
+
+    /**
+     * Get a cache item for a given cache key
+     *
+     * @param string $cacheKey
+     *
+     * @return KeyConfig|bool
+     */
+    private static function getCache(string $cacheKey): KeyConfig|bool
+    {
+        if (self::$cacheEnabled && Cache\Runtime::isRegistered($cacheKey) && $config = Cache\Runtime::get($cacheKey)) {
+            return $config;
+        }
+
+        return Cache::load($cacheKey);
+    }
+
+    /**
+     * Calculate cache key
+     *
      * @param int $id
-     * @param string|null $name
+     * @param string $name
      *
      * @return string
      */
@@ -433,7 +449,7 @@ final class KeyConfig extends Model\AbstractModel
     {
         $cacheKey = 'cs_keyconfig_' . $id;
         if ($name !== null) {
-            $cacheKey .=  '_' . md5($name);
+            $cacheKey .= '_' . md5($name);
         }
 
         return $cacheKey;

--- a/models/DataObject/Classificationstore/KeyConfig.php
+++ b/models/DataObject/Classificationstore/KeyConfig.php
@@ -25,10 +25,7 @@ use Pimcore\Model;
  */
 final class KeyConfig extends Model\AbstractModel
 {
-    /**
-     * @var bool
-     */
-    public static $cacheEnabled = false;
+    use Cache\RuntimeCacheTrait;
 
     /**
      * @var int|null
@@ -149,22 +146,6 @@ final class KeyConfig extends Model\AbstractModel
         $config->save();
 
         return $config;
-    }
-
-    /**
-     * @param bool $cacheEnabled
-     */
-    public static function setCacheEnabled($cacheEnabled)
-    {
-        self::$cacheEnabled = $cacheEnabled;
-    }
-
-    /**
-     * @return bool
-     */
-    public static function getCacheEnabled()
-    {
-        return self::$cacheEnabled;
     }
 
     /**
@@ -396,52 +377,10 @@ final class KeyConfig extends Model\AbstractModel
     }
 
     /**
-     * Set cache item for a given cache key
-     *
-     * @param KeyConfig $config
-     * @param string $cacheKey
-     */
-    private static function setCache(KeyConfig $config, string $cacheKey): void
-    {
-        if (self::$cacheEnabled) {
-            Cache\Runtime::set($cacheKey, $config);
-        }
-
-        Cache::save($config, $cacheKey, [], null, 0, true);
-    }
-
-    /**
-     * Remove a cache item for a given cache key
-     *
-     * @param string $cacheKey
-     */
-    private static function removeCache(string $cacheKey): void
-    {
-        Cache::remove($cacheKey);
-        Cache\Runtime::set($cacheKey, null);
-    }
-
-    /**
-     * Get a cache item for a given cache key
-     *
-     * @param string $cacheKey
-     *
-     * @return KeyConfig|bool
-     */
-    private static function getCache(string $cacheKey): KeyConfig|bool
-    {
-        if (self::$cacheEnabled && Cache\Runtime::isRegistered($cacheKey) && $config = Cache\Runtime::get($cacheKey)) {
-            return $config;
-        }
-
-        return Cache::load($cacheKey);
-    }
-
-    /**
      * Calculate cache key
      *
      * @param int $id
-     * @param string|null $name
+     * @param string $name
      *
      * @return string
      */


### PR DESCRIPTION
Pull request as per issue #11144

@brusch , as suggested I've created a static method to separate the cache key creation logic as per your given example. The cache keys for the classification store keys are now calculated using this method.

@weisswurstkanone , I've implemented the same for the GroupConfig, however, the GroupConfig did not use caching on behalf of the group name but just the id. So the current cache invalidation stays the same. Does it probably make sense to enable the same caching on behalf of the group name as it is done with the KeyConfig or was it left out on purpose?

Thank you 