### PR TITLE
[PhpStan] Fix PreAuthenticatedAdminToken roles parameter

### DIFF
--- a/bundles/AdminBundle/Security/Firewall/PreAuthenticatedAdminSessionListener.php
+++ b/bundles/AdminBundle/Security/Firewall/PreAuthenticatedAdminSessionListener.php
@@ -70,7 +70,7 @@ class PreAuthenticatedAdminSessionListener
         if (null !== $pimcoreUser) {
             $user = new User($pimcoreUser);
 
-            $token = new PreAuthenticatedAdminToken($user, '', $this->providerKey);
+            $token = new PreAuthenticatedAdminToken($user, $this->providerKey);
             $token->setUser($user->getUserIdentifier());
 
             try {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,11 +31,6 @@ parameters:
 			path: bundles/AdminBundle/GDPR/DataProvider/Manager.php
 
 		-
-			message: "#^Parameter \\#3 \\$roles of class Pimcore\\\\Bundle\\\\AdminBundle\\\\Security\\\\Authentication\\\\Token\\\\PreAuthenticatedAdminToken constructor expects array\\<string\\>, string given\\.$#"
-			count: 1
-			path: bundles/AdminBundle/Security/Firewall/PreAuthenticatedAdminSessionListener.php
-
-		-
 			message: "#^Parameter \\#1 \\$class of static method Pimcore\\\\Model\\\\DataObject\\\\ClassDefinition\\\\Service\\:\\:importClassDefinitionFromJson\\(\\) expects Pimcore\\\\Model\\\\DataObject\\\\ClassDefinition, Pimcore\\\\Model\\\\AbstractModel given\\.$#"
 			count: 1
 			path: bundles/CoreBundle/Command/Definition/Import/ClassCommand.php


### PR DESCRIPTION
Split from #11826 
```
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   bundles/AdminBundle/Security/Firewall/PreAuthenticatedAdminSessionListener.php                                                                                     
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  73     Parameter #3 $roles of class Pimcore\Bundle\AdminBundle\Security\Authentication\Token\PreAuthenticatedAdminToken constructor expects array<string>, string given.  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

```