### PR TITLE
[Assets] Use correct file extension when downloading svg image as jpg

### DIFF
--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -289,7 +289,7 @@ trait ImageThumbnailTrait
      */
     public function getFileExtension()
     {
-        return \Pimcore\File::getFileExtension($this->getPath(true));
+        return \Pimcore\File::getFileExtension($this->getFileSystemPath(true));
     }
 
     /**


### PR DESCRIPTION
Steps to reproduce bug:

1. Upload svg image to Pimcore assets
2. Open asset
3. On right side under "Custom download" select Format: JPG
4. Click Download

Currently you will get an svg file provided for download but it is actually a jpg with wrong file extension.