### PR TITLE
Exception "TranslationInterface service has been removed . . ." on multisite environment

### DIFF
--- a/bundles/AdminBundle/Controller/Traits/AdminStyleTrait.php
+++ b/bundles/AdminBundle/Controller/Traits/AdminStyleTrait.php
@@ -19,12 +19,28 @@ use Pimcore\Event\Admin\ElementAdminStyleEvent;
 use Pimcore\Event\AdminEvents;
 use Pimcore\Model\Element\AdminStyle;
 use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Translation\Translator;
 
 /**
  * @internal
  */
 trait AdminStyleTrait
 {
+
+    /**
+     * @var Translator
+     */
+    protected $translator;
+
+    /**
+     * 
+     * @param Translator $translator
+     */
+    public function __construct(Translator $translator) 
+    {
+        $this->translator = $translator;
+    }
+
     /**
      * @param ElementInterface $element
      * @param null|int $context
@@ -34,7 +50,7 @@ trait AdminStyleTrait
      */
     protected function addAdminStyle(ElementInterface $element, $context = null, &$data = [])
     {
-        $event = new ElementAdminStyleEvent($element, new AdminStyle($element), $context);
+        $event = new ElementAdminStyleEvent($element, new AdminStyle($element, $this->translator), $context);
         \Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::RESOLVE_ELEMENT_ADMIN_STYLE);
         $adminStyle = $event->getAdminStyle();
 

--- a/models/Element/AdminStyle.php
+++ b/models/Element/AdminStyle.php
@@ -22,7 +22,7 @@ use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Folder;
 use Pimcore\Model\Document;
 use Pimcore\Model\Site;
-use Symfony\Contracts\Translation\TranslatorInterface;
+use Pimcore\Translation\Translator;
 
 class AdminStyle
 {
@@ -49,7 +49,7 @@ class AdminStyle
     /**
      * @param AbstractObject|Asset|Document|ElementInterface $element
      */
-    public function __construct(ElementInterface $element)
+    public function __construct(ElementInterface $element, Translator $translator)
     {
         if ($element instanceof AbstractObject) {
             if ($element instanceof Folder) {
@@ -97,7 +97,6 @@ class AdminStyle
                 $site = Site::getByRootId($element->getId());
 
                 if ($site instanceof Site) {
-                    $translator = \Pimcore::getContainer()->get(TranslatorInterface::class);
                     $this->elementQtipConfig['text'] .= '<br>' . $translator->trans('site_id', [], 'admin') . ': ' . $site->getId();
                 }
 


### PR DESCRIPTION
After updating from 6.9.6 to 10.4.0 and Symfony Flex, Eception `The "Symfony\Contracts\Translation\TranslationInterface" service has been removed or inlined when the container was compiled.` was thrown:

<img width="706" alt="Screen Shot 2022-05-05 at 19 46 41" src="https://user-images.githubusercontent.com/23724310/167076987-79717f0d-3735-417f-9e46-b802d79d6adc.png">

This topic was also discussed in #10952. Hopefully this is the final solution.