### PR TITLE
Transfer permissions as boolvars

### DIFF
--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -213,7 +213,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
         $columns = array_diff(array_keys($vars), $ignored);
 
         foreach ($columns as $name) {
-            $permissions[$name] = 1;
+            $permissions[$name] = true;
         }
 
         if (null === $user) {
@@ -229,7 +229,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
             $event = new ElementEvent($this, ['isAllowed' => $isAllowed, 'permissionType' => $type, 'user' => $user]);
             \Pimcore::getEventDispatcher()->dispatch($event, AdminEvents::ELEMENT_PERMISSION_IS_ALLOWED);
 
-            $permissions[$type] = $event->getArgument('isAllowed');
+            $permissions[$type] = boolval($event->getArgument('isAllowed'));
         }
 
         return $permissions;


### PR DESCRIPTION
The user permissions are transferded as an in converted to string, it causes many wrong positive checcks as "0" is evaluated as true by chrome and firefox. So a user gets menu entries to

Create objects
Sort objects
Move objects
etc.
without havin a permission for it. The permission is evaluated in Backend on action, so it does not give the user any more rights but it does cause exceptions and errors.