### PR TITLE
[Bug][Search]: Fixes Search and Quick Search not returning children when parent folder is list=0

### DIFF
--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -90,7 +90,7 @@ class SearchController extends AdminController
         $forbiddenConditions = $this->getForbiddenCondition($types);
 
         if ($forbiddenConditions) {
-            $conditionParts[] = '(' . implode(' OR ', $forbiddenConditions) . ')';
+            $conditionParts[] = '(' . implode(' AND ', $forbiddenConditions) . ')';
         }
 
         $queryCondition = '';
@@ -304,7 +304,7 @@ class SearchController extends AdminController
         $elements = [];
         foreach ($hits as $hit) {
             $element = Element\Service::getElementById($hit->getId()->getType(), $hit->getId()->getId());
-//            if ($element->isAllowed('list')) {
+            if ($element->isAllowed('list')) {
                 $data = null;
                 if ($element instanceof DataObject\AbstractObject) {
                     $data = DataObject\Service::gridObjectData($element, $fields);
@@ -317,10 +317,10 @@ class SearchController extends AdminController
                 if ($data) {
                     $elements[] = $data;
                 }
-//            } else {
+            } else {
                 //TODO: any message that view is blocked?
                 //$data = Element\Service::gridElementData($element);
-//            }
+            }
         }
 
         // only get the real total-count when the limit parameter is given otherwise use the default limit
@@ -436,7 +436,7 @@ class SearchController extends AdminController
 
         $forbiddenConditions = $this->getForbiddenCondition();
         if ($forbiddenConditions) {
-            $conditionParts[] = '(' . implode(' OR ', $forbiddenConditions) . ')';
+            $conditionParts[] = '(' . implode(' AND ', $forbiddenConditions) . ')';
         }
 
         $matchCondition = '( MATCH (`data`,`properties`) AGAINST (' . $db->quote($query) . ' IN BOOLEAN MODE) )';

--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -461,17 +461,19 @@ class SearchController extends AdminController
         $elements = [];
         foreach ($hits as $hit) {
             $element = Element\Service::getElementById($hit->getId()->getType(), $hit->getId()->getId());
-            $data = [
-                'id' => $element->getId(),
-                'type' => $hit->getId()->getType(),
-                'subtype' => $element->getType(),
-                'className' => ($element instanceof DataObject\Concrete) ? $element->getClassName() : '',
-                'fullpathList' => htmlspecialchars($this->shortenPath($element->getRealFullPath())),
-            ];
+            if ($element->isAllowed('list')) {
+                $data = [
+                    'id' => $element->getId(),
+                    'type' => $hit->getId()->getType(),
+                    'subtype' => $element->getType(),
+                    'className' => ($element instanceof DataObject\Concrete) ? $element->getClassName() : '',
+                    'fullpathList' => htmlspecialchars($this->shortenPath($element->getRealFullPath())),
+                ];
 
-            $this->addAdminStyle($element, ElementAdminStyleEvent::CONTEXT_SEARCH, $data);
+                $this->addAdminStyle($element, ElementAdminStyleEvent::CONTEXT_SEARCH, $data);
 
-            $elements[] = $data;
+                $elements[] = $data;
+            }
         }
 
         $afterListLoadEvent = new GenericEvent($this, [

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -718,30 +718,80 @@ class Service extends Model\AbstractModel
      */
     public static function findForbiddenPaths($type, $user)
     {
+        $db = Db::get();
+
         if ($user->isAdmin()) {
-            return [];
+            return array('forbidden' => [], 'allowed' => []);
         }
 
-        // get workspaces
-        $workspaces = $user->{'getWorkspaces' . ucfirst($type)}();
-        foreach ($user->getRoles() as $roleId) {
-            $role = Model\User\Role::getById($roleId);
-            $workspaces = array_merge($workspaces, $role->{'getWorkspaces' . ucfirst($type)}());
+        $currentUserId = $user->getId();
+        $userIds = $user->getRoles();
+        $userIds[] = $currentUserId;
+
+        $userWorkspacesSql = '
+            SELECT cpath, cid, list
+            FROM users_workspaces_'.$type.'
+            WHERE userId = '.$currentUserId.'
+        ';
+        $userWorkspaces = $db->fetchAll($userWorkspacesSql);
+
+        //this collects the array that are on user-level, which have top priority
+        $userCid = [];
+        foreach ($userWorkspaces as $userWorkspace){
+            $userCid[] = $userWorkspace['cid'];
         }
+
+        $roleWorkspacesSql = '
+            SELECT
+                cpath, userid, max(list) as list
+            FROM users_workspaces_'.$type.'
+            WHERE userId IN (' . implode(',', $userIds) . ') AND cid NOT IN ('.implode(',', $userCid).')
+            GROUP BY cpath
+        ';
+        $roleWorkspaces = $db->fetchAll($roleWorkspacesSql);
+
+        $allWorkspaces = array_merge($userWorkspaces, $roleWorkspaces);
+
+        $uniquePaths = [];
+        foreach ($allWorkspaces as $workspace){
+            $uniquePaths[$workspace['cpath']] = $workspace['list'];
+        }
+        ksort($uniquePaths);
+
+        //TODO: above this should be all in one query (eg. instead of ksort, use sql sort) but had difficulties making the `group by` working properly to let user permissions take precedence
+
+        $totalPaths = count($uniquePaths);
+
+        $uniquePathsKeys = array_keys($uniquePaths);
 
         $forbidden = [];
-        if (count($workspaces) > 0) {
-            foreach ($workspaces as $workspace) {
-                if (!$workspace->getList()) {
-                    $forbidden[] = $workspace->getCpath();
+        $allowed = [];
+        if ($totalPaths > 0) {
+            for ($index = 0; $index < $totalPaths; $index++) {
+                $path = $uniquePathsKeys[$index];
+                if ($uniquePaths[$path] == 0) {
+                    $forbidden[$path] = [];
+                    for ($findIndex = $index + 1; $findIndex < $totalPaths; $findIndex++) { //NB: the starting index is the last index we got
+                        $findPath = $uniquePathsKeys[$findIndex];
+                        if (str_contains($findPath, $path)) { //it means that we found a children
+                            if ($uniquePaths[$findPath] == 1) {
+                                array_push($forbidden[$path], $findPath); //adding list=1 children
+                            }
+                        } else {
+                            break;
+                        }
+                    }
+                }else{
+                    $allowed[] = $path;
                 }
             }
         } else {
-            $forbidden[] = '/';
+            $forbidden['/'] = [];
         }
 
-        return $forbidden;
+        return array('forbidden' => $forbidden, 'allowed' => $allowed);
     }
+
 
     /**
      * renews all references, for example after unserializing an ElementInterface

--- a/tests/Model/Permissions/ModelAssetPermissionsTest.php
+++ b/tests/Model/Permissions/ModelAssetPermissionsTest.php
@@ -568,9 +568,9 @@ class ModelAssetPermissionsTest extends ModelTestCase
         $elementCount = 5;
 
         for($i = 1; $i <= $elementCount; $i++) {
-            $manyElementList[] = $this->createAsset('manyelement ' . $i, $manyElements->getId());
+            $manyElementList[] = $this->createAsset('manyelement ' . $i.'.gif', $manyElements->getId());
         }
-        $manyElementX = $this->createAsset('manyelement X', $manyElements->getId());
+        $manyElementX = $this->createAsset('manyelement X.gif', $manyElements->getId());
 
         //update role
         $role = User\Role::getByName('Testrole');

--- a/tests/Model/Permissions/ModelAssetPermissionsTest.php
+++ b/tests/Model/Permissions/ModelAssetPermissionsTest.php
@@ -32,7 +32,7 @@ class ModelAssetPermissionsTest extends ModelTestCase
      *
      * /permissionfoo --> allowed
      * /permissionfoo/bars --> not allowed
-     * /permissionbar/bars/hugo.gif --> ?? --> should not be found
+     * /permissionfoo/bars/hugo.gif --> ?? --> should not be found
      * /permissionfoo/bars/userfolder --> allowed
      * /permissionfoo/bars/userfolder/usertestobject.gif --> ??   --> should be found
      * /permissionfoo/bars/groupfolder --> allowed role
@@ -158,7 +158,7 @@ class ModelAssetPermissionsTest extends ModelTestCase
         //create role
         $role = new User\Role();
         $role->setName('Testrole');
-        $role->setWorkspacesObject([
+        $role->setWorkspacesAsset([
             (new User\Workspace\Asset())->setValues(['cId' => $this->groupfolder->getId(), 'cPath' => $this->groupfolder->getFullpath(), 'list' => true, 'view' => true]),
         ]);
         $role->save();
@@ -166,9 +166,9 @@ class ModelAssetPermissionsTest extends ModelTestCase
         //create user 1
         $this->userPermissionTest1 = new User();
         $this->userPermissionTest1->setName('Permissiontest1');
-        $this->userPermissionTest1->setPermissions(['objects']);
+        $this->userPermissionTest1->setPermissions(['assets']);
         $this->userPermissionTest1->setRoles([$role->getId()]);
-        $this->userPermissionTest1->setWorkspacesObject([
+        $this->userPermissionTest1->setWorkspacesAsset([
             (new User\Workspace\Asset())->setValues(['cId' => $this->permissionfoo->getId(), 'cPath' => $this->permissionfoo->getFullpath(), 'list' => true, 'view' => true]),
             (new User\Workspace\Asset())->setValues(['cId' => $this->permissionbar->getId(), 'cPath' => $this->permissionbar->getFullpath(), 'list' => true, 'view' => true]),
             (new User\Workspace\Asset())->setValues(['cId' => $this->foo->getId(), 'cPath' => $this->foo->getFullpath(), 'list' => false, 'view' => false]),
@@ -180,9 +180,9 @@ class ModelAssetPermissionsTest extends ModelTestCase
         //create user 2
         $this->userPermissionTest2 = new User();
         $this->userPermissionTest2->setName('Permissiontest2');
-        $this->userPermissionTest2->setPermissions(['objects']);
+        $this->userPermissionTest2->setPermissions(['assets']);
         $this->userPermissionTest2->setRoles([$role->getId()]);
-        $this->userPermissionTest2->setWorkspacesObject([
+        $this->userPermissionTest2->setWorkspacesAsset([
             (new User\Workspace\Asset())->setValues(['cId' => $this->permissionfoo->getId(), 'cPath' => $this->permissionfoo->getFullpath(), 'list' => true, 'view' => true]),
             (new User\Workspace\Asset())->setValues(['cId' => $this->permissionbar->getId(), 'cPath' => $this->permissionbar->getFullpath(), 'list' => true, 'view' => true]),
             (new User\Workspace\Asset())->setValues(['cId' => $this->foo->getId(), 'cPath' => $this->foo->getFullpath(), 'list' => false, 'view' => false]),
@@ -479,122 +479,120 @@ class ModelAssetPermissionsTest extends ModelTestCase
         );
     }
 
-    // Disabling these tests until the PR of https://github.com/pimcore/pimcore/issues/11822
-//    protected function doTestSearch(string $searchText, User $user, array $expectedResultPaths, int $limit = 100) {
-//        $controller = $this->buildController('\\Pimcore\\Bundle\\AdminBundle\\Controller\\Searchadmin\\SearchController', $user);
-//
-//        $request = new Request([
-//            'type' => 'object',
-//            'query' => $searchText,
-//            'start' => 0,
-//            'limit' => $limit
-//        ]);
-//
-//        $responseData = $controller->findAction(
-//            $request,
-//            new EventDispatcher(),
-//            new GridHelperService()
-//        );
-//
-//        $responsePaths = [];
-//        foreach($responseData['data'] as $node) {
-//            $responsePaths[] = $node['fullpath'];
-//        }
-//
-//        $this->assertCount(
-//            $responseData['total'],
-//            $responseData['data'],
-//            'Assert total count of response matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '`'
-//        );
-//
-//        $this->assertCount(
-//            count($expectedResultPaths),
-//            $responseData['data'],
-//            'Assert number of expected result matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '` (' . print_r($responsePaths, true) . ')'
-//        );
-//
-//        foreach($expectedResultPaths as $path) {
-//            $this->assertContains(
-//                $path,
-//                $responsePaths,
-//                'Result for `' . $searchText . '` does not contain `' . $path . '` for user `' . $user->getName() . '`'
-//            );
-//        }
-//
-//    }
-//
-//    public function testSearch() {
-//        $admin = User::getByName('admin');
-//
-//        //search hugo
-//        $this->doTestSearch('hugo', $admin, [$this->hugo->getFullpath()]);
-//        $this->doTestSearch('hugo', $this->userPermissionTest1, []);
-//        $this->doTestSearch('hugo', $this->userPermissionTest2, []);
-//
-//        //search bars
-//        $this->doTestSearch('bars', $admin, [
-//            $this->bars->getFullpath(),
-//            $this->hugo->getFullpath(),
-//            $this->userfolder->getFullpath(),
-//            $this->usertestobject->getFullpath(),
-//            $this->groupfolder->getFullpath(),
-//            $this->grouptestobject->getFullpath(),
-//        ]);
-//        $this->doTestSearch('bars', $this->userPermissionTest1, [
-//            $this->bars->getFullpath(),
-//            $this->userfolder->getFullpath(),
-//            $this->usertestobject->getFullpath(),
-//            $this->groupfolder->getFullpath(),
-//            $this->grouptestobject->getFullpath(),
-//        ]);
-//        $this->doTestSearch('bars', $this->userPermissionTest2, [
-//            $this->bars->getFullpath(),
-//            $this->userfolder->getFullpath(),
-//            $this->usertestobject->getFullpath(),
-//        ]);
-//
-//        //search hidden object
-//        $this->doTestSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
-//        $this->doTestSearch('hiddenobject', $this->userPermissionTest1, []);
-//        $this->doTestSearch('hiddenobject', $this->userPermissionTest2, []);
-//
-//    }
-//
-//    public function testManyElementSearch() {
-//        $admin = User::getByName('admin');
-//
-//        //prepare additional data
-//        $manyElements = $this->createFolder('manyElements', 1);
-//        $manyElementList = [];
-//        $elementCount = 100;
-//
-//        for($i = 1; $i <= $elementCount; $i++) {
-//            $manyElementList[] = $this->createAsset('manyelement ' . $i, $manyElements->getId());
-//        }
-//        $manyElementX = $this->createAsset('manyelement X', $manyElements->getId());
-//
-//        //update role
-//        $role = User\Role::getByName('Testrole');
-//        $role->setWorkspacesObject([
-//            (new User\Workspace\Asset())->setValues(['cId' => $this->groupfolder->getId(), 'cPath' => $this->groupfolder->getFullpath(), 'list' => true, 'view' => true]),
-//            (new User\Workspace\Asset())->setValues(['cId' => $manyElementX->getId(), 'cPath' => $manyElementX->getFullpath(), 'list' => true, 'view' => true]),
-//        ]);
-//        $role->save();
-//
-//
-//        //search hugo
-//        $this->doTestSearch('manyelement', $admin, array_merge(
-//                array_map(function($item) { return $item->getFullpath(); }, $manyElementList),
-//                [ $manyElementX->getFullpath() ]
-//            ), $elementCount + 1
-//        );
-//        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount + 1);
-//        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount + 1);
-//
-//        //TODO this needs to be fixed, see issue https://github.com/pimcore/pimcore/issues/11822
-////        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount);
-////        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount);
-//
-//
-//    }
+    protected function doTestSearch(string $searchText, User $user, array $expectedResultPaths, int $limit = 100) {
+        $controller = $this->buildController('\\Pimcore\\Bundle\\AdminBundle\\Controller\\Searchadmin\\SearchController', $user);
+
+        $request = new Request([
+            'type' => 'asset',
+            'query' => $searchText,
+            'start' => 0,
+            'limit' => $limit
+        ]);
+
+        $responseData = $controller->findAction(
+            $request,
+            new EventDispatcher(),
+            new GridHelperService()
+        );
+
+        $responsePaths = [];
+        foreach($responseData['data'] as $node) {
+            $responsePaths[] = $node['fullpath'];
+        }
+
+        $this->assertCount(
+            $responseData['total'],
+            $responseData['data'],
+            'Assert total count of response matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '`'
+        );
+
+        $this->assertCount(
+            count($expectedResultPaths),
+            $responseData['data'],
+            'Assert number of expected result matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '` (' . print_r($responsePaths, true) . ')'
+        );
+
+        foreach($expectedResultPaths as $path) {
+            $this->assertContains(
+                $path,
+                $responsePaths,
+                'Result for `' . $searchText . '` does not contain `' . $path . '` for user `' . $user->getName() . '`'
+            );
+        }
+
+    }
+
+    public function testSearch() {
+        $admin = User::getByName('admin');
+
+        //search hugo
+        $this->doTestSearch('hugo', $admin, [$this->hugo->getFullpath()]);
+        $this->doTestSearch('hugo', $this->userPermissionTest1, []);
+        $this->doTestSearch('hugo', $this->userPermissionTest2, []);
+
+        //search bars
+        $this->doTestSearch('bars', $admin, [
+            $this->bars->getFullpath(),
+            $this->hugo->getFullpath(),
+            $this->userfolder->getFullpath(),
+            $this->usertestobject->getFullpath(),
+            $this->groupfolder->getFullpath(),
+            $this->grouptestobject->getFullpath(),
+        ]);
+        $this->doTestSearch('bars', $this->userPermissionTest1, [
+            $this->bars->getFullpath(),
+            $this->userfolder->getFullpath(),
+            $this->usertestobject->getFullpath(),
+            $this->groupfolder->getFullpath(),
+            $this->grouptestobject->getFullpath(),
+        ]);
+        $this->doTestSearch('bars', $this->userPermissionTest2, [
+            $this->bars->getFullpath(),
+            $this->userfolder->getFullpath(),
+            $this->usertestobject->getFullpath(),
+        ]);
+
+        //search hidden object
+        $this->doTestSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
+        $this->doTestSearch('hiddenobject', $this->userPermissionTest1, []);
+        $this->doTestSearch('hiddenobject', $this->userPermissionTest2, []);
+
+    }
+
+    public function testManyElementSearch() {
+        $admin = User::getByName('admin');
+
+        //prepare additional data
+        $manyElements = $this->createFolder('manyElements', 1);
+        $manyElementList = [];
+        $elementCount = 5;
+
+        for($i = 1; $i <= $elementCount; $i++) {
+            $manyElementList[] = $this->createAsset('manyelement ' . $i, $manyElements->getId());
+        }
+        $manyElementX = $this->createAsset('manyelement X', $manyElements->getId());
+
+        //update role
+        $role = User\Role::getByName('Testrole');
+        $role->setWorkspacesAsset([
+            (new User\Workspace\Asset())->setValues(['cId' => $manyElementX->getId(), 'cPath' => $manyElementX->getFullpath(), 'list' => true, 'view' => true]),
+            (new User\Workspace\Asset())->setValues(['cId' => $this->groupfolder->getId(), 'cPath' => $this->groupfolder->getFullpath(), 'list' => true, 'view' => true]),
+        ]);
+        $role->save();
+
+
+        //search manyelement
+        $this->doTestSearch('manyelement', $admin, array_merge(
+                array_map(function($item) { return $item->getFullpath(); }, $manyElementList),
+                [ $manyElementX->getFullpath() ]
+            ), $elementCount + 1
+        );
+        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount + 1);
+        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount + 1);
+
+        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount);
+        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount);
+
+
+    }
 }

--- a/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
@@ -16,7 +16,9 @@
 namespace Pimcore\Tests\Model\Element;
 
 use Codeception\Util\Stub;
+use Pimcore\Bundle\AdminBundle\Controller\Searchadmin\SearchController;
 use Pimcore\Bundle\AdminBundle\Helper\GridHelperService;
+use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Search;
 use Pimcore\Model\User;
@@ -138,6 +140,11 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
      */
     protected $abcdefghjkl;
 
+    /**
+     * @var Asset
+     */
+    protected $assetElement;
+
     protected function prepareObjectTree()
     {
 
@@ -191,6 +198,23 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         return $object;
     }
 
+    protected function createAsset(string $key, int $parentId): Asset
+    {
+        $asset = new Asset\Image();
+
+        $asset->setKey($key);
+        $asset->setParentId($parentId);
+        $asset->setType('image');
+        $asset->setData('data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==');
+        $asset->setFilename($key);
+        $asset->save();
+
+        $searchEntry = new Search\Backend\Data($asset);
+        $searchEntry->save();
+
+        return $asset;
+    }
+
     protected function prepareUsers()
     {
         //create role
@@ -239,6 +263,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         TestHelper::cleanUp();
 
         $this->prepareObjectTree();
+        $this->assetElement = $this->createAsset('assetelement', 1);
         $this->prepareUsers();
     }
 
@@ -522,6 +547,9 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
     }
 
     protected function doTestSearch(string $searchText, User $user, array $expectedResultPaths, int $limit = 100) {
+        /**
+         * @var SearchController $controller
+         */
         $controller = $this->buildController('\\Pimcore\\Bundle\\AdminBundle\\Controller\\Searchadmin\\SearchController', $user);
 
         $request = new Request([
@@ -545,22 +573,23 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->assertCount(
             $responseData['total'],
             $responseData['data'],
-            'Assert total count of response matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '`'
+            '[Search] Assert total count of response matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '`'
         );
 
         $this->assertCount(
             count($expectedResultPaths),
             $responseData['data'],
-            'Assert number of expected result matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '` (' . print_r($responsePaths, true) . ')'
+            '[Search] Assert number of expected result matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '` (' . print_r($responsePaths, true) . ')'
         );
 
         foreach($expectedResultPaths as $path) {
             $this->assertContains(
                 $path,
                 $responsePaths,
-                'Result for `' . $searchText . '` does not contain `' . $path . '` for user `' . $user->getName() . '`'
+                '[Search] Result for `' . $searchText . '` does not contain `' . $path . '` for user `' . $user->getName() . '`'
             );
         }
+
 
     }
 
@@ -599,6 +628,12 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestSearch('hiddenobject', $this->userPermissionTest1, []);
         $this->doTestSearch('hiddenobject', $this->userPermissionTest2, []);
 
+
+        //search for asset
+        $this->doTestSearch('assetelement', $admin, []);
+        $this->doTestSearch('assetelement', $this->userPermissionTest1, []);
+        $this->doTestSearch('assetelement', $this->userPermissionTest2, []);
+
     }
 
     public function testManyElementSearch() {
@@ -625,15 +660,88 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
 
         //search manyelement
         $this->doTestSearch('manyelement', $admin, array_merge(
-                array_map(function($item) { return $item->getFullpath(); }, $manyElementList),
-                [ $manyElementX->getFullpath() ]
-            ), $elementCount + 1
+            array_map(function($item) { return $item->getFullpath(); }, $manyElementList),
+            [ $manyElementX->getFullpath() ]
+        ), $elementCount + 1
         );
         $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount + 1);
         $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount + 1);
 
         $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount);
         $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount);
+
+    }
+
+
+    protected function doTestQuickSearch(string $searchText, User $user, array $expectedResultPaths, int $limit = 100) {
+        /**
+         * @var SearchController $controller
+         */
+        $controller = $this->buildController('\\Pimcore\\Bundle\\AdminBundle\\Controller\\Searchadmin\\SearchController', $user);
+
+        $request = new Request([
+            'query' => $searchText,
+            'start' => 0,
+            'limit' => $limit
+        ]);
+
+        $responseData = $controller->quicksearchAction(
+            $request,
+            new EventDispatcher(),
+        );
+
+        $responsePaths = [];
+        foreach($responseData['data'] as $node) {
+            $responsePaths[] = $node['fullpathList'];
+        }
+
+        $this->assertCount(
+            count($expectedResultPaths),
+            $responseData['data'],
+            '[Quicksearch] Assert number of expected result matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '` (' . print_r($responsePaths, true) . ')'
+        );
+
+        foreach($expectedResultPaths as $path) {
+            $this->assertContains(
+                $path,
+                $responsePaths,
+                '[Quicksearch] Result for `' . $searchText . '` does not contain `' . $path . '` for user `' . $user->getName() . '`'
+            );
+        }
+
+    }
+
+    public function testQuickSearch() {
+        $admin = User::getByName('admin');
+
+        //search hugo
+        $this->doTestQuickSearch('hugo', $admin, [$this->hugo->getFullpath()]);
+        $this->doTestQuickSearch('hugo', $this->userPermissionTest1, []);
+        $this->doTestQuickSearch('hugo', $this->userPermissionTest2, []);
+
+        //search bars
+        $this->doTestQuickSearch('bars', $admin, [
+            $this->hugo->getFullpath(),
+            $this->usertestobject->getFullpath(),
+            $this->grouptestobject->getFullpath(),
+        ]);
+        $this->doTestQuickSearch('bars', $this->userPermissionTest1, [
+            $this->usertestobject->getFullpath(),
+            $this->grouptestobject->getFullpath(),
+        ]);
+        $this->doTestQuickSearch('bars', $this->userPermissionTest2, [
+            $this->usertestobject->getFullpath(),
+        ]);
+
+        //search hidden object
+        $this->doTestQuickSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
+        $this->doTestQuickSearch('hiddenobject', $this->userPermissionTest1, []);
+        $this->doTestQuickSearch('hiddenobject', $this->userPermissionTest2, []);
+
+        //search for asset
+        $this->doTestQuickSearch('assetelement', $admin, [$this->assetElement->getFullPath()]);
+        $this->doTestQuickSearch('assetelement', $this->userPermissionTest1, []);
+        $this->doTestQuickSearch('assetelement', $this->userPermissionTest2, []);
 
     }
 }

--- a/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
@@ -32,7 +32,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
      *
      * /permissionfoo --> allowed
      * /permissionfoo/bars --> not allowed
-     * /permissionbar/bars/hugo --> ?? --> should not be found
+     * /permissionfoo/bars/hugo --> ?? --> should not be found
      * /permissionfoo/bars/userfolder --> allowed
      * /permissionfoo/bars/userfolder/usertestobject --> ??   --> should be found
      * /permissionfoo/bars/groupfolder --> allowed role
@@ -521,122 +521,119 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         );
     }
 
-    // Disabling these tests until the PR of https://github.com/pimcore/pimcore/issues/11822
-//    protected function doTestSearch(string $searchText, User $user, array $expectedResultPaths, int $limit = 100) {
-//        $controller = $this->buildController('\\Pimcore\\Bundle\\AdminBundle\\Controller\\Searchadmin\\SearchController', $user);
-//
-//        $request = new Request([
-//            'type' => 'object',
-//            'query' => $searchText,
-//            'start' => 0,
-//            'limit' => $limit
-//        ]);
-//
-//        $responseData = $controller->findAction(
-//            $request,
-//            new EventDispatcher(),
-//            new GridHelperService()
-//        );
-//
-//        $responsePaths = [];
-//        foreach($responseData['data'] as $node) {
-//            $responsePaths[] = $node['fullpath'];
-//        }
-//
-//        $this->assertCount(
-//            $responseData['total'],
-//            $responseData['data'],
-//            'Assert total count of response matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '`'
-//        );
-//
-//        $this->assertCount(
-//            count($expectedResultPaths),
-//            $responseData['data'],
-//            'Assert number of expected result matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '` (' . print_r($responsePaths, true) . ')'
-//        );
-//
-//        foreach($expectedResultPaths as $path) {
-//            $this->assertContains(
-//                $path,
-//                $responsePaths,
-//                'Result for `' . $searchText . '` does not contain `' . $path . '` for user `' . $user->getName() . '`'
-//            );
-//        }
-//
-//    }
-//
-//    public function testSearch() {
-//        $admin = User::getByName('admin');
-//
-//        //search hugo
-//        $this->doTestSearch('hugo', $admin, [$this->hugo->getFullpath()]);
-//        $this->doTestSearch('hugo', $this->userPermissionTest1, []);
-//        $this->doTestSearch('hugo', $this->userPermissionTest2, []);
-//
-//        //search bars
-//        $this->doTestSearch('bars', $admin, [
-//            $this->bars->getFullpath(),
-//            $this->hugo->getFullpath(),
-//            $this->userfolder->getFullpath(),
-//            $this->usertestobject->getFullpath(),
-//            $this->groupfolder->getFullpath(),
-//            $this->grouptestobject->getFullpath(),
-//        ]);
-//        $this->doTestSearch('bars', $this->userPermissionTest1, [
-//            $this->bars->getFullpath(),
-//            $this->userfolder->getFullpath(),
-//            $this->usertestobject->getFullpath(),
-//            $this->groupfolder->getFullpath(),
-//            $this->grouptestobject->getFullpath(),
-//        ]);
-//        $this->doTestSearch('bars', $this->userPermissionTest2, [
-//            $this->bars->getFullpath(),
-//            $this->userfolder->getFullpath(),
-//            $this->usertestobject->getFullpath(),
-//        ]);
-//
-//        //search hidden object
-//        $this->doTestSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
-//        $this->doTestSearch('hiddenobject', $this->userPermissionTest1, []);
-//        $this->doTestSearch('hiddenobject', $this->userPermissionTest2, []);
-//
-//    }
-//
-//    public function testManyElementSearch() {
-//        $admin = User::getByName('admin');
-//
-//        //prepare additional data
-//        $manyElements = $this->createFolder('manyElements', 1);
-//        $manyElementList = [];
-//        $elementCount = 100;
-//
-//        for($i = 1; $i <= $elementCount; $i++) {
-//            $manyElementList[] = $this->createObject('manyelement ' . $i, $manyElements->getId());
-//        }
-//        $manyElementX = $this->createObject('manyelement X', $manyElements->getId());
-//
-//        //update role
-//        $role = User\Role::getByName('Testrole');
-//        $role->setWorkspacesObject([
-//            (new User\Workspace\DataObject())->setValues(['cId' => $this->groupfolder->getId(), 'cPath' => $this->groupfolder->getFullpath(), 'list' => true, 'view' => true]),
-//            (new User\Workspace\DataObject())->setValues(['cId' => $manyElementX->getId(), 'cPath' => $manyElementX->getFullpath(), 'list' => true, 'view' => true]),
-//        ]);
-//        $role->save();
-//
-//
-//        //search hugo
-//        $this->doTestSearch('manyelement', $admin, array_merge(
-//                array_map(function($item) { return $item->getFullpath(); }, $manyElementList),
-//                [ $manyElementX->getFullpath() ]
-//            ), $elementCount + 1
-//        );
-//        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount + 1);
-//        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount + 1);
-//
-//        //TODO this needs to be fixed, see issue https://github.com/pimcore/pimcore/issues/11822
-////        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount);
-////        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount);
-//
-//
-//    }
+    protected function doTestSearch(string $searchText, User $user, array $expectedResultPaths, int $limit = 100) {
+        $controller = $this->buildController('\\Pimcore\\Bundle\\AdminBundle\\Controller\\Searchadmin\\SearchController', $user);
+
+        $request = new Request([
+            'type' => 'object',
+            'query' => $searchText,
+            'start' => 0,
+            'limit' => $limit
+        ]);
+
+        $responseData = $controller->findAction(
+            $request,
+            new EventDispatcher(),
+            new GridHelperService()
+        );
+
+        $responsePaths = [];
+        foreach($responseData['data'] as $node) {
+            $responsePaths[] = $node['fullpath'];
+        }
+
+        $this->assertCount(
+            $responseData['total'],
+            $responseData['data'],
+            'Assert total count of response matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '`'
+        );
+
+        $this->assertCount(
+            count($expectedResultPaths),
+            $responseData['data'],
+            'Assert number of expected result matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '` (' . print_r($responsePaths, true) . ')'
+        );
+
+        foreach($expectedResultPaths as $path) {
+            $this->assertContains(
+                $path,
+                $responsePaths,
+                'Result for `' . $searchText . '` does not contain `' . $path . '` for user `' . $user->getName() . '`'
+            );
+        }
+
+    }
+
+    public function testSearch() {
+        $admin = User::getByName('admin');
+
+        //search hugo
+        $this->doTestSearch('hugo', $admin, [$this->hugo->getFullpath()]);
+        $this->doTestSearch('hugo', $this->userPermissionTest1, []);
+        $this->doTestSearch('hugo', $this->userPermissionTest2, []);
+
+        //search bars
+        $this->doTestSearch('bars', $admin, [
+            $this->bars->getFullpath(),
+            $this->hugo->getFullpath(),
+            $this->userfolder->getFullpath(),
+            $this->usertestobject->getFullpath(),
+            $this->groupfolder->getFullpath(),
+            $this->grouptestobject->getFullpath(),
+        ]);
+        $this->doTestSearch('bars', $this->userPermissionTest1, [
+            $this->bars->getFullpath(),
+            $this->userfolder->getFullpath(),
+            $this->usertestobject->getFullpath(),
+            $this->groupfolder->getFullpath(),
+            $this->grouptestobject->getFullpath(),
+        ]);
+        $this->doTestSearch('bars', $this->userPermissionTest2, [
+            $this->bars->getFullpath(),
+            $this->userfolder->getFullpath(),
+            $this->usertestobject->getFullpath(),
+        ]);
+
+        //search hidden object
+        $this->doTestSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
+        $this->doTestSearch('hiddenobject', $this->userPermissionTest1, []);
+        $this->doTestSearch('hiddenobject', $this->userPermissionTest2, []);
+
+    }
+
+    public function testManyElementSearch() {
+        $admin = User::getByName('admin');
+
+        //prepare additional data
+        $manyElements = $this->createFolder('manyElements', 1);
+        $manyElementList = [];
+        $elementCount = 5;
+
+        for($i = 1; $i <= $elementCount; $i++) {
+            $manyElementList[] = $this->createObject('manyelement ' . $i, $manyElements->getId());
+        }
+        $manyElementX = $this->createObject('manyelement X', $manyElements->getId());
+
+        //update role
+        $role = User\Role::getByName('Testrole');
+        $role->setWorkspacesObject([
+            (new User\Workspace\DataObject())->setValues(['cId' => $this->groupfolder->getId(), 'cPath' => $this->groupfolder->getFullpath(), 'list' => true, 'view' => true]),
+            (new User\Workspace\DataObject())->setValues(['cId' => $manyElementX->getId(), 'cPath' => $manyElementX->getFullpath(), 'list' => true, 'view' => true]),
+        ]);
+        $role->save();
+
+
+        //search manyelement
+        $this->doTestSearch('manyelement', $admin, array_merge(
+                array_map(function($item) { return $item->getFullpath(); }, $manyElementList),
+                [ $manyElementX->getFullpath() ]
+            ), $elementCount + 1
+        );
+        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount + 1);
+        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount + 1);
+
+        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount);
+        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount);
+
+    }
 }

--- a/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
@@ -263,7 +263,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         TestHelper::cleanUp();
 
         $this->prepareObjectTree();
-        $this->assetElement = $this->createAsset('assetelement', 1);
+        $this->assetElement = $this->createAsset('assetelement.gif', 1);
         $this->prepareUsers();
     }
 

--- a/tests/Model/Permissions/ModelDocumentPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDocumentPermissionsTest.php
@@ -33,7 +33,7 @@ class ModelDocumentPermissionsTest extends ModelTestCase
      *
      * /permissionfoo --> allowed
      * /permissionfoo/bars --> not allowed
-     * /permissionbar/bars/hugo --> ?? --> should not be found
+     * /permissionfoo/bars/hugo --> ?? --> should not be found
      * /permissionfoo/bars/userfolder --> allowed
      * /permissionfoo/bars/userfolder/usertestobject --> ??   --> should be found
      * /permissionfoo/bars/groupfolder --> allowed role
@@ -158,7 +158,7 @@ class ModelDocumentPermissionsTest extends ModelTestCase
         //create role
         $role = new User\Role();
         $role->setName('Testrole');
-        $role->setWorkspacesObject([
+        $role->setWorkspacesDocument([
             (new User\Workspace\Document())->setValues(['cId' => $this->groupfolder->getId(), 'cPath' => $this->groupfolder->getFullpath(), 'list' => true, 'view' => true]),
         ]);
         $role->save();
@@ -166,9 +166,9 @@ class ModelDocumentPermissionsTest extends ModelTestCase
         //create user 1
         $this->userPermissionTest1 = new User();
         $this->userPermissionTest1->setName('Permissiontest1');
-        $this->userPermissionTest1->setPermissions(['objects']);
+        $this->userPermissionTest1->setPermissions(['documents']);
         $this->userPermissionTest1->setRoles([$role->getId()]);
-        $this->userPermissionTest1->setWorkspacesObject([
+        $this->userPermissionTest1->setWorkspacesDocument([
             (new User\Workspace\Document())->setValues(['cId' => $this->permissionfoo->getId(), 'cPath' => $this->permissionfoo->getFullpath(), 'list' => true, 'view' => true]),
             (new User\Workspace\Document())->setValues(['cId' => $this->permissionbar->getId(), 'cPath' => $this->permissionbar->getFullpath(), 'list' => true, 'view' => true]),
             (new User\Workspace\Document())->setValues(['cId' => $this->foo->getId(), 'cPath' => $this->foo->getFullpath(), 'list' => false, 'view' => false]),
@@ -180,9 +180,9 @@ class ModelDocumentPermissionsTest extends ModelTestCase
         //create user 2
         $this->userPermissionTest2 = new User();
         $this->userPermissionTest2->setName('Permissiontest2');
-        $this->userPermissionTest2->setPermissions(['objects']);
+        $this->userPermissionTest2->setPermissions(['documents']);
         $this->userPermissionTest2->setRoles([$role->getId()]);
-        $this->userPermissionTest2->setWorkspacesObject([
+        $this->userPermissionTest2->setWorkspacesDocument([
             (new User\Workspace\Document())->setValues(['cId' => $this->permissionfoo->getId(), 'cPath' => $this->permissionfoo->getFullpath(), 'list' => true, 'view' => true]),
             (new User\Workspace\Document())->setValues(['cId' => $this->permissionbar->getId(), 'cPath' => $this->permissionbar->getFullpath(), 'list' => true, 'view' => true]),
             (new User\Workspace\Document())->setValues(['cId' => $this->foo->getId(), 'cPath' => $this->foo->getFullpath(), 'list' => false, 'view' => false]),
@@ -476,122 +476,120 @@ class ModelDocumentPermissionsTest extends ModelTestCase
         );
     }
 
-    // Disabling these tests until the PR of https://github.com/pimcore/pimcore/issues/11822
-//    protected function doTestSearch(string $searchText, User $user, array $expectedResultPaths, int $limit = 100) {
-//        $controller = $this->buildController('\\Pimcore\\Bundle\\AdminBundle\\Controller\\Searchadmin\\SearchController', $user);
-//
-//        $request = new Request([
-//            'type' => 'object',
-//            'query' => $searchText,
-//            'start' => 0,
-//            'limit' => $limit
-//        ]);
-//
-//        $responseData = $controller->findAction(
-//            $request,
-//            new EventDispatcher(),
-//            new GridHelperService()
-//        );
-//
-//        $responsePaths = [];
-//        foreach($responseData['data'] as $node) {
-//            $responsePaths[] = $node['fullpath'];
-//        }
-//
-//        $this->assertCount(
-//            $responseData['total'],
-//            $responseData['data'],
-//            'Assert total count of response matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '`'
-//        );
-//
-//        $this->assertCount(
-//            count($expectedResultPaths),
-//            $responseData['data'],
-//            'Assert number of expected result matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '` (' . print_r($responsePaths, true) . ')'
-//        );
-//
-//        foreach($expectedResultPaths as $path) {
-//            $this->assertContains(
-//                $path,
-//                $responsePaths,
-//                'Result for `' . $searchText . '` does not contain `' . $path . '` for user `' . $user->getName() . '`'
-//            );
-//        }
-//
-//    }
-//
-//    public function testSearch() {
-//        $admin = User::getByName('admin');
-//
-//        //search hugo
-//        $this->doTestSearch('hugo', $admin, [$this->hugo->getFullpath()]);
-//        $this->doTestSearch('hugo', $this->userPermissionTest1, []);
-//        $this->doTestSearch('hugo', $this->userPermissionTest2, []);
-//
-//        //search bars
-//        $this->doTestSearch('bars', $admin, [
-//            $this->bars->getFullpath(),
-//            $this->hugo->getFullpath(),
-//            $this->userfolder->getFullpath(),
-//            $this->usertestobject->getFullpath(),
-//            $this->groupfolder->getFullpath(),
-//            $this->grouptestobject->getFullpath(),
-//        ]);
-//        $this->doTestSearch('bars', $this->userPermissionTest1, [
-//            $this->bars->getFullpath(),
-//            $this->userfolder->getFullpath(),
-//            $this->usertestobject->getFullpath(),
-//            $this->groupfolder->getFullpath(),
-//            $this->grouptestobject->getFullpath(),
-//        ]);
-//        $this->doTestSearch('bars', $this->userPermissionTest2, [
-//            $this->bars->getFullpath(),
-//            $this->userfolder->getFullpath(),
-//            $this->usertestobject->getFullpath(),
-//        ]);
-//
-//        //search hidden object
-//        $this->doTestSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
-//        $this->doTestSearch('hiddenobject', $this->userPermissionTest1, []);
-//        $this->doTestSearch('hiddenobject', $this->userPermissionTest2, []);
-//
-//    }
-//
-//    public function testManyElementSearch() {
-//        $admin = User::getByName('admin');
-//
-//        //prepare additional data
-//        $manyElements = $this->createFolder('manyElements', 1);
-//        $manyElementList = [];
-//        $elementCount = 100;
-//
-//        for($i = 1; $i <= $elementCount; $i++) {
-//            $manyElementList[] = $this->createPage('manyelement ' . $i, $manyElements->getId());
-//        }
-//        $manyElementX = $this->createPage('manyelement X', $manyElements->getId());
-//
-//        //update role
-//        $role = User\Role::getByName('Testrole');
-//        $role->setWorkspacesObject([
-//            (new User\Workspace\Document())->setValues(['cId' => $this->groupfolder->getId(), 'cPath' => $this->groupfolder->getFullpath(), 'list' => true, 'view' => true]),
-//            (new User\Workspace\Document())->setValues(['cId' => $manyElementX->getId(), 'cPath' => $manyElementX->getFullpath(), 'list' => true, 'view' => true]),
-//        ]);
-//        $role->save();
-//
-//
-//        //search hugo
-//        $this->doTestSearch('manyelement', $admin, array_merge(
-//                array_map(function($item) { return $item->getFullpath(); }, $manyElementList),
-//                [ $manyElementX->getFullpath() ]
-//            ), $elementCount + 1
-//        );
-//        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount + 1);
-//        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount + 1);
-//
-//        //TODO this needs to be fixed, see issue https://github.com/pimcore/pimcore/issues/11822
-////        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount);
-////        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount);
-//
-//
-//    }
+    protected function doTestSearch(string $searchText, User $user, array $expectedResultPaths, int $limit = 100) {
+        $controller = $this->buildController('\\Pimcore\\Bundle\\AdminBundle\\Controller\\Searchadmin\\SearchController', $user);
+
+        $request = new Request([
+            'type' => 'document',
+            'query' => $searchText,
+            'start' => 0,
+            'limit' => $limit
+        ]);
+
+        $responseData = $controller->findAction(
+            $request,
+            new EventDispatcher(),
+            new GridHelperService()
+        );
+
+        $responsePaths = [];
+        foreach($responseData['data'] as $node) {
+            $responsePaths[] = $node['fullpath'];
+        }
+
+        $this->assertCount(
+            $responseData['total'],
+            $responseData['data'],
+            'Assert total count of response matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '`'
+        );
+
+        $this->assertCount(
+            count($expectedResultPaths),
+            $responseData['data'],
+            'Assert number of expected result matches count of nodes array for `' . $searchText . '` for user `' . $user->getName() . '` (' . print_r($responsePaths, true) . ')'
+        );
+
+        foreach($expectedResultPaths as $path) {
+            $this->assertContains(
+                $path,
+                $responsePaths,
+                'Result for `' . $searchText . '` does not contain `' . $path . '` for user `' . $user->getName() . '`'
+            );
+        }
+
+    }
+
+    public function testSearch() {
+        $admin = User::getByName('admin');
+
+        //search hugo
+        $this->doTestSearch('hugo', $admin, [$this->hugo->getFullpath()]);
+        $this->doTestSearch('hugo', $this->userPermissionTest1, []);
+        $this->doTestSearch('hugo', $this->userPermissionTest2, []);
+
+        //search bars
+        $this->doTestSearch('bars', $admin, [
+            $this->bars->getFullpath(),
+            $this->hugo->getFullpath(),
+            $this->userfolder->getFullpath(),
+            $this->usertestobject->getFullpath(),
+            $this->groupfolder->getFullpath(),
+            $this->grouptestobject->getFullpath(),
+        ]);
+        $this->doTestSearch('bars', $this->userPermissionTest1, [
+            $this->bars->getFullpath(),
+            $this->userfolder->getFullpath(),
+            $this->usertestobject->getFullpath(),
+            $this->groupfolder->getFullpath(),
+            $this->grouptestobject->getFullpath(),
+        ]);
+        $this->doTestSearch('bars', $this->userPermissionTest2, [
+            $this->bars->getFullpath(),
+            $this->userfolder->getFullpath(),
+            $this->usertestobject->getFullpath(),
+        ]);
+
+        //search hidden object
+        $this->doTestSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
+        $this->doTestSearch('hiddenobject', $this->userPermissionTest1, []);
+        $this->doTestSearch('hiddenobject', $this->userPermissionTest2, []);
+
+    }
+
+    public function testManyElementSearch() {
+        $admin = User::getByName('admin');
+
+        //prepare additional data
+        $manyElements = $this->createFolder('manyElements', 1);
+        $manyElementList = [];
+        $elementCount = 5;
+
+        for($i = 1; $i <= $elementCount; $i++) {
+            $manyElementList[] = $this->createPage('manyelement ' . $i, $manyElements->getId());
+        }
+        $manyElementX = $this->createPage('manyelement X', $manyElements->getId());
+
+        //update role
+        $role = User\Role::getByName('Testrole');
+        $role->setWorkspacesDocument([
+            (new User\Workspace\Document())->setValues(['cId' => $manyElementX->getId(), 'cPath' => $manyElementX->getFullpath(), 'list' => true, 'view' => true]),
+            (new User\Workspace\Document())->setValues(['cId' => $this->groupfolder->getId(), 'cPath' => $this->groupfolder->getFullpath(), 'list' => true, 'view' => true]),
+        ]);
+        $role->save();
+
+
+        //search manyelement
+        $this->doTestSearch('manyelement', $admin, array_merge(
+                array_map(function($item) { return $item->getFullpath(); }, $manyElementList),
+                [ $manyElementX->getFullpath() ]
+            ), $elementCount + 1
+        );
+        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount + 1);
+        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount + 1);
+
+        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount);
+        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount);
+
+
+    }
 }


### PR DESCRIPTION
fixes #11888, #11822


tldr: search worked but wasn't efficiently filtering the results in the listing, quicksearch blocked allowed children due a folder with permission `list=0`

CHANGES: Prior this PR, it took one folder with list permission disabled to disallow all its children (because it worked on a `LIKE path%` condition, any longer path would be blocked), also did not follow the rule that allowed children should turn the parent folder to list=1 to allow path traversal and didn't properly follow the [precedence ](https://github.com/pimcore/pimcore/issues/1634#issuecomment-831885117) on user level permissions and the conflicting rules on roles.

The `getForbiddenCondition` was skipped in `findAction` because the `type` in the request payload is singular, while in the `getForbiddenCondition` worked on plural ones, so it was scanning the entire `search_backend_data` (after the other filter/conditions) and relied on `($element->isAllowed('list')`, which explains why it worked at some extend, but with this PR, there are surely great reduction of this isAllowed calls/queries.
Quicksearch wasn't affected but had problems with the permissions priority rules. 
After PR, both follow the same filtering rules and results should be exactly the same.

TESTS: re-enables search related tests which now successfully passes, fixes codecep tests workspace typos.

PERFOMANCE: I have not noticed any big bump from Admin times (which skips this query conditions building). 
Prior PR quicksearch returned wrong results, so cannot do a direct comparison.
Slightly improves quicksearchByIdAction (the preview frame) perfomances (doesn't need getForbiddenCondition since it search directly by `id`). 
