### PR TITLE
[Ecommerce] Add Event to GetFields-Method of IndexController

### DIFF
--- a/bundles/EcommerceFrameworkBundle/Controller/IndexController.php
+++ b/bundles/EcommerceFrameworkBundle/Controller/IndexController.php
@@ -159,7 +159,7 @@ class IndexController extends AdminController
         ksort($fields);
 
         $event = new GenericEvent(null, ['data' => $fields]);
-        $eventDispatcher->dispatch($event, AdminEvents::GET_FIELD_NAMES_PRE_SEND_DATA);
+        $eventDispatcher->dispatch($event, AdminEvents::GET_INDEX_FIELD_NAMES_PRE_SEND_DATA);
         $data = $event->getArgument('data');
         return $this->adminJson(['data' => array_values($data)]);
     }

--- a/bundles/EcommerceFrameworkBundle/Controller/IndexController.php
+++ b/bundles/EcommerceFrameworkBundle/Controller/IndexController.php
@@ -159,7 +159,7 @@ class IndexController extends AdminController
         ksort($fields);
 
         $event = new GenericEvent(null, ['data' => $fields]);
-        $eventDispatcher->dispatch($event, AdminEvents::GET_FIELD_NAMES);
+        $eventDispatcher->dispatch($event, AdminEvents::GET_FIELD_NAMES_PRE_SEND_DATA);
         $data = $event->getArgument('data');
         return $this->adminJson(['data' => array_values($data)]);
     }

--- a/bundles/EcommerceFrameworkBundle/Controller/IndexController.php
+++ b/bundles/EcommerceFrameworkBundle/Controller/IndexController.php
@@ -112,9 +112,11 @@ class IndexController extends AdminController
      *
      * @param Request $request
      *
+     * @param EventDispatcherInterface $eventDispatcher
+     *
      * @return \Pimcore\Bundle\AdminBundle\HttpFoundation\JsonResponse
      */
-    public function getFieldsAction(Request $request)
+    public function getFieldsAction(Request $request, EventDispatcherInterface $eventDispatcher)
     {
         $indexService = Factory::getInstance()->getIndexService();
 
@@ -156,7 +158,10 @@ class IndexController extends AdminController
 
         ksort($fields);
 
-        return $this->adminJson(['data' => array_values($fields)]);
+        $event = new GenericEvent(null, ['data' => $fields]);
+        $eventDispatcher->dispatch($event, AdminEvents::GET_FIELD_NAMES);
+        $data = $event->getArgument('data');
+        return $this->adminJson(['data' => array_values($data)]);
     }
 
     /**

--- a/lib/Event/Ecommerce/AdminEvents.php
+++ b/lib/Event/Ecommerce/AdminEvents.php
@@ -25,4 +25,13 @@ final class AdminEvents
      * @var string
      */
     const GET_VALUES_FOR_FILTER_FIELD_PRE_SEND_DATA = 'pimcore.admin.ecommerce.getValuesForFilterFieldPreSendData';
+    
+    /**
+     * Fired when filter fields get fetched
+     *
+     * @Event("Symfony\Component\EventDispatcher\GenericEvent")
+     *
+     * @var string
+     */
+    const GET_FIELD_NAMES_PRE_SEND_DATA = 'pimcore.admin.ecommerce.getFieldNamesPreSendData';
 }

--- a/lib/Event/Ecommerce/AdminEvents.php
+++ b/lib/Event/Ecommerce/AdminEvents.php
@@ -33,5 +33,5 @@ final class AdminEvents
      *
      * @var string
      */
-    const GET_FIELD_NAMES_PRE_SEND_DATA = 'pimcore.admin.ecommerce.getFieldNamesPreSendData';
+    const GET_INDEX_FIELD_NAMES_PRE_SEND_DATA = 'pimcore.admin.ecommerce.getIndexFieldNamesPreSendData';
 }


### PR DESCRIPTION

Sometimes, it would be useful to exclude/change some of the fields returned by the getFieldsAction method of the IndexController. I propose dispatching an event (like it already happens within the getValuesForFilterFieldAction method).