### PR TITLE
Fix FFMPEG with durations like 00:00:11.04 (milliseconds)

### DIFF
--- a/lib/Video/Adapter.php
+++ b/lib/Video/Adapter.php
@@ -216,7 +216,7 @@ abstract class Adapter
     }
 
     /**
-     * @return float
+     * @return float|null
      *
      * @throws \Exception
      */

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -253,7 +253,7 @@ class Ffmpeg extends Adapter
     }
 
     /**
-     * @return float
+     * @return float|null
      *
      * @throws \Exception
      */

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -262,14 +262,16 @@ class Ffmpeg extends Adapter
         $output = $this->getVideoInfo();
 
         // get total video duration
-        preg_match("/Duration: ([0-9:\.]+),/", $output, $matches);
-        $durationRaw = $matches[1];
-        $durationParts = explode(':', $durationRaw);
+        $result = preg_match("/\s+Duration: ((\d\d):(\d\d):(\d\d)\.(\d+))/", $output, $matches);
 
-        // calculate duration in seconds
-        $duration = ((int)$durationParts[0] * 3600) + ((int)$durationParts[1] * 60) + (float)$durationParts[2];
+        if (false !== $result && 0 !== $result && count($matches) === 6) {
+            // calculate duration in seconds
+            $duration = ((int)$matches[2] * 3600) + ((int)$matches[3] * 60) + (float)$matches[4];
 
-        return $duration;
+            return $duration;
+        }
+
+        return null;
     }
 
     /**

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -262,11 +262,11 @@ class Ffmpeg extends Adapter
         $output = $this->getVideoInfo();
 
         // get total video duration
-        $result = preg_match("/\s+Duration: ((\d\d):(\d\d):(\d\d)\.(\d+))/", $output, $matches);
+        $result = preg_match("/Duration: (\d\d):(\d\d):(\d\d\.\d+),/", $output, $matches);
 
-        if (false !== $result && 0 !== $result && count($matches) === 6) {
+        if ($result) {
             // calculate duration in seconds
-            $duration = ((int)$matches[2] * 3600) + ((int)$matches[3] * 60) + (float)$matches[4];
+            $duration = ((int)$matches[1] * 3600) + ((int)$matches[2] * 60) + (float)$matches[3];
 
             return $duration;
         }


### PR DESCRIPTION
Ffmpeg adapter cannot parse durations where milliseconds are applied, using a better regex solves that problem
