### PR TITLE
Fix: Missing Video Thumbnails won't be generated

### DIFF
--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -77,7 +77,7 @@ class PublicServicesController extends Controller
                             if (!$thumbnailConfig instanceof Asset\Image\Thumbnail\Config) {
                                 throw new \Exception("Deferred thumbnail config file doesn't contain a valid \\Asset\\Image\\Thumbnail\\Config object");
                             }
-                        } elseif (\Pimcore::getContainer()->getParameter('pimcore.config')['assets']['image']['thumbnails']['status_cache']) {
+                        } elseif ($this->getParameter('pimcore.config')['assets']['image']['thumbnails']['status_cache']) {
                             // Delete Thumbnail Name from Cache so the next call can generate a new TmpStore entry
                             $asset->getDao()->deleteFromThumbnailCache($thumbnailName);
                         }

--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -46,7 +46,7 @@ class PublicServicesController extends Controller
      */
     public function thumbnailAction(Request $request)
     {
-        $assetId = $request->get('assetId');
+        $assetId = (int) $request->get('assetId');
         $thumbnailName = $request->get('thumbnailName');
         $filename = $request->get('filename');
         $requestedFileExtension = strtolower(File::getFileExtension($filename));
@@ -77,6 +77,9 @@ class PublicServicesController extends Controller
                             if (!$thumbnailConfig instanceof Asset\Image\Thumbnail\Config) {
                                 throw new \Exception("Deferred thumbnail config file doesn't contain a valid \\Asset\\Image\\Thumbnail\\Config object");
                             }
+                        } elseif (\Pimcore::getContainer()->getParameter('pimcore.config')['assets']['image']['thumbnails']['status_cache']) {
+                            // Delete Thumbnail Name from Cache so the next call can generate a new TmpStore entry
+                            $asset->getDao()->deleteFromThumbnailCache($thumbnailName);
                         }
                     }
 

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -816,7 +816,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
             ];
 
             if (!$thumbnail) {
-                $thumbnail = $video->getImageThumbnail([]);
+                $thumbnail = $video->getImageThumbnail([])->getPath();
             }
 
             $jsonLd['contentUrl'] = $urls['mp4'];

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -816,7 +816,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
             ];
 
             if (!$thumbnail) {
-                $thumbnail = $video->getImageThumbnail([])->getPath();
+                $thumbnail = $video->getImageThumbnail([]);
             }
 
             $jsonLd['contentUrl'] = $urls['mp4'];


### PR DESCRIPTION
We have the problem that video thumbnails are missing but in the thumbnail cache. I don't know how the thumbnails are deleted.

The getHtml5Code() method will generate a auto thumbnail name. But when this is in the cache no config will stored in the TmpStore.

The PublicServiceController can so not load the thumbnail config. I would delete the thumbnail from cache in this case.

Maybe related: https://github.com/pimcore/pimcore/discussions/12549