### PR TITLE
Fix cache argument to be priority instead of lifetime

### DIFF
--- a/models/Translation/Listing/Dao.php
+++ b/models/Translation/Listing/Dao.php
@@ -102,7 +102,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
             }
 
             if (empty($this->model->getConditionParams())) {
-                Cache::save($translations, $cacheKey, ['translator', 'translate'], 999);
+                Cache::save($translations, $cacheKey, ['translator', 'translate'], null, 999);
             }
         }
 


### PR DESCRIPTION
I'm pretty sure the last argument of the `Cache::save()` call is meant to be the priority, like in many other places, instead of the lifetime, for which it would be a rather strange value.