### PR TITLE
Remove locks for folders in Asset, Data Object and Document controllers.

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -107,8 +107,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             return $this->adminJson(['success' => false, 'message' => "asset doesn't exist"]);
         }
 
-        // check for lock
-        if ($asset->isAllowed('publish') || $asset->isAllowed('delete')) {
+        // check for lock on non-folder items only.
+        if ($type !== 'folder' && ($asset->isAllowed('publish') || $asset->isAllowed('delete'))) {
             if (Element\Editlock::isLocked($assetId, 'asset')) {
                 return $this->getEditLockResponse($assetId, 'asset');
             }

--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -102,6 +102,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     public function getDataByIdAction(Request $request, EventDispatcherInterface $eventDispatcher)
     {
         $assetId = (int)$request->get('id');
+        $type = (string)$request->get('type');
+
         $asset = Asset::getById($assetId);
         if (!$asset instanceof Asset) {
             return $this->adminJson(['success' => false, 'message' => "asset doesn't exist"]);

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -696,12 +696,6 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     public function getFolderAction(Request $request, EventDispatcherInterface $eventDispatcher)
     {
         $objectId = (int)$request->get('id');
-        // check for lock
-        if (Element\Editlock::isLocked($objectId, 'object')) {
-            return $this->getEditLockResponse($objectId, 'object');
-        }
-        Element\Editlock::lock($objectId, 'object');
-
         $object = DataObject::getById($objectId);
 
         if (!$object) {

--- a/bundles/AdminBundle/Controller/Admin/Document/FolderController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/FolderController.php
@@ -43,10 +43,6 @@ class FolderController extends DocumentControllerBase
             throw $this->createNotFoundException('Folder not found');
         }
 
-        if (($lock = $this->checkForLock($folder)) instanceof JsonResponse) {
-            return $lock;
-        }
-
         $folder = clone $folder;
         $folder->setParent(null);
 


### PR DESCRIPTION
This pull request resolves issue #12673 - removes the edit lock for folders in the Asset, Data Object and Document controllers.