### PR TITLE
Delete uuid - query update to reduce locking

### DIFF
--- a/models/Tool/UUID/Dao.php
+++ b/models/Tool/UUID/Dao.php
@@ -65,7 +65,11 @@ class Dao extends Model\Dao\AbstractDao
         if (!$uuid) {
             throw new \Exception("Couldn't delete UUID - no UUID specified.");
         }
-        $this->db->delete(self::TABLE_NAME, ['uuid' => $uuid]);
+
+        $itemId = $this->model->getItemId();
+        $type = $this->model->getType();
+
+        $this->db->delete(self::TABLE_NAME, ['itemId' => $itemId, 'type' => $type, 'uuid' => $uuid]);
     }
 
     /**


### PR DESCRIPTION
In addition to the PR #11959, there is another thing that could be optimized when deleting uuid.

"uuids" table has index on primary key which consists of three columns - itemId, type and uuid. However, when deleting uuid only "uuid" value is used in the WHERE clause. As mysql searches the row using the non-indexed column, it often sets additional gap locks on uuids table as shown below:

![image](https://user-images.githubusercontent.com/10097539/167838917-977ac79f-5dc5-42dc-9661-e24a78d6aec3.png)

After adding all three columns in the WHERE clause, delete seems to be a lot more efficient. It can find row faster using the index what requires less locking: 

![image](https://user-images.githubusercontent.com/10097539/167838998-c4fc8fb4-4435-4bd5-9b6f-af55a2132ace.png)

Please check PR.