### PR TITLE
[Grid exports] Initially enable inheritance

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridexport/csv.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridexport/csv.js
@@ -26,6 +26,7 @@ pimcore.object.gridexport.csv = Class.create(pimcore.element.gridexport.abstract
             fieldLabel: t('enable_inheritance'),
             name: 'enableInheritance',
             value: true,
+            inputValue: true,
             labelWidth: 200
         });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridexport/csv.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridexport/csv.js
@@ -25,7 +25,7 @@ pimcore.object.gridexport.csv = Class.create(pimcore.element.gridexport.abstract
         var enableInheritance = new Ext.form.Checkbox({
             fieldLabel: t('enable_inheritance'),
             name: 'enableInheritance',
-            inputValue: true,
+            value: true,
             labelWidth: 200
         });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridexport/xlsx.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridexport/xlsx.js
@@ -25,6 +25,7 @@ pimcore.object.gridexport.xlsx = Class.create(pimcore.element.gridexport.abstrac
             fieldLabel: t('enable_inheritance'),
             name: 'enableInheritance',
             value: true,
+            inputValue: true,
             labelWidth: 200
         });
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridexport/xlsx.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridexport/xlsx.js
@@ -24,7 +24,7 @@ pimcore.object.gridexport.xlsx = Class.create(pimcore.element.gridexport.abstrac
         var enableInheritance = new Ext.form.Checkbox({
             fieldLabel: t('enable_inheritance'),
             name: 'enableInheritance',
-            inputValue: true,
+            value: true,
             labelWidth: 200
         });
 


### PR DESCRIPTION
Currently due the non-existing ExtJs config `inputValue` in 
https://github.com/pimcore/pimcore/blob/52eb193be4307054a161d65bdd2ac0f7fb32227d/bundles/AdminBundle/Resources/public/js/pimcore/object/gridexport/csv.js#L28
inheritance is not enabled initially. Thus values may differ from what the user sees in the grid table. Imho in the default setting the export data should be the same as in the grid.