### PR TITLE
Thumbnail <img> fallback should have srcset attribute

### DIFF
--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -485,13 +485,12 @@ final class Thumbnail
      */
     public function getSrcset($options = []): string
     {
-        /** @var Image $asset */
+        /** @var Image $image */
         $image = $this->getAsset();
         $path = $this->getPath(true);
         $thumbConfig = $this->getConfig();
         $srcSetValues = [];
         if ($this->getConfig() && !$this->getConfig()->hasMedias() && !$this->useOriginalFile($path)) {
-            // generate the srcset
             foreach ([1, 2] as $highRes) {
                 $thumbConfigRes = clone $thumbConfig;
                 $thumbConfigRes->setHighResolution($highRes);


### PR DESCRIPTION
Addresses issue #11316. img element will now have srcset attribute like it used to have in Pimcore 6 for improved compatibility with HTTP clients that can use this attribute but not source/picture elements.