### PR TITLE
[Bug]: Escape background url that may contain % symbols in yml config

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/Controller/Admin/SettingsController.php
@@ -528,7 +528,7 @@ class SettingsController extends AdminController
                     'color_login_screen' => $values['branding.color_login_screen'],
                     'color_admin_interface' => $values['branding.color_admin_interface'],
                     'color_admin_interface_background' => $values['branding.color_admin_interface_background'],
-                    'login_screen_custom_image' => $values['branding.login_screen_custom_image'],
+                    'login_screen_custom_image' => str_replace('%', '%%', $values['branding.login_screen_custom_image']),
                 ],
         ];
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #12592 

## Additional info  
More info here https://github.com/pimcore/pimcore/issues/12592#issuecomment-1175340374 

The solution is to escape by an additional `%`
![image](https://user-images.githubusercontent.com/6014195/178509368-150d9765-5d84-4251-a3ad-3b79a116865d.png)
source: https://symfony.com/doc/current/configuration.html

At least is the quick fix for the moment, maybe need to check other places that could be accepting encoded urls


