### PR TITLE
[PHP 8.1] fix Passing null to parameter #1 ($string) of type string is deprecate

### DIFF
--- a/models/Staticroute.php
+++ b/models/Staticroute.php
@@ -66,7 +66,7 @@ final class Staticroute extends AbstractModel
     /**
      * @var array
      */
-    protected $siteId;
+    protected $siteId = [];
 
     /**
      * @var array
@@ -398,12 +398,12 @@ final class Staticroute extends AbstractModel
      *
      * @return $this
      */
-    public function setSiteId($siteId = [])
+    public function setSiteId($siteId)
     {
         $result = [];
         
         if (null === $siteId) {
-            $siteId = [];
+            return;
         }
 
         if (!is_array($siteId)) {

--- a/models/Staticroute.php
+++ b/models/Staticroute.php
@@ -403,7 +403,7 @@ final class Staticroute extends AbstractModel
         $result = [];
         
         if (null === $siteId) {
-            return;
+            $siteId = [];
         }
 
         if (!is_array($siteId)) {

--- a/models/Staticroute.php
+++ b/models/Staticroute.php
@@ -394,7 +394,7 @@ final class Staticroute extends AbstractModel
     }
 
     /**
-     * @param string|array $siteId
+     * @param string|array|null $siteId
      *
      * @return $this
      */

--- a/models/Staticroute.php
+++ b/models/Staticroute.php
@@ -398,7 +398,7 @@ final class Staticroute extends AbstractModel
      *
      * @return $this
      */
-    public function setSiteId($siteId)
+    public function setSiteId($siteId = [])
     {
         $result = [];
         

--- a/models/Staticroute.php
+++ b/models/Staticroute.php
@@ -401,6 +401,10 @@ final class Staticroute extends AbstractModel
     public function setSiteId($siteId)
     {
         $result = [];
+        
+        if (null === $siteId) {
+            $siteId = [];
+        }
 
         if (!is_array($siteId)) {
             // backwards compatibility


### PR DESCRIPTION
https://github.com/coreshop/CoreShop/runs/6981738951?check_suite_focus=true#step:17:93

