### PR TITLE
Fix: translation CSV download ignoring filters

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/translation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/translation.js
@@ -545,10 +545,12 @@ pimcore.settings.translation.domain = Class.create({
                     queryString += "&searchString=" + this.filterField.getValue() + "&domain=" + this.domain;
                     queryString += "&filter=" + proxy.encodeFilters(storeFilters);
                 }
+                pimcore.helpers.download(Ext.urlAppend(this.exportUrl, queryString));
             }.bind(this));
+        } else {
+            pimcore.helpers.download(Ext.urlAppend(this.exportUrl, queryString));
         }
 
-        pimcore.helpers.download(Ext.urlAppend(this.exportUrl, queryString));
     },
 
     onAdd: function (btn, ev) {


### PR DESCRIPTION
## Changes in this pull request  
Resolves #11429

Fixing translations CSV download ignoring filters

Issue was created in https://github.com/pimcore/pimcore/commit/371b952e022633b2e40af3b89f242b7f1745b305