### PR TITLE
[PhpStan] Fix AdminExceptionListener:recursiveAddValidationExceptionSubItems()

### DIFF
--- a/bundles/AdminBundle/EventListener/AdminExceptionListener.php
+++ b/bundles/AdminBundle/EventListener/AdminExceptionListener.php
@@ -131,7 +131,9 @@ class AdminExceptionListener implements EventSubscriberInterface
         foreach ($items as $e) {
             if ($e->getMessage()) {
                 $message .= '<b>' . $e->getMessage() . '</b>';
-                $this->addContext($e, $message);
+                if ($e instanceof ValidationException) {
+                    $this->addContext($e, $message);
+                }
                 $message .= '<br>';
 
                 $detailedInfo .= '<br><b>Message:</b><br>';

--- a/bundles/AdminBundle/EventListener/AdminExceptionListener.php
+++ b/bundles/AdminBundle/EventListener/AdminExceptionListener.php
@@ -119,7 +119,7 @@ class AdminExceptionListener implements EventSubscriberInterface
     }
 
     /**
-     * @param ValidationException[] $items
+     * @param \Exception[] $items
      * @param string $message
      * @param string $detailedInfo
      */
@@ -141,7 +141,9 @@ class AdminExceptionListener implements EventSubscriberInterface
                 $detailedInfo .= '<br><b>Trace:</b> ' . $inner->getTraceAsString() . '<br>';
             }
 
-            $this->recursiveAddValidationExceptionSubItems($e->getSubItems(), $message, $detailedInfo);
+            if ($e instanceof ValidationException) {
+                $this->recursiveAddValidationExceptionSubItems($e->getSubItems(), $message, $detailedInfo);
+            }
         }
     }
 

--- a/models/Element/ValidationException.php
+++ b/models/Element/ValidationException.php
@@ -22,11 +22,11 @@ class ValidationException extends \Exception
      */
     protected $contextStack = [];
 
-    /** @var ValidationException[] */
+    /** @var \Exception[] */
     protected $subItems = [];
 
     /**
-     * @return ValidationException[]
+     * @return \Exception[]
      */
     public function getSubItems()
     {
@@ -34,7 +34,7 @@ class ValidationException extends \Exception
     }
 
     /**
-     * @param ValidationException[] $subItems
+     * @param \Exception[] $subItems
      */
     public function setSubItems(array $subItems = [])
     {
@@ -87,10 +87,14 @@ class ValidationException extends \Exception
             $subItemParts = [];
 
             foreach ($subItems as $subItem) {
-                $subItemMessage = $subItem->getAggregatedMessage();
-                $contextStack = $subItem->getContextStack();
-                if ($contextStack) {
-                    $subItemMessage .= '[ '.$contextStack[0].' ]';
+                if ($subItem instanceof self) {
+                    $subItemMessage = $subItem->getAggregatedMessage();
+                    $contextStack = $subItem->getContextStack();
+                    if ($contextStack) {
+                        $subItemMessage .= '[ '.$contextStack[0].' ]';
+                    }
+                } else {
+                    $subItemMessage = $subItem->getMessage();
                 }
                 $subItemParts[] = $subItemMessage;
             }

--- a/models/Element/ValidationException.php
+++ b/models/Element/ValidationException.php
@@ -22,11 +22,11 @@ class ValidationException extends \Exception
      */
     protected $contextStack = [];
 
-    /** @var \Exception[] */
+    /** @var ValidationException[] */
     protected $subItems = [];
 
     /**
-     * @return \Exception[]
+     * @return ValidationException[]
      */
     public function getSubItems()
     {
@@ -34,7 +34,7 @@ class ValidationException extends \Exception
     }
 
     /**
-     * @param \Exception[] $subItems
+     * @param ValidationException[] $subItems
      */
     public function setSubItems(array $subItems = [])
     {
@@ -87,14 +87,10 @@ class ValidationException extends \Exception
             $subItemParts = [];
 
             foreach ($subItems as $subItem) {
-                if ($subItem instanceof self) {
-                    $subItemMessage = $subItem->getAggregatedMessage();
-                    $contextStack = $subItem->getContextStack();
-                    if ($contextStack) {
-                        $subItemMessage .= '[ '.$contextStack[0].' ]';
-                    }
-                } else {
-                    $subItemMessage = $subItem->getMessage();
+                $subItemMessage = $subItem->getAggregatedMessage();
+                $contextStack = $subItem->getContextStack();
+                if ($contextStack) {
+                    $subItemMessage .= '[ '.$contextStack[0].' ]';
                 }
                 $subItemParts[] = $subItemMessage;
             }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: bundles/AdminBundle/Controller/Admin/Document/DocumentController.php
 
 		-
-			message: "#^Parameter \\#1 \\$items of method Pimcore\\\\Bundle\\\\AdminBundle\\\\EventListener\\\\AdminExceptionListener\\:\\:recursiveAddValidationExceptionSubItems\\(\\) expects array\\<Pimcore\\\\Model\\\\Element\\\\ValidationException\\>, array\\<Exception\\> given\\.$#"
-			count: 2
-			path: bundles/AdminBundle/EventListener/AdminExceptionListener.php
-
-		-
 			message: "#^Offset 'image' on array\\{\\} in empty\\(\\) does not exist\\.$#"
 			count: 1
 			path: bundles/AdminBundle/GDPR/DataProvider/DataObjects.php


### PR DESCRIPTION
Split from #11826 
```
------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   bundles/AdminBundle/EventListener/AdminExceptionListener.php                                                                                                                                                                
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  85     Parameter #1 $items of method Pimcore\Bundle\AdminBundle\EventListener\AdminExceptionListener::recursiveAddValidationExceptionSubItems() expects array<Pimcore\Model\Element\ValidationException>, array<Exception> given.  
  142    Parameter #1 $items of method Pimcore\Bundle\AdminBundle\EventListener\AdminExceptionListener::recursiveAddValidationExceptionSubItems() expects array<Pimcore\Model\Element\ValidationException>, array<Exception> given.  
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
```