### PR TITLE
Fix: application log table drop fails with exception

### DIFF
--- a/lib/Maintenance/Tasks/LogArchiveTask.php
+++ b/lib/Maintenance/Tasks/LogArchiveTask.php
@@ -139,7 +139,7 @@ class LogArchiveTask implements TaskInterface
                 ]);
 
             if ($archiveTableExists) {
-                $db->exec('DROP TABLE IF EXISTS ' . ($this->config['applicationlog']['archive_alternative_database'] ?: $db->getDatabase()) . '.' . $applicationLogArchiveTable);
+                $db->exec('DROP TABLE IF EXISTS `' . ($this->config['applicationlog']['archive_alternative_database'] ?: $db->getDatabase()) . '`.' . $applicationLogArchiveTable);
             }
 
             $deleteArchiveLogDate = $deleteArchiveLogDate->sub(new DateInterval('P1M'));


### PR DESCRIPTION
on certain database names, dropping the application log tables fails because the database name is unquoted.

For example, when the database name is `customer1-pimcore`, dropping the application log table fails.

