### PR TITLE
fix: do not use application cache while building system cache

### DIFF
--- a/lib/HttpKernel/CacheWarmer/PimcoreCoreCacheWarmer.php
+++ b/lib/HttpKernel/CacheWarmer/PimcoreCoreCacheWarmer.php
@@ -46,7 +46,12 @@ class PimcoreCoreCacheWarmer implements CacheWarmerInterface
 
         if (\Pimcore::isInstalled()) {
             try {
+                $cache = \Pimcore\Cache::isEnabled();
+                \Pimcore\Cache::disable();
                 $this->dataObjectClasses($classes);
+                if ($cache) {
+                    \Pimcore\Cache::enable();
+                }
             } catch (\Exception $exception) {
                 if (!$exception instanceof DriverException) {
                     throw $exception;

--- a/lib/HttpKernel/CacheWarmer/PimcoreCoreCacheWarmer.php
+++ b/lib/HttpKernel/CacheWarmer/PimcoreCoreCacheWarmer.php
@@ -45,19 +45,20 @@ class PimcoreCoreCacheWarmer implements CacheWarmerInterface
         $this->modelClasses($classes);
 
         if (\Pimcore::isInstalled()) {
+            $cache = \Pimcore\Cache::isEnabled();
             try {
-                $cache = \Pimcore\Cache::isEnabled();
                 \Pimcore\Cache::disable();
                 $this->dataObjectClasses($classes);
-                if ($cache) {
-                    \Pimcore\Cache::enable();
-                }
             } catch (\Exception $exception) {
                 if (!$exception instanceof DriverException) {
                     throw $exception;
                 }
 
                 //Ignore. Database might not be setup yet
+            } finally {
+                if ($cache) {
+                    \Pimcore\Cache::enable();
+                }
             }
         }
 


### PR DESCRIPTION
## Changes in this pull request  

This change makes sure the application cache is not invoked when building system cache. This can cause some unexpected bugs, but can also outright fail because app cache might not be available at the time of system cache build at all.