### PR TITLE
fix(images): Unhandled stream exception

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -1355,6 +1355,11 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }
 
         $stream = $thumbnail->getStream();
+        
+        if ($stream === null) {
+            throw new \Exception("Could not generate the image thumbnail. Maybe you forgot to install the needed extension?");
+        }
+        
         $response = new StreamedResponse(function () use ($stream) {
             fpassthru($stream);
         }, 200, [

--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -1290,7 +1290,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
      *
      * @param Request $request
      *
-     * @return StreamedResponse|JsonResponse
+     * @return StreamedResponse|JsonResponse|BinaryFileResponse
      */
     public function getImageThumbnailAction(Request $request)
     {

--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -1356,8 +1356,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         $stream = $thumbnail->getStream();
         
-        if ($stream === null) {
-            throw new \Exception("Could not generate the image thumbnail. Maybe you forgot to install the needed extension?");
+        if (!$stream) {
+            return new BinaryFileResponse(PIMCORE_PATH . '/bundles/AdminBundle/Resources/public/img/filetype-not-supported.svg');
         }
         
         $response = new StreamedResponse(function () use ($stream) {

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1338,6 +1338,10 @@ class Asset extends Element\AbstractElement
                 $this->stream = tmpfile();
             }
         }
+        
+        if ($this->stream === null) {
+            throw new \Exception("Could not get image stream. Maybe you forgot to install imageick?");
+        }
 
         return $this->stream;
     }

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1338,10 +1338,6 @@ class Asset extends Element\AbstractElement
                 $this->stream = tmpfile();
             }
         }
-        
-        if ($this->stream === null) {
-            throw new \Exception("Could not get image stream. Maybe you forgot to install imageick?");
-        }
 
         return $this->stream;
     }


### PR DESCRIPTION
## Changes in this pull request  Resolves
With this fix it informs the developer that they may have forgot to install the imagick plugin.

## Additional info  
When trying to load an SVG file the following function throws a null error without providing any information why.

