### PR TITLE
[Improvement] Add attribute level placeholders support in index-service config

### DIFF
--- a/bundles/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
+++ b/bundles/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
@@ -733,6 +733,22 @@ final class Configuration implements ConfigurationInterface
                             $config = $this->tenantProcessor->mergeTenantConfig($v);
 
                             foreach ($config as $tenant => $tenantConfig) {
+                                /* merge attributes placeholders */
+                                foreach ($tenantConfig["attributes"] as $attribute => $attributeConfig) {
+                                    if (isset($attributeConfig['placeholders']) && is_array($attributeConfig['placeholders']) && count($attributeConfig['placeholders']) > 0) {
+                                        $placeholders = $attributeConfig['placeholders'];
+
+                                        // remove placeholders while replacing as we don't want to replace the placeholders
+                                        unset($attributeConfig['placeholders']);
+
+                                        $config[$tenant]['attributes'][$attribute] = $this->placeholderProcessor->mergePlaceholders($attributeConfig, $placeholders);
+
+                                        // re-add placeholders
+                                        $config[$tenant]['attributes'][$attribute]['placeholders'] = $placeholders;
+                                    }
+                                }
+                                
+                                /* merge tenant placeholders */
                                 if (isset($tenantConfig['placeholders']) && is_array($tenantConfig['placeholders']) && count($tenantConfig['placeholders']) > 0) {
                                     $placeholders = $tenantConfig['placeholders'];
 

--- a/bundles/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
+++ b/bundles/EcommerceFrameworkBundle/DependencyInjection/Configuration.php
@@ -734,7 +734,7 @@ final class Configuration implements ConfigurationInterface
 
                             foreach ($config as $tenant => $tenantConfig) {
                                 /* merge attributes placeholders */
-                                foreach ($tenantConfig["attributes"] as $attribute => $attributeConfig) {
+                                foreach ($tenantConfig["attributes"] ?? [] as $attribute => $attributeConfig) {
                                     if (isset($attributeConfig['placeholders']) && is_array($attributeConfig['placeholders']) && count($attributeConfig['placeholders']) > 0) {
                                         $placeholders = $attributeConfig['placeholders'];
 
@@ -742,11 +742,13 @@ final class Configuration implements ConfigurationInterface
                                         unset($attributeConfig['placeholders']);
 
                                         $config[$tenant]['attributes'][$attribute] = $this->placeholderProcessor->mergePlaceholders($attributeConfig, $placeholders);
-
+                                        
                                         // re-add placeholders
                                         $config[$tenant]['attributes'][$attribute]['placeholders'] = $placeholders;
                                     }
                                 }
+
+                                $tenantConfig = $config[$tenant]; // update tenantConfig by attribute placeholders
                                 
                                 /* merge tenant placeholders */
                                 if (isset($tenantConfig['placeholders']) && is_array($tenantConfig['placeholders']) && count($tenantConfig['placeholders']) > 0) {
@@ -868,6 +870,19 @@ final class Configuration implements ConfigurationInterface
                                         ->scalarNode('interpreter_id')->defaultNull()->info('Service id of interpreter for this field')->end()
                                         ->append($this->buildOptionsNode('interpreter_options'))
                                         ->booleanNode('hide_in_fieldlist_datatype')->defaultFalse()->info('Hides field in field list selection data type of filter service - default to false')->end()
+                                        ->arrayNode('placeholders')
+                                            ->info('Placeholder values in this attribute definition (locale: "%%locale%%") will be replaced by the given placeholder value (eg. "de_AT")')
+                                            ->example([
+                                                'placeholders' => [
+                                                    '%%locale%%' => 'de_AT',
+                                                ],
+                                            ])
+                                            ->defaultValue([])
+                                            ->beforeNormalization()
+                                                ->castToArray()
+                                            ->end()
+                                            ->prototype('scalar')->end()
+                                        ->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/README.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/README.md
@@ -63,7 +63,33 @@ pimcore_ecommerce_framework:
                     seoname:
                         type: varchar(255)
                         filter_group: string
-                        
+            INT:
+                attributes:
+                    name_en: &name_en
+                        locale: '%%locale%%'
+                        filter_group: string
+                        placeholders:
+                            '%%locale%%': en
+            BE:
+                attributes:
+                    name_fr:
+                        <<: *name_en
+                        # placeholders will be replaced with the value defined here
+                        # attribute level placeholders will be processed before tenant level placeholders
+                        #
+                        # in this example, the "BE" (belgium) tenant will have the attributes "name_fr", "name_de" 
+                        # and "name_nl" referencing the same attribute config as tenant "INT" (international) 
+                        # with attribute "name_en", but using use "fr", "de" and "nl" as locale 
+                        placeholders:
+                            '%%locale%%': fr
+                    name_de:
+                        <<: *name_en
+                        placeholders:
+                            '%%locale%%': de
+                    name_nl:
+                        <<: *name_en
+                        placeholders:
+                            '%%locale%%': nl
             example_tenant:
                 attributes:                          
                     rucksacksLoad:


### PR DESCRIPTION
This PR adds support for placeholder on attribute level to the index-service config.

**Example**:

```
    pimcore_ecommerce_framework:
        index_service:
            tenants:
                 INT:
                     name_en: &name
                        locale: '%%locale%%'
                        filtergroup: string
                 BE:
                     name_fr:
                        <<: *name
                        placeholders:
                            '%%locale%%': fr
                    name_de:
                        <<: *name
                        placeholders:
                            '%%locale%%': de
                    name_nl:
                        <<: *name
                        placeholders:
                            '%%locale%%': nl
```