### PR TITLE
[Assets] Handle exceptions thrown by PDO adapter when rolling back a transaction

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1105,7 +1105,13 @@ class Asset extends Element\AbstractElement
 
             $this->clearThumbnails(true);
         } catch (\Exception $e) {
-            $this->rollBack();
+            try {
+                $this->rollBack();
+            } catch (\Exception $er) {
+                // PDO adapter throws exceptions if rollback fails
+                Logger::info($er);
+            }
+
             $failureEvent = new AssetEvent($this);
             $failureEvent->setArgument('exception', $e);
             \Pimcore::getEventDispatcher()->dispatch($failureEvent, AssetEvents::POST_DELETE_FAILURE);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #10960

## Additional info  

