### PR TITLE
Fix: "Predefined Document Type"-Select not working

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/settings_abstract.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/settings_abstract.js
@@ -19,6 +19,9 @@ pimcore.document.settings_abstract = Class.create({
     },
 
     setDocumentType: function (field, newValue, oldValue) {
+        if (!newValue.data.id) {
+            return;
+        }
         var allowedFields = ["controller", "template"];
         var form = this.getLayout().getForm();
         var element = null;
@@ -26,9 +29,7 @@ pimcore.document.settings_abstract = Class.create({
         for (var i = 0; i < allowedFields.length; i++) {
             element = form.findField(allowedFields[i]);
             if (element) {
-                if (newValue.data.id > 0) {
-                    element.setValue(newValue.data[allowedFields[i]]);
-                }
+                element.setValue(newValue.data[allowedFields[i]]);
             }
         }
     },


### PR DESCRIPTION
Fixes https://github.com/pimcore/pimcore/issues/11283

The id of predefined document types are no integer anymore