### PR TITLE
Fix ResponseExceptionListener::determineErrorPath() return value

### DIFF
--- a/bundles/CoreBundle/EventListener/ResponseExceptionListener.php
+++ b/bundles/CoreBundle/EventListener/ResponseExceptionListener.php
@@ -193,7 +193,7 @@ class ResponseExceptionListener implements EventSubscriberInterface
             $defaultErrorDocumentPath = $site->getErrorDocument();
         } else {
             $localizedErrorDocumentsPaths = $this->config['documents']['error_pages']['localized'] ?: [];
-            $defaultErrorDocumentPath = $this->config['documents']['error_pages']['default'];
+            $defaultErrorDocumentPath = $this->config['documents']['error_pages']['default'] ?: '';
         }
 
         if (!empty($locale) && array_key_exists($locale, $localizedErrorDocumentsPaths)) {


### PR DESCRIPTION
## Changes in this pull request  
Resolves #11797

## Additional info  

