### PR TITLE
[Improvement] add config data for area and image editable

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/area.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/area.js
@@ -18,8 +18,12 @@ pimcore.document.editables.area = Class.create(pimcore.document.area_abstract, {
 
         this.id = id;
         this.name = name;
-        this.elements = [];
+        this.datax = {};
         this.config = this.parseConfig(config);
+
+        if (data) {
+            this.datax = data;
+        }
 
         //editable dialog box button
         try {
@@ -46,19 +50,11 @@ pimcore.document.editables.area = Class.create(pimcore.document.area_abstract, {
     },
 
     getValue: function () {
-        var data = [];
-        for (var i = 0; i < this.elements.length; i++) {
-            if (this.elements[i]) {
-                if (this.elements[i].key) {
-                    data.push({
-                        key: this.elements[i].key,
-                        type: this.elements[i].type
-                    });
-                }
-            }
+        if(this.config['type'] !== undefined){
+            this.datax['type'] = this.config['type'];
         }
 
-        return data;
+        return this.datax;
     },
 
     getType: function () {

--- a/models/Document/Editable/Area.php
+++ b/models/Document/Editable/Area.php
@@ -22,12 +22,30 @@ use Pimcore\Extension\Document\Areabrick\EditableDialogBoxInterface;
 use Pimcore\Model;
 use Pimcore\Templating\Renderer\EditableRenderer;
 use Pimcore\Tool\HtmlUtils;
+use Pimcore\Tool\Serialize;
 
 /**
  * @method \Pimcore\Model\Document\Editable\Dao getDao()
  */
 class Area extends Model\Document\Editable
 {
+    /**
+     * The Type configured for the area
+     *
+     * @internal
+     *
+     * @var string|null
+     */
+    protected $type;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBrickType()
+    {
+        return $this->type;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -41,7 +59,29 @@ class Area extends Model\Document\Editable
      */
     public function getData()
     {
-        return null;
+        return [
+            'type' => $this->type,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDataForResource()
+    {
+        return [
+            'type' => $this->type,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDataEditmode() /** : mixed */
+    {
+        return [
+            'type' => $this->type,
+        ];
     }
 
     /**
@@ -190,6 +230,12 @@ class Area extends Model\Document\Editable
      */
     public function setDataFromResource($data)
     {
+        if (strlen($data) > 2) {
+            $data = Serialize::unserialize($data);
+        }
+
+        $this->type = $data['type'] ?? null;
+
         return $this;
     }
 
@@ -198,6 +244,10 @@ class Area extends Model\Document\Editable
      */
     public function setDataFromEditmode($data)
     {
+        if (is_array($data)) {
+            $this->type = $data['type'] ?? null;
+        }
+
         return $this;
     }
 

--- a/models/Document/Editable/Image.php
+++ b/models/Document/Editable/Image.php
@@ -102,6 +102,15 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
     protected $marker = [];
 
     /**
+     * The Thumbnail config of the image
+     *
+     * @internal
+     *
+     * @var string
+     */
+    protected $thumbnail;
+
+    /**
      * {@inheritdoc}
      */
     public function getType()
@@ -124,6 +133,7 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
             'cropLeft' => $this->cropLeft,
             'hotspots' => $this->hotspots,
             'marker' => $this->marker,
+            'thumbnail' => $this->thumbnail,
         ];
     }
 
@@ -142,6 +152,7 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
             'cropLeft' => $this->cropLeft,
             'hotspots' => $this->hotspots,
             'marker' => $this->marker,
+            'thumbnail' => $this->thumbnail,
         ];
     }
 
@@ -188,6 +199,7 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
                 'cropLeft' => $this->cropLeft,
                 'hotspots' => $hotspots,
                 'marker' => $marker,
+                'thumbnail' => $this->thumbnail,
                 'predefinedDataTemplates' => $this->getConfig()['predefinedDataTemplates'] ?? null,
             ];
         }
@@ -328,6 +340,7 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
         $this->cropLeft = $data['cropLeft'] ?? null;
         $this->marker = $data['marker'] ?? null;
         $this->hotspots = $data['hotspots'] ?? null;
+        $this->thumbnail = $data['thumbnail'] ?? null;
 
         return $this;
     }
@@ -375,6 +388,7 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
             $this->cropLeft = $data['cropLeft'] ?? null;
             $this->marker = $data['marker'] ?? null;
             $this->hotspots = $data['hotspots'] ?? null;
+            $this->thumbnail = $data['thumbnail'] ?? null;
         }
 
         return $this;
@@ -402,6 +416,14 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
     public function getAlt()
     {
         return $this->getText();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getThumbnailConfig()
+    {
+        return $this->thumbnail;
     }
 
     /**


### PR DESCRIPTION
We are using a headless approach for the CMS part. For this to work we need some more config information in the backend for the area and image editable.
Area: The defined Brick type that is configured in the Twig Template. We can then serialize the brick configured in the area correctly.
Image: The defined Thumbnail Config that is configured in the Twig Template. We can then send the same Thumbnail of the image to the frontend.

## Changes in this pull request  
Adding the configured brick type in the area editable.
Adding the configured thumbnail in the image editable.
