### PR TITLE
ThumbnailTrait getStream can return null and should be handled

### DIFF
--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -365,7 +365,7 @@ EOT;
             $path = $this->getLocalFile();
         }
         
-        if (null === $path) {
+        if (!$path) {
             return null;
         }
 

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -110,6 +110,11 @@ class Image extends Model\Asset
             $reference = $thumbnail->getPathReference();
             if (in_array($reference['type'], ['asset', 'thumbnail'])) {
                 $image = $thumbnail->getLocalFile();
+                
+                if (null === $image) {
+                    return false;
+                }
+                
                 $imageWidth = $thumbnail->getWidth();
                 $imageHeight = $thumbnail->getHeight();
 
@@ -173,6 +178,10 @@ class Image extends Model\Asset
             // Imagick fallback
             $path = $this->getThumbnail(Image\Thumbnail\Config::getPreviewConfig())->getLocalFile();
 
+            if (null === $path) {
+                return false;
+            }
+            
             $imagick = new \Imagick($path);
             $imagick->setImageFormat('jpg');
             $imagick->setOption('jpeg:extent', '1kb');
@@ -354,6 +363,10 @@ EOT;
 
         if (!$path) {
             $path = $this->getLocalFile();
+        }
+        
+        if (null === $path) {
+            return null;
         }
 
         $dimensions = null;

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -185,12 +185,16 @@ trait ImageThumbnailTrait
         $pathReference = $this->getPathReference();
         if (in_array($pathReference['type'], ['thumbnail', 'asset'])) {
             try {
-                $info = @getimagesize($this->getLocalFile());
-                if ($info) {
-                    $dimensions = [
-                        'width' => $info[0],
-                        'height' => $info[1],
-                    ];
+                $localFile = $this->getLocalFile();
+
+                if (null !== $localFile) {
+                    $info = @getimagesize($localFile);
+                    if ($info) {
+                        $dimensions = [
+                            'width' => $info[0],
+                            'height' => $info[1],
+                        ];
+                    }
                 }
             } catch (\Exception $e) {
                 // noting to do
@@ -334,7 +338,13 @@ trait ImageThumbnailTrait
      */
     public function getLocalFile()
     {
-        return self::getLocalFileFromStream($this->getStream());
+        $stream = $this->getStream();
+
+        if (null === $stream) {
+            return null;
+        }
+
+        return self::getLocalFileFromStream($stream);
     }
 
     /**

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -332,7 +332,7 @@ trait ImageThumbnailTrait
     /**
      * @internal
      *
-     * @return string
+     * @return string|null
      *
      * @throws \Exception
      */


### PR DESCRIPTION
`getStream` can return null if for some reason the asset is missing resulting in following error:

```
TypeError: stream_get_meta_data(): Argument #1 ($stream) must be of type resource, null given
#24 /vendor/pimcore/pimcore/lib/Helper/TemporaryFileHelperTrait.php(36): stream_get_meta_data
#23 /vendor/pimcore/pimcore/lib/Helper/TemporaryFileHelperTrait.php(36): Pimcore\Model\Asset\Image\Thumbnail::getLocalFileFromStream
#22 /vendor/pimcore/pimcore/models/Asset/Thumbnail/ImageThumbnailTrait.php(321): Pimcore\Model\Asset\Image\Thumbnail::getLocalFile
#21 /vendor/pimcore/pimcore/models/Asset/Image.php(166): Pimcore\Model\Asset\Image::generateLowQualityPreview
#20 /vendor/pimcore/pimcore/lib/Maintenance/Tasks/LowQualityImagePreviewTask.php(75): Pimcore\Maintenance\Tasks\LowQualityImagePreviewTask::execute
#19 /vendor/pimcore/pimcore/lib/Maintenance/Executor.php(78): Pimcore\Maintenance\Executor::executeTask
#18 /vendor/pimcore/pimcore/lib/Messenger/Handler/MaintenanceTaskHandler.php(33): Pimcore\Messenger\Handler\MaintenanceTaskHandler::__invoke
#17 /vendor/symfony/messenger/Middleware/HandleMessageMiddleware.php(96): Symfony\Component\Messenger\Middleware\HandleMessageMiddleware::handle
#16 /vendor/symfony/messenger/Middleware/SendMessageMiddleware.php(74): Symfony\Component\Messenger\Middleware\SendMessageMiddleware::handle
#15 /vendor/symfony/messenger/Middleware/FailedMessageProcessingMiddleware.php(34): Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware::handle
#14 /vendor/symfony/messenger/Middleware/DispatchAfterCurrentBusMiddleware.php(68): Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware::handle
#13 /vendor/symfony/messenger/Middleware/RejectRedeliveredMessageMiddleware.php(48): Symfony\Component\Messenger\Middleware\RejectRedeliveredMessageMiddleware::handle
#12 /vendor/symfony/messenger/Middleware/AddBusNameStampMiddleware.php(37): Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware::handle
#11 /vendor/symfony/messenger/MessageBus.php(77): Symfony\Component\Messenger\MessageBus::dispatch
#10 /vendor/symfony/messenger/RoutableMessageBus.php(54): Symfony\Component\Messenger\RoutableMessageBus::dispatch
#9 /vendor/symfony/messenger/Worker.php(158): Symfony\Component\Messenger\Worker::handleMessage
#8 /vendor/symfony/messenger/Worker.php(107): Symfony\Component\Messenger\Worker::run
#7 /vendor/symfony/messenger/Command/ConsumeMessagesCommand.php(225): Symfony\Component\Messenger\Command\ConsumeMessagesCommand::execute
#6 /vendor/symfony/console/Command/Command.php(298): Symfony\Component\Console\Command\Command::run
#5 /vendor/symfony/console/Application.php(1033): Symfony\Component\Console\Application::doRunCommand
#4 /vendor/symfony/framework-bundle/Console/Application.php(96): Symfony\Bundle\FrameworkBundle\Console\Application::doRunCommand
#3 /vendor/symfony/console/Application.php(299): Symfony\Component\Console\Application::doRun
#2 /vendor/symfony/framework-bundle/Console/Application.php(82): Symfony\Bundle\FrameworkBundle\Console\Application::doRun
#1 /vendor/symfony/console/Application.php(171): Symfony\Component\Console\Application::run
#0 /bin/console(46): null

```
