### PR TITLE
[Docs] Cache config file needs to be put in local/ folder to get loaded with default config.yaml

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/09_Cache/README.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/09_Cache/README.md
@@ -21,7 +21,7 @@ Pimcore uses the `pimcore.cache.pool` Symfony cache pool, you can configure it a
 that the pool supports tags.
 
 ```yaml
-# config/local/cache.yaml
+# config/packages/cache.yaml
 framework:
     cache:
         pools:

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/09_Cache/README.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/09_Cache/README.md
@@ -21,7 +21,7 @@ Pimcore uses the `pimcore.cache.pool` Symfony cache pool, you can configure it a
 that the pool supports tags.
 
 ```yaml
-# config/cache.yaml
+# config/local/cache.yaml
 framework:
     cache:
         pools:

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/09_Performance_Guide.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/09_Performance_Guide.md
@@ -225,7 +225,7 @@ and fail-over support.
 
 Configure `Redis` adapter for `Pimcore\Cache` using these settings:
 ```yaml
-# config/cache.yaml
+# config/packages/cache.yaml
 framework:
     cache:
         pools:


### PR DESCRIPTION
`<Pimcore-Root>/config/cache.yaml` will not get loaded with default `config/config.yaml`, see https://github.com/pimcore/skeleton/blob/7f2ce31352c392dac9ef297b40727cf1ad84cede/config/config.yaml#L1-L2