### PR TITLE
Asset tree optimization

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -29,6 +29,7 @@ use Pimcore\Event\AssetEvents;
 use Pimcore\File;
 use Pimcore\Loader\ImplementationLoader\Exception\UnsupportedException;
 use Pimcore\Logger;
+use Pimcore\Messenger\AssetPreviewImageMessage;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Element;
@@ -1344,6 +1345,10 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         if ($request->get('treepreview')) {
             $thumbnailConfig = Asset\Image\Thumbnail\Config::getPreviewConfig();
             if($request->get('origin') === 'treeNode' && !$image->getThumbnail($thumbnailConfig)->exists()) {
+                \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
+                    new AssetPreviewImageMessage($image->getId())
+                );
+
                 throw $this->createNotFoundException(sprintf('Tree preview thumbnail not available for asset %s', $image->getId()));
             }
         }
@@ -1476,6 +1481,10 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $thumb = $video->getImageThumbnail($thumbnail, $time, $image);
 
         if($request->get('origin') === 'treeNode' && !$thumb->exists()) {
+            \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
+                new AssetPreviewImageMessage($video->getId())
+            );
+
             throw $this->createNotFoundException(sprintf('Tree preview thumbnail not available for asset %s', $video->getId()));
         }
 
@@ -1529,6 +1538,10 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $thumb = $document->getImageThumbnail($thumbnail, $page);
 
         if($request->get('origin') === 'treeNode' && !$thumb->exists()) {
+            \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
+                new AssetPreviewImageMessage($document->getId())
+            );
+
             throw $this->createNotFoundException(sprintf('Tree preview thumbnail not available for asset %s', $document->getId()));
         }
 

--- a/bundles/AdminBundle/Resources/public/css/admin.css
+++ b/bundles/AdminBundle/Resources/public/css/admin.css
@@ -907,7 +907,8 @@ span.warning {
 }
 
 #pimcore_tree_preview.hidden {
-    display:none;
+    position: absolute;
+    left: -2000px !important;
 }
 
 #pimcore_tree_preview iframe {

--- a/bundles/AdminBundle/Resources/public/css/admin.css
+++ b/bundles/AdminBundle/Resources/public/css/admin.css
@@ -911,9 +911,14 @@ span.warning {
     left: -2000px !important;
 }
 
-#pimcore_tree_preview iframe {
-    padding: 0;
-    margin:0;
+#pimcore_tree_preview_thumb {
+    box-sizing: border-box;
+    min-height: 300px;
+    max-width: 100%;
+}
+
+#pimcore_tree_preview_thumb img {
+    max-width: 100%;
 }
 
 .password_valid .x-form-trigger-wrap {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1114,6 +1114,7 @@ pimcore.helpers.sanitizeAllowedTypes = function (data, name) {
 };
 
 pimcore.helpers.treeNodeThumbnailTimeout = null;
+pimcore.helpers.treeNodeThumbnailHideTimeout = null;
 pimcore.helpers.treeNodeThumbnailLastClose = 0;
 
 pimcore.helpers.treeNodeThumbnailPreview = function (treeView, record, item, index, e, eOpts) {
@@ -1125,10 +1126,15 @@ pimcore.helpers.treeNodeThumbnailPreview = function (treeView, record, item, ind
             return;
         }
 
-        var uriPrefix = window.location.protocol + "//" + window.location.host;
         var thumbnail = record.data["thumbnail"];
 
         if (thumbnail) {
+
+            if (pimcore.helpers.treeNodeThumbnailHideTimeout) {
+                clearTimeout(pimcore.helpers.treeNodeThumbnailHideTimeout);
+                pimcore.helpers.treeNodeThumbnailHideTimeout = null;
+            }
+
             var treeEl = Ext.get("pimcore_panel_tree_" + this.position);
             var position = treeEl.getOffsetsTo(Ext.getBody());
             position = position[0];
@@ -1141,69 +1147,33 @@ pimcore.helpers.treeNodeThumbnailPreview = function (treeView, record, item, ind
 
             var container = Ext.get("pimcore_tree_preview");
             if (!container) {
-                container = Ext.getBody().insertHtml("beforeEnd", '<div id="pimcore_tree_preview"></div>');
+                container = Ext.getBody().insertHtml("beforeEnd", '<div id="pimcore_tree_preview" class="hidden"><div id="pimcore_tree_preview_thumb"></div></div>');
                 container = Ext.get(container);
-                container.addCls("hidden");
             }
 
-            // check for an existing iframe
-            var existingIframe = container.query("iframe")[0];
-            if (existingIframe) {
-                // stop loading the existing iframe (images, etc.)
-                var existingIframeWin = existingIframe.contentWindow;
-                if (typeof existingIframeWin["stop"] == "function") {
-                    existingIframeWin.stop();
-                } else if (typeof existingIframeWin.document["execCommand"] == "function") {
-                    existingIframeWin.document.execCommand('Stop');
-                }
-            }
+            var triggerTime = (new Date()).getTime();
+            var thumbContainer = Ext.get("pimcore_tree_preview_thumb");
+            thumbContainer.update('');
 
-            var styles = "left: " + position + "px";
-
-            // we need to create an iframe so that we can use window.stop();
-            var iframe = document.createElement("iframe");
-            iframe.setAttribute("frameborder", "0");
-            iframe.setAttribute("scrolling", "no");
-            iframe.setAttribute("marginheight", "0");
-            iframe.setAttribute("marginwidth", "0");
-            iframe.setAttribute("style", "width: 100%; height: 2500px;");
-
-            iframe.onload = function () {
-                this.contentWindow.document.body.innerHTML = '<style>' +
-                    'body { margin:0; padding: 0; } ' +
-                    '#thumb { border: 1px solid #999; background: url(' + uriPrefix + '/bundles/pimcoreadmin/img/flat-color-icons/hourglass.svg) no-repeat center center; background-size: 20px 20px; box-sizing: border-box; min-height: 300px; } ' +
-                    '#thumb.complete { border:none; border-radius: 0; background:none; max-width: 100%; }' +
-                    '#thumb.complete img { max-width: 100%; }' +
-                    '/* firefox fix: remove loading/broken image icon */ @-moz-document url-prefix() { img:-moz-loading { visibility: hidden; } img:-moz-broken { -moz-force-broken-image-icon: 0;}} ' +
-                    '</style>' +
-                    '<div id="thumb"></div>';
-
-                var thumbContainer = this.contentWindow.document.getElementById('thumb');
+            pimcore.helpers.treeNodeThumbnailTimeout = window.setTimeout(function () {
                 let img = document.createElement("img");
-                img.setAttribute("src", uriPrefix + thumbnail);
+                img.src = thumbnail;
                 img.addEventListener('load', function (ev) {
 
-                    thumbContainer.classList.add('complete');
-                    var date = new Date();
-                    if (pimcore.helpers.treeNodeThumbnailLastClose === 0 || (date.getTime() - pimcore.helpers.treeNodeThumbnailLastClose) > 300) {
-                        // open deferred
-                        pimcore.helpers.treeNodeThumbnailTimeout = window.setTimeout(function () {
-                            container.removeCls("hidden");
-                        }, 500);
-                    } else {
-                        // open immediately
+                    if(triggerTime > pimcore.helpers.treeNodeThumbnailLastClose) {
+                        thumbContainer.addCls('complete');
                         container.removeCls("hidden");
                     }
-
                 });
 
-                thumbContainer.appendChild(img);
-            };
+                img.addEventListener('error', function (ev) {
+                    container.addCls("hidden");
+                });
 
-            container.update(""); // remove all
-            container.clean(true);
-            container.dom.appendChild(iframe);
-            container.applyStyles(styles);
+                container.applyStyles("left: " + position + "px");
+                thumbContainer.dom.appendChild(img);
+
+            }, 300);
         }
     }
 };
@@ -1215,13 +1185,12 @@ pimcore.helpers.treeNodeThumbnailPreviewHide = function () {
         pimcore.helpers.treeNodeThumbnailTimeout = null;
     }
 
-    var container = Ext.get("pimcore_tree_preview");
+    let container = Ext.get("pimcore_tree_preview");
     if (container) {
-        if (!container.hasCls("hidden")) {
-            var date = new Date();
-            pimcore.helpers.treeNodeThumbnailLastClose = date.getTime();
-        }
-        container.addCls("hidden");
+        pimcore.helpers.treeNodeThumbnailLastClose = (new Date()).getTime();
+        pimcore.helpers.treeNodeThumbnailHideTimeout = window.setTimeout(function () {
+            container.addCls("hidden");
+        }, 50);
     }
 };
 

--- a/bundles/CoreBundle/Resources/config/message_handler.yaml
+++ b/bundles/CoreBundle/Resources/config/message_handler.yaml
@@ -20,6 +20,12 @@ services:
         tags:
             - { name: messenger.message_handler }
 
+    Pimcore\Messenger\Handler\AssetPreviewImageHandler:
+        arguments:
+            - '@logger'
+        tags:
+            - { name: messenger.message_handler }
+
     Pimcore\Messenger\Handler\MaintenanceTaskHandler:
         arguments:
             - '@Pimcore\Maintenance\Executor'

--- a/bundles/CoreBundle/Resources/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yaml
@@ -39,6 +39,7 @@ framework:
             'Pimcore\Messenger\SearchBackendMessage': pimcore_core
             'Pimcore\Messenger\SanityCheckMessage': pimcore_core
             'Pimcore\Messenger\AssetUpdateTasksMessage': pimcore_core
+            'Pimcore\Messenger\AssetPreviewImageMessage': pimcore_core
             'Pimcore\Messenger\GeneratePagePreviewMessage': pimcore_core
             'Pimcore\Messenger\GenerateWeb2PrintPdfMessage': pimcore_core
             'Pimcore\Messenger\VersionDeleteMessage': pimcore_core

--- a/lib/Messenger/AssetPreviewImageMessage.php
+++ b/lib/Messenger/AssetPreviewImageMessage.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Messenger;
+
+/**
+ * @internal
+ */
+class AssetPreviewImageMessage
+{
+    public function __construct(protected int $id)
+    {
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/lib/Messenger/Handler/AssetPreviewImageHandler.php
+++ b/lib/Messenger/Handler/AssetPreviewImageHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Messenger\Handler;
+
+use Pimcore\Logger;
+use Pimcore\Messenger\AssetPreviewImageMessage;
+use Pimcore\Model\Asset;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @internal
+ */
+class AssetPreviewImageHandler
+{
+    public function __construct(protected LoggerInterface $logger)
+    {
+    }
+
+    public function __invoke(AssetPreviewImageMessage $message)
+    {
+        $asset = Asset::getById($message->getId());
+
+        if ($asset instanceof Asset\Image) {
+            $asset->getThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->generate(false);
+        } elseif ($asset instanceof Asset\Document) {
+            $asset->getImageThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->generate(false);
+        } elseif ($asset instanceof Asset\Video) {
+            $asset->getImageThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->generate(false);
+        }
+    }
+}

--- a/lib/Messenger/Handler/AssetPreviewImageHandler.php
+++ b/lib/Messenger/Handler/AssetPreviewImageHandler.php
@@ -19,26 +19,54 @@ use Pimcore\Logger;
 use Pimcore\Messenger\AssetPreviewImageMessage;
 use Pimcore\Model\Asset;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Handler\Acknowledger;
+use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
+use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
 
 /**
  * @internal
  */
-class AssetPreviewImageHandler
+class AssetPreviewImageHandler implements BatchHandlerInterface
 {
+    use BatchHandlerTrait;
+
     public function __construct(protected LoggerInterface $logger)
     {
     }
 
-    public function __invoke(AssetPreviewImageMessage $message)
+    public function __invoke(AssetPreviewImageMessage $message, Acknowledger $ack = null)
     {
-        $asset = Asset::getById($message->getId());
+        return $this->handle($message, $ack);
+    }
 
-        if ($asset instanceof Asset\Image) {
-            $asset->getThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->generate(false);
-        } elseif ($asset instanceof Asset\Document) {
-            $asset->getImageThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->generate(false);
-        } elseif ($asset instanceof Asset\Video) {
-            $asset->getImageThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->generate(false);
+    // @phpstan-ignore-next-line
+    private function process(array $jobs): void
+    {
+        foreach ($jobs as [$message, $ack]) {
+            try {
+                $asset = Asset::getById($message->getId());
+
+                if ($asset instanceof Asset\Image) {
+                    $asset->getThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->generate(false);
+                } elseif ($asset instanceof Asset\Document) {
+                    $asset->getImageThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->generate(false);
+                } elseif ($asset instanceof Asset\Video) {
+                    $asset->getImageThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->generate(false);
+                } elseif ($asset instanceof Asset\Folder) {
+                    $asset->getPreviewImage(true);
+                }
+
+                $ack->ack($message);
+            } catch (\Throwable $e) {
+                $ack->nack($e);
+            }
         }
+    }
+
+
+    // @phpstan-ignore-next-line
+    private function shouldFlush(): bool
+    {
+        return 5 <= \count($this->jobs);
     }
 }

--- a/models/Asset/Folder.php
+++ b/models/Asset/Folder.php
@@ -179,14 +179,12 @@ class Folder extends Model\Asset
                         break;
                     }
 
-                    if(!$skipped) {
-                        $tile = imagecreatefromstring(stream_get_contents($tileThumb->getStream()));
-                        imagecopyresampled($collage, $tile, $offsetLeft, $offsetTop, 0, 0, $squareDimension, $squareDimension, $tileThumb->getWidth(), $tileThumb->getHeight());
+                    $tile = imagecreatefromstring(stream_get_contents($tileThumb->getStream()));
+                    imagecopyresampled($collage, $tile, $offsetLeft, $offsetTop, 0, 0, $squareDimension, $squareDimension, $tileThumb->getWidth(), $tileThumb->getHeight());
 
-                        $count++;
-                        if ($count % $colums === 0) {
-                            $offsetTop += ($squareDimension + $gutter);
-                        }
+                    $count++;
+                    if ($count % $colums === 0) {
+                        $offsetTop += ($squareDimension + $gutter);
                     }
                 }
             }

--- a/models/Asset/Folder.php
+++ b/models/Asset/Folder.php
@@ -16,6 +16,7 @@
 namespace Pimcore\Model\Asset;
 
 use Pimcore\File;
+use Pimcore\Messenger\AssetPreviewImageMessage;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Tool\Storage;
@@ -103,12 +104,13 @@ class Folder extends Model\Asset
     /**
      * @internal
      *
+     * @param bool $force
      * @return resource|null
      *
      * @throws \Doctrine\DBAL\Exception
      * @throws \League\Flysystem\FilesystemException
      */
-    public function getPreviewImage()
+    public function getPreviewImage(bool $force = false)
     {
         $storage = Storage::get('thumbnail');
         $cacheFilePath = sprintf('%s/image-thumb__%s__-folder-preview%s.jpg',
@@ -135,7 +137,7 @@ class Folder extends Model\Asset
 
         $list = new Asset\Listing();
         $list->setCondition($condition, $conditionParams);
-        $list->setOrderKey('filename');
+        $list->setOrderKey('id');
         $list->setOrder('asc');
         $list->setLimit($limit);
 
@@ -145,6 +147,7 @@ class Folder extends Model\Asset
         $squareDimension = 130;
         $offsetTop = 0;
         $colums = 3;
+        $skipped = false;
 
         if ($totalImages) {
             $collage = imagecreatetruecolor(($squareDimension * $colums) + ($gutter * ($colums - 1)), ceil(($totalImages / $colums)) * ($squareDimension + $gutter));
@@ -165,22 +168,30 @@ class Folder extends Model\Asset
                 }
 
                 if ($tileThumb) {
-                    if (!$tileThumb->exists()) {
+                    if (!$tileThumb->exists() && !$force) {
                         // only generate if all necessary thumbs are available
-                        continue;
+                        $skipped = true;
+
+                        \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
+                            new AssetPreviewImageMessage($this->getId())
+                        );
+
+                        break;
                     }
 
-                    $tile = imagecreatefromstring(stream_get_contents($tileThumb->getStream()));
-                    imagecopyresampled($collage, $tile, $offsetLeft, $offsetTop, 0, 0, $squareDimension, $squareDimension, $tileThumb->getWidth(), $tileThumb->getHeight());
+                    if(!$skipped) {
+                        $tile = imagecreatefromstring(stream_get_contents($tileThumb->getStream()));
+                        imagecopyresampled($collage, $tile, $offsetLeft, $offsetTop, 0, 0, $squareDimension, $squareDimension, $tileThumb->getWidth(), $tileThumb->getHeight());
 
-                    $count++;
-                    if ($count % $colums === 0) {
-                        $offsetTop += ($squareDimension + $gutter);
+                        $count++;
+                        if ($count % $colums === 0) {
+                            $offsetTop += ($squareDimension + $gutter);
+                        }
                     }
                 }
             }
 
-            if ($count) {
+            if ($count && !$skipped) {
                 $localFile = File::getLocalTempFilePath('jpg');
                 imagejpeg($collage, $localFile, 60);
                 $storage->write($cacheFilePath, file_get_contents($localFile));


### PR DESCRIPTION
- get rid of `<iframe>` solution, got obsolete by #7900 / simplification
- return `404` if there's no preview available, show preview only on success
- do not generate previews on request for the tree - check for existence
- do not check the existence of a preview thumbnail when generating the tree config (remote storage performance!) 


Resolves #11446