### PR TITLE
Fix link to Apache configuration file in the docs

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/01_Apache_Configuration.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/01_Apache_Configuration.md
@@ -4,7 +4,7 @@
 Make sure `Allowoverride All` is set for the `DocumentRoot`, which enables `.htaccess` support. 
 
 All the necessary rewrite rules, which are needed for Pimcore to work, are defined in the `.htaccess` of the install package, 
-see [https://github.com/pimcore/skeleton/blob/10.x/public/.htaccess](https://github.com/pimcore/skeleton/blob/10.x/public/.htaccess). 
+see [https://github.com/pimcore/skeleton/blob/10.1/public/.htaccess](https://github.com/pimcore/skeleton/blob/10.x/public/.htaccess). 
 
 #### Example 
 ```

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/01_Apache_Configuration.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/01_Apache_Configuration.md
@@ -4,7 +4,7 @@
 Make sure `Allowoverride All` is set for the `DocumentRoot`, which enables `.htaccess` support. 
 
 All the necessary rewrite rules, which are needed for Pimcore to work, are defined in the `.htaccess` of the install package, 
-see [https://github.com/pimcore/skeleton/blob/10.1/public/.htaccess](https://github.com/pimcore/skeleton/blob/10.x/public/.htaccess). 
+see [https://github.com/pimcore/skeleton/blob/10.1/public/.htaccess](https://github.com/pimcore/skeleton/blob/10.1/public/.htaccess). 
 
 #### Example 
 ```


### PR DESCRIPTION
The Apache configuration was removed from the skeleton and is now in the docs. The docs for older version now point to a non-existing file in the skeleton. This fixes it.

See: pimcore/skeleton#105