### PR TITLE
Change the function "getClosestParentOfClass" to from "private" to "p…

### DIFF
--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -531,7 +531,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
      *
      * @return self|null
      */
-    private function getClosestParentOfClass(string $classId): ?self
+    public function getClosestParentOfClass(string $classId): ?self
     {
         $parent = $this->getParent();
         if ($parent instanceof AbstractObject) {


### PR DESCRIPTION
I found this method always very useful if you need a specific parent type. Therefore I would like to have it "public" again. Otherwise I need to implement it myself, which would be mostly just copy and paste.
