### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/codeception.yml
+++ b/.github/workflows/codeception.yml
@@ -29,6 +29,9 @@ env:
     MINIO_ACCESS_KEY: "PIMCORE_OBJECT_STORAGE_ACCESS_KEY"
     MINIO_SECRET_KEY: "PIMCORE_OBJECT_STORAGE_SECRET_KEY"
 
+permissions:
+  contents: read
+
 jobs:
     codeception-tests:
         name: "Codeception tests"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,9 @@ on:
         paths:
             - 'docs/**'
 
+permissions:
+  contents: read
+
 jobs:
     docs:
         name: "Generate docs with Daux"

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -7,8 +7,13 @@ on:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
 
+permissions:
+  contents: read
+
 jobs:
     php-cs-fixer:
+        permissions:
+          contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/poeditor-export.yml
+++ b/.github/workflows/poeditor-export.yml
@@ -9,6 +9,9 @@ on:
         paths:
             - 'bundles/CoreBundle/Resources/translations/en.*json'
 
+permissions:
+  contents: read
+
 jobs:
     poeditor:
         runs-on: ubuntu-latest

--- a/.github/workflows/poeditor-import.yml
+++ b/.github/workflows/poeditor-import.yml
@@ -10,8 +10,13 @@ on:
                 default: ''
 
 
+permissions:
+  contents: read
+
 jobs:
     poeditor:
+        permissions:
+          contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,6 @@ jobs:
     stale:
         permissions:
           issues: write  # for actions/stale to close stale issues
-          pull-requests: write  # for actions/stale to close stale PRs
         runs-on: ubuntu-latest
         steps:
             - uses: actions/stale@v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,8 +4,14 @@ on:
     schedule:
         - cron: '37 7 * * *'
 
+permissions:
+  contents: read
+
 jobs:
     stale:
+        permissions:
+          issues: write  # for actions/stale to close stale issues
+          pull-requests: write  # for actions/stale to close stale PRs
         runs-on: ubuntu-latest
         steps:
             - uses: actions/stale@v4

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -27,6 +27,9 @@ env:
     PIMCORE_TEST: 1
     PIMCORE_STORAGE: 'local'
 
+permissions:
+  contents: read
+
 jobs:
     static-analysis-phpstan:
         name: "Static Analysis with PHPStan"


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
