### PR TITLE
[Improvement]: extend PIMCORE_CLASS_DEFINITION_WRITABLE to be globally read-only

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/IndexController.php
+++ b/bundles/AdminBundle/Controller/Admin/IndexController.php
@@ -265,6 +265,8 @@ class IndexController extends AdminController implements KernelResponseEventInte
             'staticroutes-writeable' => (new Staticroute())->isWriteable(),
             'perspectives-writeable' => \Pimcore\Perspective\Config::isWriteable(),
             'custom-views-writeable' => \Pimcore\CustomView\Config::isWriteable(),
+            //TODO: fix after implementation of #12321
+            'class-definition-writeable' => isset($_SERVER['PIMCORE_CLASS_DEFINITION_WRITABLE']) ? (bool)$_SERVER['PIMCORE_CLASS_DEFINITION_WRITABLE'] : true
         ];
 
         $this

--- a/bundles/AdminBundle/Controller/Admin/IndexController.php
+++ b/bundles/AdminBundle/Controller/Admin/IndexController.php
@@ -265,7 +265,6 @@ class IndexController extends AdminController implements KernelResponseEventInte
             'staticroutes-writeable' => (new Staticroute())->isWriteable(),
             'perspectives-writeable' => \Pimcore\Perspective\Config::isWriteable(),
             'custom-views-writeable' => \Pimcore\CustomView\Config::isWriteable(),
-            //TODO: fix after implementation of #12321
             'class-definition-writeable' => isset($_SERVER['PIMCORE_CLASS_DEFINITION_WRITABLE']) ? (bool)$_SERVER['PIMCORE_CLASS_DEFINITION_WRITABLE'] : true
         ];
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
@@ -92,7 +92,9 @@ pimcore.object.klass = Class.create({
                         {
                             text: t("add"),
                             iconCls: "pimcore_icon_class pimcore_icon_overlay_add",
-                            handler: this.suggestIdentifier.bind(this)
+                            handler: this.suggestIdentifier.bind(this),
+                            //TODO: should be based on isWriteable/PIMCORE_CLASS_DEFINITION_WRITABLE
+                            //disabled: true
                         }
                     ]
                 }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
@@ -71,7 +71,6 @@ pimcore.object.klass = Class.create({
                 }
             });
 
-
             this.tree = Ext.create('Ext.tree.Panel', {
                 id: "pimcore_panel_classes_tree",
                 store: this.store,
@@ -93,8 +92,7 @@ pimcore.object.klass = Class.create({
                             text: t("add"),
                             iconCls: "pimcore_icon_class pimcore_icon_overlay_add",
                             handler: this.suggestIdentifier.bind(this),
-                            //TODO: should be based on isWriteable/PIMCORE_CLASS_DEFINITION_WRITABLE
-                            //disabled: true
+                            disabled: !pimcore.settings['class-definition-writeable']
                         }
                     ]
                 }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
@@ -284,7 +284,9 @@ pimcore.object.helpers.customLayoutEditor = Class.create({
                     text: t("add_layout"),
                     iconCls: "pimcore_icon_add",
                     handler: this.suggestIdentifier.bind(this),
-                    hidden: typeof this.klass.id === 'undefined'
+                    hidden: typeof this.klass.id === 'undefined',
+                    //TODO: find a way to pass the ENV
+                    //disabled: true
                 },
                 {
                     xtype: "button",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
@@ -285,8 +285,7 @@ pimcore.object.helpers.customLayoutEditor = Class.create({
                     iconCls: "pimcore_icon_add",
                     handler: this.suggestIdentifier.bind(this),
                     hidden: typeof this.klass.id === 'undefined',
-                    //TODO: find a way to pass the ENV
-                    //disabled: true
+                    disabled: !pimcore.settings['class-definition-writeable']
                 },
                 {
                     xtype: "button",

--- a/doc/Development_Documentation/21_Deployment/05_Deployment_Tools.md
+++ b/doc/Development_Documentation/21_Deployment/05_Deployment_Tools.md
@@ -21,7 +21,7 @@ be added to version control systems and be deployed to different deployment stag
 
 The PHP configuration files and PHP classes will be written to the `var/classes` directory by default.
 
-To disallow modification and turn a class into be read-only, you can create a copy
+To disallow modification and turn a class to be read-only, you can create a copy
 at `config/pimcore/classes`.
 However, it is possible to re-enable write access and update class definitions in `config/pimcore/classes` by setting the env variable `PIMCORE_CLASS_DEFINITION_WRITABLE=1`.
 

--- a/doc/Development_Documentation/21_Deployment/05_Deployment_Tools.md
+++ b/doc/Development_Documentation/21_Deployment/05_Deployment_Tools.md
@@ -20,13 +20,14 @@ As with Pimcore configurations also Pimcore class definitions are saved as PHP c
 be added to version control systems and be deployed to different deployment stages.
 
 The PHP configuration files and PHP classes will be written to the `var/classes` directory by default.
-
 To disallow modification and turn a class to be read-only, you can create a copy
 at `config/pimcore/classes`.
-However, it is possible to re-enable write access and update class definitions in `config/pimcore/classes` by setting the env variable `PIMCORE_CLASS_DEFINITION_WRITABLE=1`.
 
-You can also set the env variable `PIMCORE_CLASS_DEFINITION_WRITABLE=0` to completely disable write access. 
-The difference between `0` and not having the env variable set is that with `0` you can also disable the creation of new classes, while without setting the `PIMCORE_CLASS_DEFINITION_WRITABLE`, you would be allowed to create new classes. 
+Regarding the class modification, there is also an optional env variable `PIMCORE_CLASS_DEFINITION_WRITABLE` that can be considered and set.
+
+- `0` To disallow completely write access, including the creation of new classes.
+- `1` To allow the modification, including the classes in `config/pimcore/classes` that normally are read-only.
+- when `not set` classes in `config/pimcore/classes` are read-only, but new classes are allowed and will be created in `var/classes`. 
 
 > **Note**: Changes on Pimcore class definitions not only have influence to configuration files but also on the database.
 > If deploying changes between different deployment stages also database changes need to be deployed. This can be done

--- a/doc/Development_Documentation/21_Deployment/05_Deployment_Tools.md
+++ b/doc/Development_Documentation/21_Deployment/05_Deployment_Tools.md
@@ -19,10 +19,14 @@ can be defined.
 As with Pimcore configurations also Pimcore class definitions are saved as PHP configuration files and therefore can
 be added to version control systems and be deployed to different deployment stages.
 
-The PHP configuration files and PHP classes will be written to the `var/classes` directory by default. However, you can create a copy
-at `config/pimcore/classes` which is then read-only.
-You can set the env variable `PIMCORE_CLASS_DEFINITION_WRITABLE=1` to
-enable write access and update your class definitions in `config/pimcore/classes`.
+The PHP configuration files and PHP classes will be written to the `var/classes` directory by default.
+
+To disallow modification and turn a class into be read-only, you can create a copy
+at `config/pimcore/classes`.
+However, it is possible to re-enable write access and update class definitions in `config/pimcore/classes` by setting the env variable `PIMCORE_CLASS_DEFINITION_WRITABLE=1`.
+
+You can also set the env variable `PIMCORE_CLASS_DEFINITION_WRITABLE=0` to completely disable write access. 
+The difference between `0` and not having the env variable set is that with `0` you can also disable the creation of new classes, while without setting the `PIMCORE_CLASS_DEFINITION_WRITABLE`, you would be allowed to create new classes. 
 
 > **Note**: Changes on Pimcore class definitions not only have influence to configuration files but also on the database.
 > If deploying changes between different deployment stages also database changes need to be deployed. This can be done

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -629,15 +629,15 @@ final class ClassDefinition extends Model\AbstractModel
     /**
      * @internal
      *
+     * with PIMCORE_CLASS_DEFINITION_WRITABLE set, it globally allow/disallow creation and change in classes
+     * when the ENV is not set, it allows modification and creation of new in classes in /var/classes but disables modification of classes in config/pimcore/classes
+     * more details in 05_Deployment_Tools.md
+     *
      * @return bool
      */
     public function isWritable(): bool
     {
-        if ($_SERVER['PIMCORE_CLASS_DEFINITION_WRITABLE'] ?? false) {
-            return true;
-        }
-
-        return !str_starts_with($this->getDefinitionFile(), PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY);
+        return $_SERVER['PIMCORE_CLASS_DEFINITION_WRITABLE'] ?? !str_starts_with($this->getDefinitionFile(), PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY);
     }
 
     /**

--- a/models/DataObject/ClassDefinition/CustomLayout.php
+++ b/models/DataObject/ClassDefinition/CustomLayout.php
@@ -261,11 +261,7 @@ class CustomLayout extends Model\AbstractModel
      */
     public function isWritable(): bool
     {
-        if ($_SERVER['PIMCORE_CLASS_DEFINITION_WRITABLE'] ?? false) {
-            return true;
-        }
-
-        return !str_starts_with($this->getDefinitionFile(), PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY);
+        return $_SERVER['PIMCORE_CLASS_DEFINITION_WRITABLE'] ?? !str_starts_with($this->getDefinitionFile(), PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY);
     }
 
     /**

--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -243,11 +243,7 @@ class Definition extends Model\AbstractModel
      */
     public function isWritable(): bool
     {
-        if ($_SERVER['PIMCORE_CLASS_DEFINITION_WRITABLE'] ?? false) {
-            return true;
-        }
-
-        return !str_starts_with($this->getDefinitionFile(), PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY);
+        return $_SERVER['PIMCORE_CLASS_DEFINITION_WRITABLE'] ?? !str_starts_with($this->getDefinitionFile(), PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY);
     }
 
     /**

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -579,11 +579,7 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
      */
     public function isWritable(): bool
     {
-        if ($_SERVER['PIMCORE_CLASS_DEFINITION_WRITABLE'] ?? false) {
-            return true;
-        }
-
-        return !str_starts_with($this->getDefinitionFile(), PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY);
+        return $_SERVER['PIMCORE_CLASS_DEFINITION_WRITABLE'] ?? !str_starts_with($this->getDefinitionFile(), PIMCORE_CUSTOM_CONFIGURATION_DIRECTORY);
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
Resolves #12323
