### PR TITLE
Fix for exception in Table.php

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -372,7 +372,9 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
             $index = 0;
 
             foreach ($row as $col) {
-                $indexedRow[$columnConfig[$index]['key']] = $col;
+                if (isset($columnConfig[$index])) {
+                    $indexedRow[$columnConfig[$index]['key']] = $col;
+                }
                 $index++;
             }
 


### PR DESCRIPTION
Fix for Table data type column size change exception.
To reproduce
* create a table datatype with fixed number of columns
* save some data in there with a object
* close the object
* add or remote columns to table
* try to reopen object.

Status: 500 | Internal Server Error
URL: /admin/object/save?task=publish
Method: PUT
Message: Warning: Undefined array key 6
Trace: 
in /var/www/html/vendor/pimcore/pimcore/models/DataObject/ClassDefinition/Data/Table.php:375

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

