### PR TITLE
Fix escaping quotes in dataobject keys for tree-childs-by-id

### DIFF
--- a/models/Element/Dao.php
+++ b/models/Element/Dao.php
@@ -16,6 +16,7 @@
 namespace Pimcore\Model\Element;
 
 use Pimcore\Model;
+use function addslashes;
 
 /**
  * @internal
@@ -94,7 +95,7 @@ abstract class Dao extends Model\Dao\AbstractDao
         if (!$current->getId()) {
             return 0;
         }
-        $fullPath = $current->getPath().$current->getKey();
+        $fullPath = addslashes($current->getPath().$current->getKey());
 
         $sql = 'SELECT ' . $this->db->quoteIdentifier($type) . ' FROM users_workspaces_'.$tableSuffix.' WHERE LOCATE(cpath,"'.$fullPath.'")=1 AND
         userId IN (' . implode(',', $userIds) . ')


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.3`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves problem if data object contains at leat one quote, sql command is ended

## Additional info  
![image](https://user-images.githubusercontent.com/16688055/165113194-42c67d25-5167-4ee1-8cfc-86318fef46c9.png)

