### PR TITLE
Remove internal annotation from navigation builder

### DIFF
--- a/lib/Navigation/Builder.php
+++ b/lib/Navigation/Builder.php
@@ -24,9 +24,6 @@ use Pimcore\Navigation\Iterator\PrefixRecursiveFilterIterator;
 use Pimcore\Navigation\Page\Document as DocumentPage;
 use Pimcore\Navigation\Page\Url;
 
-/**
- * @internal
- */
 class Builder
 {
     /**
@@ -35,11 +32,13 @@ class Builder
     private $requestHelper;
 
     /**
+     * @internal
      * @var string
      */
     protected $htmlMenuIdPrefix;
 
     /**
+     * @internal
      * @var string
      */
     protected $pageClass = DocumentPage::class;
@@ -205,6 +204,8 @@ class Builder
     }
 
     /**
+     * @internal
+     * 
      * @param Container $navigation navigation container to iterate
      * @param string $property name of property to match against
      * @param string $value value to match property against
@@ -221,6 +222,8 @@ class Builder
     }
 
     /**
+     * @internal
+     * 
      * @param Page $page
      * @param bool $isActive
      *
@@ -288,6 +291,8 @@ class Builder
     }
 
     /**
+     * @internal
+     * 
      * @param Document $parentDocument
      * @param bool $isRoot
      * @param callable $pageCallback


### PR DESCRIPTION
This pull request removes the internal annotation from the navigation builder and adds an internal annotation to all protected methods and properties of the navigation builder.

Resolves #12276