### PR TITLE
Add JavaScript events for "preDelete" and "postDelete" for Assets, Documents and Data objects.

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
@@ -123,8 +123,14 @@ pimcore.elementservice.deleteElementFromServer = function (r, options, button) {
 
         let ids = Ext.isString(id) ? id.split(',') : [id];
         ids.forEach(function (elementId) {
+           try {
+                pimcore.plugin.broker.fireEvent(preDeleteEventName, elementId);
+            } catch (e) {
+                pimcore.helpers.showPrettyError('asset', t("error"), t("delete_failed"), e.message);
+                return false;
+            }
+
             pimcore.helpers.addTreeNodeLoadingIndicator(elementType, elementId);
-            pimcore.plugin.broker.fireEvent(preDeleteEventName, elementId);
         });
 
         var affectedNodes = pimcore.elementservice.getAffectedNodes(elementType, id);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
@@ -122,14 +122,16 @@ pimcore.elementservice.deleteElementFromServer = function (r, options, button) {
         const preDeleteEventName = 'preDelete' + elementType.charAt(0).toUpperCase() + elementType.slice(1);
 
         let ids = Ext.isString(id) ? id.split(',') : [id];
-        ids.forEach(function (elementId) {
-           try {
+        try {
+            ids.forEach(function (elementId) {
                 pimcore.plugin.broker.fireEvent(preDeleteEventName, elementId);
-            } catch (e) {
-                pimcore.helpers.showPrettyError('asset', t("error"), t("delete_failed"), e.message);
-                return false;
-            }
+            });
+        } catch (e) {
+            pimcore.helpers.showPrettyError('asset', t("error"), t("delete_failed"), e.message);
+            return;
+        }
 
+        ids.forEach(function (elementId) {
             pimcore.helpers.addTreeNodeLoadingIndicator(elementType, elementId);
         });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
@@ -119,10 +119,12 @@ pimcore.elementservice.deleteElementFromServer = function (r, options, button) {
         var successHandler = options["success"];
         var elementType = options.elementType;
         var id = options.id;
+        const preDeleteEventName = 'preDelete' + elementType.charAt(0).toUpperCase() + elementType.slice(1);
 
         let ids = Ext.isString(id) ? id.split(',') : [id];
         ids.forEach(function (elementId) {
             pimcore.helpers.addTreeNodeLoadingIndicator(elementType, elementId);
+            pimcore.plugin.broker.fireEvent(preDeleteEventName, elementId);
         });
 
         var affectedNodes = pimcore.elementservice.getAffectedNodes(elementType, id);
@@ -161,6 +163,7 @@ pimcore.elementservice.deleteElementFromServer = function (r, options, button) {
         var pj = new pimcore.tool.paralleljobs({
             success: function (id, successHandler) {
                 var refreshParentNodes = [];
+                const postDeleteEventName = 'postDelete' + elementType.charAt(0).toUpperCase() + elementType.slice(1);
                 for (var index = 0; index < affectedNodes.length; index++) {
                     var node = affectedNodes[index];
                     try {
@@ -188,6 +191,10 @@ pimcore.elementservice.deleteElementFromServer = function (r, options, button) {
 
                 this.deleteProgressBar = null;
                 this.deleteWindow = null;
+
+                ids.forEach(function (elementId) {
+                    pimcore.plugin.broker.fireEvent(postDeleteEventName, elementId);
+                });
 
                 if(typeof successHandler == "function") {
                     successHandler();

--- a/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/06_Plugin_Backend_UI.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/06_Plugin_Backend_UI.md
@@ -95,17 +95,23 @@ corresponding method to the javascript plugin class.
 | postOpenAsset                        | after asset is opened, asset and type are passed as parameters                                                  |          |
 | preSaveAsset                         | before asset is saved, asset id is passed as parameter                                                          |          |
 | postSaveAsset                        | after asset is saved, asset id is passed as parameter                                                           |          |
+| preDeleteAsset                       | before asset is deleted, asset id is passed as parameter                                                        |          |
+| postDeleteAsset                      | after asset is deleted, asset id is passed as parameter                                                         |          |
 | preOpenDocument                      | before document is opened, document and type are passed as parameters                                           |          |
 | postOpenDocument                     | after document is opened, document and type are passed as parameters                                            |          |
 | preSaveDocument                      | before document is saved, document, type, task and onlySaveVersion are passed as parameters                     |          |
 | postSaveDocument                     | after document is saved, document, type, task and onlySaveVersion are passed as parameters                      |          |
+| preDeleteDocument                    | before document is deleted, document id is passed as parameter                                                  |          |
+| postDeleteDocument                   | after document is deleted, document id is passed as parameter                                                   |          |
 | postAddDocumentTree                  | after the document is successfully created in the tree, document id is passed as parameter                      |          |
 | preOpenObject                        | before object is opened, object and type are passed as parameters                                               |          |
 | postOpenObject                       | after object is opened, object and type are passed as parameters                                                |          |
 | preSaveObject                        | before object is saved, object and type are passed as parameters                                                |          |
 | postSaveObject                       | after object is saved, object is passed as parameter                                                            |          |
+| preDeleteObject                      | before object is deleted, object id is passed as parameter                                                      |          |
+| postDeleteObject                     | after object is deleted, object id is passed as parameter                                                       |          |
 | postAddObjectTree                    | after the object is successfully created in the tree, object id is passed as parameter                          |          |
-| preCreateMenuOption                  | called before navigation menu is created                                                                         |          |
+| preCreateMenuOption                  | called before navigation menu is created                                                                        |          |
 | preCreateAssetMetadataEditor         | fired when asset metadata editor tab is created                                                                 | internal |
 | prepareAssetMetadataGridConfigurator | before opening the grid config dialog, url returning the metadata definitions is passed as parameter            |          |
 | prepareAssetTreeContextMenu          | before context menu is opened, menu, tree class and asset record are passed as parameters                       |          |
@@ -116,7 +122,7 @@ corresponding method to the javascript plugin class.
 | prepareOnObjectTreeNodeClick         | before the data object is opened, after a tree node has been clicked. The node item is passed as parameter.     |          | 
 | preGetObjectFolder                   | before the data object grid folder configuration is loaded from the server. request configuration is passed.    |          |
 | preCreateObjectGrid                  | before the data object grid items are loaded from the server. request configuration are passed.                 |          |
-| postOpenReport                       | fired when a report has been opened, report grid panel gets passed as argument |          |
+| postOpenReport                       | fired when a report has been opened, report grid panel gets passed as argument                                  |          |
 
 Uninstall is called after plugin has been uninstalled - this hook can be used to remove plugin features from the UI 
 after uninstall.


### PR DESCRIPTION
## Changes in this pull request  
This PR will add JavaScript events for "preDelete" and "postDelete" for Assets, Documents and Data objects.

## Additional info  
In this PR only the ID of the deleted data type is passed to the event listeners. 
I think it could also be useful to pass the complete information about the affected data type. If there are no concerns about this, I could extend this PR to do so. 
