### PR TITLE
fix: update asset cache on miss

### DIFF
--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -184,6 +184,10 @@ class Processor
         $statusCacheEnabled = \Pimcore::getContainer()->getParameter('pimcore.config')['assets']['image']['thumbnails']['status_cache'];
         if ($statusCacheEnabled && $deferred) {
             $modificationDate = $asset->getDao()->getCachedThumbnailModificationDate($config->getName(), $filename);
+            if ($modificationDate === null && $storage->fileExists($storagePath)) {
+                $modificationDate = $storage->lastModified($storagePath);
+                $modificationDate = $asset->getDao()->addToThumbnailCache($config->getName(), $filename);
+            }
         } else {
             if ($storage->fileExists($storagePath)) {
                 $modificationDate = $storage->lastModified($storagePath);

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -186,7 +186,7 @@ class Processor
             $modificationDate = $asset->getDao()->getCachedThumbnailModificationDate($config->getName(), $filename);
             if ($modificationDate === null && $storage->fileExists($storagePath)) {
                 $modificationDate = $storage->lastModified($storagePath);
-                $modificationDate = $asset->getDao()->addToThumbnailCache($config->getName(), $filename);
+                $asset->getDao()->addToThumbnailCache($config->getName(), $filename);
             }
         } else {
             if ($storage->fileExists($storagePath)) {


### PR DESCRIPTION
## Changes in this pull request  
Resolves #12055.

## Additional info  

This is actually quite convoluted:
1. deferred=true + cache miss will create a deferred URL
2. deferred URL (deferred = false implicit) will skip updating the asset cache
3. if your asset cache is empty, but your thumbnail modification time on storage is newer than the asset, the cache never gets updated and it *always* generates the deferred URL, even though the file exists on storage

