### PR TITLE
[Improvement] Show unpublished elements in dependency-list consistently with line-through

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/dependencies.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/dependencies.js
@@ -119,7 +119,15 @@ pimcore.element.dependencies = Class.create({
                             + '" name="' + t(record.data.subtype) + '">&nbsp;</div>';
                     }
                 },
-                {text: t("path"), sortable: true, dataIndex: 'path', flex: 1, renderer: Ext.util.Format.htmlEncode}
+                {text: t("path"), sortable: true, dataIndex: 'path', flex: 1,
+                    renderer:
+                        function (value, metaData, record, rowIndex, colIndex, store) {
+                            if(record.data.published === false) {
+                                metaData.tdStyle = 'text-decoration: line-through;color: #777;';
+                            }
+                            return Ext.util.Format.htmlEncode(value);
+                        }
+                }
             ],
             flex: 1,
             columnLines: true,
@@ -219,7 +227,15 @@ pimcore.element.dependencies = Class.create({
                             + '" name="' + t(record.data.subtype) + '">&nbsp;</div>';
                     }
                 },
-                {text: t("path"), sortable: true, dataIndex: 'path', flex: 1, renderer: Ext.util.Format.htmlEncode}
+                {text: t("path"), sortable: true, dataIndex: 'path', flex: 1,
+                    renderer:
+                        function (value, metaData, record, rowIndex, colIndex, store) {
+                            if(record.data.published === false) {
+                                metaData.tdStyle = 'text-decoration: line-through;color: #777;';
+                            }
+                            return Ext.util.Format.htmlEncode(value);
+                        }
+                }
             ],
             columnLines: true,
             stripeRows: true,

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -233,6 +233,7 @@ class Service extends Model\AbstractModel
             'path' => $element->getRealFullPath(),
             'type' => self::getElementType($element),
             'subtype' => $element->getType(),
+            'published' => self::isPublished($element),
         ];
     }
 


### PR DESCRIPTION
The result can be seen in the screenshots below. Same style is also used e.g. in the many-to-many-relationshop-grid.

![grafik](https://user-images.githubusercontent.com/62158465/153558331-97566460-6670-4242-b671-bf44e8a2ed82.png)
![grafik](https://user-images.githubusercontent.com/62158465/153558414-f01370a6-ec90-41d4-a981-649e51fa651b.png)
