### PR TITLE
[Asset upload] Prevent creation of __MACOS folder when uploading a zip file which got created with MacOS

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -2306,6 +2306,10 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             for ($i = $offset; $i < ($offset + $limit); $i++) {
                 $path = $zip->getNameIndex($i);
 
+                if (str_starts_with($path, '__MACOSX/')) {
+                    continue;
+                }
+
                 if ($path !== false) {
                     if ($zip->extractTo($tmpDir . '/', $path)) {
                         $tmpFile = $tmpDir . '/' . preg_replace('@^/@', '', $path);


### PR DESCRIPTION
Zip files which get generated in MacOS usually contain a folder `__MACOS`. When you upload such a zip to Pimcore assetsm you will end up with the actual files and also the (imho useless) `__MACOS` folder:
<img width="424" alt="Bildschirmfoto 2022-05-19 um 07 54 58" src="https://user-images.githubusercontent.com/8749138/169221402-2c8477d3-ec68-409b-8f0f-b02a3fb58d77.png">

With this PR only the real files will get imported, the `__MACOS` folder will get ignored.
