### PR TITLE
missing callback on folder/links autosave

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/abstract.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/abstract.js
@@ -221,6 +221,7 @@ pimcore.element.abstract = Class.create({
         //do not run auto-save for types not supporting versions
         let nonVersionTypes = ['link', 'hardlink', 'folder'];
         if (this.data.type && in_array(this.data.type, nonVersionTypes)) {
+            typeof callback === 'function' && callback();
             return;
         }
 


### PR DESCRIPTION
fixes #11504

folder/links/hardlinks do not have autosave, but if it's enabled, there's a bug:

the callback in https://github.com/pimcore/pimcore/blob/81283dfa33051cc019ec3eb9cfc3bea940c3836e/bundles/AdminBundle/Resources/public/js/pimcore/element/abstract.js#L75
wasn't called, causing them to not close properly (at least on first click).