### PR TITLE
[Voucher] Add null check and default value for statistic usages

### DIFF
--- a/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/Single.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/TokenManager/Single.php
@@ -185,7 +185,8 @@ class Single extends AbstractTokenManager implements ExportableTokenManagerInter
     public function getStatistics($usagePeriod = null)
     {
         $overallCount = (int) $this->configuration->getUsages();
-        $usageCount = Token::getByCode($this->configuration->getToken())->getUsages();
+        $token = Token::getByCode($this->configuration->getToken());
+        $usageCount = $token instanceof Token ? $token->getUsages() : 0;
         $reservedTokenCount = (int) Token\Listing::getCountByReservation($this->seriesId);
 
         $usage = Statistic::getBySeriesId($this->seriesId, $usagePeriod);


### PR DESCRIPTION
## Changes in this pull request  

After the creation of an OnlineShopVoucherSeries object in the Pimcore admin-backend, the voucher details page throws a "call on null" exception. This PR checks for this exception and adds the default value of 0 (zero) to the usage count.

## Additional info 

Recreate the problem in the Pimcore-demo instance:

- create a new OnlineShopVoucherSeries object
- fill in SingleType token settings, save, and reload. E.g.:
![image](https://user-images.githubusercontent.com/23225429/155307451-0f19eb0a-efa3-44e9-b9dd-11750f72c9a8.png)

- on the tab "Voucher details" you will see a "500 Internal Server Error"

![image](https://user-images.githubusercontent.com/23225429/155307686-3d28586f-6a2e-409d-b0a2-d92d9e9dcadc.png)

