### PR TITLE
Asset selection fixes

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/asset.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/asset.js
@@ -256,11 +256,16 @@ pimcore.element.selector.asset = Class.create(pimcore.element.selector.abstract,
 
                             var checkbox = new Ext.grid.column.Check();
 
-                            if (value || rec) {
+                            if (typeof value ==='undefined' && rec !== null){
+                                this.resultPanel.getStore().getAt(rowIndex).set('asset-selected', true);
                                 return checkbox.renderer(true);
-                            } else {
-                                return checkbox.renderer(false);
                             }
+                              
+                            if (value && rec === null) {
+                                return checkbox.renderer(true);
+                            }
+                            
+                            return checkbox.renderer(false);
                         }.bind(this)
                     }
                 );

--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/asset.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/asset.js
@@ -173,6 +173,8 @@ pimcore.element.selector.asset = Class.create(pimcore.element.selector.abstract,
                                     if(record) {
                                         record.set('asset-selected', false);
                                     }
+
+                                    resultPanelStore.reload();
                                     
                                 }
 
@@ -247,7 +249,19 @@ pimcore.element.selector.asset = Class.create(pimcore.element.selector.abstract,
                         name: 'asset-select-checkbox',
                         text: t("select"),
                         dataIndex : 'asset-selected',
-                        sortable: false
+                        sortable: false,
+                        renderer: function (value, metaData, record, rowIndex) {
+                            var currentElementId = this.resultPanel.getStore().getAt(rowIndex).id;
+                            var rec = this.selectionStore.getData().find("id", currentElementId);
+
+                            var checkbox = new Ext.grid.column.Check();
+
+                            if (value || rec) {
+                                return checkbox.renderer(true);
+                            } else {
+                                return checkbox.renderer(false);
+                            }
+                        }.bind(this)
                     }
                 );
             }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
After #11265 I noticed 2 small bugs.
First one is that if assets are filtered and user removes asset from selection, asset wouldn't uncheck.
Second one is when filtering assets, assets that are already selected wouldn't have their checkbox selected.

