### PR TITLE
Glossary: allow html entities like &nbsp; or &copy;

### DIFF
--- a/bundles/CoreBundle/Resources/config/templating.yaml
+++ b/bundles/CoreBundle/Resources/config/templating.yaml
@@ -52,7 +52,7 @@ services:
     # GLOSSARY
 
     Pimcore\Tool\Glossary\Processor:
-        public: false
+        public: true #For Tests
 
     Symfony\Component\Templating\EngineInterface: '@pimcore.templating.engine.delegating'
 

--- a/bundles/CoreBundle/Resources/config/templating.yaml
+++ b/bundles/CoreBundle/Resources/config/templating.yaml
@@ -52,7 +52,7 @@ services:
     # GLOSSARY
 
     Pimcore\Tool\Glossary\Processor:
-        public: true #For Tests
+        public: false
 
     Symfony\Component\Templating\EngineInterface: '@pimcore.templating.engine.delegating'
 

--- a/lib/Tool/Glossary/Processor.php
+++ b/lib/Tool/Glossary/Processor.php
@@ -132,7 +132,7 @@ class Processor
 
         $es->each(function ($parentNode, $i) use ($options, $data) {
             /** @var DomCrawler|null $parentNode */
-            $text = $parentNode->html();
+            $text = htmlspecialchars($parentNode->text(), ENT_QUOTES | ENT_HTML5);
             if (
                 $parentNode instanceof DomCrawler &&
                 !in_array((string)$parentNode->nodeName(), $this->blockedTags) &&

--- a/lib/Tool/Glossary/Processor.php
+++ b/lib/Tool/Glossary/Processor.php
@@ -77,7 +77,20 @@ class Processor
      */
     public function process(string $content, array $options): string
     {
-        $data = $this->getData();
+        if ($this->editmodeResolver->isEditmode()) {
+            return $content;
+        }
+
+        $locale = $this->requestHelper->getMainRequest()->getLocale();
+        $currentDocument = $this->documentResolver->getDocument();
+        $uri = $this->requestHelper->getMainRequest()->getRequestUri();
+
+        return $this->parse($content, $options, $locale, $currentDocument, $uri);
+    }
+
+    public function parse(string $content, array $options, string $locale, ?Document $document, ?string $uri): string
+    {
+        $data = $this->getData($locale);
         if (empty($data)) {
             return $content;
         }
@@ -85,10 +98,6 @@ class Processor
         $options = array_merge([
             'limit' => -1,
         ], $options);
-
-        if ($this->editmodeResolver->isEditmode()) {
-            return $content;
-        }
 
         // why not using a simple str_ireplace(array(), array(), $subject) ?
         // because if you want to replace the terms "Donec vitae" and "Donec" you will get nested links, so the content
@@ -101,25 +110,21 @@ class Processor
             'replace' => [],
         ];
 
-        // get initial document from request (requested document, if it was a "document" request)
-        $currentDocument = $this->documentResolver->getDocument();
-        $currentUri = $this->requestHelper->getMainRequest()->getRequestUri();
-
         foreach ($data as $entry) {
-            if ($currentDocument && $currentDocument instanceof Document) {
+            if ($document instanceof Document) {
                 // check if the current document is the target link (id check)
-                if ($entry['linkType'] == 'internal' && $currentDocument->getId() == $entry['linkTarget']) {
+                if ($entry['linkType'] == 'internal' && $document->getId() == $entry['linkTarget']) {
                     continue;
                 }
 
                 // check if the current document is the target link (path check)
-                if ($currentDocument->getFullPath() == rtrim($entry['linkTarget'], ' /')) {
+                if ($document->getFullPath() == rtrim($entry['linkTarget'], ' /')) {
                     continue;
                 }
             }
 
             // check if the current URI is the target link (path check)
-            if ($currentUri == rtrim($entry['linkTarget'], ' /')) {
+            if ($uri === rtrim($entry['linkTarget'], ' /')) {
                 continue;
             }
 
@@ -132,7 +137,7 @@ class Processor
 
         $es->each(function ($parentNode, $i) use ($options, $data) {
             /** @var DomCrawler|null $parentNode */
-            $text = htmlspecialchars($parentNode->text(), ENT_QUOTES | ENT_HTML5);
+            $text = $parentNode->text();
             if (
                 $parentNode instanceof DomCrawler &&
                 !in_array((string)$parentNode->nodeName(), $this->blockedTags) &&
@@ -170,15 +175,11 @@ class Processor
     }
 
     /**
+     * @param string $locale
      * @return array
      */
-    private function getData(): array
+    private function getData(string $locale): array
     {
-        $locale = $this->requestHelper->getMainRequest()->getLocale();
-        if (!$locale) {
-            return [];
-        }
-
         $siteId = '';
         if (Site::isSiteRequest()) {
             $siteId = Site::getCurrentSite()->getId();

--- a/lib/Tool/Glossary/Processor.php
+++ b/lib/Tool/Glossary/Processor.php
@@ -154,7 +154,7 @@ class Processor
                 if ($originalText !== $text) {
                     $domNode = $parentNode->getNode(0);
                     $fragment = $domNode->ownerDocument->createDocumentFragment();
-                    $fragment->appendXML($text);
+                    $fragment->appendXML(html_entity_decode($text));
                     $clone = $domNode->cloneNode();
                     $clone->appendChild($fragment);
                     $domNode->parentNode->replaceChild($clone, $domNode);

--- a/tests/Unit/Document/Glossary/GlossaryTest.php
+++ b/tests/Unit/Document/Glossary/GlossaryTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Tests\Unit\Document\Glossary;
+
+use Pimcore\Model\Glossary;
+use Pimcore\Tests\Test\TestCase;
+use Pimcore\Tool\Glossary\Processor;
+
+class GlossaryTest extends TestCase
+{
+    /** @var Processor $processor */
+    protected $processor;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->processor = \Pimcore::getContainer()->get(Processor::class);
+    }
+
+    public function testGlossary()
+    {
+        $entry = new Glossary();
+        $entry->setText('Glossary');
+        $entry->setLink('/test');
+        $entry->setLanguage('en');
+        $entry->save();
+
+        $result = $this->processor->parse('<body><p>This is a Test for the Glossary</p></body>', [], 'en', null, null);
+
+        $expect = '<body><p>This is a Test for the <a class="pimcore_glossary" href="/test">Glossary</a></p></body>';
+
+        $this->assertSame($result, $expect);
+    }
+
+    public function testGlossaryWithHtmlEntities()
+    {
+        $entry = new Glossary();
+        $entry->setText('Entity');
+        $entry->setLink('/test');
+        $entry->setLanguage('en');
+        $entry->save();
+
+        $result = $this->processor->parse('<body><p>This is a Test for the&nbsp;Entity &copy;</p></body>', [], 'en', null, null);
+
+        $expect = '<body><p>This is a Test for the&nbsp;<a class="pimcore_glossary" href="/test">Entity</a> &copy;</p></body>';
+
+        $this->assertSame($result, html_entity_decode($expect));
+    }
+
+    public function testGlossaryWithHtmlEntities2()
+    {
+        $entry = new Glossary();
+        $entry->setText('Eintrag');
+        $entry->setLink('/test');
+        $entry->setLanguage('en');
+        $entry->save();
+
+        $result = $this->processor->parse('<body><p>Test &nbsp; Eintrag ©</p></body>', [], 'en', null, null);
+
+        $expect = '<body><p>Test &nbsp; <a class="pimcore_glossary" href="/test">Eintrag</a> &copy;</p></body>';
+
+        $this->assertSame($result, html_entity_decode($expect));
+    }
+
+    public function testGlossaryWithHtml()
+    {
+        $entry = new Glossary();
+        $entry->setText('HTML');
+        $entry->setLink('/test');
+        $entry->setLanguage('en');
+        $entry->save();
+
+        $result = $this->processor->parse('<section class="c-content" id="c-20-content-0">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12 col-lg-10">
+                    <div class="text-content">
+                        <div class="text-content__pre h6 text-center">Über uns</div>
+                        <h2 class="text-content__title text-center">Seit&nbsp; 1909</h2>
+                        <p>Another &nbsp; HTML &copy;</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>', [], 'en', null, null);
+
+        $expect = '<section class="c-content" id="c-20-content-0">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12 col-lg-10">
+                    <div class="text-content">
+                        <div class="text-content__pre h6 text-center">Über uns</div>
+                        <h2 class="text-content__title text-center">Seit&nbsp; 1909</h2>
+                        <p>Another &nbsp; <a class="pimcore_glossary" href="/test">HTML</a> ©</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>';
+
+        $this->assertSame($result, $expect);
+    }
+}

--- a/tests/Unit/Document/Glossary/GlossaryTest.php
+++ b/tests/Unit/Document/Glossary/GlossaryTest.php
@@ -11,13 +11,14 @@ declare(strict_types=1);
  * Full copyright and license information is available in
  * LICENSE.md which is distributed with this source code.
  *
- *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
- *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
 namespace Pimcore\Tests\Unit\Document\Glossary;
 
 use Pimcore\Model\Glossary;
+use Pimcore\Tests\Helper\Pimcore;
 use Pimcore\Tests\Test\TestCase;
 use Pimcore\Tool\Glossary\Processor;
 
@@ -33,7 +34,8 @@ class GlossaryTest extends TestCase
     {
         parent::setUp();
 
-        $this->processor = \Pimcore::getContainer()->get(Processor::class);
+        $pimcoreModule = $this->getModule('\\'.Pimcore::class);
+        $this->processor = $pimcoreModule->grabService(Processor::class);
     }
 
     public function testGlossary()
@@ -59,7 +61,13 @@ class GlossaryTest extends TestCase
         $entry->setLanguage('en');
         $entry->save();
 
-        $result = $this->processor->parse('<body><p>This is a Test for the&nbsp;Entity &copy;</p></body>', [], 'en', null, null);
+        $result = $this->processor->parse(
+            '<body><p>This is a Test for the&nbsp;Entity &copy;</p></body>',
+            [],
+            'en',
+            null,
+            null
+        );
 
         $expect = '<body><p>This is a Test for the&nbsp;<a class="pimcore_glossary" href="/test">Entity</a> &copy;</p></body>';
 
@@ -89,7 +97,8 @@ class GlossaryTest extends TestCase
         $entry->setLanguage('en');
         $entry->save();
 
-        $result = $this->processor->parse('<section class="c-content" id="c-20-content-0">
+        $result = $this->processor->parse(
+            '<section class="c-content" id="c-20-content-0">
         <div class="container">
             <div class="row justify-content-center">
                 <div class="col-12 col-lg-10">
@@ -101,7 +110,11 @@ class GlossaryTest extends TestCase
                 </div>
             </div>
         </div>
-    </section>', [], 'en', null, null);
+    </section>', [],
+            'en',
+            null,
+            null
+        );
 
         $expect = '<section class="c-content" id="c-20-content-0">
         <div class="container">


### PR DESCRIPTION
Solves error 

`An exception has been thrown during the rendering of a template ("Warning: DOMDocumentFragment::appendXML(): Entity: line 1: parser error : Entity 'nbsp' not defined").`