### PR TITLE
Fixed the bug concerning missing data in city array for geoip targeting

### DIFF
--- a/lib/Targeting/Condition/Country.php
+++ b/lib/Targeting/Condition/Country.php
@@ -67,7 +67,7 @@ class Country extends AbstractVariableCondition implements DataProviderDependent
     {
         $city = $visitorInfo->get(GeoIp::PROVIDER_KEY);
 
-        if (!$city) {
+        if (!$city || ! isset($city['country'])) {
             return false;
         }
 


### PR DESCRIPTION
Changes in this pull request
Resolves the issue of geoip targeting (country) not working for IP's not assigned directly to a country.
Since PHP8 we are failing horribly due to the non-existing offset of the array in line 74 of country.php.
(Before it was a warning and not that bad)

Additional info
You can reproduce the issue with certain IP addresses not being listed as part of a county but a contitent (use 66.249.93.204 for testing). You can simply set it in index.php: $_SERVER['REMOTE_ADDR'] = '66.249.93.204';

@pimcore guys :) Thx for your software so far, let's make it even better!