### PR TITLE
Check if kernel has booted when checking availability of the container

### DIFF
--- a/lib/Pimcore.php
+++ b/lib/Pimcore.php
@@ -170,10 +170,12 @@ class Pimcore
     public static function hasContainer()
     {
         if (static::hasKernel()) {
-            $container = static::getContainer();
-            if ($container) {
-                return true;
-            }
+            try {
+                $container = static::getContainer();
+                if ($container) {
+                    return true;
+                }
+            } catch (\LogicException) {}
         }
 
         return false;


### PR DESCRIPTION
In my very specific use case, I'm trying to read class definition files before loading the kernel. When including php files of class definition some calls are made to the Pimcore Runtime cache. This is fine because the runtime cache exposes a method that checks if the container is available before trying to initialize the cache instance. 

The only problem is that `Symfony\Component\HttpKernel\Kernel::getContainer` throws an error when the kernel hasn't booted yet. Which in turn causes the runtime cache to fail. 

I have added a try catch clause to the hasContainer check to make sure the kernel has also booted.

