### PR TITLE
Update 02_Nginx_Configuration.md

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
@@ -134,7 +134,7 @@ server {
         # Check that the PHP script exists before passing it
         try_files $fastcgi_script_name =404;
         # include fastcgi.conf if needed
-        #include fastcgi.conf;
+        include fastcgi.conf;
         # Bypass the fact that try_files resets $fastcgi_path_info
         # see: http://trac.nginx.org/nginx/ticket/321
         set $path_info $fastcgi_path_info;


### PR DESCRIPTION
In development config for nginx we have to set `include fastcgi.conf;` or else php is not working. 
Therefor i uncommented this line just like in production config.
