### PR TITLE
[QuantityValue] Add convenience method for quantity value unit conversion

### DIFF
--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/55_Number_Types.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/55_Number_Types.md
@@ -89,6 +89,20 @@ $convertedValue = $converter->convert($originalValue, Unit::getByAbbreviation('m
 // $convertedValue is a QuantityValue with value 3000 and unit mm
 ```
 
+Alternatively you can use
+```php
+$originalValue = new QuantityValue(3, Unit::getByAbbreviation('m')->getId());
+$convertedValue = $originalValue->convertTo(Unit::getByAbbreviation('mm'));
+// $convertedValue is a QuantityValue with value 3000 and unit mm
+```
+or
+
+```php
+$originalValue = new QuantityValue(3, Unit::getByAbbreviation('m')->getId());
+$convertedValue = $originalValue->convertTo('mm');
+// $convertedValue is a QuantityValue with value 3000 and unit mm
+```
+
 Units without base unit are expected to be a base unit itself. That is why in above example configuration meter has no base unit - but of course you can set it to meter to be more explicit.
 
 In quantity value unit configuration there is also the column "offset". This is for unit conversions where addition / subtraction is needed. For example 

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/55_Number_Types.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/55_Number_Types.md
@@ -96,7 +96,6 @@ $convertedValue = $originalValue->convertTo(Unit::getByAbbreviation('mm'));
 // $convertedValue is a QuantityValue with value 3000 and unit mm
 ```
 or
-
 ```php
 $originalValue = new QuantityValue(3, Unit::getByAbbreviation('m')->getId());
 $convertedValue = $originalValue->convertTo('mm');

--- a/models/DataObject/Data/AbstractQuantityValue.php
+++ b/models/DataObject/Data/AbstractQuantityValue.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Model\DataObject\Data;
 
+use InvalidArgumentException;
 use Pimcore;
 use Pimcore\Model\DataObject\OwnerAwareFieldInterface;
 use Pimcore\Model\DataObject\QuantityValue\Unit;
@@ -80,11 +81,23 @@ abstract class AbstractQuantityValue implements OwnerAwareFieldInterface
     }
 
     /**
-     * @param Unit $unit target unit
+     * @param Unit|string $unit target unit. if string provided, unit is tried to be found by abbreviation
      * @return self
      * @throws \Exception
      */
-    public function convertTo(Unit $unit) {
+    public function convertTo($unit) {
+        if(is_string($unit)) {
+            $unitObject = Unit::getByAbbreviation($unit);
+            if (!$unitObject instanceof Unit) {
+                throw new InvalidArgumentException('Unit with abbreviation "'.$unit.'" does not exist');
+            }
+            $unit = $unitObject;
+        }
+
+        if(!$unit instanceof Unit) {
+            throw new InvalidArgumentException('Please provide unit as '.Unit::class.' object or as string');
+        }
+
         /** @var UnitConversionService $converter */
         $converter = Pimcore::getContainer()->get(UnitConversionService::class);
         return $converter->convert($this, $unit);

--- a/models/DataObject/Data/AbstractQuantityValue.php
+++ b/models/DataObject/Data/AbstractQuantityValue.php
@@ -15,8 +15,10 @@
 
 namespace Pimcore\Model\DataObject\Data;
 
+use Pimcore;
 use Pimcore\Model\DataObject\OwnerAwareFieldInterface;
 use Pimcore\Model\DataObject\QuantityValue\Unit;
+use Pimcore\Model\DataObject\QuantityValue\UnitConversionService;
 use Pimcore\Model\DataObject\Traits\OwnerAwareFieldTrait;
 
 abstract class AbstractQuantityValue implements OwnerAwareFieldInterface
@@ -75,6 +77,17 @@ abstract class AbstractQuantityValue implements OwnerAwareFieldInterface
         }
 
         return $this->unit;
+    }
+
+    /**
+     * @param Unit $unit target unit
+     * @return self
+     * @throws \Exception
+     */
+    public function convertTo(Unit $unit) {
+        /** @var UnitConversionService $converter */
+        $converter = Pimcore::getContainer()->get(UnitConversionService::class);
+        return $converter->convert($this, $unit);
     }
 
     abstract public function getValue();

--- a/models/DataObject/QuantityValue/UnitConversionService.php
+++ b/models/DataObject/QuantityValue/UnitConversionService.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Model\DataObject\QuantityValue;
 
+use Pimcore\Model\DataObject\Data\AbstractQuantityValue;
 use Pimcore\Model\DataObject\Data\QuantityValue;
 use Psr\Container\ContainerInterface;
 
@@ -36,7 +37,7 @@ class UnitConversionService
      *
      * @throws \Exception
      */
-    public function convert(QuantityValue $quantityValue, Unit $toUnit)
+    public function convert(AbstractQuantityValue $quantityValue, Unit $toUnit)
     {
         $baseUnit = $toUnit->getBaseunit();
 


### PR DESCRIPTION
Currently you can [convert `QuantityValue` objects to another unit](https://pimcore.com/docs/pimcore/current/Development_Documentation/Objects/Object_Classes/Data_Types/Number_Types.html#page_Quantity-Value-Unit-Conversion) with
```php
$originalValue = new QuantityValue(3, Unit::getByAbbreviation('m')->getId());
$converter = $this->container->get(\Pimcore\Model\DataObject\QuantityValue\UnitConversionService::class);
$convertedValue = $converter->convert($originalValue, Unit::getByAbbreviation('mm'));
// $convertedValue is a QuantityValue with value 3000 and unit mm
```

This PR adds a shorter convenience method to do conversion like this:
```php
$originalValue = new QuantityValue(3, Unit::getByAbbreviation('m')->getId());
$convertedValue = $originalValue->convertTo(Unit::getByAbbreviation('mm'));
// $convertedValue is a QuantityValue with value 3000 and unit mm
```

and it even supports
```php
$originalValue = new QuantityValue(3, Unit::getByAbbreviation('m')->getId());
$convertedValue = $originalValue->convertTo('mm');
// $convertedValue is a QuantityValue with value 3000 and unit mm
```

Additionally I changed `UnitConversionService::convert()` to also support `InputQuantityValue` objects. With a [unit conversion service](https://pimcore.com/docs/pimcore/current/Development_Documentation/Objects/Object_Classes/Data_Types/Number_Types.html#page_Dynamic-unit-conversion) it might be possible that those can also be converted to another unit.