### PR TITLE
Fix Symfony deprecations

### DIFF
--- a/bundles/CoreBundle/PimcoreCoreBundle.php
+++ b/bundles/CoreBundle/PimcoreCoreBundle.php
@@ -41,7 +41,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class PimcoreCoreBundle extends Bundle
 {
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         if (null === $this->extension) {
             $extension = $this->createContainerExtension();

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -84,16 +84,22 @@ abstract class Kernel extends SymfonyKernel
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
-    public function getProjectDir()
+    #[\ReturnTypeWillChange]
+    public function getProjectDir()// : string
     {
         return PIMCORE_PROJECT_ROOT;
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
-    public function getCacheDir()
+    #[\ReturnTypeWillChange]
+    public function getCacheDir()// : string
     {
         if (isset($_SERVER['APP_CACHE_DIR'])) {
             return $_SERVER['APP_CACHE_DIR'].'/'.$this->environment;
@@ -104,8 +110,11 @@ abstract class Kernel extends SymfonyKernel
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
-    public function getLogDir()
+    #[\ReturnTypeWillChange]
+    public function getLogDir()// : string
     {
         return PIMCORE_LOG_DIRECTORY;
     }


### PR DESCRIPTION
```
PHP Deprecated: Method "Symfony\Component\HttpKernel\Kernel::getProjectDir()" might add "string" as a native return type declaration in the future. Do the same in child class "Pimcore\Kernel" now to avoid errors or add an explicit @return annotation to suppress this message. in /var/www/html/vendor/symfony/error-handler/DebugClassLoader.php on line 325
PHP Deprecated: Method "Symfony\Component\HttpKernel\KernelInterface::getCacheDir()" might add "string" as a native return type declaration in the future. Do the same in implementation "Pimcore\Kernel" now to avoid errors or add an explicit @return annotation to suppress this message. in /var/www/html/vendor/symfony/error-handler/DebugClassLoader.php on line 325
PHP Deprecated: Method "Symfony\Component\HttpKernel\KernelInterface::getLogDir()" might add "string" as a native return type declaration in the future. Do the same in implementation "Pimcore\Kernel" now to avoid errors or add an explicit @return annotation to suppress this message. in /var/www/html/vendor/symfony/error-handler/DebugClassLoader.php on line 325
PHP Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtension()" might add "?ExtensionInterface" as a native return type declaration in the future. Do the same in child class "Pimcore\Bundle\CoreBundle\PimcoreCoreBundle" now to avoid errors or add an explicit @return annotation to suppress this message. in /var/www/html/vendor/symfony/error-handler/DebugClassLoader.php on line 325
```