### PR TITLE
Fix nice command

### DIFF
--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -386,7 +386,7 @@ final class Console
             if (is_string($cmd)) {
                 $cmd = $nice . ' -n 19 ' . $cmd;
             } elseif (is_array($cmd)) {
-                array_unshift($cmd, $nice, '-n 19');
+                array_unshift($cmd, $nice, '-n', '19');
             }
         }
     }


### PR DESCRIPTION
## Changes in this pull request  
When addLowProcessPriority method is called, it add the nice command and '-n 19' but when this is executed by Symfony/Process the execution fails throwing the error `nice: invalid number ' 19'` which seems to be failing because of the blank space before the number

## Additional info  
I found this problem when generating thumbnails from PDF and calling `saveImage()` in `lib/Document/Adapter/Ghostscript.php`
