### PR TITLE
[DataObjects] Quote columns in getBy* static getters

### DIFF
--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -610,6 +610,8 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
                 throw new \Exception("Static getter '::getBy".ucfirst($realPropertyName)."' is not allowed for fieldtype '" . $field->getFieldType() . "'");
             }
 
+            $db = Db::get();
+
             if ($field instanceof Model\DataObject\ClassDefinition\Data\Localizedfields) {
                 $arguments = array_pad($arguments, 6, 0);
 
@@ -627,7 +629,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
                     throw new \Exception("Static getter '::getBy".ucfirst($realPropertyName)."' is not allowed for fieldtype '" . $localizedField->getFieldType() . "'");
                 }
 
-                $defaultCondition = $localizedPropertyName . ' = ' . Db::get()->quote($value) . ' ';
+                $defaultCondition = $db->quoteIdentifier($localizedPropertyName) . ' = ' . $db->quote($value) . ' ';
                 $listConfig = [
                     'condition' => $defaultCondition,
                 ];
@@ -640,7 +642,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
                 [$value, $limit, $offset, $objectTypes] = $arguments;
 
                 if (!$field instanceof AbstractRelations) {
-                    $defaultCondition = $realPropertyName . ' = ' . Db::get()->quote($value) . ' ';
+                    $defaultCondition = $db->quoteIdentifier($realPropertyName) . ' = ' . $db->quote($value) . ' ';
                 }
                 $listConfig = [
                     'condition' => $defaultCondition,


### PR DESCRIPTION
For static getters like getByFoo() (handled by magic Concrete::__callStatic)
the field name (foo) is not quoted in the query. This might result in an SQL
error when using SQL reserved words like "usage" (getByUsage()).

This fix quotes the column for both regular and localized fields.