### PR TITLE
Don't cache thumbnail urls with error image

### DIFF
--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -43,7 +43,7 @@ class PublicServicesController extends Controller
     /**
      * @param Request $request
      *
-     * @return BinaryFileResponse|StreamedResponse
+     * @return RedirectResponse|StreamedResponse
      */
     public function thumbnailAction(Request $request)
     {

--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -172,7 +172,7 @@ class PublicServicesController extends Controller
                 } catch (\Exception $e) {
                     Logger::error($e->getMessage());
 
-                    return new BinaryFileResponse(PIMCORE_WEB_ROOT . '/bundles/pimcoreadmin/img/filetype-not-supported.svg', 200);
+                    return new RedirectResponse('/bundles/pimcoreadmin/img/filetype-not-supported.svg');
                 }
             }
         }


### PR DESCRIPTION
If a deferred thumbnail couldn't be generated a error image is returned. But browser cache this urls. It should be only redirected to the error image. So the browser can receive the correct thumbnail when it could be generated.