### PR TITLE
[Improvement] use composer name for packagename

### DIFF
--- a/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/05_Pimcore_Bundles/README.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/05_Pimcore_Bundles/README.md
@@ -124,8 +124,11 @@ extension manager grid. As pimcore includes the [ocramius/package-versions](http
 library which generates a list of package versions installed via composer you can easily use that library to return the 
 installed version of your bundle.
 
-Pimcore provides a `Pimcore\Extension\Bundle\Traits\PackageVersionTrait` which you can include in your bundle. All you need
-to do is to implement a `getComposerPackageName` method returning the name of your composer package (e.g. `company/foo-bundle`):
+Pimcore provides a `Pimcore\Extension\Bundle\Traits\PackageVersionTrait` which you can include in your bundle. The trait
+includes a `getComposerPackageName` method which will return the name defined in your `composer.json` file.
+
+If you want to change the default behavior all you need to do is to override the `getComposerPackageName` method returning
+the name of your composer package (e.g. `company/foo-bundle`):
 
 
 ```php

--- a/lib/Extension/Bundle/Traits/PackageVersionTrait.php
+++ b/lib/Extension/Bundle/Traits/PackageVersionTrait.php
@@ -22,9 +22,8 @@ use PackageVersions\Versions;
 use Pimcore\Composer\PackageInfo;
 
 /**
- * Exposes a simple getVersion() implementation by looking up the installed versions via ocramius/package-versions
- * which is generated on composer install. This trait can be used by using it from a bundle class and implementing
- * getComposerPackageName() to return the name of the composer package to lookup.
+ * Exposes a simple getVersion() and getComposerPackageName() implementation by looking up the installed versions 
+ * via ocramius/package-versions which is generated on composer install.
  */
 trait PackageVersionTrait
 {

--- a/lib/Extension/Bundle/Traits/PackageVersionTrait.php
+++ b/lib/Extension/Bundle/Traits/PackageVersionTrait.php
@@ -27,12 +27,26 @@ use Pimcore\Composer\PackageInfo;
  */
 trait PackageVersionTrait
 {
+
     /**
      * Returns the composer package name used to resolve the version
      *
      * @return string
      */
-    abstract protected function getComposerPackageName(): string;
+    public function getComposerPackageName(): string {
+        $composerFile = __DIR__ . '/../composer.json';
+
+        if (file_exists($composerFile)) {
+            $composerConfig = file_get_contents($composerFile);
+            $composerConfig = json_decode($composerConfig);
+
+            if (property_exists($composerConfig, 'name')) {
+                return $composerConfig->name;
+            }
+        }
+
+        return '';
+    }
 
     /**
      * {@inheritdoc}

--- a/lib/Extension/Bundle/Traits/PackageVersionTrait.php
+++ b/lib/Extension/Bundle/Traits/PackageVersionTrait.php
@@ -34,7 +34,8 @@ trait PackageVersionTrait
      *
      * @return string
      */
-    public function getComposerPackageName(): string {
+    public function getComposerPackageName(): string
+    {
         foreach (InstalledVersions::getAllRawData() as $installed) {
             foreach ($installed['versions'] as $packageName => $packageInfo) {
                 if (!isset($packageInfo['install_path'])) {

--- a/lib/Extension/Bundle/Traits/PackageVersionTrait.php
+++ b/lib/Extension/Bundle/Traits/PackageVersionTrait.php
@@ -34,14 +34,13 @@ trait PackageVersionTrait
      * @return string
      */
     public function getComposerPackageName(): string {
-        $composerFile = __DIR__ . '/../composer.json';
-
-        if (file_exists($composerFile)) {
-            $composerConfig = file_get_contents($composerFile);
-            $composerConfig = json_decode($composerConfig);
-
-            if (property_exists($composerConfig, 'name')) {
-                return $composerConfig->name;
+        foreach([__DIR__ . '/../composer.json', __DIR__ . '/composer.json'] as $composerFile) {
+            if (file_exists($composerFile)) {
+                $composerConfig = json_decode(file_get_contents($composerFile));
+    
+                if (property_exists($composerConfig, 'name')) {
+                    return $composerConfig->name;
+                }
             }
         }
 

--- a/lib/Extension/Bundle/Traits/PackageVersionTrait.php
+++ b/lib/Extension/Bundle/Traits/PackageVersionTrait.php
@@ -35,7 +35,7 @@ trait PackageVersionTrait
      */
     public function getComposerPackageName(): string {
         foreach([__DIR__ . '/../composer.json', __DIR__ . '/composer.json'] as $composerFile) {
-            if (file_exists($composerFile)) {
+            if (is_file($composerFile)) {
                 $composerConfig = json_decode(file_get_contents($composerFile));
     
                 if (property_exists($composerConfig, 'name')) {

--- a/lib/Extension/Bundle/Traits/PackageVersionTrait.php
+++ b/lib/Extension/Bundle/Traits/PackageVersionTrait.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Extension\Bundle\Traits;
 
+use Composer\InstalledVersions;
 use PackageVersions\Versions;
 use Pimcore\Composer\PackageInfo;
 
@@ -34,12 +35,15 @@ trait PackageVersionTrait
      * @return string
      */
     public function getComposerPackageName(): string {
-        foreach([__DIR__ . '/../composer.json', __DIR__ . '/composer.json'] as $composerFile) {
-            if (is_file($composerFile)) {
-                $composerConfig = json_decode(file_get_contents($composerFile));
-    
-                if (property_exists($composerConfig, 'name')) {
-                    return $composerConfig->name;
+        foreach (InstalledVersions::getAllRawData() as $installed) {
+            foreach ($installed['versions'] as $packageName => $packageInfo) {
+                if (!isset($packageInfo['install_path'])) {
+                    // It's a replaced or provided (virtual) package
+                    continue;
+                }
+
+                if (str_starts_with(__DIR__, realpath($packageInfo['install_path']))) {
+                    return $packageName;
                 }
             }
         }


### PR DESCRIPTION
Use 'name' property of composer.json for packageVersionTrait

co-authored: @passioneight
  

## Changes in this pull request  
Resolves #6154

## Additional info  

