### PR TITLE
Fix document relations editable when adding multiple objects

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/relations.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/relations.js
@@ -470,11 +470,11 @@ pimcore.document.editables.relations = Class.create(pimcore.document.editable, {
                         type: items[i].type,
                         subtype: subtype
                     });
-
-                    if (this.config.reload) {
-                        this.reloadDocument();
-                    }
                 }
+            }
+
+            if (this.config.reload) {
+                this.reloadDocument();
             }
         }
     },


### PR DESCRIPTION
## Changes in this pull request  
Resolves #12604 

## Additional info  
Fix document relations editable when adding multiple objects

When selecting multiple objects in document the relations editable,
only the first one was added. Fixed this to be able to add multiple.
