### PR TITLE
[PhpStan] Fix errors with Symfony Request/Response object

### DIFF
--- a/bundles/CoreBundle/EventListener/TranslationDebugListener.php
+++ b/bundles/CoreBundle/EventListener/TranslationDebugListener.php
@@ -54,7 +54,7 @@ class TranslationDebugListener implements EventSubscriberInterface
             return;
         }
 
-        if ((bool)$event->getRequest()->query->get($this->parameterName, false)) {
+        if ($event->getRequest()->query->get($this->parameterName)) {
             if (\Pimcore::inDebugMode() || Authentication::authenticateSession($event->getRequest())) {
                 $this->translator->setDisableTranslations(true);
             }

--- a/lib/Http/ResponseHelper.php
+++ b/lib/Http/ResponseHelper.php
@@ -38,7 +38,7 @@ class ResponseHelper
             }
 
             foreach (['max-stale', 'post-check', 'pre-check', 'max-age'] as $directive) {
-                $response->headers->addCacheControlDirective($directive, 0);
+                $response->headers->addCacheControlDirective($directive, '0');
             }
 
             // this is for mod_pagespeed

--- a/lib/Targeting/EventListener/ToolbarListener.php
+++ b/lib/Targeting/EventListener/ToolbarListener.php
@@ -159,7 +159,7 @@ class ToolbarListener implements EventSubscriberInterface
             return false;
         }
 
-        $cookieValue = (bool)$request->cookies->get('pimcore_targeting_debug', false);
+        $cookieValue = (bool)$request->cookies->get('pimcore_targeting_debug');
         if (!$cookieValue) {
             return false;
         }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -71,11 +71,6 @@ parameters:
 			path: bundles/CoreBundle/EventListener/ResponseExceptionListener.php
 
 		-
-			message: "#^Parameter \\#2 \\$default of method Symfony\\\\Component\\\\HttpFoundation\\\\InputBag\\<string\\>\\:\\:get\\(\\) expects string\\|null, false given\\.$#"
-			count: 1
-			path: bundles/CoreBundle/EventListener/TranslationDebugListener.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between null and string will always evaluate to false\\.$#"
 			count: 1
 			path: bundles/CoreBundle/Request/ParamConverter/DataObjectParamConverter.php
@@ -246,11 +241,6 @@ parameters:
 			path: lib/Google/Cse.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of method Symfony\\\\Component\\\\HttpFoundation\\\\HeaderBag\\:\\:addCacheControlDirective\\(\\) expects bool\\|string, int given\\.$#"
-			count: 1
-			path: lib/Http/ResponseHelper.php
-
-		-
 			message: "#^Parameter \\#1 \\$x of method Pimcore\\\\Image\\\\Adapter\\:\\:crop\\(\\) expects int, float given\\.$#"
 			count: 1
 			path: lib/Image/Adapter.php
@@ -314,11 +304,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$eventDispatcher of method Pimcore\\\\Targeting\\\\Condition\\\\EventDispatchingConditionInterface\\:\\:preMatch\\(\\) expects Symfony\\\\Component\\\\EventDispatcher\\\\EventDispatcherInterface, Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface given\\.$#"
 			count: 1
 			path: lib/Targeting/ConditionMatcher.php
-
-		-
-			message: "#^Parameter \\#2 \\$default of method Symfony\\\\Component\\\\HttpFoundation\\\\InputBag\\<string\\>\\:\\:get\\(\\) expects string\\|null, false given\\.$#"
-			count: 1
-			path: lib/Targeting/EventListener/ToolbarListener.php
 
 		-
 			message: "#^Parameter \\#2 \\$value of method DOMElement\\:\\:setAttribute\\(\\) expects string, int\\|null given\\.$#"


### PR DESCRIPTION
Split from #11826 
```
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   bundles/AdminBundle/GDPR/DataProvider/Assets.php                                                                                                      
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------ 
  100    Parameter #2 $values of method Symfony\Component\HttpFoundation\ResponseHeaderBag::set() expects array<string>|string|null, int<0, max>|false given.  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ -------------------------------------------------------------------------------------------------------------------- 
  Line   bundles/AdminBundle/Security/LogoutSuccessHandler.php                                                               
 ------ -------------------------------------------------------------------------------------------------------------------- 
  114    Parameter #2 $value of class Symfony\Component\HttpFoundation\Cookie constructor expects string|null, false given.  
 ------ -------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------------- 
  Line   bundles/CoreBundle/EventListener/TranslationDebugListener.php                                                               
 ------ ---------------------------------------------------------------------------------------------------------------------------- 
  57     Parameter #2 $default of method Symfony\Component\HttpFoundation\InputBag<string>::get() expects string|null, false given.  
 ------ ---------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------------------- 
  Line   lib/Http/ResponseHelper.php                                                                                                           
 ------ -------------------------------------------------------------------------------------------------------------------------------------- 
  41     Parameter #2 $value of method Symfony\Component\HttpFoundation\HeaderBag::addCacheControlDirective() expects bool|string, int given.  
 ------ -------------------------------------------------------------------------------------------------------------------------------------- 

```