### PR TITLE
Fixed guessing mime types on temp files

### DIFF
--- a/bundles/CoreBundle/EventListener/AssetSanitizationListener.php
+++ b/bundles/CoreBundle/EventListener/AssetSanitizationListener.php
@@ -47,11 +47,14 @@ class AssetSanitizationListener implements EventSubscriberInterface
 
             if (isset($assetStream)) {
                 $streamMetaData = stream_get_meta_data($assetStream);
-                $mime = MimeTypes::getDefault()->guessMimeType($streamMetaData['uri']);
+                
+                if ($streamMetaData['uri'] !== 'php://temp') {
+                    $mime = MimeTypes::getDefault()->guessMimeType($streamMetaData['uri']);
 
-                if ($mime === 'image/svg+xml') {
-                    $sanitizedData = $this->sanitizeSVG(stream_get_contents($assetStream));
-                    $element->setData($sanitizedData);
+                    if ($mime === 'image/svg+xml') {
+                        $sanitizedData = $this->sanitizeSVG(stream_get_contents($assetStream));
+                        $element->setData($sanitizedData);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Changes in this pull request  
Im using the flysystem with the google cloud storage adapter. When you copy a folder or file to another place the following error is thrown: `The "php://temp" file does not exist or is not readable.`  This is because of the new SVG sanitation https://github.com/pimcore/pimcore/pull/11386 

I have added a small check to see if the current stream is a temp stream, since we can't read the mime type of a temp stream. 

