### PR TITLE
Add Preview Modes (Desktop, Tablet, Phone) to object preview

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/abstractPreview.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/abstractPreview.js
@@ -1,0 +1,130 @@
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+pimcore.registerNS("pimcore.element.abstractPreview");
+pimcore.element.abstractPreview = Class.create({
+
+    initialize: function (element) {
+        this.element = element;
+        this.mode = "full";
+        this.availableHeight = null;
+    },
+
+    getToolbar: function () {
+        return [
+            {
+                text: t("desktop"),
+                iconCls: "pimcore_icon_desktop",
+                handler: this.setFullMode.bind(this)
+            },
+            {
+                text: t("tablet"),
+                iconCls: "pimcore_icon_tablet",
+                handler: this.setMode.bind(this, {device: "tablet", width: 1024, height: 768})
+            },
+            {
+                text: t("phone"),
+                iconCls: "pimcore_icon_mobile",
+                handler: this.setMode.bind(this, {device: "phone", width: 375, height: 667})
+            },
+            {
+                text: t("phone"),
+                iconCls: "pimcore_icon_mobile_landscape",
+                handler: this.setMode.bind(this, {device: "phone", width: 667, height: 375})
+            }
+        ];
+    },
+
+    setFullMode: function () {
+        this.getIframe().applyStyles({
+            position: "relative",
+            border: "0",
+            width: "100%",
+            height: (this.availableHeight - 7) + "px",
+            top: "initial",
+            left: "initial"
+        });
+
+        this.loadCurrentPreview();
+    },
+
+    setMode: function (mode) {
+        var iframe = this.getIframe();
+        var availableWidth = this.framePanel.getWidth() - 10;
+        var availableHeight = this.framePanel.getHeight() - 10;
+
+        if (availableWidth < mode["width"]) {
+            Ext.MessageBox.alert(t("error"), t("screen_size_to_small"));
+            return;
+        }
+
+        if (availableHeight < mode["height"]) {
+            mode["height"] = availableHeight;
+        }
+
+        var top = Math.floor((availableHeight - mode["height"]) / 2);
+        var left = Math.floor((availableWidth - mode["width"]) / 2);
+
+        iframe.applyStyles({
+            position: "absolute",
+            border: "5px solid #323232",
+            width: mode["width"] + "px",
+            height: mode["height"] + "px",
+            top: top + "px",
+            left: left + "px"
+        });
+
+        this.mode = mode["device"];
+
+        this.loadCurrentPreview();
+    },
+
+    onLayoutResize: function (el, width, height) {
+        if (this.mode === "full") {
+            this.setLayoutFrameDimensions(width, height);
+        }
+
+        this.availableHeight = height;
+    },
+
+    createLoadingMask: function () {
+        if (!this.loadMask) {
+            this.loadMask = new Ext.LoadMask({
+                target: this.framePanel,
+                msg: t("please_wait")
+            });
+
+            this.loadMask.enable();
+        }
+    },
+
+    setLayoutFrameDimensions: function (width, height) {
+        this.getIframe().setStyle({
+            height: (height - 7) + "px"
+        });
+    },
+
+    getIframe: function () {
+        return Ext.get(this.frameId);
+    },
+
+    refresh: function () {
+        this.createLoadingMask();
+        this.loadMask.show();
+        this.element.saveToSession(function () {
+            if (this.preview) {
+                this.preview.loadCurrentPreview();
+            }
+        }.bind(this.element));
+    }
+});

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/preview.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/preview.js
@@ -12,63 +12,39 @@
  */
 
 pimcore.registerNS("pimcore.object.preview");
-pimcore.object.preview = Class.create({
-
-    initialize: function(object) {
-        this.object = object;
-    },
-
+Ext.define('pimcore.object.preview', {
+    extend: pimcore.element.abstractPreview,
 
     getLayout: function () {
-
-        if (this.layout == null) {
+        if (this.framePanel == null) {
 
             var iframeOnLoad = "pimcore.globalmanager.get('object_"
-                                        + this.object.data.general.o_id + "').preview.iFrameLoaded()";
+                                        + this.element.data.general.o_id + "').preview.iFrameLoaded()";
 
-            this.frameId = 'object_preview_iframe_' + this.object.id;
+            this.frameId = 'object_preview_iframe_' + this.element.id;
+            var toolbar = this.getToolbar();
 
-            let toolbar = [];
-            if(this.object.data.general.previewConfig) {
+            if(this.element.data.general.previewConfig) {
                 let paramPanel = this.getParamsPanel();
                 toolbar.push(paramPanel);
             }
-            this.layout = Ext.create('Ext.panel.Panel', {
+            this.framePanel = Ext.create('Ext.panel.Panel', {
                 title: t('preview'),
                 border: false,
                 autoScroll: false,
                 closable: false,
                 iconCls: "pimcore_material_icon_devices pimcore_material_icon",
                 tbar: toolbar,
+                bodyStyle: "background:#323232;",
                 html: '<iframe src="about:blank" style="width: 100%;" onload="' + iframeOnLoad
                     + '" frameborder="0" id="' + this.frameId + '"></iframe>'
             });
 
-            this.layout.on("resize", this.setLayoutFrameDimensions.bind(this));
-            this.layout.on("activate", this.refresh.bind(this));
+            this.framePanel.on("resize", this.onLayoutResize.bind(this));
+            this.framePanel.on("activate", this.refresh.bind(this));
         }
 
-        return this.layout;
-    },
-
-
-    createLoadingMask: function() {
-        if (!this.loadMask) {
-            this.loadMask = new Ext.LoadMask(
-                {
-                    target: this.layout,
-                    msg:t("please_wait")
-                });
-
-             //= new Ext.LoadMask(this.layout.getEl(), {msg: t("please_wait")});
-            this.loadMask.enable();
-        }
-    },
-
-    setLayoutFrameDimensions: function (el, width, height, rWidth, rHeight) {
-        Ext.get(this.frameId).setStyle({
-            height: (height-7) + "px"
-        });
+        return this.framePanel;
     },
 
     iFrameLoaded: function () {
@@ -78,7 +54,6 @@ pimcore.object.preview = Class.create({
     },
 
     loadCurrentPreview: function () {
-
         let params = {};
         if(this.paramSelects && this.paramSelects.length) {
             for(let i = 0; i < this.paramSelects.length; i++) {
@@ -89,36 +64,25 @@ pimcore.object.preview = Class.create({
         }
 
         var date = new Date();
-        params['id'] = this.object.data.general.o_id;
+        params['id'] = this.element.data.general.o_id;
         params['_dc'] = date.getTime();
 
         var url = Routing.generate('pimcore_admin_dataobject_dataobject_preview', params);
 
         try {
-            Ext.get(this.frameId).dom.src = url;
+            this.getIframe().dom.src = url;
         }
         catch (e) {
             console.log(e);
         }
     },
 
-    refresh: function () {
-        this.createLoadingMask();
-        this.loadMask.enable();
-        this.object.saveToSession(function () {
-            if (this.preview) {
-                this.preview.loadCurrentPreview();
-            }
-        }.bind(this.object));
-    },
-
     getParamsPanel: function() {
-
         var that = this;
         this.paramSelects = [];
 
-        let params = this.object.data.general.previewConfig;
-        for(let i=0; i<params.length; i++) {
+        let params = this.element.data.general.previewConfig;
+        for (let i = 0; i < params.length; i++) {
             let selectOptions = Object.entries(params[i].values);
             selectOptions.forEach(el => el.reverse());
 

--- a/bundles/AdminBundle/Resources/views/Admin/Index/index.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/Index/index.html.twig
@@ -308,6 +308,7 @@
 
 
     "pimcore/element/abstract.js",
+    "pimcore/element/abstractPreview.js",
     "pimcore/element/selector/selector.js",
     "pimcore/element/selector/abstract.js",
     "pimcore/element/selector/document.js",


### PR DESCRIPTION
At the moment the preview modes are only for document preview.