### PR TITLE
Change sort method permission

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -992,7 +992,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             if ($currentSortBy != $sortBy) {
                 $user = Tool\Admin::getCurrentUser();
 
-                if (!$user->isAdmin()) {
+                if (!($user->isAdmin() || $user->isAllowed('change_data_objects_sort_method'))) {
                     return $this->json(['success' => false, 'message' => 'Changing the sort method is only allowed for admin users']);
                 }
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -992,7 +992,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             if ($currentSortBy != $sortBy) {
                 $user = Tool\Admin::getCurrentUser();
 
-                if (!($user->isAdmin() || $user->isAllowed('change_data_objects_sort_method'))) {
+                if (!$user->isAdmin() && !$user->isAllowed('objects_sort_method')) {
                     return $this->json(['success' => false, 'message' => 'Changing the sort method is only allowed for admin users']);
                 }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
@@ -709,7 +709,7 @@ pimcore.object.tree = Class.create({
 
                     let currentSortMethod = record.data.sortBy;
 
-                    if (currentSortMethod !== "key" || user.admin) {
+                    if (currentSortMethod !== "key" || user.admin || user.isAllowed("change_data_objects_sort_method")) {
                         sortByItems.push({
                             text: t('by_key'),
                             iconCls: "pimcore_icon_alphabetical_sorting_az",
@@ -722,7 +722,7 @@ pimcore.object.tree = Class.create({
                         });
                     }
 
-                    if (currentSortMethod !== "index" || user.admin) {
+                    if (currentSortMethod !== "index" || user.admin || user.isAllowed("change_data_objects_sort_method")) {
                         sortByItems.push({
                             text: t('by_index'),
                             iconCls: "pimcore_icon_index_sorting",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
@@ -709,7 +709,7 @@ pimcore.object.tree = Class.create({
 
                     let currentSortMethod = record.data.sortBy;
 
-                    if (currentSortMethod !== "key" || user.admin || user.isAllowed("change_data_objects_sort_method")) {
+                    if (currentSortMethod !== "key" || user.admin || user.isAllowed("objects_sort_method")) {
                         sortByItems.push({
                             text: t('by_key'),
                             iconCls: "pimcore_icon_alphabetical_sorting_az",
@@ -722,7 +722,7 @@ pimcore.object.tree = Class.create({
                         });
                     }
 
-                    if (currentSortMethod !== "index" || user.admin || user.isAllowed("change_data_objects_sort_method")) {
+                    if (currentSortMethod !== "index" || user.admin || user.isAllowed("objects_sort_method")) {
                         sortByItems.push({
                             text: t('by_index'),
                             iconCls: "pimcore_icon_index_sorting",

--- a/bundles/CoreBundle/Migrations/Version20220411172543.php
+++ b/bundles/CoreBundle/Migrations/Version20220411172543.php
@@ -28,7 +28,7 @@ final class Version20220411172543 extends AbstractMigration
      */
     public function up(Schema $schema): void
     {
-        $this->addSql("INSERT IGNORE INTO users_permission_definitions (`key`) VALUES('change_data_objects_sort_method');");
+        $this->addSql("INSERT IGNORE INTO users_permission_definitions (`key`) VALUES('objects_sort_method');");
     }
 
     /**
@@ -36,6 +36,6 @@ final class Version20220411172543 extends AbstractMigration
      */
     public function down(Schema $schema): void
     {
-        $this->addSql("DELETE FROM users_permission_definitions WHERE `key` = 'change_data_objects_sort_method'");
+        $this->addSql("DELETE FROM users_permission_definitions WHERE `key` = 'objects_sort_method'");
     }
 }

--- a/bundles/CoreBundle/Migrations/Version20220411172543.php
+++ b/bundles/CoreBundle/Migrations/Version20220411172543.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * @internal
+ */
+final class Version20220411172543 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->addSql("INSERT IGNORE INTO users_permission_definitions (`key`) VALUES('change_data_objects_sort_method');");
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+        $this->addSql("DELETE FROM users_permission_definitions WHERE `key` = 'change_data_objects_sort_method'");
+    }
+}

--- a/bundles/CoreBundle/Resources/translations/de.json
+++ b/bundles/CoreBundle/Resources/translations/de.json
@@ -967,5 +967,6 @@
     "asset_upload_want_to_overwrite": "Do you want to overwrite file %s?",
     "asset_upload_overwrite": "Overwrite",
     "asset_upload_keep_both": "Keep both files",
-    "asset_upload_overwrite_all": "Overwrite all"
+    "asset_upload_overwrite_all": "Overwrite all",
+    "change_data_objects_sort_method": "Sortiermethode für Data Objects ändern"
 }

--- a/bundles/CoreBundle/Resources/translations/de.json
+++ b/bundles/CoreBundle/Resources/translations/de.json
@@ -968,5 +968,5 @@
     "asset_upload_overwrite": "Overwrite",
     "asset_upload_keep_both": "Keep both files",
     "asset_upload_overwrite_all": "Overwrite all",
-    "change_data_objects_sort_method": "Sortiermethode für Data Objects ändern"
+    "objects_sort_method": "Sortiermethode für Data Objects ändern"
 }

--- a/bundles/CoreBundle/Resources/translations/de.json
+++ b/bundles/CoreBundle/Resources/translations/de.json
@@ -967,6 +967,5 @@
     "asset_upload_want_to_overwrite": "Do you want to overwrite file %s?",
     "asset_upload_overwrite": "Overwrite",
     "asset_upload_keep_both": "Keep both files",
-    "asset_upload_overwrite_all": "Overwrite all",
-    "objects_sort_method": "Sortiermethode für Data Objects ändern"
+    "asset_upload_overwrite_all": "Overwrite all"
 }

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -969,5 +969,6 @@
     "asset_upload_overwrite": "Overwrite",
     "asset_upload_keep_both": "Keep both files",
     "asset_upload_overwrite_all": "Overwrite all",
-    "could_not_open_zip_file": "The uploaded zip file could not be opened."
+    "could_not_open_zip_file": "The uploaded zip file could not be opened.",
+    "change_data_objects_sort_method": "Change data objects sort method"
 }

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -970,5 +970,5 @@
     "asset_upload_keep_both": "Keep both files",
     "asset_upload_overwrite_all": "Overwrite all",
     "could_not_open_zip_file": "The uploaded zip file could not be opened.",
-    "change_data_objects_sort_method": "Change data objects sort method"
+    "objects_sort_method": "Change data objects sort method"
 }

--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -808,7 +808,7 @@ class Installer
             ['key' => 'notifications'],
             ['key' => 'notifications_send'],
             ['key' => 'sites'],
-            ['key' => 'change_data_objects_sort_method'],
+            ['key' => 'objects_sort_method'],
         ];
 
         foreach ($userPermissions as $up) {

--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -808,6 +808,7 @@ class Installer
             ['key' => 'notifications'],
             ['key' => 'notifications_send'],
             ['key' => 'sites'],
+            ['key' => 'change_data_objects_sort_method'],
         ];
 
         foreach ($userPermissions as $up) {


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.3`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #11716

## Additional info  

A backend user with the new permission `objects_sort_method` is now able to change the sorting method (key or index) of children of data objects without needing to be a full admin.
