### PR TITLE
[Task]: Change broken link to documentation of headless chrome options

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/web2print.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/web2print.js
@@ -217,7 +217,7 @@ pimcore.settings.web2print = Class.create({
                         value: t('web2print_headlesschrome_puppeteer_documentation'),
                         autoEl:{
                             tag: 'a',
-                            href: "https://pptr.dev/api/puppeteer.pdfoptions",
+                            href: "https://github.com/spiritix/php-chrome-html2pdf#options",
                         }
                     },{
                         xtype: "displayfield",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/web2print.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/web2print.js
@@ -214,9 +214,10 @@ pimcore.settings.web2print = Class.create({
                         fieldLabel: t("web2print_headlesschrome_documentation"),
                         name: 'documentation',
                         width: 600,
-                        value: t('web2print_headlesschrome_puppeteer_documentation'),
+                        value: t('web2print_headlesschrome_options_documentation'),
                         autoEl:{
                             tag: 'a',
+                            target: '_blank',
                             href: "https://github.com/spiritix/php-chrome-html2pdf#options",
                         }
                     },{
@@ -233,6 +234,7 @@ pimcore.settings.web2print = Class.create({
                         value: t('web2print_headlesschrome_json_converter_link'),
                         autoEl:{
                             tag: 'a',
+                            target: '_blank',
                             href: "https://jsonformatter.org/",
                         }
                     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/web2print.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/web2print.js
@@ -217,7 +217,7 @@ pimcore.settings.web2print = Class.create({
                         value: t('web2print_headlesschrome_puppeteer_documentation'),
                         autoEl:{
                             tag: 'a',
-                            href: "https://pptr.dev/#?product=Puppeteer&version=v5.2.1&show=api-pagepdfoptions",
+                            href: "https://pptr.dev/api/puppeteer.pdfoptions",
                         }
                     },{
                         xtype: "displayfield",


### PR DESCRIPTION
The link position is here:

![image](https://user-images.githubusercontent.com/6014195/179757036-083ed04e-a755-46ca-97e9-391527225d44.png)
