### PR TITLE
[Documents] Fix deleting a brick does not delete its content

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -443,7 +443,8 @@ class PageController extends DocumentControllerBase
         $blockStateStackData = json_decode($request->get('blockStateStack'), true);
         $blockStateStack->loadArray($blockStateStackData);
 
-        $document = Document\PageSnippet::getById($request->get('documentId'));
+        $document = clone Document\PageSnippet::getById($request->get('documentId'));
+        $document->setEditables([]);
 
         $twig->addGlobal('document', $document);
         $twig->addGlobal('editmode', true);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #8122

## Additional info  
Steps to reproduce:
1. Add new Document with areablock editable.
2. Add a brick & data
3. Save and Reload Document 
4. Remove existing brick and re-add the same brick type on same index.