### PR TITLE
[Messenger] Process certain messages in batches to speed things up

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
     "symfony/intl": "^5.2.0",
     "symfony/lock": "^5.2.0",
     "symfony/mailer": "^5.2.0",
-    "symfony/messenger": "^5.2.0",
+    "symfony/messenger": "^5.4.0",
     "symfony/mime": "^5.2.0",
     "symfony/monolog-bridge": "^5.2.0",
     "symfony/notifier": "^5.2.0",

--- a/lib/Messenger/Handler/CleanupThumbnailsHandler.php
+++ b/lib/Messenger/Handler/CleanupThumbnailsHandler.php
@@ -33,6 +33,7 @@ class CleanupThumbnailsHandler implements BatchHandlerInterface
         return $this->handle($message, $ack);
     }
 
+    // @phpstan-ignore-next-line
     private function process(array $jobs): void
     {
         foreach ($jobs as [$message, $ack]) {

--- a/lib/Messenger/Handler/CleanupThumbnailsHandler.php
+++ b/lib/Messenger/Handler/CleanupThumbnailsHandler.php
@@ -27,6 +27,7 @@ use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
 class CleanupThumbnailsHandler implements BatchHandlerInterface
 {
     use BatchHandlerTrait;
+    use HandlerHelperTrait;
 
     public function __invoke(CleanupThumbnailsMessage $message, Acknowledger $ack = null)
     {
@@ -36,6 +37,10 @@ class CleanupThumbnailsHandler implements BatchHandlerInterface
     // @phpstan-ignore-next-line
     private function process(array $jobs): void
     {
+        $jobs = $this->filterUnique($jobs, static function (CleanupThumbnailsMessage $message) {
+            return $message->getType() . '-' . $message->getName();
+        });
+
         foreach ($jobs as [$message, $ack]) {
             try {
 

--- a/lib/Messenger/Handler/CleanupThumbnailsHandler.php
+++ b/lib/Messenger/Handler/CleanupThumbnailsHandler.php
@@ -34,7 +34,6 @@ class CleanupThumbnailsHandler implements BatchHandlerInterface
         return $this->handle($message, $ack);
     }
 
-    // @phpstan-ignore-next-line
     private function process(array $jobs): void
     {
         $jobs = $this->filterUnique($jobs, static function (CleanupThumbnailsMessage $message) {

--- a/lib/Messenger/Handler/CleanupThumbnailsHandler.php
+++ b/lib/Messenger/Handler/CleanupThumbnailsHandler.php
@@ -17,18 +17,37 @@ namespace Pimcore\Messenger\Handler;
 
 use Pimcore\Messenger\CleanupThumbnailsMessage;
 use Pimcore\Model\Asset;
+use Symfony\Component\Messenger\Handler\Acknowledger;
+use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
+use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
 
 /**
  * @internal
  */
-class CleanupThumbnailsHandler
+class CleanupThumbnailsHandler implements BatchHandlerInterface
 {
-    public function __invoke(CleanupThumbnailsMessage $message)
+    use BatchHandlerTrait;
+
+    public function __invoke(CleanupThumbnailsMessage $message, Acknowledger $ack = null)
     {
-        $configClass = 'Pimcore\Model\Asset\\' . ucfirst($message->getType()) . '\Thumbnail\Config';
-        /** @var Asset\Image\Thumbnail\Config|Asset\Video\Thumbnail\Config|null $thumbConfig */
-        $thumbConfig = new $configClass();
-        $thumbConfig->setName($message->getName());
-        $thumbConfig->clearTempFiles();
+        return $this->handle($message, $ack);
+    }
+
+    private function process(array $jobs): void
+    {
+        foreach ($jobs as [$message, $ack]) {
+            try {
+
+                $configClass = 'Pimcore\Model\Asset\\' . ucfirst($message->getType()) . '\Thumbnail\Config';
+                /** @var Asset\Image\Thumbnail\Config|Asset\Video\Thumbnail\Config|null $thumbConfig */
+                $thumbConfig = new $configClass();
+                $thumbConfig->setName($message->getName());
+                $thumbConfig->clearTempFiles();
+
+                $ack->ack($message);
+            } catch (\Throwable $e) {
+                $ack->nack($e);
+            }
+        }
     }
 }

--- a/lib/Messenger/Handler/HandlerHelperTrait.php
+++ b/lib/Messenger/Handler/HandlerHelperTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Messenger\Handler;
+
+trait HandlerHelperTrait
+{
+    protected function filterUnique(array $jobs, callable $callback): array
+    {
+        $filteredJobs = [];
+        foreach ($jobs as [$message, $ack]) {
+            $key = $callback($message);
+            $filteredJobs[$key] = [$message, $ack];
+        }
+
+        return $filteredJobs;
+    }
+}

--- a/lib/Messenger/Handler/OptimizeImageHandler.php
+++ b/lib/Messenger/Handler/OptimizeImageHandler.php
@@ -39,6 +39,7 @@ class OptimizeImageHandler implements BatchHandlerInterface
         return $this->handle($message, $ack);
     }
 
+    // @phpstan-ignore-next-line
     private function process(array $jobs): void
     {
         foreach ($jobs as [$message, $ack]) {
@@ -63,6 +64,7 @@ class OptimizeImageHandler implements BatchHandlerInterface
         }
     }
 
+    // @phpstan-ignore-next-line
     private function shouldFlush(): bool
     {
         return 100 <= \count($this->jobs);

--- a/lib/Messenger/Handler/SanityCheckHandler.php
+++ b/lib/Messenger/Handler/SanityCheckHandler.php
@@ -38,7 +38,6 @@ class SanityCheckHandler implements BatchHandlerInterface
         return $this->handle($message, $ack);
     }
 
-    // @phpstan-ignore-next-line
     private function process(array $jobs): void
     {
         $jobs = $this->filterUnique($jobs, static function (SanityCheckMessage $message) {

--- a/lib/Messenger/Handler/SanityCheckHandler.php
+++ b/lib/Messenger/Handler/SanityCheckHandler.php
@@ -37,6 +37,7 @@ class SanityCheckHandler implements BatchHandlerInterface
         return $this->handle($message, $ack);
     }
 
+    // @phpstan-ignore-next-line
     private function process(array $jobs): void
     {
         foreach ($jobs as [$message, $ack]) {

--- a/lib/Messenger/Handler/SanityCheckHandler.php
+++ b/lib/Messenger/Handler/SanityCheckHandler.php
@@ -21,17 +21,35 @@ use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\Document\PageSnippet;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
+use Symfony\Component\Messenger\Handler\Acknowledger;
+use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
+use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
 
 /**
  * @internal
  */
-class SanityCheckHandler
+class SanityCheckHandler implements BatchHandlerInterface
 {
-    public function __invoke(SanityCheckMessage $message)
+    use BatchHandlerTrait;
+
+    public function __invoke(SanityCheckMessage $message, Acknowledger $ack = null)
     {
-        $element = Service::getElementById($message->getType(), $message->getId(), true);
-        if ($element) {
-            $this->performSanityCheck($element);
+        return $this->handle($message, $ack);
+    }
+
+    private function process(array $jobs): void
+    {
+        foreach ($jobs as [$message, $ack]) {
+            try {
+                $element = Service::getElementById($message->getType(), $message->getId(), true);
+                if ($element) {
+                    $this->performSanityCheck($element);
+                }
+
+                $ack->ack($message);
+            } catch (\Throwable $e) {
+                $ack->nack($e);
+            }
         }
     }
 

--- a/lib/Messenger/Handler/SanityCheckHandler.php
+++ b/lib/Messenger/Handler/SanityCheckHandler.php
@@ -31,6 +31,7 @@ use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
 class SanityCheckHandler implements BatchHandlerInterface
 {
     use BatchHandlerTrait;
+    use HandlerHelperTrait;
 
     public function __invoke(SanityCheckMessage $message, Acknowledger $ack = null)
     {
@@ -40,6 +41,10 @@ class SanityCheckHandler implements BatchHandlerInterface
     // @phpstan-ignore-next-line
     private function process(array $jobs): void
     {
+        $jobs = $this->filterUnique($jobs, static function (SanityCheckMessage $message) {
+            return $message->getType() . '-' . $message->getId();
+        });
+
         foreach ($jobs as [$message, $ack]) {
             try {
                 $element = Service::getElementById($message->getType(), $message->getId(), true);

--- a/lib/Messenger/Handler/SearchBackendHandler.php
+++ b/lib/Messenger/Handler/SearchBackendHandler.php
@@ -60,6 +60,7 @@ class SearchBackendHandler implements BatchHandlerInterface
         }
     }
 
+    // @phpstan-ignore-next-line
     private function shouldFlush(): bool
     {
         return 50 <= \count($this->jobs);

--- a/lib/Messenger/Handler/SearchBackendHandler.php
+++ b/lib/Messenger/Handler/SearchBackendHandler.php
@@ -34,6 +34,7 @@ class SearchBackendHandler implements BatchHandlerInterface
         return $this->handle($message, $ack);
     }
 
+    // @phpstan-ignore-next-line
     private function process(array $jobs): void
     {
         foreach ($jobs as [$message, $ack]) {

--- a/lib/Messenger/Handler/SearchBackendHandler.php
+++ b/lib/Messenger/Handler/SearchBackendHandler.php
@@ -28,6 +28,7 @@ use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
 class SearchBackendHandler implements BatchHandlerInterface
 {
     use BatchHandlerTrait;
+    use HandlerHelperTrait;
 
     public function __invoke(SearchBackendMessage $message, Acknowledger $ack = null)
     {
@@ -37,6 +38,10 @@ class SearchBackendHandler implements BatchHandlerInterface
     // @phpstan-ignore-next-line
     private function process(array $jobs): void
     {
+        $jobs = $this->filterUnique($jobs, static function (SearchBackendMessage $message) {
+            return $message->getType() . '-' . $message->getId();
+        });
+
         foreach ($jobs as [$message, $ack]) {
             try {
                 $element = Element\Service::getElementById($message->getType(), $message->getId());

--- a/lib/Messenger/Handler/SearchBackendHandler.php
+++ b/lib/Messenger/Handler/SearchBackendHandler.php
@@ -35,7 +35,6 @@ class SearchBackendHandler implements BatchHandlerInterface
         return $this->handle($message, $ack);
     }
 
-    // @phpstan-ignore-next-line
     private function process(array $jobs): void
     {
         $jobs = $this->filterUnique($jobs, static function (SearchBackendMessage $message) {
@@ -65,7 +64,6 @@ class SearchBackendHandler implements BatchHandlerInterface
         }
     }
 
-    // @phpstan-ignore-next-line
     private function shouldFlush(): bool
     {
         return 50 <= \count($this->jobs);

--- a/lib/Messenger/Handler/SearchBackendHandler.php
+++ b/lib/Messenger/Handler/SearchBackendHandler.php
@@ -18,26 +18,49 @@ namespace Pimcore\Messenger\Handler;
 use Pimcore\Messenger\SearchBackendMessage;
 use Pimcore\Model\Element;
 use Pimcore\Model\Search\Backend\Data;
+use Symfony\Component\Messenger\Handler\Acknowledger;
+use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
+use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
 
 /**
  * @internal
  */
-class SearchBackendHandler
+class SearchBackendHandler implements BatchHandlerInterface
 {
-    public function __invoke(SearchBackendMessage $message)
-    {
-        $element = Element\Service::getElementById($message->getType(), $message->getId());
-        if (!$element instanceof Element\ElementInterface) {
-            return;
-        }
+    use BatchHandlerTrait;
 
-        $searchEntry = Data::getForElement($element);
-        if ($searchEntry instanceof Data && $searchEntry->getId() instanceof Data\Id) {
-            $searchEntry->setDataFromElement($element);
-            $searchEntry->save();
-        } else {
-            $searchEntry = new Data($element);
-            $searchEntry->save();
+    public function __invoke(SearchBackendMessage $message, Acknowledger $ack = null)
+    {
+        return $this->handle($message, $ack);
+    }
+
+    private function process(array $jobs): void
+    {
+        foreach ($jobs as [$message, $ack]) {
+            try {
+                $element = Element\Service::getElementById($message->getType(), $message->getId());
+                if (!$element instanceof Element\ElementInterface) {
+                    return;
+                }
+
+                $searchEntry = Data::getForElement($element);
+                if ($searchEntry instanceof Data && $searchEntry->getId() instanceof Data\Id) {
+                    $searchEntry->setDataFromElement($element);
+                    $searchEntry->save();
+                } else {
+                    $searchEntry = new Data($element);
+                    $searchEntry->save();
+                }
+
+                $ack->ack($message);
+            } catch (\Throwable $e) {
+                $ack->nack($e);
+            }
         }
+    }
+
+    private function shouldFlush(): bool
+    {
+        return 50 <= \count($this->jobs);
     }
 }

--- a/lib/Messenger/Handler/VersionDeleteHandler.php
+++ b/lib/Messenger/Handler/VersionDeleteHandler.php
@@ -18,25 +18,43 @@ namespace Pimcore\Messenger\Handler;
 use Pimcore\Logger;
 use Pimcore\Messenger\VersionDeleteMessage;
 use Pimcore\Model\Version;
+use Symfony\Component\Messenger\Handler\Acknowledger;
+use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
+use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
 
 /**
  * @internal
  */
-class VersionDeleteHandler
+class VersionDeleteHandler implements BatchHandlerInterface
 {
-    public function __invoke(VersionDeleteMessage $message)
-    {
-        $versions = new Version\Listing();
-        $versions->setCondition('cid = :cid AND ctype = :ctype', [
-            'cid' => $message->getElementId(),
-            'ctype' => $message->getElementType(),
-        ]);
+    use BatchHandlerTrait;
 
-        foreach ($versions as $version) {
+    public function __invoke(VersionDeleteMessage $message, Acknowledger $ack = null)
+    {
+        return $this->handle($message, $ack);
+    }
+
+    private function process(array $jobs): void
+    {
+        foreach ($jobs as [$message, $ack]) {
             try {
-                $version->delete();
-            } catch (\Exception $e) {
-                Logger::err(sprintf('Problem deleting the version with Id: %s, reason: %s', $version->getId(), $e->getMessage()));
+                $versions = new Version\Listing();
+                $versions->setCondition('cid = :cid AND ctype = :ctype', [
+                    'cid' => $message->getElementId(),
+                    'ctype' => $message->getElementType(),
+                ]);
+
+                foreach ($versions as $version) {
+                    try {
+                        $version->delete();
+                    } catch (\Exception $e) {
+                        Logger::err(sprintf('Problem deleting the version with Id: %s, reason: %s', $version->getId(), $e->getMessage()));
+                    }
+                }
+
+                $ack->ack($message);
+            } catch (\Throwable $e) {
+                $ack->nack($e);
             }
         }
     }

--- a/lib/Messenger/Handler/VersionDeleteHandler.php
+++ b/lib/Messenger/Handler/VersionDeleteHandler.php
@@ -34,6 +34,7 @@ class VersionDeleteHandler implements BatchHandlerInterface
         return $this->handle($message, $ack);
     }
 
+    // @phpstan-ignore-next-line
     private function process(array $jobs): void
     {
         foreach ($jobs as [$message, $ack]) {


### PR DESCRIPTION
In certain cases it could take too long to process the messages, especially when dealing with a lot of updates. 
It seems to be caused by the overhead that's needed to process the messages one by one. Processing them in batches should improve the overall performance. 

See also https://github.com/symfony/symfony/pull/43354