### PR TITLE
Delete temporary files when calling Pimcore::collectGarbage()

### DIFF
--- a/doc/Development_Documentation/05_Objects/05_External_System_Interaction.md
+++ b/doc/Development_Documentation/05_Objects/05_External_System_Interaction.md
@@ -112,7 +112,7 @@ You can pass in a string instead of an array if you only want to supply a single
 
 ## Temporary files
 
-Temporary files which get created during processing are usually deleted when the current process finishes. In some cases this may be a problem when thousands of temporary files get created during processing of the current request. If you want to clear temporary files before the script ends, you can call
+Temporary files which get created during processing are usually deleted when the current process finishes. In some cases this may be a problem when thousands of temporary files get created within a process. If you want to clear temporary files before the script ends, you can call
 ```php
 \Pimcore::deleteTemporaryFiles();
 ```

--- a/doc/Development_Documentation/05_Objects/05_External_System_Interaction.md
+++ b/doc/Development_Documentation/05_Objects/05_External_System_Interaction.md
@@ -86,8 +86,7 @@ For simple CSV exports, Pimcore backend interface provides a CSV export function
  
  
 ## Memory Issues
-If you're using / creating very much objects you should call the Pimcore garbage collector after several cycle to 
-prevent memory issues
+If you're using / creating very much objects you should call the Pimcore garbage collector after several cycles to prevent memory issues
 
 ```php
 // just call this static method
@@ -110,3 +109,10 @@ $longRunningHelper->removePimcoreRuntimeCacheProtectedItems(["myVeryImportantKey
 
 ```
 You can pass in a string instead of an array if you only want to supply a single key.
+
+## Temporary files
+
+Temporary files which get created during processing are usually deleted when the current process finishes. In some cases this may be a problem when thousands of temporary files get created during processing of the current request. If you want to clear temporary files before the script ends, you can call
+```php
+\Pimcore::deleteTemporaryFiles();
+```

--- a/lib/Helper/LongRunningHelper.php
+++ b/lib/Helper/LongRunningHelper.php
@@ -38,7 +38,7 @@ final class LongRunningHelper
     protected $monologHandlers = [];
 
     /** @var string[] */
-    protected static $tmpFilePaths = [];
+    protected $tmpFilePaths = [];
 
     /**
      * LongRunningHelper constructor.
@@ -160,14 +160,14 @@ final class LongRunningHelper
     /**
      * Register a temp file which will be deleted on next call of cleanUp()
      */
-    public static function addTmpFilePath(string $tmpFilePath) {
-        self::$tmpFilePaths[] = $tmpFilePath;
+    public function addTmpFilePath(string $tmpFilePath) {
+        $this->tmpFilePaths[] = $tmpFilePath;
     }
 
     public function deleteTemporaryFiles() {
-        foreach (self::$tmpFilePaths as $tmpFilePath) {
+        foreach ($this->tmpFilePaths as $tmpFilePath) {
             @unlink($tmpFilePath);
         }
-        self::$tmpFilePaths = [];
+        $this->tmpFilePaths = [];
     }
 }

--- a/lib/Helper/LongRunningHelper.php
+++ b/lib/Helper/LongRunningHelper.php
@@ -37,6 +37,9 @@ final class LongRunningHelper
 
     protected $monologHandlers = [];
 
+    /** @var string[] */
+    protected static $tmpFilePaths = [];
+
     /**
      * LongRunningHelper constructor.
      *
@@ -56,6 +59,7 @@ final class LongRunningHelper
         $this->cleanupMonolog();
         $this->cleanupPimcoreRuntimeCache($options);
         $this->triggerPhpGarbageCollector();
+        $this->deleteTemporaryFiles();
     }
 
     protected function cleanupDoctrine()
@@ -152,5 +156,19 @@ final class LongRunningHelper
         }
 
         return [];
+    }
+
+    /**
+     * Register a temp file which will be deleted on next call of cleanUp()
+     */
+    public static function addTmpFilePath(string $tmpFilePath) {
+        self::$tmpFilePaths[] = $tmpFilePath;
+    }
+
+    private function deleteTemporaryFiles() {
+        foreach (self::$tmpFilePaths as $tmpFilePath) {
+            @unlink($tmpFilePath);
+        }
+        self::$tmpFilePaths = [];
     }
 }

--- a/lib/Helper/LongRunningHelper.php
+++ b/lib/Helper/LongRunningHelper.php
@@ -158,6 +158,7 @@ final class LongRunningHelper
     }
 
     /**
+     * @internal
      * Register a temp file which will be deleted on next call of cleanUp()
      */
     public static function addTmpFilePath(string $tmpFilePath) {

--- a/lib/Helper/LongRunningHelper.php
+++ b/lib/Helper/LongRunningHelper.php
@@ -59,7 +59,6 @@ final class LongRunningHelper
         $this->cleanupMonolog();
         $this->cleanupPimcoreRuntimeCache($options);
         $this->triggerPhpGarbageCollector();
-        $this->deleteTemporaryFiles();
     }
 
     protected function cleanupDoctrine()
@@ -165,7 +164,7 @@ final class LongRunningHelper
         self::$tmpFilePaths[] = $tmpFilePath;
     }
 
-    private function deleteTemporaryFiles() {
+    public function deleteTemporaryFiles() {
         foreach (self::$tmpFilePaths as $tmpFilePath) {
             @unlink($tmpFilePath);
         }

--- a/lib/Helper/TemporaryFileHelperTrait.php
+++ b/lib/Helper/TemporaryFileHelperTrait.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Helper;
 
+use Pimcore;
 use Pimcore\File;
 
 /**
@@ -75,7 +76,9 @@ trait TemporaryFileHelperTrait
         fclose($dest);
 
         if (!$keep) {
-            LongRunningHelper::addTmpFilePath($tmpFilePath);
+            /** @var LongRunningHelper $longRunningHelper */
+            $longRunningHelper = Pimcore::getContainer()->get(LongRunningHelper::class);
+            $longRunningHelper->addTmpFilePath($tmpFilePath);
             register_shutdown_function(static function () use ($tmpFilePath) {
                 @unlink($tmpFilePath);
             });

--- a/lib/Helper/TemporaryFileHelperTrait.php
+++ b/lib/Helper/TemporaryFileHelperTrait.php
@@ -75,6 +75,7 @@ trait TemporaryFileHelperTrait
         fclose($dest);
 
         if (!$keep) {
+            LongRunningHelper::addTmpFilePath($tmpFilePath);
             register_shutdown_function(static function () use ($tmpFilePath) {
                 @unlink($tmpFilePath);
             });

--- a/lib/Maintenance/Tasks/LowQualityImagePreviewTask.php
+++ b/lib/Maintenance/Tasks/LowQualityImagePreviewTask.php
@@ -79,6 +79,7 @@ class LowQualityImagePreviewTask implements TaskInterface
                     }
                 }
                 \Pimcore::collectGarbage();
+                \Pimcore::deleteTemporaryFiles();
             }
         } else {
             $this->logger->debug('Skip low quality image preview execution, was done within the last 24 hours');

--- a/lib/Pimcore.php
+++ b/lib/Pimcore.php
@@ -217,6 +217,18 @@ class Pimcore
     }
 
     /**
+     * Deletes temporary files which got created during the runtime of current process
+     *
+     * @static
+     */
+    public static function deleteTemporaryFiles()
+    {
+        /** @var \Pimcore\Helper\LongRunningHelper $longRunningHelper */
+        $longRunningHelper = self::getContainer()->get(\Pimcore\Helper\LongRunningHelper::class);
+        $longRunningHelper->deleteTemporaryFiles();
+    }
+
+    /**
      * this method is called with register_shutdown_function() and writes all data queued into the cache
      *
      * @internal


### PR DESCRIPTION
For long-running processes from a lot of places `\Pimcore::collectGarbage()` gets called. This clears up some resources but it currently does not remove temporary files which got created by 
https://github.com/pimcore/pimcore/blob/e05650390cb6e515fe3f37afeb5ef995eda10f80/lib/Helper/TemporaryFileHelperTrait.php#L56-L84

This may become a problem for jobs with lots of such temporary files like https://github.com/pimcore/pimcore/blob/e05650390cb6e515fe3f37afeb5ef995eda10f80/lib/Maintenance/Tasks/LowQualityImagePreviewTask.php#L57-L82

In worst case this maintenance task will copy *all* asset files to `PIMCORE_SYSTEM_TEMP_DIRECTORY` and will only delete them when the whole script is finished. This means that you need at least the same amount of hard disk space as the assets already consume.

With this PR temporary files will get deleted when calling `\Pimcore::collectGarbage()`.