### PR TITLE
addCondition default $value value should be array

### DIFF
--- a/bundles/EcommerceFrameworkBundle/OrderManager/Order/Listing.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/Order/Listing.php
@@ -319,7 +319,7 @@ class Listing extends AbstractOrderList implements OrderListInterface
      *
      * @return $this
      */
-    public function addCondition($condition, $value = null)
+    public function addCondition($condition, $value = [])
     {
         if (!is_array($value)) {
             $value = [$value];

--- a/bundles/EcommerceFrameworkBundle/OrderManager/Order/Listing.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/Order/Listing.php
@@ -319,8 +319,12 @@ class Listing extends AbstractOrderList implements OrderListInterface
      *
      * @return $this
      */
-    public function addCondition($condition, $value = [])
+    public function addCondition($condition, $value = null)
     {
+        if (null === $value) {
+            $value = [];
+        }
+                
         if (!is_array($value)) {
             $value = [$value];
         }


### PR DESCRIPTION
if you don't give a value for addCondition the function calls setParameters with [null] which gives an "SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens" Error
So the default value should be [], since setParameters requires array anyway