### PR TITLE
Added latestVersion to forbiddenNames

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/data.js
@@ -21,7 +21,7 @@ pimcore.object.classes.data.data = Class.create({
         "userpermissions", "dependencies", "modificationdate", "usermodification", "byid", "bypath", "data",
         "versions", "properties", "permissions", "permissionsforuser", "childamount", "apipluginbroker", "resource",
         "parentClass", "definition", "locked", "language", "omitmandatorycheck", "idpath", "object", "fieldname",
-        "property", "localizedfields", "parentid", "children", "scheduledtasks"
+        "property", "localizedfields", "parentid", "children", "scheduledtasks", "latestVersion"
     ],
 
     /**


### PR DESCRIPTION
This commit adds "latestVersion" as forbiddenName to object fields. If the field is called "latestVersion"  opening existing or creating new object would stop working in the admin and exception will be thrown in bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php inside function getLatestVersion on line 2319

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.4`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

