### PR TITLE
Fix Xliff12Escaper's unescapeXliff function to respect ph elements

### DIFF
--- a/lib/Translation/Escaper/Xliff12Escaper.php
+++ b/lib/Translation/Escaper/Xliff12Escaper.php
@@ -89,7 +89,7 @@ class Xliff12Escaper
     {
         $content = $this->parseInnerXml($content);
 
-        if (preg_match("/<\/?(bpt|ept)/", $content)) {
+        if (preg_match("/<\/?(bpt|ept|ph)/", $content)) {
             $xml = new Crawler($content);
             $els = $xml->filter('bpt, ept, ph');
             /** @var \DOMElement $el */


### PR DESCRIPTION
Exporting documents having `<br />` - tags in the content and re - importing them using the Xliff Export/Import functionality does transform `<br />` to `&lt;br...`