### PR TITLE
Reset fallback document after assigning it

### DIFF
--- a/bundles/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
@@ -157,7 +157,7 @@ class DocumentFallbackListener implements EventSubscriberInterface
 
         if ($this->fallbackDocument && $event->isMainRequest()) {
             $this->documentResolver->setDocument($event->getRequest(), $this->fallbackDocument);
-            $this->fallbackDocument = null
+            $this->fallbackDocument = null;
         }
     }
 }

--- a/bundles/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
@@ -157,6 +157,7 @@ class DocumentFallbackListener implements EventSubscriberInterface
 
         if ($this->fallbackDocument && $event->isMainRequest()) {
             $this->documentResolver->setDocument($event->getRequest(), $this->fallbackDocument);
+            $this->fallbackDocument = null
         }
     }
 }


### PR DESCRIPTION
A problem occurs in some special cases, i.e. when a cli script or some long running processes perform subsequent requests like so:

```
$kernel   = Kernel::get();
$request  = Request::create($somePath, 'GET');
$response = $kernel->handle($request);
```

The problem is that in the above use case the document once assigned in line 119 will be used in subsequent calls. That will overwrite an already correctly set document in the DocumentResolver in line 159.

When the fallback document is set to `null` afterwards, that won't happen.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.3`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

