### PR TITLE
Fix Admin QR Code Generator for use with Sites

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -401,7 +401,7 @@ class PageController extends DocumentControllerBase
             throw $this->createNotFoundException('Page not found');
         }
 
-        $url = $request->getScheme() . '://' . $request->getHttpHost() . $page->getFullPath();
+        $url = $page->getUrl();
 
         $result = Builder::create()
             ->writer(new PngWriter())


### PR DESCRIPTION
Update Admin PageController qrCodeAction() to generate correct URLs with server name as configured for current Site, if Sites feature is used

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [x] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

Steps to reproduce:
- Create site and enter domain name like "www.my-domain.com" for the Site
- Create a page within Site
- In Admin click on "Preview" and then on "QR Code"
- QR Code will use current server name, instead of the configured value "www.my-domain.com" from the Site
