### PR TITLE
[DataObject] Grid column config pre send data event

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -188,11 +188,12 @@ class DataObjectHelperController extends AdminController
      * @Route("/grid-delete-column-config", name="griddeletecolumnconfig", methods={"DELETE"})
      *
      * @param Request $request
+     * @param EventDispatcherInterface $eventDispatcher
      * @param Config $config
      *
      * @return JsonResponse
      */
-    public function gridDeleteColumnConfigAction(Request $request, Config $config)
+    public function gridDeleteColumnConfigAction(Request $request, EventDispatcherInterface $eventDispatcher, Config $config)
     {
         $gridConfigId = $request->get('gridConfigId');
         $gridConfig = GridConfig::getById($gridConfigId);
@@ -209,6 +210,16 @@ class DataObjectHelperController extends AdminController
         $newGridConfig = $this->doGetGridColumnConfig($request, $config, true);
         $newGridConfig['deleteSuccess'] = $success;
 
+        $event = new GenericEvent($this, [
+            'data' => $newGridConfig,
+            'request' => $request,
+            'config' => $config,
+            'context' => 'delete',
+        ]);
+
+        $eventDispatcher->dispatch($event, AdminEvents::OBJECT_GRID_GET_COLUMN_CONFIG_PRE_SEND_DATA);
+        $newGridConfig = $event->getArgument('data');
+
         return $this->adminJson($newGridConfig);
     }
 
@@ -216,13 +227,24 @@ class DataObjectHelperController extends AdminController
      * @Route("/grid-get-column-config", name="gridgetcolumnconfig", methods={"GET"})
      *
      * @param Request $request
+     * @param EventDispatcherInterface $eventDispatcher
      * @param Config $config
      *
      * @return JsonResponse
      */
-    public function gridGetColumnConfigAction(Request $request, Config $config)
+    public function gridGetColumnConfigAction(Request $request, EventDispatcherInterface $eventDispatcher, Config $config)
     {
         $result = $this->doGetGridColumnConfig($request, $config);
+
+        $event = new GenericEvent($this, [
+            'data' => $result,
+            'request' => $request,
+            'config' => $config,
+            'context' => 'get',
+        ]);
+
+        $eventDispatcher->dispatch($event, AdminEvents::OBJECT_GRID_GET_COLUMN_CONFIG_PRE_SEND_DATA);
+        $result = $event->getArgument('data');
 
         return $this->adminJson($result);
     }

--- a/lib/Event/AdminEvents.php
+++ b/lib/Event/AdminEvents.php
@@ -386,6 +386,20 @@ final class AdminEvents
     const OBJECT_GET_PRE_SEND_DATA = 'pimcore.admin.dataobject.get.preSendData';
 
     /**
+     * Subject: \Pimcore\Bundle\AdminBundle\Controller\Admin\DataObject\DataObjectHelperController
+     * Arguments:
+     *  - data | array | the response data which this can be modified
+     *  - request | Request | the Request object passed to the action
+     *  - config | Config | the Config object passed to the action
+     *  - context | string | 'get' or 'delete'
+     *
+     * @Event("Symfony\Component\EventDispatcher\GenericEvent")
+     *
+     * @var string
+     */
+    const OBJECT_GRID_GET_COLUMN_CONFIG_PRE_SEND_DATA = 'pimcore.admin.dataobject.gridGetColumnConfig.preSendData';
+
+    /**
      * Subject: \Pimcore\Bundle\AdminBundle\Controller\Admin\DataObjectController
      * Arguments:
      *  - objects | array | the list of object tree nodes


### PR DESCRIPTION
Allow modifying the grid column configuration before it is sent by dispatching
an admin event similar to the object pre send data event.