### PR TITLE
Update install.sql

### DIFF
--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -273,6 +273,7 @@ CREATE TABLE `email_log` (
   `bcc` longtext,
   `sentDate` int(11) UNSIGNED DEFAULT NULL,
   `subject` varchar(500) DEFAULT NULL,
+  `error` text, DEFAULT NULL, 
   PRIMARY KEY (`id`),
   KEY `sentDate` (`sentDate`, `id`),
   FULLTEXT KEY `fulltext` (`from`,`to`,`cc`,`bcc`,`subject`,`params`),

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -273,7 +273,7 @@ CREATE TABLE `email_log` (
   `bcc` longtext,
   `sentDate` int(11) UNSIGNED DEFAULT NULL,
   `subject` varchar(500) DEFAULT NULL,
-  `error` text, DEFAULT NULL, 
+  `error` text DEFAULT NULL, 
   PRIMARY KEY (`id`),
   KEY `sentDate` (`sentDate`, `id`),
   FULLTEXT KEY `fulltext` (`from`,`to`,`cc`,`bcc`,`subject`,`params`),


### PR DESCRIPTION
The 'error' field is missing. 
Without the field, errors while sending emails aren't get stored. As a result, it's not possible to see any errors in the Sent Emails Panel of the Newsletter module.

This is how it should look like, and does after adding the field and clearing cache.

![image](https://user-images.githubusercontent.com/20427487/158463638-be174a0c-856b-4866-a45c-a08e0858e8cd.png)

Please merge