### PR TITLE
[Calculated value] Prevent entering an undefined calculated value field type

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/calculatedValue.js
@@ -88,6 +88,8 @@ pimcore.object.classes.data.calculatedValue = Class.create(pimcore.object.classe
                 name: "elementType",
                 value: this.datax.elementType,
                 labelWidth: 140,
+                forceSelection: true,
+
                 store: [
                     ['input', t('input')],
                     ['textarea', t('textarea')],


### PR DESCRIPTION
Steps to reproduce:
1. Create data object class with calculaterd value field
2. In field `Type` type "invalid"
3. Save class
4. Reload class definition -> Field type "invalid" is really saved

For good luck https://github.com/pimcore/pimcore/blob/e8362bf58a6a8b7a63e21b24fe4410b9bd540938/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js#L60-L66 falls back to a text field but nevertheless it does not make sense to allow custom values here.