### PR TITLE
Fix 'number of bound variables does not match number of tokens' in Required By Operator

### DIFF
--- a/lib/DataObject/GridColumnConfig/Operator/RequiredBy.php
+++ b/lib/DataObject/GridColumnConfig/Operator/RequiredBy.php
@@ -73,7 +73,7 @@ final class RequiredBy extends AbstractOperator
             $result->value = $count;
         } else {
             $resultList = [];
-            $query = 'select * from dependencies where targettype = ? AND targetid = ' . $element->getId() . $typeCondition;
+            $query = 'select * from dependencies where targettype = ? AND targetid = ?'. $typeCondition;
             $dependencies = $db->fetchAll($query, [Service::getElementType($element), $element->getId()]);
             foreach ($dependencies as $dependency) {
                 $sourceType = $dependency['sourcetype'];


### PR DESCRIPTION
Using the Required By Operator in the Grid Options results in an exception:

> An exception occurred while executing 'select * from dependencies where targettype = ? AND targetid = 7666 AND sourcetype = 'object'' with params ["object", 7666]: SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens

## Changes in this pull request  
The code had both the element id in the string and in the parameters. Changed it to be a parameter and removed it from the query.
