### PR TITLE
Restore Info Block for definition files

### DIFF
--- a/bundles/CoreBundle/Resources/config/class_builder.yaml
+++ b/bundles/CoreBundle/Resources/config/class_builder.yaml
@@ -14,6 +14,7 @@ services:
 
     Pimcore\DataObject\ClassBuilder\FieldDefinitionDocBlockBuilderInterface:
         class: 'Pimcore\DataObject\ClassBuilder\FieldDefinitionDocBlockBuilder'
+        public: true
 
     Pimcore\DataObject\ClassBuilder\FieldDefinitionPropertiesBuilderInterface:
         class: 'Pimcore\DataObject\ClassBuilder\FieldDefinitionPropertiesBuilder'
@@ -45,4 +46,4 @@ services:
     Pimcore\DataObject\ClassBuilder\PHPObjectBrickContainerClassDumperInterface:
         class: 'Pimcore\DataObject\ClassBuilder\PHPObjectBrickContainerClassDumper'
         public: true
-    
+

--- a/lib/DataObject/ClassBuilder/ClassBuilder.php
+++ b/lib/DataObject/ClassBuilder/ClassBuilder.php
@@ -38,27 +38,27 @@ class ClassBuilder implements ClassBuilderInterface
         $cd = '<?php';
         $cd .= "\n\n";
         $cd .= '/**' . "\n";
-        $cd .= '* Inheritance: '.($classDefinition->getAllowInherit() ? 'yes' : 'no')."\n";
-        $cd .= '* Variants: '.($classDefinition->getAllowVariants() ? 'yes' : 'no')."\n";
+        $cd .= ' * Inheritance: '.($classDefinition->getAllowInherit() ? 'yes' : 'no')."\n";
+        $cd .= ' * Variants: '.($classDefinition->getAllowVariants() ? 'yes' : 'no')."\n";
 
-        if ($classDefinition->getDescription()) {
+        if ($description = $classDefinition->getDescription()) {
             $description = str_replace(
                 ['/**', '*/', '//', "\n"],
-                ['', '', '', "\n* "],
-                $classDefinition->getDescription()
+                ['', '', '', "\n * "],
+                $description
             );
 
-            $cd .= '* '.$description."\n";
+            $cd .= ' * '.$description."\n";
         }
 
-        $cd .= "\n\n";
-        $cd .= "Fields Summary:\n";
+        $cd .= " *\n";
+        $cd .= " * Fields Summary:\n";
 
         foreach ($classDefinition->getFieldDefinitions() as $fieldDefinition) {
-            $cd .= $this->fieldDefinitionDocBlockBuilder->buildFieldDefinitionDocBlock($fieldDefinition);
+            $cd .= ' * ' . str_replace("\n", "\n * ", trim($this->fieldDefinitionDocBlockBuilder->buildFieldDefinitionDocBlock($fieldDefinition))) . "\n";
         }
 
-        $cd .= '*/';
+        $cd .= ' */';
         $cd .= "\n\n";
         $cd .= 'namespace Pimcore\\Model\\DataObject;';
         $cd .= "\n\n";

--- a/lib/DataObject/ClassBuilder/FieldCollectionClassBuilder.php
+++ b/lib/DataObject/ClassBuilder/FieldCollectionClassBuilder.php
@@ -33,13 +33,13 @@ class FieldCollectionClassBuilder implements FieldCollectionClassBuilderInterfac
         }
 
         $infoDocBlock = '/**' . "\n";
-        $infoDocBlock .= "Fields Summary:\n";
+        $infoDocBlock .= " * Fields Summary:\n";
 
         foreach ($definition->getFieldDefinitions() as $fieldDefinition) {
-            $infoDocBlock .= $this->fieldDefinitionDocBlockBuilder->buildFieldDefinitionDocBlock($fieldDefinition);
+            $infoDocBlock .= ' * ' . str_replace("\n", "\n * ", trim($this->fieldDefinitionDocBlockBuilder->buildFieldDefinitionDocBlock($fieldDefinition))) . "\n";
         }
 
-        $infoDocBlock .= '*/';
+        $infoDocBlock .= ' */';
 
         // create class file
         $cd = '<?php';

--- a/lib/DataObject/ClassBuilder/ObjectBrickClassBuilder.php
+++ b/lib/DataObject/ClassBuilder/ObjectBrickClassBuilder.php
@@ -33,13 +33,13 @@ class ObjectBrickClassBuilder implements ObjectBrickClassBuilderInterface
         }
 
         $infoDocBlock = '/**' . "\n";
-        $infoDocBlock .= "Fields Summary:\n";
+        $infoDocBlock .= " * Fields Summary:\n";
 
         foreach ($definition->getFieldDefinitions() as $fieldDefinition) {
-            $infoDocBlock .= $this->fieldDefinitionDocBlockBuilder->buildFieldDefinitionDocBlock($fieldDefinition);
+            $infoDocBlock .= ' * ' . str_replace("\n", "\n * ", trim($this->fieldDefinitionDocBlockBuilder->buildFieldDefinitionDocBlock($fieldDefinition))) . "\n";
         }
 
-        $infoDocBlock .= '*/';
+        $infoDocBlock .= ' */';
 
         $cd = '<?php';
         $cd .= "\n\n";

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -511,7 +511,7 @@ final class ClassDefinition extends Model\AbstractModel
             $data .= $this->getInfoDocBlock();
             $data .= "\n\n";
 
-            $data .= "\nreturn ".$exportedClass.";\n";
+            $data .= 'return '.$exportedClass.";\n";
 
             \Pimcore\File::putPhpFile($definitionFile, $data);
         }
@@ -528,22 +528,22 @@ final class ClassDefinition extends Model\AbstractModel
         $cd .= ' * Inheritance: '.($this->getAllowInherit() ? 'yes' : 'no')."\n";
         $cd .= ' * Variants: '.($this->getAllowVariants() ? 'yes' : 'no')."\n";
 
-        if ($this->getDescription()) {
-            $description = str_replace(['/**', '*/', '//'], '', $this->getDescription());
+        if ($description = $this->getDescription()) {
+            $description = str_replace(['/**', '*/', '//'], '', $description);
             $description = str_replace("\n", "\n * ", $description);
 
             $cd .= ' * '.$description."\n";
         }
 
-        $cd .= "\n\n";
-        $cd .= "Fields Summary:\n";
+        $cd .= " *\n";
+        $cd .= " * Fields Summary:\n";
 
         $fieldDefinitionDocBlockBuilder = \Pimcore::getContainer()->get(FieldDefinitionDocBlockBuilderInterface::class);
         foreach ($this->getFieldDefinitions() as $fieldDefinition) {
-            $cd .= $fieldDefinitionDocBlockBuilder->buildFieldDefinitionDocBlock($fieldDefinition);
+            $cd .= ' * ' . str_replace("\n", "\n * ", trim($fieldDefinitionDocBlockBuilder->buildFieldDefinitionDocBlock($fieldDefinition))) . "\n";
         }
 
-        $cd .= '*/';
+        $cd .= ' */';
 
         return $cd;
     }

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -525,14 +525,14 @@ final class ClassDefinition extends Model\AbstractModel
     protected function getInfoDocBlock(): string
     {
         $cd = '/**' . "\n";
-        $cd .= '* Inheritance: '.($this->getAllowInherit() ? 'yes' : 'no')."\n";
-        $cd .= '* Variants: '.($this->getAllowVariants() ? 'yes' : 'no')."\n";
+        $cd .= ' * Inheritance: '.($this->getAllowInherit() ? 'yes' : 'no')."\n";
+        $cd .= ' * Variants: '.($this->getAllowVariants() ? 'yes' : 'no')."\n";
 
         if ($this->getDescription()) {
             $description = str_replace(['/**', '*/', '//'], '', $this->getDescription());
-            $description = str_replace("\n", "\n* ", $description);
+            $description = str_replace("\n", "\n * ", $description);
 
-            $cd .= '* '.$description."\n";
+            $cd .= ' * '.$description."\n";
         }
 
         $cd .= "\n\n";

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -16,12 +16,12 @@
 namespace Pimcore\Model\DataObject;
 
 use Pimcore\Cache;
+use Pimcore\DataObject\ClassBuilder\FieldDefinitionDocBlockBuilderInterface;
 use Pimcore\DataObject\ClassBuilder\PHPClassDumperInterface;
 use Pimcore\Db;
 use Pimcore\Event\DataObjectClassDefinitionEvents;
 use Pimcore\Event\Model\DataObject\ClassDefinitionEvent;
 use Pimcore\Event\Traits\RecursionBlockingEventDispatchHelperTrait;
-use Pimcore\File;
 use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
@@ -508,11 +508,44 @@ final class ClassDefinition extends Model\AbstractModel
 
             $data = '<?php';
             $data .= "\n\n";
+            $data .= $this->getInfoDocBlock();
+            $data .= "\n\n";
 
             $data .= "\nreturn ".$exportedClass.";\n";
 
             \Pimcore\File::putPhpFile($definitionFile, $data);
         }
+    }
+
+    /**
+     * @return string
+     *
+     * @internal
+     */
+    protected function getInfoDocBlock(): string
+    {
+        $cd = '/**' . "\n";
+        $cd .= '* Inheritance: '.($this->getAllowInherit() ? 'yes' : 'no')."\n";
+        $cd .= '* Variants: '.($this->getAllowVariants() ? 'yes' : 'no')."\n";
+
+        if ($this->getDescription()) {
+            $description = str_replace(['/**', '*/', '//'], '', $this->getDescription());
+            $description = str_replace("\n", "\n* ", $description);
+
+            $cd .= '* '.$description."\n";
+        }
+
+        $cd .= "\n\n";
+        $cd .= "Fields Summary:\n";
+
+        $fieldDefinitionDocBlockBuilder = \Pimcore::getContainer()->get(FieldDefinitionDocBlockBuilderInterface::class);
+        foreach ($this->getFieldDefinitions() as $fieldDefinition) {
+            $cd .= $fieldDefinitionDocBlockBuilder->buildFieldDefinitionDocBlock($fieldDefinition);
+        }
+
+        $cd .= '*/';
+
+        return $cd;
     }
 
     public function delete()

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Model\DataObject\Fieldcollection;
 
+use Pimcore\DataObject\ClassBuilder\FieldDefinitionDocBlockBuilderInterface;
 use Pimcore\DataObject\ClassBuilder\PHPFieldCollectionClassDumperInterface;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
@@ -194,6 +195,8 @@ class Definition extends Model\AbstractModel
 
             $data = '<?php';
             $data .= "\n\n";
+            $data .=  $this->getInfoDocBlock();
+            $data .= "\n\n";
 
             $data .= "\nreturn " . $exportedClass . ";\n";
 
@@ -268,5 +271,25 @@ class Definition extends Model\AbstractModel
     public function getPhpClassFile()
     {
         return $this->locateFile(ucfirst($this->getKey()), 'DataObject/Fieldcollection/Data/%s.php');
+    }
+
+    /**
+     * @internal
+     *
+     * @return string
+     */
+    protected function getInfoDocBlock(): string
+    {
+        $cd = '/**' . "\n";
+        $cd .= "Fields Summary:\n";
+
+        $fieldDefinitionDocBlockBuilder = \Pimcore::getContainer()->get(FieldDefinitionDocBlockBuilderInterface::class);
+        foreach ($this->getFieldDefinitions() as $fieldDefinition) {
+            $cd .= $fieldDefinitionDocBlockBuilder->buildFieldDefinitionDocBlock($fieldDefinition);
+        }
+
+        $cd .= '*/';
+
+        return $cd;
     }
 }

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -198,7 +198,7 @@ class Definition extends Model\AbstractModel
             $data .=  $this->getInfoDocBlock();
             $data .= "\n\n";
 
-            $data .= "\nreturn " . $exportedClass . ";\n";
+            $data .= 'return ' . $exportedClass . ";\n";
 
             \Pimcore\File::put($definitionFile, $data);
         }
@@ -281,14 +281,14 @@ class Definition extends Model\AbstractModel
     protected function getInfoDocBlock(): string
     {
         $cd = '/**' . "\n";
-        $cd .= "Fields Summary:\n";
+        $cd .= " * Fields Summary:\n";
 
         $fieldDefinitionDocBlockBuilder = \Pimcore::getContainer()->get(FieldDefinitionDocBlockBuilderInterface::class);
         foreach ($this->getFieldDefinitions() as $fieldDefinition) {
-            $cd .= $fieldDefinitionDocBlockBuilder->buildFieldDefinitionDocBlock($fieldDefinition);
+            $cd .= ' * ' . str_replace("\n", "\n * ", trim($fieldDefinitionDocBlockBuilder->buildFieldDefinitionDocBlock($fieldDefinition))) . "\n";
         }
 
-        $cd .= '*/';
+        $cd .= ' */';
 
         return $cd;
     }

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -263,7 +263,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
             $data .= $this->getInfoDocBlock();
             $data .= "\n\n";
 
-            $data .= "\nreturn " . $exportedClass . ";\n";
+            $data .= 'return ' . $exportedClass . ";\n";
 
             \Pimcore\File::put($definitionFile, $data);
         }

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -260,6 +260,8 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
 
             $data = '<?php';
             $data .= "\n\n";
+            $data .= $this->getInfoDocBlock();
+            $data .= "\n\n";
 
             $data .= "\nreturn " . $exportedClass . ";\n";
 


### PR DESCRIPTION
Restores the deleted info blocks in class/fieldcollection/objectbrick definition files.
See https://github.com/pimcore/pimcore/pull/11373#discussion_r883468253