### PR TITLE
Fix non "thumbnail-able" images to be prefixed (eg. SVG's)

### DIFF
--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -313,6 +313,9 @@ trait ImageThumbnailTrait
             } elseif ($type === 'thumbnail') {
                 $prefix = \Pimcore::getContainer()->getParameter('pimcore.config')['assets']['frontend_prefixes']['thumbnail'];
                 $path = $prefix . urlencode_ignore_slash($path);
+            } elseif ($type === 'asset') {
+                $prefix = \Pimcore::getContainer()->getParameter('pimcore.config')['assets']['frontend_prefixes']['source'];
+                $path = $prefix . urlencode_ignore_slash($path);
             } else {
                 $path = urlencode_ignore_slash($path);
             }


### PR DESCRIPTION
SVG's don't get thumbnailed but should also be serveable via prefixes from CDN's or Blob Storages. In my case it is Google Cloud Storage. Configuring Pimcore like mentioned in the Docs doesn't work with SVGs. This fixes it.
