### PR TITLE
Passing null to parameter #1 ($bundle) of type string is deprecated

### DIFF
--- a/lib/Localization/LocaleService.php
+++ b/lib/Localization/LocaleService.php
@@ -96,7 +96,7 @@ class LocaleService implements LocaleServiceInterface
      */
     public function getLocaleList()
     {
-        $locales = \ResourceBundle::getLocales(null);
+        $locales = \ResourceBundle::getLocales();
 
         return $locales;
     }

--- a/lib/Localization/LocaleService.php
+++ b/lib/Localization/LocaleService.php
@@ -96,7 +96,7 @@ class LocaleService implements LocaleServiceInterface
      */
     public function getLocaleList()
     {
-        $locales = \ResourceBundle::getLocales();
+        $locales = \ResourceBundle::getLocales('');
 
         return $locales;
     }


### PR DESCRIPTION
ResourceBundle::getLocales(): Passing null to parameter #1 ($bundle) of type string is deprecated in PHP 8.1

