### PR TITLE
Allow Resetting Translator Initialization

### DIFF
--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -256,6 +256,14 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
     }
 
     /**
+     * Reset Catalogues initialization
+     */
+    public function resetCache()
+    {
+        $this->initializedCatalogues = [];
+    }
+
+    /**
      * @param string $id
      * @param string $translated
      * @param array $parameters


### PR DESCRIPTION
If you're processing data via messenger, all cache properties won't get updated until the worker gets restarted. We're pushing modified data in real-time based on customer's translation, so it's required to allow to reset translator's initialization. Otherwise, the translation catalog won't get updated while handling incoming envelopes.