### PR TITLE
Fix/dynamic multiselect options not loaded in grid

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
@@ -102,11 +102,18 @@ pimcore.object.helpers.grid = Class.create({
                     }
                 }
 
-                if (pimcore.object.tags[type] && pimcore.object.tags[type].prototype.allowBatchAppend) {
-                    batchAppendColumns.push(key);
-                }
-                if (pimcore.object.tags[type] && pimcore.object.tags[type].prototype.allowBatchRemove) {
-                    batchRemoveColumns.push(key);
+                // Don't add batch options if field has dynamic options
+                if (
+                    !fieldConfig.hasOwnProperty('layout')
+                    || !fieldConfig.layout.hasOwnProperty('dynamicOptions')
+                    || fieldConfig.layout.dynamicOptions !== true
+                ) {
+                    if (pimcore.object.tags[type] && pimcore.object.tags[type].prototype.allowBatchAppend) {
+                        batchAppendColumns.push(key);
+                    }
+                    if (pimcore.object.tags[type] && pimcore.object.tags[type].prototype.allowBatchRemove) {
+                        batchRemoveColumns.push(key);
+                    }
                 }
 
                 readerFields.push(readerFieldConfig);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #12038

## Additional info  

When using an options provider to generate options depending on a value from the data object the options were not loaded in the grid, because the data object is not available when retrieving the general grid configuration. It does work for the regular select, because it has a separate grid data implementation for the grid-proxy setup. Fixed by adding the same implementation for the multiselect field and updating the JavaScript file accordingly.