### PR TITLE
[DataObjects] Migrations - fix error: All parts of a PRIMARY KEY must be NOT NULL

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20211103055110.php
+++ b/bundles/CoreBundle/Migrations/Version20211103055110.php
@@ -36,7 +36,7 @@ class Version20211103055110 extends AbstractMigration
 
             if ($schema->hasTable($objectDatastoreTableRelation)) {
                 $this->addSql(
-                    "UPDATE $objectDatastoreTableRelation SET `type` = NULL WHERE `type` = 'object'"
+                    "UPDATE $objectDatastoreTableRelation SET `type` = 'object' WHERE `type` = NULL"
                 );
                 $this->addSql(
                     "ALTER TABLE $objectDatastoreTableRelation CHANGE COLUMN

--- a/bundles/CoreBundle/Migrations/Version20211103055110.php
+++ b/bundles/CoreBundle/Migrations/Version20211103055110.php
@@ -36,7 +36,7 @@ class Version20211103055110 extends AbstractMigration
 
             if ($schema->hasTable($objectDatastoreTableRelation)) {
                 $this->addSql(
-                    "UPDATE $objectDatastoreTableRelation SET `type` = 'object' WHERE `type` = NULL"
+                    "UPDATE $objectDatastoreTableRelation SET `type` = 'object' WHERE `type` = NULL OR `type` =''"
                 );
                 $this->addSql(
                     "ALTER TABLE $objectDatastoreTableRelation CHANGE COLUMN

--- a/bundles/CoreBundle/Migrations/Version20211103055110.php
+++ b/bundles/CoreBundle/Migrations/Version20211103055110.php
@@ -36,15 +36,11 @@ class Version20211103055110 extends AbstractMigration
 
             if ($schema->hasTable($objectDatastoreTableRelation)) {
                 $this->addSql(
-                    "ALTER TABLE $objectDatastoreTableRelation CHANGE COLUMN 
-                        `type` `type` VARCHAR(50)  NULL DEFAULT NULL ;"
+                    "UPDATE $objectDatastoreTableRelation SET `type` = NULL WHERE `type` = 'object'"
                 );
                 $this->addSql(
-                    "UPDATE $objectDatastoreTableRelation SET `type` = NULL WHERE `type` =''"
-                );
-                $this->addSql(
-                    "ALTER TABLE $objectDatastoreTableRelation CHANGE COLUMN 
-                        `type` `type` ENUM('object', 'asset', 'document') NULL DEFAULT NULL ;"
+                    "ALTER TABLE $objectDatastoreTableRelation CHANGE COLUMN
+                        `type` `type` ENUM('object', 'asset', 'document') NOT NULL;"
                 );
             }
         }
@@ -61,11 +57,8 @@ class Version20211103055110 extends AbstractMigration
 
             if ($schema->hasTable($objectDatastoreTableRelation)) {
                 $this->addSql(
-                    "UPDATE $objectDatastoreTableRelation SET `type` = '' WHERE `type` IS NULL"
-                );
-                $this->addSql(
-                    "ALTER TABLE $objectDatastoreTableRelation CHANGE COLUMN 
-                        `type` `type` VARCHAR(50) NOT NULL DEFAULT '' ;"
+                    "ALTER TABLE $objectDatastoreTableRelation CHANGE COLUMN
+                        `type` `type` VARCHAR(50) NOT NULL DEFAULT '';"
                 );
             }
         }

--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -146,7 +146,7 @@ class Dao extends Model\Dao\AbstractDao
               `id` BIGINT(20) NOT NULL PRIMARY KEY  AUTO_INCREMENT,
               `src_id` int(11) UNSIGNED NOT NULL DEFAULT '0',
               `dest_id` int(11) UNSIGNED NOT NULL DEFAULT '0',
-              `type` enum('object', 'asset','document')  NULL DEFAULT NULL,
+              `type` enum('object', 'asset','document') NOT NULL,
               `fieldname` varchar(70) NOT NULL DEFAULT '0',
               `index` int(11) unsigned NOT NULL DEFAULT '0',
               `ownertype` enum('object','fieldcollection','localizedfield','objectbrick') NOT NULL DEFAULT 'object',


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/11379

## Additional info  
follow up to #10760
