### PR TITLE
[Asset folder] Go to list view if there are no previewable assets inside

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/folder.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/folder.js
@@ -62,6 +62,11 @@ pimcore.asset.folder = Class.create(pimcore.asset.asset, {
             fields: ['url', "filename", "filenameDisplay", "type", "id", "idPath"],
             listeners: {
                 "load": function () {
+                    if(this.store.getCount() === 0) {
+                        this.tabbar.setActiveItem(this.listfolder.getLayout());
+                        this.tabbar.remove(this.dataview);
+                    }
+
                     try {
                         this.dataview.reload();
                     }


### PR DESCRIPTION
Currently when you open an asset folder which does not contain any previewable items, it looks like this:
<img width="659" alt="Bildschirmfoto 2022-02-24 um 08 27 11" src="https://user-images.githubusercontent.com/8749138/155477927-20d76f5c-d3d4-4f7e-80b9-ab17e7eff5e0.png">
The user might get the impression that the folder is empty.

With this PR if there are no previewable assets inside the folder, the list view will automatically get opened and the preview panel gets removed:
<img width="602" alt="Bildschirmfoto 2022-02-24 um 08 26 19" src="https://user-images.githubusercontent.com/8749138/155478129-6fdea23c-69c1-4d69-9a1b-d9d70027ef82.png">

