### PR TITLE
[Bug]: uuids deadlock issue on delete, extra update query

### DIFF
--- a/models/Tool/UUID.php
+++ b/models/Tool/UUID.php
@@ -156,7 +156,7 @@ final class UUID extends Model\AbstractModel
         $uuid = Uid::v5($namespace, $this->getInstanceIdentifier() . '~' . $this->getType() . '~' . $this->getItemId());
         $this->uuid = $uuid->toRfc4122();
 
-        if (!$this->uuidExists($this->uuid)) {
+        if (!$this->getDao()->exists($this->uuid)) {
             $this->getDao()->create();
         }
 
@@ -225,18 +225,6 @@ final class UUID extends Model\AbstractModel
         $self = new self;
 
         return $self->getDao()->getByUuid($uuid);
-    }
-
-    /**
-     * @param string $uuid
-     *
-     * @return bool
-     */
-    public static function uuidExists($uuid)
-    {
-        $self = new self;
-
-        return $self->getDao()->exists($uuid);
     }
 
     /**

--- a/models/Tool/UUID.php
+++ b/models/Tool/UUID.php
@@ -156,7 +156,9 @@ final class UUID extends Model\AbstractModel
         $uuid = Uid::v5($namespace, $this->getInstanceIdentifier() . '~' . $this->getType() . '~' . $this->getItemId());
         $this->uuid = $uuid->toRfc4122();
 
-        $this->getDao()->save();
+        if (!$this->uuidExists($this->uuid)) {
+            $this->getDao()->create();
+        }
 
         return $this->uuid;
     }
@@ -223,6 +225,18 @@ final class UUID extends Model\AbstractModel
         $self = new self;
 
         return $self->getDao()->getByUuid($uuid);
+    }
+
+    /**
+     * @param string $uuid
+     *
+     * @return bool
+     */
+    public static function uuidExists($uuid)
+    {
+        $self = new self;
+
+        return $self->getDao()->exists($uuid);
     }
 
     /**

--- a/models/Tool/UUID/Dao.php
+++ b/models/Tool/UUID/Dao.php
@@ -28,19 +28,22 @@ class Dao extends Model\Dao\AbstractDao
 
     public function save()
     {
-        $data = $this->model->getObjectVars();
-
-        foreach ($data as $key => $value) {
-            if (!in_array($key, $this->getValidTableColumns(static::TABLE_NAME))) {
-                unset($data[$key]);
-            }
-        }
+        $data = $this->getValidObjectVars();
 
         $this->db->insertOrUpdate(self::TABLE_NAME, $data);
     }
 
     public function create()
     {
+        $data = $this->getValidObjectVars();
+
+        $this->db->insert(self::TABLE_NAME, $data);
+    }
+
+    /**
+     * @return array
+     */
+    private function getValidObjectVars() {
         $data = $this->model->getObjectVars();
 
         foreach ($data as $key => $value) {
@@ -49,7 +52,7 @@ class Dao extends Model\Dao\AbstractDao
             }
         }
 
-        $this->db->insert(self::TABLE_NAME, $data);
+        return $data;
     }
 
     /**

--- a/models/Tool/UUID/Dao.php
+++ b/models/Tool/UUID/Dao.php
@@ -39,6 +39,19 @@ class Dao extends Model\Dao\AbstractDao
         $this->db->insertOrUpdate(self::TABLE_NAME, $data);
     }
 
+    public function create()
+    {
+        $data = $this->model->getObjectVars();
+
+        foreach ($data as $key => $value) {
+            if (!in_array($key, $this->getValidTableColumns(static::TABLE_NAME))) {
+                unset($data[$key]);
+            }
+        }
+
+        $this->db->insert(self::TABLE_NAME, $data);
+    }
+
     /**
      * @throws \Exception
      */
@@ -63,5 +76,17 @@ class Dao extends Model\Dao\AbstractDao
         $model->setValues($data);
 
         return $model;
+    }
+
+    /**
+     * @param string $uuid
+     *
+     * @return bool
+     */
+    public function exists($uuid)
+    {
+        $result = $this->db->fetchOne('SELECT EXISTS(SELECT uuid FROM ' . self::TABLE_NAME . ' where uuid = ?)', [$uuid]);
+
+        return (bool)$result;
     }
 }

--- a/models/Tool/UUID/Dao.php
+++ b/models/Tool/UUID/Dao.php
@@ -85,8 +85,6 @@ class Dao extends Model\Dao\AbstractDao
      */
     public function exists($uuid)
     {
-        $result = $this->db->fetchOne('SELECT uuid FROM ' . self::TABLE_NAME . ' where uuid = ?', [$uuid]);
-
-        return (bool)$result;
+        return (bool) $this->db->fetchOne('SELECT uuid FROM ' . self::TABLE_NAME . ' where uuid = ?', [$uuid]);
     }
 }

--- a/models/Tool/UUID/Dao.php
+++ b/models/Tool/UUID/Dao.php
@@ -85,7 +85,7 @@ class Dao extends Model\Dao\AbstractDao
      */
     public function exists($uuid)
     {
-        $result = $this->db->fetchOne('SELECT EXISTS(SELECT uuid FROM ' . self::TABLE_NAME . ' where uuid = ?)', [$uuid]);
+        $result = $this->db->fetchOne('SELECT uuid FROM ' . self::TABLE_NAME . ' where uuid = ?', [$uuid]);
 
         return (bool)$result;
     }


### PR DESCRIPTION
When deleting objects, from multiple connections at the same time, deadlocks often happen on the "uuids" table. This happens if two or more users delete their own objects for their accounts. For example, it can also be reproduced if two or more admin users delete different folders from administration, with larger amount of objects, at the same time.  

![uiids-deadlock-log](https://user-images.githubusercontent.com/10097539/165077322-df5ce8d2-e173-4015-8510-0eac44a9dd1e.png)

MySql version: 5.7.24 (also reproduced on 8.0.28)
Isolation level: REPEATABLE-READ
The uuids table has over 500000 records. 

In the query log, I noticed that the following query is generated:
START TRANSACTION
...
INSERT INTO `uuids` (`itemId`, `type`, `uuid`, `instanceIdentifier`) VALUES ('278219', 'object', '22f4d69d-b1e9-58e4-80d8-91eb0ca9f1d7', 'demo-ecommerce') ON DUPLICATE KEY UPDATE `itemId` = '278219', `type` = 'object', `uuid` = '22f4d69d-b1e9-58e4-80d8-91eb0ca9f1d7', `instanceIdentifier` = 'demo-ecommerce'
DELETE FROM uuids WHERE uuid = '22f4d69d-b1e9-58e4-80d8-91eb0ca9f1d7'
COMMIT

I think that "INSERT INTO ... ON DUPLICATE KEY UPDATE" increases the chance for deadlock as it adds exclusive gap lock (X). Then, DELETE fails when two other connections hold insert intention lock and gap lock at the same time.

Also, it seems like UPDATE is not really necessary to be executed every time when deleting uuid. I would suggest, when creating uiid, to first check if uuid exists. If not, skip save (as nothing needs to be changed). Otherwise, if does not exist, it will perform INSERT which doesn't use gap lock (X, REC_NOT_GAP). Please check PR code.

After this change, deadlocks are not happening anymore and both, delete and insert of uuid work fine. 