### PR TITLE
Fix — grid options cant save

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
@@ -104,7 +104,7 @@ pimcore.object.helpers.grid = Class.create({
 
                 // Don't add batch options if field has dynamic options
                 if (
-                    !fieldConfig.hasOwnProperty('layout')
+                    !fieldConfig.hasOwnProperty('layout') || typeof (fieldConfig.layout) === 'undefined'
                     || !fieldConfig.layout.hasOwnProperty('dynamicOptions')
                     || fieldConfig.layout.dynamicOptions !== true
                 ) {


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.4`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [x] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [x] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  

## Changes in this pull request  
Resolves #12281

## Additional info  

When I'm trying to apply grid options the `fieldConfig` in `bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js` has a `layout` but it's undefined. So when JS is trying to check `fieldConfig.layout.hasOwnProperty('dynamicOptions')` it's actually trying to call `hasOwnProperty` on undefined. 
I've fixed it by check type of `fieldConfig.layout`
