### PR TITLE
[Asset folder preview] Respect limit / Prevent error "Maximum supported image dimension is 65500 pixels"

### DIFF
--- a/models/Asset/Folder.php
+++ b/models/Asset/Folder.php
@@ -139,7 +139,7 @@ class Folder extends Model\Asset
         $list->setOrder('asc');
         $list->setLimit($limit);
 
-        $totalImages = min($limit, $list->getTotalCount());
+        $totalImages = $list->getCount();
         $count = 0;
         $gutter = 5;
         $squareDimension = 130;

--- a/models/Asset/Folder.php
+++ b/models/Asset/Folder.php
@@ -139,7 +139,7 @@ class Folder extends Model\Asset
         $list->setOrder('asc');
         $list->setLimit($limit);
 
-        $totalImages = $list->getTotalCount();
+        $totalImages = min($limit, $list->getTotalCount());
         $count = 0;
         $gutter = 5;
         $squareDimension = 130;
@@ -183,7 +183,10 @@ class Folder extends Model\Asset
             if ($count) {
                 $localFile = File::getLocalTempFilePath('jpg');
                 imagejpeg($collage, $localFile, 60);
-                $storage->write($cacheFilePath, file_get_contents($localFile));
+
+                if(filesize($localFile) > 0) {
+                    $storage->write($cacheFilePath, file_get_contents($localFile));
+                }
                 unlink($localFile);
 
                 return $storage->readStream($cacheFilePath);


### PR DESCRIPTION
Steps to reproduce bug:
1. Create folder with at least 1440 images -> because then the image height will be > 65500 in https://github.com/pimcore/pimcore/blob/e8362bf58a6a8b7a63e21b24fe4410b9bd540938/models/Asset/Folder.php#L156
2. Call https://example.org/admin/asset/get-folder-thumbnail?id=123 (or move mouse cursor over the folder in PImcore backend (with enabled tree preview)

There will be the error `imagejpeg(): gd-jpeg: JPEG library reports unrecoverable error: Maximum supported image dimension is 65500 pixels`

The reason is that https://github.com/pimcore/pimcore/blob/e8362bf58a6a8b7a63e21b24fe4410b9bd540938/models/Asset/Listing/Dao.php#L101-L109 does not use the set `limit` but returns the *total* count.
I first wondered if we should differentiate between `$listing->getTotalCount()` and `$listing->count()`. Still not sure but this would be a big BC break, so I adjusted only `Folder::getPreviewImage()` to use the correct count.


The other change is that when anything goes wrong with folder thumbnail creation and thus thumbnail file size will be zero, we do not store it to thumbnail storage because otherwise it is tried to load this 0-byte-image in https://github.com/pimcore/pimcore/blob/e8362bf58a6a8b7a63e21b24fe4410b9bd540938/models/Asset/Folder.php#L134-L139