### PR TITLE
[Feature]: enables fallback locale for admin translations

### DIFF
--- a/doc/Development_Documentation/18_Tools_and_Features/25_System_Settings.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/25_System_Settings.md
@@ -12,7 +12,7 @@ Contains settings about changing appearance of Pimcore admin like login screen c
 ## Localization & Internationalization (i18n/l10n) 
 These settings are used in documents to specify the content language (in properties tab), for objects in localized-fields, 
 for shared translations, ... simply everywhere the editor can choose or use a language for the content.
-Fallback languages are currently used in object's localized fields and shared translations.
+Fallback languages are currently used in object's localized fields, shared translations and admin translations.
 
 ## Debug
 

--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -280,7 +280,6 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
             $translated = $this->translator->trans($normalizedId, $parameters, $domain, $locale);
         }
 
-        $lookForFallback = empty($translated);
         if ($normalizedId != $translated && $translated) {
             return $translated;
         } elseif ($normalizedId == $translated) {
@@ -325,8 +324,11 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
             }
         }
 
-        // now check for custom fallback locales, only for shared translations
-        if ($lookForFallback && $domain == 'messages') {
+        // now check for custom fallback locales
+        if (
+            ($domain === Translation::DOMAIN_DEFAULT && empty($translated)) ||
+            ($domain === Translation::DOMAIN_ADMIN && $id === $translated)
+        ) {
             foreach (Tool::getFallbackLanguagesFor($locale) as $fallbackLanguage) {
                 $this->lazyInitialize($domain, $fallbackLanguage);
                 $catalogue = $this->getCatalogue($fallbackLanguage);


### PR DESCRIPTION
## Changes in this pull request  
Implements fallback local handling for admin translations

## Additional info  

I unfortunately got no response on my question regarding this topic in the Gitter chat. So that's why I have implemented the changes as a proposal to enable the local handling for admin translations.

Depending on the translation domain, I updated the check to see if the translation is empty or for the admin domain equal to the id. 

I have also updated the docs and some translation keys for Ext JS - I unfortunately can not provide all translations ;)

Looking forward to your feedback.
