### PR TITLE
Added runtime exception if preg_match returns empty $matches

### DIFF
--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -116,6 +116,10 @@ class PublicServicesController extends Controller
 
                     preg_match("@([^\@]+)(\@[0-9.]+x)?\.([a-zA-Z]{2,5})@", $filename, $matches);
 
+                    if (empty($matches) || ! isset($matches[1])) {
+                        throw new \RuntimeException('Requested asset does not exist');
+                    }
+
                     if (array_key_exists(2, $matches) && $matches[2]) {
                         $highResFactor = (float) str_replace(['@', 'x'], '', $matches[2]);
                         $thumbnailConfig->setHighResolution($highResFactor);


### PR DESCRIPTION
Hey Folks!

## Changes in this pull request  
Resolves the issue of receiving a 500 in backend if a user in frontend requests a non-existent image url.

For example the image 
https://www.baufritz.com/01_H%C3%A4user/Kundenh%C3%A4user/2004/Schauer/Bilder/image-thumb__3005__houseStage/22112005170126.jpg
does exist. Changing the name to a non-existing one returns a 404, which is great.

But requesting that URI without an image returns a 200 and internally creates a 500 due to the not existing key `$matches[1]`
https://www.baufritz.com/01_H%C3%A4user/Kundenh%C3%A4user/2004/Schauer/Bilder/image-thumb__3005__houseStage/

Now, with the runtimeException thrown the default behaviour of Pimcore is being set in motion (throws a 404 as it should).



p.s. keep going - I love pimcore :)
