### PR TITLE
ClassDefinition Import ignores previewGeneratorReference, showFieldLookup and enableGridLocking

### DIFF
--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -196,7 +196,15 @@ class Service
             $fieldCollection->setLayoutDefinitions($layout);
         }
 
-        foreach (['parentClass', 'implementsInterfaces', 'title', 'group', 'generateTypeDeclarations'] as $importPropertyName) {
+        $importPropertyNames = [
+            'parentClass',
+            'implementsInterfaces',
+            'title',
+            'group',
+            'generateTypeDeclarations',
+        ];
+
+        foreach ($importPropertyNames as $importPropertyName) {
             if (isset($importData[$importPropertyName])) {
                 $fieldCollection->{'set' . ucfirst($importPropertyName)}($importData[$importPropertyName]);
             }
@@ -273,15 +281,20 @@ class Service
         }
 
         $objectBrick->setClassDefinitions($toAssignClassDefinitions);
-        $objectBrick->setParentClass($importData['parentClass']);
-        $objectBrick->setImplementsInterfaces($importData['implementsInterfaces'] ?? null);
-        $objectBrick->setGenerateTypeDeclarations($importData['generateTypeDeclarations'] ?? null);
-        if (isset($importData['title'])) {
-            $objectBrick->setTitle($importData['title']);
+        $importPropertyNames = [
+            'parentClass',
+            'implementsInterfaces',
+            'title',
+            'group',
+            'generateTypeDeclarations',
+        ];
+
+        foreach ($importPropertyNames as $importPropertyName) {
+            if (isset($importData[$importPropertyName])) {
+                $objectBrick->{'set' . ucfirst($importPropertyName)}($importData[$importPropertyName]);
+            }
         }
-        if (isset($importData['group'])) {
-            $objectBrick->setGroup($importData['group']);
-        }
+
         $objectBrick->save();
 
         return true;

--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -151,6 +151,8 @@ class Service
             'previewGeneratorReference',
             'compositeIndices',
             'generateTypeDeclarations',
+            'showFieldLookup',
+            'enableGridLocking',
         ];
 
         foreach ($importPropertyNames as $importPropertyName) {

--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -133,10 +133,27 @@ class Service
         }
         $class->setModificationDate(time());
         $class->setUserModification($userId);
+        $importPropertyNames = [
+            'description',
+            'icon',
+            'group',
+            'allowInherit',
+            'allowVariants',
+            'showVariants',
+            'parentClass',
+            'implementsInterfaces',
+            'listingParentClass',
+            'useTraits',
+            'listingUseTraits',
+            'previewUrl',
+            'propertyVisibility',
+            'linkGeneratorReference',
+            'previewGeneratorReference',
+            'compositeIndices',
+            'generateTypeDeclarations',
+        ];
 
-        foreach (['description', 'icon', 'group', 'allowInherit', 'allowVariants', 'showVariants', 'parentClass',
-                    'implementsInterfaces', 'listingParentClass', 'useTraits', 'listingUseTraits', 'previewUrl', 'propertyVisibility',
-                    'linkGeneratorReference', 'compositeIndices', 'generateTypeDeclarations', ] as $importPropertyName) {
+        foreach ($importPropertyNames as $importPropertyName) {
             if (isset($importData[$importPropertyName])) {
                 $class->{'set' . ucfirst($importPropertyName)}($importData[$importPropertyName]);
             }


### PR DESCRIPTION
If you export a class and import it to a other pimcore instance the previewGeneratorReference field is empty