### PR TITLE
Custom layout for object bricks

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
@@ -1345,11 +1345,7 @@ class ClassController extends AdminController implements KernelControllerEventIn
                     ];
             } else {
                 if ($forObjectEditor) {
-                    $itemLayoutDefinitions = null;
-
-                    if ($itemLayoutDefinitions === null) {
-                        $layout = $item->getLayoutDefinitions();
-                    }
+                    $layout = $item->getLayoutDefinitions();
 
                     $currentLayoutId = $request->get('layoutId', null);
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
@@ -586,7 +586,7 @@ class ClassController extends AdminController implements KernelControllerEventIn
         $classIds = explode(',', $request->get('classId'));
         $list = new DataObject\ClassDefinition\CustomLayout\Listing();
 
-        $list->setCondition('classId IN (' . rtrim(str_repeat('?,', count($classIds)), ',').') AND id not LIKE \'%.%\'', $classIds);
+        $list->setCondition('classId IN (' . rtrim(str_repeat('?,', count($classIds)), ',').') AND id not LIKE \'%.brick.%\'', $classIds);
         $list = $list->load();
         $result = [];
         foreach ($list as $item) {

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
@@ -1320,7 +1320,7 @@ class ClassController extends AdminController implements KernelControllerEventIn
                     $layoutId = $request->get('layoutId');
                     $itemLayoutDefinitions = null;
                     if($layoutId) {
-                        $layout = DataObject\ClassDefinition\CustomLayout::getByName($layoutId.'.brick.'.$item->getKey());
+                        $layout = DataObject\ClassDefinition\CustomLayout::getById($layoutId.'.brick.'.$item->getKey());
                         if ($layout instanceof DataObject\ClassDefinition\CustomLayout) {
                             $itemLayoutDefinitions = $layout->getLayoutDefinitions();
                         }

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
@@ -1320,7 +1320,7 @@ class ClassController extends AdminController implements KernelControllerEventIn
                     $layoutId = $request->get('layoutId');
                     $itemLayoutDefinitions = null;
                     if($layoutId) {
-                        $layout = DataObject\ClassDefinition\CustomLayout::getByName($layoutId.'.'.$item->getKey());
+                        $layout = DataObject\ClassDefinition\CustomLayout::getByName($layoutId.'.brick.'.$item->getKey());
                         if ($layout instanceof DataObject\ClassDefinition\CustomLayout) {
                             $itemLayoutDefinitions = $layout->getLayoutDefinitions();
                         }
@@ -1345,7 +1345,6 @@ class ClassController extends AdminController implements KernelControllerEventIn
                     ];
             } else {
                 if ($forObjectEditor) {
-                    $layoutId = $request->get('layoutId');
                     $itemLayoutDefinitions = null;
 
                     if ($itemLayoutDefinitions === null) {
@@ -1358,7 +1357,7 @@ class ClassController extends AdminController implements KernelControllerEventIn
                     if ($currentLayoutId == -1 && $user->isAdmin()) {
                         DataObject\Service::createSuperLayout($layout);
                     } elseif ($currentLayoutId) {
-                        $customLayout = DataObject\ClassDefinition\CustomLayout::getById($layoutId.'.brick.'.$item->getKey());
+                        $customLayout = DataObject\ClassDefinition\CustomLayout::getById($currentLayoutId.'.brick.'.$item->getKey());
                         if ($customLayout instanceof DataObject\ClassDefinition\CustomLayout) {
                             $layout = $customLayout->getLayoutDefinitions();
                         }

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
@@ -614,6 +614,7 @@ class ClassController extends AdminController implements KernelControllerEventIn
         $mapping = [];
 
         $customLayouts = new DataObject\ClassDefinition\CustomLayout\Listing();
+        $customLayouts->setCondition('id not LIKE \'%.brick.%\'');
         $customLayouts->setOrder('ASC');
         $customLayouts->setOrderKey('name');
         $customLayouts = $customLayouts->load();

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
@@ -82,7 +82,7 @@ pimcore.object.classes.klass = Class.create({
         panelButtons.push({
             text: t("configure_custom_layouts"),
             iconCls: "pimcore_icon_class pimcore_icon_overlay_add",
-            hidden: (this instanceof pimcore.object.fieldcollections.field) || (this instanceof pimcore.object.objectbricks.field),
+            hidden: this instanceof pimcore.object.fieldcollections.field,
             handler: this.configureCustomLayouts.bind(this)
         });
 
@@ -150,7 +150,7 @@ pimcore.object.classes.klass = Class.create({
 
     configureCustomLayouts: function() {
         try {
-            var dialog = new pimcore.object.helpers.customLayoutEditor(this.data);
+            new pimcore.object.helpers.customLayoutEditor(this.data);
         } catch (e) {
             console.log(e);
         }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/objectbricks.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/objectbricks.js
@@ -74,17 +74,17 @@ pimcore.object.classes.data.objectbricks = Class.create(pimcore.object.classes.d
                 fieldLabel: t("allowed_bricks"),
                 name: "allowedTypes",
                 value: this.datax.allowedTypes,
-                displayField: "text",
-                valueField: "text",
+                displayField: "title",
+                valueField: "key",
                 store: Ext.create('Ext.data.JsonStore', {
                     fields: ['text'],
                     proxy: {
                         type: 'ajax',
-                        url: Routing.generate('pimcore_admin_dataobject_class_objectbricktree'),
+                        url: Routing.generate('pimcore_admin_dataobject_class_objectbricklist'),
                         reader: {
-                            type: 'json'
+                            type: 'json',
+                            rootProperty: 'objectbricks'
                         }
-
                     },
                     autoLoad: true
                 }),

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/objectbricks.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/objectbricks.js
@@ -68,12 +68,34 @@ pimcore.object.classes.data.objectbricks = Class.create(pimcore.object.classes.d
                 checked: this.datax.border,
             }
         ]);
+
+        if(this.inCustomLayoutEditor) {
+            this.specificPanel.add(new Ext.ux.form.MultiSelect({
+                fieldLabel: t("allowed_bricks"),
+                name: "allowedTypes",
+                value: this.datax.allowedTypes,
+                displayField: "text",
+                valueField: "text",
+                store: Ext.create('Ext.data.JsonStore', {
+                    fields: ['text'],
+                    proxy: {
+                        type: 'ajax',
+                        url: Routing.generate('pimcore_admin_dataobject_class_objectbricktree'),
+                        reader: {
+                            type: 'json'
+                        }
+
+                    },
+                    autoLoad: true
+                }),
+                width: 600
+            }));
+        }
         
         return this.layout;
     },
 
     isValid: function ($super) {
-
         if(!$super()) {
             return false;
         }
@@ -97,7 +119,8 @@ pimcore.object.classes.data.objectbricks = Class.create(pimcore.object.classes.d
             Ext.apply(this.datax,
                 {
                     maxItems: source.datax.maxItems,
-                    border: source.datax.border
+                    border: source.datax.border,
+                    allowedTypes: source.datax.allowedTypes
                 });
         }
     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
@@ -218,7 +218,7 @@ pimcore.object.helpers.customLayoutEditor = Class.create({
                         if (data.data) {
                             Ext.each(data.data, function (data) {
                                 if(typeof this.klass.key !== 'undefined') {
-                                    data.id = data.id+'.'+this.klass.key;
+                                    data.id = data.id+'.brick.'+this.klass.key;
                                 }
                             }.bind(this));
                         }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
@@ -521,6 +521,7 @@ pimcore.object.helpers.customLayoutEditor = Class.create({
             title: t('class'),
             region: "west",
             autoScroll: true,
+            rootVisible: false,
             split: true,
             disabled: true,
             root: {
@@ -597,7 +598,6 @@ pimcore.object.helpers.customLayoutEditor = Class.create({
                     baseNode.appendChild(this.recursiveAddNode(child, baseNode, attributePrefix, isCustom));
                 }
                 rootNode.expand();
-                baseNode.expand();
             }
         }
     },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
@@ -228,7 +228,6 @@ pimcore.object.helpers.customLayoutEditor = Class.create({
                 }
             },
             fields: ['id', 'name'],
-            autoLoad: true,
             forceSelection:true,
             listeners: {
                 load: function() {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
@@ -200,8 +200,8 @@ pimcore.object.helpers.customLayoutEditor = Class.create({
         if(typeof this.klass.id !== 'undefined') {
             classId = [this.klass.id];
         } else if(typeof this.klass.classDefinitions !== 'undefined') {
-            for(var i=0;i< this.klass.classDefinitions.length;i++) {
-                classId.push(this.klass.classDefinitions[i].classname);
+            for(var i in this.klass.availableClasses) {
+                classId.push(this.klass.availableClasses[i].id);
             }
         }
         this.layoutComboStore = new Ext.data.Store({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbricks/field.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbricks/field.js
@@ -189,6 +189,8 @@ pimcore.object.objectbricks.field = Class.create(pimcore.object.classes.klass, {
                 this.availableClasses[rec.get("text")] = data;
                 this.baseStore[rec.get("text")] = data;
             }
+
+            this.data.availableClasses = this.availableClasses;
         }.bind(this));
     },
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
@@ -87,7 +87,10 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
         for (var i = 0; i < this.data.length; i++) {
             if (this.data[i] != null) {
                 this.preventDelete[this.data[i].type] = this.data[i].inherited;
-                this.addBlockElement(i, this.data[i].type, this.data[i], true, this.data[i].title, false);
+
+                if (this.fieldConfig.allowedTypes.length === 0 || this.fieldConfig.allowedTypes.indexOf(this.data[i].type) > -1) {
+                    this.addBlockElement(i, this.data[i].type, this.data[i], true, this.data[i].title, false);
+                }
             }
         }
 
@@ -104,6 +107,10 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
 
                 var elementData = data[i];
                 if (this.addedTypes[elementData.key]) {
+                    continue;
+                }
+
+                if(this.fieldConfig.allowedTypes.length > 0 && this.fieldConfig.allowedTypes.indexOf(elementData.key) === -1) {
                     continue;
                 }
 

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1021,7 +1021,7 @@ class Service extends Model\Element\Service
         $classId = $object->getClassId();
         $list = new ClassDefinition\CustomLayout\Listing();
         $list->setOrderKey('name');
-        $condition = 'classId = ' . $list->quote($classId);
+        $condition = 'classId = ' . $list->quote($classId).' AND id NOT LIKE \'%.brick.%\'';
         if (is_array($layoutPermissions) && count($layoutPermissions)) {
             $layoutIds = array_values($layoutPermissions);
             $condition .= ' AND id IN (' . implode(',', array_map([$list, 'quote'], $layoutIds)) . ')';


### PR DESCRIPTION
This PR implements custom layouts for object bricks.

There are 2 features:
1. In class custom layout for an object brick container you can define which bricks should be addable / visible in this custom layout
2. For a certain object brick define the fields which shall be visible (in a specific custom layout)

As it is only possible to select one custom layout to be used for loading a certain object, it would not make sense to be able to create custom layouts on object brick level. Thus on the object bricks only *existing* custom layouts from the corresponding classes are shown. This way you can *extend* an existing class custom layout. 

As a minor change this PR removes the tree root for class definition tree in custom layout panel (the left tree) to save space - tree root does not make sense here imho (in contrast on custom layout tree where it does make sense as a drop target)

Partly resolves #10924

If this PR is ok, we can do the same for field collections.