### PR TITLE
Fix Use current player position as preview for 0 second

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -1437,7 +1437,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }
 
         $time = null;
-        if ($request->get('time')) {
+        if (is_numeric($request->get('time'))) {
             $time = (int)$request->get('time');
         }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/translation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/translation.js
@@ -494,7 +494,7 @@ pimcore.settings.translation.domain = Class.create({
                             var csvSettings = Ext.encode(this.config.csvSettings);
                             ImportForm.getForm().submit({
                                 url: this.mergeUrl,
-                                params: {importFile: this.config.tmpFile, csvSettings: csvSettings, domain: this.domain},
+                                params: {csvSettings: csvSettings, domain: this.domain},
                                 waitMsg: t("please_wait"),
                                 success: function (el, response) {
                                     try {

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -210,7 +210,7 @@ class Ffmpeg extends Adapter
      */
     public function saveImage($file, $timeOffset = null)
     {
-        if (!$timeOffset) {
+        if (!is_numeric($timeOffset)) {
             $timeOffset = 5;
         }
 

--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -32,7 +32,7 @@ final class ImageThumbnail
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
     protected $timeOffset;
 
@@ -110,12 +110,12 @@ final class ImageThumbnail
 
             if (empty($this->pathReference)) {
                 $timeOffset = $this->timeOffset;
-                if (!$this->timeOffset && $cs) {
+                if (!is_numeric($timeOffset) && is_numeric($cs)) {
                     $timeOffset = $cs;
                 }
 
                 // fallback
-                if (!$timeOffset && $this->asset instanceof Model\Asset\Video) {
+                if (!is_numeric($timeOffset) && $this->asset instanceof Model\Asset\Video) {
                     $timeOffset = ceil($this->asset->getDuration() / 3);
                 }
 


### PR DESCRIPTION
Button "Use current player position as preview" does not work when player is stopped at a position under 1 second (0 second), that happens because in this case `$timeOffset = 0`, and it does not fulfil condition `if($timeOffset)`, so it is necessary to check if it is numeric instead.
<img width="1245" alt="player-position-preview" src="https://user-images.githubusercontent.com/6807023/155328913-944e48a4-88c3-4796-8740-623652852e35.png">

