### PR TITLE
Static Class Builder should not call "classSaved"

### DIFF
--- a/lib/DataObject/ClassBuilder/FieldDefinitionBuilder.php
+++ b/lib/DataObject/ClassBuilder/FieldDefinitionBuilder.php
@@ -27,12 +27,6 @@ class FieldDefinitionBuilder implements FieldDefinitionBuilderInterface
             $cd .= $fieldDefinition->getSetterCode($classDefinition);
         }
 
-        // call the method "classSaved" if exists, this is used to create additional data tables or whatever which depends on the field definition, for example for localizedfields
-        //TODO Pimcore 11 remove method_exists call
-        if (!$fieldDefinition instanceof ClassDefinition\Data\DataContainerAwareInterface && method_exists($fieldDefinition, 'classSaved')) {
-            $fieldDefinition->classSaved($classDefinition);
-        }
-
         return $cd;
     }
 }

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -465,6 +465,16 @@ final class ClassDefinition extends Model\AbstractModel
         $this->getDao()->save($isUpdate);
 
         $this->generateClassFiles($saveDefinitionFile);
+        
+        if (is_array($classDefinition->getFieldDefinitions()) && count($classDefinition->getFieldDefinitions())) {
+            foreach ($classDefinition->getFieldDefinitions() as $def) {
+                // call the method "classSaved" if exists, this is used to create additional data tables or whatever which depends on the field definition, for example for localizedfields
+                //TODO Pimcore 11 remove method_exists call
+                if (!$fieldDefinition instanceof ClassDefinition\Data\DataContainerAwareInterface && method_exists($fieldDefinition, 'classSaved')) {
+                    $fieldDefinition->classSaved($classDefinition);
+                }
+            }
+        }
 
         // empty object cache
         try {

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -466,13 +466,11 @@ final class ClassDefinition extends Model\AbstractModel
 
         $this->generateClassFiles($saveDefinitionFile);
         
-        if (is_array($classDefinition->getFieldDefinitions()) && count($classDefinition->getFieldDefinitions())) {
-            foreach ($classDefinition->getFieldDefinitions() as $def) {
-                // call the method "classSaved" if exists, this is used to create additional data tables or whatever which depends on the field definition, for example for localizedfields
-                //TODO Pimcore 11 remove method_exists call
-                if (!$fieldDefinition instanceof ClassDefinition\Data\DataContainerAwareInterface && method_exists($fieldDefinition, 'classSaved')) {
-                    $fieldDefinition->classSaved($classDefinition);
-                }
+        foreach ($fieldDefinitions as $fd) {
+            // call the method "classSaved" if exists, this is used to create additional data tables or whatever which depends on the field definition, for example for localizedfields
+            //TODO Pimcore 11 remove method_exists call
+            if (!$fd instanceof ClassDefinition\Data\DataContainerAwareInterface && method_exists($fd, 'classSaved')) {
+                $fd->classSaved($this);
             }
         }
 


### PR DESCRIPTION
"classSaved" should not be called during "static" class building where no database might be available. It should be called during the "ClassDefinition" save function