### PR TITLE
Fix: Error in GeneratePagePreviewHandler

### DIFF
--- a/lib/Image/Chromium.php
+++ b/lib/Image/Chromium.php
@@ -17,6 +17,7 @@ namespace Pimcore\Image;
 
 use HeadlessChromium\BrowserFactory;
 use HeadlessChromium\Communication\Message;
+use Pimcore\Logger;
 use Pimcore\Tool\Console;
 use Pimcore\Tool\Session;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
@@ -96,7 +97,10 @@ class Chromium
                 'captureBeyondViewport' => true,
                 'clip' => $page->getFullPageClip(),
             ])->saveToFile($outputFile);
-        } catch (\Exception) {
+        } catch (\Throwable $e) {
+            Logger::debug('Could not create image from url: ' . $url);
+            Logger::debug((string) $e);
+
             return false;
         } finally {
             $browser->close();

--- a/lib/Image/Chromium.php
+++ b/lib/Image/Chromium.php
@@ -96,10 +96,12 @@ class Chromium
                 'captureBeyondViewport' => true,
                 'clip' => $page->getFullPageClip(),
             ])->saveToFile($outputFile);
+        } catch (\Exception) {
+            return false;
         } finally {
             $browser->close();
-
-            return true;
         }
+
+        return true;
     }
 }

--- a/lib/Image/HtmlToImage.php
+++ b/lib/Image/HtmlToImage.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Image;
 
+use Pimcore\Logger;
 use Pimcore\Tool\Console;
 use Pimcore\Tool\Session;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
@@ -105,6 +106,8 @@ class HtmlToImage
         if (file_exists($outputFile) && filesize($outputFile) > 1000) {
             return true;
         }
+
+        Logger::debug('Could not create image from url: ' . $url);
 
         return false;
     }

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -678,15 +678,16 @@ class Service extends Model\Element\Service
 
         if ($tool) {
             /** @var Chromium|HtmlToImage $tool */
-            $tool::convert($url, $tmpFile);
-            $im = \Pimcore\Image::getInstance();
-            $im->load($tmpFile);
-            $im->scaleByWidth(800);
-            $im->save($file, 'jpeg', 85);
+            if ($tool::convert($url, $tmpFile)) {
+                $im = \Pimcore\Image::getInstance();
+                $im->load($tmpFile);
+                $im->scaleByWidth(800);
+                $im->save($file, 'jpeg', 85);
 
-            unlink($tmpFile);
+                unlink($tmpFile);
 
-            $success = true;
+                $success = true;
+            }
         }
 
         return $success;


### PR DESCRIPTION
Error in GeneratePagePreviewHandler if HtmlToImage::convert() doesn't work and returns false.
```
08:39:37 ERROR     [pimcore] Unable to load image: /var/www/html/var/tmp/screenshot_tmp_2122.png
08:39:37 ERROR     [pimcore] unable to open image `/var/www/html/var/tmp/screenshot_tmp_2122.png': No such file or directory @ error/blob.c/OpenBlob/2924
08:39:37 CRITICAL  [messenger] Error thrown while handling message Pimcore\Messenger\GeneratePagePreviewMessage. Removing from transport after 3 retries. Error: "Handling "Pimcore\Messenger\GeneratePagePreviewMessage" failed: Call to a member function stripImage() on null" ["message" => Pimcore\Messenger\GeneratePagePreviewMessage^ { …},"class" => "Pimcore\Messenger\GeneratePagePreviewMessage","retryCount" => 3,"error" => "Handling "Pimcore\Messenger\GeneratePagePreviewMessage" failed: Call to a member function stripImage() on null","exception" => Symfony\Component\Messenger\Exception\HandlerFailedException^ { …}]
```