### PR TITLE
Fix: Error thrown while handling message Pimcore\Messenger\AssetUpdateTasksMessage

### DIFF
--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -33,6 +33,9 @@ class AssetUpdateTasksHandler
     public function __invoke(AssetUpdateTasksMessage $message)
     {
         $asset = Asset::getById($message->getId());
+        if (!$asset) {
+            return;
+        }
         $this->logger->debug(sprintf('Processing asset with ID %s | Path: %s', $asset->getId(), $asset->getRealFullPath()));
 
         if ($asset instanceof Asset\Image) {

--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -34,6 +34,7 @@ class AssetUpdateTasksHandler
     {
         $asset = Asset::getById($message->getId());
         if (!$asset) {
+            $this->logger->debug(sprintf('Asset with ID %s not found', $message->getId()));
             return;
         }
         $this->logger->debug(sprintf('Processing asset with ID %s | Path: %s', $asset->getId(), $asset->getRealFullPath()));


### PR DESCRIPTION
```
12:55:08 WARNING   [messenger] Error thrown while handling message Pimcore\Messenger\AssetUpdateTasksMessage. Sending for retry #1 using 1000 ms delay. Error: "Handling "Pimcore\Messenger\AssetUpdateTasksMessage" failed: Call to a member function getId() on null" ["message" => Pimcore\Messenger\AssetUpdateTasksMessage^ { …},"class" => "Pimcore\Messenger\AssetUpdateTasksMessage","retryCount" => 1,"delay" => 1000,"error" => "Handling "Pimcore\Messenger\AssetUpdateTasksMessage" failed: Call to a member function getId() on null","exception" => Symfony\Component\Messenger\Exception\HandlerFailedException^ { …}]
12:55:24 WARNING   [messenger] Error thrown while handling message Pimcore\Messenger\AssetUpdateTasksMessage. Sending for retry #2 using 2000 ms delay. Error: "Handling "Pimcore\Messenger\AssetUpdateTasksMessage" failed: Call to a member function getId() on null" ["message" => Pimcore\Messenger\AssetUpdateTasksMessage^ { …},"class" => "Pimcore\Messenger\AssetUpdateTasksMessage","retryCount" => 2,"delay" => 2000,"error" => "Handling "Pimcore\Messenger\AssetUpdateTasksMessage" failed: Call to a member function getId() on null","exception" => Symfony\Component\Messenger\Exception\HandlerFailedException^ { …}]
12:55:26 WARNING   [messenger] Error thrown while handling message Pimcore\Messenger\AssetUpdateTasksMessage. Sending for retry #3 using 4000 ms delay. Error: "Handling "Pimcore\Messenger\AssetUpdateTasksMessage" failed: Call to a member function getI["message" => Pimcore\Messenger\AssetUpdateTasksMessage^ { …},"class" => "Pimcore\Messenger\AssetUpdateTasksMessage","retryCount" => 3,"delay" => 4000,"error" => "Handling "Pimcore\Messenger\AssetUpdateTasksMessage" failed: Call to a member function getId() on null","exception" => Symfony\Component\Messenger\Exception\HandlerFailedException^ { …}]
12:55:30 CRITICAL  [messenger] Error thrown while handling message Pimcore\Messenger\AssetUpdateTasksMessage. Removing from transport after 3 retries. Error: "Handling "Pimcore\Messenger\AssetUpdateTasksMessage" failed: Call to a member function getId() on null" ["message" => Pimcore\Messenger\AssetUpdateTasksMessage^ { …},"class" => "Pimcore\Messenger\AssetUpdateTasksMessage","retryCount" => 3,"error" => "Handling "Pimcore\Messenger\AssetUpdateTasksMessage" failed: Call to a member function getId() on null","exception" => Symfony\Component\Messenger\Exception\HandlerFailedException^ { …}]

```