### PR TITLE
Prevent error when updating an asset via WebDav

### DIFF
--- a/models/Asset/WebDAV/File.php
+++ b/models/Asset/WebDAV/File.php
@@ -129,7 +129,9 @@ class File extends DAV\File
             $this->asset->setStream($file);
             $this->asset->save();
 
-            fclose($file);
+            if (is_resource($file)) {
+                fclose($file);
+            }
             unlink($tmpFile);
 
             return null;


### PR DESCRIPTION
In the `$this->asset->save()` call, the stream can get closed, which leads to a TypeError when trying to close the stream again.
The extra `is_resource` check prevents this.

This can be reproduced by trying to upload an asset twice:




```
➜  webdav curl --user "***" -D- -T 'testimage.jpg' 'https://demo.pimcore.fun/admin/asset/webdav/testimage.jpg'
HTTP/1.1 100 Continue

HTTP/1.1 201 Created
Date: Mon, 04 Apr 2022 13:26:00 GMT



➜  webdav curl --user "***" -D- -T 'testimage.jpg' 'https://demo.pimcore.fun/admin/asset/webdav/testimage.jpg'
HTTP/1.1 100 Continue

HTTP/1.1 500 Internal Server Error
Date: Mon, 04 Apr 2022 13:26:01 GMT


<?xml version="1.0" encoding="utf-8"?>
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
  <s:sabredav-version>4.3.1</s:sabredav-version>
  <s:exception>TypeError</s:exception>
  <s:message>fclose(): supplied resource is not a valid stream resource</s:message>
</d:error>
```