### PR TITLE
[Thumbnails] Fix auto-cleaning in PublicServicesController and unify getStream()

### DIFF
--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -100,10 +100,6 @@ class PublicServicesController extends Controller
                         }
 
                         $imageThumbnail = $asset->getImageThumbnail($thumbnailConfig, $time);
-                        if (!$imageThumbnail->existsOnStorage()) {
-                            $asset->clearThumbnail($thumbnailConfig->getName());
-                        }
-
                         $thumbnailStream = $imageThumbnail->getStream();
                     } elseif ($asset instanceof Asset\Document) {
                         $page = 1;
@@ -115,10 +111,6 @@ class PublicServicesController extends Controller
                         $thumbnailConfig->setName(str_replace('document_', '', $thumbnailConfig->getName()));
 
                         $imageThumbnail = $asset->getImageThumbnail($thumbnailConfig, $page);
-                        if (!$imageThumbnail->existsOnStorage()) {
-                            $asset->clearThumbnail($thumbnailConfig->getName());
-                        }
-
                         $thumbnailStream = $imageThumbnail->getStream();
                     } elseif ($asset instanceof Asset\Image) {
                         //check if high res image is called
@@ -139,10 +131,6 @@ class PublicServicesController extends Controller
                         }
 
                         $imageThumbnail = $asset->getThumbnail($thumbnailConfig);
-                        if (!$imageThumbnail->existsOnStorage()) {
-                            $asset->clearThumbnail($thumbnailConfig->getName());
-                        }
-
                         $thumbnailStream = $imageThumbnail->getStream();
                     }
 

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -103,21 +103,6 @@ final class Thumbnail
     }
 
     /**
-     * @return null|resource
-     */
-    public function getStream()
-    {
-        $pathReference = $this->getPathReference(false);
-        if ($pathReference['type'] === 'asset') {
-            return $this->asset->getStream();
-        } elseif (isset($pathReference['storagePath'])) {
-            return Tool\Storage::get('thumbnail')->readStream($pathReference['storagePath']);
-        }
-
-        return null;
-    }
-
-    /**
      * @param string $eventName
      *
      * @return bool

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -15,7 +15,9 @@
 
 namespace Pimcore\Model\Asset\Thumbnail;
 
+use League\Flysystem\UnableToReadFile;
 use Pimcore\Helper\TemporaryFileHelperTrait;
+use Pimcore\Logger;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Asset\Image;
 use Pimcore\Tool;
@@ -96,13 +98,33 @@ trait ImageThumbnailTrait
      */
     public function getStream()
     {
-        $pathReference = $this->getPathReference();
-
         try {
-            return Storage::get($pathReference['type'])->readStream($pathReference['src']);
+            return $this->doGetStream();
+        } catch (UnableToReadFile $e) {
+            // seems that the cache information is wrong, so we clear it and try to generate the thumbnail
+            // this can happen when someone deletes thumbnails directly on the storage without using the API,
+            // so the info in the cache stays and gets invalid
+            $this->getAsset()->getDao()->deleteFromThumbnailCache($this->getConfig()->getName());
+
+            try {
+                return $this->doGetStream();
+            } catch (\Exception $e) {
+                Logger::error($e);
+                return null;
+            }
         } catch (\Exception $e) {
+            Logger::error($e);
             return null;
         }
+    }
+
+    /**
+     * @return resource|null
+     */
+    private function doGetStream()
+    {
+        $pathReference = $this->getPathReference();
+        return Storage::get($pathReference['type'])->readStream($pathReference['src']);
     }
 
     public function getPathReference(bool $deferredAllowed = false): array

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -97,8 +97,9 @@ trait ImageThumbnailTrait
     public function getStream()
     {
         $pathReference = $this->getPathReference(false);
-
-        if (isset($pathReference['storagePath'])) {
+        if ($pathReference['type'] === 'asset') {
+            return $this->asset->getStream();
+        } elseif (isset($pathReference['storagePath'])) {
             return Tool\Storage::get('thumbnail')->readStream($pathReference['storagePath']);
         }
 


### PR DESCRIPTION
fixes #11880

Related to #11702

Made `\Pimcore\Model\Asset\Thumbnail\ImageThumbnailTrait::getStream()` to work the same as `\Pimcore\Model\Asset\Image\Thumbnail::getStream()`