### PR TITLE
[Maintenance] Fix VersionsCleanupStackTraceDbTask (performance + logic)

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20220419120333.php
+++ b/bundles/CoreBundle/Migrations/Version20220419120333.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Model\DataObject\ClassDefinition\Listing;
+
+final class Version20220419120333 extends AbstractMigration
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getDescription(): string
+    {
+        return 'Add index to versions.stackTrace to accelerate maintenance task "VersionsCleanupStackTraceDbTask"';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $versionsTable = $schema->getTable('versions');
+
+        if (!$versionsTable->hasIndex('stackTrace')) {
+            $versionsTable->addIndex(['stackTrace'], 'stackTrace', [], ['lengths' => [1]]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $versionsTable = $schema->getTable('versions');
+
+        if (!$versionsTable->hasIndex('stackTrace')) {
+            $versionsTable->dropIndex('stackTrace');
+        }
+    }
+}

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -339,7 +339,7 @@ CREATE TABLE `notes` (
   PRIMARY KEY (`id`),
   KEY `cid_ctype` (`cid`, `ctype`),
   KEY `date` (`date`),
-  KEY `user` (`user`),
+  KEY `user` (`user`)
 ) DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `notes_data`;

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -339,7 +339,7 @@ CREATE TABLE `notes` (
   PRIMARY KEY (`id`),
   KEY `cid_ctype` (`cid`, `ctype`),
   KEY `date` (`date`),
-  KEY `user` (`user`)
+  KEY `user` (`user`),
 ) DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `notes_data`;
@@ -744,7 +744,8 @@ CREATE TABLE `versions` (
   KEY `ctype_cid` (`ctype`, `cid`),
   KEY `date` (`date`),
   KEY `binaryFileHash` (`binaryFileHash`),
-  KEY `autoSave` (`autoSave`)
+  KEY `autoSave` (`autoSave`),
+  KEY `stackTrace` (`stackTrace`(1))
 ) DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `website_settings`;

--- a/lib/Maintenance/Tasks/VersionsCleanupStackTraceDbTask.php
+++ b/lib/Maintenance/Tasks/VersionsCleanupStackTraceDbTask.php
@@ -45,11 +45,10 @@ class VersionsCleanupStackTraceDbTask implements TaskInterface
         $list = new Version\Listing();
         $list->setCondition('date < ' . (time() - 86400 * 7) . ' AND stackTrace IS NOT NULL');
 
-        $total = $list->getTotalCount();
         $perIteration = 500;
+        $list->setLimit($perIteration);
 
-        for ($i = 0; $i < ceil($total / $perIteration); $i++) {
-            $list->setLimit($perIteration);
+        do {
             $versions = $list->load();
 
             foreach ($versions as $version) {
@@ -62,6 +61,6 @@ class VersionsCleanupStackTraceDbTask implements TaskInterface
                 }
             }
             \Pimcore::collectGarbage();
-        }
+        } while(count($versions) === $perIteration);
     }
 }

--- a/lib/Maintenance/Tasks/VersionsCleanupStackTraceDbTask.php
+++ b/lib/Maintenance/Tasks/VersionsCleanupStackTraceDbTask.php
@@ -26,19 +26,6 @@ use Psr\Log\LoggerInterface;
 class VersionsCleanupStackTraceDbTask implements TaskInterface
 {
     /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
-     * @param LoggerInterface $logger
-     */
-    public function __construct(LoggerInterface $logger)
-    {
-        $this->logger = $logger;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function execute()

--- a/lib/Maintenance/Tasks/VersionsCleanupStackTraceDbTask.php
+++ b/lib/Maintenance/Tasks/VersionsCleanupStackTraceDbTask.php
@@ -44,15 +44,12 @@ class VersionsCleanupStackTraceDbTask implements TaskInterface
     {
         $list = new Version\Listing();
         $list->setCondition('date < ' . (time() - 86400 * 7) . ' AND stackTrace IS NOT NULL');
-        $list->setOrderKey('date');
-        $list->setOrder('DESC');
 
         $total = $list->getTotalCount();
         $perIteration = 500;
 
-        for ($i = 0; $i < (ceil($total / $perIteration)); $i++) {
+        for ($i = 0; $i < ceil($total / $perIteration); $i++) {
             $list->setLimit($perIteration);
-            $list->setOffset($i * $perIteration);
             $versions = $list->load();
 
             foreach ($versions as $version) {


### PR DESCRIPTION
Current logic in https://github.com/pimcore/pimcore/blob/9ecae6b4a0e53b3d9fd4603dc4ba707efbe3583e/lib/Maintenance/Tasks/VersionsCleanupStackTraceDbTask.php#L55 is wrong because:
1. Imagine you have 600 matching versions
2. Initially you select with `LIMIT 0,500`
3. The `stackTrace` for those 500 found versions gets set to `NULL`
4. When you select with `LIMIT 500,500` in the next iteration, you will not find anything because after 3. there are only 100 versions left which match the condition `stackTrace IS NOT NULL`

But the even more severe problem is performance: We just had these processes:
<img width="1240" alt="Bildschirmfoto 2022-04-06 um 11 40 35" src="https://user-images.githubusercontent.com/8749138/161949837-aaeccd97-70fd-4457-83b7-219e02d01533.png">
(Don't know if maintenance job locking did not work but was running with Pimcore 10.0, so this does not matter for now)

The problem is the `filesort` which has to be done because the database uses the index on `autoSave` (this condition gets added in https://github.com/pimcore/pimcore/blob/9ecae6b4a0e53b3d9fd4603dc4ba707efbe3583e/models/Version/Listing/Dao.php#L30-L36)
We could create an optimized index but ordering in this case is not necessary anyway as we want to change stack trace for all found versions.