### PR TITLE
[Admin] Fix searching objects for specific class

### DIFF
--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -198,9 +198,6 @@ class SearchController extends AdminController
         }
 
         if (is_array($classnames) && !empty($classnames[0])) {
-            if (in_array('folder', $subtypes)) {
-                $classnames[] = 'folder';
-            }
             $conditionClassnameParts = [];
             foreach ($classnames as $classname) {
                 $conditionClassnameParts[] = $db->quote($classname);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #

## Additional info  
1. Go to Search -> DataObject in Admin
2. Select a class type
3. Click Search => results are not class specific 
