### PR TITLE
Disabled the option to drag and drop objects if the target is a paginated tree

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tree.js
@@ -291,6 +291,12 @@ pimcore.object.tree = Class.create({
             return false;
         }
 
+        // dropping objects not allowed on the paginated tree
+        if((newParent.needsPaging) || (newParent.childNodes.length > pimcore.settings['object_tree_paging_limit'])){
+            pimcore.helpers.showNotification(t("error"), t("element_cannot_be_moved_because_target_is_paginated"), "error");
+            return false;
+        }
+
         if(newParent.data.id == oldParent.data.id && oldParent.data.sortBy != 'index') {
             pimcore.helpers.showNotification(t("error"), t("element_cannot_be_moved"), "error");
             return false;

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -167,6 +167,7 @@
     "locked": "Locked",
     "element_cannot_be_move_because_it_is_locked": "Element cannot be moved because it is locked.",
     "element_cannot_be_moved": "The element cannot be moved here",
+    "element_cannot_be_moved_because_target_is_paginated": "The element cannot be moved here because the target is a paginated tree/folder",
     "no_collections_allowed": "No Collections allowed",
     "filter_condition": "Filter Condition",
     "all_types": "All Types",

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -167,7 +167,7 @@
     "locked": "Locked",
     "element_cannot_be_move_because_it_is_locked": "Element cannot be moved because it is locked.",
     "element_cannot_be_moved": "The element cannot be moved here",
-    "element_cannot_be_moved_because_target_is_paginated": "The element cannot be moved here because the target is a paginated tree/folder",
+    "element_cannot_be_moved_because_target_is_paginated": "The element cannot be moved here because the target is a paginated tree/folder. Please use \"Search & Move\" option under the \"Advanced\" menu for moving this.",
     "no_collections_allowed": "No Collections allowed",
     "filter_condition": "Filter Condition",
     "all_types": "All Types",

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -167,7 +167,7 @@
     "locked": "Locked",
     "element_cannot_be_move_because_it_is_locked": "Element cannot be moved because it is locked.",
     "element_cannot_be_moved": "The element cannot be moved here",
-    "element_cannot_be_moved_because_target_is_paginated": "The element cannot be moved here because the target is a paginated tree/folder. Please use \"Search & Move\" option under the \"Advanced\" menu for moving this.",
+    "element_cannot_be_moved_because_target_is_paginated": "The element cannot be dragged here because the target is a paginated tree/folder. Please use \"Search & Move\" option under the \"Advanced\" context menu of the target to move the elements.",
     "no_collections_allowed": "No Collections allowed",
     "filter_condition": "Filter Condition",
     "all_types": "All Types",


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.4`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #11097 

Disabled the option to drag and drop objects if the target is a paginated tree

## Additional info  

