### PR TITLE
Glossary fix for &lt; &gt; and &amp;

### DIFF
--- a/lib/Tool/Glossary/Processor.php
+++ b/lib/Tool/Glossary/Processor.php
@@ -137,7 +137,7 @@ class Processor
 
         $es->each(function ($parentNode, $i) use ($options, $data) {
             /** @var DomCrawler|null $parentNode */
-            $text = $parentNode->text();
+            $text = htmlentities($parentNode->text(), ENT_XML1);
             if (
                 $parentNode instanceof DomCrawler &&
                 !in_array((string)$parentNode->nodeName(), $this->blockedTags) &&
@@ -159,7 +159,7 @@ class Processor
                 if ($originalText !== $text) {
                     $domNode = $parentNode->getNode(0);
                     $fragment = $domNode->ownerDocument->createDocumentFragment();
-                    $fragment->appendXML(html_entity_decode($text));
+                    $fragment->appendXML($text);
                     $clone = $domNode->cloneNode();
                     $clone->appendChild($fragment);
                     $domNode->parentNode->replaceChild($clone, $domNode);

--- a/tests/Unit/Document/Glossary/GlossaryTest.php
+++ b/tests/Unit/Document/Glossary/GlossaryTest.php
@@ -132,4 +132,24 @@ class GlossaryTest extends TestCase
 
         $this->assertSame($result, $expect);
     }
+
+    public function testGlossaryWithAnotherHtml()
+    {
+        $entry = new Glossary();
+        $entry->setText('hans');
+        $entry->setLink('/hans');
+        $entry->setLanguage('en');
+        $entry->save();
+
+        $result = $this->processor->parse(
+            '<p>hans &amp; gretl</p>', [],
+            'en',
+            null,
+            null
+        );
+
+        $expect = '<p><a class="pimcore_glossary" href="/hans">hans</a> &amp; gretl</p>';
+
+        $this->assertSame($result, $expect);
+    }
 }

--- a/tests/Unit/Document/Glossary/GlossaryTest.php
+++ b/tests/Unit/Document/Glossary/GlossaryTest.php
@@ -152,4 +152,24 @@ class GlossaryTest extends TestCase
 
         $this->assertSame($result, $expect);
     }
+
+    public function testGlossaryWithLowerThenAndGreaterThenHtml()
+    {
+        $entry = new Glossary();
+        $entry->setText('huber');
+        $entry->setLink('/huber');
+        $entry->setLanguage('en');
+        $entry->save();
+
+        $result = $this->processor->parse(
+            '<p>Huber &lt;&gt; is the best</p>', [],
+            'en',
+            null,
+            null
+        );
+
+        $expect = '<p><a class="pimcore_glossary" href="/huber">huber</a> &lt;&gt; is the best</p>';
+
+        $this->assertSame($result, $expect);
+    }
 }


### PR DESCRIPTION
Fix before didn't work with &amp;. this now does.