### PR TITLE
[Bug]: Fix Objectbrick unique field overwriting 

### DIFF
--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -156,6 +156,7 @@ class Dao extends Model\Dao\AbstractDao
             }
         }
 
+        /** @var bool $isBrickUpdate */
         if ($isBrickUpdate) {
             $this->db->update($storetable, $data, ['o_id'=> $object->getId()]);
         }else{

--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -156,7 +156,11 @@ class Dao extends Model\Dao\AbstractDao
             }
         }
 
-        $this->db->insertOrUpdate($storetable, $data);
+        if ($isBrickUpdate) {
+            $this->db->update($storetable, $data, ['o_id'=> $object->getId()]);
+        }else{
+            $this->db->insert($storetable, $data);
+        }
 
         // get data for query table
         // $tableName = $this->model->getDefinition()->getTableName($object->getClass(), true);

--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -95,17 +95,17 @@ class Dao extends Model\Dao\AbstractDao
             Logger::warning('Error during removing old relations: ' . $e);
         }
 
+        if ($this->model->getObject()->getClass()->getAllowInherit() && isset($params['isUpdate']) && $params['isUpdate'] === false) {
+            // if this is a fresh object, then we don't need the check
+            $isBrickUpdate = false; // used to indicate whether we want to consider the default value
+        } else {
+            // or brick has been added
+            $existsResult = $this->db->fetchOne('SELECT o_id FROM ' . $storetable . ' WHERE o_id = ? LIMIT 1', $object->getId());
+            $isBrickUpdate = $existsResult ? true : false;  // used to indicate whether we want to consider the default value
+        }
+        
         foreach ($fieldDefinitions as $fieldName => $fd) {
             $getter = 'get' . ucfirst($fd->getName());
-
-            if ($this->model->getObject()->getClass()->getAllowInherit() && isset($params['isUpdate']) && $params['isUpdate'] === false) {
-                // if this is a fresh object, then we don't need the check
-                $isBrickUpdate = false; // used to indicate whether we want to consider the default value
-            } else {
-                // or brick has been added
-                $existsResult = $this->db->fetchOne('SELECT o_id FROM ' . $storetable . ' WHERE o_id = ? LIMIT 1', $object->getId());
-                $isBrickUpdate = $existsResult ? true : false;  // used to indicate whether we want to consider the default value
-            }
 
             if ($fd instanceof CustomResourcePersistingInterface) {
                 if ((!isset($params['newParent']) || !$params['newParent']) && isset($params['isUpdate']) && $params['isUpdate'] && !DataObject::isDirtyDetectionDisabled() && $this->model instanceof Model\Element\DirtyIndicatorInterface) {
@@ -156,7 +156,6 @@ class Dao extends Model\Dao\AbstractDao
             }
         }
 
-        /** @var bool $isBrickUpdate */
         if ($isBrickUpdate) {
             $this->db->update($storetable, $data, ['o_id'=> $object->getId()]);
         }else{


### PR DESCRIPTION
## Changes in this pull request  
fixes #11993

## Additional info  
`insertOrUpdate` is causing problems because when a new object is saved and there's an unique index, due the nature of `ON DUPLICATE KEY UPDATE` and since the newly created `o_id` is not present in the table `object_brick_store_x_y`, it will change the existing `o_id`, causing the object brick to get assigned to the newly created object.
There was a `isBrickUpdate` check (with a limit 1 sql query) called a for each field definition, moved out the loop as it is needed to be just checked once beforehand.