### PR TITLE
ClassDefinition: maxItems property should be int or null

### DIFF
--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -1165,23 +1165,23 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
     }
 
     /**
-     * @param int|string|null $number
+     * @param mixed $number
      *
      * @return int|null
      */
     public function getAsIntegerCast($number)
     {
-        return strlen($number) === 0 ? '' : (int)$number;
+        return strlen((string) $number) === 0 ? null : (int)$number;
     }
 
     /**
      * @param mixed $number
      *
-     * @return float
+     * @return float|null
      */
     public function getAsFloatCast($number)
     {
-        return strlen($number) === 0 ? '' : (float)$number;
+        return strlen((string) $number) === 0 ? null : (float)$number;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -79,7 +79,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
     public $maxItems;
 
@@ -1033,7 +1033,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMaxItems()
     {
@@ -1041,11 +1041,11 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
     }
 
     /**
-     * @param int $maxItems
+     * @param int|null $maxItems
      */
     public function setMaxItems($maxItems)
     {
-        $this->maxItems = $maxItems;
+        $this->maxItems = $this->getAsIntegerCast($maxItems);
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -161,7 +161,7 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
     public $maxItems;
 
@@ -784,7 +784,7 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
         $getInheritedValues = DataObject::doGetInheritedValues();
 
         if (!$omitMandatoryCheck) {
-            if ($this->maxItems > 0 && count($activeGroups) > $this->maxItems) {
+            if ($this->maxItems && count($activeGroups) > $this->maxItems) {
                 throw new Model\Element\ValidationException(
                     'Groups in field [' . $this->getName() . '] is bigger than ' . $this->getMaxItems()
                 );
@@ -940,15 +940,15 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
     }
 
     /**
-     * @param int $maxItems
+     * @param int|null $maxItems
      */
     public function setMaxItems($maxItems)
     {
-        $this->maxItems = (int) $maxItems;
+        $this->maxItems = $this->getAsIntegerCast($maxItems);
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMaxItems()
     {

--- a/models/DataObject/ClassDefinition/Data/ExternalImage.php
+++ b/models/DataObject/ClassDefinition/Data/ExternalImage.php
@@ -37,21 +37,21 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
     public $previewWidth;
 
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
     public $inputWidth;
 
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
     public $previewHeight;
 
@@ -82,7 +82,7 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
     }
 
     /**
-     * @param int $previewWidth
+     * @param int|null $previewWidth
      */
     public function setPreviewWidth($previewWidth)
     {
@@ -90,7 +90,7 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getPreviewHeight()
     {
@@ -98,7 +98,7 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
     }
 
     /**
-     * @param int $previewHeight
+     * @param int|null $previewHeight
      */
     public function setPreviewHeight($previewHeight)
     {
@@ -106,7 +106,7 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getInputWidth()
     {
@@ -114,7 +114,7 @@ class ExternalImage extends Data implements ResourcePersistenceAwareInterface, Q
     }
 
     /**
-     * @param int $inputWidth
+     * @param int|null $inputWidth
      */
     public function setInputWidth($inputWidth)
     {

--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -51,7 +51,7 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
     public $maxItems;
 
@@ -557,7 +557,7 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
     }
 
     /**
-     * @param int|string|null $maxItems
+     * @param int|null $maxItems
      *
      * @return $this
      */
@@ -569,7 +569,7 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMaxItems()
     {

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -58,7 +58,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
     public $maxItems;
 
@@ -495,7 +495,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
     }
 
     /**
-     * @param int|string|null $maxItems
+     * @param int|null $maxItems
      *
      * @return $this
      */
@@ -507,7 +507,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMaxItems()
     {

--- a/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
@@ -61,7 +61,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
     public $maxItems;
 
@@ -644,7 +644,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
     }
 
     /**
-     * @param string|int|null $maxItems
+     * @param int|null $maxItems
      *
      * @return $this
      */
@@ -656,7 +656,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMaxItems()
     {

--- a/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -75,7 +75,7 @@ class Multiselect extends Data implements
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
     public $maxItems;
 
@@ -196,7 +196,7 @@ class Multiselect extends Data implements
     }
 
     /**
-     * @param int|string|null $maxItems
+     * @param int|null $maxItems
      *
      * @return $this
      */
@@ -208,7 +208,7 @@ class Multiselect extends Data implements
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMaxItems()
     {

--- a/models/DataObject/ClassDefinition/Data/Objectbricks.php
+++ b/models/DataObject/ClassDefinition/Data/Objectbricks.php
@@ -46,7 +46,7 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
     public $maxItems;
 
@@ -58,7 +58,7 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
     public $border = false;
 
     /**
-     * @param string|int|null $maxItems
+     * @param int|null $maxItems
      *
      * @return $this
      */
@@ -70,7 +70,7 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMaxItems()
     {

--- a/models/DataObject/ClassDefinition/Data/Slider.php
+++ b/models/DataObject/ClassDefinition/Data/Slider.php
@@ -53,14 +53,14 @@ class Slider extends Data implements ResourcePersistenceAwareInterface, QueryRes
     /**
      * @internal
      *
-     * @var float
+     * @var float|null
      */
     public $minValue;
 
     /**
      * @internal
      *
-     * @var float
+     * @var float|null
      */
     public $maxValue;
 
@@ -69,19 +69,19 @@ class Slider extends Data implements ResourcePersistenceAwareInterface, QueryRes
      *
      * @var bool
      */
-    public $vertical;
+    public $vertical = false;
 
     /**
-     * v
+     * @internal
      *
-     * @var float
+     * @var float|null
      */
     public $increment;
 
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
     public $decimalPrecision;
 
@@ -158,7 +158,7 @@ class Slider extends Data implements ResourcePersistenceAwareInterface, QueryRes
     }
 
     /**
-     * @param float $minValue
+     * @param float|null $minValue
      *
      * @return $this
      */
@@ -170,7 +170,7 @@ class Slider extends Data implements ResourcePersistenceAwareInterface, QueryRes
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getMaxValue()
     {
@@ -178,11 +178,9 @@ class Slider extends Data implements ResourcePersistenceAwareInterface, QueryRes
     }
 
     /**
-     * @param string|int|null $maxValue
+     * @param float|null $maxValue
      *
      * @return $this
-     *
-     * @internal param float $minValue
      */
     public function setMaxValue($maxValue)
     {
@@ -220,7 +218,7 @@ class Slider extends Data implements ResourcePersistenceAwareInterface, QueryRes
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getIncrement()
     {
@@ -228,7 +226,7 @@ class Slider extends Data implements ResourcePersistenceAwareInterface, QueryRes
     }
 
     /**
-     * @param float $increment
+     * @param float|null $increment
      *
      * @return $this
      */
@@ -240,7 +238,7 @@ class Slider extends Data implements ResourcePersistenceAwareInterface, QueryRes
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getDecimalPrecision()
     {
@@ -248,7 +246,7 @@ class Slider extends Data implements ResourcePersistenceAwareInterface, QueryRes
     }
 
     /**
-     * @param int $decimalPrecision
+     * @param int|null $decimalPrecision
      *
      * @return $this
      */

--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -54,7 +54,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
     public $cols;
 
@@ -63,12 +63,12 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
      *
      * @var bool
      */
-    public $colsFixed;
+    public $colsFixed = false;
 
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
     public $rows;
 
@@ -77,7 +77,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
      *
      * @var bool
      */
-    public $rowsFixed;
+    public $rowsFixed = false;
 
     /**
      * Default data
@@ -167,7 +167,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getCols()
     {
@@ -175,7 +175,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
     }
 
     /**
-     * @param int $cols
+     * @param int|null $cols
      *
      * @return $this
      */
@@ -187,7 +187,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getRows()
     {
@@ -195,7 +195,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
     }
 
     /**
-     * @param int $rows
+     * @param int|null $rows
      *
      * @return $this
      */


### PR DESCRIPTION
It's not constantly the same behaviour at the moment.

Data types `Fieldcollections`,  `ManyToManyObjectRelation`, `ManyToManyRelation`, `Multiselect` and `Objectbricks` use the getAsIntegerCast method which return int or empty string (but the doc type says int or null).

Data type `Block` do not cast. So it can be int or null.

Data type `Classificationstore` always cast to int.

I constantly use the getAsIntegerCast method and correct the return to int or null.
