### PR TITLE
[Bugfix] Fix translation for reordering block items.

### DIFF
--- a/bundles/CoreBundle/Resources/translations/de.extended.json
+++ b/bundles/CoreBundle/Resources/translations/de.extended.json
@@ -367,7 +367,7 @@
     "mandatory": "Verpflichtend",
     "emails": "E-Mails",
     "disallow_addremove": "Hinzufügen/Entfernen ablehnen",
-    "disallow_reorder": "Aufnahme ablehnen",
+    "disallow_reorder": "Umsortierung ablehnen",
     "reload_definition": "Definition neu laden",
     "bulk_export": "Massenexport",
     "bulk_import": "Massenimport",

--- a/bundles/CoreBundle/Resources/translations/en.extended.json
+++ b/bundles/CoreBundle/Resources/translations/en.extended.json
@@ -374,7 +374,7 @@
   "target_subtype": "Target Type",
   "mandatory": "Mandatory",
   "disallow_addremove": "Disallow Add\/Remove",
-  "disallow_reorder": "Dissallow Reordering",
+  "disallow_reorder": "Disallow Reordering",
   "reload_definition": "Reload Definition",
   "saving": "Saving",
   "definition": "Definition",

--- a/bundles/CoreBundle/Resources/translations/pl.extended.json
+++ b/bundles/CoreBundle/Resources/translations/pl.extended.json
@@ -367,7 +367,7 @@
     "mandatory": "Obowiązkowy",
     "emails": "E-maile",
     "disallow_addremove": "Disallow Add/Remove",
-    "disallow_reorder": "Dissallow Reordering",
+    "disallow_reorder": "Disallow Reordering",
     "reload_definition": "Przeładuj Definicję",
     "bulk_export": "Masowy eksport konfiguracji",
     "bulk_import": "Maskowy import konfiguracji",


### PR DESCRIPTION
## Changes in this pull request  
This PR will fix a misleading German translation for allowing/disallowing the reordering of items in a block data type.
Also fixes typos for English and Polish translation.

