### PR TITLE
Custom reports shared user role fix

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/item.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/item.js
@@ -457,7 +457,7 @@ pimcore.report.custom.item = Class.create({
                 minChars: 1,
                 store: userStore,
                 displayField: 'label',
-                valueField: 'id',
+                valueField: 'label',
                 forceSelection: true,
                 filterPickList: true,
                 value: this.data.sharedUserNames ? this.data.sharedUserNames : ""
@@ -492,7 +492,7 @@ pimcore.report.custom.item = Class.create({
                 minChars: 1,
                 store: rolesStore,
                 displayField: 'label',
-                valueField: 'id',
+                valueField: 'label',
                 forceSelection: true,
                 filterPickList: true,
                 value: this.data.sharedRoleNames ? this.data.sharedRoleNames : ""

--- a/models/Tool/CustomReport/Config.php
+++ b/models/Tool/CustomReport/Config.php
@@ -518,23 +518,6 @@ class Config extends Model\AbstractModel implements \JsonSerializable
     }
 
     /**
-     * @param int[] $sharedUserIds
-     */
-    public function setSharedUserIds($sharedUserIds): void
-    {
-        $userNames = [];
-        if ($sharedUserIds) {
-            foreach ($sharedUserIds as $id) {
-                $user = Model\User::getById($id);
-                if ($user) {
-                    $userNames[] = $user->getName();
-                }
-            }
-        }
-        $this->sharedUserNames = $userNames;
-    }
-
-    /**
      * @return int[]
      */
     public function getSharedRoleIds()
@@ -550,23 +533,6 @@ class Config extends Model\AbstractModel implements \JsonSerializable
         }
 
         return $sharedRoleIds;
-    }
-
-    /**
-     * @param int[] $sharedRoleIds
-     */
-    public function setSharedRoleIds($sharedRoleIds): void
-    {
-        $roleNames = [];
-        if ($sharedRoleIds) {
-            foreach ($sharedRoleIds as $id) {
-                $role = Model\User\Role::getById($id);
-                if ($role) {
-                    $roleNames[] = $role->getName();
-                }
-            }
-        }
-        $this->sharedRoleNames = $roleNames;
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
Save of a Custom-Report was saving the ID instead of the Name for the sharedUserName and sharedRoleNames. 
This lead to Users not seeing their Reports, since the logic was expecting a name in the DB.


