### PR TITLE
Custom Reports: Send drilldownFilters to createCSVAction

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/report.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/report.js
@@ -542,15 +542,23 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
     createCsv: function (btn, exportFile, offset, withHeader) {
         let filterData = this.store.getFilters().items;
         let proxy = this.store.getProxy();
+        let drillDownFilters = this.drillDownFilters;
+
+        let params = {
+            exportFile: exportFile,
+            offset: offset,
+            name: this.config.name,
+            filter: filterData.length > 0 ? encodeURIComponent(proxy.encodeFilters(filterData)) : "",
+            headers: withHeader,
+        }
+
+        Object.keys(drillDownFilters).forEach(function(key) {
+            params[`drillDownFilters[${key}]`] = drillDownFilters[key]
+        })
+
         Ext.Ajax.request({
             url: Routing.generate('pimcore_admin_reports_customreport_createcsv'),
-            params: {
-                exportFile: exportFile,
-                offset: offset,
-                name: this.config.name,
-                filter: filterData.length > 0 ? encodeURIComponent(proxy.encodeFilters(filterData)) : "",
-                headers: withHeader,
-            },
+            params: params,
             success: function (response) {
                 response = JSON.parse(response["responseText"]);
                 if(response["finished"]) {


### PR DESCRIPTION
## Changes in this pull request  
Currently the `\Pimcore\Bundle\AdminBundle\Controller\Reports\CustomReportController::createCsvAction()` allows to provide
* `sort`
* `dir`
* `filter`
* `drillDownFilters`
* `headers`
* `offset`
* `exportFile`

While most of them are sent, `sort`, `dir` and `drillDownFilters` aren't.
The result will be an unfiltered list or at least a list which is not filtered by custom filters.

This PR allows at least the usage of `drillDownFilters` which are available in the JS-methods scope.

