### PR TITLE
[Bug]: Added search test with empty roles/no user level rules, fixed potential empty implode problem

### DIFF
--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -345,9 +345,10 @@ class SearchController extends AdminController
     }
 
     /**
+     * @internal
      * @param array $types
      *
-     * @return array
+     * @return string
      */
     protected function getPermittedPaths($types = ['asset', 'document', 'object'])
     {

--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -359,9 +359,7 @@ class SearchController extends AdminController
         $allowedTypes = [];
 
         foreach ($types as $type) {
-            if (!$user->isAllowed($type . 's')) { //the permissions are just plural
-                $allowedTypes[] = '(maintype != \'' . $type . '\' AND 1 = 0)'; //hacky, always false
-            }else{
+            if ($user->isAllowed($type . 's')) { //the permissions are just plural
                 $elementPaths = Element\Service::findForbiddenPaths($type, $user);
 
                 $forbiddenPathSql = [];
@@ -400,6 +398,12 @@ class SearchController extends AdminController
 
                 $allowedTypes[] = $forbiddenAndAllowedSql;
             }
+        }
+        
+        //if allowedTypes is still empty after getting the workspaces, it means that there are no any master permissions set
+        // by setting a `false` condition in the query makes sure that nothing would be displayed.
+        if (!$allowedTypes){
+            $allowedTypes = ['false'];
         }
 
         return '('.implode(' OR ', $allowedTypes) .')';

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -723,7 +723,7 @@ class Service extends Model\AbstractModel
         $db = Db::get();
 
         if ($user->isAdmin()) {
-            return ['forbidden' => [], 'allowed' => []];
+            return ['forbidden' => [], 'allowed' => ['/']];
         }
 
         $workspaceCids = [];

--- a/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
@@ -672,13 +672,6 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             [$this->bars->getFullpath()]
         );
 
-        //Normally it would return an "Access Denied" by AdminController
-//        $this->doTestTreeGetChildsById(
-//            $this->permissionfoo,
-//            $this->userPermissionTest6,
-//            []
-//        );
-
         // test /permissionfoo/bars
         $this->doTestTreeGetChildsById(
             $this->bars,
@@ -716,12 +709,6 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             [$this->userfolder->getFullpath()]
         );
 
-//        $this->doTestTreeGetChildsById(
-//            $this->bars,
-//            $this->userPermissionTest6,
-//            []
-//        );
-
         // test /permissionfoo/bars/userfolder
         $this->doTestTreeGetChildsById(
             $this->userfolder,
@@ -758,12 +745,6 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             $this->userPermissionTest5,
             [$this->usertestobject->getFullpath()]
         );
-
-//        $this->doTestTreeGetChildsById(
-//            $this->userfolder,
-//            $this->userPermissionTest6,
-//            []
-//        );
 
         // test /permissionfoo/bars/groupfolder
         $this->doTestTreeGetChildsById(

--- a/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
@@ -262,6 +262,22 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             (new User\Workspace\DataObject())->setValues(['cId' => $this->groupfolder->getId(), 'cPath' => $this->groupfolder->getFullpath(), 'list' => false, 'view' => false, 'save'=>true, 'publish'=>true, 'settings' => false]),
         ]);
         $this->userPermissionTest2->save();
+
+        //create user 3, with no roles, only usertestobject allowed
+        $this->userPermissionTest3 = new User();
+        $this->userPermissionTest3->setName('Permissiontest3');
+        $this->userPermissionTest3->setPermissions(['objects']);
+        $this->userPermissionTest3->setWorkspacesObject([
+            (new User\Workspace\DataObject())->setValues(['cId' => $this->usertestobject->getId(), 'cPath' => $this->usertestobject->getFullpath(), 'list' => true, 'view' => true]),
+        ]);
+        $this->userPermissionTest3->save();
+
+        //create user 4, with no user workspace rules, only from roles
+        $this->userPermissionTest4 = new User();
+        $this->userPermissionTest4->setName('Permissiontest4');
+        $this->userPermissionTest4->setPermissions(['objects']);
+        $this->userPermissionTest4->setRoles([$role->getId(), $role2->getId()]);
+        $this->userPermissionTest4->save();
     }
 
     public function setUp(): void
@@ -281,11 +297,13 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         TestHelper::cleanUp();
         User::getByName('Permissiontest1')->delete();
         User::getByName('Permissiontest2')->delete();
+        User::getByName('Permissiontest3')->delete();
+        User::getByName('Permissiontest4')->delete();
         User\Role::getByName('Testrole')->delete();
         User\Role::getByName('Dummyrole')->delete();
     }
 
-    protected function doHasChildrenTest(DataObject\AbstractObject $element, bool $resultAdmin, bool $resultPermissionTest1, bool $resultPermissionTest2)
+    protected function doHasChildrenTest(DataObject\AbstractObject $element, bool $resultAdmin, bool $resultPermissionTest1, bool $resultPermissionTest2, bool $resultPermissionTest3, bool $resultPermissionTest4)
     {
         $admin = User::getByName('admin');
 
@@ -312,23 +330,39 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             ),
             'Has children of `' . $element->getFullpath() . '` for user UserPermissionTest2'
         );
+
+        $this->assertEquals(
+            $resultPermissionTest3,
+            $element->getDao()->hasChildren(
+                [DataObject::OBJECT_TYPE_OBJECT, DataObject::OBJECT_TYPE_FOLDER], true, $this->userPermissionTest3
+            ),
+            'Has children of `' . $element->getFullpath() . '` for user UserPermissionTest3'
+        );
+
+        $this->assertEquals(
+            $resultPermissionTest4,
+            $element->getDao()->hasChildren(
+                [DataObject::OBJECT_TYPE_OBJECT, DataObject::OBJECT_TYPE_FOLDER], true, $this->userPermissionTest4
+            ),
+            'Has children of `' . $element->getFullpath() . '` for user UserPermissionTest4'
+        );
     }
 
-    public function testHasChildren()
-    {
-        $this->doHasChildrenTest($this->a, true, true, false); //didn't work before
-        $this->doHasChildrenTest($this->permissionfoo, true, true, true); //didn't work before
-        $this->doHasChildrenTest($this->bars, true, true, true);
-        $this->doHasChildrenTest($this->hugo, false, false, false);
-        $this->doHasChildrenTest($this->userfolder, true, true, true);
-        $this->doHasChildrenTest($this->groupfolder, true, true, false); //didn't work before
-        $this->doHasChildrenTest($this->grouptestobject, false, false, false);
-        $this->doHasChildrenTest($this->permissionbar, true, false, false);
-        $this->doHasChildrenTest($this->foo, true, false, false);
-        $this->doHasChildrenTest($this->hiddenobject, false, false, false);
-    }
+//    public function testHasChildren()
+//    {
+//        $this->doHasChildrenTest($this->a, true, true, false, false, false);
+//        $this->doHasChildrenTest($this->permissionfoo, true, true, true, true, true);
+//        $this->doHasChildrenTest($this->bars, true, true, true, true, true);
+//        $this->doHasChildrenTest($this->hugo, false, false, false, false, false);
+//        $this->doHasChildrenTest($this->userfolder, true, true, true, true, false);
+//        $this->doHasChildrenTest($this->groupfolder, true, true, false, false, true);
+//        $this->doHasChildrenTest($this->grouptestobject, false, false, false, false, false);
+//        $this->doHasChildrenTest($this->permissionbar, true, false, false, false, false);
+//        $this->doHasChildrenTest($this->foo, true, false, false, false, false);
+//        $this->doHasChildrenTest($this->hiddenobject, false, false, false, false, false);
+//    }
 
-    protected function doIsAllowedTest(DataObject\AbstractObject $element, string $type, bool $resultAdmin, bool $resultPermissionTest1, bool $resultPermissionTest2)
+    protected function doIsAllowedTest(DataObject\AbstractObject $element, string $type, bool $resultAdmin, bool $resultPermissionTest1, bool $resultPermissionTest2, bool $resultPermissionTest3, bool $resultPermissionTest4)
     {
         $admin = User::getByName('admin');
 
@@ -349,37 +383,52 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             $element->isAllowed($type, $this->userPermissionTest2),
             '`' . $type . '` of `' . $element->getFullpath() . '` is allowed for UserPermissionTest2'
         );
+
+        $this->assertEquals(
+            $resultPermissionTest3,
+            $element->isAllowed($type, $this->userPermissionTest3),
+            '`' . $type . '` of `' . $element->getFullpath() . '` is allowed for UserPermissionTest3'
+        );
+
+        $this->assertEquals(
+            $resultPermissionTest4,
+            $element->isAllowed($type, $this->userPermissionTest4),
+            '`' . $type . '` of `' . $element->getFullpath() . '` is allowed for UserPermissionTest4'
+        );
     }
 
-    public function testIsAllowed()
-    {
-        $this->doIsAllowedTest($this->permissionfoo, 'list', true, true, true);
-        $this->doIsAllowedTest($this->permissionfoo, 'view', true, true, true);
-
-        $this->doIsAllowedTest($this->bars, 'list', true, true, true);
-        $this->doIsAllowedTest($this->bars, 'view', true, false, false);
-
-        $this->doIsAllowedTest($this->hugo, 'list', true, false, false);
-        $this->doIsAllowedTest($this->hugo, 'view', true, false, false);
-
-        $this->doIsAllowedTest($this->userfolder, 'list', true, true, true);
-        $this->doIsAllowedTest($this->userfolder, 'view', true, true, true);
-
-        $this->doIsAllowedTest($this->groupfolder, 'list', true, true, false);
-        $this->doIsAllowedTest($this->groupfolder, 'view', true, true, false);
-
-        $this->doIsAllowedTest($this->grouptestobject, 'list', true, true, false);
-        $this->doIsAllowedTest($this->grouptestobject, 'view', true, true, false);
-
-        $this->doIsAllowedTest($this->permissionbar, 'list', true, true, true);
-        $this->doIsAllowedTest($this->permissionbar, 'view', true, true, true);
-
-        $this->doIsAllowedTest($this->foo, 'list', true, false, false);
-        $this->doIsAllowedTest($this->foo, 'view', true, false, false);
-
-        $this->doIsAllowedTest($this->hiddenobject, 'list', true, false, false);
-        $this->doIsAllowedTest($this->hiddenobject, 'view', true, false, false);
-    }
+//    public function testIsAllowed()
+//    {
+//        $this->doIsAllowedTest($this->permissionfoo, 'list', true, true, true, true, true);
+//        $this->doIsAllowedTest($this->permissionfoo, 'view', true, true, true, false, false);
+//
+//        $this->doIsAllowedTest($this->bars, 'list', true, true, true, true, true);
+//        $this->doIsAllowedTest($this->bars, 'view', true, false, false, false, false);
+//
+//        $this->doIsAllowedTest($this->hugo, 'list', true, false, false, false, false);
+//        $this->doIsAllowedTest($this->hugo, 'view', true, false, false, false, false);
+//
+//        $this->doIsAllowedTest($this->userfolder, 'list', true, true, true, true, false);
+//        $this->doIsAllowedTest($this->userfolder, 'view', true, true, true, false, false);
+//
+//        $this->doIsAllowedTest($this->usertestobject, 'list', true, true, true, true, false);
+//        $this->doIsAllowedTest($this->usertestobject, 'view', true, true, true, true, false);
+//
+//        $this->doIsAllowedTest($this->groupfolder, 'list', true, true, false, false, true);
+//        $this->doIsAllowedTest($this->groupfolder, 'view', true, true, false, false, true);
+//
+//        $this->doIsAllowedTest($this->grouptestobject, 'list', true, true, false, false, true);
+//        $this->doIsAllowedTest($this->grouptestobject, 'view', true, true, false, false, true);
+//
+//        $this->doIsAllowedTest($this->permissionbar, 'list', true, true, true, false, false);
+//        $this->doIsAllowedTest($this->permissionbar, 'view', true, true, true, false, false);
+//
+//        $this->doIsAllowedTest($this->foo, 'list', true, false, false, false, false);
+//        $this->doIsAllowedTest($this->foo, 'view', true, false, false, false, false);
+//
+//        $this->doIsAllowedTest($this->hiddenobject, 'list', true, false, false, false, false);
+//        $this->doIsAllowedTest($this->hiddenobject, 'view', true, false, false, false, false);
+//    }
 
     protected function doAreAllowedTest(DataObject\AbstractObject $element, User $user, array $expectedPermissions)
     {
@@ -393,105 +442,113 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             );
         }
     }
-
-    public function testAreAllowed()
-    {
-        $admin = User::getByName('admin');
-
-        //check permissions of groupfolder (directly defined) and grouptestobject (inherited)
-        foreach ([$this->groupfolder, $this->grouptestobject] as $element) {
-            $this->doAreAllowedTest($element, $admin,
-                [
-                    'save' => 1,
-                    'delete' => 1,
-                    'publish' => 1,
-                    'settings' => 1,
-                    'versions' => 1,
-                ]
-            );
-            $this->doAreAllowedTest($element, $this->userPermissionTest1,
-                [
-                    'save' => 1,
-                    'delete' => 0,
-                    'publish' => 0,
-                    'settings' => 1,
-                    'versions' => 0,
-                ]
-            );
-            $this->doAreAllowedTest($element, $this->userPermissionTest2,
-                [
-                    'save' => 1,
-                    'delete' => 0,
-                    'publish' => 1,
-                    'settings' => 0,
-                    'versions' => 0,
-                ]
-            );
-        }
-
-        //check permissions of userfolder (directly defined) and usertestobject (inherited)
-        foreach ([$this->userfolder, $this->usertestobject] as $element) {
-            $this->doAreAllowedTest($element, $admin,
-                [
-                    'view' => 1,
-                    'delete' => 1,
-                    'publish' => 1,
-                    'versions' => 1,
-                    'create' => 1,
-                    'rename' => 1,
-                ]
-            );
-            $this->doAreAllowedTest($element, $this->userPermissionTest1,
-                [
-                    'view' => 1,
-                    'delete' => 0,
-                    'publish' => 0,
-                    'versions' => 0,
-                    'create' => 1,
-                    'rename' => 1,
-                ]
-            );
-            $this->doAreAllowedTest($element, $this->userPermissionTest2,
-                [
-                    'view' => 1,
-                    'delete' => 0,
-                    'publish' => 0,
-                    'versions' => 0,
-                    'create' => 0,
-                    'rename' => 0,
-                ]
-            );
-        }
-
-        //check when no parent workspace is found, it should be allow list=1 when children are found, in this case for
-        // admin and user1 to get to `c`
-        foreach ([$this->a, $this->b, $this->c] as $element) {
-            $this->doAreAllowedTest($element, $admin,
-                [
-                    'list' => 1,
-                    'delete' => 1,
-                    'publish' => 1,
-                    'versions' => 1,
-                ]
-            );
-            $this->doAreAllowedTest($element, $this->userPermissionTest1,
-                [
-                    'list' => 1,
-                    'delete' => 0,
-                    'publish' => 0,
-                    'versions' => 0,
-                ]
-            );
-            $this->doAreAllowedTest($element, $this->userPermissionTest2,
-                [
-                    'list' => 0,
-                    'delete' => 0,
-                    'publish' => 0,
-                    'versions' => 0,
-                ]
-            );
-        }
-    }
+//
+//    public function testAreAllowed()
+//    {
+//        $admin = User::getByName('admin');
+//
+//        //check permissions of groupfolder (directly defined) and grouptestobject (inherited)
+//        foreach ([$this->groupfolder, $this->grouptestobject] as $element) {
+//            $this->doAreAllowedTest($element, $admin,
+//                [
+//                    'save' => 1,
+//                    'delete' => 1,
+//                    'publish' => 1,
+//                    'settings' => 1,
+//                    'versions' => 1,
+//                ]
+//            );
+//            $this->doAreAllowedTest($element, $this->userPermissionTest1,
+//                [
+//                    'save' => 1,
+//                    'delete' => 0,
+//                    'publish' => 0,
+//                    'settings' => 1,
+//                    'versions' => 0,
+//                ]
+//            );
+//            $this->doAreAllowedTest($element, $this->userPermissionTest2,
+//                [
+//                    'save' => 1,
+//                    'delete' => 0,
+//                    'publish' => 1,
+//                    'settings' => 0,
+//                    'versions' => 0,
+//                ]
+//            );
+//            $this->doAreAllowedTest($element, $this->userPermissionTest3, []);
+//            $this->doAreAllowedTest($element, $this->userPermissionTest4,
+//                [
+//                    'list' => 1,
+//                    'view' => 1,
+//                ]
+//            );
+//        }
+//
+//        //check permissions of userfolder (directly defined) and usertestobject (inherited)
+//        foreach ([$this->userfolder, $this->usertestobject] as $element) {
+//            $this->doAreAllowedTest($element, $admin,
+//                [
+//                    'view' => 1,
+//                    'delete' => 1,
+//                    'publish' => 1,
+//                    'versions' => 1,
+//                    'create' => 1,
+//                    'rename' => 1,
+//                ]
+//            );
+//            $this->doAreAllowedTest($element, $this->userPermissionTest1,
+//                [
+//                    'view' => 1,
+//                    'delete' => 0,
+//                    'publish' => 0,
+//                    'versions' => 0,
+//                    'create' => 1,
+//                    'rename' => 1,
+//                ]
+//            );
+//            $this->doAreAllowedTest($element, $this->userPermissionTest2,
+//                [
+//                    'view' => 1,
+//                    'delete' => 0,
+//                    'publish' => 0,
+//                    'versions' => 0,
+//                    'create' => 0,
+//                    'rename' => 0,
+//                ]
+//            );
+//
+//        }
+//
+//        //check when no parent workspace is found, it should be allow list=1 when children are found, in this case for
+//        // admin and user1 to get to `c`
+//        foreach ([$this->a, $this->b, $this->c] as $element) {
+//            $this->doAreAllowedTest($element, $admin,
+//                [
+//                    'list' => 1,
+//                    'delete' => 1,
+//                    'publish' => 1,
+//                    'versions' => 1,
+//                ]
+//            );
+//            $this->doAreAllowedTest($element, $this->userPermissionTest1,
+//                [
+//                    'list' => 1,
+//                    'delete' => 0,
+//                    'publish' => 0,
+//                    'versions' => 0,
+//                ]
+//            );
+//            $this->doAreAllowedTest($element, $this->userPermissionTest2,
+//                [
+//                    'list' => 0,
+//                    'delete' => 0,
+//                    'publish' => 0,
+//                    'versions' => 0,
+//                ]
+//            );
+//        }
+//    }
 
     protected function buildController(string $classname, User $user)
     {
@@ -558,15 +615,27 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             [$this->bars->getFullpath()]
         );
 
-        $this->doTestTreeGetChildsById( //did not work before (count vs. total)
+        $this->doTestTreeGetChildsById(
             $this->permissionfoo,
             $this->userPermissionTest1,
             [$this->bars->getFullpath()]
         );
 
-        $this->doTestTreeGetChildsById( //did not work before
+        $this->doTestTreeGetChildsById(
             $this->permissionfoo,
             $this->userPermissionTest2,
+            [$this->bars->getFullpath()]
+        );
+
+        $this->doTestTreeGetChildsById(
+            $this->permissionfoo,
+            $this->userPermissionTest3,
+            [$this->bars->getFullpath()]
+        );
+
+        $this->doTestTreeGetChildsById(
+            $this->permissionfoo,
+            $this->userPermissionTest4,
             [$this->bars->getFullpath()]
         );
 
@@ -583,10 +652,22 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             [$this->userfolder->getFullpath(), $this->groupfolder->getFullpath()]
         );
 
-        $this->doTestTreeGetChildsById( //did not work before (count vs. total)
+        $this->doTestTreeGetChildsById(
             $this->bars,
             $this->userPermissionTest2,
             [$this->userfolder->getFullpath()]
+        );
+
+        $this->doTestTreeGetChildsById(
+            $this->bars,
+            $this->userPermissionTest3,
+            [$this->userfolder->getFullpath()]
+        );
+
+        $this->doTestTreeGetChildsById(
+            $this->bars,
+            $this->userPermissionTest4,
+            [$this->groupfolder->getFullpath()]
         );
 
         // test /permissionfoo/bars/userfolder
@@ -608,6 +689,18 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             [$this->usertestobject->getFullpath()]
         );
 
+        $this->doTestTreeGetChildsById(
+            $this->userfolder,
+            $this->userPermissionTest3,
+            [$this->usertestobject->getFullpath()]
+        );
+
+        $this->doTestTreeGetChildsById(
+            $this->userfolder,
+            $this->userPermissionTest4,
+            []
+        );
+
         // test /permissionfoo/bars/groupfolder
         $this->doTestTreeGetChildsById(
             $this->groupfolder,
@@ -621,10 +714,22 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             [$this->grouptestobject->getFullpath()]
         );
 
-        $this->doTestTreeGetChildsById( //did not work before (count vs. total)
+        $this->doTestTreeGetChildsById(
             $this->groupfolder,
             $this->userPermissionTest2,
             []
+        );
+
+        $this->doTestTreeGetChildsById(
+            $this->groupfolder,
+            $this->userPermissionTest3,
+            []
+        );
+
+        $this->doTestTreeGetChildsById(
+            $this->groupfolder,
+            $this->userPermissionTest4,
+            [$this->grouptestobject->getFullpath()]
         );
 
         // test /permissionbar
@@ -646,6 +751,17 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             []
         );
 
+        $this->doTestTreeGetChildsById(
+            $this->permissionbar,
+            $this->userPermissionTest3,
+            []
+        );
+
+        $this->doTestTreeGetChildsById(
+            $this->permissionbar,
+            $this->userPermissionTest4,
+            []
+        );
         // test /permissionbar/foo
         $this->doTestTreeGetChildsById(
             $this->foo,
@@ -664,6 +780,19 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             $this->userPermissionTest2,
             []
         );
+
+        $this->doTestTreeGetChildsById(
+            $this->permissionbar,
+            $this->userPermissionTest3,
+            []
+        );
+
+        $this->doTestTreeGetChildsById(
+            $this->permissionbar,
+            $this->userPermissionTest4,
+            []
+        );
+
     }
 
     protected function doTestSearch(string $searchText, User $user, array $expectedResultPaths, int $limit = 100)
@@ -712,47 +841,66 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         }
     }
 
-    public function testSearch()
-    {
-        $admin = User::getByName('admin');
-
-        //search hugo
-        $this->doTestSearch('hugo', $admin, [$this->hugo->getFullpath()]);
-        $this->doTestSearch('hugo', $this->userPermissionTest1, []);
-        $this->doTestSearch('hugo', $this->userPermissionTest2, []);
-
-        //search bars
-        $this->doTestSearch('bars', $admin, [
-            $this->bars->getFullpath(),
-            $this->hugo->getFullpath(),
-            $this->userfolder->getFullpath(),
-            $this->usertestobject->getFullpath(),
-            $this->groupfolder->getFullpath(),
-            $this->grouptestobject->getFullpath(),
-        ]);
-        $this->doTestSearch('bars', $this->userPermissionTest1, [
-            $this->bars->getFullpath(),
-            $this->userfolder->getFullpath(),
-            $this->usertestobject->getFullpath(),
-            $this->groupfolder->getFullpath(),
-            $this->grouptestobject->getFullpath(),
-        ]);
-        $this->doTestSearch('bars', $this->userPermissionTest2, [
-            $this->bars->getFullpath(),
-            $this->userfolder->getFullpath(),
-            $this->usertestobject->getFullpath(),
-        ]);
-
-        //search hidden object
-        $this->doTestSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
-        $this->doTestSearch('hiddenobject', $this->userPermissionTest1, []);
-        $this->doTestSearch('hiddenobject', $this->userPermissionTest2, []);
-
-        //search for asset
-        $this->doTestSearch('assetelement', $admin, []);
-        $this->doTestSearch('assetelement', $this->userPermissionTest1, []);
-        $this->doTestSearch('assetelement', $this->userPermissionTest2, []);
-    }
+//    public function testSearch()
+//    {
+//        $admin = User::getByName('admin');
+//
+//        //search hugo
+//        $this->doTestSearch('hugo', $admin, [$this->hugo->getFullpath()]);
+//        $this->doTestSearch('hugo', $this->userPermissionTest1, []);
+//        $this->doTestSearch('hugo', $this->userPermissionTest2, []);
+//        $this->doTestSearch('hugo', $this->userPermissionTest3, []);
+//        $this->doTestSearch('hugo', $this->userPermissionTest4, []);
+//
+//        //search bars
+//        $this->doTestSearch('bars', $admin, [
+//            $this->bars->getFullpath(),
+//            $this->hugo->getFullpath(),
+//            $this->userfolder->getFullpath(),
+//            $this->usertestobject->getFullpath(),
+//            $this->groupfolder->getFullpath(),
+//            $this->grouptestobject->getFullpath(),
+//        ]);
+//        $this->doTestSearch('bars', $this->userPermissionTest1, [
+//            $this->bars->getFullpath(),
+//            $this->userfolder->getFullpath(),
+//            $this->usertestobject->getFullpath(),
+//            $this->groupfolder->getFullpath(),
+//            $this->grouptestobject->getFullpath(),
+//        ]);
+//        $this->doTestSearch('bars', $this->userPermissionTest2, [
+//            $this->bars->getFullpath(),
+//            $this->userfolder->getFullpath(),
+//            $this->usertestobject->getFullpath(),
+//        ]);
+//
+//        $this->doTestSearch('bars', $this->userPermissionTest3, [
+//        $this->bars->getFullpath(),
+//        $this->userfolder->getFullpath(),
+//        $this->usertestobject->getFullpath(),
+//        ]);
+//
+//        $this->doTestSearch('bars', $this->userPermissionTest4, [
+//        $this->bars->getFullpath(),
+//        $this->groupfolder->getFullpath(),
+//        $this->grouptestobject->getFullpath(),
+//        ]);
+//
+//        //search hidden object
+//        $this->doTestSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
+//        $this->doTestSearch('hiddenobject', $this->userPermissionTest1, []);
+//        $this->doTestSearch('hiddenobject', $this->userPermissionTest2, []);
+//        $this->doTestSearch('hiddenobject', $this->userPermissionTest3, []);
+//        $this->doTestSearch('hiddenobject', $this->userPermissionTest4, []);
+//
+//
+//        //search for asset
+//        $this->doTestSearch('assetelement', $admin, []);
+//        $this->doTestSearch('assetelement', $this->userPermissionTest1, []);
+//        $this->doTestSearch('assetelement', $this->userPermissionTest2, []);
+//        $this->doTestSearch('assetelement', $this->userPermissionTest3, []);
+//        $this->doTestSearch('assetelement', $this->userPermissionTest4, []);
+//    }
 
     public function testManyElementSearch()
     {
@@ -761,7 +909,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         //prepare additional data
         $manyElements = $this->createFolder('manyElements', 1);
         $manyElementList = [];
-        $elementCount = 5;
+        $elementCount = 50;
 
         for ($i = 1; $i <= $elementCount; $i++) {
             $manyElementList[] = $this->createObject('manyelement ' . $i, $manyElements->getId());
@@ -786,9 +934,13 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         );
         $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount + 1);
         $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount + 1);
+        $this->doTestSearch('manyelement', $this->userPermissionTest3, [], $elementCount + 1);
+        $this->doTestSearch('manyelement', $this->userPermissionTest4, [$manyElementX->getFullpath()], $elementCount + 1);
 
         $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount);
         $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount);
+        $this->doTestSearch('manyelement', $this->userPermissionTest3, [], $elementCount);
+        $this->doTestSearch('manyelement', $this->userPermissionTest4, [$manyElementX->getFullpath()], $elementCount);
     }
 
     protected function doTestQuickSearch(string $searchText, User $user, array $expectedResultPaths, int $limit = 100)
@@ -837,6 +989,8 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestQuickSearch('hugo', $admin, [$this->hugo->getFullpath()]);
         $this->doTestQuickSearch('hugo', $this->userPermissionTest1, []);
         $this->doTestQuickSearch('hugo', $this->userPermissionTest2, []);
+        $this->doTestQuickSearch('hugo', $this->userPermissionTest3, []);
+        $this->doTestQuickSearch('hugo', $this->userPermissionTest4, []);
 
         //search bars
         $this->doTestQuickSearch('bars', $admin, [
@@ -851,15 +1005,25 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestQuickSearch('bars', $this->userPermissionTest2, [
             $this->usertestobject->getFullpath(),
         ]);
+        $this->doTestQuickSearch('bars', $this->userPermissionTest3, [
+            $this->usertestobject->getFullpath(),
+        ]);
+        $this->doTestQuickSearch('bars', $this->userPermissionTest4, [
+            $this->grouptestobject->getFullpath(),
+        ]);
 
         //search hidden object
         $this->doTestQuickSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
         $this->doTestQuickSearch('hiddenobject', $this->userPermissionTest1, []);
         $this->doTestQuickSearch('hiddenobject', $this->userPermissionTest2, []);
+        $this->doTestQuickSearch('hiddenobject', $this->userPermissionTest3, []);
+        $this->doTestQuickSearch('hiddenobject', $this->userPermissionTest4, []);
 
         //search for asset
         $this->doTestQuickSearch('assetelement', $admin, [$this->assetElement->getFullPath()]);
         $this->doTestQuickSearch('assetelement', $this->userPermissionTest1, []);
         $this->doTestQuickSearch('assetelement', $this->userPermissionTest2, []);
+        $this->doTestQuickSearch('assetelement', $this->userPermissionTest3, []);
+        $this->doTestQuickSearch('assetelement', $this->userPermissionTest4, []);
     }
 }

--- a/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
@@ -672,11 +672,12 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             [$this->bars->getFullpath()]
         );
 
-        $this->doTestTreeGetChildsById(
-            $this->permissionfoo,
-            $this->userPermissionTest6,
-            []
-        );
+        //Normally it would return an "Access Denied" by AdminController
+//        $this->doTestTreeGetChildsById(
+//            $this->permissionfoo,
+//            $this->userPermissionTest6,
+//            []
+//        );
 
         // test /permissionfoo/bars
         $this->doTestTreeGetChildsById(
@@ -715,11 +716,11 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             [$this->userfolder->getFullpath()]
         );
 
-        $this->doTestTreeGetChildsById(
-            $this->bars,
-            $this->userPermissionTest6,
-            []
-        );
+//        $this->doTestTreeGetChildsById(
+//            $this->bars,
+//            $this->userPermissionTest6,
+//            []
+//        );
 
         // test /permissionfoo/bars/userfolder
         $this->doTestTreeGetChildsById(
@@ -758,11 +759,11 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             [$this->usertestobject->getFullpath()]
         );
 
-        $this->doTestTreeGetChildsById(
-            $this->userfolder,
-            $this->userPermissionTest6,
-            []
-        );
+//        $this->doTestTreeGetChildsById(
+//            $this->userfolder,
+//            $this->userPermissionTest6,
+//            []
+//        );
 
         // test /permissionfoo/bars/groupfolder
         $this->doTestTreeGetChildsById(

--- a/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
@@ -297,7 +297,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             (new User\Workspace\DataObject())->setValues(['cId' => $this->usertestobject->getId(), 'cPath' => $this->usertestobject->getFullpath(), 'list' => true, 'view' => true]),
             (new User\Workspace\Asset())->setValues(['cId' => $this->assetElement->getId(), 'cPath' => $this->assetElement->getFullpath(), 'list' => true, 'view' => true]),
         ]);
-        $this->userPermissionTest5->save();
+        $this->userPermissionTest6->save();
     }
 
     public function setUp(): void
@@ -320,6 +320,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         User::getByName('Permissiontest3')->delete();
         User::getByName('Permissiontest4')->delete();
         User::getByName('Permissiontest5')->delete();
+        User::getByName('Permissiontest6')->delete();
         User\Role::getByName('Testrole')->delete();
         User\Role::getByName('Dummyrole')->delete();
     }

--- a/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
@@ -348,19 +348,19 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         );
     }
 
-//    public function testHasChildren()
-//    {
-//        $this->doHasChildrenTest($this->a, true, true, false, false, false);
-//        $this->doHasChildrenTest($this->permissionfoo, true, true, true, true, true);
-//        $this->doHasChildrenTest($this->bars, true, true, true, true, true);
-//        $this->doHasChildrenTest($this->hugo, false, false, false, false, false);
-//        $this->doHasChildrenTest($this->userfolder, true, true, true, true, false);
-//        $this->doHasChildrenTest($this->groupfolder, true, true, false, false, true);
-//        $this->doHasChildrenTest($this->grouptestobject, false, false, false, false, false);
-//        $this->doHasChildrenTest($this->permissionbar, true, false, false, false, false);
-//        $this->doHasChildrenTest($this->foo, true, false, false, false, false);
-//        $this->doHasChildrenTest($this->hiddenobject, false, false, false, false, false);
-//    }
+    public function testHasChildren()
+    {
+        $this->doHasChildrenTest($this->a, true, true, false, false, false);
+        $this->doHasChildrenTest($this->permissionfoo, true, true, true, true, true);
+        $this->doHasChildrenTest($this->bars, true, true, true, true, true);
+        $this->doHasChildrenTest($this->hugo, false, false, false, false, false);
+        $this->doHasChildrenTest($this->userfolder, true, true, true, true, false);
+        $this->doHasChildrenTest($this->groupfolder, true, true, false, false, true);
+        $this->doHasChildrenTest($this->grouptestobject, false, false, false, false, false);
+        $this->doHasChildrenTest($this->permissionbar, true, false, false, false, false);
+        $this->doHasChildrenTest($this->foo, true, false, false, false, false);
+        $this->doHasChildrenTest($this->hiddenobject, false, false, false, false, false);
+    }
 
     protected function doIsAllowedTest(DataObject\AbstractObject $element, string $type, bool $resultAdmin, bool $resultPermissionTest1, bool $resultPermissionTest2, bool $resultPermissionTest3, bool $resultPermissionTest4)
     {
@@ -397,38 +397,38 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         );
     }
 
-//    public function testIsAllowed()
-//    {
-//        $this->doIsAllowedTest($this->permissionfoo, 'list', true, true, true, true, true);
-//        $this->doIsAllowedTest($this->permissionfoo, 'view', true, true, true, false, false);
-//
-//        $this->doIsAllowedTest($this->bars, 'list', true, true, true, true, true);
-//        $this->doIsAllowedTest($this->bars, 'view', true, false, false, false, false);
-//
-//        $this->doIsAllowedTest($this->hugo, 'list', true, false, false, false, false);
-//        $this->doIsAllowedTest($this->hugo, 'view', true, false, false, false, false);
-//
-//        $this->doIsAllowedTest($this->userfolder, 'list', true, true, true, true, false);
-//        $this->doIsAllowedTest($this->userfolder, 'view', true, true, true, false, false);
-//
-//        $this->doIsAllowedTest($this->usertestobject, 'list', true, true, true, true, false);
-//        $this->doIsAllowedTest($this->usertestobject, 'view', true, true, true, true, false);
-//
-//        $this->doIsAllowedTest($this->groupfolder, 'list', true, true, false, false, true);
-//        $this->doIsAllowedTest($this->groupfolder, 'view', true, true, false, false, true);
-//
-//        $this->doIsAllowedTest($this->grouptestobject, 'list', true, true, false, false, true);
-//        $this->doIsAllowedTest($this->grouptestobject, 'view', true, true, false, false, true);
-//
-//        $this->doIsAllowedTest($this->permissionbar, 'list', true, true, true, false, false);
-//        $this->doIsAllowedTest($this->permissionbar, 'view', true, true, true, false, false);
-//
-//        $this->doIsAllowedTest($this->foo, 'list', true, false, false, false, false);
-//        $this->doIsAllowedTest($this->foo, 'view', true, false, false, false, false);
-//
-//        $this->doIsAllowedTest($this->hiddenobject, 'list', true, false, false, false, false);
-//        $this->doIsAllowedTest($this->hiddenobject, 'view', true, false, false, false, false);
-//    }
+    public function testIsAllowed()
+    {
+        $this->doIsAllowedTest($this->permissionfoo, 'list', true, true, true, true, true);
+        $this->doIsAllowedTest($this->permissionfoo, 'view', true, true, true, false, false);
+
+        $this->doIsAllowedTest($this->bars, 'list', true, true, true, true, true);
+        $this->doIsAllowedTest($this->bars, 'view', true, false, false, false, false);
+
+        $this->doIsAllowedTest($this->hugo, 'list', true, false, false, false, false);
+        $this->doIsAllowedTest($this->hugo, 'view', true, false, false, false, false);
+
+        $this->doIsAllowedTest($this->userfolder, 'list', true, true, true, true, false);
+        $this->doIsAllowedTest($this->userfolder, 'view', true, true, true, false, false);
+
+        $this->doIsAllowedTest($this->usertestobject, 'list', true, true, true, true, false);
+        $this->doIsAllowedTest($this->usertestobject, 'view', true, true, true, true, false);
+
+        $this->doIsAllowedTest($this->groupfolder, 'list', true, true, false, false, true);
+        $this->doIsAllowedTest($this->groupfolder, 'view', true, true, false, false, true);
+
+        $this->doIsAllowedTest($this->grouptestobject, 'list', true, true, false, false, true);
+        $this->doIsAllowedTest($this->grouptestobject, 'view', true, true, false, false, true);
+
+        $this->doIsAllowedTest($this->permissionbar, 'list', true, true, true, false, false);
+        $this->doIsAllowedTest($this->permissionbar, 'view', true, true, true, false, false);
+
+        $this->doIsAllowedTest($this->foo, 'list', true, false, false, false, false);
+        $this->doIsAllowedTest($this->foo, 'view', true, false, false, false, false);
+
+        $this->doIsAllowedTest($this->hiddenobject, 'list', true, false, false, false, false);
+        $this->doIsAllowedTest($this->hiddenobject, 'view', true, false, false, false, false);
+    }
 
     protected function doAreAllowedTest(DataObject\AbstractObject $element, User $user, array $expectedPermissions)
     {
@@ -442,113 +442,113 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             );
         }
     }
-//
-//    public function testAreAllowed()
-//    {
-//        $admin = User::getByName('admin');
-//
-//        //check permissions of groupfolder (directly defined) and grouptestobject (inherited)
-//        foreach ([$this->groupfolder, $this->grouptestobject] as $element) {
-//            $this->doAreAllowedTest($element, $admin,
-//                [
-//                    'save' => 1,
-//                    'delete' => 1,
-//                    'publish' => 1,
-//                    'settings' => 1,
-//                    'versions' => 1,
-//                ]
-//            );
-//            $this->doAreAllowedTest($element, $this->userPermissionTest1,
-//                [
-//                    'save' => 1,
-//                    'delete' => 0,
-//                    'publish' => 0,
-//                    'settings' => 1,
-//                    'versions' => 0,
-//                ]
-//            );
-//            $this->doAreAllowedTest($element, $this->userPermissionTest2,
-//                [
-//                    'save' => 1,
-//                    'delete' => 0,
-//                    'publish' => 1,
-//                    'settings' => 0,
-//                    'versions' => 0,
-//                ]
-//            );
-//            $this->doAreAllowedTest($element, $this->userPermissionTest3, []);
-//            $this->doAreAllowedTest($element, $this->userPermissionTest4,
-//                [
-//                    'list' => 1,
-//                    'view' => 1,
-//                ]
-//            );
-//        }
-//
-//        //check permissions of userfolder (directly defined) and usertestobject (inherited)
-//        foreach ([$this->userfolder, $this->usertestobject] as $element) {
-//            $this->doAreAllowedTest($element, $admin,
-//                [
-//                    'view' => 1,
-//                    'delete' => 1,
-//                    'publish' => 1,
-//                    'versions' => 1,
-//                    'create' => 1,
-//                    'rename' => 1,
-//                ]
-//            );
-//            $this->doAreAllowedTest($element, $this->userPermissionTest1,
-//                [
-//                    'view' => 1,
-//                    'delete' => 0,
-//                    'publish' => 0,
-//                    'versions' => 0,
-//                    'create' => 1,
-//                    'rename' => 1,
-//                ]
-//            );
-//            $this->doAreAllowedTest($element, $this->userPermissionTest2,
-//                [
-//                    'view' => 1,
-//                    'delete' => 0,
-//                    'publish' => 0,
-//                    'versions' => 0,
-//                    'create' => 0,
-//                    'rename' => 0,
-//                ]
-//            );
-//
-//        }
-//
-//        //check when no parent workspace is found, it should be allow list=1 when children are found, in this case for
-//        // admin and user1 to get to `c`
-//        foreach ([$this->a, $this->b, $this->c] as $element) {
-//            $this->doAreAllowedTest($element, $admin,
-//                [
-//                    'list' => 1,
-//                    'delete' => 1,
-//                    'publish' => 1,
-//                    'versions' => 1,
-//                ]
-//            );
-//            $this->doAreAllowedTest($element, $this->userPermissionTest1,
-//                [
-//                    'list' => 1,
-//                    'delete' => 0,
-//                    'publish' => 0,
-//                    'versions' => 0,
-//                ]
-//            );
-//            $this->doAreAllowedTest($element, $this->userPermissionTest2,
-//                [
-//                    'list' => 0,
-//                    'delete' => 0,
-//                    'publish' => 0,
-//                    'versions' => 0,
-//                ]
-//            );
-//        }
-//    }
+
+    public function testAreAllowed()
+    {
+        $admin = User::getByName('admin');
+
+        //check permissions of groupfolder (directly defined) and grouptestobject (inherited)
+        foreach ([$this->groupfolder, $this->grouptestobject] as $element) {
+            $this->doAreAllowedTest($element, $admin,
+                [
+                    'save' => 1,
+                    'delete' => 1,
+                    'publish' => 1,
+                    'settings' => 1,
+                    'versions' => 1,
+                ]
+            );
+            $this->doAreAllowedTest($element, $this->userPermissionTest1,
+                [
+                    'save' => 1,
+                    'delete' => 0,
+                    'publish' => 0,
+                    'settings' => 1,
+                    'versions' => 0,
+                ]
+            );
+            $this->doAreAllowedTest($element, $this->userPermissionTest2,
+                [
+                    'save' => 1,
+                    'delete' => 0,
+                    'publish' => 1,
+                    'settings' => 0,
+                    'versions' => 0,
+                ]
+            );
+            $this->doAreAllowedTest($element, $this->userPermissionTest3, []);
+            $this->doAreAllowedTest($element, $this->userPermissionTest4,
+                [
+                    'list' => 1,
+                    'view' => 1,
+                ]
+            );
+        }
+
+        //check permissions of userfolder (directly defined) and usertestobject (inherited)
+        foreach ([$this->userfolder, $this->usertestobject] as $element) {
+            $this->doAreAllowedTest($element, $admin,
+                [
+                    'view' => 1,
+                    'delete' => 1,
+                    'publish' => 1,
+                    'versions' => 1,
+                    'create' => 1,
+                    'rename' => 1,
+                ]
+            );
+            $this->doAreAllowedTest($element, $this->userPermissionTest1,
+                [
+                    'view' => 1,
+                    'delete' => 0,
+                    'publish' => 0,
+                    'versions' => 0,
+                    'create' => 1,
+                    'rename' => 1,
+                ]
+            );
+            $this->doAreAllowedTest($element, $this->userPermissionTest2,
+                [
+                    'view' => 1,
+                    'delete' => 0,
+                    'publish' => 0,
+                    'versions' => 0,
+                    'create' => 0,
+                    'rename' => 0,
+                ]
+            );
+
+        }
+
+        //check when no parent workspace is found, it should be allow list=1 when children are found, in this case for
+        // admin and user1 to get to `c`
+        foreach ([$this->a, $this->b, $this->c] as $element) {
+            $this->doAreAllowedTest($element, $admin,
+                [
+                    'list' => 1,
+                    'delete' => 1,
+                    'publish' => 1,
+                    'versions' => 1,
+                ]
+            );
+            $this->doAreAllowedTest($element, $this->userPermissionTest1,
+                [
+                    'list' => 1,
+                    'delete' => 0,
+                    'publish' => 0,
+                    'versions' => 0,
+                ]
+            );
+            $this->doAreAllowedTest($element, $this->userPermissionTest2,
+                [
+                    'list' => 0,
+                    'delete' => 0,
+                    'publish' => 0,
+                    'versions' => 0,
+                ]
+            );
+        }
+    }
 
     protected function buildController(string $classname, User $user)
     {
@@ -841,66 +841,66 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         }
     }
 
-//    public function testSearch()
-//    {
-//        $admin = User::getByName('admin');
-//
-//        //search hugo
-//        $this->doTestSearch('hugo', $admin, [$this->hugo->getFullpath()]);
-//        $this->doTestSearch('hugo', $this->userPermissionTest1, []);
-//        $this->doTestSearch('hugo', $this->userPermissionTest2, []);
-//        $this->doTestSearch('hugo', $this->userPermissionTest3, []);
-//        $this->doTestSearch('hugo', $this->userPermissionTest4, []);
-//
-//        //search bars
-//        $this->doTestSearch('bars', $admin, [
-//            $this->bars->getFullpath(),
-//            $this->hugo->getFullpath(),
-//            $this->userfolder->getFullpath(),
-//            $this->usertestobject->getFullpath(),
-//            $this->groupfolder->getFullpath(),
-//            $this->grouptestobject->getFullpath(),
-//        ]);
-//        $this->doTestSearch('bars', $this->userPermissionTest1, [
-//            $this->bars->getFullpath(),
-//            $this->userfolder->getFullpath(),
-//            $this->usertestobject->getFullpath(),
-//            $this->groupfolder->getFullpath(),
-//            $this->grouptestobject->getFullpath(),
-//        ]);
-//        $this->doTestSearch('bars', $this->userPermissionTest2, [
-//            $this->bars->getFullpath(),
-//            $this->userfolder->getFullpath(),
-//            $this->usertestobject->getFullpath(),
-//        ]);
-//
-//        $this->doTestSearch('bars', $this->userPermissionTest3, [
-//        $this->bars->getFullpath(),
-//        $this->userfolder->getFullpath(),
-//        $this->usertestobject->getFullpath(),
-//        ]);
-//
-//        $this->doTestSearch('bars', $this->userPermissionTest4, [
-//        $this->bars->getFullpath(),
-//        $this->groupfolder->getFullpath(),
-//        $this->grouptestobject->getFullpath(),
-//        ]);
-//
-//        //search hidden object
-//        $this->doTestSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
-//        $this->doTestSearch('hiddenobject', $this->userPermissionTest1, []);
-//        $this->doTestSearch('hiddenobject', $this->userPermissionTest2, []);
-//        $this->doTestSearch('hiddenobject', $this->userPermissionTest3, []);
-//        $this->doTestSearch('hiddenobject', $this->userPermissionTest4, []);
-//
-//
-//        //search for asset
-//        $this->doTestSearch('assetelement', $admin, []);
-//        $this->doTestSearch('assetelement', $this->userPermissionTest1, []);
-//        $this->doTestSearch('assetelement', $this->userPermissionTest2, []);
-//        $this->doTestSearch('assetelement', $this->userPermissionTest3, []);
-//        $this->doTestSearch('assetelement', $this->userPermissionTest4, []);
-//    }
+    public function testSearch()
+    {
+        $admin = User::getByName('admin');
+
+        //search hugo
+        $this->doTestSearch('hugo', $admin, [$this->hugo->getFullpath()]);
+        $this->doTestSearch('hugo', $this->userPermissionTest1, []);
+        $this->doTestSearch('hugo', $this->userPermissionTest2, []);
+        $this->doTestSearch('hugo', $this->userPermissionTest3, []);
+        $this->doTestSearch('hugo', $this->userPermissionTest4, []);
+
+        //search bars
+        $this->doTestSearch('bars', $admin, [
+            $this->bars->getFullpath(),
+            $this->hugo->getFullpath(),
+            $this->userfolder->getFullpath(),
+            $this->usertestobject->getFullpath(),
+            $this->groupfolder->getFullpath(),
+            $this->grouptestobject->getFullpath(),
+        ]);
+        $this->doTestSearch('bars', $this->userPermissionTest1, [
+            $this->bars->getFullpath(),
+            $this->userfolder->getFullpath(),
+            $this->usertestobject->getFullpath(),
+            $this->groupfolder->getFullpath(),
+            $this->grouptestobject->getFullpath(),
+        ]);
+        $this->doTestSearch('bars', $this->userPermissionTest2, [
+            $this->bars->getFullpath(),
+            $this->userfolder->getFullpath(),
+            $this->usertestobject->getFullpath(),
+        ]);
+
+        $this->doTestSearch('bars', $this->userPermissionTest3, [
+        $this->bars->getFullpath(),
+        $this->userfolder->getFullpath(),
+        $this->usertestobject->getFullpath(),
+        ]);
+
+        $this->doTestSearch('bars', $this->userPermissionTest4, [
+        $this->bars->getFullpath(),
+        $this->groupfolder->getFullpath(),
+        $this->grouptestobject->getFullpath(),
+        ]);
+
+        //search hidden object
+        $this->doTestSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
+        $this->doTestSearch('hiddenobject', $this->userPermissionTest1, []);
+        $this->doTestSearch('hiddenobject', $this->userPermissionTest2, []);
+        $this->doTestSearch('hiddenobject', $this->userPermissionTest3, []);
+        $this->doTestSearch('hiddenobject', $this->userPermissionTest4, []);
+
+
+        //search for asset
+        $this->doTestSearch('assetelement', $admin, []);
+        $this->doTestSearch('assetelement', $this->userPermissionTest1, []);
+        $this->doTestSearch('assetelement', $this->userPermissionTest2, []);
+        $this->doTestSearch('assetelement', $this->userPermissionTest3, []);
+        $this->doTestSearch('assetelement', $this->userPermissionTest4, []);
+    }
 
     public function testManyElementSearch()
     {

--- a/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
@@ -875,15 +875,12 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         ]);
 
         $this->doTestSearch('bars', $this->userPermissionTest3, [
-        $this->bars->getFullpath(),
-        $this->userfolder->getFullpath(),
-        $this->usertestobject->getFullpath(),
+            $this->usertestobject->getFullpath(),
         ]);
 
         $this->doTestSearch('bars', $this->userPermissionTest4, [
-        $this->bars->getFullpath(),
-        $this->groupfolder->getFullpath(),
-        $this->grouptestobject->getFullpath(),
+            $this->groupfolder->getFullpath(),
+            $this->grouptestobject->getFullpath(),
         ]);
 
         //search hidden object

--- a/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
@@ -282,8 +282,18 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         //create user 5, with no roles, assets and data objects allowed in parallel
         $this->userPermissionTest5 = new User();
         $this->userPermissionTest5->setName('Permissiontest5');
-        $this->userPermissionTest5->setPermissions(['objects', 'assets']);
+        $this->userPermissionTest5->setPermissions(['assets', 'objects']);
         $this->userPermissionTest5->setWorkspacesObject([
+            (new User\Workspace\DataObject())->setValues(['cId' => $this->usertestobject->getId(), 'cPath' => $this->usertestobject->getFullpath(), 'list' => true, 'view' => true]),
+            (new User\Workspace\Asset())->setValues(['cId' => $this->assetElement->getId(), 'cPath' => $this->assetElement->getFullpath(), 'list' => true, 'view' => true]),
+        ]);
+        $this->userPermissionTest5->save();
+
+        //create user 5, with no roles, with no permissions set but workspaces configured --> should not find anything
+        $this->userPermissionTest6 = new User();
+        $this->userPermissionTest6->setName('Permissiontest6');
+        $this->userPermissionTest6->setPermissions([]);
+        $this->userPermissionTest6->setWorkspacesObject([
             (new User\Workspace\DataObject())->setValues(['cId' => $this->usertestobject->getId(), 'cPath' => $this->usertestobject->getFullpath(), 'list' => true, 'view' => true]),
             (new User\Workspace\Asset())->setValues(['cId' => $this->assetElement->getId(), 'cPath' => $this->assetElement->getFullpath(), 'list' => true, 'view' => true]),
         ]);
@@ -656,6 +666,12 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             [$this->bars->getFullpath()]
         );
 
+        $this->doTestTreeGetChildsById(
+            $this->permissionfoo,
+            $this->userPermissionTest6,
+            []
+        );
+
         // test /permissionfoo/bars
         $this->doTestTreeGetChildsById(
             $this->bars,
@@ -691,6 +707,12 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             $this->bars,
             $this->userPermissionTest5,
             [$this->userfolder->getFullpath()]
+        );
+
+        $this->doTestTreeGetChildsById(
+            $this->bars,
+            $this->userPermissionTest6,
+            []
         );
 
         // test /permissionfoo/bars/userfolder
@@ -730,6 +752,12 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             [$this->usertestobject->getFullpath()]
         );
 
+        $this->doTestTreeGetChildsById(
+            $this->userfolder,
+            $this->userPermissionTest6,
+            []
+        );
+
         // test /permissionfoo/bars/groupfolder
         $this->doTestTreeGetChildsById(
             $this->groupfolder,
@@ -764,6 +792,12 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestTreeGetChildsById(
             $this->groupfolder,
             $this->userPermissionTest5,
+            []
+        );
+
+        $this->doTestTreeGetChildsById(
+            $this->groupfolder,
+            $this->userPermissionTest6,
             []
         );
 
@@ -803,6 +837,12 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             $this->userPermissionTest5,
             []
         );
+
+        $this->doTestTreeGetChildsById(
+            $this->permissionbar,
+            $this->userPermissionTest6,
+            []
+        );
         // test /permissionbar/foo
         $this->doTestTreeGetChildsById(
             $this->foo,
@@ -837,6 +877,12 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestTreeGetChildsById(
             $this->foo,
             $this->userPermissionTest5,
+            []
+        );
+
+        $this->doTestTreeGetChildsById(
+            $this->foo,
+            $this->userPermissionTest6,
             []
         );
 
@@ -899,6 +945,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestSearch('hugo', $this->userPermissionTest3, []);
         $this->doTestSearch('hugo', $this->userPermissionTest4, []);
         $this->doTestSearch('hugo', $this->userPermissionTest5, []);
+        $this->doTestSearch('hugo', $this->userPermissionTest6, []);
 
         //search bars
         $this->doTestSearch('bars', $admin, [
@@ -935,6 +982,8 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             $this->usertestobject->getFullpath(),
         ]);
 
+        $this->doTestSearch('bars', $this->userPermissionTest6, []);
+
         //search hidden object
         $this->doTestSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
         $this->doTestSearch('hiddenobject', $this->userPermissionTest1, []);
@@ -942,6 +991,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestSearch('hiddenobject', $this->userPermissionTest3, []);
         $this->doTestSearch('hiddenobject', $this->userPermissionTest4, []);
         $this->doTestSearch('hiddenobject', $this->userPermissionTest5, []);
+        $this->doTestSearch('hiddenobject', $this->userPermissionTest6, []);
 
 
         //search for asset
@@ -951,6 +1001,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestSearch('assetelement', $this->userPermissionTest3, []);
         $this->doTestSearch('assetelement', $this->userPermissionTest4, []);
         $this->doTestSearch('assetelement', $this->userPermissionTest5, []);
+        $this->doTestSearch('assetelement', $this->userPermissionTest6, []);
     }
 
     public function testManyElementSearch()
@@ -1043,6 +1094,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestQuickSearch('hugo', $this->userPermissionTest3, []);
         $this->doTestQuickSearch('hugo', $this->userPermissionTest4, []);
         $this->doTestQuickSearch('hugo', $this->userPermissionTest5, []);
+        $this->doTestQuickSearch('hugo', $this->userPermissionTest6, []);
 
         //search bars
         $this->doTestQuickSearch('bars', $admin, [
@@ -1066,6 +1118,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestQuickSearch('bars', $this->userPermissionTest5, [
             $this->usertestobject->getFullpath(),
         ]);
+        $this->doTestQuickSearch('bars', $this->userPermissionTest6, []);
 
         //search hidden object
         $this->doTestQuickSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
@@ -1081,5 +1134,6 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestQuickSearch('assetelement', $this->userPermissionTest3, []);
         $this->doTestQuickSearch('assetelement', $this->userPermissionTest4, []);
         $this->doTestQuickSearch('assetelement', $this->userPermissionTest5, [$this->assetElement->getFullPath()]);
+        $this->doTestQuickSearch('assetelement', $this->userPermissionTest6, []);
     }
 }

--- a/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
@@ -278,6 +278,16 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->userPermissionTest4->setPermissions(['objects']);
         $this->userPermissionTest4->setRoles([$role->getId(), $role2->getId()]);
         $this->userPermissionTest4->save();
+
+        //create user 5, with no roles, assets and data objects allowed in parallel
+        $this->userPermissionTest5 = new User();
+        $this->userPermissionTest5->setName('Permissiontest5');
+        $this->userPermissionTest5->setPermissions(['objects', 'assets']);
+        $this->userPermissionTest5->setWorkspacesObject([
+            (new User\Workspace\DataObject())->setValues(['cId' => $this->usertestobject->getId(), 'cPath' => $this->usertestobject->getFullpath(), 'list' => true, 'view' => true]),
+            (new User\Workspace\Asset())->setValues(['cId' => $this->assetElement->getId(), 'cPath' => $this->assetElement->getFullpath(), 'list' => true, 'view' => true]),
+        ]);
+        $this->userPermissionTest5->save();
     }
 
     public function setUp(): void
@@ -299,6 +309,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         User::getByName('Permissiontest2')->delete();
         User::getByName('Permissiontest3')->delete();
         User::getByName('Permissiontest4')->delete();
+        User::getByName('Permissiontest5')->delete();
         User\Role::getByName('Testrole')->delete();
         User\Role::getByName('Dummyrole')->delete();
     }
@@ -639,6 +650,12 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             [$this->bars->getFullpath()]
         );
 
+        $this->doTestTreeGetChildsById(
+            $this->permissionfoo,
+            $this->userPermissionTest5,
+            [$this->bars->getFullpath()]
+        );
+
         // test /permissionfoo/bars
         $this->doTestTreeGetChildsById(
             $this->bars,
@@ -668,6 +685,12 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             $this->bars,
             $this->userPermissionTest4,
             [$this->groupfolder->getFullpath()]
+        );
+
+        $this->doTestTreeGetChildsById(
+            $this->bars,
+            $this->userPermissionTest5,
+            [$this->userfolder->getFullpath()]
         );
 
         // test /permissionfoo/bars/userfolder
@@ -701,6 +724,12 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             []
         );
 
+        $this->doTestTreeGetChildsById(
+            $this->userfolder,
+            $this->userPermissionTest5,
+            [$this->usertestobject->getFullpath()]
+        );
+
         // test /permissionfoo/bars/groupfolder
         $this->doTestTreeGetChildsById(
             $this->groupfolder,
@@ -730,6 +759,12 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             $this->groupfolder,
             $this->userPermissionTest4,
             [$this->grouptestobject->getFullpath()]
+        );
+
+        $this->doTestTreeGetChildsById(
+            $this->groupfolder,
+            $this->userPermissionTest5,
+            []
         );
 
         // test /permissionbar
@@ -762,6 +797,12 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             $this->userPermissionTest4,
             []
         );
+
+        $this->doTestTreeGetChildsById(
+            $this->permissionbar,
+            $this->userPermissionTest5,
+            []
+        );
         // test /permissionbar/foo
         $this->doTestTreeGetChildsById(
             $this->foo,
@@ -782,14 +823,20 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         );
 
         $this->doTestTreeGetChildsById(
-            $this->permissionbar,
+            $this->foo,
             $this->userPermissionTest3,
             []
         );
 
         $this->doTestTreeGetChildsById(
-            $this->permissionbar,
+            $this->foo,
             $this->userPermissionTest4,
+            []
+        );
+
+        $this->doTestTreeGetChildsById(
+            $this->foo,
+            $this->userPermissionTest5,
             []
         );
 
@@ -851,6 +898,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestSearch('hugo', $this->userPermissionTest2, []);
         $this->doTestSearch('hugo', $this->userPermissionTest3, []);
         $this->doTestSearch('hugo', $this->userPermissionTest4, []);
+        $this->doTestSearch('hugo', $this->userPermissionTest5, []);
 
         //search bars
         $this->doTestSearch('bars', $admin, [
@@ -883,12 +931,17 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             $this->grouptestobject->getFullpath(),
         ]);
 
+        $this->doTestSearch('bars', $this->userPermissionTest5, [
+            $this->usertestobject->getFullpath(),
+        ]);
+
         //search hidden object
         $this->doTestSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
         $this->doTestSearch('hiddenobject', $this->userPermissionTest1, []);
         $this->doTestSearch('hiddenobject', $this->userPermissionTest2, []);
         $this->doTestSearch('hiddenobject', $this->userPermissionTest3, []);
         $this->doTestSearch('hiddenobject', $this->userPermissionTest4, []);
+        $this->doTestSearch('hiddenobject', $this->userPermissionTest5, []);
 
 
         //search for asset
@@ -897,6 +950,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestSearch('assetelement', $this->userPermissionTest2, []);
         $this->doTestSearch('assetelement', $this->userPermissionTest3, []);
         $this->doTestSearch('assetelement', $this->userPermissionTest4, []);
+        $this->doTestSearch('assetelement', $this->userPermissionTest5, []);
     }
 
     public function testManyElementSearch()
@@ -988,6 +1042,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestQuickSearch('hugo', $this->userPermissionTest2, []);
         $this->doTestQuickSearch('hugo', $this->userPermissionTest3, []);
         $this->doTestQuickSearch('hugo', $this->userPermissionTest4, []);
+        $this->doTestQuickSearch('hugo', $this->userPermissionTest5, []);
 
         //search bars
         $this->doTestQuickSearch('bars', $admin, [
@@ -1008,6 +1063,9 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestQuickSearch('bars', $this->userPermissionTest4, [
             $this->grouptestobject->getFullpath(),
         ]);
+        $this->doTestQuickSearch('bars', $this->userPermissionTest5, [
+            $this->usertestobject->getFullpath(),
+        ]);
 
         //search hidden object
         $this->doTestQuickSearch('hiddenobject', $admin, [$this->hiddenobject->getFullpath()]);
@@ -1022,5 +1080,6 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->doTestQuickSearch('assetelement', $this->userPermissionTest2, []);
         $this->doTestQuickSearch('assetelement', $this->userPermissionTest3, []);
         $this->doTestQuickSearch('assetelement', $this->userPermissionTest4, []);
+        $this->doTestQuickSearch('assetelement', $this->userPermissionTest5, [$this->assetElement->getFullPath()]);
     }
 }

--- a/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
@@ -285,6 +285,8 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->userPermissionTest5->setPermissions(['assets', 'objects']);
         $this->userPermissionTest5->setWorkspacesObject([
             (new User\Workspace\DataObject())->setValues(['cId' => $this->usertestobject->getId(), 'cPath' => $this->usertestobject->getFullpath(), 'list' => true, 'view' => true]),
+        ]);
+        $this->userPermissionTest5->setWorkspacesAsset([
             (new User\Workspace\Asset())->setValues(['cId' => $this->assetElement->getId(), 'cPath' => $this->assetElement->getFullpath(), 'list' => true, 'view' => true]),
         ]);
         $this->userPermissionTest5->save();
@@ -295,8 +297,11 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
         $this->userPermissionTest6->setPermissions([]);
         $this->userPermissionTest6->setWorkspacesObject([
             (new User\Workspace\DataObject())->setValues(['cId' => $this->usertestobject->getId(), 'cPath' => $this->usertestobject->getFullpath(), 'list' => true, 'view' => true]),
+        ]);
+        $this->userPermissionTest6->setWorkspacesAsset([
             (new User\Workspace\Asset())->setValues(['cId' => $this->assetElement->getId(), 'cPath' => $this->assetElement->getFullpath(), 'list' => true, 'view' => true]),
         ]);
+
         $this->userPermissionTest6->save();
     }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/planning/issues/57

## Additional info  
Added 2 users, one(3) without roles and one(4) without user level permissions.

There were another place that similary to #11998 with implodes that would break the query, 

`forbiddenConditions` changed from `AND` to `OR`: the forbiddenConditions are one line per each element. It should be slighlty quicker, instead of checking every condition is met. 

removed `$forbiddenConditions[] = ' maintype != \'' . $type . '\' ';` when user master permission is not enabled.