### PR TITLE
Cookies should be auto-secure

### DIFF
--- a/bundles/AdminBundle/Security/Authenticator/AdminAbstractAuthenticator.php
+++ b/bundles/AdminBundle/Security/Authenticator/AdminAbstractAuthenticator.php
@@ -122,7 +122,7 @@ abstract class AdminAbstractAuthenticator extends AbstractAuthenticator implemen
 
         if ($url) {
             $response = new RedirectResponse($url);
-            $response->headers->setCookie(new Cookie('pimcore_admin_sid', true, 0, '/', null, false, true));
+            $response->headers->setCookie(new Cookie('pimcore_admin_sid', true));
 
             return $response;
         }

--- a/bundles/AdminBundle/Security/Event/LogoutListener.php
+++ b/bundles/AdminBundle/Security/Event/LogoutListener.php
@@ -115,7 +115,8 @@ class LogoutListener implements EventSubscriberInterface, LoggerAwareInterface
 
         // cleanup pimcore-cookies => 315554400 => strtotime('1980-01-01')
         $response->headers->setCookie(new Cookie('pimcore_opentabs', null, 315554400));
-        $response->headers->clearCookie('pimcore_admin_sid', '/', null, false, true);
+        // clear cookie -> we can't use $response->headers->clearCookie() because it doesn't allow $secure = null
+        $response->headers->setCookie(new Cookie('pimcore_admin_sid', null, 1));
 
         if ($response instanceof RedirectResponse) {
             $this->logger->debug('Logout succeeded, redirecting to ' . $response->getTargetUrl());

--- a/bundles/AdminBundle/Security/Event/LogoutListener.php
+++ b/bundles/AdminBundle/Security/Event/LogoutListener.php
@@ -114,7 +114,7 @@ class LogoutListener implements EventSubscriberInterface, LoggerAwareInterface
         }
 
         // cleanup pimcore-cookies => 315554400 => strtotime('1980-01-01')
-        $response->headers->setCookie(new Cookie('pimcore_opentabs', null, 315554400, '/'));
+        $response->headers->setCookie(new Cookie('pimcore_opentabs', null, 315554400));
         $response->headers->clearCookie('pimcore_admin_sid', '/', null, false, true);
 
         if ($response instanceof RedirectResponse) {

--- a/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
+++ b/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
@@ -335,7 +335,7 @@ class AdminAuthenticator extends AbstractGuardAuthenticator implements LoggerAwa
 
         if ($url) {
             $response = new RedirectResponse($url);
-            $response->headers->setCookie(new Cookie('pimcore_admin_sid', true, 0, '/', null, false, true));
+            $response->headers->setCookie(new Cookie('pimcore_admin_sid', true));
 
             return $response;
         }

--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -246,7 +246,7 @@ class PublicServicesController extends Controller
 
         $customAdminPathIdentifier = $this->getParameter('pimcore_admin.custom_admin_path_identifier');
         if (!empty($customAdminPathIdentifier) && $request->cookies->get('pimcore_custom_admin') != $customAdminPathIdentifier) {
-            $redirect->headers->setCookie(new Cookie('pimcore_custom_admin', $customAdminPathIdentifier, strtotime('+1 year'), '/', null, false, true));
+            $redirect->headers->setCookie(new Cookie('pimcore_custom_admin', $customAdminPathIdentifier, strtotime('+1 year')));
         }
 
         return $redirect;

--- a/lib/Targeting/Storage/Cookie/AbstractCookieSaveHandler.php
+++ b/lib/Targeting/Storage/Cookie/AbstractCookieSaveHandler.php
@@ -74,11 +74,7 @@ abstract class AbstractCookieSaveHandler implements CookieSaveHandlerInterface
         $response->headers->setCookie(new Cookie(
             $name,
             $value,
-            $expire,
-            '/',
-            null,
-            false,
-            true
+            $expire
         ));
     }
 


### PR DESCRIPTION
resolves #12377

Unlike as requested in #12377 I think it would be better to just use Symfony's "auto secure", rather than introducing another config option. 