### PR TITLE
Quantity value bugfix

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
@@ -19,6 +19,7 @@ pimcore.object.tags.quantityValue = Class.create(pimcore.object.tags.abstract, {
     initialize: function (data, fieldConfig) {
         this.data = data;
         this.fieldConfig = fieldConfig;
+        this.applyDefaultValue();
     },
 
     applyDefaultValue: function() {


### PR DESCRIPTION
Set the default value for quantityValue type (as the inputQuantityValue already does it correctly)
This should fix the issue described at https://github.com/pimcore/pimcore/issues/6381 
