### PR TITLE
Fix CKEditor: Tables in new created areabricks have no border

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/wysiwyg.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/wysiwyg.js
@@ -269,7 +269,7 @@ pimcore.document.editables.wysiwyg = Class.create(pimcore.document.editable, {
         var value = this.getValue();
         var textarea = Ext.get(this.textarea);
 
-        // Sync dom classname with ext js (CKEditor has set class names)
+        // Sync DOM class names with ExtJs (CKEditor may have added classes in the meantime)
         textarea.setCls(textarea.dom.className);
 
         if (trim(strip_tags(value)).length < 1) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/wysiwyg.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/wysiwyg.js
@@ -266,18 +266,20 @@ pimcore.document.editables.wysiwyg = Class.create(pimcore.document.editable, {
     },
 
     checkValue: function (mark) {
-
         var value = this.getValue();
+        var textarea = Ext.get(this.textarea);
 
-        if(trim(strip_tags(value)).length < 1) {
-            Ext.get(this.textarea).addCls("empty");
+        // Sync dom classname with ext js (CKEditor has set class names)
+        textarea.setCls(textarea.dom.className);
+
+        if (trim(strip_tags(value)).length < 1) {
+            textarea.addCls("empty");
         } else {
-            Ext.get(this.textarea).removeCls("empty");
+            textarea.removeCls("empty");
         }
 
-
         if (this.required) {
-            this.validateRequiredValue(value, Ext.get(this.textarea), this, mark);
+            this.validateRequiredValue(value, textarea, this, mark);
         }
     },
 


### PR DESCRIPTION
Fix https://github.com/pimcore/pimcore/issues/11879

The line `Ext.get(this.textarea).removeCls("empty");` removes all css classes from CKEditor because ExtJs cache the class names.