### PR TITLE
[Asset] Thumbnails: small performance fix for exists()

### DIFF
--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -339,9 +339,16 @@ trait ImageThumbnailTrait
     public function exists(): bool
     {
         $pathReference = $this->getPathReference(true);
-        if ($pathReference['type'] === 'asset') {
+        if (
+            $pathReference['type'] === 'asset' ||
+            $pathReference['type'] === 'data-uri' ||
+            $pathReference['type'] === 'thumbnail'
+        ) {
             return true;
+        } elseif ($pathReference['type'] === 'deferred') {
+            return false;
         } elseif (isset($pathReference['storagePath'])) {
+            // this is probably redundant, but as it doesn't hurt we can keep it
             return Storage::get('thumbnail')->fileExists($pathReference['storagePath']);
         }
 


### PR DESCRIPTION
This fix saves one `fileExists()` call on the storage, which could slow down the performance when using remote storages. 