### PR TITLE
Allow to open log file object when using custom PIMCORE_PRIVATE_VAR

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/LogController.php
+++ b/bundles/AdminBundle/Controller/Admin/LogController.php
@@ -238,7 +238,15 @@ class LogController extends AdminController implements KernelControllerEventInte
     {
         $filePath = $request->get('filePath');
 
-        if (!str_starts_with($filePath, PIMCORE_LOG_FILEOBJECT_DIRECTORY)) {
+        if (!filter_var($filePath, FILTER_VALIDATE_URL)) {
+            $filePath = PIMCORE_PROJECT_ROOT.DIRECTORY_SEPARATOR.$filePath;
+            $filePath = realpath($filePath);
+            $fileObjectPath = realpath(PIMCORE_LOG_FILEOBJECT_DIRECTORY);
+        } else {
+            $fileObjectPath = PIMCORE_LOG_FILEOBJECT_DIRECTORY;
+        }
+
+        if (!str_starts_with($filePath, $fileObjectPath)) {
             throw new AccessDeniedHttpException('Accessing file out of scope');
         }
 

--- a/bundles/AdminBundle/Controller/Admin/LogController.php
+++ b/bundles/AdminBundle/Controller/Admin/LogController.php
@@ -237,15 +237,8 @@ class LogController extends AdminController implements KernelControllerEventInte
     public function showFileObjectAction(Request $request)
     {
         $filePath = $request->get('filePath');
-        if (!filter_var($filePath, FILTER_VALIDATE_URL)) {
-            $filePath = PIMCORE_PROJECT_ROOT . DIRECTORY_SEPARATOR . $filePath;
-            $filePath = realpath($filePath);
-            $fileObjectPath = realpath(PIMCORE_LOG_FILEOBJECT_DIRECTORY);
-        } else {
-            $fileObjectPath = PIMCORE_LOG_FILEOBJECT_DIRECTORY;
-        }
 
-        if (!preg_match('@^' . $fileObjectPath . '@', $filePath)) {
+        if (!str_starts_with($filePath, PIMCORE_LOG_FILEOBJECT_DIRECTORY)) {
             throw new AccessDeniedHttpException('Accessing file out of scope');
         }
 

--- a/bundles/AdminBundle/Controller/Admin/LogController.php
+++ b/bundles/AdminBundle/Controller/Admin/LogController.php
@@ -239,6 +239,9 @@ class LogController extends AdminController implements KernelControllerEventInte
         $filePath = $request->get('filePath');
 
         if (!filter_var($filePath, FILTER_VALIDATE_URL)) {
+            if(!file_exists($filePath)) {
+                $filePath = PIMCORE_PROJECT_ROOT.DIRECTORY_SEPARATOR.$filePath;
+            }
             $filePath = realpath($filePath);
             $fileObjectPath = realpath(PIMCORE_LOG_FILEOBJECT_DIRECTORY);
         } else {

--- a/bundles/AdminBundle/Controller/Admin/LogController.php
+++ b/bundles/AdminBundle/Controller/Admin/LogController.php
@@ -239,7 +239,6 @@ class LogController extends AdminController implements KernelControllerEventInte
         $filePath = $request->get('filePath');
 
         if (!filter_var($filePath, FILTER_VALIDATE_URL)) {
-            $filePath = PIMCORE_PROJECT_ROOT.DIRECTORY_SEPARATOR.$filePath;
             $filePath = realpath($filePath);
             $fileObjectPath = realpath(PIMCORE_LOG_FILEOBJECT_DIRECTORY);
         } else {


### PR DESCRIPTION
Steps to reproduce bug:
1. Create `/config/pimcore/constants.php` with
    ```php
    <?php
    const PIMCORE_PRIVATE_VAR = '/tmp/private-var';
    ```
2. Create `ApplicationLogger` log with `LogFileObject`, e.g. with following script named `test.php`
    ```php
    <?php
    $logger = \Pimcore\Log\ApplicationLogger::getInstance('ProcessManager', true);
    $fileObject = new \Pimcore\Log\FileObject('some interesting data');
    $logger->error('my error message', ['fileObject' => $fileObject]);
    ```
3. Run script with `bin/console pimcore:run-script test.php`
3. Go to Pimcore backend, open Tools > Application Logger
4. Click "Open" in the column "File Object" for the just created log
5. You will get a 403 response -> with this PR you will see the created FileObject file with content `some interesting data`

The reason is that in https://github.com/pimcore/pimcore/blob/fa0162f80154a6c71e8cbc1b94ae3f81a29d9dad/bundles/AdminBundle/Controller/Admin/LogController.php#L240-L250 it is assumed that `PIMCORE_LOG_FILEOBJECT_DIRECTORY` is always inside `PIMCORE_PROJECT_ROOT`. But with above configuration it is not because of https://github.com/pimcore/pimcore/blob/fa0162f80154a6c71e8cbc1b94ae3f81a29d9dad/lib/Bootstrap.php#L199 
So I changed the check to only test if the given `$filePath` is somewhere under `PIMCORE_LOG_FILEOBJECT_DIRECTORY` - what `PIMCORE_PROJECT_ROOT` is, does not matter.