### PR TITLE
Avoid multiple Thumbnail::getPath() calls in Video::getHtml5Code()

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -768,7 +768,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
     /**
      * @param array $urls
-     * @param string|null $thumbnail
+     * @param Asset\Image\Thumbnail|Asset\Video\ImageThumbnail|null $thumbnail
      *
      * @return string
      */
@@ -824,9 +824,10 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
                 $jsonLd['contentUrl'] = Tool::getHostUrl() . $urls['mp4'];
             }
 
-            $jsonLd['thumbnailUrl'] = (string)$thumbnail;
-            if (!preg_match('@https?://@', (string)$thumbnail)) {
-                $jsonLd['thumbnailUrl'] = Tool::getHostUrl() . $thumbnail;
+            $thumbnailUrl = (string)$thumbnail;
+            $jsonLd['thumbnailUrl'] = $thumbnailUrl;
+            if (!preg_match('@https?://@', $thumbnailUrl)) {
+                $jsonLd['thumbnailUrl'] = Tool::getHostUrl() . $thumbnailUrl;
             }
 
             $code .= "\n\n<script type=\"application/ld+json\">\n" . json_encode($jsonLd) . "\n</script>\n\n";
@@ -836,7 +837,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
             $attributes = [
                 'width' => $this->getWidth(),
                 'height' => $this->getHeight(),
-                'poster' => $thumbnail,
+                'poster' => $thumbnailUrl,
                 'controls' => 'controls',
                 'class' => 'pimcore_video',
             ];


### PR DESCRIPTION
I splitted this from #12697 

The _toString() (and so the getPath()) method would call very often (Line 827, 828, 829, 869, 872).

The doc type of the param is also wrong. It can only be a Thumbnail object. See line 380/400.