### PR TITLE
Add getObjects to annotated class methods inside of generated listing…

### DIFF
--- a/lib/DataObject/ClassBuilder/ListingClassBuilder.php
+++ b/lib/DataObject/ClassBuilder/ListingClassBuilder.php
@@ -45,6 +45,7 @@ class ListingClassBuilder implements ListingClassBuilderInterface
         $cd .= ' * @method DataObject\\'.ucfirst($classDefinition->getName())."|false current()\n";
         $cd .= ' * @method DataObject\\'.ucfirst($classDefinition->getName())."[] load()\n";
         $cd .= ' * @method DataObject\\'.ucfirst($classDefinition->getName())."[] getData()\n";
+        $cd .= ' * @method DataObject\\'.ucfirst($classDefinition->getName())."[] getObjects()\n";
         $cd .= ' */';
         $cd .= "\n\n";
         $cd .= 'class Listing extends '.$extendListingClass . "\n";


### PR DESCRIPTION
… classes

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.4`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [*] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [*] Features need to be proper documented in `doc/` 
- [*] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [*] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

Generated Listing classes will now also have a typed method annotation for the `getObjects` function additionally to `getData` and `load`.