### PR TITLE
[Admin] Fix displaying multiselect with options provider and render type "list"

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multiselect.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multiselect.js
@@ -74,7 +74,7 @@ pimcore.object.tags.multiselect = Class.create(pimcore.object.tags.abstract, {
         var storeData = this.prepareStoreDataAndFilterLabels(field.layout);
 
         var store = Ext.create('Ext.data.JsonStore', {
-            fields: ['id', 'text'],
+            fields: [{name: 'id', type: 'string'}, 'text'],
             data: storeData
         });
 
@@ -120,7 +120,7 @@ pimcore.object.tags.multiselect = Class.create(pimcore.object.tags.abstract, {
         }
 
         var store = Ext.create('Ext.data.Store', {
-            fields: ['id', 'text'],
+            fields: [{name: 'id', type: 'string'}, 'text'],
             data: storeData
         });
 


### PR DESCRIPTION
If a multiselect (render type "list") with an options provider returns numeric IDs
(as given as an example in the documentation) the multiselect element isn't correctly
rendered in the edit layout: The set items are not selected.

This fix forces the "id" field of the store to be handled as a string, exactly as a
static definition of items would be.

Resolves #11623
