### PR TITLE
[Grid] Enhance performance to get data object classes for opened folder

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20220425082914.php
+++ b/bundles/CoreBundle/Migrations/Version20220425082914.php
@@ -29,11 +29,11 @@ final class Version20220425082914 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `objects` DROP INDEX `type`, ADD INDEX `type_path` (o_type, o_path)');
+        $this->addSql('ALTER TABLE `objects` DROP INDEX `type`, ADD INDEX `type_path_classId` (o_type, o_path, o_classId)');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `objects` DROP INDEX `type_path`, ADD INDEX `type` (o_type)');
+        $this->addSql('ALTER TABLE `objects` DROP INDEX `type_path_classId`, ADD INDEX `type` (o_type)');
     }
 }

--- a/bundles/CoreBundle/Migrations/Version20220425082914.php
+++ b/bundles/CoreBundle/Migrations/Version20220425082914.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220425082914 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Improve data object grid loading performance';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE `objects` DROP INDEX `type`, ADD INDEX `type_path` (o_type, o_path)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE `objects` DROP INDEX `type_path`, ADD INDEX `type` (o_type)');
+    }
+}

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -385,7 +385,7 @@ CREATE TABLE `objects` (
   KEY `index` (`o_index`),
   KEY `published` (`o_published`),
   KEY `parentId` (`o_parentId`),
-  KEY `type` (`o_type`),
+  KEY `type_path_classId` (`o_type`, `o_path`, `o_classId`),
   KEY `o_modificationDate` (`o_modificationDate`),
   KEY `o_classId` (`o_classId`)
 ) AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;


### PR DESCRIPTION
Follow-up of #11856

I noticed that most of the time (actually on every project I checked) the query https://github.com/pimcore/pimcore/blob/75bbc5bbacbd57383ccb20e52bbb151397b81a78/models/DataObject/AbstractObject/Dao.php#L478 uses the index `type` - even if all entries in the `objects` table have `o_type='object'`. It would be better to use an index for `o_path`.

I saw 2 alternatives: 
1. Add `USE INDEX (fullpath)` but I actually do not like this because it complicates maintenance when the query gets changed in future
2. Create composite index on `o_type`, `o_path`

This PR implements 2.

Here is the comparison:

**Without this PR**:
```sql
explain SELECT o_classId FROM objects WHERE o_path LIKE '/Artikel/%' AND o_type = 'object' AND o_classId NOT IN ('Artikel') LIMIT 1
```
| id | select_type | table   | partitions | type | possible_keys                                        | key    | key_len | ref   | rows    | filtered | Extra                              |
|----|-------------|---------|------------|------|------------------------------------------------------|--------|---------|-------|---------|----------|------------------------------------|
| 1  | SIMPLE      | objects | NULL       | ref  | fullpath,o_classId,data_director_classId_path,type | type | 2       | const | 3080750 | 16.76    | Using index condition; Using where |

Execution Time: 24.858 s

**With this PR**:
| id | select_type | table   | partitions | type  | possible_keys                                           | key       | key_len | ref  | rows    | filtered | Extra                              |
|----|-------------|---------|------------|-------|---------------------------------------------------------|-----------|---------|------|---------|----------|------------------------------------|
| 1  | SIMPLE      | objects | NULL       | range | fullpath,o_classId,data_director_classId_path,type_path | type_path | 2300    | NULL | 1718724 | 50.01    | Using index condition; Using where |

Execution Time: 1.509 s

PS: As the index `type` previously contained only the column `o_type` and MySQL uses index prefixes, it is safe to extend the index by another column - should have no influence on other queries which use this index.