### PR TITLE
[Application logger] Support manual setting of "source" via context

### DIFF
--- a/doc/Development_Documentation/18_Tools_and_Features/17_Application_Logger.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/17_Application_Logger.md
@@ -230,7 +230,7 @@ class TestController
             'fileObject'    => $fileObject,
             'relatedObject' => $myObject, 
             'component'     => 'different component',
-            'source'        => 'Stack trace or context-relevant information' // if empty, gets automatically filled with class:method:line from where the log got executed
+            'source'        => 'Stack trace or context-relevant information' // optional, if empty, gets automatically filled with class:method:line from where the log got executed
         ]);
     }
 }

--- a/doc/Development_Documentation/18_Tools_and_Features/17_Application_Logger.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/17_Application_Logger.md
@@ -229,7 +229,8 @@ class TestController
         $logger->error('my error message', [
             'fileObject'    => $fileObject,
             'relatedObject' => $myObject, 
-            'component'     => 'different component'
+            'component'     => 'different component',
+            'source'        => 'Stack trace or context-relevant information' // if empty, gets automatically filled with class:method:line from where the log got executed
         ]);
     }
 }

--- a/lib/Log/ApplicationLogger.php
+++ b/lib/Log/ApplicationLogger.php
@@ -176,7 +176,9 @@ class ApplicationLogger implements LoggerInterface
             $context['relatedObjectType'] = Service::getElementType($relatedObject);
         }
 
-        $context['source'] = $this->resolveLoggingSource();
+        if(!isset($context['source'])) {
+            $context['source'] = $this->resolveLoggingSource();
+        }
 
         foreach ($this->loggers as $logger) {
             if ($logger instanceof \Psr\Log\LoggerInterface) {


### PR DESCRIPTION
Consider the following code to log something to application logger:
```php
$logger = $this->get(ApplicationLogger::class);
$logger->error('my error message', [
    'relatedObject' => $myObject, 
    'component'     => 'different component'
]);
```

Now in https://github.com/pimcore/pimcore/blob/f415841de9a3b09308a2be99580261a31e4fec40/lib/Log/ApplicationLogger.php#L179 it gets calculated from which method the `log()` method got called. 
There are 2 problems with this:
1. You cannot disable this. Sometimes it might simply not be necessary to log the `source` because it will always be the same (e.g. when you have a central Logger object which logs to the ApplicationLogger - then `source` will be the same value for all the logs)
2. You cannot customize it. In some cases you may want to set a different `source` - again with the example of the central `Logger` object in your application, you might want to use the method which called your central `Logger::log()` method. Or you may even want to input some other context in here.

This PR allows to set `source` similar to the other `context` fields like `relatedObject`, `component` etc.:
```php
$logger = $this->get(ApplicationLogger::class);
$logger->error('my error message', [
    'relatedObject' => $myObject, 
    'component'     => 'different component'
    'source' => 'My source'
]);
```