### PR TITLE
Fix Symfony deprecations - Command::execute() might add "int" as a native return type

### DIFF
--- a/bundles/CoreBundle/Command/Bundle/DisableCommand.php
+++ b/bundles/CoreBundle/Command/Bundle/DisableCommand.php
@@ -46,7 +46,10 @@ class DisableCommand extends AbstractBundleCommand
         PostStateChange::configureStateChangeCommandOptions($this);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $deprecation = 'Disabling bundle is deprecated and will not work in Pimcore 11. Use config/bundles.php to register/de-register bundles instead.';
         trigger_deprecation(

--- a/bundles/CoreBundle/Command/Bundle/EnableCommand.php
+++ b/bundles/CoreBundle/Command/Bundle/EnableCommand.php
@@ -66,7 +66,10 @@ class EnableCommand extends AbstractBundleCommand
         PostStateChange::configureStateChangeCommandOptions($this);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $deprecation = 'Enabling bundle is deprecated and will not work in Pimcore 11. Use config/bundles.php to register/de-register bundles instead.';
         trigger_deprecation(

--- a/bundles/CoreBundle/Command/Bundle/InstallCommand.php
+++ b/bundles/CoreBundle/Command/Bundle/InstallCommand.php
@@ -45,7 +45,10 @@ class InstallCommand extends AbstractBundleCommand
         PostStateChange::configureStateChangeCommandOptions($this);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $bundle = $this->getBundle();
 

--- a/bundles/CoreBundle/Command/Bundle/ListCommand.php
+++ b/bundles/CoreBundle/Command/Bundle/ListCommand.php
@@ -42,7 +42,10 @@ class ListCommand extends AbstractBundleCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $returnData = [
             'headers' => [

--- a/bundles/CoreBundle/Command/Bundle/UninstallCommand.php
+++ b/bundles/CoreBundle/Command/Bundle/UninstallCommand.php
@@ -44,7 +44,10 @@ class UninstallCommand extends AbstractBundleCommand
         PostStateChange::configureStateChangeCommandOptions($this);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $bundle = $this->getBundle();
 

--- a/bundles/CoreBundle/Command/CacheClearCommand.php
+++ b/bundles/CoreBundle/Command/CacheClearCommand.php
@@ -62,7 +62,10 @@ class CacheClearCommand extends AbstractCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $io->newLine();

--- a/bundles/CoreBundle/Command/CacheWarmingCommand.php
+++ b/bundles/CoreBundle/Command/CacheWarmingCommand.php
@@ -114,7 +114,7 @@ class CacheWarmingCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->getOption('maintenance-mode')) {
             // set the timeout between each iteration to 0 if maintenance mode is on, because

--- a/bundles/CoreBundle/Command/ClassesDefinitionsBuildCommand.php
+++ b/bundles/CoreBundle/Command/ClassesDefinitionsBuildCommand.php
@@ -50,7 +50,7 @@ class ClassesDefinitionsBuildCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $objectClassesFolder = PIMCORE_CLASS_DEFINITION_DIRECTORY;
         $files = glob($objectClassesFolder.'/*.php');

--- a/bundles/CoreBundle/Command/ClassesRebuildCommand.php
+++ b/bundles/CoreBundle/Command/ClassesRebuildCommand.php
@@ -65,7 +65,7 @@ class ClassesRebuildCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->getOption('delete-classes')) {
             $questionResult = true;

--- a/bundles/CoreBundle/Command/CustomLayoutRebuildCommand.php
+++ b/bundles/CoreBundle/Command/CustomLayoutRebuildCommand.php
@@ -63,7 +63,7 @@ class CustomLayoutRebuildCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->getOption('delete-custom-layouts')) {
             $questionResult = true;

--- a/bundles/CoreBundle/Command/Definition/Import/AbstractStructureImportCommand.php
+++ b/bundles/CoreBundle/Command/Definition/Import/AbstractStructureImportCommand.php
@@ -58,7 +58,7 @@ abstract class AbstractStructureImportCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $path = $this->getPath();
         $type = $this->getType();

--- a/bundles/CoreBundle/Command/DeleteClassificationStoreCommand.php
+++ b/bundles/CoreBundle/Command/DeleteClassificationStoreCommand.php
@@ -40,7 +40,7 @@ class DeleteClassificationStoreCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $storeId = $input->getArgument('storeId');
 

--- a/bundles/CoreBundle/Command/DeleteUnusedLocaleDataCommand.php
+++ b/bundles/CoreBundle/Command/DeleteUnusedLocaleDataCommand.php
@@ -49,7 +49,7 @@ class DeleteUnusedLocaleDataCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $db = Db::get();
         $skipLocales = [];

--- a/bundles/CoreBundle/Command/Document/GeneratePagePreviews.php
+++ b/bundles/CoreBundle/Command/Document/GeneratePagePreviews.php
@@ -102,7 +102,7 @@ class GeneratePagePreviews extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $hostUrl = $input->getOption('urlPrefix');
         if (!$hostUrl) {

--- a/bundles/CoreBundle/Command/Document/MigrateElementsCommand.php
+++ b/bundles/CoreBundle/Command/Document/MigrateElementsCommand.php
@@ -39,7 +39,7 @@ class MigrateElementsCommand extends AbstractCommand
             ->setDescription('Migrates document elements to editables. See issue https://github.com/pimcore/pimcore/issues/7384 first');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (!$this->runCommand) {
             return 0;

--- a/bundles/CoreBundle/Command/EmailLogsCleanupCommand.php
+++ b/bundles/CoreBundle/Command/EmailLogsCleanupCommand.php
@@ -43,7 +43,7 @@ class EmailLogsCleanupCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $daysAgo = $input->getOption('older-than-days');
 

--- a/bundles/CoreBundle/Command/ExtJSCommand.php
+++ b/bundles/CoreBundle/Command/ExtJSCommand.php
@@ -54,7 +54,7 @@ class ExtJSCommand extends AbstractCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $io->newLine();

--- a/bundles/CoreBundle/Command/GenerateStaticPagesCommand.php
+++ b/bundles/CoreBundle/Command/GenerateStaticPagesCommand.php
@@ -50,7 +50,7 @@ class GenerateStaticPagesCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $path = $input->getOption('path');
 

--- a/bundles/CoreBundle/Command/InternalMigrationHelpersCommand.php
+++ b/bundles/CoreBundle/Command/InternalMigrationHelpersCommand.php
@@ -49,7 +49,7 @@ class InternalMigrationHelpersCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->getOption('is-installed')) {
             try {

--- a/bundles/CoreBundle/Command/InternalModelDaoMappingGeneratorCommand.php
+++ b/bundles/CoreBundle/Command/InternalModelDaoMappingGeneratorCommand.php
@@ -38,7 +38,7 @@ class InternalModelDaoMappingGeneratorCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $finder = new Finder();
         $finder

--- a/bundles/CoreBundle/Command/InternalUnicodeCldrLanguageTerritoryGeneratorCommand.php
+++ b/bundles/CoreBundle/Command/InternalUnicodeCldrLanguageTerritoryGeneratorCommand.php
@@ -42,7 +42,7 @@ class InternalUnicodeCldrLanguageTerritoryGeneratorCommand extends AbstractComma
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $source = 'https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/supplementalData.xml';
         $data = file_get_contents($source);

--- a/bundles/CoreBundle/Command/LowQualityImagePreviewCommand.php
+++ b/bundles/CoreBundle/Command/LowQualityImagePreviewCommand.php
@@ -64,7 +64,7 @@ class LowQualityImagePreviewCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $conditionVariables = [];
 

--- a/bundles/CoreBundle/Command/MaintenanceCommand.php
+++ b/bundles/CoreBundle/Command/MaintenanceCommand.php
@@ -82,7 +82,7 @@ class MaintenanceCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $validJobs = $this->getArrayOptionValue($input, 'job');
         $excludedJobs = $this->getArrayOptionValue($input, 'excludedJobs');

--- a/bundles/CoreBundle/Command/MaintenanceModeCommand.php
+++ b/bundles/CoreBundle/Command/MaintenanceModeCommand.php
@@ -54,7 +54,7 @@ class MaintenanceModeCommand extends AbstractCommand
      *
      * @throws Exception
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         //Default behavior is 'enable'
         $disable = ($input->getOption('disable') ?? false);

--- a/bundles/CoreBundle/Command/Migrate/StorageCommand.php
+++ b/bundles/CoreBundle/Command/Migrate/StorageCommand.php
@@ -51,7 +51,7 @@ class StorageCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $storages = $input->getArgument('storage');
 

--- a/bundles/CoreBundle/Command/Migrate/ThumbnailsFolderStructureCommand.php
+++ b/bundles/CoreBundle/Command/Migrate/ThumbnailsFolderStructureCommand.php
@@ -38,7 +38,7 @@ class ThumbnailsFolderStructureCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $thumbnailStorage = Storage::get('thumbnail');
 

--- a/bundles/CoreBundle/Command/MysqlToolsCommand.php
+++ b/bundles/CoreBundle/Command/MysqlToolsCommand.php
@@ -43,7 +43,7 @@ class MysqlToolsCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // display error message
         if (!$input->getOption('mode')) {

--- a/bundles/CoreBundle/Command/OptimizeImageThumbnailsCommand.php
+++ b/bundles/CoreBundle/Command/OptimizeImageThumbnailsCommand.php
@@ -46,7 +46,7 @@ class OptimizeImageThumbnailsCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $storage = Storage::get('thumbnail');
         $savedBytesTotal = 0;

--- a/bundles/CoreBundle/Command/RecyclebinCleanupCommand.php
+++ b/bundles/CoreBundle/Command/RecyclebinCleanupCommand.php
@@ -43,7 +43,7 @@ class RecyclebinCleanupCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $daysAgo = $input->getOption('older-than-days');
 

--- a/bundles/CoreBundle/Command/RequirementsCheckCommand.php
+++ b/bundles/CoreBundle/Command/RequirementsCheckCommand.php
@@ -45,7 +45,7 @@ class RequirementsCheckCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         switch ($input->getOption('min-level')) {
             case 'warning':

--- a/bundles/CoreBundle/Command/ResetPasswordCommand.php
+++ b/bundles/CoreBundle/Command/ResetPasswordCommand.php
@@ -52,7 +52,7 @@ class ResetPasswordCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $userArgument = $input->getArgument('user');
 

--- a/bundles/CoreBundle/Command/RunScriptCommand.php
+++ b/bundles/CoreBundle/Command/RunScriptCommand.php
@@ -42,7 +42,7 @@ class RunScriptCommand extends AbstractCommand
         $this->configureDryRunOption();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $script = $input->getArgument('script');
 

--- a/bundles/CoreBundle/Command/SearchBackendReindexCommand.php
+++ b/bundles/CoreBundle/Command/SearchBackendReindexCommand.php
@@ -40,7 +40,7 @@ class SearchBackendReindexCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // clear all data
         $db = \Pimcore\Db::get();

--- a/bundles/CoreBundle/Command/ThumbnailsClearCommand.php
+++ b/bundles/CoreBundle/Command/ThumbnailsClearCommand.php
@@ -48,7 +48,7 @@ class ThumbnailsClearCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $possibleOptions = ['image', 'video'];
         if (!in_array($input->getOption('type'), $possibleOptions)) {

--- a/bundles/CoreBundle/Command/WorkflowDumpCommand.php
+++ b/bundles/CoreBundle/Command/WorkflowDumpCommand.php
@@ -56,7 +56,7 @@ EOF
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $container = $this->getApplication()->getKernel()->getContainer();
         $serviceId = $input->getArgument('name');

--- a/bundles/EcommerceFrameworkBundle/Command/CleanupPendingOrdersCommand.php
+++ b/bundles/EcommerceFrameworkBundle/Command/CleanupPendingOrdersCommand.php
@@ -38,7 +38,7 @@ class CleanupPendingOrdersCommand extends AbstractCommand
      *
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $checkoutManager = Factory::getInstance()->getCheckoutManager(new Cart());
         $checkoutManager->cleanUpPendingOrders();

--- a/bundles/EcommerceFrameworkBundle/Command/IndexService/EsSyncCommand.php
+++ b/bundles/EcommerceFrameworkBundle/Command/IndexService/EsSyncCommand.php
@@ -53,7 +53,7 @@ class EsSyncCommand extends AbstractIndexServiceCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $mode = $input->getArgument('mode');
         $tenantName = $input->getOption('tenant');

--- a/bundles/EcommerceFrameworkBundle/Command/IndexService/ResetQueueCommand.php
+++ b/bundles/EcommerceFrameworkBundle/Command/IndexService/ResetQueueCommand.php
@@ -44,7 +44,7 @@ class ResetQueueCommand extends AbstractIndexServiceCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (!($tenant = $input->getOption('tenant'))) {
             throw new \Exception('No tenant given');

--- a/bundles/EcommerceFrameworkBundle/Command/Voucher/CleanupReservationsCommand.php
+++ b/bundles/EcommerceFrameworkBundle/Command/Voucher/CleanupReservationsCommand.php
@@ -37,7 +37,7 @@ class CleanupReservationsCommand extends AbstractCommand
      *
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->output->writeln('<comment>*</comment> Cleaning up <info>reservations</info>');
         Factory::getInstance()->getVoucherService()->cleanUpReservations();

--- a/bundles/EcommerceFrameworkBundle/Command/Voucher/CleanupStatisticsCommand.php
+++ b/bundles/EcommerceFrameworkBundle/Command/Voucher/CleanupStatisticsCommand.php
@@ -37,7 +37,7 @@ class CleanupStatisticsCommand extends AbstractCommand
      *
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->output->writeln('<comment>*</comment> Cleaning up <info>statistics</info>');
         Factory::getInstance()->getVoucherService()->cleanUpStatistics();

--- a/bundles/InstallBundle/Command/InstallCommand.php
+++ b/bundles/InstallBundle/Command/InstallCommand.php
@@ -314,7 +314,7 @@ class InstallCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->isInteractive() && !$this->io->confirm('This will install Pimcore with the given settings. Do you want to continue?')) {
             return 0;

--- a/doc/Development_Documentation/05_Objects/05_External_System_Interaction.md
+++ b/doc/Development_Documentation/05_Objects/05_External_System_Interaction.md
@@ -32,7 +32,7 @@ class AwesomeCommand extends AbstractCommand
             ->setDescription('Awesome command');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         //create single object
         $object = new DataObject\Myclass();

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/11_Console_CLI.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/11_Console_CLI.md
@@ -52,7 +52,7 @@ class AwesomeCommand extends AbstractCommand
             ->setDescription('Awesome command');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // dump
         $this->dump("Isn't that awesome?");


### PR DESCRIPTION
## Changes in this pull request  
Fixes deprecations:
```

Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Pimcore\Bundle\CoreBundle\Command\Bundle\DisableCommand" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Pimcore\Bundle\CoreBundle\Command\Bundle\EnableCommand" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Pimcore\Bundle\CoreBundle\Command\Bundle\InstallCommand" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Pimcore\Bundle\CoreBundle\Command\Bundle\UninstallCommand" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Pimcore\Bundle\CoreBundle\Command\CacheClearCommand" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Pimcore\Bundle\CoreBundle\Command\ClassesRebuildCommand" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Pimcore\Bundle\CoreBundle\Command\CustomLayoutRebuildCommand" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Pimcore\Bundle\CoreBundle\Command\ExtJSCommand" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Pimcore\Bundle\CoreBundle\Command\MaintenanceCommand" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Pimcore\Bundle\CoreBundle\Command\OptimizeImageThumbnailsCommand" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "Pimcore\Bundle\CoreBundle\Command\WorkflowDumpCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
Show context Show trace
```
and more like this....

## Additional info  

