### PR TITLE
[Element] Fix permission issue for listing children

### DIFF
--- a/models/Asset/Dao.php
+++ b/models/Asset/Dao.php
@@ -332,7 +332,7 @@ class Dao extends Model\Element\Dao
             $userIds = $user->getRoles();
             $userIds[] = $user->getId();
 
-            $query .= ' AND (select `list` as locate from `users_workspaces_asset` where `userId` in (' . implode(',', $userIds) . ') and LOCATE(cpath,CONCAT(a.path,a.filename))=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1';
+            $query .= ' AND (select `list` as locate from `users_workspaces_asset` where `userId` in (' . implode(',', $userIds) . ') and LOCATE(cpath,CONCAT(a.path,a.filename))=1  ORDER BY list DESC LIMIT 1)=1';
         }
         $query .= ' LIMIT 1;';
         $c = $this->db->fetchOne($query, $this->model->getId());

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -316,7 +316,7 @@ class Dao extends Model\Element\Dao
             $userIds = $user->getRoles();
             $userIds[] = $user->getId();
 
-            $sql .= ' AND (select `list` as locate from `users_workspaces_object` where `userId` in (' . implode(',', $userIds) . ') and LOCATE(cpath,CONCAT(o.o_path,o.o_key))=1 ORDER BY LENGTH(cpath) DESC LIMIT 1)=1';
+            $sql .= ' AND (select `list` as locate from `users_workspaces_object` where `userId` in (' . implode(',', $userIds) . ') and LOCATE(cpath,CONCAT(o.o_path,o.o_key))=1 ORDER BY list DESC LIMIT 1)=1';
         }
         $sql .= ' LIMIT 1';
 

--- a/models/Document/Dao.php
+++ b/models/Document/Dao.php
@@ -341,7 +341,7 @@ class Dao extends Model\Element\Dao
             $userIds = $user->getRoles();
             $userIds[] = $user->getId();
 
-            $sql .= ' AND (select `list` as locate from `users_workspaces_document` where `userId` in (' . implode(',', $userIds) . ') and LOCATE(cpath,CONCAT(d.path,d.`key`))=1  ORDER BY LENGTH(cpath) DESC LIMIT 1)=1';
+            $sql .= ' AND (select `list` as locate from `users_workspaces_document` where `userId` in (' . implode(',', $userIds) . ') and LOCATE(cpath,CONCAT(d.path,d.`key`))=1  ORDER BY list DESC LIMIT 1)=1';
         }
 
         $sql .= ' LIMIT 1';


### PR DESCRIPTION
## Changes in this pull request  

Changes to order by method of the 3 DAOs for docs, assets and objects to ensure that the result will be correct if a user has multiple roles / acl settings.

## Additional info  
Recreate the bug:

* create an element (in any of the trees)
* create 2 children with 1 being named longer than the other one
* create 2 roles and set them up, that one mustn't list the children with the longer name and at least list rights for the shorter named child
* setup a user and give it both roles we just created
* login as this user and check, that the user is not having a `+` icon next to the level 1 entry in the tree, since the longer named path won't return a 1 for list and the other element is not being considered due to the limit 1 part of the sql query


=> solution: 
rather sort by field `list` desc instead of length(cpath) to ensure, that entries with `list = 1` will be on top
