### PR TITLE
Bug: Solve typo when outputting a DataObject class

### DIFF
--- a/lib/DataObject/ClassBuilder/ClassBuilder.php
+++ b/lib/DataObject/ClassBuilder/ClassBuilder.php
@@ -75,7 +75,7 @@ class ClassBuilder implements ClassBuilderInterface
                         $classDefinition->getName()
                     ).'\Listing|\\Pimcore\\Model\\DataObject\\'.ucfirst(
                         $classDefinition->getName()
-                    ).'|$fieldDefinition getBy'.ucfirst(
+                    ).'|null getBy'.ucfirst(
                         $fieldDefinition->getName()
                     ).'($field, $value, $locale = null, $limit = 0, $offset = 0, $objectTypes = null)'."\n";
 


### PR DESCRIPTION
## 📚 Description

I updated recently Pimcore from `10.3.2` to `10.4.4` and I spot an error when running the following command in order to load the `rest` tests:
```php
$classDefinitionManager = new ClassDefinitionManager();
$classDefinitionManager->createOrUpdateClassDefinitions();
```

The issue happens when updating the definitions, the header is changed in some classes at `var/classes/DataObject/xxx.php` from
```php
* @method static \Pimcore\Model\DataObject\User\Listing|\Pimcore\Model\DataObject\User|null getByLocalizedfields($field, $value, $locale = null, $limit = 0, $offset = 0, $objectTypes = null)
```
to
```php
* @method static \Pimcore\Model\DataObject\User\Listing|\Pimcore\Model\DataObject\User|$fieldDefinition getByLocalizedfields($field, $value, $locale = null, $limit = 0, $offset = 0, $objectTypes = null)
```

This causes the loader cannot find the method and the program throwns an exception.


I investigated and apparently, the error is new in recent versions since the last refactor (https://github.com/pimcore/pimcore/commit/6706dba38446ab23ca2ea1a704cae261eac45fbf).

In the previous version (10.3.2), all this logic was placed in the following class ([ClassDefinition](https://github.com/pimcore/pimcore/blob/v10.3.2/models/DataObject/ClassDefinition.php)).

The line [`).'|null getBy'.ucfirst(`](https://github.com/pimcore/pimcore/blob/v10.3.2/models/DataObject/ClassDefinition.php#L514) was recently changed to [`).'|$fieldDefinition getBy'.ucfirst(`](https://github.com/pimcore/pimcore/blob/10.x/lib/DataObject/ClassBuilder/ClassBuilder.php#L78), I changed locally back to `|null` and is working again 😄.

