### PR TITLE
QuantityValue: Abbreviation is in grid not translateable

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/inputQuantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/inputQuantityValue.js
@@ -124,7 +124,7 @@ pimcore.object.tags.inputQuantityValue = Class.create(pimcore.object.tags.abstra
             }
 
             if (value) {
-                return (value.value ? value.value : "") + " " + value.unitAbbr;
+                return (value.value ? value.value : "") + " " + t(value.unitAbbr);
             } else {
                 return "";
             }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/quantityValue.js
@@ -226,7 +226,7 @@ pimcore.object.tags.quantityValue = Class.create(pimcore.object.tags.abstract, {
             }
 
             if (value) {
-                return (value.value ? value.value : "") + " " + value.unitAbbr;
+                return (value.value ? value.value : "") + " " + t(value.unitAbbr);
             } else {
                 return "";
             }

--- a/models/DataObject/Data/InputQuantityValue.php
+++ b/models/DataObject/Data/InputQuantityValue.php
@@ -60,7 +60,8 @@ class InputQuantityValue extends AbstractQuantityValue
     {
         $value = $this->getValue();
         if ($this->getUnit() instanceof Unit) {
-            $value .= ' ' . $this->getUnit()->getAbbreviation();
+            $translator = \Pimcore::getContainer()->get('translator');
+            $value .= ' ' . $translator->trans($this->getUnit()->getAbbreviation(), [], 'admin');
         }
 
         return $value;

--- a/models/DataObject/Data/QuantityValue.php
+++ b/models/DataObject/Data/QuantityValue.php
@@ -73,7 +73,8 @@ class QuantityValue extends AbstractQuantityValue
         }
 
         if ($this->getUnit() instanceof Unit) {
-            $value .= ' ' . $this->getUnit()->getAbbreviation();
+            $translator = \Pimcore::getContainer()->get('translator');
+            $value .= ' ' . $translator->trans($this->getUnit()->getAbbreviation(), [], 'admin');
         }
 
         return $value ? (string)$value : '';


### PR DESCRIPTION
In the edit mode it is translated, but not in the grid view.