### PR TITLE
[Improvement]: dispatch an event after an element was loaded

### DIFF
--- a/lib/Event/AssetEvents.php
+++ b/lib/Event/AssetEvents.php
@@ -117,6 +117,13 @@ final class AssetEvents
     const POST_DELETE_FAILURE = 'pimcore.asset.postDeleteFailure';
 
     /**
+     * @Event("Pimcore\Event\Model\AssetEvent")
+     *
+     * @var string
+     */
+    const POST_LOAD = 'pimcore.asset.postLoad';
+
+    /**
      * Arguments:
      *  - target_element | Pimcore\Model\Asset | contains the target asset used in copying process
      *

--- a/lib/Event/AssetEvents.php
+++ b/lib/Event/AssetEvents.php
@@ -117,6 +117,9 @@ final class AssetEvents
     const POST_DELETE_FAILURE = 'pimcore.asset.postDeleteFailure';
 
     /**
+     * Arguments:
+     *  - params | array | contains the values that were passed to getById() as the second parameter
+     *
      * @Event("Pimcore\Event\Model\AssetEvent")
      *
      * @var string

--- a/lib/Event/DataObjectEvents.php
+++ b/lib/Event/DataObjectEvents.php
@@ -117,6 +117,9 @@ final class DataObjectEvents
     const POST_DELETE_FAILURE = 'pimcore.dataobject.postDeleteFailure';
 
     /**
+     * Arguments:
+     *  - params | array | contains the values that were passed to getById() as the second parameter
+     *
      * @Event("Pimcore\Event\Model\DataObjectEvent")
      *
      * @var string

--- a/lib/Event/DataObjectEvents.php
+++ b/lib/Event/DataObjectEvents.php
@@ -117,6 +117,13 @@ final class DataObjectEvents
     const POST_DELETE_FAILURE = 'pimcore.dataobject.postDeleteFailure';
 
     /**
+     * @Event("Pimcore\Event\Model\DataObjectEvent")
+     *
+     * @var string
+     */
+    const POST_LOAD = 'pimcore.dataobject.postLoad';
+
+    /**
      * Arguments:
      *  - target_element | Pimcore\Model\AbstractObject | contains the target object used in copying process
      *

--- a/lib/Event/DocumentEvents.php
+++ b/lib/Event/DocumentEvents.php
@@ -105,6 +105,13 @@ final class DocumentEvents
     const POST_DELETE_FAILURE = 'pimcore.document.postDeleteFailure';
 
     /**
+     * @Event("Pimcore\Event\Model\DocumentEvent")
+     *
+     * @var string
+     */
+    const POST_LOAD = 'pimcore.document.postLoad';
+
+    /**
      * Processor contains the processor object used to generate the PDF
      *
      * Arguments:

--- a/lib/Event/DocumentEvents.php
+++ b/lib/Event/DocumentEvents.php
@@ -105,6 +105,9 @@ final class DocumentEvents
     const POST_DELETE_FAILURE = 'pimcore.document.postDeleteFailure';
 
     /**
+     * Arguments:
+     *  - params | array | contains the values that were passed to getById() as the second parameter
+     *
      * @Event("Pimcore\Event\Model\DocumentEvent")
      *
      * @var string

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -277,6 +277,8 @@ class Asset extends Element\AbstractElement
             return null;
         }
 
+        \Pimcore::getEventDispatcher()->dispatch(new AssetEvent($asset), AssetEvents::POST_LOAD);
+
         return $asset;
     }
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -277,7 +277,10 @@ class Asset extends Element\AbstractElement
             return null;
         }
 
-        \Pimcore::getEventDispatcher()->dispatch(new AssetEvent($asset), AssetEvents::POST_LOAD);
+        \Pimcore::getEventDispatcher()->dispatch(
+            new AssetEvent($asset, ['params' => $params]),
+            AssetEvents::POST_LOAD
+        );
 
         return $asset;
     }

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -423,6 +423,8 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             return null;
         }
 
+        \Pimcore::getEventDispatcher()->dispatch(new DataObjectEvent($object), DataObjectEvents::POST_LOAD);
+
         return $object;
     }
 

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -423,7 +423,10 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             return null;
         }
 
-        \Pimcore::getEventDispatcher()->dispatch(new DataObjectEvent($object), DataObjectEvents::POST_LOAD);
+        \Pimcore::getEventDispatcher()->dispatch(
+            new DataObjectEvent($object, ['params' => $params]),
+            DataObjectEvents::POST_LOAD
+        );
 
         return $object;
     }

--- a/models/Document.php
+++ b/models/Document.php
@@ -293,6 +293,8 @@ class Document extends Element\AbstractElement
             return null;
         }
 
+        \Pimcore::getEventDispatcher()->dispatch(new DocumentEvent($document), DocumentEvents::POST_LOAD);
+
         return $document;
     }
 

--- a/models/Document.php
+++ b/models/Document.php
@@ -293,7 +293,10 @@ class Document extends Element\AbstractElement
             return null;
         }
 
-        \Pimcore::getEventDispatcher()->dispatch(new DocumentEvent($document), DocumentEvents::POST_LOAD);
+        \Pimcore::getEventDispatcher()->dispatch(
+            new DocumentEvent($document, ['params' => $params]),
+            DocumentEvents::POST_LOAD
+        );
 
         return $document;
     }


### PR DESCRIPTION
I'd like to propose dispatching an event after an element was loaded ([like Doctrine does](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/events.html#postload)).

Our use case for this is recording which elements get loaded during a request, to be able to tag the response (via a header field) with this, which will later allow us to ban the affected pages from a reverse proxy cache (e.g. Varnish) when an element changes.

Manually recording which elements are used per request is tedious, and this event would greatly help us with it.