### PR TITLE
Fix new PhpStan errors

### DIFF
--- a/lib/Localization/IntlFormatter.php
+++ b/lib/Localization/IntlFormatter.php
@@ -120,7 +120,9 @@ class IntlFormatter
     /**
      * @param string $format
      *
-     * @return \IntlDateFormatter|\Symfony\Component\Intl\DateFormatter\IntlDateFormatter
+     * @return \IntlDateFormatter
+     *
+     * @throws \RuntimeException
      */
     protected function buildDateTimeFormatters($format)
     {


### PR DESCRIPTION
```
 ------ ---------------------------------------------------------------- 
  Line   lib/Localization/IntlFormatter.php                              
 ------ ---------------------------------------------------------------- 
  201    Property Pimcore\Localization\IntlFormatter::$dateFormatters    
         (array<IntlDateFormatter>) does not accept                      
         array<Symfony\Component\Intl\DateFormatter\IntlDateFormatter>.  
 ------ ---------------------------------------------------------------- 


Error: ] Found 1 error
```