### PR TITLE
[DataObject] Fix AdvancedManyToMany(Object)Relation field save with empty metadata

### DIFF
--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -303,10 +303,8 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
                         $setter = 'set' . ucfirst($c['key']);
                         $value = $relation[$c['key']] ?? null;
 
-                        if ($c['type'] == 'multiselect') {
-                            if (is_array($value) && count($value)) {
-                                $value = implode(',', $value);
-                            }
+                        if ($c['type'] == 'multiselect' && is_array($value)) {
+                            $value = implode(',', $value);
                         }
 
                         $metaData->$setter($value);

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -411,10 +411,8 @@ class AdvancedManyToManyRelation extends ManyToManyRelation implements IdRewrite
                         $setter = 'set' . ucfirst($key);
                         $value = $element[$key] ?? null;
 
-                        if ($columnConfig['type'] === 'multiselect') {
-                            if (is_array($value) && count($value)) {
-                                $value = implode(',', $value);
-                            }
+                        if ($columnConfig['type'] === 'multiselect' && is_array($value)) {
+                            $value = implode(',', $value);
                         }
 
                         $metaData->$setter($value);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #11883

## Additional info  

