### PR TITLE
 Handle aborted requests to stop spamming console errors

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/startup.js
@@ -163,12 +163,16 @@ Ext.onReady(function () {
         'X-pimcore-extjs-version-minor': Ext.getVersion().getMinor()
     });
     Ext.Ajax.on('requestexception', function (conn, response, options) {
-        console.error("xhr request to " + options.url + " failed");
+        if(response.aborted){
+            console.log("xhr request to " + options.url + " aborted");
+        }else{
+            console.error("xhr request to " + options.url + " failed");
+        }
 
         var jsonData = response.responseJson;
         if (!jsonData) {
             try {
-                jsonData = Ext.decode(response.responseText);
+                jsonData = Ext.decode(response.responseText, response.aborted);
             } catch (e) {
 
             }


### PR DESCRIPTION
If we make several ajax requests that abort previous one (i.e. press next page several time) it will spam the console with errors from ext.js, because it try to decode "undefined"-json.
If the request is aborted, don't raise the error from ext by sending safe flag & also send console.log instead of console.error from startup.js.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  
Before & after
![:: Pimcore 2022-03-23 13-32-17](https://user-images.githubusercontent.com/17313784/159694447-135f4e7f-d80c-4056-9e8d-b4de9e3b9329.png)

