### PR TITLE
Fix: Error with handling AssetPreviewImageMessage

### DIFF
--- a/models/Asset/Document/ImageThumbnail.php
+++ b/models/Asset/Document/ImageThumbnail.php
@@ -91,34 +91,15 @@ final class ImageThumbnail
 
             try {
                 if (!$deferred) {
-                    $storage = Storage::get('asset_cache');
-                    $cacheFilePath = sprintf(
-                        '%s/%s/image-thumb__%s__document_original_image/page_%s.png',
-                        rtrim($this->asset->getRealPath(), '/'),
-                        $this->asset->getId(),
-                        $this->asset->getId(),
-                        $this->page
-                    );
-
-                    if (!$storage->fileExists($cacheFilePath)) {
-                        $lock = \Pimcore::getContainer()->get(LockFactory::class)->createLock($cacheFilePath);
-                        $converter = \Pimcore\Document::getInstance();
-                        $converter->load($this->asset);
-                        if ($lock->acquire()) {
-                            $tempFile = File::getLocalTempFilePath('png');
-                            $converter->saveImage($tempFile, $this->page);
-                            $generated = true;
-                            $lock->release();
-                            $storage->write($cacheFilePath, file_get_contents($tempFile));
-                            unlink($tempFile);
-                        }
+                    if ($cacheFileStream = $this->getCacheFileStream()) {
+                        $generated = true;
                     }
-
-                    $cacheFileStream = $storage->readStream($cacheFilePath);
                 }
 
                 if ($config) {
-                    $this->pathReference = Image\Thumbnail\Processor::process($this->asset, $config, $cacheFileStream, $deferred, $generated);
+                    if ($deferred || $cacheFileStream) {
+                        $this->pathReference = Image\Thumbnail\Processor::process($this->asset, $config, $cacheFileStream, $deferred, $generated);
+                    }
                 }
             } catch (\Exception $e) {
                 Logger::error("Couldn't create image-thumbnail of document " . $this->asset->getRealFullPath());
@@ -138,6 +119,43 @@ final class ImageThumbnail
             ]);
             \Pimcore::getEventDispatcher()->dispatch($event, AssetEvents::DOCUMENT_IMAGE_THUMBNAIL);
         }
+    }
+
+    /**
+     * @return resource|null
+     */
+    private function getCacheFileStream()
+    {
+        $storage = Storage::get('asset_cache');
+        $cacheFilePath = sprintf(
+            '%s/%s/image-thumb__%s__document_original_image/page_%s.png',
+            rtrim($this->asset->getRealPath(), '/'),
+            $this->asset->getId(),
+            $this->asset->getId(),
+            $this->page
+        );
+
+        if (!$storage->fileExists($cacheFilePath)) {
+            $lock = \Pimcore::getContainer()->get(LockFactory::class)->createLock($cacheFilePath);
+            if ($lock->acquire()) {
+                $tempFile = File::getLocalTempFilePath('png');
+                try {
+                    $converter = \Pimcore\Document::getInstance();
+                    $converter->load($this->asset);
+                    $converter->saveImage($tempFile, $this->page);
+                    $storage->write($cacheFilePath, file_get_contents($tempFile));
+                } finally {
+                    unlink($tempFile);
+                    $lock->release();
+                }
+            } else {
+                Logger::info('Creation of cache file stream of document ' . $this->asset->getRealFullPath() . ' is locked');
+
+                return null;
+            }
+        }
+
+        return $storage->readStream($cacheFilePath);
     }
 
     /**


### PR DESCRIPTION
Error when the cache file creation is locked:
```
08:51:45 ERROR     [pimcore] Couldn't create image-thumbnail of document /test.pdf
08:51:45 ERROR     [pimcore] Unable to read file from location: test/185/image-thumb__185__document_original_image/page_1.png. fopen(/var/www/html/public/var/tmp/asset-cache/test/185/image-thumb__185__document_original_image/page_1.png): Failed to open stream: No such file or directory
08:51:45 WARNING   [messenger] Error thrown while handling message Pimcore\Messenger\AssetPreviewImageMessage. Sending for retry #1 using 1000 ms delay. Error: "Handling "Pimcore\Messenger\AssetPreviewImageMessage" failed: stream_get_contents(): Argument #1 ($stream) must be of type resource, null given" ["message" => Pimcore\Messenger\AssetPreviewImageMessage^ { …},"class" => "Pimcore\Messenger\AssetPreviewImageMessage","retryCount" => 1,"delay" => 1000,"error" => "Handling "Pimcore\Messenger\AssetPreviewImageMessage" failed: stream_get_contents(): Argument #1 ($stream) must be of type resource, null given","exception" => Symfony\Component\Messenger\Exception\HandlerFailedException^ { …}]
```