### PR TITLE
Update baseline - remove ignored error pattern

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -169,7 +169,7 @@
   "require-dev": {
     "codeception/codeception": "^4.1.12",
     "codeception/phpunit-wrapper": "^9",
-    "phpstan/phpstan": "^1.7.3",
+    "phpstan/phpstan": "^1.8.1",
     "phpstan/phpstan-symfony": "^1.2.2",
     "phpunit/phpunit": "^9.3",
     "spiritix/php-chrome-html2pdf": "^1.6",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -146,11 +146,6 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
 
 		-
-			message: "#^Call to function is_array\\(\\) with mixed will always evaluate to false\\.$#"
-			count: 1
-			path: bundles/EcommerceFrameworkBundle/IndexService/Worker/DefaultFindologic.php
-
-		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/OfferTool/DefaultService.php


### PR DESCRIPTION
## Changes in this pull request  
Resolves 
```
Error: Ignored error pattern #^Call to function is_array\(\) with mixed will always evaluate to false\.$# in path /home/runner/work/pimcore/pimcore/bundles/EcommerceFrameworkBundle/IndexService/Worker/DefaultFindologic.php was not matched in reported errors.
 ------ ----------------------------------------------------------------------- 
  Line   bundles/EcommerceFrameworkBundle/IndexService/Worker/DefaultFindologi  
         c.php                                                                  
 ------ ----------------------------------------------------------------------- 
         Ignored error pattern #^Call to function is_array\(\) with mixed will  
         always evaluate to false\.$# in path                                   
         /home/runner/work/pimcore/pimcore/bundles/EcommerceFrameworkBundle/In  
         dexService/Worker/DefaultFindologic.php was not matched in reported    
         errors.                                                                
 ------ ----------------------------------------------------------------------- 
```
## Additional info  

