### PR TITLE
[Improvement][JS][Dataobject]: Adding willClose property (save,publish and close/publish and close )

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/asset.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/asset.js
@@ -13,7 +13,7 @@
 
 pimcore.registerNS("pimcore.asset.asset");
 pimcore.asset.asset = Class.create(pimcore.element.abstract, {
-
+    willClose: false,
     getData: function () {
         Ext.Ajax.request({
             url: Routing.generate('pimcore_admin_asset_getdatabyid'),
@@ -406,6 +406,11 @@ pimcore.asset.asset = Class.create(pimcore.element.abstract, {
                 if(typeof callback == "function") {
                     callback();
                 }
+
+                if (this.willClose){
+                    this.close();
+                }
+
             }.bind(this),
             failure: function () {
                 this.tab.unmask();
@@ -413,14 +418,14 @@ pimcore.asset.asset = Class.create(pimcore.element.abstract, {
             params: params
         });
     },
-
-    saveClose: function(){
-        this.save(null, function () {
-            var tabPanel = Ext.getCmp("pimcore_panel_tabs");
-            tabPanel.remove(this.tab);
-        }.bind(this));
+    close: function(){
+        var tabPanel = Ext.getCmp("pimcore_panel_tabs");
+        tabPanel.remove(this.tab);
     },
-
+    saveClose: function(){
+        this.willClose = true;
+        this.save(null);
+    },
     remove: function () {
         var options = {
             "elementType" : "asset",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/document.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/document.js
@@ -13,7 +13,7 @@
 
 pimcore.registerNS("pimcore.document.document");
 pimcore.document.document = Class.create(pimcore.element.abstract, {
-
+    willClose: false,
     getData: function () {
         var options = this.options || {};
         Ext.Ajax.request({
@@ -162,6 +162,11 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
                     if (typeof callback == "function") {
                         callback();
                     }
+
+                    if (this.willClose){
+                        this.close();
+                    }
+
                 }.bind(this),
                 failure: function () {
                     this.tab.unmask();
@@ -190,15 +195,13 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
     },
 
     saveClose: function (only) {
-        this.save('version', only, function () {
-            this.close();
-        }.bind(this));
+        this.willClose = true;
+        this.save('version', only);
     },
 
     publishClose: function () {
-        this.publish(null, function () {
-            this.close();
-        }.bind(this));
+        this.willClose = true;
+        this.publish(null);
     },
 
     publish: function (only, callback) {
@@ -244,9 +247,8 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
     },
 
     unpublishClose: function () {
-        this.unpublish(null, function () {
-            this.close();
-        }.bind(this));
+        this.willClose = true;
+        this.unpublish(null);
     },
 
     reload: function () {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/object.js
@@ -13,7 +13,7 @@
 
 pimcore.registerNS("pimcore.object.object");
 pimcore.object.object = Class.create(pimcore.object.abstract, {
-
+    willClose: false,
     initialize: function (id, options) {
         this.id = intval(id);
         this.options = options;
@@ -666,15 +666,13 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
     },
 
     saveClose: function (only) {
-        this.save(null, only, function () {
-            this.close();
-        }.bind(this))
+        this.willClose = true;
+        this.save(null, only);
     },
 
     publishClose: function () {
-        this.publish(null, function () {
-            this.close();
-        }.bind(this))
+        this.willClose = true;
+        this.publish(null)
     },
 
     publish: function (only, callback) {
@@ -714,9 +712,8 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
     },
 
     unpublishClose: function () {
-        this.unpublish(null, function () {
-            this.close();
-        }.bind(this));
+        this.willClose = true;
+        this.unpublish(null);
     },
 
     saveToSession: function (callback) {
@@ -825,6 +822,11 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                     if (typeof callback == "function") {
                         callback();
                     }
+
+                    if (this.willClose){
+                        this.close();
+                    }
+
                 }.bind(this),
                 failure: function (response) {
                     this.tab.unmask();


### PR DESCRIPTION
improves #11823

~~I wouldn't consider it as a bug, but~~ this change will give more versatility (eg. decide wheter reload or not like described in #11823 or implementing a post save event listener that "cancels" the closing action, by turning `object.willClose` to `false`.
It seems it that makes 'callback' parameter in save() obsolete because it was mostly used to do the closing.