### PR TITLE
Document::setChildren() should cache empty array

### DIFF
--- a/models/Document.php
+++ b/models/Document.php
@@ -657,7 +657,7 @@ class Document extends Element\AbstractElement
      */
     public function setChildren($children, $includingUnpublished = false)
     {
-        if (empty($children)) {
+        if ($children === null) {
             // unset all cached children
             $this->hasChildren = [];
             $this->children = [];


### PR DESCRIPTION
Split from https://github.com/pimcore/pimcore/pull/11826