### PR TITLE
[Relations > Object search modal] Do not show folders when a classname has been specified

### DIFF
--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -198,9 +198,6 @@ class SearchController extends AdminController
         }
 
         if (is_array($classnames) && !empty($classnames[0])) {
-            if (in_array('folder', $subtypes)) {
-                $classnames[] = 'folder';
-            }
             $conditionClassnameParts = [];
             foreach ($classnames as $classname) {
                 $conditionClassnameParts[] = $db->quote($classname);


### PR DESCRIPTION
Steps to reproduce
1. Create folder `a` under `/`
3. Create class `Category`
4. Create class `Product` with many-to-many object relation to `Category`
5. Create `Category` object in `/`
2. Run `bin/console maintenance` to update `search_backend_data` table
6. Create object of class `Product` and open relation search (click looking glass icon) -> class `Category` gets preselected but you will also see folder `a`

Of course you could select `type=object` but imho it is not correct that we see folders (which do not even have `Category` objects inside) when we filter for a certain class.
With this PR only objects of the filtered class name will get shown.