### PR TITLE
[Docs] Remove description how to setup cronjob randomness

### DIFF
--- a/doc/Development_Documentation/01_Getting_Started/01_Advanced_Installation_Topics.md
+++ b/doc/Development_Documentation/01_Getting_Started/01_Advanced_Installation_Topics.md
@@ -45,6 +45,9 @@ pimcore_install:
 
 
 ## Add some randomness to the maintenance cron job
+
+In case you've got multiple Pimcore Projects on one (Development-)Server, you can add some randomness to the start times of the cron jobs to mitigate the risk of multiple tasks starting in parallel.
+
 ```bash
 # We need bash since RANDOM is a bash builtin
 SHELL=/bin/bash

--- a/doc/Development_Documentation/01_Getting_Started/01_Advanced_Installation_Topics.md
+++ b/doc/Development_Documentation/01_Getting_Started/01_Advanced_Installation_Topics.md
@@ -42,15 +42,3 @@ pimcore_install:
             host:                 %env(DB_HOST)%
             port:                 %env(DB_PORT)%
 ```
-
-
-## Add some randomness to the maintenance cron job
-
-In case you've got multiple Pimcore Projects on one (Development-)Server, you can add some randomness to the start times of the cron jobs to mitigate the risk of multiple tasks starting in parallel.
-
-```bash
-# We need bash since RANDOM is a bash builtin
-SHELL=/bin/bash
-
-*/5 * * * * sleep $[ ( $RANDOM \% 120 ) + 1 ]s ; /your/project/bin/console maintenance
-```


### PR DESCRIPTION
This explanation somehow got missing in the newer docs. I just asked myself why someone would want to do this, so I [dug for the reason](https://github.com/pimcore/pimcore/commit/cbbd9adf63efe53138824cebc1ebe790493a35df#diff-d875910eed5015570bbe4577091b0fad971b2eba0f929c2809dcf81d8fdb3b8eR77). I'd suggest re-adding the explanation to the docs.

To be honest, I'm not entirely sure if this is actually needed in Pimcore X, since we've got the message queue now. What do you think?