### PR TITLE
Fixed the integrity constraint violation issue when deleting classification store group

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classificationstore/groupsPanel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classificationstore/groupsPanel.js
@@ -312,7 +312,6 @@ pimcore.object.classificationstore.groupsPanel = Class.create({
                         var data = grid.getStore().getAt(rowIndex);
                         var id = data.data.id;
 
-                        this.relationsStore.removeAll(true);
                         this.relationsGrid.hide();
                         this.relationsPanel.disable();
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #11284 
