### PR TITLE
[Maintenance] Optimize tables with full text indexes periodically

### DIFF
--- a/bundles/CoreBundle/Resources/config/maintenance.yaml
+++ b/bundles/CoreBundle/Resources/config/maintenance.yaml
@@ -107,3 +107,7 @@ services:
             - '@logger'
         tags:
             - { name: pimcore.maintenance.task, type: documents_static_page_generate }
+
+    Pimcore\Maintenance\Tasks\FullTextIndexOptimizeTask:
+        tags:
+            - { name: pimcore.maintenance.task, type: optimize_fulltext_indexes }

--- a/lib/Maintenance/Tasks/FullTextIndexOptimizeTask.php
+++ b/lib/Maintenance/Tasks/FullTextIndexOptimizeTask.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Maintenance\Tasks;
+
+use Pimcore\Db;
+use Pimcore\Maintenance\TaskInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Lock\LockFactory;
+
+/**
+ * @internal
+ */
+class FullTextIndexOptimizeTask implements TaskInterface
+{
+    /** @var \Symfony\Component\Lock\LockInterface */
+    private $lock;
+
+    public function __construct(LockFactory $lockFactory)
+    {
+        $this->lock = $lockFactory->createLock(self::class, 86400 * 7, false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute()
+    {
+        if($this->lock->acquire(false)) {
+            Db::get()->exec('OPTIMIZE TABLE search_backend_data');
+            Db::get()->exec('OPTIMIZE TABLE email_log');
+        }
+    }
+}


### PR DESCRIPTION
Full text indexes get slower over time because of gaps caused by deleting entries and because word counts get fragmented. In a concrete case we had the problem of ~600K entries in `search_backend_data` and the query
```mysql
SELECT id FROM search_backend_data WHERE MATCH (`data`,`properties`) AGAINST ('123456' IN BOOLEAN MODE);
```
took 28 seconds.
This gets used in https://github.com/pimcore/pimcore/blob/f415841de9a3b09308a2be99580261a31e4fec40/bundles/AdminBundle/Helper/GridHelperService.php#L617
and also in other places like object search.

After running 
`OPTIMIZE TABLE search_backend_data`
this same query takes 0.1 seconds.
It is even documented in the MySQL docs: https://dev.mysql.com/doc/refman/8.0/en/fulltext-fine-tuning.html#fulltext-optimize

This PR adds a maintenance task which optimizes the tables with fulltext indexes once every 7 days - currently those are `search_backend_data` and `email_log`. I also thought about fetching all tables which have fulltext indexes and optimize those but this would pull control of third-party tables like from plugins or application-specific implementation away from the owners.