### PR TITLE
[Console::getExecutable()] Search for executables also outside open_basedir folders

### DIFF
--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -125,6 +125,16 @@ final class Console
 
                 $executableFinder = new ExecutableFinder();
                 $fullQualifiedPath = $executableFinder->find($executablePath);
+
+                if(!$fullQualifiedPath) {
+                    $checkCmd = 'which '.escapeshellarg($executablePath);
+                    if (self::getSystemEnvironment() === 'windows') {
+                        $checkCmd = 'where '.escapeshellarg($path).':'.$name;
+                    }
+                    $fullQualifiedPath = shell_exec($checkCmd.' '.$executablePath);
+                    $fullQualifiedPath = trim(strtok($fullQualifiedPath, "\n")); // get the first line/result
+                }
+
                 if ($fullQualifiedPath) {
                     if (!$customCheckMethod || self::$customCheckMethod($executablePath)) {
                         self::$executableCache[$name] = $fullQualifiedPath;


### PR DESCRIPTION
Currently executables which are not in a directory which is allowed in PHP's `open_basedir` setting do not get found. I already described this in https://github.com/symfony/symfony/issues/41006#issuecomment-971419456 and fixed it for PHP binary in #10843

But for other executables this problem still exists. Imho `open_basedir` defines from which folders PHP is allowed to read files. But we do not want to read a file from there but we want to get the executable path and execute it independent of PHP.

For this reason I added the code from https://github.com/pimcore/pimcore/blob/01ae62571cb2d738cc9b166dad7b0622ab5cbc1d/lib/Tool/Console.php#L112-L118 to `Console::getExecutable()`.