### PR TITLE
Fix: AbstractUser::getById() doesn't check the type

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -248,7 +248,7 @@ class Asset extends Element\AbstractElement
         $path = Element\Service::correctPath($path);
 
         try {
-            $asset = new Asset();
+            $asset = new static();
             $asset->getDao()->getByPath($path);
 
             return static::getById($asset->getId(), $force);
@@ -299,16 +299,19 @@ class Asset extends Element\AbstractElement
         }
 
         if ($force || !($asset = \Pimcore\Cache::load($cacheKey))) {
-            $asset = new Asset();
+            $asset = new static();
 
             try {
                 $asset->getDao()->getById($id);
                 $className = 'Pimcore\\Model\\Asset\\' . ucfirst($asset->getType());
 
-                /** @var Asset $asset */
-                $asset = self::getModelFactory()->build($className);
+                if (get_class($asset) !== $className) {
+                    /** @var Asset $asset */
+                    $asset = self::getModelFactory()->build($className);
+                    $asset->getDao()->getById($id);
+                }
+
                 \Pimcore\Cache\Runtime::set($cacheKey, $asset);
-                $asset->getDao()->getById($id);
                 $asset->__setDataVersionTimestamp($asset->getModificationDate());
 
                 $asset->resetDirtyMap();

--- a/models/Document.php
+++ b/models/Document.php
@@ -244,7 +244,7 @@ class Document extends Element\AbstractElement
         }
 
         try {
-            $helperDoc = new Document();
+            $helperDoc = new static();
             $helperDoc->getDao()->getByPath($path);
             $doc = static::getById($helperDoc->getId(), $force);
             \Pimcore\Cache\Runtime::set($cacheKey, $doc);
@@ -297,7 +297,7 @@ class Document extends Element\AbstractElement
         }
 
         if ($force || !($document = \Pimcore\Cache::load($cacheKey))) {
-            $document = new Document();
+            $document = new static();
 
             try {
                 $document->getDao()->getById($id);
@@ -316,11 +316,13 @@ class Document extends Element\AbstractElement
                 }
             }
 
-            /** @var Document $document */
-            $document = self::getModelFactory()->build($className);
-            \Pimcore\Cache\Runtime::set($cacheKey, $document);
+            if (get_class($document) !== $className) {
+                /** @var Document $document */
+                $document = self::getModelFactory()->build($className);
+                $document->getDao()->getById($id);
+            }
 
-            $document->getDao()->getById($id);
+            \Pimcore\Cache\Runtime::set($cacheKey, $document);
             $document->__setDataVersionTimestamp($document->getModificationDate());
 
             $document->resetDirtyMap();

--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -66,6 +66,7 @@ class AbstractUser extends Model\AbstractModel
                 $className = Service::getClassNameForType($user->getType());
 
                 if (get_class($user) !== $className) {
+                    /** @var AbstractUser $user */
                     $user = $className::getById($user->getId());
                 }
 

--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -63,19 +63,23 @@ class AbstractUser extends Model\AbstractModel
             } else {
                 $user = new static();
                 $user->getDao()->getById($id);
+                $className = Service::getClassNameForType($user->getType());
 
-                if (get_class($user) == 'Pimcore\\Model\\User\\AbstractUser') {
-                    $className = Service::getClassNameForType($user->getType());
+                if (get_class($user) !== $className) {
                     $user = $className::getById($user->getId());
                 }
 
                 \Pimcore\Cache\Runtime::set($cacheKey, $user);
             }
-
-            return $user;
         } catch (Model\Exception\NotFoundException $e) {
             return null;
         }
+
+        if (!$user || !static::typeMatch($user)) {
+            return null;
+        }
+
+        return $user;
     }
 
     /**
@@ -297,5 +301,22 @@ class AbstractUser extends Model\AbstractModel
     protected function update()
     {
         $this->getDao()->update();
+    }
+
+    /**
+     * @internal
+     *
+     * @param AbstractUser $user
+     *
+     * @return bool
+     */
+    protected static function typeMatch(AbstractUser $user): bool
+    {
+        $staticType = static::class;
+        if ($staticType !== AbstractUser::class && !$user instanceof $staticType) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/models/User/Service.php
+++ b/models/User/Service.php
@@ -15,6 +15,8 @@
 
 namespace Pimcore\Model\User;
 
+use Pimcore\Model\User;
+
 /**
  * @internal
  */
@@ -29,13 +31,17 @@ class Service
      *
      * @return string|null
      */
-    public static function getClassNameForType($type)
+    public static function getClassNameForType($type): ?string
     {
         switch ($type) {
-            case 'user': return '\\Pimcore\\Model\\User';
-            case 'userfolder': return '\\Pimcore\\Model\\User\\Folder';
-            case 'role': return '\\Pimcore\\Model\\User\\Role';
-            case 'rolefolder': return '\\Pimcore\\Model\\User\\Role\\Folder';
+            case 'user':
+                return User::class;
+            case 'userfolder':
+                return User\Folder::class;
+            case 'role':
+                return User\Role::class;
+            case 'rolefolder':
+                return User\Role\Folder::class;
             default:
                 return null;
         }

--- a/models/User/Service.php
+++ b/models/User/Service.php
@@ -33,17 +33,12 @@ class Service
      */
     public static function getClassNameForType($type): ?string
     {
-        switch ($type) {
-            case 'user':
-                return User::class;
-            case 'userfolder':
-                return User\Folder::class;
-            case 'role':
-                return User\Role::class;
-            case 'rolefolder':
-                return User\Role\Folder::class;
-            default:
-                return null;
-        }
+        return match ($type) {
+            'user' => User::class,
+            'userfolder' => User\Folder::class,
+            'role' => User\Role::class,
+            'rolefolder' => User\Role\Folder::class,
+            default => null,
+        };
     }
 }


### PR DESCRIPTION
Fix https://github.com/pimcore/pimcore/issues/12024

The getById method of AbstractUser doesn't check the type.
It only load the correct type if it is loaded over AbstractUser class.

I changed this and optimize the Asset/Document Model in the same behavior (There it is loaded always over the Main Class and loaded again with the type). 

DataObjects load first only the typeInfo and than by the correct Type the data. There is no optimization possible.