### PR TITLE
Set _locale when handling slug route

### DIFF
--- a/lib/Routing/Dynamic/DataObjectRouteHandler.php
+++ b/lib/Routing/Dynamic/DataObjectRouteHandler.php
@@ -125,9 +125,10 @@ final class DataObjectRouteHandler implements DynamicRouteHandlerInterface
         preg_match("/\/(\w+)\/.*/", $slugUrl, $matches);
 
         if (is_array($matches) && count($matches) === 2) {
-            // TODO check, whether locale is valid. Own SluggableInterface implementations may have
-            // other patterns
-            $route->setDefault('_locale', $matches[1]);
+            $validLanguages = \Pimcore\Tool::getValidLanguages();
+            if (\in_array($matches[1], $validLanguages, true)) {
+                $route->setDefault('_locale', $matches[1]);
+            }
         }
     }
 }

--- a/lib/Routing/Dynamic/DataObjectRouteHandler.php
+++ b/lib/Routing/Dynamic/DataObjectRouteHandler.php
@@ -111,6 +111,23 @@ final class DataObjectRouteHandler implements DynamicRouteHandlerInterface
             $this->config['routing']['allow_processing_unpublished_fallback_document']
         );
 
+        $this->matchLocale($route, $slug);
+
         return $route;
+    }
+
+    private function matchLocale(DataObjectRoute $route, DataObject\Data\UrlSlug $slug)
+    {
+        if (!$slugUrl = $slug->getSlug()) {
+            return;
+        }
+
+        preg_match("/\/(\w+)\/.*/", $slugUrl, $matches);
+
+        if (is_array($matches) && count($matches) === 2) {
+            // TODO check, whether locale is valid. Own SluggableInterface implementations may have
+            // other patterns
+            $route->setDefault('_locale', $matches[1]);
+        }
     }
 }


### PR DESCRIPTION
## Changes in this pull request and Additional info
When processing a DataObject with a slugged route, AND the route contains a locale part, then the locale is never processed.

This PR add's some funtionality, like the \Pimcore\Model\Staticroute::match() does. If a static route has a `_locale` parameter and a proper pattern given, it will be resolved. This PR looks anly at the first part of the path of the url and uses it as `_locale`

Maybe the static route mechanism would make sense for slugs too, but this is out of my scope.

