### PR TITLE
Support modern bundle structure

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Compiler/AreabrickPass.php
+++ b/bundles/CoreBundle/DependencyInjection/Compiler/AreabrickPass.php
@@ -203,21 +203,18 @@ final class AreabrickPass implements CompilerPassInterface
      */
     protected function findBundleBricks(ContainerBuilder $container, string $name, array $metadata, array $excludedClasses = []): array
     {
-        $directory = implode(DIRECTORY_SEPARATOR, [
-            $metadata['path'],
-            'Document',
-            'Areabrick',
-        ]);
+        $sourcePath = is_dir($metadata['path'].'/src') ? $metadata['path'].'/src' : $metadata['path'];
+        $directory = $sourcePath.'/Document/Areabrick';
 
         // update cache when directory is added/removed
         $container->addResource(new FileExistenceResource($directory));
 
-        if (!file_exists($directory) || !is_dir($directory)) {
+        if (!is_dir($directory)) {
             return [];
-        } else {
-            // update container cache when areabricks are added/changed
-            $container->addResource(new DirectoryResource($directory, '/\.php$/'));
         }
+
+        // update container cache when areabricks are added/changed
+        $container->addResource(new DirectoryResource($directory, '/\.php$/'));
 
         $finder = new Finder();
         $finder
@@ -230,7 +227,7 @@ final class AreabrickPass implements CompilerPassInterface
             $shortClassName = $classPath->getBasename('.php');
 
             // relative path in bundle path
-            $relativePath = str_replace($metadata['path'], '', $classPath->getPathInfo());
+            $relativePath = str_replace($sourcePath, '', $classPath->getPathInfo());
             $relativePath = trim($relativePath, DIRECTORY_SEPARATOR);
 
             // namespace starting from bundle path
@@ -257,8 +254,6 @@ final class AreabrickPass implements CompilerPassInterface
                     $areas[] = [
                         'brickId' => $brickId,
                         'serviceId' => $serviceId,
-                        'bundleName' => $name,
-                        'bundleMetadata' => $metadata,
                         'reflector' => $reflector,
                     ];
                 }

--- a/lib/Config/BundleConfigLocator.php
+++ b/lib/Config/BundleConfigLocator.php
@@ -69,15 +69,18 @@ class BundleConfigLocator
     {
         $result = [];
         foreach ($this->kernel->getBundles() as $bundle) {
-            $directory = $bundle->getPath() . '/Resources/config/pimcore';
-            if (!(file_exists($directory) && is_dir($directory))) {
+            $bundlePath = $bundle->getPath();
+            $configDir = is_dir($bundlePath.'/Resources/config') ? $bundlePath.'/Resources/config' : $bundlePath.'/config';
+            $pimcoreConfigDir = $configDir. '/pimcore';
+
+            if (!is_dir($pimcoreConfigDir)) {
                 continue;
             }
 
             // try to find environment specific file first, fall back to generic one if none found (e.g. config_dev.yaml > config.yaml)
-            $finder = $this->buildContainerConfigFinder($name, $directory, true);
-            if ($finder->count() === 0) {
-                $finder = $this->buildContainerConfigFinder($name, $directory, false);
+            $finder = $this->buildContainerConfigFinder($name, $pimcoreConfigDir, true);
+            if (!$finder->hasResults()) {
+                $finder = $this->buildContainerConfigFinder($name, $pimcoreConfigDir, false);
             }
 
             foreach ($finder as $file) {

--- a/lib/Config/BundleConfigLocator.php
+++ b/lib/Config/BundleConfigLocator.php
@@ -70,17 +70,14 @@ class BundleConfigLocator
         $result = [];
         foreach ($this->kernel->getBundles() as $bundle) {
             $bundlePath = $bundle->getPath();
-            $configDir = is_dir($bundlePath.'/Resources/config') ? $bundlePath.'/Resources/config' : $bundlePath.'/config';
-            $pimcoreConfigDir = $configDir. '/pimcore';
-
-            if (!is_dir($pimcoreConfigDir)) {
+            if (!is_dir($dir = $bundlePath.'/Resources/config/pimcore') && !is_dir($dir = $bundlePath.'/config/pimcore')) {
                 continue;
             }
 
             // try to find environment specific file first, fall back to generic one if none found (e.g. config_dev.yaml > config.yaml)
-            $finder = $this->buildContainerConfigFinder($name, $pimcoreConfigDir, true);
+            $finder = $this->buildContainerConfigFinder($name, $dir, true);
             if (!$finder->hasResults()) {
-                $finder = $this->buildContainerConfigFinder($name, $pimcoreConfigDir, false);
+                $finder = $this->buildContainerConfigFinder($name, $dir, false);
             }
 
             foreach ($finder as $file) {

--- a/lib/Controller/Config/ControllerDataProvider.php
+++ b/lib/Controller/Config/ControllerDataProvider.php
@@ -163,21 +163,17 @@ class ControllerDataProvider
 
         $templates = [];
 
-        $symfonyPath = realpath(implode(DIRECTORY_SEPARATOR, [PIMCORE_PROJECT_ROOT, 'templates']));
-        if ($symfonyPath && is_dir($symfonyPath)) {
-            $templates = array_merge($templates, $this->findTemplates($symfonyPath));
+        if (is_dir($symfonyPath = PIMCORE_PROJECT_ROOT.'/templates')) {
+            $templates[] = $this->findTemplates($symfonyPath);
         }
 
         foreach ($this->getBundles() as $bundle) {
-            $bundlePath = realpath(implode(DIRECTORY_SEPARATOR, [$bundle->getPath(), 'Resources', 'views']));
-            if ($bundlePath && is_dir($bundlePath)) {
-                $templates = array_merge($templates, $this->findTemplates($bundlePath, $bundle->getName()));
+            if (is_dir($bundlePath = $bundle->getPath().'/Resources/views') || is_dir($bundlePath = $bundle->getPath().'/templates')) {
+                $templates[] = $this->findTemplates($bundlePath, $bundle->getName());
             }
         }
 
-        $this->templates = $templates;
-
-        return $this->templates;
+        return $this->templates = array_merge(...$templates);
     }
 
     /**

--- a/lib/Document/Editable/EditableHandler.php
+++ b/lib/Document/Editable/EditableHandler.php
@@ -191,7 +191,7 @@ class EditableHandler implements LoggerAwareInterface
 
             $hasDialogBoxConfiguration = $brick instanceof EditableDialogBoxInterface;
 
-            // autoresolve icon as <bundleName>/Resources/public/areas/<id>/icon.png
+            // autoresolve icon as <bundleName>/Resources/public/areas/<id>/icon.png or <bundleName>/public/areas/<id>/icon.png
             if (null === $icon) {
                 $bundle = null;
 

--- a/lib/Document/Editable/EditableHandler.php
+++ b/lib/Document/Editable/EditableHandler.php
@@ -199,7 +199,8 @@ class EditableHandler implements LoggerAwareInterface
                     $bundle = $this->bundleLocator->getBundle($brick);
 
                     // check if file exists
-                    $iconPath = sprintf('%s/Resources/public/areas/%s/icon.png', $bundle->getPath(), $brick->getId());
+                    $publicDir = is_dir($bundle->getPath().'/Resources/public') ? $bundle->getPath().'/Resources/public' : $bundle->getPath().'/public';
+                    $iconPath = sprintf('%s/areas/%s/icon.png', $publicDir, $brick->getId());
                     if (file_exists($iconPath)) {
                         // build URL to icon
                         $icon = $this->webPathResolver->getPath($bundle, 'areas/' . $brick->getId(), 'icon.png');

--- a/lib/HttpKernel/WebPathResolver.php
+++ b/lib/HttpKernel/WebPathResolver.php
@@ -37,7 +37,7 @@ class WebPathResolver
      */
     public function getPrefix(BundleInterface $bundle)
     {
-        if (!is_dir($bundle->getPath() . '/Resources/public')) {
+        if (!is_dir($bundle->getPath() . '/Resources/public') && !is_dir($bundle->getPath() . '/public')) {
             throw new \InvalidArgumentException(sprintf(
                 'Bundle %s does not have Resources/public folder',
                 $bundle->getName()


### PR DESCRIPTION
Symfony changed its "Directory Structure Best Practice for Reusable Bundles" in its 4.4 version.

In the old one, everything was just in the bundle root dir `/` (or maybe inside `/src`, in which case this was considered "root").
In the new one, the PHP classes moved inside `/src` and the contents of `Resources` are unpacked into the root `/` (with sometimes different names).

Below is a comparison of the old and the new structure:

<table>
<thead align="center">
<td><a href="https://symfony.com/doc/4.3/bundles/best_practices.html#directory-structure">Symfony < 4.4</a></td>
<td><a href="https://symfony.com/doc/4.4/bundles/best_practices.html#directory-structure">Symfony >= 4.4</a></td>
</thead>
<tr>
<td valign="top">
<pre>
/
├─ AcmeBlogBundle.php
├─ Controller/
├─ README.md
├─ LICENSE
├─ Resources/
│  ├─ config/
│  ├─ doc/
│  │  └─ index.rst
│  ├─ translations/
│  ├─ views/
│  └─ public/
└─ Tests/
</pre>
</td>
<td valign="top">
<pre>
/
├─ config/
├─ docs/
│  └─ index.md
├─ public/
├─ src/
│  ├─ Controller/
│  ├─ DependencyInjection/
│  └─ AcmeBlogBundle.php
├─ templates/
├─ tests/
├─ translations/
├─ LICENSE
└─ README.md
<pre>
</td>
</tr>
</table>

Pimcore doesn't support the new bundle structure at the moment, because it doesn't look at the new locations for Areabricks, config, templates and assets, which means:
- Areabricks are in `/src/Document/Areabrick/` instead of `/Document/Areabrick`
- config is in `/config` instead of `/Resources/config/`
- templates are in `/templates` instead of `Resources/views/`
- assets are in `/public` instead of `/Resources/public/`

The solution is to look in both possible location, as Symfony does e.g. [here](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/TwigBundle/TemplateIterator.php#L69), [here](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php#L178), [here](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php#L139) or [here](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1365).


Resolves #10912