### PR TITLE
[Core] Fix deprecations

### DIFF
--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -541,7 +541,7 @@ class CoreCacheHandler implements LoggerAwareInterface
         if ($data instanceof ElementInterface) {
             // fetch a fresh copy
             $type = Service::getElementType($data);
-            $data = Service::getElementById($type, $data->getId(), true);
+            $data = Service::getElementById($type, $data->getId(), ['force' => true]);
 
             if (!$data->__isBasedOnLatestData()) {
                 $this->logger->warning('Not saving {key} to cache as element is not based on latest data', [

--- a/lib/Messenger/Handler/SanityCheckHandler.php
+++ b/lib/Messenger/Handler/SanityCheckHandler.php
@@ -46,7 +46,7 @@ class SanityCheckHandler implements BatchHandlerInterface
 
         foreach ($jobs as [$message, $ack]) {
             try {
-                $element = Service::getElementById($message->getType(), $message->getId(), true);
+                $element = Service::getElementById($message->getType(), $message->getId(), ['force' => true]);
                 if ($element) {
                     $this->performSanityCheck($element);
                 }

--- a/tests/Model/LazyLoading/AbstractLazyLoadingTest.php
+++ b/tests/Model/LazyLoading/AbstractLazyLoadingTest.php
@@ -151,7 +151,7 @@ class AbstractLazyLoadingTest extends ModelTestCase
         Cache::getHandler()->removeClearedTags($object->getCacheTags());
         Cache::save($object, \Pimcore\Model\Element\Service::getElementCacheTag('object', $object->getId()), [], null, 9999, true);
 
-        Cache\Runtime::clear();
+        Cache\RuntimeCache::clear();
         //reload from cache and check again
         $objectCache = Concrete::getById($object->getId());
 


### PR DESCRIPTION
## Changes in this pull request  
Fixes:
```
80x DEPRECATION: Since pimcore/pimcore 10.5: Using $force=true on Pimcore\Model\Element\Service::getElementById is deprecated, please use array-syntax [force=>true] instead./home/runner/work/pimcore/pimcore/vendor/symfony/contracts/Deprecation/function.php:25
80x DEPRECATION: Since pimcore/pimcore 10.5.0: Pimcore\Cache\Runtime::clear is deprecated. Use RuntimeCache::clear instead!/home/runner/work/pimcore/pimcore/vendor/symfony/contracts/Deprecation/function.php:25
```

## Additional info  

