### PR TITLE
[Bug]: Custom View Classes not working if is not associative array

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -202,8 +202,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             if (!empty($cv['classes'])) {
                 $cvConditions = [];
                 $cvClasses = $cv['classes'];
+                $isAssociative = array_keys($cvClasses) !== range(0, count($cvClasses) - 1);
                 foreach ($cvClasses as $key => $cvClass) {
-                    $cvConditions[] = "objects.o_classId = '" . $key . "'";
+                    $cvConditions[] = "objects.o_classId = '" . ($isAssociative ? $key : $cvClass) . "'";
                 }
 
                 $cvConditions[] = "objects.o_type = 'folder'";


### PR DESCRIPTION
## Changes in this pull request  
fixes #12134

## Additional info  
the custom view's filter `classes` uses the array key of an associative array since #7143 and X, but in the demo, the `pimcore_custom_views` in the setting store table are using a sequential array and this change fixes it.


