### PR TITLE
[Documents] Reset draft changes on applying Content Master Document

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/settings_abstract.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/settings_abstract.js
@@ -140,6 +140,7 @@ pimcore.document.settings_abstract = Class.create({
                                                     "contentMasterDocumentPath_" + this.document.id).getValue()
                                             },
                                             success:function () {
+                                                this.document.resetChanges();
                                                 this.document.reload();
                                             }.bind(this)
                                         });


### PR DESCRIPTION
## Changes in this pull request  
Resolves #11918


## Additional info  
- On applying content master in Document Settings, the document is reloaded with dirty changes and if `autoSave` feature is turned on (default behavior), then it saves the overwrites the changes from content master. The issue fixed by calling resetChanges() to reset the dirty changes before calling reload().