### PR TITLE
Fix generated PhpDoc parameter type of many-to-one relation field setters

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -654,6 +654,18 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
     /**
      * {@inheritdoc}
      */
+    public function getPhpdocInputType(): ?string
+    {
+        if ($phpdocType = $this->getPhpdocType()) {
+            return $phpdocType . '|null';
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getPhpdocReturnType(): ?string
     {
         if ($phpdocType = $this->getPhpdocType()) {


### PR DESCRIPTION
While creating #12645, I noticed that the PhpDoc parameter type of many-to-one relation field setter misses the `null` part.

While the parameter type of the setter is generated as `?\Pimcore\Model\Element\AbstractElement`, the PhpDoc type is only e.g. `@param \Pimcore\Model\Document\Snippet | \Pimcore\Model\Document\Page`

With this PR, it would be `@param \Pimcore\Model\Document\Snippet | \Pimcore\Model\Document\Page|null` instead.

> **Note**
The PhpDoc type of the getter is already correct: `@return \Pimcore\Model\Document\Snippet | \Pimcore\Model\Document\Page|null`