### PR TITLE
Fix: Cannot instantiate abstract class Pimcore\Model\Document\PrintAbstract

### DIFF
--- a/models/Document.php
+++ b/models/Document.php
@@ -244,7 +244,7 @@ class Document extends Element\AbstractElement
         }
 
         try {
-            $helperDoc = new static();
+            $helperDoc = new Document();
             $helperDoc->getDao()->getByPath($path);
             $doc = static::getById($helperDoc->getId(), $force);
             \Pimcore\Cache\Runtime::set($cacheKey, $doc);
@@ -297,7 +297,12 @@ class Document extends Element\AbstractElement
         }
 
         if ($force || !($document = \Pimcore\Cache::load($cacheKey))) {
-            $document = new static();
+            $reflectionClass = new \ReflectionClass(static::class);
+            if ($reflectionClass->isAbstract()) {
+                $document = new Document();
+            } else {
+                $document = new static();
+            }
 
             try {
                 $document->getDao()->getById($id);

--- a/tests/Model/Document/DocumentTest.php
+++ b/tests/Model/Document/DocumentTest.php
@@ -19,6 +19,8 @@ use Pimcore\Model\Document\Editable\Input;
 use Pimcore\Model\Document\Email;
 use Pimcore\Model\Document\Link;
 use Pimcore\Model\Document\Page;
+use Pimcore\Model\Document\PrintAbstract;
+use Pimcore\Model\Document\Printpage;
 use Pimcore\Model\Document\Service;
 use Pimcore\Model\Element\Service as ElementService;
 use Pimcore\Tests\Test\ModelTestCase;
@@ -271,5 +273,17 @@ class DocumentTest extends ModelTestCase
         $loadedDocument = Service::getElementFromSession('document', $document->getId());
 
         $this->assertEquals(count($document->getEditables()), count($loadedDocument->getEditables()));
+    }
+
+    public function testDocumentPrint()
+    {
+        $printpage = TestHelper::createEmptyDocument('print-', true, true, '\\Pimcore\\Model\\Document\\Printpage');
+        $this->assertInstanceOf(Printpage::class, $printpage);
+
+        //Load via abstract class
+        $printpage = PrintAbstract::getById($printpage->getId());
+        $this->assertInstanceOf(Printpage::class, $printpage);
+        $printpage = PrintAbstract::getByPath($printpage->getRealFullPath());
+        $this->assertInstanceOf(Printpage::class, $printpage);
     }
 }


### PR DESCRIPTION
Regression from https://github.com/pimcore/pimcore/pull/12026

```
In Document.php line 300:
Cannot instantiate abstract class Pimcore\Model\Document\PrintAbstract
```

The Document Model has abstract classes as child classes. There are getById calls of this abstract classes.