### PR TITLE
Static Page from Site needs Current Site

### DIFF
--- a/bundles/CoreBundle/EventListener/Frontend/StaticPageGeneratorListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/StaticPageGeneratorListener.php
@@ -98,11 +98,12 @@ class StaticPageGeneratorListener implements EventSubscriberInterface
             $filename = urldecode($request->getPathInfo());
 
             if (Site::isSiteRequest()) {
-                $path = Site::getCurrentSite()->getRootPath();
-
                 if ($request->getPathInfo() === '/') {
                     $path = '';
                     $filename = '/' . Site::getCurrentSite()->getRootDocument()->getKey();
+                }
+                else {
+                    $path = Site::getCurrentSite()->getRootPath();
                 }
             }
             $filename = $path .  $filename  . '.html';

--- a/bundles/CoreBundle/EventListener/Frontend/StaticPageGeneratorListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/StaticPageGeneratorListener.php
@@ -27,6 +27,7 @@ use Pimcore\Http\RequestHelper;
 use Pimcore\Logger;
 use Pimcore\Model\Document\Page;
 use Pimcore\Model\Document\PageSnippet;
+use Pimcore\Model\Site;
 use Pimcore\Tool\Storage;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -59,7 +60,7 @@ class StaticPageGeneratorListener implements EventSubscriberInterface
             DocumentEvents::POST_ADD => 'onPostAddUpdateDeleteDocument',
             DocumentEvents::POST_DELETE => 'onPostAddUpdateDeleteDocument',
             DocumentEvents::POST_UPDATE => 'onPostAddUpdateDeleteDocument',
-            KernelEvents::REQUEST => ['onKernelRequest', 580], //this must run before targeting listener
+            KernelEvents::REQUEST => ['onKernelRequest', 510], //this must run before targeting listener
             KernelEvents::RESPONSE => ['onKernelResponse', -120], //this must run after code injection listeners
         ];
     }
@@ -93,7 +94,19 @@ class StaticPageGeneratorListener implements EventSubscriberInterface
         $storage = Storage::get('document_static');
 
         try {
-            $filename = urldecode($request->getPathInfo()) . '.html';
+            $path = '';
+            $filename = urldecode($request->getPathInfo());
+
+            if (Site::isSiteRequest()) {
+                $path = Site::getCurrentSite()->getRootPath();
+
+                if ($request->getPathInfo() === '/') {
+                    $path = '';
+                    $filename = '/' . Site::getCurrentSite()->getRootDocument()->getKey();
+                }
+            }
+            $filename = $path .  $filename  . '.html';
+
             if ($storage->fileExists($filename)) {
                 $content = $storage->read($filename);
                 $date = date(\DateTime::ISO8601, $storage->lastModified($filename));

--- a/bundles/CoreBundle/EventListener/Frontend/StaticPageGeneratorListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/StaticPageGeneratorListener.php
@@ -99,7 +99,6 @@ class StaticPageGeneratorListener implements EventSubscriberInterface
 
             if (Site::isSiteRequest()) {
                 if ($request->getPathInfo() === '/') {
-                    $path = '';
                     $filename = '/' . Site::getCurrentSite()->getRootDocument()->getKey();
                 }
                 else {


### PR DESCRIPTION
Static Pages Resolver for Site Pages need to have Sites resolved and use them to serve them. This adds a bit of overhead and maybe looses a bit of performance, but without it, site Static Pages don't work.

