### PR TITLE
[Maintenance] Log job start

### DIFF
--- a/lib/Maintenance/Executor.php
+++ b/lib/Maintenance/Executor.php
@@ -75,6 +75,9 @@ final class Executor implements ExecutorInterface
         }
 
         try {
+            $this->logger->info('Starting job with ID {id}', [
+                'id' => $name,
+            ]);
             $task->execute();
 
             $this->logger->info('Finished job with ID {id}', [


### PR DESCRIPTION
Currently when running `bin/console maintenance -vv` you only see which jobs are finished or skipped. If you see that the maintenance command takes a lot of resources / time, it would help to know which job causes this. Thus this PR adds a log when starting a certain maintenance job. This way you can call  `bin/console maintenance -vv` and when it slows down, you see which job is responsible.