### PR TITLE
[Session] Do not use deprecated session service injections

### DIFF
--- a/bundles/AdminBundle/PimcoreAdminBundle.php
+++ b/bundles/AdminBundle/PimcoreAdminBundle.php
@@ -15,7 +15,6 @@
 
 namespace Pimcore\Bundle\AdminBundle;
 
-use Pimcore\Bundle\AdminBundle\DependencyInjection\Compiler\AdminSessionBagsPass;
 use Pimcore\Bundle\AdminBundle\DependencyInjection\Compiler\ContentSecurityPolicyUrlsPass;
 use Pimcore\Bundle\AdminBundle\DependencyInjection\Compiler\GDPRDataProviderPass;
 use Pimcore\Bundle\AdminBundle\DependencyInjection\Compiler\ImportExportLocatorsPass;
@@ -47,7 +46,6 @@ class PimcoreAdminBundle extends Bundle
         $container->addCompilerPass(new ImportExportLocatorsPass());
         $container->addCompilerPass(new TranslationServicesPass());
         $container->addCompilerPass(new ContentSecurityPolicyUrlsPass());
-        $container->addCompilerPass(new AdminSessionBagsPass());
 
         /** @var SecurityExtension $extension */
         $extension = $container->getExtension('security');

--- a/bundles/AdminBundle/PimcoreAdminBundle.php
+++ b/bundles/AdminBundle/PimcoreAdminBundle.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Bundle\AdminBundle;
 
+use Pimcore\Bundle\AdminBundle\DependencyInjection\Compiler\AdminSessionBagsPass;
 use Pimcore\Bundle\AdminBundle\DependencyInjection\Compiler\ContentSecurityPolicyUrlsPass;
 use Pimcore\Bundle\AdminBundle\DependencyInjection\Compiler\GDPRDataProviderPass;
 use Pimcore\Bundle\AdminBundle\DependencyInjection\Compiler\ImportExportLocatorsPass;
@@ -46,6 +47,7 @@ class PimcoreAdminBundle extends Bundle
         $container->addCompilerPass(new ImportExportLocatorsPass());
         $container->addCompilerPass(new TranslationServicesPass());
         $container->addCompilerPass(new ContentSecurityPolicyUrlsPass());
+        $container->addCompilerPass(new AdminSessionBagsPass());
 
         /** @var SecurityExtension $extension */
         $extension = $container->getExtension('security');

--- a/bundles/AdminBundle/Session/Handler/AdminSessionHandler.php
+++ b/bundles/AdminBundle/Session/Handler/AdminSessionHandler.php
@@ -22,6 +22,7 @@ use Pimcore\Session\Attribute\LockableAttributeBagInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -41,10 +42,6 @@ class AdminSessionHandler implements LoggerAwareInterface, AdminSessionHandlerIn
      */
     private $openedSessions = 0;
 
-    /**
-     * @var SessionInterface
-     */
-    protected $session;
 
     protected $readOnlySessionBagsCache = [];
 
@@ -58,9 +55,8 @@ class AdminSessionHandler implements LoggerAwareInterface, AdminSessionHandlerIn
      */
     protected $requestHelper;
 
-    public function __construct(SessionInterface $session, RequestHelper $requestHelper)
+    public function __construct(RequestHelper $requestHelper)
     {
-        $this->session = $session;
         $this->requestHelper = $requestHelper;
     }
 
@@ -69,14 +65,15 @@ class AdminSessionHandler implements LoggerAwareInterface, AdminSessionHandlerIn
      */
     public function getSessionId()
     {
-        if (!$this->session->isStarted()) {
+        $request = $this->requestHelper->getRequest();
+        if (!$request->getSession()->isStarted()) {
             // this is just to initialize the session :)
             $this->useSession(static function (SessionInterface $session) {
                 return $session->getId();
             });
         }
 
-        return $this->session->getId();
+        return $request->getSession()->getId();
     }
 
     /**
@@ -84,7 +81,7 @@ class AdminSessionHandler implements LoggerAwareInterface, AdminSessionHandlerIn
      */
     public function getSessionName()
     {
-        return $this->session->getName();
+        return $this->requestHelper->getRequest()->getSession()->getName();
     }
 
     /**
@@ -142,7 +139,7 @@ class AdminSessionHandler implements LoggerAwareInterface, AdminSessionHandlerIn
      */
     public function invalidate(int $lifetime = null): bool
     {
-        return $this->session->invalidate($lifetime);
+        return $this->requestHelper->getRequest()->getSession()->invalidate($lifetime);
     }
 
     /**
@@ -235,8 +232,9 @@ class AdminSessionHandler implements LoggerAwareInterface, AdminSessionHandlerIn
 
         $this->logger->debug('Opening admin session {name}', ['name' => $sessionName]);
 
-        if (!$this->session->isStarted()) {
-            $this->session->start();
+        $request = $this->requestHelper->getRequest();
+        if (!$request->getSession()->isStarted()) {
+            $request->getSession()->start();
         }
 
         $this->openedSessions++;
@@ -246,7 +244,7 @@ class AdminSessionHandler implements LoggerAwareInterface, AdminSessionHandlerIn
             'count' => $this->openedSessions,
         ]);
 
-        return $this->session;
+        return $request->getSession();
     }
 
     /**
@@ -261,7 +259,7 @@ class AdminSessionHandler implements LoggerAwareInterface, AdminSessionHandlerIn
         $this->openedSessions--;
 
         if (0 === $this->openedSessions) {
-            $this->session->save();
+            $this->requestHelper->getRequest()->getSession()->save();
 
             $this->logger->debug('Admin session {name} was written and closed', [
                 'name' => $this->getSessionName(),

--- a/bundles/AdminBundle/Session/Handler/AdminSessionHandler.php
+++ b/bundles/AdminBundle/Session/Handler/AdminSessionHandler.php
@@ -65,7 +65,7 @@ class AdminSessionHandler implements LoggerAwareInterface, AdminSessionHandlerIn
      */
     public function getSessionId()
     {
-        if ($this->requestHelper->getSession()->isStarted()) {
+        if (!$this->requestHelper->getSession()->isStarted()) {
             // this is just to initialize the session :)
             $this->useSession(static function (SessionInterface $session) {
                 return $session->getId();

--- a/bundles/AdminBundle/Session/Handler/AdminSessionHandler.php
+++ b/bundles/AdminBundle/Session/Handler/AdminSessionHandler.php
@@ -65,15 +65,14 @@ class AdminSessionHandler implements LoggerAwareInterface, AdminSessionHandlerIn
      */
     public function getSessionId()
     {
-        $request = $this->requestHelper->getRequest();
-        if (!$request->getSession()->isStarted()) {
+        if ($this->requestHelper->getSession()->isStarted()) {
             // this is just to initialize the session :)
             $this->useSession(static function (SessionInterface $session) {
                 return $session->getId();
             });
         }
 
-        return $request->getSession()->getId();
+        return $this->requestHelper->getSession()->getId();
     }
 
     /**
@@ -232,9 +231,8 @@ class AdminSessionHandler implements LoggerAwareInterface, AdminSessionHandlerIn
 
         $this->logger->debug('Opening admin session {name}', ['name' => $sessionName]);
 
-        $request = $this->requestHelper->getRequest();
-        if (!$request->getSession()->isStarted()) {
-            $request->getSession()->start();
+        if (!$this->requestHelper->getSession()->isStarted()) {
+            $this->requestHelper->getSession()->start();
         }
 
         $this->openedSessions++;
@@ -244,7 +242,7 @@ class AdminSessionHandler implements LoggerAwareInterface, AdminSessionHandlerIn
             'count' => $this->openedSessions,
         ]);
 
-        return $request->getSession();
+        return $this->requestHelper->getSession();
     }
 
     /**

--- a/bundles/CoreBundle/DependencyInjection/Compiler/SessionConfiguratorPass.php
+++ b/bundles/CoreBundle/DependencyInjection/Compiler/SessionConfiguratorPass.php
@@ -31,7 +31,7 @@ final class SessionConfiguratorPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('session')) {
+        if (!$container->has('session')) {
             return;
         }
 
@@ -40,7 +40,7 @@ final class SessionConfiguratorPass implements CompilerPassInterface
         }
 
         // configure the core session through our configurator service (mainly to register custom attribute bags)
-        $session = $container->getDefinition('session');
+        $session = $container->findDefinition('session');
 
         // just to make sure nobody else (symfony core, other bundle) sets a configurator and we overwrite it here
         if ($session->getConfigurator()) {

--- a/bundles/CoreBundle/DependencyInjection/Compiler/SessionConfiguratorPass.php
+++ b/bundles/CoreBundle/DependencyInjection/Compiler/SessionConfiguratorPass.php
@@ -36,6 +36,7 @@ final class SessionConfiguratorPass implements CompilerPassInterface
             return;
         }
 
+        // @phpstan-ignore-next-line
         if (!$container->hasDefinition(SessionConfigurator::class)) {
             return;
         }

--- a/bundles/CoreBundle/DependencyInjection/Compiler/SessionConfiguratorPass.php
+++ b/bundles/CoreBundle/DependencyInjection/Compiler/SessionConfiguratorPass.php
@@ -37,7 +37,7 @@ final class SessionConfiguratorPass implements CompilerPassInterface
         }
 
         // @phpstan-ignore-next-line
-        if (!$container->hasDefinition(SessionConfigurator::class)) {
+        if (!$container->has(SessionConfigurator::class)) {
             return;
         }
 

--- a/bundles/CoreBundle/DependencyInjection/Compiler/SessionConfiguratorPass.php
+++ b/bundles/CoreBundle/DependencyInjection/Compiler/SessionConfiguratorPass.php
@@ -31,6 +31,7 @@ final class SessionConfiguratorPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        // @phpstan-ignore-next-line
         if (!$container->has('session')) {
             return;
         }

--- a/bundles/CoreBundle/Resources/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yaml
@@ -20,6 +20,7 @@ framework:
         # use the native PHP session mechanism
         handler_id:  null
         cookie_samesite: 'strict'
+        storage_factory_id: session.storage.factory.native
     php_errors:
         log: true
     assets: ~

--- a/bundles/CoreBundle/Resources/config/pimcore/test.yaml
+++ b/bundles/CoreBundle/Resources/config/pimcore/test.yaml
@@ -1,7 +1,7 @@
 framework:
     test: ~
     session:
-        storage_id: session.storage.factory.mock_file
+        storage_factory_id: session.storage.factory.mock_file
     profiler: false
     mailer:
         transports:

--- a/bundles/CoreBundle/Resources/config/pimcore/test.yaml
+++ b/bundles/CoreBundle/Resources/config/pimcore/test.yaml
@@ -1,7 +1,7 @@
 framework:
     test: ~
     session:
-        storage_id: session.storage.mock_file
+        storage_id: session.storage.factory.mock_file
     profiler: false
     mailer:
         transports:

--- a/bundles/CoreBundle/Resources/config/services.yaml
+++ b/bundles/CoreBundle/Resources/config/services.yaml
@@ -6,15 +6,6 @@ services:
     #
     # SESSION
     #
-
-    session:
-        public: true
-        class: Symfony\Component\HttpFoundation\Session\Session
-        arguments:
-            $storage: '@session.storage'
-            $flashes: '@session.flash_bag'
-
-
     # Sessions need to be configured (e.g. adding custom attribute bags) before they are started. The configurator handles
     # a collection of configurator instances which can be added via addConfigurator or by using the pimcore.session.configurator
     # DI tag. See the SessionConfiguratorPass for details.

--- a/bundles/EcommerceFrameworkBundle/CartManager/SessionCart.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/SessionCart.php
@@ -44,7 +44,7 @@ class SessionCart extends AbstractCart implements CartInterface
     protected static function getSessionBag(): AttributeBagInterface
     {
         /** @var AttributeBagInterface $sessionBag */
-        $sessionBag = \Pimcore::getContainer()->get('session')->getBag(SessionConfigurator::ATTRIBUTE_BAG_CART);
+        $sessionBag = \Pimcore::getContainer()->get('request_stack')->getSession()->getBag(SessionConfigurator::ATTRIBUTE_BAG_CART);
 
         if (empty($sessionBag->get('carts'))) {
             $sessionBag->set('carts', []);

--- a/bundles/EcommerceFrameworkBundle/CartManager/SessionCart.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/SessionCart.php
@@ -16,6 +16,7 @@
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\CartManager;
 
 use Pimcore\Bundle\EcommerceFrameworkBundle\Tools\SessionConfigurator;
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 
 class SessionCart extends AbstractCart implements CartInterface
@@ -43,8 +44,17 @@ class SessionCart extends AbstractCart implements CartInterface
 
     protected static function getSessionBag(): AttributeBagInterface
     {
+        try {
+            $session = \Pimcore::getContainer()->get('request_stack')->getSession();
+        } catch (SessionNotFoundException $e) {
+            trigger_deprecation('pimcore/pimcore', '10.5',
+                sprintf('Session used with non existing request stack in %s, that will not be possible in Pimcore 11.', __CLASS__));
+
+            $session = \Pimcore::getContainer()->get('session');
+        }
+
         /** @var AttributeBagInterface $sessionBag */
-        $sessionBag = \Pimcore::getContainer()->get('request_stack')->getSession()->getBag(SessionConfigurator::ATTRIBUTE_BAG_CART);
+        $sessionBag = $session->getBag(SessionConfigurator::ATTRIBUTE_BAG_CART);
 
         if (empty($sessionBag->get('carts'))) {
             $sessionBag->set('carts', []);

--- a/bundles/EcommerceFrameworkBundle/EventListener/Frontend/TrackingCodeFlashMessageListener.php
+++ b/bundles/EcommerceFrameworkBundle/EventListener/Frontend/TrackingCodeFlashMessageListener.php
@@ -21,8 +21,8 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Tracking\TrackingManager;
 use Pimcore\Http\Request\Resolver\PimcoreContextResolver;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -37,18 +37,18 @@ class TrackingCodeFlashMessageListener implements EventSubscriberInterface
     const FLASH_MESSAGE_BAG_KEY = 'ecommerceframework_trackingcode_flashmessagelistener';
 
     /**
-     * @var SessionInterface
+     * @var RequestStack
      */
-    protected $session;
+    protected RequestStack $requestStack;
 
     /**
      * @var TrackingManager
      */
     protected $trackingManger;
 
-    public function __construct(SessionInterface $session, TrackingManager $trackingManager)
+    public function __construct(RequestStack $requestStack, TrackingManager $trackingManager)
     {
-        $this->session = $session;
+        $this->requestStack = $requestStack;
         $this->trackingManger = $trackingManager;
     }
 
@@ -74,8 +74,9 @@ class TrackingCodeFlashMessageListener implements EventSubscriberInterface
 
         // Check FlashBag cookie exists to avoid autostart session by accessing the FlashBag.
         $flashBagCookie = (bool)$request->cookies->get(self::FLASH_MESSAGE_BAG_KEY);
-        if ($flashBagCookie && $this->session instanceof Session) {
-            $trackedCodes = $this->session->getFlashBag()->get(self::FLASH_MESSAGE_BAG_KEY);
+        $session = $this->requestStack->getSession();
+        if ($flashBagCookie && $session instanceof Session) {
+            $trackedCodes = $session->getFlashBag()->get(self::FLASH_MESSAGE_BAG_KEY);
 
             if (is_array($trackedCodes) && count($trackedCodes)) {
                 foreach ($this->trackingManger->getTrackers() as $tracker) {
@@ -96,15 +97,16 @@ class TrackingCodeFlashMessageListener implements EventSubscriberInterface
     {
         $response = $event->getResponse();
         $request = $event->getRequest();
+        $session = $this->requestStack->getSession();
 
         /**
          * If tracking codes are forwarded as FlashMessage, then set a cookie which is checked in subsequent request for successful handshake
          * else clear cookie, if set and FlashBag is already processed.
          */
         if (
-            $this->session instanceof Session &&
-            $this->session->isStarted() &&
-            $this->session->getFlashBag()->has(self::FLASH_MESSAGE_BAG_KEY)
+            $session instanceof Session &&
+            $session->isStarted() &&
+            $session->getFlashBag()->has(self::FLASH_MESSAGE_BAG_KEY)
         ) {
             $response->headers->setCookie(new Cookie(self::FLASH_MESSAGE_BAG_KEY, '1'));
             $response->headers->set('X-Pimcore-Output-Cache-Disable-Reason', 'Tracking Codes Passed');

--- a/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
@@ -48,6 +48,10 @@ class PricingManager implements PricingManagerInterface
     protected $actionMapping = [];
 
     /**
+     * TODO: use RequestStack to get session
+     *
+     * @deprecated will be removed in Pimcore 11
+     *
      * @var SessionInterface
      */
     protected $session;

--- a/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\CheckoutableInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\PriceInfoInterface as PriceSystemPriceInfoInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Tools\SessionConfigurator;
 use Pimcore\Targeting\VisitorInfoStorageInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -48,13 +49,17 @@ class PricingManager implements PricingManagerInterface
     protected $actionMapping = [];
 
     /**
-     * TODO: use RequestStack to get session
      *
      * @deprecated will be removed in Pimcore 11
      *
      * @var SessionInterface
      */
     protected $session;
+
+    /**
+     * @var RequestStack
+     */
+    protected RequestStack $requestStack;
 
     /**
      * @var array
@@ -114,6 +119,19 @@ class PricingManager implements PricingManagerInterface
     public function isEnabled(): bool
     {
         return $this->enabled;
+    }
+
+    /**
+     * @TODO move to constructor injection in Pimcore 11
+     *
+     * @required
+     * @internal
+     *
+     * @param RequestStack $requestStack
+     */
+    public function setRequestStack(RequestStack $requestStack): void
+    {
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -232,7 +250,7 @@ class PricingManager implements PricingManagerInterface
     public function getEnvironment()
     {
         /** @var AttributeBagInterface $sessionBag */
-        $sessionBag = $this->session->getBag(SessionConfigurator::ATTRIBUTE_BAG_PRICING_ENVIRONMENT);
+        $sessionBag = $this->requestStack->getSession()->getBag(SessionConfigurator::ATTRIBUTE_BAG_PRICING_ENVIRONMENT);
 
         $class = $this->options['environment_class'];
 

--- a/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
@@ -22,7 +22,6 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\CheckoutableInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\PriceInfoInterface as PriceSystemPriceInfoInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Tools\SessionConfigurator;
 use Pimcore\Targeting\VisitorInfoStorageInterface;
-use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -231,17 +230,8 @@ class PricingManager implements PricingManagerInterface
      */
     public function getEnvironment()
     {
-        try {
-            $session = \Pimcore::getContainer()->get('request_stack')->getSession();
-        } catch (SessionNotFoundException $e) {
-            trigger_deprecation('pimcore/pimcore', '10.5',
-                sprintf('Session used with non existing request stack in %s, that will not be possible in Pimcore 11.', __CLASS__));
-
-            $session = \Pimcore::getContainer()->get('session');
-        }
-
         /** @var AttributeBagInterface $sessionBag */
-        $sessionBag = $session->getBag(SessionConfigurator::ATTRIBUTE_BAG_PRICING_ENVIRONMENT);
+        $sessionBag = $this->session->getBag(SessionConfigurator::ATTRIBUTE_BAG_PRICING_ENVIRONMENT);
 
         $class = $this->options['environment_class'];
 

--- a/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\CheckoutableInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\PriceInfoInterface as PriceSystemPriceInfoInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Tools\SessionConfigurator;
 use Pimcore\Targeting\VisitorInfoStorageInterface;
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -230,9 +231,17 @@ class PricingManager implements PricingManagerInterface
      */
     public function getEnvironment()
     {
-        $requestStack = \Pimcore::getContainer()->get('request_stack');
+        try {
+            $session = \Pimcore::getContainer()->get('request_stack')->getSession();
+        } catch (SessionNotFoundException $e) {
+            trigger_deprecation('pimcore/pimcore', '10.5',
+                sprintf('Session used with non existing request stack in %s, that will not be possible in Pimcore 11.', __CLASS__));
+
+            $session = \Pimcore::getContainer()->get('session');
+        }
+
         /** @var AttributeBagInterface $sessionBag */
-        $sessionBag = $requestStack->getSession()->getBag(SessionConfigurator::ATTRIBUTE_BAG_PRICING_ENVIRONMENT);
+        $sessionBag = $session->getBag(SessionConfigurator::ATTRIBUTE_BAG_PRICING_ENVIRONMENT);
 
         $class = $this->options['environment_class'];
 

--- a/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
@@ -59,7 +59,7 @@ class PricingManager implements PricingManagerInterface
     /**
      * @var RequestStack
      */
-    protected RequestStack $requestStack;
+    protected $requestStack;
 
     /**
      * @var array
@@ -119,19 +119,6 @@ class PricingManager implements PricingManagerInterface
     public function isEnabled(): bool
     {
         return $this->enabled;
-    }
-
-    /**
-     * @TODO move to constructor injection in Pimcore 11
-     *
-     * @required
-     * @internal
-     *
-     * @param RequestStack $requestStack
-     */
-    public function setRequestStack(RequestStack $requestStack): void
-    {
-        $this->requestStack = $requestStack;
     }
 
     /**
@@ -249,8 +236,9 @@ class PricingManager implements PricingManagerInterface
      */
     public function getEnvironment()
     {
+        $requestStack = \Pimcore::getContainer()->get('request_stack');
         /** @var AttributeBagInterface $sessionBag */
-        $sessionBag = $this->requestStack->getSession()->getBag(SessionConfigurator::ATTRIBUTE_BAG_PRICING_ENVIRONMENT);
+        $sessionBag = $requestStack->getSession()->getBag(SessionConfigurator::ATTRIBUTE_BAG_PRICING_ENVIRONMENT);
 
         $class = $this->options['environment_class'];
 

--- a/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/PricingManager.php
@@ -22,7 +22,6 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\CheckoutableInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\PriceInfoInterface as PriceSystemPriceInfoInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Tools\SessionConfigurator;
 use Pimcore\Targeting\VisitorInfoStorageInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -55,11 +54,6 @@ class PricingManager implements PricingManagerInterface
      * @var SessionInterface
      */
     protected $session;
-
-    /**
-     * @var RequestStack
-     */
-    protected $requestStack;
 
     /**
      * @var array

--- a/bundles/EcommerceFrameworkBundle/SessionEnvironment.php
+++ b/bundles/EcommerceFrameworkBundle/SessionEnvironment.php
@@ -37,6 +37,10 @@ class SessionEnvironment extends Environment implements EnvironmentInterface
     const SESSION_KEY_CHECKOUT_TENANT = 'currentcheckouttenant';
 
     /**
+     * TODO: use RequestStack to get session
+     *
+     * @deprecated will be removed in Pimcore 11
+     *
      * @var SessionInterface
      */
     protected $session;

--- a/bundles/EcommerceFrameworkBundle/SessionEnvironment.php
+++ b/bundles/EcommerceFrameworkBundle/SessionEnvironment.php
@@ -19,6 +19,7 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle;
 
 use Pimcore\Bundle\EcommerceFrameworkBundle\Tools\SessionConfigurator;
 use Pimcore\Localization\LocaleServiceInterface;
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -82,7 +83,7 @@ class SessionEnvironment extends Environment implements EnvironmentInterface
         }
 
         //if the session was not explicitly started in cli environment, do nothing
-        if ('cli' === php_sapi_name() && !$this->requestStack->getSession()->isStarted()) {
+        if ('cli' === php_sapi_name() && !$this->checkSessionStartedInCli()) {
             return;
         }
 
@@ -106,7 +107,7 @@ class SessionEnvironment extends Environment implements EnvironmentInterface
     public function save()
     {
         //if the session was not explicitly started in cli environment, do nothing
-        if ('cli' === php_sapi_name() && !$this->requestStack->getSession()->isStarted()) {
+        if ('cli' === php_sapi_name() && !$this->checkSessionStartedInCli()) {
             return;
         }
 
@@ -126,7 +127,7 @@ class SessionEnvironment extends Environment implements EnvironmentInterface
         parent::clearEnvironment();
 
         //if the session was not explicitly started in cli environment, do nothing
-        if ('cli' === php_sapi_name() && !$this->requestStack->getSession()->isStarted()) {
+        if ('cli' === php_sapi_name() && !$this->checkSessionStartedInCli()) {
             return;
         }
 
@@ -148,8 +149,43 @@ class SessionEnvironment extends Environment implements EnvironmentInterface
     protected function getSessionBag(): AttributeBagInterface
     {
         /** @var AttributeBagInterface $sessionBag */
-        $sessionBag = $this->requestStack->getSession()->getBag(SessionConfigurator::ATTRIBUTE_BAG_ENVIRONMENT);
+        $sessionBag = $this->getSession()->getBag(SessionConfigurator::ATTRIBUTE_BAG_ENVIRONMENT);
 
         return $sessionBag;
     }
+
+
+    private function getSession(bool $preventDeprecationWarning = false): SessionInterface {
+
+        try {
+            return $this->requestStack->getSession();
+        } catch (SessionNotFoundException $e) {
+
+            if(!$preventDeprecationWarning) {
+                trigger_deprecation('pimcore/pimcore', '10.5',
+                    sprintf('Session used with non existing request stack in %s, that will not be possible in Pimcore 11.', SessionEnvironment::class));
+            }
+
+            return \Pimcore::getContainer()->get('session');
+        }
+    }
+
+    /**
+     * @deprecated
+     * @todo Remove in Pimcore 11
+     */
+    private function checkSessionStartedInCli(): bool {
+
+        $session = $this->getSession(true);
+        if($session->isStarted()) {
+
+            trigger_deprecation('pimcore/pimcore', '10.5',
+                sprintf('Do not depend on started session in CLI mode for %s, that will not be possible in Pimcore 11.', SessionEnvironment::class));
+
+            return true;
+        }
+
+        return false;
+    }
+
 }

--- a/bundles/EcommerceFrameworkBundle/SessionEnvironment.php
+++ b/bundles/EcommerceFrameworkBundle/SessionEnvironment.php
@@ -19,6 +19,7 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle;
 
 use Pimcore\Bundle\EcommerceFrameworkBundle\Tools\SessionConfigurator;
 use Pimcore\Localization\LocaleServiceInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
@@ -37,13 +38,17 @@ class SessionEnvironment extends Environment implements EnvironmentInterface
     const SESSION_KEY_CHECKOUT_TENANT = 'currentcheckouttenant';
 
     /**
-     * TODO: use RequestStack to get session
      *
      * @deprecated will be removed in Pimcore 11
      *
      * @var SessionInterface
      */
     protected $session;
+
+    /**
+     * @var RequestStack
+     */
+    protected RequestStack $requestStack;
 
     /**
      * @var bool
@@ -57,6 +62,19 @@ class SessionEnvironment extends Environment implements EnvironmentInterface
         $this->session = $session;
     }
 
+    /**
+     * @TODO move to constructor injection in Pimcore 11
+     *
+     * @required
+     * @internal
+     *
+     * @param RequestStack $requestStack
+     */
+    public function setRequestStack(RequestStack $requestStack): void
+    {
+        $this->requestStack = $requestStack;
+    }
+
     protected function load()
     {
         if ($this->sessionLoaded) {
@@ -64,7 +82,7 @@ class SessionEnvironment extends Environment implements EnvironmentInterface
         }
 
         //if the session was not explicitly started in cli environment, do nothing
-        if ('cli' === php_sapi_name() && !$this->session->isStarted()) {
+        if ('cli' === php_sapi_name() && !$this->requestStack->getSession()->isStarted()) {
             return;
         }
 
@@ -88,7 +106,7 @@ class SessionEnvironment extends Environment implements EnvironmentInterface
     public function save()
     {
         //if the session was not explicitly started in cli environment, do nothing
-        if ('cli' === php_sapi_name() && !$this->session->isStarted()) {
+        if ('cli' === php_sapi_name() && !$this->requestStack->getSession()->isStarted()) {
             return;
         }
 
@@ -108,7 +126,7 @@ class SessionEnvironment extends Environment implements EnvironmentInterface
         parent::clearEnvironment();
 
         //if the session was not explicitly started in cli environment, do nothing
-        if ('cli' === php_sapi_name() && !$this->session->isStarted()) {
+        if ('cli' === php_sapi_name() && !$this->requestStack->getSession()->isStarted()) {
             return;
         }
 
@@ -130,7 +148,7 @@ class SessionEnvironment extends Environment implements EnvironmentInterface
     protected function getSessionBag(): AttributeBagInterface
     {
         /** @var AttributeBagInterface $sessionBag */
-        $sessionBag = $this->session->getBag(SessionConfigurator::ATTRIBUTE_BAG_ENVIRONMENT);
+        $sessionBag = $this->requestStack->getSession()->getBag(SessionConfigurator::ATTRIBUTE_BAG_ENVIRONMENT);
 
         return $sessionBag;
     }

--- a/bundles/EcommerceFrameworkBundle/Tracking/TrackingManager.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/TrackingManager.php
@@ -79,6 +79,8 @@ class TrackingManager implements TrackingManagerInterface
     }
 
     /**
+     * @deprecated
+     *
      * @param Session $session
      * @required
      */

--- a/bundles/EcommerceFrameworkBundle/Tracking/TrackingManager.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/TrackingManager.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\EnvironmentInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\EventListener\Frontend\TrackingCodeFlashMessageListener;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractOrder;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\ProductInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
@@ -52,9 +53,17 @@ class TrackingManager implements TrackingManagerInterface
     protected $enviroment = null;
 
     /**
+     *
+     * @deprecated will be removed in Pimcore 11
+     *
      * @var Session
      */
     protected $session;
+
+    /**
+     * @var RequestStack
+     */
+    protected RequestStack $requestStack;
 
     /**
      * @param TrackerInterface[] $trackers
@@ -76,6 +85,19 @@ class TrackingManager implements TrackingManagerInterface
     public function setSession(SessionInterface $session)
     {
         $this->session = $session;
+    }
+
+    /**
+     * @TODO move to constructor injection in Pimcore 11
+     *
+     * @required
+     * @internal
+     *
+     * @param RequestStack $requestStack
+     */
+    public function setRequestStack(RequestStack $requestStack): void
+    {
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -300,7 +322,7 @@ class TrackingManager implements TrackingManagerInterface
             }
         }
 
-        $this->session->getFlashBag()->set(TrackingCodeFlashMessageListener::FLASH_MESSAGE_BAG_KEY, $trackedCodes);
+        $this->requestStack->getSession()->getFlashBag()->set(TrackingCodeFlashMessageListener::FLASH_MESSAGE_BAG_KEY, $trackedCodes);
 
         return $this;
     }

--- a/bundles/EcommerceFrameworkBundle/Tracking/TrackingManager.php
+++ b/bundles/EcommerceFrameworkBundle/Tracking/TrackingManager.php
@@ -322,7 +322,9 @@ class TrackingManager implements TrackingManagerInterface
             }
         }
 
-        $this->requestStack->getSession()->getFlashBag()->set(TrackingCodeFlashMessageListener::FLASH_MESSAGE_BAG_KEY, $trackedCodes);
+        /** @var Session $session */
+        $session = $this->requestStack->getSession();
+        $session->getFlashBag()->set(TrackingCodeFlashMessageListener::FLASH_MESSAGE_BAG_KEY, $trackedCodes);
 
         return $this;
     }

--- a/doc/Development_Documentation/10_E-Commerce_Framework/13_Checkout_Manager/07_Integrating_Payment.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/13_Checkout_Manager/07_Integrating_Payment.md
@@ -59,7 +59,7 @@ A client side handling could look like as follows:
 /**
  * @Route("/checkout-payment-response", name="shop-checkout-payment-response")
  */
-public function paymentResponseAction(Request $request, Factory $factory, SessionInterface $session) {
+public function paymentResponseAction(Request $request, Factory $factory, RequestStack $requestStack) {
      
     // ... do some stuff, and get $cart
      
@@ -77,7 +77,7 @@ public function paymentResponseAction(Request $request, Factory $factory, Sessio
         // $paymentStatus = $payment->executeDebit();
         // $orderAgent = Factory::getInstance()->getOrderManager()->createOrderAgent($order);
         // $orderAgent->updatePayment($paymentStatus);
- 
+        $session = $requestStack->getSession();
         $session->set("last_order_id", $order->getId());
         $goto = $this->generateUrl('shop-checkout-completed');
          

--- a/lib/Http/RequestHelper.php
+++ b/lib/Http/RequestHelper.php
@@ -15,8 +15,10 @@
 
 namespace Pimcore\Http;
 
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\RequestContext;
 
 class RequestHelper
@@ -267,5 +269,15 @@ class RequestHelper
         );
 
         return $request;
+    }
+
+    /**
+     * Gets the current session from RequestStack
+     *
+     * @throws SessionNotFoundException
+     */
+    public function getSession() : SessionInterface
+    {
+        return $this->requestStack->getSession();
     }
 }

--- a/tests/Model/Document/DocumentTest.php
+++ b/tests/Model/Document/DocumentTest.php
@@ -269,6 +269,7 @@ class DocumentTest extends ModelTestCase
 
         $document->setEditable($input);
 
+        $this->buildSession();
         ElementService::saveElementToSession($document);
         $loadedDocument = Service::getElementFromSession('document', $document->getId());
 

--- a/tests/Model/Permissions/ModelAssetPermissionsTest.php
+++ b/tests/Model/Permissions/ModelAssetPermissionsTest.php
@@ -725,23 +725,23 @@ class ModelAssetPermissionsTest extends ModelTestCase
         //update role
         $role = User\Role::getByName('Testrole');
         $role->setWorkspacesAsset([
-            (new User\Workspace\Asset())->setValues(['cId' => $manyElementX->getId(), 'cPath' => $manyElementX->getFullpath(), 'list' => true, 'view' => true]),
-            (new User\Workspace\Asset())->setValues(['cId' => $this->groupfolder->getId(), 'cPath' => $this->groupfolder->getFullpath(), 'list' => true, 'view' => true]),
+            (new User\Workspace\Asset())->setValues(['cId' => $manyElementX->getId(), 'cPath' => $manyElementX->getRealFullPath(), 'list' => true, 'view' => true]),
+            (new User\Workspace\Asset())->setValues(['cId' => $this->groupfolder->getId(), 'cPath' => $this->groupfolder->getRealFullPath(), 'list' => true, 'view' => true]),
         ]);
         $role->save();
 
         //search manyelement
         $this->doTestSearch('manyelement', $admin, array_merge(
                 array_map(function ($item) {
-                    return $item->getFullpath();
+                    return $item->getRealFullPath();
                 }, $manyElementList),
-                [ $manyElementX->getFullpath() ]
+                [ $manyElementX->getRealFullPath() ]
             ), $elementCount + 1
         );
-        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount + 1);
-        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount + 1);
+        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getRealFullPath()], $elementCount + 1);
+        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getRealFullPath()], $elementCount + 1);
 
-        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount);
-        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount);
+        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getRealFullPath()], $elementCount);
+        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getRealFullPath()], $elementCount);
     }
 }

--- a/tests/Model/Permissions/ModelDocumentPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDocumentPermissionsTest.php
@@ -728,23 +728,23 @@ class ModelDocumentPermissionsTest extends ModelTestCase
         //update role
         $role = User\Role::getByName('Testrole');
         $role->setWorkspacesDocument([
-            (new User\Workspace\Document())->setValues(['cId' => $manyElementX->getId(), 'cPath' => $manyElementX->getFullpath(), 'list' => true, 'view' => true]),
-            (new User\Workspace\Document())->setValues(['cId' => $this->groupfolder->getId(), 'cPath' => $this->groupfolder->getFullpath(), 'list' => true, 'view' => true]),
+            (new User\Workspace\Document())->setValues(['cId' => $manyElementX->getId(), 'cPath' => $manyElementX->getRealFullPath(), 'list' => true, 'view' => true]),
+            (new User\Workspace\Document())->setValues(['cId' => $this->groupfolder->getId(), 'cPath' => $this->groupfolder->getRealFullPath(), 'list' => true, 'view' => true]),
         ]);
         $role->save();
 
         //search manyelement
         $this->doTestSearch('manyelement', $admin, array_merge(
                 array_map(function ($item) {
-                    return $item->getFullpath();
+                    return $item->getRealFullPath();
                 }, $manyElementList),
-                [ $manyElementX->getFullpath() ]
+                [ $manyElementX->getRealFullPath() ]
             ), $elementCount + 1
         );
-        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount + 1);
-        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount + 1);
+        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getRealFullPath()], $elementCount + 1);
+        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getRealFullPath()], $elementCount + 1);
 
-        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getFullpath()], $elementCount);
-        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getFullpath()], $elementCount);
+        $this->doTestSearch('manyelement', $this->userPermissionTest1, [$manyElementX->getRealFullPath()], $elementCount);
+        $this->doTestSearch('manyelement', $this->userPermissionTest2, [$manyElementX->getRealFullPath()], $elementCount);
     }
 }

--- a/tests/_support/Test/EcommerceTestCase.php
+++ b/tests/_support/Test/EcommerceTestCase.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Environment;
 use Pimcore\Bundle\EcommerceFrameworkBundle\EnvironmentInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Tools\SessionConfigurator;
 use Pimcore\Localization\LocaleService;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
@@ -55,6 +56,14 @@ abstract class EcommerceTestCase extends TestCase
             $configurator->configure($this->session);
 
             $this->session->getBag(SessionConfigurator::ATTRIBUTE_BAG_CART)->set('carts', []);
+
+            $requestStack = \Pimcore::getContainer()->get('request_stack');
+            if (!$request = $requestStack->getCurrentRequest()) {
+                $request = new Request();
+                $requestStack->push($request);
+            }
+
+            $request->setSession($this->session);
         }
 
         return $this->session;

--- a/tests/_support/Test/ModelTestCase.php
+++ b/tests/_support/Test/ModelTestCase.php
@@ -17,12 +17,23 @@ namespace Pimcore\Tests\Test;
 
 use Pimcore\Tests\Helper\DataType\Calculator;
 use Pimcore\Tests\ModelTester;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 /**
  * @property ModelTester $tester
  */
 abstract class ModelTestCase extends TestCase
 {
+
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+
     /**
      * {@inheritdoc}
      */
@@ -50,5 +61,23 @@ abstract class ModelTestCase extends TestCase
     protected function needsDb()
     {
         return true;
+    }
+
+
+    protected function buildSession(): SessionInterface
+    {
+        if (null === $this->session) {
+            $this->session = new Session(new MockArraySessionStorage());
+
+            $requestStack = \Pimcore::getContainer()->get('request_stack');
+            if (!$request = $requestStack->getCurrentRequest()) {
+                $request = new Request();
+                $requestStack->push($request);
+            }
+
+            $request->setSession($this->session);
+        }
+
+        return $this->session;
     }
 }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #11042

## Additional info  
- [x] Registering a session bag through Session Configurator will not work anymore on Symfony 6 as Session service is removed. Use Event Listeners to register session bags before the session is started. Done here https://github.com/pimcore/pimcore/pull/12294