### PR TITLE
change grid read method to post instead of get. If the data gets comp…

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
@@ -136,7 +136,7 @@ pimcore.object.helpers.grid = Class.create({
             batchActions: false,
             actionMethods: {
                 create : 'POST',
-                read   : 'GET',
+                read   : 'POST',
                 update : 'POST',
                 destroy: 'POST'
             },


### PR DESCRIPTION
…lex with many long field names, the get request fails, du maximum length.

Currently the grid use GET method for the read operations. On environments with big classes and much bricks and field collections you get the error if the maximum url length is reached.
Alle Operations of the grid already use POST method except GET, which is better, because you never know the data.
