### PR TITLE
[BackOffice] change PaginateListingSubscriber

### DIFF
--- a/lib/Model/Paginator/EventSubscriber/PaginateListingSubscriber.php
+++ b/lib/Model/Paginator/EventSubscriber/PaginateListingSubscriber.php
@@ -26,8 +26,8 @@ class PaginateListingSubscriber implements EventSubscriberInterface
         $paginationAdapter = $event->target;
 
         if ($paginationAdapter instanceof PaginateListingInterface) {
-            $items = $paginationAdapter->getItems($event->getOffset(), $event->getLimit());
             $event->count = $paginationAdapter->count();
+            $items = $paginationAdapter->getItems($event->getOffset(), $event->getLimit());
             $event->items = $items;
             $event->stopPropagation();
         }


### PR DESCRIPTION
I can't see more than 10 entries in the order backoffice. When I swap these two lines, it works. In 6.9 these two lines are swapped too. I've seen this was changed on branch 10.x recently with commit 4013e6c.

