### PR TITLE
[PhpStan] Use DoctrineDbalAdapter instead of PdoAdapter

### DIFF
--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -33,7 +33,7 @@ use Pimcore\Tool\Console;
 use Pimcore\Tool\Requirements;
 use Pimcore\Tool\Requirements\Check;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Cache\Adapter\PdoAdapter;
+use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
@@ -600,8 +600,8 @@ class Installer
                 }
             }
 
-            $pdoCacheAdapter = new PdoAdapter($db);
-            $pdoCacheAdapter->createTable();
+            $cacheAdapter = new DoctrineDbalAdapter($db);
+            $cacheAdapter->createTable();
 
             $doctrineTransportConn = new \Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection([], $db);
             $doctrineTransportConn->setup();

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
     "symfony/monolog-bundle": "^3.5",
     "symfony/asset": "^5.3",
     "symfony/browser-kit": "^5.2.0",
-    "symfony/cache": "^5.2.0",
+    "symfony/cache": "^5.4",
     "symfony/config": "^5.3",
     "symfony/console": "^5.3.0",
     "symfony/css-selector": "^5.2.0",

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -887,8 +887,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
     {
         if ($this->__rawRelationData === null) {
             $db = Db::get();
-            $relations = $db->fetchAll('SELECT * FROM object_relations_' . $this->getClassId() . ' WHERE src_id = ?', [$this->getId()]);
-            $this->__rawRelationData = $relations ?? [];
+            $this->__rawRelationData = $db->fetchAll('SELECT * FROM object_relations_' . $this->getClassId() . ' WHERE src_id = ?', [$this->getId()]);
         }
 
         return $this->__rawRelationData;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -216,11 +216,6 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/VoucherService/DefaultService.php
 
 		-
-			message: "#^Parameter \\#1 \\$connOrDsn of class Symfony\\\\Component\\\\Cache\\\\Adapter\\\\PdoAdapter constructor expects PDO\\|string, Pimcore\\\\Db\\\\Connection given\\.$#"
-			count: 1
-			path: bundles/InstallBundle/Installer.php
-
-		-
 			message: "#^Parameter \\#5 \\$priority of static method Pimcore\\\\Cache\\:\\:save\\(\\) expects int, null given\\.$#"
 			count: 1
 			path: lib/Cache/Tool/Warming.php
@@ -479,11 +474,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$definition of static method Pimcore\\\\Model\\\\DataObject\\\\Classificationstore\\\\Service\\:\\:getFieldDefinitionFromJson\\(\\) expects array, Pimcore\\\\Model\\\\DataObject\\\\ClassDefinition\\\\Data\\|null given\\.$#"
 			count: 1
 			path: models/DataObject/Classificationstore/Service.php
-
-		-
-			message: "#^Variable \\$relations on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: models/DataObject/Concrete.php
 
 		-
 			message: "#^Parameter \\#1 \\$index of method Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\<Pimcore\\\\Model\\\\DataObject\\\\Fieldcollection\\\\Data\\\\AbstractData\\>\\:\\:get\\(\\) expects int, string given\\.$#"


### PR DESCRIPTION
Split from #11826 
```
------ ------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   bundles/InstallBundle/Installer.php                                                                                                       
 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 
  603    Parameter #1 $connOrDsn of class Symfony\Component\Cache\Adapter\PdoAdapter constructor expects PDO|string, Pimcore\Db\Connection given.  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------
```