### PR TITLE
Add configName to PERSPECTIVE_POST_GET_RUNTIME event

### DIFF
--- a/lib/Event/AdminEvents.php
+++ b/lib/Event/AdminEvents.php
@@ -530,6 +530,7 @@ final class AdminEvents
      *
      * Arguments:
      *  - result | The result array
+     *  - configName | Name of the current perspective
      *
      * @Event("Symfony\Component\EventDispatcher\GenericEvent")
      *

--- a/lib/Perspective/Config.php
+++ b/lib/Perspective/Config.php
@@ -255,6 +255,7 @@ final class Config
 
         $event = new GenericEvent(null, [
             'result' => $result,
+            'configName' => $currentConfigName,
         ]);
         \Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::PERSPECTIVE_POST_GET_RUNTIME);
 


### PR DESCRIPTION
Followup to https://github.com/pimcore/pimcore/pull/10815

In the PERSPECTIVE_POST_GET_RUNTIME event we didn't have the info which perspective is active.