### PR TITLE
[Tracking] Fix warning undefined array index in GoogleTagManager

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Tracking/Tracker/GoogleTagManager.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/Tracker/GoogleTagManager.php
@@ -321,7 +321,7 @@ class GoogleTagManager extends Tracker implements
 
     protected function getDeferredItems(string $dimension)
     {
-        return $this->deferred[$dimension];
+        return $this->deferred[$dimension] ?? null;
     }
 
     protected function consolidateDeferredDimensions()


### PR DESCRIPTION
Fixes Warning undefined array key "impressions".

`$this->deferred["impressions"]` is not always set

![image](https://user-images.githubusercontent.com/9052094/157240003-ef24969c-3811-4089-9d27-bae7bd06ac3e.png)
