### PR TITLE
[Improvement]: automatically run migrations in correct order

### DIFF
--- a/bundles/CoreBundle/Resources/config/migrations.yaml
+++ b/bundles/CoreBundle/Resources/config/migrations.yaml
@@ -13,3 +13,6 @@ services:
     Doctrine\Migrations\DependencyFactory:
         alias: 'doctrine.migrations.dependency_factory'
 
+    Pimcore\Migrations\DirectoryAwareVersionComparator:
+        arguments:
+            $config: '@doctrine.migrations.configuration'

--- a/bundles/CoreBundle/Resources/config/pimcore/doctrine_migrations.yaml
+++ b/bundles/CoreBundle/Resources/config/pimcore/doctrine_migrations.yaml
@@ -1,7 +1,7 @@
 doctrine_migrations:
     connection: default
     migrations_paths:
-        'Pimcore\Bundle\CoreBundle\Migrations': '@PimcoreCoreBundle/Migrations'
+        Pimcore\Bundle\CoreBundle\Migrations: '@PimcoreCoreBundle/Migrations'
     storage:
         table_storage:
             table_name: 'migration_versions'
@@ -12,8 +12,7 @@ doctrine_migrations:
     all_or_nothing: false
     check_database_platform: false
     factories:
-        'Doctrine\Migrations\MigrationsRepository': 'Pimcore\Migrations\FilteredMigrationsRepository'
-        'Doctrine\Migrations\Metadata\Storage\MetadataStorage': 'Pimcore\Migrations\FilteredTableMetadataStorage'
-
-
-
+        Doctrine\Migrations\MigrationsRepository: 'Pimcore\Migrations\FilteredMigrationsRepository'
+        Doctrine\Migrations\Metadata\Storage\MetadataStorage: 'Pimcore\Migrations\FilteredTableMetadataStorage'
+    services:
+        Doctrine\Migrations\Version\Comparator: 'Pimcore\Migrations\DirectoryAwareVersionComparator'

--- a/lib/Migrations/DirectoryAwareVersionComparator.php
+++ b/lib/Migrations/DirectoryAwareVersionComparator.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Migrations;
+
+use Doctrine\Migrations\Configuration\Configuration;
+use Doctrine\Migrations\Version\Comparator;
+use Doctrine\Migrations\Version\Version;
+
+/**
+ * Orders versions by their namespaces in registration order.
+ */
+final class DirectoryAwareVersionComparator implements Comparator
+{
+    /** @var array<string, int> */
+    private array $orderByNamespace;
+
+    public function __construct(Configuration $config)
+    {
+        $this->orderByNamespace = array_flip(array_keys($config->getMigrationDirectories()));
+    }
+
+    public function compare(Version $a, Version $b): int
+    {
+        try {
+            return $this->getOrder($a) <=> $this->getOrder($b);
+        } catch (\ReflectionException) {
+            return (string) $a <=> (string) $b;
+        }
+    }
+
+    /**
+     * @throws \ReflectionException
+     *
+     * @return array{int, string}
+     */
+    private function getOrder(Version $version): array
+    {
+        $class = new \ReflectionClass((string) $version);
+        $className = $class->getShortName();
+        $namespace = $class->getNamespaceName();
+        $namespaceOrder = $this->orderByNamespace[$namespace] ?? 0;
+
+        return [$namespaceOrder, $className];
+    }
+}


### PR DESCRIPTION
Doctrine Migrations compares migration versions [by their FQCN by default](https://github.com/doctrine/migrations/blob/3.5.x/lib/Doctrine/Migrations/Version/AlphabeticalComparator.php#L13), which means that they will most likely be run in the wrong order if you simply run `bin/console doctrine:migrations:migrate`, since `App\...` migrations will be executed before `Pimcore\Bundle\CoreBundle\...`. You can prevent this by running core migrations first, via `--prefix=Pimcore\\Bundle\\CoreBundle`. But if you've many bundles installed that have migrations themselves, it becomes tedious to manually maintain the order in which migrations should run.

But since Pimcore has a bundle registration priority and a bundle dependency system, we're able to automatically determine the correct order of migrations. Bundles with a higher priority or those that other bundles depend on are registered earlier, which means that their `config/pimcore/config.yaml` will be loaded first, resulting in the correct `doctrine_migrations: { migrations_paths: { ... }}` sequence. Now if we sort by the migration version class namespace first and then the class name, we should have the correct order.