### PR TITLE
Fix: SQL syntax error in AbstractObject\Dao->isAllowed() with unsaved objects

### DIFF
--- a/models/Asset/Dao.php
+++ b/models/Asset/Dao.php
@@ -480,7 +480,9 @@ class Dao extends Model\Element\Dao
                 $obj = $obj->getParent();
             }
         }
-        $parentIds[] = $this->model->getId();
+        if ($id = $this->model->getId()) {
+            $parentIds[] = $id;
+        }
 
         $userIds = $user->getRoles();
         $userIds[] = $user->getId();

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -496,7 +496,9 @@ class Dao extends Model\Element\Dao
     protected function collectParentIds()
     {
         $parentIds = $this->getParentIds();
-        $parentIds[] = $this->model->getId();
+        if ($id = $this->model->getId()) {
+            $parentIds[] = $id;
+        }
 
         return $parentIds;
     }

--- a/models/Document/Dao.php
+++ b/models/Document/Dao.php
@@ -514,7 +514,9 @@ class Dao extends Model\Element\Dao
                 $obj = $obj->getParent();
             }
         }
-        $parentIds[] = $this->model->getId();
+        if ($id = $this->model->getId()) {
+            $parentIds[] = $id;
+        }
 
         $userIds = $user->getRoles();
         $userIds[] = $user->getId();

--- a/models/Element/Dao.php
+++ b/models/Element/Dao.php
@@ -121,7 +121,9 @@ abstract class Dao extends Model\Dao\AbstractDao
         }
 
         $parentIds = $this->getParentIds();
-        $parentIds[] = $this->model->getId();
+        if ($id = $this->model->getId()) {
+            $parentIds[] = $id;
+        }
 
         $currentUserId = $user->getId();
         $userIds = $user->getRoles();


### PR DESCRIPTION
Example:
```
An exception occurred while executing 'SELECT `create` FROM users_workspaces_object WHERE cid IN (1,27293,28389,) AND userId IN (9,64) ORDER BY LENGTH(cpath) DESC, FIELD(userId, 64) DESC, `create` DESC LIMIT 1':
```