### PR TITLE
[Actions] Minio: switched to new config

### DIFF
--- a/.github/workflows/codeception.yml
+++ b/.github/workflows/codeception.yml
@@ -43,8 +43,10 @@ jobs:
                 ports:
                     - 9000:9000
                 env:
-                    MINIO_ACCESS_KEY: "${{ env.MINIO_ACCESS_KEY }}"
-                    MINIO_SECRET_KEY: "${{ env.MINIO_SECRET_KEY }}"
+                    MINIO_ROOT_USER: "${{ env.MINIO_ACCESS_KEY }}"
+                    MINIO_ROOT_PASSWORD: "${{ env.MINIO_SECRET_KEY }}"
+                    MINIO_SERVER_ACCESS_KEY: "${{ env.MINIO_ACCESS_KEY }}"
+                    MINIO_SERVER_SECRET_KEY: "${{ env.MINIO_SECRET_KEY }}"
                     MINIO_DEFAULT_BUCKETS: "asset,assetcache,thumbnail,version,recyclebin,admin"
                 options: --name minio-server
             redis:


### PR DESCRIPTION
Seems that there's a breaking change from version `2022.3.3` to `2022.3.5`, as they do not support the deprecated config anymore - at least it works with the new one 😉