### PR TITLE
[Asset] Thumbnail cache: only relevant when $deferred=true

### DIFF
--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -182,7 +182,7 @@ class Processor
 
         $modificationDate = null;
         $statusCacheEnabled = \Pimcore::getContainer()->getParameter('pimcore.config')['assets']['image']['thumbnails']['status_cache'];
-        if ($statusCacheEnabled) {
+        if ($statusCacheEnabled && $deferred) {
             $modificationDate = $asset->getDao()->getCachedThumbnailModificationDate($config->getName(), $filename);
         } else {
             if ($storage->fileExists($storagePath)) {


### PR DESCRIPTION
when requesting a thumbnail not deferred we need to ensure it exists ... 

Follow up to #11702 