### PR TITLE
fix: PHP 8.1 doesn't allow passing null to explode()

### DIFF
--- a/models/Staticroute.php
+++ b/models/Staticroute.php
@@ -215,9 +215,14 @@ final class Staticroute extends AbstractModel
      */
     private function getDefaultsArray()
     {
-        $defaults = [];
+        $array = $this->getDefaults();
+        if ($array === null) {
+            return [];
+        }
+        
+        $defaults = [];      
 
-        $t = explode('|', $this->getDefaults());
+        $t = explode('|', $array);
         foreach ($t as $v) {
             $d = explode('=', $v);
             if (strlen($d[0]) > 0 && strlen($d[1]) > 0) {

--- a/models/Staticroute.php
+++ b/models/Staticroute.php
@@ -216,7 +216,7 @@ final class Staticroute extends AbstractModel
     private function getDefaultsArray()
     {
         $array = $this->getDefaults();
-        if ($array === null) {
+        if (empty($array)) {
             return [];
         }
         

--- a/models/Staticroute.php
+++ b/models/Staticroute.php
@@ -215,14 +215,14 @@ final class Staticroute extends AbstractModel
      */
     private function getDefaultsArray()
     {
-        $array = $this->getDefaults();
-        if (empty($array)) {
+        $defaultsString = $this->getDefaults();
+        if (empty($defaultsString)) {
             return [];
         }
         
         $defaults = [];      
 
-        $t = explode('|', $array);
+        $t = explode('|', $defaultsString);
         foreach ($t as $v) {
             $d = explode('=', $v);
             if (strlen($d[0]) > 0 && strlen($d[1]) > 0) {


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.3`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/` 
- [x] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [x] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  

## Additional info  

When on PHP 8.1, this produces a deprecation:
```
Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated
```