### PR TITLE
Add possibility to save version note via ajax

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -1023,7 +1023,9 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                 // save to session only
                 Asset\Service::saveElementToSession($asset);
             } else {
-                $asset->save();
+                $asset->save([
+                    'versionNote' => $request->get('versionNote') ?? null
+                ]);
             }
 
             $treeData = $this->getTreeNodeConfig($asset);

--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -1024,7 +1024,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                 Asset\Service::saveElementToSession($asset);
             } else {
                 $asset->save([
-                    'versionNote' => $request->get('versionNote') ?? null
+                    'versionNote' => $request->get('versionNote')
                 ]);
             }
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1365,7 +1365,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             //                }
             //            }
 
-            $object->save();
+            $object->save([
+                'versionNote' => $request->get('versionNote') ?? null
+            ]);
             $treeData = $this->getTreeNodeConfig($object);
 
             $newObject = DataObject::getById($object->getId(), true);
@@ -1398,14 +1400,16 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             $draftData = [];
 
             if ($object->isPublished() || $isAutoSave) {
-                $version = $object->saveVersion(true, true, null, $isAutoSave);
+                $version = $object->saveVersion(true, true,  $request->get('versionNote') ?? null, $isAutoSave);
                 $draftData = [
                     'id' => $version->getId(),
                     'modificationDate' => $version->getDate(),
                     'isAutoSave' => $version->isAutoSave(),
                 ];
             } else {
-                $object->save();
+                $object->save([
+                    'versionNote' => $request->get('versionNote') ?? null
+                ]);
             }
 
             if ($request->get('task') == 'version') {

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1366,7 +1366,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             //            }
 
             $object->save([
-                'versionNote' => $request->get('versionNote') ?? null
+                'versionNote' => $request->get('versionNote')
             ]);
             $treeData = $this->getTreeNodeConfig($object);
 
@@ -1400,7 +1400,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             $draftData = [];
 
             if ($object->isPublished() || $isAutoSave) {
-                $version = $object->saveVersion(true, true,  $request->get('versionNote') ?? null, $isAutoSave);
+                $version = $object->saveVersion(true, true,  $request->get('versionNote'), $isAutoSave);
                 $draftData = [
                     'id' => $version->getId(),
                     'modificationDate' => $version->getDate(),
@@ -1408,7 +1408,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 ];
             } else {
                 $object->save([
-                    'versionNote' => $request->get('versionNote') ?? null
+                    'versionNote' => $request->get('versionNote')
                 ]);
             }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch, e.g. `10.0`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  
By adding this we can call saving objects & asset, with new param via ajax "versionNote"
