### PR TITLE
fix: video file extension check should not be case-sensitive

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -374,7 +374,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
         // compatibility mode when FFMPEG is not present or no thumbnail config is given
         if (!\Pimcore\Video::isAvailable() || !$thumbnailConfig) {
-            if ($asset instanceof Asset && preg_match("/\.(f4v|flv|mp4)/", $asset->getFullPath())) {
+            if ($asset instanceof Asset && preg_match("/\.(f4v|flv|mp4)/i", $asset->getFullPath())) {
                 $image = $this->getPosterThumbnailImage($asset);
 
                 return $this->getHtml5Code(['mp4' => (string) $asset], $image);


### PR DESCRIPTION
## Changes in this pull request  
File extensions of video editables are currently compared with case-sensitivity. However there are many reasons why editors might upload videos with all-caps namings or extensions like `.MP4` instead of `.mp4`. In these cases the video output fails because of the case-sensitive comparison and results in a broken-looking "asset not found" placeholder image in the frontend.