### PR TITLE
[10.4] Fix 'Only direct children' checkbox in variants tab

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/VariantsController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/VariantsController.php
@@ -81,7 +81,6 @@ class VariantsController extends AdminController
 
         $allParams = array_merge($request->request->all(), $request->query->all());
         $allParams['folderId'] = $parentObject->getId();
-        $allParams['only_direct_children'] = 'true';
         $allParams['classId'] = $parentObject->getClassId();
 
         $csrfProtection->checkCsrfToken($request);


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.4`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #7726

## Additional info  

`only_direct_children` was being hard-coded to 'true' breaking the checkbox in the Variants tab of a product
