### PR TITLE
reapeating Headers of Custom-Report export

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/report.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/report.js
@@ -205,7 +205,7 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
                 }]
             });
             this.progressWindow.show();
-            this.createCsv(btn, "", 0);
+            this.createCsv(btn, "", 0, btn.getItemId() === 'exportWithHeaders' ? "1" : "");
         };
 
         topBar.push("->");
@@ -539,7 +539,7 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
         return this.panel;
     },
 
-    createCsv: function (btn, exportFile, offset) {
+    createCsv: function (btn, exportFile, offset, withHeader) {
         let filterData = this.store.getFilters().items;
         let proxy = this.store.getProxy();
         Ext.Ajax.request({
@@ -549,7 +549,7 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
                 offset: offset,
                 name: this.config.name,
                 filter: filterData.length > 0 ? encodeURIComponent(proxy.encodeFilters(filterData)) : "",
-                headers: btn.getItemId() === 'exportWithHeaders' ? "1" : "",
+                headers: withHeader,
             },
             success: function (response) {
                 response = JSON.parse(response["responseText"]);
@@ -561,7 +561,7 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
                 }else{
                     this.progressBar.updateProgress(response["progress"],Number.parseFloat(response["progress"]*100).toFixed(0)+"%");
                     if(!this.progressStop){
-                        this.createCsv(btn, response["exportFile"], response["offset"]);
+                        this.createCsv(btn, response["exportFile"], response["offset"], 0);
                     }
                 }
             }.bind(this)


### PR DESCRIPTION
The header of a custom-report when exporting to CSV was repeating every 5000 rows. Changed this to only print the header once at the beginning.


