### PR TITLE
[Improvement] Copy the icon path by clicking the icon

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/Misc/iconList.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/Misc/iconList.html.twig
@@ -51,6 +51,9 @@
             width: 50px;
         }
 
+        .language-icon img{
+            width: 16px;
+        }
     </style>
 </head>
 <body>
@@ -126,7 +129,15 @@
     {% endfor %}
 </table>
 
+{{ pimcore_minimize_scripts(['pimcore/common.js', 'pimcore/functions.js','pimcore/helpers.js']) | raw }}
+<script>
+    [...document.getElementsByTagName('img')]
+        .forEach(el => {
+            el.addEventListener("click", () => {
+                pimcore.helpers.copyStringToClipboard(el.dataset.imgpath)
+            });
+        });
+</script>
 
 </body>
 </html>
-

--- a/bundles/AdminBundle/Resources/views/Admin/Misc/iconList.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/Misc/iconList.html.twig
@@ -25,6 +25,7 @@
             float: left;
             font-size: 10px;
             word-wrap: break-word;
+            cursor: pointer;
         }
 
         .icon.black {
@@ -53,6 +54,7 @@
 
         .language-icon img{
             width: 16px;
+            cursor: pointer;
         }
     </style>
 </head>
@@ -65,6 +67,7 @@
 </div>
 
 <div id="color_icons" class="icons">
+    <div style="margin-bottom: 20px; text-align: left">ℹ Click on icon to copy path to clipboard.</div>
     {% for icon in colorIcons %}
         {% set iconPath = icon|replace({(webRoot): ''}) %}
         <div class="icon">

--- a/bundles/AdminBundle/Resources/views/Admin/Misc/iconList.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/Misc/iconList.html.twig
@@ -135,7 +135,7 @@
 <script src="/bundles/pimcoreadmin/js/pimcore/common.js"></script>
 <script src="/bundles/pimcoreadmin/js/pimcore/functions.js"></script>
 <script src="/bundles/pimcoreadmin/js/pimcore/helpers.js"></script>
-<script>
+<script {{ pimcore_csp.getNonceHtmlAttribute()|raw }}>
     [...document.getElementsByTagName('img')]
         .forEach(el => {
             el.addEventListener("click", () => {

--- a/bundles/AdminBundle/Resources/views/Admin/Misc/iconList.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/Misc/iconList.html.twig
@@ -129,7 +129,9 @@
     {% endfor %}
 </table>
 
-{{ pimcore_minimize_scripts(['pimcore/common.js', 'pimcore/functions.js','pimcore/helpers.js']) | raw }}
+<script src="/bundles/pimcoreadmin/js/pimcore/common.js"></script>
+<script src="/bundles/pimcoreadmin/js/pimcore/functions.js"></script>
+<script src="/bundles/pimcoreadmin/js/pimcore/helpers.js"></script>
 <script>
     [...document.getElementsByTagName('img')]
         .forEach(el => {

--- a/lib/Twig/Extension/AdminExtension.php
+++ b/lib/Twig/Extension/AdminExtension.php
@@ -83,6 +83,11 @@ class AdminExtension extends AbstractExtension
     {
         $content = file_get_contents($icon);
 
-        return sprintf('<img src="data:%s;base64,%s" title="%s"/>', mime_content_type($icon), base64_encode($content), basename($icon));
+        return sprintf('<img src="data:%s;base64,%s" title="%s" data-imgpath="%s" />',
+            mime_content_type($icon),
+            base64_encode($content),
+            basename($icon),
+            str_replace(PIMCORE_WEB_ROOT, '', $icon)
+        );
     }
 }


### PR DESCRIPTION
Since adding inline svg icons to html to reduce concurrent requests ( #11089 ), the icon's url is no longer easily accessible.

This PR adds the possibility to retrieve the relative path to the icon in the clipboard by clicking on the image.