### PR TITLE
Patch 2

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -10,6 +10,7 @@
     types will be introduced in Pimcore 11. You must add return types, if you're extending any of these Pimcore classes.
     Please check changes [here](https://github.com/pimcore/pimcore/pull/10846/files)
 - [Data objects] Default values now get saved to versions -> Restoring a version also restores the default values (before those fields were null after restoring)
+- Method `create()` from `Pimcore\Model\DataObject\Classificationstore\CollectionGroupRelation` and `Pimcore\Model\DataObject\Classificationstore\KeyGroupRelation` no longer saves the new object, but just returns the instance. Related changes can be found here: https://github.com/pimcore/pimcore/pull/11326/files 
 
 ## 10.2.0
 - [Maintenance] Maintenance tasks are now handled with Symfony Messenger. The `pimcore:maintenance` command will add the maintenance messages to the bus and runs them afterwards immediately from the queue. However it's recommended to setup independent workers that process the queues, by running `bin/console messenger:consume pimcore_core pimcore_maintenance` (using e.g. Supervisor) and adding `--async` option to the `pimcore:maintenance` command that stops the maintenance command to process the queue directly. Details about setting it up for production environments, please check [Symfony Messenger Component docs](https://symfony.com/doc/current/messenger.html#deploying-to-production).
@@ -391,6 +392,3 @@ framework:
 - Removed deprecated `marshal()` and `unmarshal()` methods from object data-types.
 - `DynamicTextLabelInterface::renderLayoutText()` must handle nullable object param.
 - [AdminBundle] Marked classes and controllers as @internal/final - please see all changes here: https://github.com/pimcore/pimcore/pull/8453/files & https://github.com/pimcore/pimcore/pull/8988/files
-
-## 10.3.0
-- Method `create()` from `Pimcore\Model\DataObject\Classificationstore\CollectionGroupRelation` and `Pimcore\Model\DataObject\Classificationstore\KeyGroupRelation` no longer saves the new object, but just returns the instance. Related changes can be found here: https://github.com/pimcore/pimcore/pull/11326/files 

--- a/lib/Document/Editable/Block/BlockState.php
+++ b/lib/Document/Editable/Block/BlockState.php
@@ -105,7 +105,7 @@ final class BlockState implements \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             'blocks' => $this->blocks,


### PR DESCRIPTION
## Changes in this pull request  

Fixes a deprecation message 

> Deprecated: Return type of Pimcore\Document\Editable\Block\BlockState::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/vendor/pimcore/pimcore/lib/Document/Editable/Block/BlockState.php on line 108


