### PR TITLE
Add an option "allowedTypes" to the video editable.

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1999,6 +1999,7 @@ pimcore.helpers.editmode.openLinkEditPanel = function (data, callback) {
 
 pimcore.helpers.editmode.openVideoEditPanel = function (data, callback) {
 
+    const allowedTypes = data.allowedTypes;
     var window = null;
     var form = null;
     var fieldPath = new Ext.form.TextField({
@@ -2011,13 +2012,16 @@ pimcore.helpers.editmode.openVideoEditPanel = function (data, callback) {
         enableKeyEvents: true,
         listeners: {
             keyup: function (el) {
-                if ((el.getValue().indexOf("youtu.be") >= 0 || el.getValue().indexOf("youtube.com") >= 0) && el.getValue().indexOf("http") >= 0) {
+                if (allowedTypes.includes("youtube")
+                    && (el.getValue().indexOf("youtu.be") >= 0 || el.getValue().indexOf("youtube.com") >= 0) && el.getValue().indexOf("http") >= 0) {
                     form.getComponent("type").setValue("youtube");
                     updateType("youtube");
-                } else if (el.getValue().indexOf("vimeo") >= 0 && el.getValue().indexOf("http") >= 0) {
+                } else if (allowedTypes.includes("vimeo")
+                    && el.getValue().indexOf("vimeo") >= 0 && el.getValue().indexOf("http") >= 0) {
                     form.getComponent("type").setValue("vimeo");
                     updateType("vimeo");
-                } else if ((el.getValue().indexOf("dai.ly") >= 0 || el.getValue().indexOf("dailymotion") >= 0) && el.getValue().indexOf("http") >= 0) {
+                } else if (allowedTypes.includes("dailymotion")
+                    && (el.getValue().indexOf("dai.ly") >= 0 || el.getValue().indexOf("dailymotion") >= 0) && el.getValue().indexOf("http") >= 0) {
                     form.getComponent("type").setValue("dailymotion");
                     updateType("dailymotion");
                 }
@@ -2093,8 +2097,10 @@ pimcore.helpers.editmode.openVideoEditPanel = function (data, callback) {
         });
     };
 
-    fieldPath.on("render", initDD);
-    poster.on("render", initDD);
+    if (allowedTypes.includes("asset")) {
+        fieldPath.on("render", initDD);
+        poster.on("render", initDD);
+    }
 
     var searchButton = new Ext.Button({
         iconCls: "pimcore_icon_search",
@@ -2196,7 +2202,7 @@ pimcore.helpers.editmode.openVideoEditPanel = function (data, callback) {
             editable: false,
             width: 270,
             mode: "local",
-            store: ["asset", "youtube", "vimeo", "dailymotion"],
+            store: allowedTypes,
             value: data.type,
             listeners: {
                 select: function (combo) {
@@ -2249,7 +2255,6 @@ pimcore.helpers.editmode.openVideoEditPanel = function (data, callback) {
             }
         ]
     });
-
 
     window = new Ext.Window({
         width: 510,

--- a/doc/Development_Documentation/03_Documents/01_Editables/38_Video.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/38_Video.md
@@ -8,19 +8,20 @@ Local asset videos support the automatic generation and transcoding of videos us
 
 ## Configuration
 
-| Name                      | Type      | Description                                                                                                                                                                                                             |
-|---------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `attributes`              | array     | Additional attributes for the generated `<video>` tag - only for type asset                                                                                                                                             |
-| `disableProgressReload`   | bool      | Set to true to disable the automatic page refresh while the video thumbnail is generated                                                                                                                                |
-| `editmodeImagePreview`    | bool      | Set to true to display only an image and not the video player in editmode, this can be necessary if you have many videos on one page (performance)                                                                      |
-| `height`                  | integer   | Height of the video in pixel                                                                                                                                                                                            |
-| `imagethumbnail`          | string    | Name of the image-thumbnail, this thumbnail config is used to generate the preview image (poster image), if not specified Pimcore tries to get the information out of the video thumbnail. see also: Video Thumbnails   |
-| `removeAttributes`        | array     | You can remove standard attributes using this configuration, e.g. "removeAttributes" => ["controls","poster"]                                                                                                           |
-| `thumbnail`               | string    | Name of the video-thumbnail (required when using automatic-transcoding of videos) see: [Video Thumbnails](../../04_Assets/03_Working_with_Thumbnails/03_Video_Thumbnails.md)                                            |
-| `width`                   | integer   | Width of the video in pixel                                                                                                                                                                                             |
-| `youtube`                 | array     | Parameters for youtube integration. Possible parameters: [https://developers.google.com/youtube/player_parameters](https://developers.google.com/youtube/player_parameters) - only for type ***youtube***               |
-| `class`                   | string    | A CSS class that is added to the surrounding container of this element in editmode                                                                                                                                      |
-| `required`                | boolean   | (default: false) set to true to make field value required for publish                                                                                                                                                   |
+| Name                    | Type      | Description                                                                                                                                                                                                           |
+|-------------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `allowedTypes`          | array     | You can limit the available types for this editable by passing the allowed types explicitly. If this option is not used, all types are available.                                                                     |
+| `attributes`            | array     | Additional attributes for the generated `<video>` tag - only for type asset                                                                                                                                           |
+| `disableProgressReload` | bool      | Set to true to disable the automatic page refresh while the video thumbnail is generated                                                                                                                              |
+| `editmodeImagePreview`  | bool      | Set to true to display only an image and not the video player in editmode, this can be necessary if you have many videos on one page (performance)                                                                    |
+| `height`                | integer   | Height of the video in pixel                                                                                                                                                                                          |
+| `imagethumbnail`        | string    | Name of the image-thumbnail, this thumbnail config is used to generate the preview image (poster image), if not specified Pimcore tries to get the information out of the video thumbnail. see also: Video Thumbnails |
+| `removeAttributes`      | array     | You can remove standard attributes using this configuration, e.g. "removeAttributes" => ["controls","poster"]                                                                                                         |
+| `thumbnail`             | string    | Name of the video-thumbnail (required when using automatic-transcoding of videos) see: [Video Thumbnails](../../04_Assets/03_Working_with_Thumbnails/03_Video_Thumbnails.md)                                          |
+| `width`                 | integer   | Width of the video in pixel                                                                                                                                                                                           |
+| `youtube`               | array     | Parameters for youtube integration. Possible parameters: [https://developers.google.com/youtube/player_parameters](https://developers.google.com/youtube/player_parameters) - only for type ***youtube***             |
+| `class`                 | string    | A CSS class that is added to the surrounding container of this element in editmode                                                                                                                                    |
+| `required`              | boolean   | (default: false) set to true to make field value required for publish                                                                                                                                                 |
 
 ## Methods
 
@@ -49,7 +50,7 @@ Output returned by `getPosterAsset`:
 
 ### Basic Usage - a Local Asset
 
-To create a container for local video files you can just use the `$this->video` helperwithout any options.
+To create a container for local video files you can just use the `$this->video` helper without any options.
 
 ```twig
 <section id="campaign_video">
@@ -92,6 +93,17 @@ In the configuration, you could also specify additional options for external ser
                 autoplay: true,
                 loop: true
             }
+       })
+    }}
+</section>
+```
+
+It is possible to limit the available types for this editable. The selection can be restricted via the "allowedTypes" parameter.
+
+```twig
+<section id="campaign_video">
+    {{ pimcore_video('campaignVideo', {
+            allowedTypes: ['asset', 'youtube']
        })
     }}
 </section>

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -196,7 +196,6 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         return 'video';
     }
 
-
     /**
      * @param array $allowedTypes
      *
@@ -1035,6 +1034,10 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
      */
     public function getVideoType()
     {
+        if (empty($this->type) === true) {
+            $this->type = $this->allowedTypes[0];
+        }
+
         return $this->type;
     }
 
@@ -1043,7 +1046,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
      */
     public function getVideoAsset()
     {
-        if ($this->getVideoType() == self::TYPE_ASSET) {
+        if ($this->getVideoType() === self::TYPE_ASSET) {
             return Asset\Video::getById($this->id);
         }
 

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -26,6 +26,18 @@ use Pimcore\Tool;
  */
 class Video extends Model\Document\Editable implements IdRewriterInterface
 {
+    public const TYPE_ASSET = 'asset';
+    public const TYPE_YOUTUBE = 'youtube';
+    public const TYPE_VIMEO = 'vimeo';
+    public const TYPE_DAILYMOTION = 'dailymotion';
+
+    public const ALLOWED_TYPES = [
+        self::TYPE_ASSET,
+        self::TYPE_YOUTUBE,
+        self::TYPE_VIMEO,
+        self::TYPE_DAILYMOTION,
+    ];
+
     /**
      * contains depending on the type of the video the unique identifier eg. "http://www.youtube.com", "789", ...
      *
@@ -36,13 +48,13 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
     protected $id;
 
     /**
-     * one of asset, youtube, vimeo, dailymotion
+     * one of self::ALLOWED_TYPES
      *
      * @internal
      *
      * @var string|null
      */
-    protected $type = 'asset';
+    protected $type;
 
     /**
      * asset ID of poster image
@@ -66,6 +78,33 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
      * @var string
      */
     protected $description = '';
+
+    /**
+     * @internal
+     *
+     * @var array
+     */
+    protected $allowedTypes;
+
+    /**
+     * @param int|string $id
+     *
+     * @return Video
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
 
     /**
      * @param string $title
@@ -157,25 +196,61 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         return 'video';
     }
 
+
+    /**
+     * @param array $allowedTypes
+     *
+     * @return $this
+     */
+    public function setAllowedTypes($allowedTypes)
+    {
+        $this->allowedTypes = $allowedTypes;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAllowedTypes()
+    {
+        return $this->allowedTypes;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function getData()
     {
         $path = $this->id;
-        if ($this->type == 'asset' && ($video = Asset::getById($this->id))) {
+        if ($this->type === self::TYPE_ASSET && ($video = Asset::getById($this->id))) {
             $path = $video->getFullPath();
+        }
+
+        $this->allowedTypes = self::ALLOWED_TYPES;
+
+        if (
+            isset($this->getConfig()['allowedTypes']) === true
+            && empty($this->getConfig()['allowedTypes']) === false
+            && empty(array_diff($this->getConfig()['allowedTypes'], self::ALLOWED_TYPES))
+        ) {
+            $this->allowedTypes = $this->getConfig()['allowedTypes'];
+        }
+
+        if (empty($this->type) === true) {
+            $this->type = $this->allowedTypes[0]; // Set the first type in array as default selection for dropdown
         }
 
         $poster = Asset::getById($this->poster);
 
         return [
-            'id' => $this->id,
-            'type' => $this->type,
-            'title' => $this->title,
-            'description' => $this->description,
-            'path' => $path,
-            'poster' => $poster ? $poster->getFullPath() : '',
+            'id'           => $this->id,
+            'type'         => $this->type,
+            'allowedTypes' => $this->allowedTypes,
+            'title'        => $this->title,
+            'description'  => $this->description,
+            'path'         => $path,
+            'poster'       => $poster ? $poster->getFullPath() : '',
         ];
     }
 
@@ -185,11 +260,12 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
     public function getDataForResource()
     {
         return [
-            'id' => $this->id,
-            'type' => $this->type,
-            'title' => $this->title,
-            'description' => $this->description,
-            'poster' => $this->poster,
+            'id'           => $this->id,
+            'type'         => $this->type,
+            'allowedTypes' => $this->allowedTypes,
+            'title'        => $this->title,
+            'description'  => $this->description,
+            'poster'       => $this->poster,
         ];
     }
 
@@ -206,15 +282,15 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
         if (!$this->id || !$this->type) {
             return $this->getEmptyCode();
-        } elseif ($this->type == 'asset') {
+        } elseif ($this->type === self::TYPE_ASSET) {
             return $this->getAssetCode($inAdmin);
-        } elseif ($this->type == 'youtube') {
+        } elseif ($this->type === self::TYPE_YOUTUBE) {
             return $this->getYoutubeCode();
-        } elseif ($this->type == 'vimeo') {
+        } elseif ($this->type === self::TYPE_VIMEO) {
             return $this->getVimeoCode();
-        } elseif ($this->type == 'dailymotion') {
+        } elseif ($this->type === self::TYPE_DAILYMOTION) {
             return $this->getDailymotionCode();
-        } elseif ($this->type == 'url') {
+        } elseif ($this->type === 'url') {
             return $this->getUrlCode();
         }
 
@@ -228,13 +304,13 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
     {
         $dependencies = [];
 
-        if ($this->type == 'asset') {
+        if ($this->type === self::TYPE_ASSET) {
             $asset = Asset::getById($this->id);
             if ($asset instanceof Asset) {
                 $key = 'asset_' . $asset->getId();
                 $dependencies[$key] = [
                     'id' => $asset->getId(),
-                    'type' => 'asset',
+                    'type' => self::TYPE_ASSET,
                 ];
             }
         }
@@ -243,7 +319,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
             $key = 'asset_' . $poster->getId();
             $dependencies[$key] = [
                 'id' => $poster->getId(),
-                'type' => 'asset',
+                'type' => self::TYPE_ASSET,
             ];
         }
 
@@ -255,24 +331,24 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
      */
     public function checkValidity()
     {
-        $sane = true;
-        if ($this->type == 'asset' && !empty($this->id)) {
+        $valid = true;
+        if ($this->type === self::TYPE_ASSET && !empty($this->id)) {
             $el = Asset::getById($this->id);
             if (!$el instanceof Asset) {
-                $sane = false;
-                Logger::notice('Detected insane relation, removing reference to non existent asset with id [' . $this->id . ']');
-                $this->id = null;
+                $valid = false;
+                Logger::notice('Detected invalid relation, removing reference to non existent asset with id ['.$this->id.']');
+                $this->id   = null;
                 $this->type = null;
             }
         }
 
         if (!($poster = Asset::getById($this->poster))) {
-            $sane = false;
-            Logger::notice('Detected insane relation, removing reference to non existent asset with id [' . $this->id . ']');
+            $valid = false;
+            Logger::notice('Detected invalid relation, removing reference to non existent asset with id ['.$this->id.']');
             $this->poster = null;
         }
 
-        return $sane;
+        return $valid;
     }
 
     /**
@@ -312,7 +388,9 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
      */
     public function setDataFromEditmode($data)
     {
-        if (isset($data['type'])) {
+        if (isset($data['type'])
+            && in_array($data['type'], self::ALLOWED_TYPES, true) === true
+        ) {
             $this->type = $data['type'];
         }
 
@@ -496,7 +574,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
     private function parseYoutubeId()
     {
         $youtubeId = '';
-        if ($this->type == 'youtube') {
+        if ($this->type === self::TYPE_YOUTUBE) {
             if ($youtubeId = $this->id) {
                 if (strpos($youtubeId, '//') !== false) {
                     $parts = parse_url($this->id);
@@ -592,8 +670,8 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
         // this is to be backward compatible to <= v 1.4.7
         $configurations = $clipConfig;
-        if (array_key_exists('youtube', $config) && is_array($config['youtube'])) {
-            $configurations = array_merge($clipConfig, $config['youtube']);
+        if (array_key_exists(self::TYPE_YOUTUBE, $config) && is_array($config[self::TYPE_YOUTUBE])) {
+            $configurations = array_merge($clipConfig, $config[self::TYPE_YOUTUBE]);
         }
 
         if (!empty($configurations)) {
@@ -667,8 +745,8 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
             // this is to be backward compatible to <= v 1.4.7
             $configurations = $clipConfig;
-            if (isset($config['vimeo']) && is_array($config['vimeo'])) {
-                $configurations = array_merge($clipConfig, $config['vimeo']);
+            if (isset($config[self::TYPE_VIMEO]) && is_array($config[self::TYPE_VIMEO])) {
+                $configurations = array_merge($clipConfig, $config[self::TYPE_VIMEO]);
             }
 
             if (!empty($configurations)) {
@@ -735,8 +813,8 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
             // this is to be backward compatible to <= v 1.4.7
             $configurations = $clipConfig;
-            if (isset($config['dailymotion']) && is_array($config['dailymotion'])) {
-                $configurations = array_merge($clipConfig, $config['dailymotion']);
+            if (isset($config[self::TYPE_DAILYMOTION]) && is_array($config[self::TYPE_DAILYMOTION])) {
+                $configurations = array_merge($clipConfig, $config[self::TYPE_DAILYMOTION]);
             }
 
             if (!empty($configurations)) {
@@ -965,7 +1043,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
      */
     public function getVideoAsset()
     {
-        if ($this->getVideoType() == 'asset') {
+        if ($this->getVideoType() == self::TYPE_ASSET) {
             return Asset\Video::getById($this->id);
         }
 
@@ -1013,32 +1091,12 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
     }
 
     /**
-     * @param int|string $id
-     *
-     * @return Video
-     */
-    public function setId($id)
-    {
-        $this->id = $id;
-
-        return $this;
-    }
-
-    /**
-     * @return int|string
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    /**
      * { @inheritdoc }
      */
     public function rewriteIds($idMapping) /** : void */
     {
-        if ($this->type == 'asset' && array_key_exists('asset', $idMapping) && array_key_exists($this->getId(), $idMapping['asset'])) {
-            $this->setId($idMapping['asset'][$this->getId()]);
+        if ($this->type == self::TYPE_ASSET && array_key_exists(self::TYPE_ASSET, $idMapping) && array_key_exists($this->getId(), $idMapping[self::TYPE_ASSET])) {
+            $this->setId($idMapping[self::TYPE_ASSET][$this->getId()]);
         }
     }
 }


### PR DESCRIPTION
Resolves #2999

This PR adds an "allowedTypes" option to the video editable to limit the selectable video types.

If this parameter is not set or is empty or its content is invalid, all available types are displayed.

