### PR TITLE
Added Default Value and Default Value Generator to Textarea

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/textarea.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/textarea.js
@@ -66,6 +66,21 @@ pimcore.object.classes.data.textarea = Class.create(pimcore.object.classes.data.
 
     getSpecificPanelItems: function (datax, inEncryptedField) {
         return [
+	    {
+                xtype: "textfield",
+                fieldLabel: t("default_value"),
+                name: "defaultValue",
+                value: datax.defaultValue,
+                width: 600
+            },
+            {
+                xtype: 'textfield',
+                width: 600,
+                fieldLabel: t("default_value_generator"),
+                labelWidth: 140,
+                name: 'defaultValueGenerator',
+                value: datax.defaultValueGenerator
+            },
             {
                 xtype: "textfield",
                 fieldLabel: t("width"),
@@ -118,6 +133,8 @@ pimcore.object.classes.data.textarea = Class.create(pimcore.object.classes.data.
                     width: source.datax.width,
                     height: source.datax.height,
                     maxLength: source.datax.maxLength,
+		    defaultValue: source.datax.defaultValue,
+                    defaultValueGenerator: source.datax.defaultValueGenerator,
                     showCharCount: source.datax.showCharCount,
                     excludeFromSearchIndex: source.datax.excludeFromSearchIndex
                 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/textarea.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/textarea.js
@@ -21,6 +21,14 @@ pimcore.object.tags.textarea = Class.create(pimcore.object.tags.abstract, {
         this.fieldConfig = fieldConfig;
 
     },
+		
+    applyDefaultValue: function() {
+        this.defaultValue = null;
+        if ((typeof this.data === "undefined" || !this.data) && this.fieldConfig.defaultValue && this.context.type === "classificationstore") {
+            this.data = this.fieldConfig.defaultValue;
+            this.defaultValue = this.fieldConfig.defaultValue;
+        }
+    },
 
     getGridColumnEditor: function(field) {
         var editorConfig = {};

--- a/models/DataObject/ClassDefinition/Data/Textarea.php
+++ b/models/DataObject/ClassDefinition/Data/Textarea.php
@@ -25,6 +25,7 @@ class Textarea extends Data implements ResourcePersistenceAwareInterface, QueryR
     use Model\DataObject\Traits\SimpleComparisonTrait;
     use Extension\ColumnType;
     use Extension\QueryColumnType;
+    use Model\DataObject\Traits\DefaultValueTrait;
     use Model\DataObject\Traits\SimpleNormalizerTrait;
 
     /**
@@ -49,6 +50,12 @@ class Textarea extends Data implements ResourcePersistenceAwareInterface, QueryR
      * @var string|int
      */
     public $height = 0;
+    /**
+     * @internal
+     *
+     * @var string|null
+     */
+    public $defaultValue;
 
     /**
      * @internal
@@ -198,6 +205,8 @@ class Textarea extends Data implements ResourcePersistenceAwareInterface, QueryR
      */
     public function getDataForResource($data, $object = null, $params = [])
     {
+	$data = $this->handleDefaultValue($data, $object, $params);
+
         return $data;
     }
 
@@ -316,6 +325,36 @@ class Textarea extends Data implements ResourcePersistenceAwareInterface, QueryR
     public function isFilterable(): bool
     {
         return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doGetDefaultValue($object, $context = [])
+    {
+        return $this->getDefaultValue();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDefaultValue()
+    {
+        return $this->defaultValue;
+    }
+
+    /**
+     * @param string $defaultValue
+     *
+     * @return $this
+     */
+    public function setDefaultValue($defaultValue)
+    {
+        if ((string)$defaultValue !== '') {
+            $this->defaultValue = $defaultValue;
+        }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Added Default Value and Default Value Generator to the Field "Textarea". The approach was basically copying the the the definition of the "input" field.

However, I would prefer some more testing by a indendent third person with more experience of pimcore than me. (!!!!)

Not sure whether the the initial function of ./vendor/pimcore/pimcore/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/textarea.js should not be more like the following

    initialize: function (data, fieldConfig) {

        this.data = "";

        if (data) {
            this.data = data;
        }
        this.fieldConfig = fieldConfig;
    },


