### PR TITLE
Tool::getHostname() -> return configured website domain when not in HTTP request context

### DIFF
--- a/lib/Tool.php
+++ b/lib/Tool.php
@@ -395,8 +395,9 @@ final class Tool
     {
         $request = self::resolveRequest($request);
 
-        if (null === $request) {
-            return null;
+        if (null === $request || !$request->getHost() || $request->getHost() === 'localhost') {
+            $domain = \Pimcore\Config::getSystemConfiguration('general')['domain'];
+            return $domain ?: null;
         }
 
         return $request->getHost();
@@ -444,7 +445,7 @@ final class Tool
         }
 
         // get it from System settings
-        if (!$hostname || $hostname == 'localhost') {
+        if (!$hostname || $hostname === 'localhost') {
             $systemConfig = Config::getSystemConfiguration('general');
             $hostname = $systemConfig['domain'] ?? null;
 


### PR DESCRIPTION
Currently for CLI processes `\Pimcore\Tool::getHostname()` always returns null. With this PR in such cases the domain from system settings gets returned.