### PR TITLE
Remove javascript alert().

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/workflow/transitions.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/workflow/transitions.js
@@ -40,8 +40,5 @@ pimcore.workflow.transitions.perform = function (ctype, cid, elementEditor, work
 
 
         },
-        failure: function(res) {
-            alert('oh no!');
-        }
     });
 };


### PR DESCRIPTION
If an error occurs when changing a workflow place, a JavaScript alert is currently displayed.

My suggestion would be to delete the error handling here altogether, because I can't think of a sensible way to handle it either. A server error is displayed to the user anyway.