### PR TITLE
[Docs] Fix example env() usage

### DIFF
--- a/doc/Development_Documentation/01_Getting_Started/01_Advanced_Installation_Topics.md
+++ b/doc/Development_Documentation/01_Getting_Started/01_Advanced_Installation_Topics.md
@@ -39,8 +39,8 @@ pimcore_install:
             
             # env variables can be directly read with the %env() syntax
             # see https://symfony.com/blog/new-in-symfony-3-2-runtime-environment-variables
-            host:                 %env(DB_HOST)%
-            port:                 %env(DB_PORT)%
+            host:                 "%env(DB_HOST)%"
+            port:                 "%env(DB_PORT)%"
 ```
 
 


### PR DESCRIPTION
## Changes in this pull request  
Just a minor fix in the example `%env()%` usage, as `"` are required for plain scalar values.  See [Symfony](https://symfony.com/blog/new-in-symfony-3-2-runtime-environment-variables)


