### PR TITLE
[DOCS] Fix varaible name in explaining comment in the docs

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
@@ -129,7 +129,7 @@ server {
     location ~ ^/index\.php(/|$) {
         send_timeout 1800;
         fastcgi_read_timeout 1800;
-        # regex to split $uri to $fastcgi_script_name and $fastcgi_path
+        # regex to split $uri to $fastcgi_script_name and $fastcgi_path_info
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         # Check that the PHP script exists before passing it
         try_files $fastcgi_script_name =404;
@@ -404,7 +404,7 @@ server {
     location ~ ^/index\.php(/|$) {
         send_timeout 1800;
         fastcgi_read_timeout 1800;
-        # regex to split $uri to $fastcgi_script_name and $fastcgi_path
+        # regex to split $uri to $fastcgi_script_name and $fastcgi_path_info
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         # Check that the PHP script exists before passing it
         try_files $fastcgi_script_name =404;


### PR DESCRIPTION
## Changes in this pull request  

Fixes a variable name in the explaining comment of [fastcgi_split_path_info](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_split_path_info).