### PR TITLE
refactor: Folder properties declared twice

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -877,10 +877,6 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                     'o_published' => true,
                 ]);
 
-                $folder->setCreationDate(time());
-                $folder->setUserOwner($this->getAdminUser()->getId());
-                $folder->setUserModification($this->getAdminUser()->getId());
-
                 try {
                     $folder->save();
                     $success = true;


### PR DESCRIPTION
Removed duplicate folder declaration properties.

<img width="811" alt="Bildschirmfoto 2022-07-02 um 09 32 15" src="https://user-images.githubusercontent.com/3622712/176991284-79b0485b-038e-4904-9107-b5ca5c392cb3.png">

