### PR TITLE
[Bug] Allow file extension "jpeg" in custom logo upload.

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/Controller/Admin/SettingsController.php
@@ -39,6 +39,7 @@ use Pimcore\Tool;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -107,13 +108,16 @@ class SettingsController extends AdminController
      */
     public function uploadCustomLogoAction(Request $request)
     {
-        $fileExt = File::getFileExtension($_FILES['Filedata']['name']);
-        if (!in_array($fileExt, ['svg', 'png', 'jpg'])) {
-            throw new \Exception('Unsupported file format');
+        $logoFile = $request->files->get('Filedata');
+
+        if (!$logoFile instanceof UploadedFile
+            || !in_array($logoFile->guessExtension(), ['svg', 'png', 'jpg'])
+        ) {
+            throw new \Exception('Unsupported file format.');
         }
 
         $storage = Tool\Storage::get('admin');
-        $storage->writeStream(self::CUSTOM_LOGO_PATH, fopen($_FILES['Filedata']['tmp_name'], 'rb'));
+        $storage->writeStream(self::CUSTOM_LOGO_PATH, fopen($logoFile->getPathname(), 'rb'));
 
         // set content-type to text/html, otherwise (when application/json is sent) chrome will complain in
         // Ext.form.Action.Submit and mark the submission as failed


### PR DESCRIPTION
Allow file extension "jpeg" in custom logo upload. Update file type identification.
  

## Changes in this pull request  

Without this PR it is not possible to upload a file with the extension "jpeg" as custom logo.

Also, the detection of the file type has been changed from evaluating the file name to Symfony's guessExtension method (https://github.com/symfony/symfony/blob/6.0/src/Symfony/Component/HttpFoundation/File/UploadedFile.php#method_guessExtension).


## Additional information

While creating this PR, I also noticed that the error handling on the client side is not optimal. A forbidden file is not uploaded without a hint and the error message appears only in the JavaScript console.