### PR TITLE
Bugfix: Update User does not work anymore

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -284,7 +284,7 @@ class UserController extends AdminController implements KernelControllerEventInt
      */
     public function updateAction(Request $request)
     {
-        $user = User\UserRole::getById((int)$request->get('id'));
+        $user = User::getById((int)$request->get('id'));
 
         if (!$user) {
             throw $this->createNotFoundException();


### PR DESCRIPTION
## Changes in this pull request  
The update action needs load a User object and not a UserRole object. Otherwise changes are not saved.


## Additional info  

