### PR TITLE
fix deadlock issues in classificationstore, fieldcollections and relations

### DIFF
--- a/models/DataObject/Classificationstore/Dao.php
+++ b/models/DataObject/Classificationstore/Dao.php
@@ -64,7 +64,11 @@ class Dao extends Model\Dao\AbstractDao
         $dataTable = $this->getDataTableName();
         $fieldname = $this->model->getFieldname();
 
-        $this->db->delete($dataTable, ['o_id' => $objectId, 'fieldname' => $fieldname]);
+        $dataExists = $this->db->fetchOne("SELECT count(*) c FROM `".$dataTable."` WHERE
+         `o_id` = '".$objectId."' AND `fieldname` = '".$fieldname."' ");
+        if($dataExists) {
+            $this->db->delete($dataTable, ['o_id' => $objectId, 'fieldname' => $fieldname]);
+        }
 
         $items = $this->model->getItems();
         $activeGroups = $this->model->getActiveGroups();
@@ -121,7 +125,11 @@ class Dao extends Model\Dao\AbstractDao
 
         $groupsTable = $this->getGroupsTableName();
 
-        $this->db->delete($groupsTable, ['o_id' => $objectId, 'fieldname' => $fieldname]);
+        $dataExists = $this->db->fetchOne("SELECT count(*) c FROM `".$groupsTable."` WHERE
+         `o_id` = '".$objectId."' AND `fieldname` = '".$fieldname."' ");
+        if($dataExists) {
+            $this->db->delete($groupsTable, ['o_id' => $objectId, 'fieldname' => $fieldname]);
+        }
 
         if (is_array($activeGroups)) {
             foreach ($activeGroups as $activeGroupId => $enabled) {

--- a/models/DataObject/Classificationstore/Dao.php
+++ b/models/DataObject/Classificationstore/Dao.php
@@ -64,8 +64,8 @@ class Dao extends Model\Dao\AbstractDao
         $dataTable = $this->getDataTableName();
         $fieldname = $this->model->getFieldname();
 
-        $dataExists = $this->db->fetchOne("SELECT count(*) c FROM `".$dataTable."` WHERE
-         `o_id` = '".$objectId."' AND `fieldname` = '".$fieldname."' ");
+        $dataExists = $this->db->fetchOne("SELECT `o_id` FROM `".$dataTable."` WHERE
+         `o_id` = '".$objectId."' AND `fieldname` = '".$fieldname."' LIMIT 1");
         if($dataExists) {
             $this->db->delete($dataTable, ['o_id' => $objectId, 'fieldname' => $fieldname]);
         }
@@ -125,8 +125,8 @@ class Dao extends Model\Dao\AbstractDao
 
         $groupsTable = $this->getGroupsTableName();
 
-        $dataExists = $this->db->fetchOne("SELECT count(*) c FROM `".$groupsTable."` WHERE
-         `o_id` = '".$objectId."' AND `fieldname` = '".$fieldname."' ");
+        $dataExists = $this->db->fetchOne("SELECT `o_id` FROM `".$groupsTable."` WHERE
+         `o_id` = '".$objectId."' AND `fieldname` = '".$fieldname."' LIMIT 1");
         if($dataExists) {
             $this->db->delete($groupsTable, ['o_id' => $objectId, 'fieldname' => $fieldname]);
         }

--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -231,7 +231,11 @@ class Dao extends Model\DataObject\AbstractObject\Dao
             $condition = '(' . $condition . ' AND ownerType != "localizedfield" AND ownerType != "fieldcollection")';
         }
 
-        $this->db->deleteWhere('object_relations_' . $this->model->getClassId(), $condition);
+        $dataExists = $this->db->fetchOne("SELECT count(*) c FROM `object_relations_". $this->model->getClassId()."`
+        WHERE ".$condition);
+        if($dataExists) {
+            $this->db->deleteWhere('object_relations_' . $this->model->getClassId(), $condition);
+        }
 
         $inheritedValues = DataObject::doGetInheritedValues();
         DataObject::setGetInheritedValues(false);

--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -231,8 +231,8 @@ class Dao extends Model\DataObject\AbstractObject\Dao
             $condition = '(' . $condition . ' AND ownerType != "localizedfield" AND ownerType != "fieldcollection")';
         }
 
-        $dataExists = $this->db->fetchOne("SELECT count(*) c FROM `object_relations_". $this->model->getClassId()."`
-        WHERE ".$condition);
+        $dataExists = $this->db->fetchOne("SELECT `src_id` FROM `object_relations_". $this->model->getClassId()."`
+        WHERE ".$condition ." LIMIT 1");
         if($dataExists) {
             $this->db->deleteWhere('object_relations_' . $this->model->getClassId(), $condition);
         }

--- a/models/DataObject/Fieldcollection/Dao.php
+++ b/models/DataObject/Fieldcollection/Dao.php
@@ -167,10 +167,14 @@ class Dao extends Model\Dao\AbstractDao
             $tableName = $definition->getTableName($object->getClass());
 
             try {
-                $this->db->delete($tableName, [
-                    'o_id' => $object->getId(),
-                    'fieldname' => $this->model->getFieldname(),
-                ]);
+                $dataExists = $this->db->fetchOne("SELECT count(*) c FROM `".$tableName."` WHERE
+         `o_id` = '".$object->getId()."' AND `fieldname` = '".$this->model->getFieldname()."' ");
+                if($dataExists) {
+                    $this->db->delete($tableName, [
+                        'o_id' => $object->getId(),
+                        'fieldname' => $this->model->getFieldname(),
+                    ]);
+                }
             } catch (\Exception $e) {
                 // create definition if it does not exist
                 $definition->createUpdateTable($object->getClass());
@@ -180,10 +184,14 @@ class Dao extends Model\Dao\AbstractDao
                 $tableName = $definition->getLocalizedTableName($object->getClass());
 
                 try {
-                    $this->db->delete($tableName, [
-                        'ooo_id' => $object->getId(),
-                        'fieldname' => $this->model->getFieldname(),
-                    ]);
+                    $dataExists = $this->db->fetchOne("SELECT count(*) c FROM `".$tableName."` WHERE
+         `ooo_id` = '".$object->getId()."' AND `fieldname` = '".$this->model->getFieldname()."' ");
+                    if($dataExists) {
+                        $this->db->delete($tableName, [
+                            'ooo_id' => $object->getId(),
+                            'fieldname' => $this->model->getFieldname(),
+                        ]);
+                    }
                 } catch (\Exception $e) {
                     Logger::error($e);
                 }

--- a/models/DataObject/Fieldcollection/Dao.php
+++ b/models/DataObject/Fieldcollection/Dao.php
@@ -167,8 +167,8 @@ class Dao extends Model\Dao\AbstractDao
             $tableName = $definition->getTableName($object->getClass());
 
             try {
-                $dataExists = $this->db->fetchOne("SELECT count(*) c FROM `".$tableName."` WHERE
-         `o_id` = '".$object->getId()."' AND `fieldname` = '".$this->model->getFieldname()."' ");
+                $dataExists = $this->db->fetchOne("SELECT `o_id` FROM `".$tableName."` WHERE
+         `o_id` = '".$object->getId()."' AND `fieldname` = '".$this->model->getFieldname()."' LIMIT 1");
                 if($dataExists) {
                     $this->db->delete($tableName, [
                         'o_id' => $object->getId(),
@@ -184,8 +184,8 @@ class Dao extends Model\Dao\AbstractDao
                 $tableName = $definition->getLocalizedTableName($object->getClass());
 
                 try {
-                    $dataExists = $this->db->fetchOne("SELECT count(*) c FROM `".$tableName."` WHERE
-         `ooo_id` = '".$object->getId()."' AND `fieldname` = '".$this->model->getFieldname()."' ");
+                    $dataExists = $this->db->fetchOne("SELECT `ooo_id` FROM `".$tableName."` WHERE
+         `ooo_id` = '".$object->getId()."' AND `fieldname` = '".$this->model->getFieldname()."' LIMIT 1 ");
                     if($dataExists) {
                         $this->db->delete($tableName, [
                             'ooo_id' => $object->getId(),


### PR DESCRIPTION
fix deadlock issues in classificationstore, fieldcollections and relations

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #8228 

## Additional info  

Delete without having the data and insertion on the same table creates gap lock which causes deadlock for parallel processing on the same class

Also, created another PR to fix in 6.9 for legacy codes #11688 
