### PR TITLE
[Assets][Metadata]: Adds BC Layer for childs property in grid metadata tree

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/helpers/metadataTree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/helpers/metadataTree.js
@@ -130,6 +130,12 @@ pimcore.asset.helpers.metadataTree = Class.create({
         var keys = Object.keys(data);
         for (var i = 0; i < keys.length; i++) {
             if (data[keys[i]]) {
+                
+                //BC layer for asset metadata class definition
+                if(!data[keys[i]].children) {
+                    data[keys[i]].children = data[keys[i]].childs;
+                }
+                
                 if (data[keys[i]].children) {
 
                     var text = t(data[keys[i]].nodeLabel);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/helpers/metadataTree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/helpers/metadataTree.js
@@ -132,6 +132,7 @@ pimcore.asset.helpers.metadataTree = Class.create({
             if (data[keys[i]]) {
                 
                 //BC layer for asset metadata class definition
+                //TODO: Remove this in Pimcore 11 
                 if(!data[keys[i]].children) {
                     data[keys[i]].children = data[keys[i]].childs;
                 }


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/asset-metadata-class-definitions/issues/64


## Additional info  
It's either the change here or the [ajax return value](https://github.com/pimcore/asset-metadata-class-definitions/pull/51)
 as there's likely nothing else in between that can fix the problem

https://github.com/pimcore/pimcore/blob/d37bc728774da0b66f2886b78216b0a2e6caccf3/bundles/AdminBundle/Resources/public/js/pimcore/asset/helpers/gridConfigDialog.js#L636
https://github.com/pimcore/pimcore/blob/d37bc728774da0b66f2886b78216b0a2e6caccf3/bundles/AdminBundle/Resources/public/js/pimcore/asset/helpers/metadataTree.js#L112-L119

Related to https://github.com/pimcore/pimcore/pull/11762
