### PR TITLE
Added nullcheck before method_exists

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Interpreter/IdList.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Interpreter/IdList.php
@@ -31,11 +31,11 @@ class IdList implements InterpreterInterface
 
         if (is_array($value)) {
             foreach ($value as $val) {
-                if (method_exists($val, 'getId')) {
+                if ($val && method_exists($val, 'getId')) {
                     $ids[] = $val->getId();
                 }
             }
-        } elseif (method_exists($value, 'getId')) {
+        } elseif ($value && method_exists($value, 'getId')) {
             $ids[] = $value->getId();
         }
 


### PR DESCRIPTION
Breaks saving of objects that extend AbstractProduct but have no value for the index field which is interpreted as IdList.

This happens if an index is used for multiple object types which do not share some of the indexed fields.