### PR TITLE
Children grid doesn't open when there are no select options

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
@@ -404,7 +404,7 @@ pimcore.object.helpers.grid = Class.create({
 
                         fc.locked = this.getColumnLock(field);
 
-                        if ((fieldType === "select" || fieldType === "multiselect") && field.layout.options.length > 0) {
+                        if ((fieldType === "select" || fieldType === "multiselect") && field.layout.options && field.layout.options.length > 0) {
                             field.layout.options.forEach(option => {
                                 option.key = t(option.key);
                             });


### PR DESCRIPTION
I had a class where field.layout.options was null. I got a js error and the Grid didnt open.
Im not exactly sure why it was null, maybe it has to do with a faulty OptionsProvider used for that select, but i think this additional check doesent hurt anyone.