### PR TITLE
[Bug]: prevents fatal error when getCurrentUser is null in getUserPermissions

### DIFF
--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -566,7 +566,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
             $user = \Pimcore\Tool\Admin::getCurrentUser();
         }
 
-        if ((!$user && php_sapi_name() === 'cli') || $user->isAdmin()) {
+        if ((!$user && php_sapi_name() === 'cli') || $user?->isAdmin()) {
             $defaultValue = 1;
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Follow-up https://github.com/pimcore/pimcore/pull/12394

`getCurrentUser()` can be null and could potentially throw a fatal error
