### PR TITLE
[Translations] Only auto-create if currently no translation for key exists -> not on every exception

### DIFF
--- a/models/Translation.php
+++ b/models/Translation.php
@@ -22,6 +22,7 @@ use Pimcore\Event\TranslationEvents;
 use Pimcore\File;
 use Pimcore\Localization\LocaleServiceInterface;
 use Pimcore\Tool;
+use Symfony\Component\Translation\Exception\NotFoundResourceException;
 
 /**
  * @method \Pimcore\Model\Translation\Dao getDao()
@@ -271,20 +272,24 @@ final class Translation extends AbstractModel
 
         try {
             $translation->getDao()->getByKey($id);
-        } catch (\Exception $e) {
+        } catch (NotFoundResourceException) {
             if (!$create) {
                 return null;
-            } else {
-                $translation->setKey($id);
-                $translation->setCreationDate(time());
-                $translation->setModificationDate(time());
+            }
 
-                $translations = [];
-                foreach ($languages as $lang) {
-                    $translations[$lang] = '';
-                }
-                $translation->setTranslations($translations);
-                $translation->save();
+            $translation->setKey($id);
+            $translation->setCreationDate(time());
+            $translation->setModificationDate(time());
+
+            $translations = [];
+            foreach ($languages as $lang) {
+                $translations[$lang] = '';
+            }
+            $translation->setTranslations($translations);
+            $translation->save();
+        } catch(\Exception) {
+            if (!$create) {
+                return null;
             }
         }
 

--- a/models/Translation.php
+++ b/models/Translation.php
@@ -273,6 +273,10 @@ final class Translation extends AbstractModel
         try {
             $translation->getDao()->getByKey($id);
         } catch (\Exception $e) {
+            if(!$create && !$returnIdIfEmpty) {
+                return null;
+            }
+
             $translation->setKey($id);
             $translation->setCreationDate(time());
             $translation->setModificationDate(time());

--- a/models/Translation.php
+++ b/models/Translation.php
@@ -272,7 +272,7 @@ final class Translation extends AbstractModel
 
         try {
             $translation->getDao()->getByKey($id);
-        } catch (NotFoundResourceException) {
+        } catch (\Exception $e) {
             if (!$create) {
                 return null;
             }
@@ -281,15 +281,13 @@ final class Translation extends AbstractModel
             $translation->setCreationDate(time());
             $translation->setModificationDate(time());
 
-            $translations = [];
-            foreach ($languages as $lang) {
-                $translations[$lang] = '';
-            }
-            $translation->setTranslations($translations);
-            $translation->save();
-        } catch(\Exception) {
-            if (!$create) {
-                return null;
+            if($e instanceof NotFoundResourceException) {
+                $translations = [];
+                foreach ($languages as $lang) {
+                    $translations[$lang] = '';
+                }
+                $translation->setTranslations($translations);
+                $translation->save();
             }
         }
 

--- a/models/Translation.php
+++ b/models/Translation.php
@@ -273,15 +273,11 @@ final class Translation extends AbstractModel
         try {
             $translation->getDao()->getByKey($id);
         } catch (\Exception $e) {
-            if (!$create) {
-                return null;
-            }
-
             $translation->setKey($id);
             $translation->setCreationDate(time());
             $translation->setModificationDate(time());
 
-            if($e instanceof NotFoundResourceException) {
+            if($create && $e instanceof NotFoundResourceException) {
                 $translations = [];
                 foreach ($languages as $lang) {
                     $translations[$lang] = '';

--- a/models/Translation/Dao.php
+++ b/models/Translation/Dao.php
@@ -41,7 +41,7 @@ class Dao extends Model\Dao\AbstractDao
     /**
      * @param string $key
      *
-     * @throws \Exception
+     * @throws NotFoundResourceException
      */
     public function getByKey($key)
     {

--- a/models/Translation/Dao.php
+++ b/models/Translation/Dao.php
@@ -16,6 +16,7 @@
 namespace Pimcore\Model\Translation;
 
 use Pimcore\Model;
+use Symfony\Component\Translation\Exception\NotFoundResourceException;
 
 /**
  * @internal
@@ -61,7 +62,7 @@ class Dao extends Model\Dao\AbstractDao
                 $this->model->setType($d['type']);
             }
         } else {
-            throw new \Exception("Translation-Key -->'" . $key . "'<-- not found");
+            throw new NotFoundResourceException("Translation-Key -->'" . $key . "'<-- not found");
         }
     }
 


### PR DESCRIPTION
We faced a problem where some admin translations got removed. Currently we do not know why but I found a potential problem in https://github.com/pimcore/pimcore/blob/2322eebf98296fc00e21f0ca0054947c1328e184/models/Translation.php#L272-L289

There could also be other exceptions being thrown by `$translation->getDao()->getByKey($id);` - even if there is an existing translation for the given key. In those cases of course we do not want to auto-create an empty translation (and thus overwrite the existing translation).

BTW:
Is it actually correct to return `null` in https://github.com/pimcore/pimcore/blob/2322eebf98296fc00e21f0ca0054947c1328e184/models/Translation.php#L275-L277
regardless of `$returnIdIfEmpty`? Imho this is not correct because if `$returnIdIfEmpty = true` and `$create = false` we should return `$id`, shouldn't we?