### PR TITLE
Doc path forPublic tmp dir

### DIFF
--- a/doc/Development_Documentation/22_Administration_of_Pimcore/02_Cleanup_Data_Storage.md
+++ b/doc/Development_Documentation/22_Administration_of_Pimcore/02_Cleanup_Data_Storage.md
@@ -50,13 +50,13 @@ maintenance command: `./bin/console pimcore:maintenance -J logmaintenance`
 ## Temporary Files
 Pimcore stores temporary files in 2 different locations, depending on whether they are public accessible or not.   
 **Private temporary directory**: `var/tmp/`  
-Used for uploads, imports, exports, page, previews, ... 
-**Public temporary directory**: `web/var/tmp/`  
+Used for uploads, imports, exports, page, previews, ...  
+**Public temporary directory**: `public/var/tmp/`  
 Used for image/video/document thumbnails used in the web-application. 
   
  
 All temporary files can be deleted at any time.   
-**WARNING: Deleting all files in `web/var/tmp/` can have a huge impact on performance until all needed thumbnails are generated again.**
+**WARNING: Deleting all files in `public/var/tmp/` can have a huge impact on performance until all needed thumbnails are generated again.**
 
 ## Recycle Bin
 Deleting items in Pimcore moves them to the recycle bin first. The recycle bin works quite similar to the versioning, 


### PR DESCRIPTION
web/var/tmp/ path does not exist, it's public/var/tmp/

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

