### PR TITLE
[Bug]: Prevent Document Link targeting itself causing redirection loop

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/LinkController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/LinkController.php
@@ -124,11 +124,6 @@ class LinkController extends DocumentControllerBase
                 if ($data['linktype'] == 'internal' && $data['internalType']) {
                     $target = Element\Service::getElementByPath($data['internalType'], $path);
                     if ($target) {
-
-                        if ($link->getId() == $target->getId()){
-                            throw new \RuntimeException('Detected infinite redirection loop: the selected target is the same as the link itself.');
-                        }
-
                         $data['internal'] = $target->getId();
                     }
                 }
@@ -138,11 +133,6 @@ class LinkController extends DocumentControllerBase
                         $data['linktype'] = 'internal';
                         $data['internalType'] = 'document';
                         $data['internal'] = $target->getId();
-
-                        if ($link->getPath() == $target->getPath()){
-                            throw new \RuntimeException('Detected infinite redirection loop: the path filled is the same as the link itself.');
-                        }
-
                     } elseif ($target = Asset::getByPath($path)) {
                         $data['linktype'] = 'internal';
                         $data['internalType'] = 'asset';
@@ -161,10 +151,6 @@ class LinkController extends DocumentControllerBase
                         $data['linktype'] = 'internal';
                     }
                 }
-
-
-                $link->getId();
-
             } else {
                 // clear content of link
                 $data['linktype'] = 'internal';

--- a/bundles/AdminBundle/Controller/Admin/Document/LinkController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/LinkController.php
@@ -124,6 +124,11 @@ class LinkController extends DocumentControllerBase
                 if ($data['linktype'] == 'internal' && $data['internalType']) {
                     $target = Element\Service::getElementByPath($data['internalType'], $path);
                     if ($target) {
+
+                        if ($link->getId() == $target->getId()){
+                            throw new \RuntimeException('Detected infinite redirection loop: the selected target is the same as the link itself.');
+                        }
+
                         $data['internal'] = $target->getId();
                     }
                 }
@@ -133,6 +138,11 @@ class LinkController extends DocumentControllerBase
                         $data['linktype'] = 'internal';
                         $data['internalType'] = 'document';
                         $data['internal'] = $target->getId();
+
+                        if ($link->getPath() == $target->getPath()){
+                            throw new \RuntimeException('Detected infinite redirection loop: the path filled is the same as the link itself.');
+                        }
+
                     } elseif ($target = Asset::getByPath($path)) {
                         $data['linktype'] = 'internal';
                         $data['internalType'] = 'asset';
@@ -151,6 +161,10 @@ class LinkController extends DocumentControllerBase
                         $data['linktype'] = 'internal';
                     }
                 }
+
+
+                $link->getId();
+
             } else {
                 // clear content of link
                 $data['linktype'] = 'internal';

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/link.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/link.js
@@ -339,7 +339,8 @@ pimcore.document.link = Class.create(pimcore.document.document, {
             });
 
             pathField.on("render", function (el) {
-                var dd = new Ext.dd.DropZone(el.getEl().dom.parentNode.parentNode, {
+                let currentId = this.data.id;
+                let dd = new Ext.dd.DropZone(el.getEl().dom.parentNode.parentNode, {
                     ddGroup: "element",
 
                     getTargetFromEvent: function (e) {
@@ -347,6 +348,10 @@ pimcore.document.link = Class.create(pimcore.document.document, {
                     },
 
                     onNodeOver: function (target, dd, e, data) {
+                        if (data.records[0].data.id == currentId){
+                            return false;
+                        }
+
                         if (data.records.length === 1 && (
                             data.records[0].data.elementType === "document" ||
                             data.records[0].data.elementType === "asset" ||
@@ -358,7 +363,7 @@ pimcore.document.link = Class.create(pimcore.document.document, {
 
                     onNodeDrop: function (target, dd, e, data) {
 
-                        if(!pimcore.helpers.dragAndDropValidateSingleItem(data) || !isChangeAllowed) {
+                        if(!pimcore.helpers.dragAndDropValidateSingleItem(data) || !isChangeAllowed || data.records[0].data.id == currentId) {
                             return false;
                         }
 
@@ -459,6 +464,10 @@ pimcore.document.link = Class.create(pimcore.document.document, {
                     hidden: !isChangeAllowed,
                     handler: function () {
                         pimcore.helpers.itemselector(false, function (data) {
+                            if (this.data.id == data.id){
+                                Ext.Msg.alert(t('error'),t('link_recursion_error'));
+                                return false;
+                            }
                             pathField.setValue(data.fullpath);
                             linkTypeField.setValue('internal');
                             internalTypeField.setValue(data.type);

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -971,5 +971,6 @@
     "asset_upload_keep_both": "Keep both files",
     "asset_upload_overwrite_all": "Overwrite all",
     "could_not_open_zip_file": "The uploaded zip file could not be opened.",
-    "objects_sort_method": "Change data objects sort method"
+    "objects_sort_method": "Change data objects sort method",
+    "link_recursion_error": "The link is redirecting to itself, causing an infinite loop"
 }

--- a/models/Document/Link.php
+++ b/models/Document/Link.php
@@ -368,11 +368,11 @@ class Link extends Model\Document
         try {
             if ($this->internal) {
                 if ($this->internalType == 'document') {
-                    $this->object = Document::getById($this->internal);
 
-                    if ($this->getId() == $this->internal){
-                        throw new \Exception('Prevented infinite redirection loop: attempted to linking "'. $this->getKey().'" to itself. ');
+                    if ($this->getId() == $this->internal) {
+                        throw new \Exception('Prevented infinite redirection loop: attempted to linking "' . $this->getKey() . '" to itself. ');
                     }
+                    $this->object = Document::getById($this->internal);
 
                 } elseif ($this->internalType == 'asset') {
                     $this->object = Asset::getById($this->internal);

--- a/models/Document/Link.php
+++ b/models/Document/Link.php
@@ -369,6 +369,11 @@ class Link extends Model\Document
             if ($this->internal) {
                 if ($this->internalType == 'document') {
                     $this->object = Document::getById($this->internal);
+
+                    if ($this->getId() == $this->internal){
+                        throw new \Exception('Prevented infinite redirection loop: attempted to linking "'. $this->getKey().'" to itself. ');
+                    }
+
                 } elseif ($this->internalType == 'asset') {
                     $this->object = Asset::getById($this->internal);
                 } elseif ($this->internalType == 'object') {

--- a/tests/Model/Document/DocumentTest.php
+++ b/tests/Model/Document/DocumentTest.php
@@ -261,6 +261,7 @@ class DocumentTest extends ModelTestCase
         $this->assertEquals(1, $linkDocument->getInternal());
 
         //Set the same internal target id as itself
+        codecept_debug('[WARNING] Testing document/link circular reference, if it is not progressing from here, please stop the tests and fix the code');
         $linkDocument->setInternal($linkDocument->getId());
         $linkDocument->save();
 

--- a/tests/Model/Document/DocumentTest.php
+++ b/tests/Model/Document/DocumentTest.php
@@ -249,6 +249,28 @@ class DocumentTest extends ModelTestCase
         $this->assertEquals($target->getId(), $newTarget->getId());
     }
 
+    public function testLinkItself()
+    {
+        /** @var Link $linkDocument */
+        $linkDocument = TestHelper::createEmptyDocument('', true, true, '\\Pimcore\\Model\\Document\\Link');
+        $linkDocument->setInternalType('document');
+        $linkDocument->setInternal(1);
+        $linkDocument->setLinktype('internal');
+        $linkDocument->save();
+
+        $this->assertEquals(1, $linkDocument->getInternal());
+
+        //Set the same internal target id as itself
+        $linkDocument->setInternal($linkDocument->getId());
+        $linkDocument->save();
+
+        $linkDocument = Link::getById($linkDocument->getId());
+
+        // when trying to set the target id as itself, it silently logs and saves internal ID as NULL
+        $this->assertNull($linkDocument->getInternal());
+    }
+
+
     public function testSetGetChildren()
     {
         $parentDoc = TestHelper::createEmptyDocumentPage();


### PR DESCRIPTION
## Changes in this pull request  
Resolves #12599

## Additional info  
In the Link model, it silently log an error if the link target is the same id and nullifies the `id`.
On Frontend, it doesn't show it's droppable when the same document is dragged over. 
When using the search, it throws an error if you select the link itself.

## To reproduce

Create some custom implementation that tries to change a link target path to be the same as itself (same as in the provided tests)
Create a link and try to link itself by drag and drop (from folder tree)
Create a link and use the search function to assign itself to the redirection target
