### PR TITLE
[Grid] Remove unnecessary child count when loading classes

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -475,7 +475,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             );
 
             $objectData['childdata']['id'] = $objectFromDatabase->getId();
-            $objectData['childdata']['data']['classes'] = $this->prepareChildClasses($objectFromDatabase->getDao()->getClasses());
+            $objectData['childdata']['data']['classes'] = $this->prepareChildClasses($objectFromDatabase->getDao()->getClasses(Tool\Admin::getCurrentUser()));
             $objectData['childdata']['data']['general'] = $objectData['general'];
             /** -------------------------------------------------------------
              *   Load remaining general data from latest version
@@ -739,7 +739,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
             $objectData['properties'] = Element\Service::minimizePropertiesForEditmode($object->getProperties());
             $objectData['userPermissions'] = $object->getUserPermissions();
-            $objectData['classes'] = $this->prepareChildClasses($object->getDao()->getClasses());
+            $objectData['classes'] = $this->prepareChildClasses($object->getDao()->getClasses(Tool\Admin::getCurrentUser()));
 
             // grid-config
             $configFile = PIMCORE_CONFIGURATION_DIRECTORY . '/object/grid/' . $object->getId() . '-user_' . $this->getAdminUser()->getId() . '.psf';

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -475,7 +475,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             );
 
             $objectData['childdata']['id'] = $objectFromDatabase->getId();
-            $objectData['childdata']['data']['classes'] = $this->prepareChildClasses($objectFromDatabase->getDao()->getClasses(Tool\Admin::getCurrentUser()));
+            $objectData['childdata']['data']['classes'] = $this->prepareChildClasses($objectFromDatabase->getDao()->getClasses());
             $objectData['childdata']['data']['general'] = $objectData['general'];
             /** -------------------------------------------------------------
              *   Load remaining general data from latest version
@@ -739,7 +739,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
             $objectData['properties'] = Element\Service::minimizePropertiesForEditmode($object->getProperties());
             $objectData['userPermissions'] = $object->getUserPermissions();
-            $objectData['classes'] = $this->prepareChildClasses($object->getDao()->getClasses(Tool\Admin::getCurrentUser()));
+            $objectData['classes'] = $this->prepareChildClasses($object->getDao()->getClasses());
 
             // grid-config
             $configFile = PIMCORE_CONFIGURATION_DIRECTORY . '/object/grid/' . $object->getId() . '-user_' . $this->getAdminUser()->getId() . '.psf';

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -471,25 +471,10 @@ class Dao extends Model\Element\Dao
             $path = '';
         }
 
-        $permissionCondition = '';
-        if ($user && !$user->isAdmin()) {
-            $roleIds = $user->getRoles();
-            $currentUserId = $user->getId();
-            $permissionIds = array_merge($roleIds, [$currentUserId]);
-
-            $inheritedPermission = $this->isInheritingPermission('list', $permissionIds);
-
-            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_object uwo WHERE userId IN ('.implode(',', $permissionIds).') AND list=1 AND LOCATE(CONCAT(o.o_path,o.o_key),cpath)=1 AND
-            NOT EXISTS(SELECT list FROM users_workspaces_object WHERE userId ='.$currentUserId.'  AND list=0 AND cpath = uwo.cpath))';
-            $isDisallowedCurrentRow = 'EXISTS(SELECT list FROM users_workspaces_object uworow WHERE userId IN ('.implode(',', $permissionIds).')  AND cid = o_id AND list=0)';
-
-            $permissionCondition .= ' AND IF('.$anyAllowedRowOrChildren.',1,IF('.$inheritedPermission.', '.$isDisallowedCurrentRow.' = 0, 0)) = 1';
-        }
-
         $classIds = [];
         do {
             $classId = $this->db->fetchOne(
-                "SELECT o_classId FROM objects WHERE o_path LIKE ? AND o_type = 'object'".($classIds ? ' AND o_classId NOT IN ('.rtrim(str_repeat('?,', count($classIds)), ',').')' : '').$permissionCondition.' LIMIT 1',
+                "SELECT o_classId FROM objects WHERE o_path LIKE ? AND o_type = 'object'".($classIds ? ' AND o_classId NOT IN ('.rtrim(str_repeat('?,', count($classIds)), ',').')' : '').' LIMIT 1',
                 array_merge([$this->db->escapeLike($path).'/%'], $classIds));
             if ($classId) {
                 $classIds[] = $classId;

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -464,7 +464,7 @@ class Dao extends Model\Element\Dao
     /**
      * @return array
      */
-    public function getClasses(Model\User $user = null)
+    public function getClasses()
     {
         $path = $this->model->getRealFullPath();
         if (!$this->model->getId() || $this->model->getId() == 1) {

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -464,17 +464,32 @@ class Dao extends Model\Element\Dao
     /**
      * @return array
      */
-    public function getClasses()
+    public function getClasses(Model\User $user = null)
     {
         $path = $this->model->getRealFullPath();
         if (!$this->model->getId() || $this->model->getId() == 1) {
             $path = '';
         }
 
+        $permissionCondition = '';
+        if ($user && !$user->isAdmin()) {
+            $roleIds = $user->getRoles();
+            $currentUserId = $user->getId();
+            $permissionIds = array_merge($roleIds, [$currentUserId]);
+
+            $inheritedPermission = $this->isInheritingPermission('list', $permissionIds);
+
+            $anyAllowedRowOrChildren = 'EXISTS(SELECT list FROM users_workspaces_object uwo WHERE userId IN ('.implode(',', $permissionIds).') AND list=1 AND LOCATE(CONCAT(o.o_path,o.o_key),cpath)=1 AND
+            NOT EXISTS(SELECT list FROM users_workspaces_object WHERE userId ='.$currentUserId.'  AND list=0 AND cpath = uwo.cpath))';
+            $isDisallowedCurrentRow = 'EXISTS(SELECT list FROM users_workspaces_object uworow WHERE userId IN ('.implode(',', $permissionIds).')  AND cid = o_id AND list=0)';
+
+            $permissionCondition .= ' AND IF('.$anyAllowedRowOrChildren.',1,IF('.$inheritedPermission.', '.$isDisallowedCurrentRow.' = 0, 0)) = 1';
+        }
+
         $classIds = [];
         do {
             $classId = $this->db->fetchOne(
-                "SELECT o_classId FROM objects WHERE o_path LIKE ? AND o_type = 'object'".($classIds ? ' AND o_classId NOT IN ('.rtrim(str_repeat('?,', count($classIds)), ',').')' : '').' LIMIT 1',
+                "SELECT o_classId FROM objects WHERE o_path LIKE ? AND o_type = 'object'".($classIds ? ' AND o_classId NOT IN ('.rtrim(str_repeat('?,', count($classIds)), ',').')' : '').$permissionCondition.' LIMIT 1',
                 array_merge([$this->db->escapeLike($path).'/%'], $classIds));
             if ($classId) {
                 $classIds[] = $classId;

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -466,31 +466,27 @@ class Dao extends Model\Element\Dao
      */
     public function getClasses()
     {
-        if ($this->getChildAmount()) {
-            $path = $this->model->getRealFullPath();
-            if (!$this->model->getId() || $this->model->getId() == 1) {
-                $path = '';
-            }
-
-            $classIds = [];
-            do {
-                $classId = $this->db->fetchOne(
-                    "SELECT o_classId FROM objects WHERE o_path LIKE ? AND o_type = 'object'".($classIds ? ' AND o_classId NOT IN ('.rtrim(str_repeat('?,', count($classIds)), ',').')' : '').' LIMIT 1',
-                    array_merge([$this->db->escapeLike($path).'/%'], $classIds));
-                if ($classId) {
-                    $classIds[] = $classId;
-                }
-            } while ($classId);
-
-            $classes = [];
-            foreach ($classIds as $classId) {
-                $classes[] = DataObject\ClassDefinition::getById($classId);
-            }
-
-            return $classes;
+        $path = $this->model->getRealFullPath();
+        if (!$this->model->getId() || $this->model->getId() == 1) {
+            $path = '';
         }
 
-        return [];
+        $classIds = [];
+        do {
+            $classId = $this->db->fetchOne(
+                "SELECT o_classId FROM objects WHERE o_path LIKE ? AND o_type = 'object'".($classIds ? ' AND o_classId NOT IN ('.rtrim(str_repeat('?,', count($classIds)), ',').')' : '').' LIMIT 1',
+                array_merge([$this->db->escapeLike($path).'/%'], $classIds));
+            if ($classId) {
+                $classIds[] = $classId;
+            }
+        } while ($classId);
+
+        $classes = [];
+        foreach ($classIds as $classId) {
+            $classes[] = DataObject\ClassDefinition::getById($classId);
+        }
+
+        return $classes;
     }
 
     /**


### PR DESCRIPTION
When loading the data object classes for the grid, the call
https://github.com/pimcore/pimcore/blob/fad54cc4ee3ddd4c177ecc4a7972a1f86b819000/models/DataObject/AbstractObject/Dao.php#L469
is expensive and not necessary (needs 5 seconds in our case with > 4M objects in a folder)

This PR is a follow-up of #11856
Improves problems mentioned in #9727