### PR TITLE
Fix Phpstan errors

### DIFF
--- a/bundles/EcommerceFrameworkBundle/VoucherService/DefaultService.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/DefaultService.php
@@ -222,7 +222,7 @@ class DefaultService implements VoucherServiceInterface
 
         // calculate not applied rules with voucher conditions
         $notAppliedRules = array_udiff($validRules, $appliedRules, function ($rule1, $rule2) {
-            return strcmp($rule1->getId(), $rule2->getId());
+            return $rule1->getId() == $rule2->getId();
         });
         $notAppliedRulesWithVoucherCondition = [];
         foreach ($notAppliedRules as $notAppliedRule) {

--- a/bundles/EcommerceFrameworkBundle/VoucherService/DefaultService.php
+++ b/bundles/EcommerceFrameworkBundle/VoucherService/DefaultService.php
@@ -222,7 +222,7 @@ class DefaultService implements VoucherServiceInterface
 
         // calculate not applied rules with voucher conditions
         $notAppliedRules = array_udiff($validRules, $appliedRules, function ($rule1, $rule2) {
-            return $rule1->getId() == $rule2->getId();
+            return $rule1->getId() <=> $rule2->getId();
         });
         $notAppliedRulesWithVoucherCondition = [];
         foreach ($notAppliedRules as $notAppliedRule) {

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -336,22 +336,6 @@ final class Config implements \ArrayAccess
         return $config;
     }
 
-    private static function getArrayValue($keys, $array)
-    {
-        $len = count($keys);
-        $pointer = $array;
-        for ($i = 0; $i < $len; $i++) {
-            $key = $keys[$i];
-            if (array_key_exists($key, $pointer)) {
-                $pointer = $pointer[$key];
-            } else {
-                return null;
-            }
-        }
-
-        return $pointer;
-    }
-
     /**
      * @return PimcoreConfig
      *


### PR DESCRIPTION
## Changes in this pull request  
Fix Phpstan errors:
```
------ -------------------------------------------------------------------- 
  Line   bundles/EcommerceFrameworkBundle/VoucherService/DefaultService.php  
 ------ -------------------------------------------------------------------- 
  225    Parameter #1 $string1 of function strcmp expects string, int|null   
         given.                                                              
  225    Parameter #2 $string2 of function strcmp expects string, int|null   
         given.                                                              
 ------ -------------------------------------------------------------------- 
 ------ ---------------------------------------------------------- 
  Line   lib/Config.php                                            
 ------ ---------------------------------------------------------- 
  3      Static method Pimcore\Config::getArrayValue() is unused.  
 ------ ----------------------------------------------------------
```

## Additional info  

