### PR TITLE
[Versions] Add grid filters for version tabs

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/versions.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/versions.js
@@ -26,7 +26,7 @@ pimcore.asset.versions = Class.create({
             if (!Ext.ClassManager.get(modelName)) {
                 Ext.define(modelName, {
                     extend: 'Ext.data.Model',
-                    fields: ['id', 'date', 'scheduled', 'note', {
+                    fields: ['id', { name: "date", type: 'date', dateFormat: 'timestamp' }, 'scheduled', 'note', {
                         name: 'name', convert: function (v, rec) {
                             if (rec.data) {
                                 if (rec.data.user) {
@@ -77,7 +77,7 @@ pimcore.asset.versions = Class.create({
 
             var grid = Ext.create('Ext.grid.Panel', {
                 store: this.store,
-                plugins: [this.cellEditing],
+                plugins: [this.cellEditing, 'gridfilters'],
                 columns: [
                     {text: t("published"), width:50, sortable: false, dataIndex: 'id', renderer: function(d, metaData, cellValues) {
                         var d = cellValues.get('date');
@@ -88,19 +88,18 @@ pimcore.asset.versions = Class.create({
                         }
                         return "";
                     }.bind(this), editable: false},
-                    {text: t("date"), width:150, sortable: true, dataIndex: 'date', renderer: function(d) {
-                        var date = new Date(d * 1000);
-                        return Ext.Date.format(date, "Y-m-d H:i:s");
+                    {text: t("date"), width:150, sortable: true, dataIndex: 'date', filter: 'date', renderer: function(d) {
+                        return Ext.Date.format(d, "Y-m-d H:i:s");
                     }},
                     {text: "ID", sortable: true, dataIndex: 'id', editable: false, width: 60},
-                    {text: t("user"), sortable: true, dataIndex: 'name'},
+                    {text: t("user"), sortable: true, dataIndex: 'name', filter: 'list'},
                     {text: t("scheduled"), width:130, sortable: true, dataIndex: 'scheduled', renderer: function(d) {
                         if (d != null){
                         	var date = new Date(d * 1000);
                             return Ext.Date.format(date, "Y-m-d H:i:s");
                     	}
                     }, editable: false},
-                    {text: t("note"), sortable: true, dataIndex: 'note', editor: new Ext.form.TextField(), renderer: Ext.util.Format.htmlEncode}
+                    {text: t("note"), sortable: true, dataIndex: 'note', editor: new Ext.form.TextField(), filter: 'string', renderer: Ext.util.Format.htmlEncode}
                 ],
                 stripeRows: true,
                 width: 450,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/versions.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/versions.js
@@ -26,7 +26,7 @@ pimcore.document.versions = Class.create({
             if (!Ext.ClassManager.get(modelName)) {
                 Ext.define(modelName, {
                     extend: 'Ext.data.Model',
-                    fields: ['id', 'date', 'note', {
+                    fields: ['id', { name: "date", type: 'date', dateFormat: 'timestamp' }, 'note', {
                         name: 'name', convert: function (v, rec) {
                             if (rec.data) {
                                 if (rec.data.user) {
@@ -94,7 +94,7 @@ pimcore.document.versions = Class.create({
 
             this.grid = Ext.create('Ext.grid.Panel', {
                 store: this.store,
-                plugins: [this.cellEditing],
+                plugins: [this.cellEditing, 'gridfilters'],
                 columns: [
                     checkShow,
                     {
@@ -121,13 +121,12 @@ pimcore.document.versions = Class.create({
                         editable: false
                     },
                     {
-                        text: t("date"), width: 150, sortable: true, dataIndex: 'date', renderer: function (d) {
-                            var date = new Date(d * 1000);
-                            return Ext.Date.format(date, "Y-m-d H:i:s");
+                        text: t("date"), width: 150, sortable: true, dataIndex: 'date', filter: 'date', renderer: function (d) {
+                            return Ext.Date.format(d, "Y-m-d H:i:s");
                         }, editable: false
                     },
                     {text: "ID", sortable: true, dataIndex: 'id', editable: false, width: 60},
-                    {text: t("user"), sortable: true, dataIndex: 'name', editable: false},
+                    {text: t("user"), sortable: true, dataIndex: 'name', editable: false, filter: 'list'},
                     {
                         text: t("scheduled"),
                         width: 130,
@@ -142,7 +141,7 @@ pimcore.document.versions = Class.create({
                         },
                         editable: false
                     },
-                    {text: t("note"), sortable: true, dataIndex: 'note', editor: new Ext.form.TextField(), renderer: Ext.util.Format.htmlEncode},
+                    {text: t("note"), sortable: true, dataIndex: 'note', editor: new Ext.form.TextField(), filter: 'string', renderer: Ext.util.Format.htmlEncode},
                     {
                         xtype: "checkcolumn",
                         text: t("auto_save"),
@@ -151,7 +150,7 @@ pimcore.document.versions = Class.create({
                         width: 50
                     },
                     checkPublic,
-                    {text: t("public_url"), width: 300, sortable: false, dataIndex: 'publicurl', editable: false}
+                    {text: t("public_url"), width: 300, sortable: false, dataIndex: 'publicurl', filter: 'string', editable: false}
                 ],
                 columnLines: true,
                 trackMouseOver: true,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/versions.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/versions.js
@@ -26,7 +26,7 @@ pimcore.object.versions = Class.create({
             if (!Ext.ClassManager.get(modelName)) {
                 Ext.define(modelName, {
                     extend: 'Ext.data.Model',
-                    fields: ['id', 'date', 'scheduled', 'note', {
+                    fields: ['id', { name: "date", type: 'date', dateFormat: 'timestamp' }, 'scheduled', 'note', {
                         name: 'name', convert: function (v, rec) {
                             if (rec.data) {
                                 if (rec.data.user) {
@@ -76,7 +76,7 @@ pimcore.object.versions = Class.create({
 
             var grid = Ext.create('Ext.grid.Panel', {
                 store: this.store,
-                plugins: [this.cellEditing],
+                plugins: [this.cellEditing, 'gridfilters'],
                 columns: [
                     {
                         text: t("published"),
@@ -100,13 +100,12 @@ pimcore.object.versions = Class.create({
                         editable: false
                     },
                     {
-                        text: t("date"), width: 150, sortable: true, dataIndex: 'date', renderer: function (d) {
-                            var date = new Date(d * 1000);
-                            return Ext.Date.format(date, "Y-m-d H:i:s");
+                        text: t("date"), width: 150, sortable: true, dataIndex: 'date', filter: 'date', renderer: function (d) {
+                            return Ext.Date.format(d, "Y-m-d H:i:s");
                         }
                     },
                     {text: "ID", sortable: true, dataIndex: 'id', editable: false, width: 60},
-                    {text: t("user"), sortable: true, dataIndex: 'name'},
+                    {text: t("user"), sortable: true, dataIndex: 'name', filter: 'list'},
                     {
                         text: t("scheduled"),
                         width: 130,
@@ -120,7 +119,7 @@ pimcore.object.versions = Class.create({
                         },
                         editable: false
                     },
-                    {text: t("note"), sortable: true, dataIndex: 'note', editor: new Ext.form.TextField(), renderer: Ext.util.Format.htmlEncode},
+                    {text: t("note"), sortable: true, dataIndex: 'note', filter: 'string', editor: new Ext.form.TextField(), renderer: Ext.util.Format.htmlEncode},
                     {
                         xtype: "checkcolumn",
                         text: t("auto_save"),


### PR DESCRIPTION
Depending on how many versions are to be kept an element's version list can become quite long. This PR adds grid filters in the version tabs for data objects, assets and documents for the columns Date, User, Note (plus Public URL for documents):
<img width="627" alt="Bildschirmfoto 2022-02-16 um 14 20 16" src="https://user-images.githubusercontent.com/8749138/154273302-b166f0de-56db-433e-9fc3-d27d55868dcc.png">
 