### PR TITLE
[Application logger] Correct log file object path if PIMCORE_PROJECT_ROOT is /app

### DIFF
--- a/lib/Log/FileObject.php
+++ b/lib/Log/FileObject.php
@@ -67,7 +67,7 @@ final class FileObject
      */
     public function getFilename()
     {
-        return str_replace(PIMCORE_PROJECT_ROOT.'/', '', $this->filename);
+        return preg_replace('/^'.preg_quote(\PIMCORE_PROJECT_ROOT, '/').'/', '', $this->filename);
     }
 
     /**


### PR DESCRIPTION
Imagine you have an `ApplicationLogger` log with `logFileObject=var/application-logger/3/620e5330c29b24.63887070`

When PIMCORE_PROJECT_ROOT is `/app` then the current replacement in https://github.com/pimcore/pimcore/blob/131ec1750f20b35142afeb4d1a0addeb1edfd38c/lib/Log/FileObject.php#L70 will return the path `varlication-logger/3/620e5330c29b24.63887070`