### PR TITLE
Prevents the calling of video processing method multiple times from the As…

### DIFF
--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -86,6 +86,7 @@ class AssetUpdateTasksHandler
                 $asset->removeCustomSetting('videoHeight');
             }
         } catch (\Exception $e) {
+            Logger::err('Unable to get dimensions of video: ' . $asset->getId());
             throw new UnrecoverableMessageHandlingException($e->getMessage (), 0, $e);
         }
 

--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -20,6 +20,7 @@ use Pimcore\Messenger\AssetUpdateTasksMessage;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Version;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
 /**
  * @internal
@@ -72,6 +73,7 @@ class AssetUpdateTasksHandler
             $asset->setCustomSetting('duration', $asset->getDurationFromBackend());
         } catch (\Exception $e) {
             Logger::err('Unable to get duration of video: ' . $asset->getId());
+            throw new UnrecoverableMessageHandlingException($e->getMessage (), 0, $e);
         }
 
         try {
@@ -84,7 +86,7 @@ class AssetUpdateTasksHandler
                 $asset->removeCustomSetting('videoHeight');
             }
         } catch (\Exception $e) {
-            Logger::err('Unable to get dimensions of video: ' . $asset->getId());
+            throw new UnrecoverableMessageHandlingException($e->getMessage (), 0, $e);
         }
 
         $asset->handleEmbeddedMetaData(true);


### PR DESCRIPTION
Prevents the calling of video processing method multiple times from the AssetUpdateTasksMessage if an exception is thrown

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.4`
- Feature/Improvement: choose `10.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`10.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #12504 

## Additional info  

