### PR TITLE
fix: PHP 8.1 deprecation: passing null to strlen()

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Extension/Text.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Text.php
@@ -36,7 +36,7 @@ trait Text
      */
     public function isEmpty($data)
     {
-        return strlen($data) < 1;
+        return empty($data) || strlen($data) < 1;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Extension/Text.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Text.php
@@ -36,7 +36,7 @@ trait Text
      */
     public function isEmpty($data)
     {
-        return !is_string($data) || strlen($data) < 1;
+        return strlen((string) $data) < 1;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Extension/Text.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Text.php
@@ -36,7 +36,7 @@ trait Text
      */
     public function isEmpty($data)
     {
-        return empty($data) || strlen($data) < 1;
+        return !is_string($data) || strlen($data) < 1;
     }
 
     /**


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.3`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  

## Additional info  

```
Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated
```