### PR TITLE
[Documents] Refactor editables update after saving the document

### DIFF
--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -128,15 +128,14 @@ abstract class PageSnippet extends Model\Document
      */
     protected function update($params = [])
     {
-        // update this
-        parent::update($params);
-
         // update elements
-        $this->getEditables();
+        $editables = $this->getEditables();
         $this->getDao()->deleteAllEditables();
 
-        if (is_array($this->getEditables()) && count($this->getEditables()) > 0) {
-            foreach ($this->getEditables() as $name => $editable) {
+        parent::update($params);
+
+        if (is_array($editables) && count($editables) > 0) {
+            foreach ($editables as $name => $editable) {
                 if (!$editable->getInherited()) {
                     $editable->setDao(null);
                     $editable->setDocumentId($this->getId());
@@ -147,7 +146,7 @@ abstract class PageSnippet extends Model\Document
 
         // scheduled tasks are saved in $this->saveVersion();
         // save version if needed
-        $this->saveVersion(false, false, isset($params['versionNote']) ? $params['versionNote'] : null);
+        $this->saveVersion(false, false, $params['versionNote'] ?? null);
     }
 
     /**

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -134,7 +134,7 @@ abstract class PageSnippet extends Model\Document
 
         parent::update($params);
 
-        if (is_array($editables) && count($editables) > 0) {
+        if (is_array($editables) && count($editables)) {
             foreach ($editables as $name => $editable) {
                 if (!$editable->getInherited()) {
                     $editable->setDao(null);

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -128,6 +128,8 @@ abstract class PageSnippet extends Model\Document
      */
     protected function update($params = [])
     {
+        // update this
+        parent::update($params);
 
         // update elements
         $this->getEditables();
@@ -144,10 +146,6 @@ abstract class PageSnippet extends Model\Document
         }
 
         // scheduled tasks are saved in $this->saveVersion();
-
-        // update this
-        parent::update($params);
-
         // save version if needed
         $this->saveVersion(false, false, isset($params['versionNote']) ? $params['versionNote'] : null);
     }

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -135,7 +135,7 @@ abstract class PageSnippet extends Model\Document
         parent::update($params);
 
         if (is_array($editables) && count($editables)) {
-            foreach ($editables as $name => $editable) {
+            foreach ($editables as $editable) {
                 if (!$editable->getInherited()) {
                     $editable->setDao(null);
                     $editable->setDocumentId($this->getId());


### PR DESCRIPTION
## Changes in this pull request  
Resolves #11421

## Additional info  
On saving the document page, the editables are cleaned up and re-interested into the database before the document is updated. 
Similarly, when restoring the document from recycle-bin, the editables are inserted first and then document is inserted into the db.

After introducing the foreign key on `documents_editables` table which references `documents` https://github.com/pimcore/pimcore/pull/11236/files#diff-16a66ecef029997901ca218419d1d956f02bad7ae4361808f4eee946aba41134R79, it is throwing exception as when restoring the document from recyclebin, it first tries to insert the editables with no corresponding entry in `documents` table.

This PR fixes the issue by refactoring the editables update after the document is updated.

