### PR TITLE
Fix: toggle tag highlighting check if element is not null

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/edit.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/edit.js
@@ -167,7 +167,7 @@ pimcore.document.edit = Class.create({
         Object.values(this.getEditables()).forEach(editable => {
             let ed = this.frame.Ext.get(editable.getId());
 
-            if(!ed.hasCls("pimcore_editable_inc") && !ed.hasCls("pimcore_editable_areablock")
+            if(ed !== null && !ed.hasCls("pimcore_editable_inc") && !ed.hasCls("pimcore_editable_areablock")
                 && !ed.hasCls("pimcore_editable_block") && !ed.hasCls("pimcore_editable_area")) {
                 if(!this.tagHighlightingActive) {
                     let mask = ed.mask();


### PR DESCRIPTION
### Problem
In admin, while working with a custom area brick setup, I receive a javascript error when pressing the toggle tag highlighter to highlight all editable elements in a Document.

<img width="978" alt="Bildschirmfoto 2022-06-28 um 11 18 22" src="https://user-images.githubusercontent.com/3622712/176142707-9543552f-4f9f-42e9-bb20-14b404501e36.png">

### Fix
This fix checks whether the element exists, and the `hasCls` method can be called or not. If this fix is applied, then the editable highlighting works perfectly fine.
