### PR TITLE
Imagick > Transparent Background becomes Black

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -105,6 +105,9 @@ class Imagick extends Adapter
                     // only for vector graphics
                     // the below causes problems with PSDs when target format is PNG32 (nobody knows why ;-))
                     $i->setBackgroundColor(new \ImagickPixel('transparent'));
+                    //for certain edge-cases simply setting the background-color to transparent does not seem to work
+                    //workaround by using transparentPaintImage (somehow even works without setting a target. no clue why)
+                    $i->transparentPaintImage('',1,0,false);
                 }
 
                 $this->setColorspaceToRGB();


### PR DESCRIPTION
For certain edge-cases the web-thumbnails of .ai-Files turn the transparent space black instead of white.

![image](https://user-images.githubusercontent.com/21100616/160799082-e3ecfcf2-7b57-4cad-b4ac-13fb03d137af.png)
![test1_schwarz](https://user-images.githubusercontent.com/21100616/160800388-4eb797e3-d7cd-4c65-aa42-562cc5bd8bf8.jpg)

Since this only seems to happen with .ai-Files and gitHub does not allow to upload .ai-Files. Here is a link to some working and not working test files.
https://www.filesharing.com/file/details/3003983/test-files.zip