### PR TITLE
[PhpStan] Fix ApplicationLoggerDb level parameter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
     "lcobucci/jwt": "^4.0",
     "league/csv": "^9.7",
     "mjaschen/phpgeo": "^3.0",
+    "monolog/monolog": "^2.3",
     "mpratt/embera": "^2.0.14",
     "myclabs/deep-copy": "^1.10.1",
     "neitanod/forceutf8": "^2.0.4",

--- a/lib/Log/Handler/ApplicationLoggerDb.php
+++ b/lib/Log/Handler/ApplicationLoggerDb.php
@@ -16,8 +16,14 @@
 namespace Pimcore\Log\Handler;
 
 use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Logger;
 use Pimcore\Db;
+use Psr\Log\LogLevel;
 
+/**
+ * @phpstan-import-type Level from \Monolog\Logger
+ * @phpstan-import-type LevelName from \Monolog\Logger
+ */
 class ApplicationLoggerDb extends AbstractProcessingHandler
 {
     const TABLE_NAME = 'application_logs';
@@ -31,10 +37,12 @@ class ApplicationLoggerDb extends AbstractProcessingHandler
 
     /**
      * @param Db\ConnectionInterface $db
-     * @param string $level
+     * @param int|string $level
      * @param bool $bubble
+     *
+     * @phpstan-param Level|LevelName|LogLevel::* $level
      */
-    public function __construct(Db\ConnectionInterface $db, $level = 'debug', $bubble = true)
+    public function __construct(Db\ConnectionInterface $db, $level = Logger::DEBUG, $bubble = true)
     {
         $this->db = $db;
         parent::__construct($level, $bubble);


### PR DESCRIPTION
Split from #11826 
```
Line   lib/Log/Handler/ApplicationLoggerDb.php                                                                                                                                                           
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  40     Parameter #1 $level of method Monolog\Handler\AbstractHandler::__construct() expects                                                                                                              
         100|200|250|300|400|500|550|600|'ALERT'|'alert'|'CRITICAL'|'critical'|'DEBUG'|'debug'|'EMERGENCY'|'emergency'|'ERROR'|'error'|'INFO'|'info'|'NOTICE'|'notice'|'WARNING'|'warning', string given. 
```