### PR TITLE
Allow skipping the loading of the `.env*` file

### DIFF
--- a/doc/Development_Documentation/21_Deployment/03_Configuration_Environments.md
+++ b/doc/Development_Documentation/21_Deployment/03_Configuration_Environments.md
@@ -7,6 +7,12 @@ configurations including a fallback mechanism.
 Pimcore is relying on Symfony's environments, with some extras, however all the essential 
 information can be found in the [Symfony Docs](https://symfony.com/doc/5.2/configuration.html#configuration-environments)
 
+> Note: While Pimcore uses Symfony's DotEnv component to allow you to 
+[configure environment variables in `.env` files](https://symfony.com/doc/5.4/configuration.html#configuring-environment-variables-in-env-files), 
+sometimes (e.g. in *prod* environments) you may want to configure everything via real 
+environment variables instead. In this case, you can disable loading of `.env` files 
+by setting the `PIMCORE_SKIP_DOTENV_FILE` environment variable to a truthy value.
+
 In addition to Symfony configurations, Pimcore also supports environment specific configs for: 
 
 * <https://github.com/pimcore/demo/tree/10.x/config/pimcore> 

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -19,6 +19,7 @@ use Pimcore\Model\DataObject;
 use Pimcore\Model\Document;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\Debug;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -146,7 +147,12 @@ class Bootstrap
 
     private static function prepareEnvVariables()
     {
-        (new Dotenv())->bootEnv(PIMCORE_PROJECT_ROOT .'/.env');
+        $finder = new Finder();
+        $finder->files()->name('.env*')->in(PIMCORE_PROJECT_ROOT)->depth('== 0');
+
+        if ($finder->hasResults()) {
+            (new Dotenv())->bootEnv(PIMCORE_PROJECT_ROOT.'/.env');
+        }
     }
 
     public static function defineConstants()

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -19,7 +19,6 @@ use Pimcore\Model\DataObject;
 use Pimcore\Model\Document;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\Debug;
-use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -147,11 +146,8 @@ class Bootstrap
 
     private static function prepareEnvVariables()
     {
-        $finder = new Finder();
-        $finder->files()->name('.env*')->in(PIMCORE_PROJECT_ROOT)->depth('== 0');
-
-        if ($finder->hasResults()) {
-            (new Dotenv())->bootEnv(PIMCORE_PROJECT_ROOT.'/.env');
+        if ($_SERVER['SKIP_DOTENV_FILE'] ?? false) {
+            (new Dotenv())->bootEnv(PIMCORE_PROJECT_ROOT .'/.env');
         }
     }
 

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -146,7 +146,7 @@ class Bootstrap
 
     private static function prepareEnvVariables()
     {
-        if (!($_SERVER['SKIP_DOTENV_FILE'] ?? false)) {
+        if (!($_SERVER['PIMCORE_SKIP_DOTENV_FILE'] ?? false)) {
             (new Dotenv())->bootEnv(PIMCORE_PROJECT_ROOT .'/.env');
         }
     }

--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -146,7 +146,7 @@ class Bootstrap
 
     private static function prepareEnvVariables()
     {
-        if ($_SERVER['SKIP_DOTENV_FILE'] ?? false) {
+        if (!($_SERVER['SKIP_DOTENV_FILE'] ?? false)) {
             (new Dotenv())->bootEnv(PIMCORE_PROJECT_ROOT .'/.env');
         }
     }


### PR DESCRIPTION
## Changes in this pull request  

Pimcore wants to load `.env*` files when bootstrapping and fails when there's none. But sometimes you don't have an `.env*` file, because everything is already set as "real" env variables (e.g. in a prod environment). 

Currently, you have to create an empty `.env` file to keep Pimcore happy, but it would be nice to be able to skip this (overhead). Therefore, I added a `SKIP_DOTENV_FILE` env variable that, when set, skips the `.env*` file loading.