### PR TITLE
Thumbnail Processor: Avoid output of complete error stacktraces

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -90,7 +90,7 @@ class Imagick extends Adapter
 
             $imagePathLoad = $imagePathLoad . '[0]';
 
-            if (!$i->readImage($imagePathLoad) || !filesize($imagePath)) {
+            if (!$i->readImage($imagePathLoad) || !@filesize($imagePath)) {
                 return false;
             }
 
@@ -153,7 +153,7 @@ class Imagick extends Adapter
             }
         } catch (\Exception $e) {
             Logger::error('Unable to load image: ' . $imagePath);
-            Logger::error($e);
+            Logger::error($e->getMessage());
 
             return false;
         }

--- a/models/Asset/Document/ImageThumbnail.php
+++ b/models/Asset/Document/ImageThumbnail.php
@@ -117,7 +117,7 @@ final class ImageThumbnail
                 }
             } catch (\Exception $e) {
                 Logger::error("Couldn't create image-thumbnail of document " . $this->asset->getRealFullPath());
-                Logger::error($e);
+                Logger::error($e->getMessage());
             }
 
             if (empty($this->pathReference)) {

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -170,7 +170,7 @@ final class Thumbnail
                     $this->pathReference = Thumbnail\Processor::process($this->asset, $this->config, null, $deferred, $generated);
                 } catch (\Exception $e) {
                     Logger::error("Couldn't create thumbnail of image " . $this->asset->getRealFullPath());
-                    Logger::error($e);
+                    Logger::error($e->getMessage());
                 }
             }
         }

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -95,6 +95,8 @@ class Processor
      * @param bool $generated
      *
      * @return array
+     *
+     * @throws \Exception
      */
     public static function process(Asset $asset, Config $config, $fileSystemPath = null, $deferred = false, &$generated = false)
     {

--- a/models/Asset/MetaData/EmbeddedMetaDataTrait.php
+++ b/models/Asset/MetaData/EmbeddedMetaDataTrait.php
@@ -245,7 +245,7 @@ trait EmbeddedMetaDataTrait
         $data = [];
 
         if (is_file($filePath)) {
-            $result = getimagesize($filePath, $info);
+            $result = @getimagesize($filePath, $info);
             if ($result) {
                 $mapping = [
                     '1#000' => 'EnvelopeRecordVersion',

--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -159,7 +159,7 @@ final class ImageThumbnail
                         );
                     } catch (\Exception $e) {
                         Logger::error("Couldn't create image-thumbnail of video " . $this->asset->getRealFullPath());
-                        Logger::error($e);
+                        Logger::error($e->getMessage());
                     }
                 }
             }


### PR DESCRIPTION
If you execute the ThumbnailsImageCommand with some orphan image assets you get many exceptions with stacktraces. 
  
I think it should be enough to output only the message. So you can easier find the orphan images.

