### PR TITLE
Add filter for filename options to thumbnail commands

### DIFF
--- a/bundles/CoreBundle/Command/LowQualityImagePreviewCommand.php
+++ b/bundles/CoreBundle/Command/LowQualityImagePreviewCommand.php
@@ -87,7 +87,7 @@ class LowQualityImagePreviewCommand extends AbstractCommand
 
         if ($filenameRegex = $input->getOption('filenameRegex')) {
             $conditions[] = '`filename` REGEXP ?';
-            $conditionVariables[] = $filenameRegex . '%';
+            $conditionVariables[] = $filenameRegex;
         }
 
         $generator = null;

--- a/bundles/CoreBundle/Command/LowQualityImagePreviewCommand.php
+++ b/bundles/CoreBundle/Command/LowQualityImagePreviewCommand.php
@@ -47,16 +47,10 @@ class LowQualityImagePreviewCommand extends AbstractCommand
                 'only create thumbnails of images in this folder (ID)'
             )
             ->addOption(
-                'filenamePrefix',
+                'filenameRegex',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'only create thumbnails of images with filenames starting with (filenamePrefix)'
-            )
-            ->addOption(
-                'filenamePostfix',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'only create thumbnails of images with filenames ending with (filenamePostfix)'
+                'only create thumbnails of images with filenames matching the given regex'
             )
             ->addOption(
                 'force',
@@ -91,14 +85,9 @@ class LowQualityImagePreviewCommand extends AbstractCommand
             $conditions[] = sprintf('id in (%s)', implode(',', $ids));
         }
 
-        if ($filenamePrefix = $input->getOption('filenamePrefix')) {
-            $conditions[] = '`filename` LIKE ?';
-            $conditionVariables[] = $filenamePrefix . '%';
-        }
-
-        if ($filenamePostfix = $input->getOption('filenamePostfix')) {
-            $conditions[] = '`filename` LIKE ?';
-            $conditionVariables[] = '%' . $filenamePostfix;
+        if ($filenameRegex = $input->getOption('filenameRegex')) {
+            $conditions[] = '`filename` REGEXP ?';
+            $conditionVariables[] = $filenameRegex . '%';
         }
 
         $generator = null;

--- a/bundles/CoreBundle/Command/LowQualityImagePreviewCommand.php
+++ b/bundles/CoreBundle/Command/LowQualityImagePreviewCommand.php
@@ -47,10 +47,10 @@ class LowQualityImagePreviewCommand extends AbstractCommand
                 'only create thumbnails of images in this folder (ID)'
             )
             ->addOption(
-                'filenameRegex',
+                'pathPattern',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'only create thumbnails of images with filenames matching the given regex'
+                'Filter images against the given regex pattern (path + filename), example:  ^/Sample.*urban.jpg$'
             )
             ->addOption(
                 'force',
@@ -85,8 +85,8 @@ class LowQualityImagePreviewCommand extends AbstractCommand
             $conditions[] = sprintf('id in (%s)', implode(',', $ids));
         }
 
-        if ($filenameRegex = $input->getOption('filenameRegex')) {
-            $conditions[] = '`filename` REGEXP ?';
+        if ($regex= $input->getOption('pathPattern')) {
+            $conditions[] = 'CONCAT(path, filename) REGEXP ?';
             $conditionVariables[] = $filenameRegex;
         }
 

--- a/bundles/CoreBundle/Command/LowQualityImagePreviewCommand.php
+++ b/bundles/CoreBundle/Command/LowQualityImagePreviewCommand.php
@@ -85,9 +85,9 @@ class LowQualityImagePreviewCommand extends AbstractCommand
             $conditions[] = sprintf('id in (%s)', implode(',', $ids));
         }
 
-        if ($regex= $input->getOption('pathPattern')) {
+        if ($regex = $input->getOption('pathPattern')) {
             $conditions[] = 'CONCAT(path, filename) REGEXP ?';
-            $conditionVariables[] = $filenameRegex;
+            $conditionVariables[] = $regex;
         }
 
         $generator = null;

--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -123,9 +123,9 @@ class ThumbnailsImageCommand extends AbstractCommand
             $conditions[] = '('. implode(' OR ', $parentConditions) . ')';
         }
 
-        if ($filenameRegex = $input->getOption('filenameRegex')) {
-            $conditions[] = '`filename` REGEXP ?';
-            $conditionVariables[] = $filenameRegex;
+        if ($regex = $input->getOption('pathPattern')) {
+            $conditions[] = 'CONCAT(path, filename) REGEXP ?';
+            $conditionVariables[] = $regex;
         }
 
         if ($ids = $input->getOption('id')) {

--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -52,10 +52,10 @@ class ThumbnailsImageCommand extends AbstractCommand
                 'only create thumbnails of images with this (IDs)'
             )
             ->addOption(
-                'filenameRegex',
+                'pathPattern',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'only create thumbnails of images with filenames matching the given regex'
+                'Filter images against the given regex pattern (path + filename), example:  ^/Sample.*urban.jpg$'
             )
             ->addOption(
                 'thumbnails',

--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -52,16 +52,10 @@ class ThumbnailsImageCommand extends AbstractCommand
                 'only create thumbnails of images with this (IDs)'
             )
             ->addOption(
-                'filenamePrefix',
+                'filenameRegex',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'only create thumbnails of images with filenames starting with (filenamePrefix)'
-            )
-            ->addOption(
-                'filenamePostfix',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'only create thumbnails of images with filenames ending with (filenamePostfix)'
+                'only create thumbnails of images with filenames matching the given regex'
             )
             ->addOption(
                 'thumbnails',
@@ -129,14 +123,9 @@ class ThumbnailsImageCommand extends AbstractCommand
             $conditions[] = '('. implode(' OR ', $parentConditions) . ')';
         }
 
-        if ($filenamePrefix = $input->getOption('filenamePrefix')) {
-            $conditions[] = '`filename` LIKE ?';
-            $conditionVariables[] = $filenamePrefix . '%';
-        }
-
-        if ($filenamePostfix = $input->getOption('filenamePostfix')) {
-            $conditions[] = '`filename` LIKE ?';
-            $conditionVariables[] = '%' . $filenamePostfix;
+        if ($filenameRegex = $input->getOption('filenameRegex')) {
+            $conditions[] = '`filename` REGEXP ?';
+            $conditionVariables[] = $filenameRegex . '%';
         }
 
         if ($ids = $input->getOption('id')) {

--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -125,7 +125,7 @@ class ThumbnailsImageCommand extends AbstractCommand
 
         if ($filenameRegex = $input->getOption('filenameRegex')) {
             $conditions[] = '`filename` REGEXP ?';
-            $conditionVariables[] = $filenameRegex . '%';
+            $conditionVariables[] = $filenameRegex;
         }
 
         if ($ids = $input->getOption('id')) {


### PR DESCRIPTION
Add options to filter by filename to commands:

- pimcore:image:low-quality-preview
- pimcore:thumbnails:image

**Use case:**
Pre-generate thumbnails for a productgrid while all product images have the same naming structure and the needed images all end with the same postfix. 