### PR TITLE
[Bug]: [DataObject][Tree] Expand/Collapse children on leaf element

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -284,7 +284,6 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         $hasChildren = $child->getDao()->hasChildren($allowedTypes, null, $this->getAdminUser());
 
         $tmpObject['allowDrop'] = false;
-        $tmpObject['leaf'] = !$hasChildren;
 
         $tmpObject['isTarget'] = true;
         if ($tmpObject['type'] != DataObject::OBJECT_TYPE_VARIANT) {
@@ -319,9 +318,6 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         }
 
         if ($tmpObject['leaf']) {
-            $tmpObject['expandable'] = false;
-            $tmpObject['expanded'] = true;
-            $tmpObject['leaf'] = false;
             $tmpObject['loaded'] = true;
         }
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -317,10 +317,6 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             $tmpObject['cls'] .= 'pimcore_treenode_lockOwner ';
         }
 
-        if ($tmpObject['leaf']) {
-            $tmpObject['loaded'] = true;
-        }
-
         return $tmpObject;
     }
 


### PR DESCRIPTION
This button is not supposed to appear on elements that have no children (leaf)
![image](https://user-images.githubusercontent.com/6014195/163219406-11e5a34a-1c5a-4208-936d-8d023d287a50.png)

it seems that there was something that was intended to be transitional (BC purposes) for [ExtJs6](https://github.com/pimcore/pimcore/commit/64d1197078fa9a54e428b12626148bb38f76c41f) 
`$tmpObject['leaf'] = !$hasChildren;` is declared twice, i kept the one at line 295