### PR TITLE
[Admin] Documents - Fix not possible to open documents in localhost -…

### DIFF
--- a/lib/Tool.php
+++ b/lib/Tool.php
@@ -395,7 +395,7 @@ final class Tool
     {
         $request = self::resolveRequest($request);
 
-        if (null === $request || !$request->getHost() || $request->getHost() === 'localhost') {
+        if (null === $request || !$request->getHost()) {
             $domain = \Pimcore\Config::getSystemConfiguration('general')['domain'];
 
             return $domain ?: null;


### PR DESCRIPTION
## Changes in this pull request  
Resolves #11590

## Additional info  
Reverted the change `$request->getHost() === 'localhost'` introduced in #11418 as it changes the behavior internally for calls to `Tool::getHostname()`. Before the change the `localhost` host was returned from the method and after it started returning `null` if there's no hostname set in the System Settings or configs, which in turn broke some functions.
