### PR TITLE
Improve generated types of many-to-one relation fields

### DIFF
--- a/bundles/EcommerceFrameworkBundle/src/Model/AbstractOrder.php
+++ b/bundles/EcommerceFrameworkBundle/src/Model/AbstractOrder.php
@@ -18,8 +18,11 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
 
 use Carbon\Carbon;
 use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Customer;
 use Pimcore\Model\DataObject\Fieldcollection;
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\DataObject\Objectbrick;
+use Pimcore\Model\DataObject\OnlineShopOrder;
+use Pimcore\Model\DataObject\OnlineShopVoucherToken;
 
 /**
  * Abstract base class for order pimcore objects
@@ -88,9 +91,9 @@ abstract class AbstractOrder extends Concrete
      */
     abstract public function setGiftItems(?array $giftItems): static;
 
-    abstract public function getCustomer(): ?AbstractElement;
+    abstract public function getCustomer(): ?Customer;
 
-    abstract public function setCustomer(?AbstractElement $customer): static;
+    abstract public function setCustomer(?Customer $customer): static;
 
     abstract public function getPriceModifications(): ?Fieldcollection;
 
@@ -106,9 +109,9 @@ abstract class AbstractOrder extends Concrete
 
     abstract public function getPaymentInfo(): ?Fieldcollection;
 
-    abstract public function setPaymentInfo(?\Pimcore\Model\DataObject\Fieldcollection $paymentInfo): static;
+    abstract public function setPaymentInfo(?Fieldcollection $paymentInfo): static;
 
-    abstract public function getPaymentProvider(): ?\Pimcore\Model\DataObject\Objectbrick;
+    abstract public function getPaymentProvider(): ?Objectbrick;
 
     /**
      * returns latest payment info entry
@@ -211,14 +214,14 @@ abstract class AbstractOrder extends Concrete
     /**
      * Get voucherTokens - Voucher Tokens
      *
-     * @return \Pimcore\Model\DataObject\OnlineShopVoucherToken[]
+     * @return OnlineShopVoucherToken[]
      */
     abstract public function getVoucherTokens(): array;
 
     /**
      * Set voucherTokens - Voucher Tokens
      *
-     * @param \Pimcore\Model\DataObject\OnlineShopVoucherToken[]|null $voucherTokens
+     * @param OnlineShopVoucherToken[]|null $voucherTokens
      *
      * @return $this
      */
@@ -243,9 +246,9 @@ abstract class AbstractOrder extends Concrete
     /**
      * Set successorOrder - Successor Order
      *
-     * @param AbstractOrder|null $successorOrder
+     * @param OnlineShopOrder|null $successorOrder
      *
      * @return $this
      */
-    abstract public function setSuccessorOrder(?\Pimcore\Model\Element\AbstractElement $successorOrder): static;
+    abstract public function setSuccessorOrder(?OnlineShopOrder $successorOrder): static;
 }

--- a/bundles/EcommerceFrameworkBundle/src/Model/AbstractOrder.php
+++ b/bundles/EcommerceFrameworkBundle/src/Model/AbstractOrder.php
@@ -17,11 +17,10 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
 
 use Carbon\Carbon;
+use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\Concrete;
-use Pimcore\Model\DataObject\Customer;
 use Pimcore\Model\DataObject\Fieldcollection;
 use Pimcore\Model\DataObject\Objectbrick;
-use Pimcore\Model\DataObject\OnlineShopOrder;
 use Pimcore\Model\DataObject\OnlineShopVoucherToken;
 
 /**
@@ -91,9 +90,9 @@ abstract class AbstractOrder extends Concrete
      */
     abstract public function setGiftItems(?array $giftItems): static;
 
-    abstract public function getCustomer(): ?Customer;
+    abstract public function getCustomer(): ?AbstractObject;
 
-    abstract public function setCustomer(?Customer $customer): static;
+    abstract public function setCustomer(?AbstractObject $customer): static;
 
     abstract public function getPriceModifications(): ?Fieldcollection;
 
@@ -246,9 +245,9 @@ abstract class AbstractOrder extends Concrete
     /**
      * Set successorOrder - Successor Order
      *
-     * @param OnlineShopOrder|null $successorOrder
+     * @param AbstractOrder|null $successorOrder
      *
      * @return $this
      */
-    abstract public function setSuccessorOrder(?OnlineShopOrder $successorOrder): static;
+    abstract public function setSuccessorOrder(?AbstractObject $successorOrder): static;
 }

--- a/bundles/EcommerceFrameworkBundle/src/Model/AbstractOrderItem.php
+++ b/bundles/EcommerceFrameworkBundle/src/Model/AbstractOrderItem.php
@@ -18,16 +18,16 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\Model;
 
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Fieldcollection;
-use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\DataObject\AbstractObject;
 
 /**
  * Abstract base class for order item pimcore objects
  */
 abstract class AbstractOrderItem extends Concrete
 {
-    abstract public function getProduct(): ?AbstractElement;
+    abstract public function getProduct(): ?AbstractObject;
 
-    abstract public function setProduct(?AbstractElement $product);
+    abstract public function setProduct(?AbstractObject $product);
 
     abstract public function getProductNumber(): ?string;
 

--- a/bundles/EcommerceFrameworkBundle/src/OfferTool/AbstractOfferItem.php
+++ b/bundles/EcommerceFrameworkBundle/src/OfferTool/AbstractOfferItem.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\OfferTool;
 
 use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\UnsupportedException;
+use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\Concrete;
 
 /**
@@ -27,9 +28,9 @@ abstract class AbstractOfferItem extends Concrete
     /**
      * @return AbstractOfferToolProduct|null
      */
-    abstract public function getProduct(): ?\Pimcore\Model\Element\AbstractElement;
+    abstract public function getProduct(): ?AbstractObject;
 
-    abstract public function setProduct(?\Pimcore\Model\Element\AbstractElement $product);
+    abstract public function setProduct(?AbstractObject $product);
 
     abstract public function getProductNumber(): ?string;
 

--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -575,7 +575,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
 
     public function getReturnTypeDeclaration(): ?string
     {
-        return $this->getPhpdocReturnType();
+        return $this->getParameterTypeDeclaration();
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -20,11 +20,14 @@ use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Relations\AbstractRelations;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData;
 use Pimcore\Model\DataObject\Localizedfield;
 use Pimcore\Model\Document;
+use Pimcore\Model\Document\Page;
+use Pimcore\Model\Document\Snippet;
 use Pimcore\Model\Element;
 use Pimcore\Normalizer\NormalizerInterface;
 
@@ -548,7 +551,38 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
 
     public function getParameterTypeDeclaration(): ?string
     {
-        return $this->getPhpdocReturnType();
+        $types = [];
+
+        // add documents
+        if ($this->getDocumentsAllowed()) {
+            $types[] = '\\' . Page::class;
+            $types[] = '\\' . Snippet::class;
+            $types[] = '\\' . Document::class;
+
+            foreach ($this->getDocumentTypes() as $item) {
+                $types[] = sprintf('\Pimcore\Model\Document\%s', ucfirst($item['documentTypes']));
+            }
+        }
+
+        // add assets
+        if ($this->getAssetsAllowed()) {
+            $types[] = '\\' . Asset::class;
+
+            foreach ($this->getAssetTypes() as $item) {
+                $types[] = sprintf('\Pimcore\Model\Asset\%s', ucfirst($item['assetTypes']));
+            }
+        }
+
+        // add objects
+        if ($this->getObjectsAllowed()) {
+            $types[] = '\\' . AbstractObject::class;
+
+            foreach ($this->getClasses() as $item) {
+                $types[] = sprintf('\Pimcore\Model\DataObject\%s', ucfirst($item['classes']));
+            }
+        }
+
+        return implode('|', $types) . '|null';
     }
 
     public function getReturnTypeDeclaration(): ?string

--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -548,12 +548,12 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
 
     public function getParameterTypeDeclaration(): ?string
     {
-        return '?\\' . Element\AbstractElement::class;
+        return $this->getPhpdocReturnType();
     }
 
     public function getReturnTypeDeclaration(): ?string
     {
-        return '?\\' . Element\AbstractElement::class;
+        return $this->getPhpdocReturnType();
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -558,28 +558,16 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
             $types[] = '\\' . Page::class;
             $types[] = '\\' . Snippet::class;
             $types[] = '\\' . Document::class;
-
-            foreach ($this->getDocumentTypes() as $item) {
-                $types[] = sprintf('\Pimcore\Model\Document\%s', ucfirst($item['documentTypes']));
-            }
         }
 
         // add assets
         if ($this->getAssetsAllowed()) {
             $types[] = '\\' . Asset::class;
-
-            foreach ($this->getAssetTypes() as $item) {
-                $types[] = sprintf('\Pimcore\Model\Asset\%s', ucfirst($item['assetTypes']));
-            }
         }
 
         // add objects
         if ($this->getObjectsAllowed()) {
             $types[] = '\\' . AbstractObject::class;
-
-            foreach ($this->getClasses() as $item) {
-                $types[] = sprintf('\Pimcore\Model\DataObject\%s', ucfirst($item['classes']));
-            }
         }
 
         return implode('|', $types) . '|null';

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -71,7 +71,7 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/src/IndexService/IndexUpdateService.php
 
 		-
-			message: "#^Parameter \\#1 \\$product of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\OfferTool\\\\AbstractOfferItem\\:\\:setProduct\\(\\) expects Pimcore\\\\Model\\\\Element\\\\AbstractElement\\|null, Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\CheckoutableInterface given\\.$#"
+			message: "#^Parameter \\#1 \\$product of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\OfferTool\\\\AbstractOfferItem\\:\\:setProduct\\(\\) expects Pimcore\\\\Model\\\\DataObject\\\\AbstractObject\\|null, Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\CheckoutableInterface given\\.$#"
 			count: 2
 			path: bundles/EcommerceFrameworkBundle/src/OfferTool/DefaultService.php
 
@@ -81,7 +81,7 @@ parameters:
 			path: bundles/EcommerceFrameworkBundle/src/OrderManager/Order/Listing.php
 
 		-
-			message: "#^Parameter \\#1 \\$product of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractOrderItem\\:\\:setProduct\\(\\) expects Pimcore\\\\Model\\\\Element\\\\AbstractElement\\|null, Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\CheckoutableInterface given\\.$#"
+			message: "#^Parameter \\#1 \\$product of method Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\AbstractOrderItem\\:\\:setProduct\\(\\) expects Pimcore\\\\Model\\\\DataObject\\\\AbstractObject\\|null, Pimcore\\\\Bundle\\\\EcommerceFrameworkBundle\\\\Model\\\\CheckoutableInterface given\\.$#"
 			count: 1
 			path: bundles/EcommerceFrameworkBundle/src/OrderManager/V7/OrderManager.php
 


### PR DESCRIPTION
Many-to-one relation fields return single objects, which means we can specify them as return/parameter type. This is currently only the case in PhpDoc, but not for the real types, which is possible since PHP 8.

Currently, it is:
```php
* @return \Pimcore\Model\Document\Snippet | \Pimcore\Model\Document\Page | \Pimcore\Model\Document\Folder|null
*/
public function getMyField(): ?\Pimcore\Model\Element\AbstractElement
{
```

```php
* @param \Pimcore\Model\Document\Snippet | \Pimcore\Model\Document\Page | \Pimcore\Model\Document\Folder $myField
* @return \Pimcore\Model\DataObject\MyClass
*/
public function setMyField(?\Pimcore\Model\Element\AbstractElement $myField)
{
```

With this PR, it would be:

```php
* @return \Pimcore\Model\Document\Snippet | \Pimcore\Model\Document\Page | \Pimcore\Model\Document\Folder|null
*/
public function getMyField(): \Pimcore\Model\Document\Snippet | \Pimcore\Model\Document\Page | \Pimcore\Model\Document\Folder|null
{
```

```php
* @param \Pimcore\Model\Document\Snippet | \Pimcore\Model\Document\Page | \Pimcore\Model\Document\Folder $myField
* @return \Pimcore\Model\DataObject\MyClass
*/
public function setMyField(\Pimcore\Model\Document\Snippet | \Pimcore\Model\Document\Page | \Pimcore\Model\Document\Folder|null $myField)
{
```

> **Note**
I think this would be a BC break in case someone overrode the models [like described here](https://pimcore.com/docs/pimcore/current/Development_Documentation/Extending_Pimcore/Overriding_Models.html), though.