### PR TITLE
Re-acknowledge AWS Aurora compatibilty

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/01_System_Requirements.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/01_System_Requirements.md
@@ -47,6 +47,7 @@ Both **mod_php** and **FCGI (FPM)** are supported.
 - MariaDB >= 10.3
 - MySQL >= 8.0
 - Percona Server (supported versions see MySQL)
+- [AWS Aurora](https://aws.amazon.com/de/about-aws/whats-new/2021/11/amazon-aurora-mysql-8-0/) (supported versions see MySQL)
 
 #### Features
 - InnoDB / XtraDB storage engine


### PR DESCRIPTION
As of pimcore X the docs [stopped mentioning](https://github.com/pimcore/pimcore/pull/8683) compatibility with AWS Aurora. This was due to the fact that AWS Aurora [did not support MySQL 8 at the moment](https://github.com/pimcore/pimcore/pull/8683/files#r635112117). AWS Aurora seems to be [supporting MySQL 8 now](https://aws.amazon.com/de/about-aws/whats-new/2021/11/amazon-aurora-mysql-8-0/). Let's add this database backend as a compatible option back to the docs.

