### PR TITLE
fix object reload and maskEl error

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
@@ -818,7 +818,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                         }
                     }
 
-                    if (this.tab) {
+                    if (this.tab && this.tab.getData()) {
                         this.tab.unmask();
                     }
 
@@ -872,7 +872,6 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                 tabIndex: currentTabIndex,
                 uiState: uiState
             };
-            this.tab = null;
 
             window.setTimeout(function (id) {
                 pimcore.helpers.openObject(id, "object", options);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
@@ -818,7 +818,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                         }
                     }
 
-                    if (this.tab && this.tab.getData()) {
+                    if (this.tab && (this.tab.getMaskTarget() || this.tab.el).getData()) {
                         this.tab.unmask();
                     }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #10975

## Additional info  
This PR will resolve the maskEl error mentioned in #10975 without breaking the Object.reload function.
In the previous fix from the issue, the tab was set to null, but this meant that the tab could no longer be closed afterwards and thus remained open. When trying to reopen the same tab due to the reload, an error occurs because the tab is already open and js stops working.

Here is an image of that error:
![153215843-79b71c58-c389-4e9e-ba20-ab68af5ef3e4](https://user-images.githubusercontent.com/91049331/153359452-83084f26-2124-45b4-bed8-a58dda6ca861.png)

The closeTabPanel in pimcore/element/abstract.js will not work with tab = null set before in the Object.reload function, because tabPanel.remove(this.tab) will not remove the tab then:
```
_closeTabPanel: function () {
        this.tab.fireEventedAction("close", [this.tab, {}]);
        var tabPanel = Ext.getCmp("pimcore_panel_tabs");
        tabPanel.remove(this.tab);
},
```
![Screenshot_10_02_22__08_45](https://user-images.githubusercontent.com/91049331/153360960-3a921f9a-1feb-4925-b0a2-c662e9f2fd48.png)

**This PR fixes the maskEl error as follows:**
Right now the unmask() method is called in the object.save() method:
![Screenshot_10_02_22__09_02](https://user-images.githubusercontent.com/91049331/153363555-1473f31b-dc80-44a5-9e7f-72b5512955d9.png)
And in the unmask method this.getData() gets called and after that data.maskEl, but data is not testet for null. So when data is null (it is, when reloading the object) the maskEl error is thrown (see #10975 for that).
![Screenshot_10_02_22__09_13](https://user-images.githubusercontent.com/91049331/153365203-8d805ffd-3ed3-4174-8b15-b1bd4dacb75b.png)

So testing data for null before calling unmask in object.save() will solve the error and will have no downside:
![Screenshot_10_02_22__11_21](https://user-images.githubusercontent.com/91049331/153387165-081f5ad4-79f0-4267-92f9-ecdc62932132.png)

