### PR TITLE
[Bug]: Optimize tables command: use fetchAll() instead of exec()

### DIFF
--- a/lib/Maintenance/Tasks/FullTextIndexOptimizeTask.php
+++ b/lib/Maintenance/Tasks/FullTextIndexOptimizeTask.php
@@ -34,12 +34,13 @@ class FullTextIndexOptimizeTask implements TaskInterface
 
     /**
      * {@inheritdoc}
+     * @throws \Doctrine\DBAL\Exception
      */
     public function execute()
     {
         if ($this->lock->acquire(false)) {
-            Db::get()->exec('OPTIMIZE TABLE search_backend_data');
-            Db::get()->exec('OPTIMIZE TABLE email_log');
+            Db::get()->fetchAllAssociative('OPTIMIZE TABLE search_backend_data');
+            Db::get()->fetchAllAssociative('OPTIMIZE TABLE email_log');
         }
     }
 }


### PR DESCRIPTION
resolve #12269 