### PR TITLE
[Redirects panel] Search should always start at page 1

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/redirects.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/redirects.js
@@ -102,7 +102,7 @@ pimcore.settings.redirects = Class.create({
                         var input = field;
                         var proxy = this.store.getProxy();
                         proxy.extraParams.filter = input.getValue();
-                        this.store.load();
+                        this.pagingtoolbar.moveFirst();
                     }
                 }.bind(this)
             }


### PR DESCRIPTION
Steps to reproduce:
1. Go to Redirects in Pimcore admin panel, create redirect with `Source`=test
1. Create over 25 redirects with other sources
2. Select `items per page`=25
3. Go to page 2
4. Search for "test" -> no results shown because store proxy param "start" is still on 25

With this PR when a search is started, pagination will always go back to page 1, similarly as it is done in https://github.com/pimcore/pimcore/blob/fad54cc4ee3ddd4c177ecc4a7972a1f86b819000/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/gridTabAbstract.js#L249