### PR TITLE
[Grid column config] For admin users allow to show invisible fields

### DIFF
--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1336,11 +1336,18 @@ class Service extends Model\Element\Service
     {
         if ($layout instanceof ClassDefinition\Data) {
             $name = $layout->getName();
-            if (empty($fieldDefinitions[$name]) || $fieldDefinitions[$name]->getInvisible()) {
+            if (empty($fieldDefinitions[$name])) {
                 return false;
             }
 
-            $layout->setNoteditable($layout->getNoteditable() | $fieldDefinitions[$name]->getNoteditable());
+            if($fieldDefinitions[$name]->getInvisible()) {
+                $user = AdminTool::getCurrentUser();
+                if(!$user->isAdmin()) {
+                    return false;
+                }
+            }
+
+            $layout->setNoteditable($layout->getNoteditable() || $fieldDefinitions[$name]->getNoteditable());
         }
 
         if (method_exists($layout, 'getChildren')) {
@@ -1488,6 +1495,13 @@ class Service extends Model\Element\Service
                 $context['ownerType'] = 'localizedfield';
             }
             $context['ownerName'] = 'localizedfields';
+        }
+
+        if($layout instanceof DataObject\ClassDefinition\Data && $layout->getInvisible()) {
+            $user = AdminTool::getCurrentUser();
+            if ($user->isAdmin()) {
+                $layout->setInvisible(false);
+            }
         }
 
         if (method_exists($layout, 'getChildren')) {


### PR DESCRIPTION
Currently data object fields which are set to be `invisible` can not be shown in the grid. In the edit view there is the special `Admin mode` which enables admin users to see invisible fields. In grid column config this does not exist.
With this PR admin users are allowed to add invisible fields to grid column config. 
If such a grid column config gets shared with non-admin users, those will not see invisible fields.