### PR TITLE
[Fix] create language inherited child didn't set the controller & template

### DIFF
--- a/models/Document/DocType.php
+++ b/models/Document/DocType.php
@@ -117,6 +117,10 @@ class DocType extends Model\AbstractModel
      */
     public static function getById($id)
     {
+        if (empty($id)) {
+            return null;
+        }
+
         try {
             $docType = new self();
             $docType->getDao()->getById($id);

--- a/models/Document/DocType/Dao.php
+++ b/models/Document/DocType/Dao.php
@@ -45,27 +45,22 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
      *
      * @throws \Exception
      */
-    public function getById($id = null)
+    public function getById(?string $id = null): void
     {
-        if (empty($id)) {
-            return null;
+        $data = null;
+        if ($id !== null) {
+            $data = $this->getDataByName($id);
         }
 
-        $this->model->setId($id);
-        $data = $this->getDataByName($this->model->getId());
-
-        if ($data && $id != null) {
-            $data['id'] = $id;
-        }
-
-        if ($data) {
-            $this->assignVariablesToModel($data);
-        } else {
+        if (empty($data)) {
             throw new Model\Exception\NotFoundException(sprintf(
                 'Document Type with ID "%s" does not exist.',
                 $this->model->getId()
             ));
         }
+
+        $data['id'] = $id;
+        $this->assignVariablesToModel($data);
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
Resolves bug #11507

## Additional info  
Related snippet from DocumentController::addAction():

```
$docType = Document\DocType::getById($request->get('docTypeId'));
if ($docType) {
   // ...
} elseif ($request->get('translationsBaseDocument')) {
    // This section was never reached because $docType was always a DocType object
    $translationsBaseDocument = Document::getById($request->get('translationsBaseDocument'));
    if ($translationsBaseDocument instanceof Document\PageSnippet) {
        $createValues['template'] = $translationsBaseDocument->getTemplate();
        $createValues['controller'] = $translationsBaseDocument->getController();
    }
}
```

## Note
Seems that this bug is introduced in f008e2b973f1ffbad20f982f70230287df1a18d9 - not 100% sure this is the right fix to this but I assume that change was also done for a reason