### PR TITLE
Translate workflow transition notes title and titles of notes list of object

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/workflow/transitionPanel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/workflow/transitionPanel.js
@@ -171,7 +171,7 @@ pimcore.workflow.transitionPanel = Class.create({
                 width: 530,
                 height: height,
                 iconCls: this.transitionConfig.iconCls,
-                title: this.transitionConfig.label,
+                title: t(this.transitionConfig.label),
                 layout: "fit",
                 closeAction:'close',
                 plain: true,

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -23,6 +23,7 @@ use DeepCopy\Matcher\PropertyTypeMatcher;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Query\QueryBuilder as DoctrineQueryBuilder;
 use League\Csv\EscapeFormula;
+use Pimcore;
 use Pimcore\Db;
 use Pimcore\Event\SystemEvents;
 use Pimcore\File;

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -43,6 +43,7 @@ use Pimcore\Model\Tool\TmpStore;
 use Pimcore\Tool\Serialize;
 use Pimcore\Tool\Session;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @method \Pimcore\Model\Element\Dao getDao()
@@ -1344,7 +1345,7 @@ class Service extends Model\AbstractModel
             'ctype' => $note->getCtype(),
             'cpath' => $cpath,
             'date' => $note->getDate(),
-            'title' => $note->getTitle(),
+            'title' => Pimcore::getContainer()->get(TranslatorInterface::class)->trans($note->getTitle(),[],'admin'),
             'description' => $note->getDescription(),
         ];
 


### PR DESCRIPTION
## Changes in this pull request  
When using translation keys on workflow transition titles, translations are correctly displayed in workflow actions menu 
![image](https://user-images.githubusercontent.com/43100677/168120003-776b109f-7819-4323-a830-308ee2c0d9f8.png)

but not in transition note window title :
![image](https://user-images.githubusercontent.com/43100677/168120173-a64f0054-df4c-4f0d-93d3-7dc974bd135d.png)

neither in the list of notes of the object :
![image](https://user-images.githubusercontent.com/43100677/168120196-fb697324-6e28-4540-b346-a449ce2ed639.png)

Proposal in the MR is to translate transition note window title
![image](https://user-images.githubusercontent.com/43100677/168120403-882098cc-2557-4731-9d06-3b53673d014c.png)

and tile of each notes when browsing list of of notes of an object (translation key is still stored in database to be able to show an adapted translated title in each available language, no change)
![image](https://user-images.githubusercontent.com/43100677/168120612-cfc64f8d-7088-44a7-905c-d6bb3305ef9b.png)


## Additional info  

