### PR TITLE
[IndexFieldSelection] Implement NormalizerInterface to support in blocks

### DIFF
--- a/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelection.php
+++ b/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelection.php
@@ -21,8 +21,9 @@ use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\ClassDefinition\Data\QueryResourcePersistenceAwareInterface;
 use Pimcore\Model\DataObject\ClassDefinition\Data\ResourcePersistenceAwareInterface;
 use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Normalizer\NormalizerInterface;
 
-class IndexFieldSelection extends Data implements ResourcePersistenceAwareInterface, QueryResourcePersistenceAwareInterface
+class IndexFieldSelection extends Data implements ResourcePersistenceAwareInterface, QueryResourcePersistenceAwareInterface, NormalizerInterface
 {
     use Data\Extension\ColumnType;
     use Data\Extension\QueryColumnType;
@@ -326,5 +327,29 @@ class IndexFieldSelection extends Data implements ResourcePersistenceAwareInterf
     public function getPhpdocReturnType(): ?string
     {
         return '\\' . ObjectData\IndexFieldSelection::class . '|null';
+    }
+
+    public function normalize($value, $params = [])
+    {
+        if ($value instanceof ObjectData\IndexFieldSelection) {
+            return [
+                'tenant' => $value->getTenant(),
+                'field' => $value->getField(),
+                'preSelect' => $value->getPreSelect(),
+            ];
+        }
+        return null;
+    }
+
+    public function denormalize($value, $params = [])
+    {
+        if (is_array($value)) {
+            $tenant = $value['tenant'];
+            $field = $value['field'];
+            $preSelect = $value['preSelect'];
+
+            return new ObjectData\IndexFieldSelection($tenant, $field, $preSelect);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Changes in this pull request

Resolves #11861

 Fix to support Index Field Selection in blocks again in PCX.

## Additional info  

- The other classes in the EcommerceFrameworkBundle seem to work fine (those classes implicitly inherit that interface).
- No real type check is performed before the construction of the `ObjectData\IndexFieldSelection`. Should be correct from DB and could intervene when the constructor parameters of `ObjectData\IndexFieldSelection` will be typed in the future.
