### PR TITLE
Translate titles of notes if needed and workflow note window title

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/workflow/transitionPanel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/workflow/transitionPanel.js
@@ -171,7 +171,7 @@ pimcore.workflow.transitionPanel = Class.create({
                 width: 530,
                 height: height,
                 iconCls: this.transitionConfig.iconCls,
-                title: this.transitionConfig.label,
+                title: t(this.transitionConfig.label),
                 layout: "fit",
                 closeAction:'close',
                 plain: true,

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -23,6 +23,7 @@ use DeepCopy\Matcher\PropertyTypeMatcher;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Query\QueryBuilder as DoctrineQueryBuilder;
 use League\Csv\EscapeFormula;
+use Pimcore;
 use Pimcore\Db;
 use Pimcore\Event\SystemEvents;
 use Pimcore\File;
@@ -43,6 +44,7 @@ use Pimcore\Model\Tool\TmpStore;
 use Pimcore\Tool\Serialize;
 use Pimcore\Tool\Session;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @method \Pimcore\Model\Element\Dao getDao()
@@ -1344,7 +1346,7 @@ class Service extends Model\AbstractModel
             'ctype' => $note->getCtype(),
             'cpath' => $cpath,
             'date' => $note->getDate(),
-            'title' => $note->getTitle(),
+            'title' => Pimcore::getContainer()->get(TranslatorInterface::class)->trans($note->getTitle(),[],'admin'),
             'description' => $note->getDescription(),
         ];
 


### PR DESCRIPTION
BUG Translate titles of notes if needed (notes list of object) and workfow note window title (transition title can be a translation key)

Sorry I had to recreate PR #12113

## Changes in this pull request  
When using translation keys on workflow transition titles, translations are correctly displayed in workflow actions menu
![168120003-776b109f-7819-4323-a830-308ee2c0d9f8](https://user-images.githubusercontent.com/43100677/168849432-d226b607-dc87-4d67-b386-44b2c204bd70.png)

but not in transition note window title :
![168120173-a64f0054-df4c-4f0d-93d3-7dc974bd135d](https://user-images.githubusercontent.com/43100677/168849518-f34f24dc-8965-497b-9766-2423dcc7c327.png)

neither in the list of notes of the object :
![168120196-fb697324-6e28-4540-b346-a449ce2ed639](https://user-images.githubusercontent.com/43100677/168849567-d2763e39-f2c9-4b47-8c14-1a8d58d833dc.png)

Proposal in the MR is to translate transition note window title
![168120403-882098cc-2557-4731-9d06-3b53673d014c](https://user-images.githubusercontent.com/43100677/168849639-d445e868-a465-4f0b-8679-e08680d85a6d.png)

and tile of each notes when browsing list of of notes of an object (translation key is still stored in database to be able to show an adapted translated title in each available language, no change)
![168120612-cfc64f8d-7088-44a7-905c-d6bb3305ef9b](https://user-images.githubusercontent.com/43100677/168849675-35e486aa-8914-45c6-a1ff-38de778742e4.png)

