### PR TITLE
[Reports] Regard drilldown filters on export

### DIFF
--- a/bundles/AdminBundle/Controller/Reports/CustomReportController.php
+++ b/bundles/AdminBundle/Controller/Reports/CustomReportController.php
@@ -427,6 +427,9 @@ class CustomReportController extends ReportsControllerBase
         $dir = $request->get('dir');
         $filters = $request->get('filter') ? json_decode(urldecode($request->get('filter')), true) : null;
         $drillDownFilters = $request->get('drillDownFilters', null);
+        if($drillDownFilters) {
+            $drillDownFilters = json_decode($drillDownFilters, true);
+        }
         $includeHeaders = $request->get('headers', false);
 
         $config = CustomReport\Config::getByName($request->get('name'));

--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/report.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/report.js
@@ -542,6 +542,7 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
     createCsv: function (btn, exportFile, offset, withHeader) {
         let filterData = this.store.getFilters().items;
         let proxy = this.store.getProxy();
+
         Ext.Ajax.request({
             url: Routing.generate('pimcore_admin_reports_customreport_createcsv'),
             params: {
@@ -550,6 +551,7 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
                 name: this.config.name,
                 filter: filterData.length > 0 ? encodeURIComponent(proxy.encodeFilters(filterData)) : "",
                 headers: withHeader,
+                drillDownFilters: JSON.stringify(this.drillDownFilters)
             },
             success: function (response) {
                 response = JSON.parse(response["responseText"]);
@@ -566,5 +568,5 @@ pimcore.report.custom.report = Class.create(pimcore.report.abstract, {
                 }
             }.bind(this)
         });
-    },
+    }
 });


### PR DESCRIPTION
Steps to reproduce bug:

1. Create 2 data object classes `Product` and `Category`
2. Create a custom SQL report with the query `SELECT id,name FROM classes`
    For field `name` set `Filter Drilldown`=`filter_and_show`
3. Open report, filter for `Name`=`Product` with drilldown filter -> only 1 row is shown
4. Click `Export as CSV` button

Expected behaviour: Export the filtered report
Actual behaviour: Unfiltered report gets exported

With this PR the drilldown filters get used also for export.