### PR TITLE
Fix deprecations with jsonSerialize() methods

### DIFF
--- a/bundles/AdminBundle/HttpFoundation/JsonResponse.php
+++ b/bundles/AdminBundle/HttpFoundation/JsonResponse.php
@@ -28,7 +28,7 @@ class JsonResponse extends BaseJsonResponse
     /**
      * {@inheritdoc}
      */
-    public function setData($data = [])// : self
+    public function setData($data = [])// : static
     {
         $serializer = Serialize::getAdminSerializer();
 

--- a/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionCombo.php
+++ b/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionCombo.php
@@ -106,7 +106,7 @@ class IndexFieldSelectionCombo extends Select
      * @return $this
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()// : self
+    public function jsonSerialize()// : static
     {
         if (Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionCombo.php
+++ b/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionCombo.php
@@ -105,7 +105,8 @@ class IndexFieldSelectionCombo extends Select
     /**
      * @return $this
      */
-    public function jsonSerialize()
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()// : self
     {
         if (Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/bundles/EcommerceFrameworkBundle/Tracking/AbstractData.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/AbstractData.php
@@ -115,7 +115,8 @@ abstract class AbstractData implements \JsonSerializable
      *
      * @return array
      */
-    public function jsonSerialize()
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()// : array
     {
         $json = [];
         $vars = get_object_vars($this);

--- a/doc/Development_Documentation/26_Best_Practice/20_Building_Custom_Rest_APIs.md
+++ b/doc/Development_Documentation/26_Best_Practice/20_Building_Custom_Rest_APIs.md
@@ -2,11 +2,11 @@
 
 Pimcore offers a bundle called [Datahub](https://github.com/pimcore/data-hub), offering a highly configurable GraphQL interface on most Pimcore entities.
 
-However a common use case for applications build with Pimcore is integrating with external systems, 
+However a common use case for applications build with Pimcore is integrating with external systems,
 which requires custom response from API endpoints.
- 
-One way to achieve this requirement is to build custom controller action that exposes just the right data 
-in the desired format. 
+
+One way to achieve this requirement is to build custom controller action that exposes just the right data
+in the desired format.
 
 ### Example
 
@@ -46,21 +46,21 @@ class CustomRestController extends FrontendController
 
 ```
 
-Sometimes it is necessary to serialize complete element for API  response. 
-This can be achieved by [overriding a model](../20_Extending_Pimcore/03_Overriding_Models.md) 
+Sometimes it is necessary to serialize complete element for API  response.
+This can be achieved by [overriding a model](../20_Extending_Pimcore/03_Overriding_Models.md)
 which implements the `\JsonSerializable` interface and implementing `jsonSerialize` method to return the data you require to be serialized.
-    
+
  ```php
  <?php
- 
+
  namespace App\Model\DataObject;
- 
- class BlogArticle extends \Pimcore\Model\DataObject\BlogArticle implements \JsonSerializable {
- 
-     public function jsonSerialize()
+
+ class BlogArticle extends \Pimcore\Model\DataObject\BlogArticle implements \JsonSerializable
+ {
+     public function jsonSerialize(): array
      {
          $vars = get_object_vars($this);
- 
+
          return $vars;
      }
  }

--- a/lib/Document/Editable/Block/BlockState.php
+++ b/lib/Document/Editable/Block/BlockState.php
@@ -105,7 +105,7 @@ final class BlockState implements \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'blocks' => $this->blocks,

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -806,7 +806,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
     /**
      * {@inheritdoc}
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : self
+    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
     {
         $classId = $this->allowedClassId;
 

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -806,7 +806,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
     /**
      * {@inheritdoc}
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
+    public function enrichLayoutDefinition(/* ?Concrete */ $object, /* array */ $context = []) // : static
     {
         $classId = $this->allowedClassId;
 

--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -1073,7 +1073,7 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
     /**
      * {@inheritdoc}
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : self
+    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
     {
         $this->activeGroupDefinitions = [];
         $activeGroupIds = $this->recursiveGetActiveGroupsIds($object);

--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -1073,7 +1073,7 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
     /**
      * {@inheritdoc}
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
+    public function enrichLayoutDefinition(/* ?Concrete */ $object, /* array */ $context = []) // : static
     {
         $this->activeGroupDefinitions = [];
         $activeGroupIds = $this->recursiveGetActiveGroupsIds($object);

--- a/models/DataObject/ClassDefinition/Data/EncryptedField.php
+++ b/models/DataObject/ClassDefinition/Data/EncryptedField.php
@@ -479,7 +479,13 @@ class EncryptedField extends Data implements ResourcePersistenceAwareInterface, 
     {
         $delegate = $this->getDelegate();
 
-        if (method_exists($delegate, 'enrichLayoutDefinition')) {
+        //TODO Pimcore 11: remove method_exists BC layer
+        if ($delegate instanceof LayoutDefinitionEnrichmentInterface || method_exists($delegate, 'enrichLayoutDefinition')) {
+            if (!$delegate instanceof LayoutDefinitionEnrichmentInterface) {
+                trigger_deprecation('pimcore/pimcore', '10.1',
+                    sprintf('Usage of method_exists is deprecated since version 10.1 and will be removed in Pimcore 11.' .
+                        'Implement the %s interface instead.', LayoutDefinitionEnrichmentInterface::class));
+            }
             $delegate->enrichLayoutDefinition($object, $context);
         }
 

--- a/models/DataObject/ClassDefinition/Data/EncryptedField.php
+++ b/models/DataObject/ClassDefinition/Data/EncryptedField.php
@@ -29,7 +29,7 @@ use Pimcore\Normalizer\NormalizerInterface;
  *
  * How to generate a key: vendor/bin/generate-defuse-key
  */
-class EncryptedField extends Data implements ResourcePersistenceAwareInterface, TypeDeclarationSupportInterface, EqualComparisonInterface, VarExporterInterface, NormalizerInterface
+class EncryptedField extends Data implements ResourcePersistenceAwareInterface, TypeDeclarationSupportInterface, EqualComparisonInterface, VarExporterInterface, NormalizerInterface, LayoutDefinitionEnrichmentInterface
 {
     use Extension\ColumnType;
 
@@ -475,7 +475,7 @@ class EncryptedField extends Data implements ResourcePersistenceAwareInterface, 
     /**
      * @inheritdoc
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : self
+    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
     {
         $delegate = $this->getDelegate();
 

--- a/models/DataObject/ClassDefinition/Data/EncryptedField.php
+++ b/models/DataObject/ClassDefinition/Data/EncryptedField.php
@@ -475,7 +475,7 @@ class EncryptedField extends Data implements ResourcePersistenceAwareInterface, 
     /**
      * @inheritdoc
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
+    public function enrichLayoutDefinition(/* ?Concrete */ $object, /* array */ $context = []) // : static
     {
         $delegate = $this->getDelegate();
 

--- a/models/DataObject/ClassDefinition/Data/Gender.php
+++ b/models/DataObject/ClassDefinition/Data/Gender.php
@@ -57,7 +57,8 @@ class Gender extends Model\DataObject\ClassDefinition\Data\Select
     /**
      * @return $this
      */
-    public function jsonSerialize()
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()// : self
     {
         if (Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Data/Gender.php
+++ b/models/DataObject/ClassDefinition/Data/Gender.php
@@ -58,7 +58,7 @@ class Gender extends Model\DataObject\ClassDefinition\Data\Select
      * @return $this
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()// : self
+    public function jsonSerialize()// : static
     {
         if (Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Data/Language.php
+++ b/models/DataObject/ClassDefinition/Data/Language.php
@@ -98,7 +98,8 @@ class Language extends Model\DataObject\ClassDefinition\Data\Select
     /**
      * @return $this
      */
-    public function jsonSerialize()
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()// : self
     {
         if (Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Data/Language.php
+++ b/models/DataObject/ClassDefinition/Data/Language.php
@@ -99,7 +99,7 @@ class Language extends Model\DataObject\ClassDefinition\Data\Select
      * @return $this
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()// : self
+    public function jsonSerialize()// : static
     {
         if (Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Data/Languagemultiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Languagemultiselect.php
@@ -101,7 +101,7 @@ class Languagemultiselect extends Model\DataObject\ClassDefinition\Data\Multisel
      * @return $this
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()// : self
+    public function jsonSerialize()// : static
     {
         if (Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Data/Languagemultiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Languagemultiselect.php
@@ -100,7 +100,8 @@ class Languagemultiselect extends Model\DataObject\ClassDefinition\Data\Multisel
     /**
      * @return $this
      */
-    public function jsonSerialize()
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()// : self
     {
         if (Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Data/LayoutDefinitionEnrichmentInterface.php
+++ b/models/DataObject/ClassDefinition/Data/LayoutDefinitionEnrichmentInterface.php
@@ -32,5 +32,5 @@ interface LayoutDefinitionEnrichmentInterface
      *
      * @throws \Exception
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) /* : self */;
+    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) /* : static */;
 }

--- a/models/DataObject/ClassDefinition/Data/LayoutDefinitionEnrichmentInterface.php
+++ b/models/DataObject/ClassDefinition/Data/LayoutDefinitionEnrichmentInterface.php
@@ -32,5 +32,5 @@ interface LayoutDefinitionEnrichmentInterface
      *
      * @throws \Exception
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) /* : static */;
+    public function enrichLayoutDefinition(/* ?Concrete */ $object, /* array */ $context = []) /* : static */;
 }

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -568,7 +568,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
     /**
      * {@inheritdoc}
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
+    public function enrichLayoutDefinition(/* ?Concrete */ $object, /* array */ $context = []) // : static
     {
         if (!$this->visibleFields) {
             return $this;

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -568,7 +568,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
     /**
      * {@inheritdoc}
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : self
+    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
     {
         if (!$this->visibleFields) {
             return $this;

--- a/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -585,7 +585,7 @@ class Multiselect extends Data implements
      * @return $this
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()// : static
+    public function jsonSerialize()// : self
     {
         if ($this->getOptionsProviderClass() && Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -585,7 +585,7 @@ class Multiselect extends Data implements
      * @return $this
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()// : self
+    public function jsonSerialize()// : static
     {
         if ($this->getOptionsProviderClass() && Service::doRemoveDynamicOptions()) {
             $this->options = null;
@@ -700,7 +700,7 @@ class Multiselect extends Data implements
     /**
      * {@inheritdoc}
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : self
+    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
     {
         $this->doEnrichDefinitionDefinition($object, $this->getName(),
             'layout', DataObject\ClassDefinition\Helper\OptionsProviderResolver::MODE_MULTISELECT, $context);

--- a/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -700,7 +700,7 @@ class Multiselect extends Data implements
     /**
      * {@inheritdoc}
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
+    public function enrichLayoutDefinition(/* ?Concrete */ $object, /* array */ $context = []) // : static
     {
         $this->doEnrichDefinitionDefinition($object, $this->getName(),
             'layout', DataObject\ClassDefinition\Helper\OptionsProviderResolver::MODE_MULTISELECT, $context);

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -461,7 +461,7 @@ class Select extends Data implements
     /**
      * {@inheritdoc}
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : self
+    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
     {
         $this->doEnrichDefinitionDefinition($object, $this->getName(),
             'layout', DataObject\ClassDefinition\Helper\OptionsProviderResolver::MODE_SELECT, $context);
@@ -575,7 +575,7 @@ class Select extends Data implements
      * @return $this
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()// : self
+    public function jsonSerialize()// : static
     {
         if ($this->getOptionsProviderClass() && Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -575,7 +575,7 @@ class Select extends Data implements
      * @return $this
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()// : static
+    public function jsonSerialize()// : self
     {
         if ($this->getOptionsProviderClass() && Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -461,7 +461,7 @@ class Select extends Data implements
     /**
      * {@inheritdoc}
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
+    public function enrichLayoutDefinition(/* ?Concrete */ $object, /* array */ $context = []) // : static
     {
         $this->doEnrichDefinitionDefinition($object, $this->getName(),
             'layout', DataObject\ClassDefinition\Helper\OptionsProviderResolver::MODE_SELECT, $context);

--- a/models/DataObject/ClassDefinition/Data/TargetGroup.php
+++ b/models/DataObject/ClassDefinition/Data/TargetGroup.php
@@ -135,7 +135,7 @@ class TargetGroup extends Model\DataObject\ClassDefinition\Data\Select
      * @return $this
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()// : self
+    public function jsonSerialize()// : static
     {
         if (Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Data/TargetGroup.php
+++ b/models/DataObject/ClassDefinition/Data/TargetGroup.php
@@ -134,7 +134,8 @@ class TargetGroup extends Model\DataObject\ClassDefinition\Data\Select
     /**
      * @return $this
      */
-    public function jsonSerialize()
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()// : self
     {
         if (Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Data/TargetGroupMultiselect.php
+++ b/models/DataObject/ClassDefinition/Data/TargetGroupMultiselect.php
@@ -73,7 +73,7 @@ class TargetGroupMultiselect extends Model\DataObject\ClassDefinition\Data\Multi
      * @return $this
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()// : self
+    public function jsonSerialize()// : static
     {
         if (Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Data/TargetGroupMultiselect.php
+++ b/models/DataObject/ClassDefinition/Data/TargetGroupMultiselect.php
@@ -72,7 +72,8 @@ class TargetGroupMultiselect extends Model\DataObject\ClassDefinition\Data\Multi
     /**
      * @return $this
      */
-    public function jsonSerialize()
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()// : self
     {
         if (Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Data/User.php
+++ b/models/DataObject/ClassDefinition/Data/User.php
@@ -182,7 +182,8 @@ class User extends Model\DataObject\ClassDefinition\Data\Select
     /**
      * @return $this
      */
-    public function jsonSerialize()
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()// : self
     {
         if (Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Data/User.php
+++ b/models/DataObject/ClassDefinition/Data/User.php
@@ -183,7 +183,7 @@ class User extends Model\DataObject\ClassDefinition\Data\Select
      * @return $this
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()// : self
+    public function jsonSerialize()// : static
     {
         if (Service::doRemoveDynamicOptions()) {
             $this->options = null;

--- a/models/DataObject/ClassDefinition/Layout/Iframe.php
+++ b/models/DataObject/ClassDefinition/Layout/Iframe.php
@@ -79,7 +79,7 @@ class Iframe extends Model\DataObject\ClassDefinition\Layout implements LayoutDe
     /**
      * {@inheritdoc}
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
+    public function enrichLayoutDefinition(/* ?Concrete */ $object, /* array */ $context = []) // : static
     {
         $this->width = $this->getWidth() ? $this->getWidth() : 500;
         $this->height = $this->getHeight() ? $this->getHeight() : 500;

--- a/models/DataObject/ClassDefinition/Layout/Iframe.php
+++ b/models/DataObject/ClassDefinition/Layout/Iframe.php
@@ -79,7 +79,7 @@ class Iframe extends Model\DataObject\ClassDefinition\Layout implements LayoutDe
     /**
      * {@inheritdoc}
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : self
+    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
     {
         $this->width = $this->getWidth() ? $this->getWidth() : 500;
         $this->height = $this->getHeight() ? $this->getHeight() : 500;

--- a/models/DataObject/ClassDefinition/Layout/Text.php
+++ b/models/DataObject/ClassDefinition/Layout/Text.php
@@ -128,7 +128,7 @@ class Text extends Model\DataObject\ClassDefinition\Layout implements Model\Data
     /**
      * {@inheritdoc}
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
+    public function enrichLayoutDefinition(/* ?Concrete */ $object, /* array */ $context = []) // : static
     {
         $renderer = Model\DataObject\ClassDefinition\Helper\DynamicTextResolver::resolveRenderingClass(
             $this->getRenderingClass()

--- a/models/DataObject/ClassDefinition/Layout/Text.php
+++ b/models/DataObject/ClassDefinition/Layout/Text.php
@@ -128,7 +128,7 @@ class Text extends Model\DataObject\ClassDefinition\Layout implements Model\Data
     /**
      * {@inheritdoc}
      */
-    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : self
+    public function enrichLayoutDefinition(/*?Concrete */ $object, /**  array */ $context = []) // : static
     {
         $renderer = Model\DataObject\ClassDefinition\Helper\DynamicTextResolver::resolveRenderingClass(
             $this->getRenderingClass()


### PR DESCRIPTION
See https://github.com/pimcore/pimcore/pull/11356
Fix all usages of jsonSerialize() method

Additional:
- "return $this" should be return typehint "static"
(Maybe in PHP 8.2 it is possible to use return type $this: https://wiki.php.net/rfc/this_return_type)
- EncryptedField: Add missing LayoutDefinitionEnrichmentInterface