### PR TITLE
[Grid] Enhance performance to get data object classes for opened folder

### DIFF
--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -449,7 +449,16 @@ class Dao extends Model\Element\Dao
             if (!$this->model->getId() || $this->model->getId() == 1) {
                 $path = '';
             }
-            $classIds = $this->db->fetchCol("SELECT o_classId FROM objects WHERE o_path LIKE ? AND o_type = 'object' GROUP BY o_classId", $this->db->escapeLike($path) . '/%');
+
+            $classIds = [];
+            do {
+                $classId = $this->db->fetchOne(
+                    "SELECT o_classId FROM objects WHERE o_path LIKE ? AND o_type = 'object'".($classIds ? " AND o_classId NOT IN (".rtrim(str_repeat('?,', count($classIds)), ',').")":"")." LIMIT 1",
+                    array_merge([$this->db->escapeLike($path).'/%'], $classIds));
+                if($classId) {
+                    $classIds[] = $classId;
+                }
+            } while($classId);
 
             $classes = [];
             foreach ($classIds as $classId) {


### PR DESCRIPTION
Currently we execute https://github.com/pimcore/pimcore/blob/9ecae6b4a0e53b3d9fd4603dc4ba707efbe3583e/models/DataObject/AbstractObject/Dao.php#L452 to get the classes for the objects in the grid. This `GROUP BY` is very slow when you have millons of objects.

This PR uses a different approach. It iteratively searches for an object of a class which it does not already know. This way no grouping is necessary.

In our client project I could reduce query times from 26s to 1s with this approach (in this case the folder had only objects of one class).