### PR TITLE
[DataObject] Link fields accept strings

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -74,7 +74,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
             $data->_setOwnerFieldname('');
             $data->_setOwnerLanguage(null);
 
-            if ($data->getLinktype() == 'internal' && !$data->getPath()) {
+            if ($data->getLinktype() === 'internal' && !$data->getPath()) {
                 $data->setLinktype(null);
                 $data->setInternalType(null);
                 if ($data->isEmpty()) {
@@ -88,13 +88,11 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
                 $data->setInternalType(null);
                 $data->setInternal(null);
             }
+
+            return Serialize::serialize($data);
         }
 
-        if (is_null($data)) {
-            return null;
-        }
-
-        return Serialize::serialize($data);
+        return null;
     }
 
     /**
@@ -104,7 +102,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
      * @param null|DataObject\Concrete $object
      * @param mixed $params
      *
-     * @return DataObject\Data\Link
+     * @return DataObject\Data\Link|null
      */
     public function getDataFromResource($data, $object = null, $params = [])
     {
@@ -119,13 +117,15 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
 
             try {
                 $this->checkValidity($link, true, $params);
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 $link->setInternalType(null);
                 $link->setInternal(null);
             }
+
+            return $link;
         }
 
-        return $link;
+        return null;
     }
 
     /**
@@ -218,7 +218,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
      */
     public function getVersionPreview($data, $object = null, $params = [])
     {
-        return $data;
+        return (string) $data;
     }
 
     /**
@@ -241,6 +241,8 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
                         }
                     }
                 }
+            } else {
+                throw new Element\ValidationException('Expected DataObject\\Data\\Link');
             }
         }
     }

--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -226,24 +226,22 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
      */
     public function checkValidity($data, $omitMandatoryCheck = false, $params = [])
     {
-        if ($data) {
-            if ($data instanceof DataObject\Data\Link) {
-                if ((int)$data->getInternal() > 0) {
-                    if ($data->getInternalType() == 'document') {
-                        $doc = Document::getById($data->getInternal());
-                        if (!$doc instanceof Document) {
-                            throw new Element\ValidationException('invalid internal link, referenced document with id [' . $data->getInternal() . '] does not exist');
-                        }
-                    } elseif ($data->getInternalType() == 'asset') {
-                        $asset = Asset::getById($data->getInternal());
-                        if (!$asset instanceof Asset) {
-                            throw new Element\ValidationException('invalid internal link, referenced asset with id [' . $data->getInternal() . '] does not exist');
-                        }
+        if ($data instanceof DataObject\Data\Link) {
+            if ((int)$data->getInternal() > 0) {
+                if ($data->getInternalType() == 'document') {
+                    $doc = Document::getById($data->getInternal());
+                    if (!$doc instanceof Document) {
+                        throw new Element\ValidationException('invalid internal link, referenced document with id [' . $data->getInternal() . '] does not exist');
+                    }
+                } elseif ($data->getInternalType() == 'asset') {
+                    $asset = Asset::getById($data->getInternal());
+                    if (!$asset instanceof Asset) {
+                        throw new Element\ValidationException('invalid internal link, referenced asset with id [' . $data->getInternal() . '] does not exist');
                     }
                 }
-            } else {
-                throw new Element\ValidationException('Expected DataObject\\Data\\Link');
             }
+        } elseif ($data !== null) {
+            throw new Element\ValidationException('Expected DataObject\\Data\\Link or null');
         }
     }
 

--- a/tests/Model/DataType/BlockTest.php
+++ b/tests/Model/DataType/BlockTest.php
@@ -16,13 +16,14 @@
 namespace Pimcore\Tests\Model\DataType;
 
 use Pimcore\Cache;
+use Pimcore\Model\Asset\Image;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\Data\BlockElement;
 use Pimcore\Model\DataObject\Data\Hotspotimage;
 use Pimcore\Model\DataObject\Data\Link;
 use Pimcore\Model\DataObject\Service;
-use Pimcore\Model\DataObject\Unittest;
 use Pimcore\Model\DataObject\unittestBlock;
+use Pimcore\Model\Document\Page;
 use Pimcore\Tests\Test\ModelTestCase;
 use Pimcore\Tests\Util\TestHelper;
 
@@ -51,13 +52,12 @@ class BlockTest extends ModelTestCase
     }
 
     /**
-     * @return Unittest
+     * @return unittestBlock
      *
      * @throws \Exception
      */
     protected function createBlockObject()
     {
-        /** @var Unittest $object */
         $object = new unittestBlock();
         $object->setParent(Service::createFolderByPath('/blocks'));
         $object->setKey('block1');
@@ -67,20 +67,20 @@ class BlockTest extends ModelTestCase
     }
 
     /**
-     * @param $document
+     * @param Page $document
      *
      * @return Link
      */
     protected function createLinkData($document)
     {
         $link = new Link();
-        $link->setPath($document);
+        $link->setPath($document->getFullPath());
 
         return $link;
     }
 
     /**
-     * @param $image
+     * @param Image $image
      *
      * @return Hotspotimage
      */
@@ -104,9 +104,8 @@ class BlockTest extends ModelTestCase
         ];
 
         $hotspots[] = $hotspot2;
-        $hotspotImage = new Hotspotimage($image, $hotspots);
 
-        return $hotspotImage;
+        return new Hotspotimage($image, $hotspots);
     }
 
     /**

--- a/tests/Model/DataType/LinkTest.php
+++ b/tests/Model/DataType/LinkTest.php
@@ -25,7 +25,7 @@ use Pimcore\Tests\Util\TestHelper;
 /**
  * Class LinkTest
  *
- * @group model.datatype.block
+ * @group model.datatype.link
  */
 class LinkTest extends ModelTestCase
 {

--- a/tests/Model/DataType/LinkTest.php
+++ b/tests/Model/DataType/LinkTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Tests\Model\DataType;
+
+use Pimcore\Model\DataObject\Data\Link;
+use Pimcore\Model\DataObject\Service;
+use Pimcore\Model\DataObject\unittestLink;
+use Pimcore\Tests\Test\ModelTestCase;
+use Pimcore\Tests\Util\TestHelper;
+
+/**
+ * Class LinkTest
+ *
+ * @group model.datatype.block
+ */
+class LinkTest extends ModelTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        TestHelper::cleanUp();
+    }
+
+    public function tearDown(): void
+    {
+        TestHelper::cleanUp();
+        parent::tearDown();
+    }
+
+    protected function setUpTestClasses()
+    {
+        $this->tester->setupPimcoreClass_Link();
+    }
+
+    /**
+     * @return unittestLink
+     *
+     * @throws \Exception
+     */
+    protected function createLinkObject()
+    {
+        $object = new unittestLink();
+        $object->setParent(Service::createFolderByPath('/links'));
+        $object->setKey('link1');
+        $object->setPublished(true);
+
+        return $object;
+    }
+
+    /**
+     * Verifies that Link data is loaded correctly after save and reload
+     *
+     * @throws \Exception
+     */
+    public function testSave()
+    {
+        $linkObject = $this->createLinkObject();
+        $link = new Link();
+        $link->setDirect('https://pimcore.com/');
+        $linkObject->setTestlink($link);
+        $linkObject->setLtestlink($link);
+        $linkObject->save();
+
+        $linkObjectReloaded = unittestLink::getById($linkObject->getId(), true);
+
+        $this->assertEquals($link->getDirect(), $linkObjectReloaded->getTestlink()->getDirect());
+        $this->assertEquals($link->getDirect(), $linkObjectReloaded->getLtestlink()->getDirect());
+    }
+}

--- a/tests/Model/DataType/LinkTest.php
+++ b/tests/Model/DataType/LinkTest.php
@@ -18,6 +18,7 @@ namespace Pimcore\Tests\Model\DataType;
 use Pimcore\Model\DataObject\Data\Link;
 use Pimcore\Model\DataObject\Service;
 use Pimcore\Model\DataObject\unittestLink;
+use Pimcore\Model\Element\ValidationException;
 use Pimcore\Tests\Test\ModelTestCase;
 use Pimcore\Tests\Util\TestHelper;
 
@@ -78,5 +79,22 @@ class LinkTest extends ModelTestCase
 
         $this->assertEquals($link->getDirect(), $linkObjectReloaded->getTestlink()->getDirect());
         $this->assertEquals($link->getDirect(), $linkObjectReloaded->getLtestlink()->getDirect());
+    }
+
+    /**
+     * Verifies that Link data throws correct exceptions if invalid data is given
+     *
+     * @throws \Exception
+     */
+    public function testCheckValidity()
+    {
+        $linkObject = $this->createLinkObject();
+        $linkObject->setTestlink('https://pimcore.com/');
+        $linkObject->setLtestlink('https://pimcore.com/');
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Expected DataObject\\Data\\Link');
+
+        $linkObject->save();
     }
 }

--- a/tests/Model/DataType/LinkTest.php
+++ b/tests/Model/DataType/LinkTest.php
@@ -93,7 +93,7 @@ class LinkTest extends ModelTestCase
         $linkObject->setLtestlink('https://pimcore.com/');
 
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Expected DataObject\\Data\\Link');
+        $this->expectExceptionMessage('Expected DataObject\\Data\\Link or null');
 
         $linkObject->save();
     }

--- a/tests/_support/Helper/Model.php
+++ b/tests/_support/Helper/Model.php
@@ -383,6 +383,47 @@ class Model extends AbstractDefinitionHelper
     }
 
     /**
+     * Set up a class used for Link Test.
+     *
+     * @param string $name
+     * @param string $filename
+     *
+     * @return ClassDefinition|null
+     *
+     * @throws \Exception
+     */
+    public function setupPimcoreClass_Link($name = 'unittestLink', $filename = 'link-import.json')
+    {
+        /** @var ClassManager $cm */
+        $cm = $this->getClassManager();
+
+        if (!$class = $cm->getClass($name)) {
+            $root = new ClassDefinition\Layout\Panel();
+            $panel = (new ClassDefinition\Layout\Panel())->setName('MyLayout');
+            $rootPanel = (new ClassDefinition\Layout\Tabpanel())->setName('Layout');
+            $rootPanel->addChild($panel);
+
+            $link = new ClassDefinition\Data\Link();
+            $link->setName('testlink');
+
+            $lFields = new \Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields();
+            $lFields->setName('localizedfields');
+
+            $llink = new ClassDefinition\Data\Link();
+            $llink->setName('ltestlink');
+
+            $lFields->addChild($llink);
+
+            $panel->addChild($link);
+            $panel->addChild($lFields);
+            $root->addChild($rootPanel);
+            $class = $this->createClass($name, $root, $filename, true);
+        }
+
+        return $class;
+    }
+
+    /**
      * Set up a class which (hopefully) contains all data types
      *
      * @param string $name

--- a/tests/_support/Helper/Model.php
+++ b/tests/_support/Helper/Model.php
@@ -417,7 +417,7 @@ class Model extends AbstractDefinitionHelper
             $panel->addChild($link);
             $panel->addChild($lFields);
             $root->addChild($rootPanel);
-            $class = $this->createClass($name, $root, $filename, true);
+            $class = $this->createClass($name, $root, $filename, true, null, false);
         }
 
         return $class;
@@ -686,10 +686,11 @@ class Model extends AbstractDefinitionHelper
      * @param string $filename
      * @param bool $inheritanceAllowed
      * @param string|null $id
+     * @param bool $generateTypeDeclarations
      *
      * @return ClassDefinition
      */
-    protected function createClass($name, $layout, $filename, $inheritanceAllowed = false, $id = null)
+    protected function createClass($name, $layout, $filename, $inheritanceAllowed = false, $id = null, $generateTypeDeclarations = true)
     {
         $cm = $this->getClassManager();
         $def = new ClassDefinition();
@@ -700,7 +701,7 @@ class Model extends AbstractDefinitionHelper
         $def->setName($name);
         $def->setLayoutDefinitions($layout);
         $def->setAllowInherit($inheritanceAllowed);
-        $def->setGenerateTypeDeclarations(true);
+        $def->setGenerateTypeDeclarations($generateTypeDeclarations);
         $json = ClassDefinition\Service::generateClassDefinitionJson($def);
         $cm->saveJson($filename, $json);
 


### PR DESCRIPTION
In Pimcore 6.9: If you set an string value to an Link field the value is saved and returned also if you reload the object.

In Pimcore X there is a typehint on the setter method. So it is not possible to set strings. But it can be still in the db.

I add a test and optimize the methods so it can only be Link object or null (from db/user)