### PR TITLE
Respect manually set request attribute "_pimcore_frontend_request"

### DIFF
--- a/lib/Http/RequestHelper.php
+++ b/lib/Http/RequestHelper.php
@@ -140,8 +140,8 @@ class RequestHelper
         $request = $this->getRequest($request);
         $attribute = self::ATTRIBUTE_FRONTEND_REQUEST;
 
-        if ($request->attributes->has($attribute) && $request->attributes->get($attribute)) {
-            return true;
+        if ($request->attributes->has($attribute)) {
+            return (bool)$request->attributes->get($attribute);
         }
 
         $frontendRequest = $this->detectFrontendRequest($request);


### PR DESCRIPTION
Currently you cannot mark a HTTP request as non-frontend without the `RequestHelper` trying to detect it again (with hard-coded URL conditions), see https://github.com/pimcore/pimcore/blob/81ba8b753b8d8609eba67df1a18f57c0f4542add/lib/Http/RequestHelper.php#L138-L152

To reproduce bug, run following script:
```php
<?php
$request = new \Symfony\Component\HttpFoundation\Request;
$request->attributes->set(\Pimcore\Http\RequestHelper::ATTRIBUTE_FRONTEND_REQUEST, false);
\Pimcore::getContainer()->get('request_stack')->push($request);

var_dump(\Pimcore::getContainer()->get('pimcore.http.request_helper')->isFrontendRequest($request)); // outputs true
```
The reason why it returns `true` is on the one hand that the current attribute status gets only returned if it is `true` (see `if ($request->attributes->has($attribute) && $request->attributes->get($attribute))`) and on the other hand that https://github.com/pimcore/pimcore/blob/81ba8b753b8d8609eba67df1a18f57c0f4542add/lib/Http/RequestHelper.php#L161-L180 does not check for request context (whose config comes from https://github.com/pimcore/pimcore/blob/81ba8b753b8d8609eba67df1a18f57c0f4542add/bundles/CoreBundle/Resources/config/pimcore/default.yaml#L238-L248 and could be extended but the hard-coded list in `RequestHelper::detectFrontendRequest()` cannot).