### PR TITLE
[Improvement] Core: Support key and index in backend search

### DIFF
--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -245,6 +245,13 @@ class SearchController extends AdminController
 
         $sortingSettings = \Pimcore\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($allParams);
         if ($sortingSettings['orderKey']) {
+            // Order by key column instead of filename
+            $orderKeyQuote = true;
+            if ($sortingSettings['orderKey'] === 'filename') {
+                $sortingSettings['orderKey'] = 'CAST(`key` AS CHAR CHARACTER SET utf8) COLLATE utf8_general_ci';
+                $orderKeyQuote = false;
+            }
+
             // we need a special mapping for classname as this is stored in subtype column
             $sortMapping = [
                 'classname' => 'subtype',
@@ -254,7 +261,7 @@ class SearchController extends AdminController
             if (array_key_exists($sortingSettings['orderKey'], $sortMapping)) {
                 $sort = $sortMapping[$sortingSettings['orderKey']];
             }
-            $searcherList->setOrderKey($sort);
+            $searcherList->setOrderKey($sort, $orderKeyQuote);
         }
         if ($sortingSettings['order']) {
             $searcherList->setOrder($sortingSettings['order']);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/asset.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/asset.js
@@ -151,7 +151,7 @@ pimcore.element.selector.asset = Class.create(pimcore.element.selector.abstract,
                                 + '" name="' + t(record.data.subtype) + '">&nbsp;</div>';
                         }
                     },
-                    {text: t("filename"), flex: 1, sortable: false, dataIndex: 'filename'}
+                    {text: t("filename"), flex: 1, sortable: true, dataIndex: 'filename'}
                 ],
                 viewConfig: {
                     forceFit: true
@@ -212,7 +212,7 @@ pimcore.element.selector.asset = Class.create(pimcore.element.selector.abstract,
                 },
                 {text: 'ID', width: 40, sortable: true, dataIndex: 'id', hidden: true},
                 {text: t("path"), flex: 200, sortable: true, dataIndex: 'fullpath', renderer: Ext.util.Format.htmlEncode},
-                {text: t("filename"), width: 200, sortable: false, dataIndex: 'filename', hidden: true, renderer: Ext.util.Format.htmlEncode},
+                {text: t("filename"), width: 200, sortable: true, dataIndex: 'filename', hidden: true, renderer: Ext.util.Format.htmlEncode},
                 {text: t("preview"), width: 150, sortable: false, dataIndex: 'subtype',
                     renderer: function (value, metaData, record, rowIndex, colIndex, store) {
                         var routes = {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/document.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/document.js
@@ -152,7 +152,7 @@ pimcore.element.selector.document = Class.create(pimcore.element.selector.abstra
                             return '<div class="pimcore_icon_' + value + '" name="' + t(record.data.subtype) + '">&nbsp;</div>';
                         }
                     },
-                    {text: t("filename"), flex: 1, sortable: false, dataIndex: 'filename'}
+                    {text: t("filename"), flex: 1, sortable: true, dataIndex: 'filename'}
                 ],
                 viewConfig: {
                     forceFit: true
@@ -201,7 +201,7 @@ pimcore.element.selector.document = Class.create(pimcore.element.selector.abstra
                 {text: t("path"), flex: 200, sortable: true, dataIndex: 'fullpath'},
                 {text: t("title"), flex: 200, sortable: false, dataIndex: 'title', hidden: false},
                 {text: t("description"), width: 200, sortable: false, dataIndex: 'description', hidden: true},
-                {text: t("filename"), width: 200, sortable: false, dataIndex: 'filename', hidden: true}
+                {text: t("filename"), width: 200, sortable: true, dataIndex: 'filename', hidden: true}
             ];
 
             this.pagingtoolbar = this.getPagingToolbar();

--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/object.js
@@ -236,7 +236,7 @@ pimcore.element.selector.object = Class.create(pimcore.element.selector.abstract
                 store: this.selectionStore,
                 columns: [
                     {text: t("type"), width: 40, sortable: true, dataIndex: 'subtype'},
-                    {text: t("filename"), flex: 1, sortable: false, dataIndex: 'filename'}
+                    {text: t("key"), flex: 1, sortable: true, dataIndex: 'filename'}
                 ],
                 viewConfig: {
                     forceFit: true
@@ -388,7 +388,7 @@ pimcore.element.selector.object = Class.create(pimcore.element.selector.abstract
             {text: 'ID', width: 40, sortable: true, dataIndex: 'id', hidden: true},
             {text: t("published"), width: 40, sortable: true, dataIndex: 'published', hidden: true},
             {text: t("path"), flex: 200, sortable: true, dataIndex: 'fullpath', renderer: Ext.util.Format.htmlEncode},
-            {text: t("filename"), width: 200, sortable: false, dataIndex: 'filename', hidden: true, renderer: Ext.util.Format.htmlEncode},
+            {text: t("key"), width: 200, sortable: true, dataIndex: 'filename', hidden: true, renderer: Ext.util.Format.htmlEncode},
             {text: t("class"), width: 200, sortable: true, dataIndex: 'classname'}
         ];
 

--- a/bundles/CoreBundle/Migrations/Version20220511085800.php
+++ b/bundles/CoreBundle/Migrations/Version20220511085800.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220511085800 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add key and index to search_backend_data table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (!$schema->getTable('search_backend_data')->hasColumn('key')) {
+            $this->addSql('ALTER TABLE `search_backend_data`
+                ADD COLUMN `key` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin default \'\',
+                ADD INDEX `key` (`key`)
+            ;');
+        }
+        if (!$schema->getTable('search_backend_data')->hasColumn('index')) {
+            $this->addSql('ALTER TABLE `search_backend_data`
+                ADD COLUMN `index` int(11) unsigned DEFAULT \'0\',
+                ADD INDEX `index` (`index`)
+            ;');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->getTable('search_backend_data')->hasColumn('key')) {
+            $this->addSql('ALTER TABLE `search_backend_data`
+                DROP INDEX `key`,
+                DROP COLUMN `key`
+            ;');
+        }
+        if ($schema->getTable('search_backend_data')->hasColumn('index')) {
+            $this->addSql('ALTER TABLE `search_backend_data`
+                DROP INDEX `index`,
+                DROP COLUMN `index`
+            ;');
+        }
+    }
+}

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -459,6 +459,8 @@ CREATE TABLE `schedule_tasks` (
 DROP TABLE IF EXISTS `search_backend_data`;
 CREATE TABLE `search_backend_data` (
   `id` int(11) NOT NULL,
+  `key` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin default '',
+  `index` int(11) unsigned DEFAULT '0',
   `fullpath` varchar(765) CHARACTER SET utf8 COLLATE utf8_general_ci DEFAULT NULL, /* path in utf8 (3-byte) using the full key length of 3072 bytes */
   `maintype` varchar(8) NOT NULL DEFAULT '',
   `type` varchar(20) DEFAULT NULL,
@@ -471,6 +473,8 @@ CREATE TABLE `search_backend_data` (
   `data` longtext,
   `properties` text,
   PRIMARY KEY (`id`,`maintype`),
+  KEY `key` (`key`),
+  KEY `index` (`index`),
   KEY `fullpath` (`fullpath`),
   KEY `maintype` (`maintype`),
   KEY `type` (`type`),

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,9 +1,11 @@
 # Upgrade Notes
+
 ## 10.5.0
 - [Sitemap] Pimcore is now also supporting Presta/Sitemap `^3.2` (which supports Symfony 6 and uses max level of PHPStan).
   Please note, if the routing import config is in use, it is recommended to correct the config path (by removing `/Resources`) to follow the [new folder tree structure](https://github.com/prestaconcept/PrestaSitemapBundle/releases/tag/v3.0.0),
   eg. "@PrestaSitemapBundle/~~Resources/~~config/routing.yaml", to ensure a smoother upgrade to upcoming major release.
-  
+- [Backend search] `key` and `index` columns have been added to the search index. Run `./bin/console pimcore:search-backend-reindex` to reindex.
+
 ## 10.4.0
 - **Important**: The folder structure for storing thumbnails changed, please run `bin/console pimcore:migrate:thumbnails-folder-structure` after the update to copy existing thumbnails to new folder structure. If you're dealing with a huge amount of thumbnails you should consider that this change might increase the load on your system as well as page-loading times during the migration command is executed, as non-existing thumbnails are then generated on demand. 
 - [Image Optimizer] Optimize Image messages are now routed to different queue

--- a/models/Search/Backend/Data.php
+++ b/models/Search/Backend/Data.php
@@ -44,6 +44,10 @@ class Data extends \Pimcore\Model\AbstractModel
      */
     protected ?Data\Id $id = null;
 
+    protected ?string $key = null;
+
+    protected ?int $index = null;
+
     /**
      * @var string
      */
@@ -142,6 +146,28 @@ class Data extends \Pimcore\Model\AbstractModel
     {
         $this->id = $id;
 
+        return $this;
+    }
+
+    public function getKey(): ?string
+    {
+        return $this->key;
+    }
+
+    public function setKey(?string $key): static
+    {
+        $this->key = $key;
+        return $this;
+    }
+
+    public function getIndex(): ?int
+    {
+        return $this->index;
+    }
+
+    public function setIndex(?int $index): static
+    {
+        $this->index = $index;
         return $this;
     }
 
@@ -363,6 +389,7 @@ class Data extends \Pimcore\Model\AbstractModel
         $this->data = null;
 
         $this->id = new Data\Id($element);
+        $this->key = $element->getKey();
         $this->fullPath = $element->getRealFullPath();
         $this->creationDate = $element->getCreationDate();
         $this->modificationDate = $element->getModificationDate();
@@ -372,8 +399,12 @@ class Data extends \Pimcore\Model\AbstractModel
         $this->type = $element->getType();
         if ($element instanceof DataObject\Concrete) {
             $this->subtype = $element->getClassName();
+            $this->index = $element->getIndex();
         } else {
             $this->subtype = $this->type;
+            if ($element instanceof Document) {
+                $this->index = $element->getIndex();
+            }
         }
 
         $this->properties = '';

--- a/models/Search/Backend/Data/Dao.php
+++ b/models/Search/Backend/Data/Dao.php
@@ -56,6 +56,8 @@ class Dao extends \Pimcore\Model\Dao\AbstractDao
         try {
             $data = [
                 'id' => $this->model->getId()->getId(),
+                'key' => $this->model->getKey(),
+                'index' => $this->model->getIndex(),
                 'fullpath' => $this->model->getFullPath(),
                 'maintype' => $this->model->getId()->getType(),
                 'type' => $this->model->getType(),

--- a/models/Search/Backend/Data/Listing/Dao.php
+++ b/models/Search/Backend/Data/Listing/Dao.php
@@ -46,6 +46,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
             if ($element) {
                 $entry = new Search\Backend\Data();
                 $entry->setId(new Search\Backend\Data\Id($element));
+                $entry->setKey($entryData['key']);
+                $entry->setIndex((int)$entryData['index']);
                 $entry->setFullPath($entryData['fullpath']);
                 $entry->setType($entryData['type']);
                 $entry->setSubtype($entryData['subtype']);


### PR DESCRIPTION
This allows sorting by key and index.
Index shouldn't be sorted by default, but may be manipulated via the LIST_BEFORE_LIST_LOAD admin event.

## Changes in this pull request  
Resolves #6782
