### PR TITLE
[Ecommerce] Fix warning: Undefined array key "key" in ElasticSearch ProductList

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -1252,7 +1252,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     protected function convertBucketValues(array $bucket)
     {
         $data = [
-            'value' => $bucket['key'],
+            'value' => $bucket['key'] ?? null,
             'count' => $bucket['doc_count'],
         ];
 


### PR DESCRIPTION
Fix warning 
> Warning: Undefined array key "key" File: /var/www/html/vendor/pimcore/pimcore/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php Line: 1255

For range aggregation the `key` may not be set, but `from` and `to` for example.