### PR TITLE
Fix Deprecations from Codeception/Symfony

### DIFF
--- a/bundles/AdminBundle/EventListener/GridConfigListener.php
+++ b/bundles/AdminBundle/EventListener/GridConfigListener.php
@@ -32,7 +32,7 @@ class GridConfigListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             DataObjectClassDefinitionEvents::POST_DELETE => 'onClassDelete',

--- a/bundles/AdminBundle/EventListener/ImportConfigListener.php
+++ b/bundles/AdminBundle/EventListener/ImportConfigListener.php
@@ -30,7 +30,7 @@ class ImportConfigListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             DataObjectClassDefinitionEvents::POST_DELETE => 'onClassDelete',

--- a/bundles/CoreBundle/EventListener/ElementTagsListener.php
+++ b/bundles/CoreBundle/EventListener/ElementTagsListener.php
@@ -31,7 +31,7 @@ class ElementTagsListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             DataObjectEvents::POST_COPY => 'onPostCopy',

--- a/bundles/CoreBundle/EventListener/UUIDListener.php
+++ b/bundles/CoreBundle/EventListener/UUIDListener.php
@@ -33,7 +33,7 @@ class UUIDListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             DataObjectEvents::POST_ADD => 'onPostAdd',

--- a/bundles/EcommerceFrameworkBundle/EventListener/IndexUpdateListener.php
+++ b/bundles/EcommerceFrameworkBundle/EventListener/IndexUpdateListener.php
@@ -23,7 +23,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class IndexUpdateListener implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    /**
+     * @return array
+     */
+    #[\ReturnTypeWillChange]
+    public static function getSubscribedEvents()//: array
     {
         return [
             DataObjectEvents::POST_ADD => 'onObjectUpdate',

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -1,7 +1,7 @@
 settings:
     memory_limit: 1024M
-    bootstrap: _bootstrap.php
     colors: true
+bootstrap: _bootstrap.php
 namespace: Pimcore\Tests
 actor: Tester
 paths:

--- a/lib/Console/Application.php
+++ b/lib/Console/Application.php
@@ -102,7 +102,7 @@ final class Application extends \Symfony\Bundle\FrameworkBundle\Console\Applicat
         return $inputDefinition;
     }
 
-    public function add(Command $command)
+    public function add(Command $command): ?Command
     {
         if ($command instanceof DoctrineCommand) {
             $definition = $command->getDefinition();

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -974,8 +974,11 @@ class Mail extends Email
 
     /**
      * {@inheritdoc}
+     *
+     * @return $this
      */
-    public function addTo(...$addresses)
+    #[\ReturnTypeWillChange]
+    public function addTo(...$addresses)//: static
     {
         $addresses = $this->formatAddress(...$addresses);
 
@@ -984,8 +987,11 @@ class Mail extends Email
 
     /**
      * {@inheritdoc}
+     *
+     * @return $this
      */
-    public function addCc(...$addresses)
+    #[\ReturnTypeWillChange]
+    public function addCc(...$addresses)//: static
     {
         $addresses = $this->formatAddress(...$addresses);
 
@@ -994,8 +1000,11 @@ class Mail extends Email
 
     /**
      * {@inheritdoc}
+     *
+     * @return $this
      */
-    public function addBcc(...$addresses)
+    #[\ReturnTypeWillChange]
+    public function addBcc(...$addresses)//: static
     {
         $addresses = $this->formatAddress(...$addresses);
 
@@ -1004,8 +1013,11 @@ class Mail extends Email
 
     /**
      * {@inheritdoc}
+     *
+     * @return $this
      */
-    public function addFrom(...$addresses)
+    #[\ReturnTypeWillChange]
+    public function addFrom(...$addresses)//: static
     {
         $addresses = $this->formatAddress(...$addresses);
 
@@ -1014,8 +1026,11 @@ class Mail extends Email
 
     /**
      * {@inheritdoc}
+     *
+     * @return $this
      */
-    public function addReplyTo(...$addresses)
+    #[\ReturnTypeWillChange]
+    public function addReplyTo(...$addresses)//: static
     {
         $addresses = $this->formatAddress(...$addresses);
 

--- a/lib/Session/Attribute/LockableAttributeBag.php
+++ b/lib/Session/Attribute/LockableAttributeBag.php
@@ -71,8 +71,11 @@ class LockableAttributeBag extends AttributeBag implements LockableAttributeBagI
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
-    public function remove($name)
+    #[\ReturnTypeWillChange]
+    public function remove($name)//: mixed
     {
         $this->checkLock();
 
@@ -81,8 +84,11 @@ class LockableAttributeBag extends AttributeBag implements LockableAttributeBagI
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
-    public function clear()
+    #[\ReturnTypeWillChange]
+    public function clear()//: mixed
     {
         $this->checkLock();
 

--- a/lib/Tool/DomCrawler.php
+++ b/lib/Tool/DomCrawler.php
@@ -49,7 +49,7 @@ class DomCrawler extends Crawler
     /**
      * {@inheritDoc}
      */
-    public function html(string $default = null)
+    public function html(string $default = null): string
     {
         if ($this->wrappedHtmlFragment) {
             $html = $this->filter(self::FRAGMENT_WRAPPER_TAG)->html();

--- a/lib/Twig/TokenParser/AssetCompressParser.php
+++ b/lib/Twig/TokenParser/AssetCompressParser.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Pimcore\Twig\TokenParser;
 
 use Pimcore\Twig\Node\AssetCompressNode;
+use Twig\Node\Node;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
 
@@ -29,7 +30,7 @@ use Twig\TokenParser\AbstractTokenParser;
  */
 class AssetCompressParser extends AbstractTokenParser
 {
-    public function parse(Token $token)
+    public function parse(Token $token): Node
     {
         $lineno = $token->getLine();
 
@@ -45,7 +46,7 @@ class AssetCompressParser extends AbstractTokenParser
         return $token->test('endpimcoreassetcompress');
     }
 
-    public function getTag()
+    public function getTag(): string
     {
         return 'pimcoreassetcompress';
     }

--- a/lib/Twig/TokenParser/GlossaryTokenParser.php
+++ b/lib/Twig/TokenParser/GlossaryTokenParser.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Pimcore\Twig\TokenParser;
 
 use Pimcore\Twig\Node\GlossaryNode;
+use Twig\Node\Node;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
 
@@ -31,7 +32,7 @@ class GlossaryTokenParser extends AbstractTokenParser
     /**
      * {@inheritdoc}
      */
-    public function parse(Token $token)
+    public function parse(Token $token): Node
     {
         trigger_deprecation(
             'pimcore/pimcore',


### PR DESCRIPTION
Fix following deprecations from Codeception/Symfony (see codeception log):
```
DEPRECATION: 'settings: bootstrap: _bootstrap.php' option is deprecated! Replace it with: 'bootstrap: _bootstrap.php' (not under settings section). See: https://codeception.com/docs/reference/Configuration
DEPRECATION: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\UUIDListener" now to avoid errors or add an explicit @return annotation to suppress this message./var/www/html/vendor/symfony/error-handler/DebugClassLoader.php:325
DEPRECATION: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\ElementTagsListener" now to avoid errors or add an explicit @return annotation to suppress this message./var/www/html/vendor/symfony/error-handler/DebugClassLoader.php:325
DEPRECATION: Method "Symfony\Component\Console\Application::add()" might add "?Command" as a native return type declaration in the future. Do the same in child class "Pimcore\Console\Application" now to avoid errors or add an explicit @return annotation to suppress this message./var/www/html/vendor/symfony/error-handler/DebugClassLoader.php:325
DEPRECATION: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\EcommerceFrameworkBundle\EventListener\IndexUpdateListener" now to avoid errors or add an explicit @return annotation to suppress this message./var/www/html/vendor/symfony/error-handler/DebugClassLoader.php:325
DEPRECATION: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\AdminBundle\EventListener\GridConfigListener" now to avoid errors or add an explicit @return annotation to suppress this message./var/www/html/vendor/symfony/error-handler/DebugClassLoader.php:325
DEPRECATION: Method "Symfony\Component\DomCrawler\Crawler::html()" might add "string" as a native return type declaration in the future. Do the same in child class "Pimcore\Tool\DomCrawler" now to avoid errors or add an explicit @return annotation to suppress this message./var/www/html/vendor/symfony/error-handler/DebugClassLoader.php:325
DEPRECATION: Method "Symfony\Component\Mime\Email::addTo()" might add "static" as a native return type declaration in the future. Do the same in child class "Pimcore\Mail" now to avoid errors or add an explicit @return annotation to suppress this message./var/www/html/vendor/symfony/error-handler/DebugClassLoader.php:325
DEPRECATION: Method "Symfony\Component\Mime\Email::addCc()" might add "static" as a native return type declaration in the future. Do the same in child class "Pimcore\Mail" now to avoid errors or add an explicit @return annotation to suppress this message./var/www/html/vendor/symfony/error-handler/DebugClassLoader.php:325
DEPRECATION: Method "Symfony\Component\Mime\Email::addBcc()" might add "static" as a native return type declaration in the future. Do the same in child class "Pimcore\Mail" now to avoid errors or add an explicit @return annotation to suppress this message./var/www/html/vendor/symfony/error-handler/DebugClassLoader.php:325
DEPRECATION: Method "Symfony\Component\Mime\Email::addFrom()" might add "static" as a native return type declaration in the future. Do the same in child class "Pimcore\Mail" now to avoid errors or add an explicit @return annotation to suppress this message./var/www/html/vendor/symfony/error-handler/DebugClassLoader.php:325
DEPRECATION: Method "Symfony\Component\Mime\Email::addReplyTo()" might add "static" as a native return type declaration in the future. Do the same in child class "Pimcore\Mail" now to avoid errors or add an explicit @return annotation to suppress this message./var/www/html/vendor/symfony/error-handler/DebugClassLoader.php:325
DEPRECATION: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\AdminBundle\EventListener\ImportConfigListener" now to avoid errors or add an explicit @return annotation to suppress this message./var/www/html/vendor/symfony/error-handler/DebugClassLoader.php:325
DEPRECATION: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\EcommerceFrameworkBundle\EventListener\IndexUpdateListener" now to avoid errors or add an explicit @return annotation to suppress this message./var/www/html/vendor/symfony/error-handler/DebugClassLoader.php:325
DEPRECATION: Method "Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface::remove()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Pimcore\Session\Attribute\LockableAttributeBag" now to avoid errors or add an explicit @return annotation to suppress this message./var/www/html/vendor/symfony/error-handler/DebugClassLoader.php:325
DEPRECATION: Method "Symfony\Component\HttpFoundation\Session\SessionBagInterface::clear()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Pimcore\Session\Attribute\LockableAttributeBag" now to avoid errors or add an explicit @return annotation to suppress this message./var/www/html/vendor/symfony/error-handler/DebugClassLoader.php:325
```
