### PR TITLE
[Custom Report] Allow . in niceName/group fields

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/item.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/item.js
@@ -898,7 +898,7 @@ pimcore.report.custom.item = Class.create({
         let error = false;
 
         ['group', 'groupIconClass', 'iconClass', 'niceName', 'reportClass'].forEach(function (name) {
-            if(m[name].length && !m[name].match(/^[_a-zA-Z]+[_a-zA-Z0-9-\s]*$/)) {
+            if(m[name].length && !m[name].match(/^[_a-zA-Z]+[_a-zA-Z0-9-.\s]*$/)) {
                 error = name;
             }
         });


### PR DESCRIPTION
This fields are translateable and translation identifer have . chars if you make a hierarchy.