### PR TITLE
[Bug]: Fix Adv. Many-to-Many Relation/Structured Table losing grid data on context switch

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/advancedManyToManyObjectRelation.js
@@ -386,6 +386,10 @@ pimcore.object.classes.data.advancedManyToManyObjectRelation = Class.create(pimc
         return this.datax;
     },
 
+    applyData: function (){
+        return this.getData();
+    },
+
     applySpecialData: function(source) {
         if (source.datax) {
             if (!this.datax) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/advancedManyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/advancedManyToManyRelation.js
@@ -574,6 +574,10 @@ pimcore.object.classes.data.advancedManyToManyRelation = Class.create(pimcore.ob
         return this.datax;
     },
 
+    applyData: function (){
+        return this.getData();
+    },
+
     applySpecialData: function(source) {
         if (source.datax) {
             if (!this.datax) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/structuredTable.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/structuredTable.js
@@ -298,6 +298,10 @@ pimcore.object.classes.data.structuredTable = Class.create(pimcore.object.classe
         return this.datax;
     },
 
+    applyData: function (){
+        return this.getData();
+    },
+
     applySpecialData: function(source) {
         if (source.datax) {
             if (!this.datax) {


### PR DESCRIPTION
fixes #11837

The data was only "lost" while editing the class definitions (before the actual `save`).