### PR TITLE
[Asset] Thumbnails: exclude assets by paths from pimcore:thumbnails:image command

### DIFF
--- a/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsImageCommand.php
@@ -172,6 +172,26 @@ class ThumbnailsImageCommand extends AbstractCommand
             return;
         }
 
+        $thumbnail = Image\Thumbnail\Config::getByName($thumbnailConfigName);
+        $excludePaths = $thumbnail->getExcludePaths() ?: [];
+
+        foreach ($excludePaths as $path) {
+            if (str_starts_with($image->getFullPath(), $path["fullpath"])) {
+                if ($output->isVerbose()) {
+                    $output->writeln(
+                        sprintf(
+                            'skipped thumbnail [%s] for image [%d] because of excludePaths [%s]',
+                            $thumbnailConfigName,
+                            $image->getId(),
+                            $path["fullpath"]
+                        )
+                    );
+                }
+
+                return;
+            }
+        }
+
         $thumbnailsToGenerate = $this->fetchThumbnailConfigs($input, $thumbnailConfigName);
 
         if ($input->getOption('force')) {

--- a/bundles/CoreBundle/Resources/translations/en.extended.json
+++ b/bundles/CoreBundle/Resources/translations/en.extended.json
@@ -178,6 +178,8 @@
   "rasterize_svg_info_text": "SVGs get automatically rasterized when a transformation other than resize or scale by width\/height is used.",
   "preserve_animation": "Preserve animations for GIF",
   "preserve_animation_info_text": "Supported transformations are: Frame, Cover, Contain, Resize, ScaleByWidth, ScaleByHeight",
+  "exclude_paths": "Exclude paths",
+  "exclude_paths_info_text": "Thumbnail for asset from paths listed above will be NOT generated in background with pimcore:thumbnails:image command",
   "valid_languages_frontend_description": "These settings are used in documents to specify the content language (in properties tab), for objects in localized-fields, for shared translations, ... simply everywhere the editor can choose or use a language for the content.<br \/>Fallback languages are currently used in object's localized fields and shared translations.",
   "delete_language_note": "Note: Removing language from the list will not delete its respective data. Please use console command 'pimcore:locale:delete-unused-tables' for cleanup.",
   "maximum_items": "max. items",

--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -157,6 +157,13 @@ final class Config extends Model\AbstractModel
      * @var bool
      */
     protected $preserveAnimation = false;
+    
+    /**
+     * @internal
+     *
+     * @var array
+     */
+    protected $excludePaths = [];
 
     /**
      * @internal
@@ -909,6 +916,22 @@ final class Config extends Model\AbstractModel
     public function setDownloadable(bool $downloadable): void
     {
         $this->downloadable = $downloadable;
+    }
+
+    /**
+     * @param array $excludePaths
+     */
+    public function setExcludePaths(array $excludePaths): void
+    {
+        $this->excludePaths = $excludePaths;
+    }
+
+    /**
+     * @return array
+     */
+    public function getExcludePaths(): array
+    {
+        return $this->excludePaths;
     }
 
     public function __clone()

--- a/models/Asset/Image/Thumbnail/Config/Dao.php
+++ b/models/Asset/Image/Thumbnail/Config/Dao.php
@@ -96,7 +96,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
         $data = [];
         $allowedProperties = ['name', 'description', 'group', 'items', 'medias', 'format',
             'quality', 'highResolution', 'creationDate', 'modificationDate', 'preserveColor', 'preserveMetaData',
-            'rasterizeSVG', 'downloadable', 'preserveAnimation', ];
+            'rasterizeSVG', 'downloadable', 'preserveAnimation', 'excludePaths'];
 
         foreach ($dataRaw as $key => $value) {
             if (in_array($key, $allowedProperties)) {


### PR DESCRIPTION
## Changes in this pull request  
In Image Thumbnails configuration panel there is a collapsible Advanced Fieldset to which we added new GridPanel that allows user to drag&drop folders or images from tree. Thumbnail for assets to which paths were assign to that field will be NOT generated in background with pimcore:thumbnails:image command.

## Additional info  
We faced with a situation where client didn't want to generate specific thumbnail configuration for couple paths because of some reasons (ex. they use for product photos thumbnails with FRAME transformation and not with CONTAIN which on the other hand is perfect for dimensions picture). After that PR admin can limit that directly in Pimcore interface.