### PR TITLE
 fix: UserController::updateUser does not update all properties

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -284,7 +284,7 @@ class UserController extends AdminController implements KernelControllerEventInt
      */
     public function updateAction(Request $request)
     {
-        $user = User\UserRole::getById((int)$request->get('id'));
+        $user = User\AbstractUser::getById((int)$request->get('id'));
 
         if (!$user) {
             throw $this->createNotFoundException();


### PR DESCRIPTION
Using User\UserRole leads to the bug that not all properties of a user are updated.
I suggest using AbstractUserinstead.