### PR TITLE
classification store getter must not load store from parent object

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20220201132131.php
+++ b/bundles/CoreBundle/Migrations/Version20220201132131.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Model\DataObject\ClassDefinition\Listing;
+
+final class Version20220201132131 extends AbstractMigration
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getDescription(): string
+    {
+        return 'Updates class definition files';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->regenerateClasses();
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->regenerateClasses();
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private function regenerateClasses()
+    {
+        $listing = new Listing();
+        foreach ($listing->getClasses() as $class) {
+            $this->write(sprintf('Saving php files for class: %s', $class->getName()));
+            $class->generateClassFiles(false);
+        }
+    }
+}

--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -1386,4 +1386,55 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
 
         return null;
     }
+
+
+    /**
+     * Creates getter code which is used for generation of php file for object classes using this data type
+     *
+     * @param DataObject\ClassDefinition|DataObject\Objectbrick\Definition|DataObject\Fieldcollection\Definition $class
+     *
+     * @return string
+     */
+    public function getGetterCode($class)
+    {
+        $key = $this->getName();
+
+        if ($class->getGenerateTypeDeclarations() && $this instanceof DataObject\ClassDefinition\Data\TypeDeclarationSupportInterface && $this->getReturnTypeDeclaration()) {
+            $typeDeclaration = ': ' . $this->getReturnTypeDeclaration();
+        } else {
+            $typeDeclaration = '';
+        }
+
+        $code = '/**' . "\n";
+        $code .= '* Get ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
+        $code .= '* @return ' . $this->getPhpdocReturnType() . "\n";
+        $code .= '*/' . "\n";
+        $code .= 'public function get' . ucfirst($key) . '()' . $typeDeclaration . "\n";
+        $code .= '{' . "\n";
+
+        $code .= $this->getPreGetValueHookCode($key);
+
+        $code .= "\t" . '$data = $this->getClass()->getFieldDefinition("' . $key . '")->preGetData($this);' . "\n\n";
+
+//        // insert this line if inheritance from parent objects is allowed
+//        if ($class instanceof DataObject\ClassDefinition && $class->getAllowInherit() && $this->supportsInheritance()) {
+//            $code .= "\t" . 'if (\Pimcore\Model\DataObject::doGetInheritedValues() && $this->getClass()->getFieldDefinition("' . $key . '")->isEmpty($data)) {' . "\n";
+//            $code .= "\t\t" . 'try {' . "\n";
+//            $code .= "\t\t\t" . 'return $this->getValueFromParent("' . $key . '");' . "\n";
+//            $code .= "\t\t" . '} catch (InheritanceParentNotFoundException $e) {' . "\n";
+//            $code .= "\t\t\t" . '// no data from parent available, continue ...' . "\n";
+//            $code .= "\t\t" . '}' . "\n";
+//            $code .= "\t" . '}' . "\n\n";
+//        }
+//        $code .= "\t" . 'if ($data instanceof \\Pimcore\\Model\\DataObject\\Data\\EncryptedField) {' . "\n";
+//        $code .= "\t\t" . 'return $data->getPlain();' . "\n";
+//        $code .= "\t" . '}' . "\n\n";
+
+        $code .= "\t" . 'return $data;' . "\n";
+        $code .= "}\n\n";
+
+        return $code;
+    }
+
+
 }

--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -1399,10 +1399,9 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
     {
         $key = $this->getName();
 
+        $typeDeclaration = '';
         if ($class->getGenerateTypeDeclarations() && $this instanceof DataObject\ClassDefinition\Data\TypeDeclarationSupportInterface && $this->getReturnTypeDeclaration()) {
             $typeDeclaration = ': ' . $this->getReturnTypeDeclaration();
-        } else {
-            $typeDeclaration = '';
         }
 
         $code = '/**' . "\n";
@@ -1415,26 +1414,9 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
         $code .= $this->getPreGetValueHookCode($key);
 
         $code .= "\t" . '$data = $this->getClass()->getFieldDefinition("' . $key . '")->preGetData($this);' . "\n\n";
-
-//        // insert this line if inheritance from parent objects is allowed
-//        if ($class instanceof DataObject\ClassDefinition && $class->getAllowInherit() && $this->supportsInheritance()) {
-//            $code .= "\t" . 'if (\Pimcore\Model\DataObject::doGetInheritedValues() && $this->getClass()->getFieldDefinition("' . $key . '")->isEmpty($data)) {' . "\n";
-//            $code .= "\t\t" . 'try {' . "\n";
-//            $code .= "\t\t\t" . 'return $this->getValueFromParent("' . $key . '");' . "\n";
-//            $code .= "\t\t" . '} catch (InheritanceParentNotFoundException $e) {' . "\n";
-//            $code .= "\t\t\t" . '// no data from parent available, continue ...' . "\n";
-//            $code .= "\t\t" . '}' . "\n";
-//            $code .= "\t" . '}' . "\n\n";
-//        }
-//        $code .= "\t" . 'if ($data instanceof \\Pimcore\\Model\\DataObject\\Data\\EncryptedField) {' . "\n";
-//        $code .= "\t\t" . 'return $data->getPlain();' . "\n";
-//        $code .= "\t" . '}' . "\n\n";
-
         $code .= "\t" . 'return $data;' . "\n";
         $code .= "}\n\n";
 
         return $code;
     }
-
-
 }

--- a/tests/Model/Inheritance/ClassificationstoreTest.php
+++ b/tests/Model/Inheritance/ClassificationstoreTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Tests\Model\Inheritance;
+
+use Pimcore\Model\DataObject\Inheritance;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Tests\Test\ModelTestCase;
+use Pimcore\Tests\Util\TestHelper;
+use Pimcore\Model\DataObject\Classificationstore;
+
+/**
+ * Class ClassificationstoreTest
+ *
+ * @package Pimcore\Tests\Model\Inheritance
+ * @group model.inheritance.classificationstore
+ */
+class ClassificationstoreTest extends ModelTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        TestHelper::cleanUp();
+        \Pimcore::setAdminMode();
+    }
+
+    public function tearDown(): void
+    {
+        TestHelper::cleanUp();
+        parent::tearDown();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUpTestClasses()
+    {
+        $class = ClassDefinition::getByName('inheritance');
+
+        if ($class) {
+            $store = Classificationstore\StoreConfig::getByName('teststore');
+            if (!$store) {
+                $store = new Classificationstore\StoreConfig();
+                $store->setName('teststore');
+                $store->save();
+            }
+
+            $this->configureStore($store);
+        }
+    }
+
+    /**
+     * @param Classificationstore\StoreConfig $store
+     */
+    protected function configureStore(Classificationstore\StoreConfig $store)
+    {
+        $group = Classificationstore\GroupConfig::getByName('group1', $store->getId());
+        if (!$group) {
+            // create group
+            $group = new Classificationstore\GroupConfig();
+            $group->setStoreId($store->getId());
+            $group->setName('group1');
+            $group->save();
+        }
+
+
+        $key1 = Classificationstore\KeyConfig::getByName('field1', $store->getId());
+        if (!$key1) {
+            //create field1
+            $key1 = new Classificationstore\KeyConfig();
+            $key1->setDefinition(json_encode(new ClassDefinition\Data\Input()));
+            $key1->setStoreId($store->getId());
+            $key1->setName('field1');
+            $key1->setDescription('Input Field 1');
+            $key1->setEnabled(true);
+            $key1->setType('input');
+            $key1->save();
+        }
+
+        $key2 = Classificationstore\KeyConfig::getByName('field2', $store->getId());
+        if (!$key2) {
+            //create field2
+            $key2 = new Classificationstore\KeyConfig();
+            $key1->setDefinition(json_encode(new ClassDefinition\Data\Input()));
+            $key2->setStoreId($store->getId());
+            $key2->setName('field2');
+            $key2->setDescription('Input Field 2');
+            $key2->setEnabled(true);
+            $key2->setType('input');
+            $key2->save();
+        }
+
+
+        $keygroup1 = Classificationstore\KeyGroupRelation::getByGroupAndKeyId($group->getId(), $key1->getId());
+        if (!$keygroup1) {
+            //create key group relation
+            $keygroup1 = new Classificationstore\KeyGroupRelation();
+            $keygroup1->setKeyId($key1->getId());
+            $keygroup1->setGroupId($group->getId());
+            $keygroup1->setSorter(1);
+            $keygroup1->save();
+        }
+
+
+        $keygroup2 = Classificationstore\KeyGroupRelation::getByGroupAndKeyId($group->getId(), $key2->getId());
+        if (!$keygroup2) {
+            $keygroup2 = new Classificationstore\KeyGroupRelation();
+            $keygroup2->setKeyId($key2->getId());
+            $keygroup2->setGroupId($group->getId());
+            $keygroup2->setSorter(2);
+            $keygroup2->save();
+        }
+    }
+
+    /**
+     * Tests the following scenario:
+     *
+     * root
+     *    |-one
+     *        |-two
+     *
+     * add classification store to one(parent) and change value of 2 fields in the store,
+     * then add store to two(child) and change value of 1 field in the store,
+     * asserts inherited and non-inherited values on child & parent.
+     *
+     */
+    public function testInheritance()
+    {
+        $group = Classificationstore\GroupConfig::getByName('group1');
+        $key1 = Classificationstore\KeyConfig::getByName('field1');
+        $key2 = Classificationstore\KeyConfig::getByName('field2');
+
+        $one = new Inheritance();
+        $one->setKey('one');
+        $one->setParentId(1);
+        $one->setPublished(true);
+
+        /** @var Classificationstore $oneStore */
+        $oneStore = $one->getTeststore();
+
+        $oneStore->setLocalizedKeyValue($group->getId(), $key1->getId(), 'oneinput1');
+        $oneStore->setLocalizedKeyValue($group->getId(), $key2->getId(), 'oneinput2');
+
+        $one->save();
+
+        $two = new Inheritance();
+        $two->setKey('two');
+        $two->setParentId($one->getId());
+        $two->setPublished(true);
+
+        /** @var Classificationstore $twoStore */
+        $twoStore = $two->getTeststore();
+        $twoStore->setLocalizedKeyValue($group->getId(), $key1->getId(), 'twoinput1');
+        $twoStore->setActiveGroups($twoStore->getActiveGroups() + [1 => true]);
+        $twoStore->save();
+
+        $this->assertEquals('twoinput1', $twoStore->getLocalizedKeyValue($group->getId(), $key1->getId()));
+    }
+
+}

--- a/tests/_support/Helper/Model.php
+++ b/tests/_support/Helper/Model.php
@@ -632,6 +632,10 @@ class Model extends AbstractDefinitionHelper
             $panel->addChild($otherPanel);
             $panel->addChild($this->createDataChild('objectbricks', 'mybricks'));
 
+            $csField = $this->createDataChild('classificationstore', 'teststore');
+            $csField->setStoreId(1);
+            $panel->addChild($csField);
+
             $root->addChild($rootPanel);
             $class = $this->createClass($name, $root, $filename, true);
         }


### PR DESCRIPTION
### Prerequisites: 
- class definition with classification store attribute and inheritance activated, see [class_Test_export.zip](https://github.com/pimcore/pimcore/files/7933824/class_Test_export.zip)

- create parent data object with at least one attribute of a group added to classification store field

### Problem: 
try to create child object and add additional classification store group/key

```php
        $child = new Test();
        $child->setKey('c10 ' . time());
        $child->setParentId(24798);
        $child->setPublished(true);

        $store = $child->getStore();
        $store->setLocalizedKeyValue(75, 326, 'foo');
        $store->setActiveGroups($store->getActiveGroups() + [75 => true]);

        $child->save();
```
does not add any classification store data in created object, when loading object again it only contains inherited values. 

### Reason: 
Getter `getStore()` returns classification store of parent object, not the childs object one ... when modifying it, the classification store object of the parent object will be modified, but when saving the child object, the empty child classification store is stored. 


### TODOs: 

- [x] double check
- [x] remove not needed commented code
- [x] create a test for this scenario

