### PR TITLE
Create redirect if pretty url is changed

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -232,6 +232,7 @@ class PageController extends DocumentControllerBase
                 $redirect->setSource($oldPage->getPrettyUrl());
                 $redirect->setTarget($page->getPrettyUrl());
                 $redirect->setStatusCode(301);
+                $redirect->setType(Redirect::TYPE_AUTO_CREATE);
                 $redirect->save();
             }
 

--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -27,6 +27,7 @@ use Pimcore\Messenger\GeneratePagePreviewMessage;
 use Pimcore\Model\Document;
 use Pimcore\Model\Document\Targeting\TargetingDocumentInterface;
 use Pimcore\Model\Element;
+use Pimcore\Model\Redirect;
 use Pimcore\Model\Schedule\Task;
 use Pimcore\Templating\Renderer\EditableRenderer;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -155,19 +156,19 @@ class PageController extends DocumentControllerBase
      */
     public function saveAction(Request $request, StaticPageGenerator $staticPageGenerator)
     {
-        $page = Document\Page::getById($request->get('id'));
+        $oldPage = Document\Page::getById($request->get('id'));
 
-        if (!$page) {
+        if (!$oldPage) {
             throw $this->createNotFoundException('Page not found');
         }
 
         /** @var Document\Page|null $pageSession */
-        $pageSession = $this->getFromSession($page);
+        $pageSession = $this->getFromSession($oldPage);
 
         if ($pageSession) {
             $page = $pageSession;
         } else {
-            $page = $this->getLatestVersion($page);
+            $page = $this->getLatestVersion($oldPage);
         }
 
         $page->setUserModification($this->getAdminUser()->getId());
@@ -220,6 +221,18 @@ class PageController extends DocumentControllerBase
             if ($staticGeneratorEnabled = $page->getStaticGeneratorEnabled()) {
                 $data['staticGeneratorEnabled'] = $staticGeneratorEnabled;
                 $data['staticLastGenerated'] = $staticPageGenerator->getLastModified($page);
+            }
+
+            if ($page->getPrettyUrl() !== $oldPage->getPrettyUrl()
+                && empty($oldPage->getPrettyUrl()) === false
+                && empty($page->getPrettyUrl()) === false
+            ) {
+                $redirect = new Redirect();
+
+                $redirect->setSource($oldPage->getPrettyUrl());
+                $redirect->setTarget($page->getPrettyUrl());
+                $redirect->setStatusCode(301);
+                $redirect->save();
             }
 
             return $this->adminJson([


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.3`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #11592 

## Additional info  
A redirect is only created if:
- The pretty URL has changed
- The new pretty URL is not empty (if the pretty URL was removed a 404 is the correct error code)
- The old pretty URL is not empty(if there was no pretty URL before we do not need to redirect)

