### PR TITLE
Fixed Deprecated error message in admin login

### DIFF
--- a/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
+++ b/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
@@ -134,10 +134,7 @@ class AdminAuthenticator extends AbstractGuardAuthenticator implements LoggerAwa
             return $response;
         }
 
-        $perspective = $request->get('perspective');
-        $perspective = ($perspective !== null)? strip_tags($perspective): [];
-
-        $event = new LoginRedirectEvent('pimcore_admin_login', ['perspective' => $perspective ]);
+        $event = new LoginRedirectEvent('pimcore_admin_login', ['perspective' => strip_tags($request->get('perspective', ''))]);
         $this->dispatcher->dispatch($event, AdminEvents::LOGIN_REDIRECT);
 
         $url = $this->router->generate($event->getRouteName(), $event->getRouteParams());

--- a/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
+++ b/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
@@ -134,7 +134,10 @@ class AdminAuthenticator extends AbstractGuardAuthenticator implements LoggerAwa
             return $response;
         }
 
-        $event = new LoginRedirectEvent('pimcore_admin_login', ['perspective' => strip_tags($request->get('perspective'))]);
+        $perspective = $request->get('perspective');
+        $perspective = ($perspective !== null)? strip_tags($perspective): [];
+
+        $event = new LoginRedirectEvent('pimcore_admin_login', ['perspective' => $perspective ]);
         $this->dispatcher->dispatch($event, AdminEvents::LOGIN_REDIRECT);
 
         $url = $this->router->generate($event->getRouteName(), $event->getRouteParams());


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.3`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

Fixed the deprecated error message with strip_tags() function, when admin does the login/logout from the admin interface.

## Additional info  

