### PR TITLE
Annotate static getContainer method as deprecated

### DIFF
--- a/lib/Pimcore.php
+++ b/lib/Pimcore.php
@@ -162,6 +162,7 @@ class Pimcore
      * needing to access the container directly. This exists mainly for compatibility with legacy code.
      *
      * @internal
+     * @deprecated
      *
      * @return ContainerInterface|null
      */

--- a/lib/Pimcore.php
+++ b/lib/Pimcore.php
@@ -162,7 +162,7 @@ class Pimcore
      * needing to access the container directly. This exists mainly for compatibility with legacy code.
      *
      * @internal
-     * @deprecated
+     * @deprecated this method just exists for legacy reasons and shouldn't be used in new code
      *
      * @return ContainerInterface|null
      */


### PR DESCRIPTION
Annotate discouraged method as deprecated to stop people from using it in new code

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.4`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Relates to: https://github.com/pimcore/pimcore/issues/10952#issuecomment-1139347223

The use of `\Pimcore::getContainer()` is a bad practice, as services should be wired in instead of yoinking them out of the container. The comment for the method says that it only really exists for legacy compatibility, yet it's still being used in [new](https://github.com/pimcore/pimcore/blob/10.x/lib/Console/Traits/Parallelization.php#L138) [code](https://github.com/pimcore/data-hub/blob/1.4/src/GraphQL/Mutation/MutationType.php#L260) (thanks @micru).

Annotating it as deprecated will actually mark it as such in the IDE, hopefully resulting in no new code using this.