### PR TITLE
Fix - Name and Editable field of the targetGroup data type was not wo…

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/targetGroup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/targetGroup.js
@@ -41,7 +41,6 @@ pimcore.object.classes.data.targetGroup = Class.create(pimcore.object.classes.da
         initData.fieldtype = "targetGroup";
         initData.datatype = "data";
         initData.name = "targetGroup";
-        initData.noteditable = false;
         treeNode.set("text", "targetGroup");
 
         this.initData(initData);
@@ -51,6 +50,16 @@ pimcore.object.classes.data.targetGroup = Class.create(pimcore.object.classes.da
 
     getTypeName: function () {
         return t("target_group");
+    },
+
+    getLayout: function ($super) {
+
+        $super();
+
+        var nameField = this.layout.getComponent("standardSettings").getComponent("name");
+        nameField.disable();
+
+        return this.layout;
     },
 
     getGroup: function () {


### PR DESCRIPTION
Name and Editable field of the targetGroup data type was not working as expected

Actual behavior: It was not possible to edit the name of a targetGroup, but the field "name" was not disabled. And the field "editable" was always false even if we edit it to true/false.

Fix: Made the "targetGroup" field disabled and the "editable" field can be set to true/false.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

