### PR TITLE
Fix Symfony deprecations - EventSubscriberInterface::getSubscribedEvents() might add "array" as a native return type

### DIFF
--- a/bundles/AdminBundle/EventListener/AdminAuthenticationDoubleCheckListener.php
+++ b/bundles/AdminBundle/EventListener/AdminAuthenticationDoubleCheckListener.php
@@ -78,7 +78,7 @@ class AdminAuthenticationDoubleCheckListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER => 'onKernelController',

--- a/bundles/AdminBundle/EventListener/AdminSecurityListener.php
+++ b/bundles/AdminBundle/EventListener/AdminSecurityListener.php
@@ -44,7 +44,7 @@ class AdminSecurityListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => 'onKernelResponse',

--- a/bundles/AdminBundle/EventListener/BruteforceProtectionListener.php
+++ b/bundles/AdminBundle/EventListener/BruteforceProtectionListener.php
@@ -49,7 +49,7 @@ class BruteforceProtectionListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER => 'onKernelController',

--- a/bundles/AdminBundle/EventListener/CsrfProtectionListener.php
+++ b/bundles/AdminBundle/EventListener/CsrfProtectionListener.php
@@ -51,7 +51,7 @@ class CsrfProtectionListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => ['handleRequest', 11],

--- a/bundles/AdminBundle/EventListener/EnablePreviewTimeSliderListener.php
+++ b/bundles/AdminBundle/EventListener/EnablePreviewTimeSliderListener.php
@@ -64,7 +64,7 @@ class EnablePreviewTimeSliderListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => 'onKernelResponse',

--- a/bundles/AdminBundle/EventListener/HttpCacheListener.php
+++ b/bundles/AdminBundle/EventListener/HttpCacheListener.php
@@ -53,7 +53,7 @@ class HttpCacheListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => 'onKernelResponse',

--- a/bundles/AdminBundle/EventListener/UsageStatisticsListener.php
+++ b/bundles/AdminBundle/EventListener/UsageStatisticsListener.php
@@ -54,7 +54,7 @@ class UsageStatisticsListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/bundles/AdminBundle/EventListener/UserPerspectiveListener.php
+++ b/bundles/AdminBundle/EventListener/UserPerspectiveListener.php
@@ -50,7 +50,7 @@ class UserPerspectiveListener implements EventSubscriberInterface, LoggerAwareIn
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/bundles/CoreBundle/EventListener/DumpTranslationEntriesListener.php
+++ b/bundles/CoreBundle/EventListener/DumpTranslationEntriesListener.php
@@ -43,7 +43,7 @@ class DumpTranslationEntriesListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::TERMINATE => 'onKernelTerminate',

--- a/bundles/CoreBundle/EventListener/EventedControllerListener.php
+++ b/bundles/CoreBundle/EventListener/EventedControllerListener.php
@@ -30,7 +30,7 @@ class EventedControllerListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER => 'onKernelController',

--- a/bundles/CoreBundle/EventListener/Frontend/BlockStateListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/BlockStateListener.php
@@ -45,7 +45,7 @@ class BlockStateListener implements EventSubscriberInterface, LoggerAwareInterfa
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/bundles/CoreBundle/EventListener/Frontend/ContentTemplateListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/ContentTemplateListener.php
@@ -43,7 +43,7 @@ class ContentTemplateListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::VIEW => ['onKernelView', 16],

--- a/bundles/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/DocumentFallbackListener.php
@@ -76,7 +76,7 @@ class DocumentFallbackListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             // priority must be before

--- a/bundles/CoreBundle/EventListener/Frontend/DocumentMetaDataListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/DocumentMetaDataListener.php
@@ -46,7 +46,7 @@ class DocumentMetaDataListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => ['onKernelRequest'],

--- a/bundles/CoreBundle/EventListener/Frontend/DocumentRendererListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/DocumentRendererListener.php
@@ -33,7 +33,7 @@ class DocumentRendererListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             DocumentEvents::RENDERER_PRE_RENDER => 'onPreRender',

--- a/bundles/CoreBundle/EventListener/Frontend/EditmodeListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/EditmodeListener.php
@@ -70,7 +70,7 @@ class EditmodeListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/bundles/CoreBundle/EventListener/Frontend/ElementListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/ElementListener.php
@@ -63,7 +63,7 @@ class ElementListener implements EventSubscriberInterface, LoggerAwareInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER => ['onKernelController', 30], // has to be after DocumentFallbackListener

--- a/bundles/CoreBundle/EventListener/Frontend/GlobalTemplateVariablesListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/GlobalTemplateVariablesListener.php
@@ -51,7 +51,7 @@ class GlobalTemplateVariablesListener implements EventSubscriberInterface, Logge
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER => ['onKernelController', 15], // has to be after DocumentFallbackListener

--- a/bundles/CoreBundle/EventListener/Frontend/GoogleSearchConsoleVerificationListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/GoogleSearchConsoleVerificationListener.php
@@ -29,7 +29,7 @@ class GoogleSearchConsoleVerificationListener implements EventSubscriberInterfac
 {
     use PimcoreContextAwareTrait;
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => ['onKernelRequest', 64],

--- a/bundles/CoreBundle/EventListener/Frontend/HardlinkCanonicalListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/HardlinkCanonicalListener.php
@@ -48,7 +48,7 @@ class HardlinkCanonicalListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => 'onKernelResponse',

--- a/bundles/CoreBundle/EventListener/Frontend/InternalWysiwygHtmlAttributeFilterListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/InternalWysiwygHtmlAttributeFilterListener.php
@@ -33,7 +33,7 @@ class InternalWysiwygHtmlAttributeFilterListener implements EventSubscriberInter
     use PimcoreContextAwareTrait;
     use StaticPageContextAwareTrait;
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => 'onKernelResponse',

--- a/bundles/CoreBundle/EventListener/Frontend/LocaleListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/LocaleListener.php
@@ -33,7 +33,7 @@ class LocaleListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => ['onKernelRequest', 1], // need to be after ElementListener

--- a/bundles/CoreBundle/EventListener/Frontend/OutputTimestampListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/OutputTimestampListener.php
@@ -37,7 +37,7 @@ class OutputTimestampListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/bundles/CoreBundle/EventListener/Frontend/RoutingListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/RoutingListener.php
@@ -58,7 +58,7 @@ class RoutingListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             // run with high priority as we need to set the site early

--- a/bundles/CoreBundle/EventListener/Frontend/StaticPageGeneratorListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/StaticPageGeneratorListener.php
@@ -54,7 +54,7 @@ class StaticPageGeneratorListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             DocumentEvents::POST_ADD => 'onPostAddUpdateDeleteDocument',

--- a/bundles/CoreBundle/EventListener/MessengerClearRuntimeCacheListener.php
+++ b/bundles/CoreBundle/EventListener/MessengerClearRuntimeCacheListener.php
@@ -29,7 +29,7 @@ class MessengerClearRuntimeCacheListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             WorkerMessageReceivedEvent::class => 'handle',

--- a/bundles/CoreBundle/EventListener/PimcoreContextListener.php
+++ b/bundles/CoreBundle/EventListener/PimcoreContextListener.php
@@ -48,7 +48,7 @@ class PimcoreContextListener implements EventSubscriberInterface, LoggerAwareInt
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             // run after router to be able to match the _route attribute

--- a/bundles/CoreBundle/EventListener/PimcoreHeaderListener.php
+++ b/bundles/CoreBundle/EventListener/PimcoreHeaderListener.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class PimcoreHeaderListener implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => 'onKernelResponse',

--- a/bundles/CoreBundle/EventListener/ResponseExceptionListener.php
+++ b/bundles/CoreBundle/EventListener/ResponseExceptionListener.php
@@ -59,7 +59,7 @@ class ResponseExceptionListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::EXCEPTION => 'onKernelException',

--- a/bundles/CoreBundle/EventListener/ResponseHeaderListener.php
+++ b/bundles/CoreBundle/EventListener/ResponseHeaderListener.php
@@ -37,7 +37,7 @@ class ResponseHeaderListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => ['onKernelResponse', 32],

--- a/bundles/CoreBundle/EventListener/ResponseStackListener.php
+++ b/bundles/CoreBundle/EventListener/ResponseStackListener.php
@@ -37,7 +37,7 @@ class ResponseStackListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => ['onKernelResponse', 24],

--- a/bundles/CoreBundle/EventListener/SearchBackendListener.php
+++ b/bundles/CoreBundle/EventListener/SearchBackendListener.php
@@ -39,7 +39,7 @@ class SearchBackendListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             DataObjectEvents::POST_ADD => 'onPostAddUpdateElement',

--- a/bundles/CoreBundle/EventListener/TranslationDebugListener.php
+++ b/bundles/CoreBundle/EventListener/TranslationDebugListener.php
@@ -37,7 +37,7 @@ class TranslationDebugListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/bundles/CoreBundle/EventListener/WebDebugToolbarListener.php
+++ b/bundles/CoreBundle/EventListener/WebDebugToolbarListener.php
@@ -48,7 +48,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => ['onKernelResponse', -118],

--- a/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
+++ b/bundles/CoreBundle/EventListener/WorkflowManagementListener.php
@@ -56,7 +56,7 @@ class WorkflowManagementListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             DataObjectEvents::POST_ADD => 'onElementPostAdd',

--- a/bundles/EcommerceFrameworkBundle/EventListener/Frontend/TrackingCodeFlashMessageListener.php
+++ b/bundles/EcommerceFrameworkBundle/EventListener/Frontend/TrackingCodeFlashMessageListener.php
@@ -52,7 +52,7 @@ class TrackingCodeFlashMessageListener implements EventSubscriberInterface
         $this->trackingManger = $trackingManager;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/bundles/EcommerceFrameworkBundle/EventListener/SessionBagListener.php
+++ b/bundles/EcommerceFrameworkBundle/EventListener/SessionBagListener.php
@@ -31,7 +31,10 @@ class SessionBagListener implements EventSubscriberInterface
 
     const ATTRIBUTE_BAG_PAYMENT_ENVIRONMENT = 'ecommerceframework_payment_environment';
 
-    public static function getSubscribedEvents()
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()// : array
     {
         return [
             //run after Symfony\Component\HttpKernel\EventListener\SessionListener

--- a/doc/Development_Documentation/03_Documents/01_Editables/40_WYSIWYG.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/40_WYSIWYG.md
@@ -146,7 +146,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class EditmodeListener implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             BundleManagerEvents::EDITMODE_JS_PATHS => 'onEditmodeJsPaths'

--- a/doc/Development_Documentation/18_Tools_and_Features/28_Marketing_Settings/05_Analytics.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/28_Marketing_Settings/05_Analytics.md
@@ -85,7 +85,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class GoogleTrackingCodeListener implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             GoogleAnalyticsEvents::CODE_TRACKING_DATA => 'onTrackingData'

--- a/doc/Development_Documentation/18_Tools_and_Features/37_Targeting_and_Personalization/11_Frontend_Javascript.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/37_Targeting_and_Personalization/11_Frontend_Javascript.md
@@ -44,7 +44,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class TargetingCodeListener implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             TargetingEvents::TARGETING_CODE => 'onTargetingCode',

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/35_Working_with_Sessions.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/35_Working_with_Sessions.md
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  
 class SessionBagListener implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             //run after Symfony\Component\HttpKernel\EventListener\SessionListener

--- a/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/13_Loading_Admin_UI_Assets.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/13_Loading_Admin_UI_Assets.md
@@ -26,7 +26,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class AdminAssetsListener implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             BundleManagerEvents::JS_PATHS => 'onJsPaths'

--- a/doc/Development_Documentation/26_Best_Practice/71_Style_Backend_Depending_On_App-Env.md
+++ b/doc/Development_Documentation/26_Best_Practice/71_Style_Backend_Depending_On_App-Env.md
@@ -33,7 +33,7 @@ namespace App\EventSubscriber;
 
 class AdminAssetsSubscriber implements \Symfony\Component\EventDispatcher\EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             \Pimcore\Event\BundleManagerEvents::CSS_PATHS => 'onCssPaths',

--- a/lib/Analytics/GoogleTagManager/EventSubscriber/TrackingCodeSubscriber.php
+++ b/lib/Analytics/GoogleTagManager/EventSubscriber/TrackingCodeSubscriber.php
@@ -51,7 +51,7 @@ class TrackingCodeSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             GoogleTagManagerEvents::CODE_HEAD => ['onCodeHead'],

--- a/lib/Analytics/GoogleTagManager/EventSubscriber/TrackingCodeSubscriber.php
+++ b/lib/Analytics/GoogleTagManager/EventSubscriber/TrackingCodeSubscriber.php
@@ -50,8 +50,9 @@ class TrackingCodeSubscriber implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array
      */
-    public static function getSubscribedEvents(): array
+    public static function getSubscribedEvents()// : array
     {
         return [
             GoogleTagManagerEvents::CODE_HEAD => ['onCodeHead'],

--- a/lib/Sitemap/EventListener/SitemapGeneratorListener.php
+++ b/lib/Sitemap/EventListener/SitemapGeneratorListener.php
@@ -40,7 +40,6 @@ class SitemapGeneratorListener implements EventSubscriberInterface
 
     /**
      * @return string[]
-     * @return array
      */
     public static function getSubscribedEvents()// : array
     {

--- a/lib/Sitemap/EventListener/SitemapGeneratorListener.php
+++ b/lib/Sitemap/EventListener/SitemapGeneratorListener.php
@@ -41,7 +41,7 @@ class SitemapGeneratorListener implements EventSubscriberInterface
     /**
      * @return string[]
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             SitemapPopulateEvent::ON_SITEMAP_POPULATE => 'onPopulateSitemap',

--- a/lib/Sitemap/EventListener/SitemapGeneratorListener.php
+++ b/lib/Sitemap/EventListener/SitemapGeneratorListener.php
@@ -40,8 +40,9 @@ class SitemapGeneratorListener implements EventSubscriberInterface
 
     /**
      * @return string[]
+     * @return array
      */
-    public static function getSubscribedEvents(): array
+    public static function getSubscribedEvents()// : array
     {
         return [
             SitemapPopulateEvent::ON_SITEMAP_POPULATE => 'onPopulateSitemap',

--- a/lib/Targeting/EventListener/DocumentTargetGroupListener.php
+++ b/lib/Targeting/EventListener/DocumentTargetGroupListener.php
@@ -63,7 +63,6 @@ class DocumentTargetGroupListener implements EventSubscriberInterface
 
     /**
      * @return string[]
-     * @return array
      */
     public static function getSubscribedEvents()// : array
     {

--- a/lib/Targeting/EventListener/DocumentTargetGroupListener.php
+++ b/lib/Targeting/EventListener/DocumentTargetGroupListener.php
@@ -63,8 +63,9 @@ class DocumentTargetGroupListener implements EventSubscriberInterface
 
     /**
      * @return string[]
+     * @return array
      */
-    public static function getSubscribedEvents(): array
+    public static function getSubscribedEvents()// : array
     {
         return [
             TargetingEvents::PRE_RESOLVE => 'onVisitorInfoResolve',

--- a/lib/Targeting/EventListener/DocumentTargetGroupListener.php
+++ b/lib/Targeting/EventListener/DocumentTargetGroupListener.php
@@ -64,7 +64,7 @@ class DocumentTargetGroupListener implements EventSubscriberInterface
     /**
      * @return string[]
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             TargetingEvents::PRE_RESOLVE => 'onVisitorInfoResolve',

--- a/lib/Targeting/EventListener/FullPageCacheCookieCleanupListener.php
+++ b/lib/Targeting/EventListener/FullPageCacheCookieCleanupListener.php
@@ -31,7 +31,6 @@ class FullPageCacheCookieCleanupListener implements EventSubscriberInterface
 {
     /**
      * @return string[]
-     * @return array
      */
     public static function getSubscribedEvents()//: array
     {

--- a/lib/Targeting/EventListener/FullPageCacheCookieCleanupListener.php
+++ b/lib/Targeting/EventListener/FullPageCacheCookieCleanupListener.php
@@ -31,8 +31,9 @@ class FullPageCacheCookieCleanupListener implements EventSubscriberInterface
 {
     /**
      * @return string[]
+     * @return array
      */
-    public static function getSubscribedEvents(): array
+    public static function getSubscribedEvents()//: array
     {
         return [
             FullPageCacheEvents::PREPARE_RESPONSE => 'onPrepareFullPageCacheResponse',

--- a/lib/Targeting/EventListener/FullPageCacheCookieCleanupListener.php
+++ b/lib/Targeting/EventListener/FullPageCacheCookieCleanupListener.php
@@ -32,7 +32,7 @@ class FullPageCacheCookieCleanupListener implements EventSubscriberInterface
     /**
      * @return string[]
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FullPageCacheEvents::PREPARE_RESPONSE => 'onPrepareFullPageCacheResponse',

--- a/lib/Targeting/EventListener/TargetingListener.php
+++ b/lib/Targeting/EventListener/TargetingListener.php
@@ -90,7 +90,7 @@ class TargetingListener implements EventSubscriberInterface
     /**
      * @return array
      */
-    public static function getSubscribedEvents(): array
+    public static function getSubscribedEvents()//: array
     {
         return [
             // needs to run before ElementListener to make sure there's a

--- a/lib/Targeting/EventListener/TargetingListener.php
+++ b/lib/Targeting/EventListener/TargetingListener.php
@@ -90,7 +90,7 @@ class TargetingListener implements EventSubscriberInterface
     /**
      * @return array
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             // needs to run before ElementListener to make sure there's a

--- a/lib/Targeting/EventListener/TargetingSessionBagListener.php
+++ b/lib/Targeting/EventListener/TargetingSessionBagListener.php
@@ -34,8 +34,9 @@ class TargetingSessionBagListener implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array
      */
-    public static function getSubscribedEvents(): array
+    public static function getSubscribedEvents()//: array
     {
         return [
             FullPageCacheEvents::IGNORED_SESSION_KEYS => 'configureIgnoredSessionKeys',

--- a/lib/Targeting/EventListener/TargetingSessionBagListener.php
+++ b/lib/Targeting/EventListener/TargetingSessionBagListener.php
@@ -35,7 +35,7 @@ class TargetingSessionBagListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FullPageCacheEvents::IGNORED_SESSION_KEYS => 'configureIgnoredSessionKeys',

--- a/lib/Targeting/EventListener/ToolbarListener.php
+++ b/lib/Targeting/EventListener/ToolbarListener.php
@@ -98,7 +98,7 @@ class ToolbarListener implements EventSubscriberInterface
     /**
      * @return array[]
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             TargetingEvents::PRE_RESOLVE => ['onPreResolve', -10],

--- a/lib/Targeting/EventListener/VisitedPagesCountListener.php
+++ b/lib/Targeting/EventListener/VisitedPagesCountListener.php
@@ -42,7 +42,7 @@ class VisitedPagesCountListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             TargetingEvents::VISITED_PAGES_COUNT_MATCH => 'onVisitedPagesCountMatch', // triggered from conditions depending on page count

--- a/lib/Targeting/EventListener/VisitedPagesCountListener.php
+++ b/lib/Targeting/EventListener/VisitedPagesCountListener.php
@@ -41,8 +41,9 @@ class VisitedPagesCountListener implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array
      */
-    public static function getSubscribedEvents(): array
+    public static function getSubscribedEvents()// : array
     {
         return [
             TargetingEvents::VISITED_PAGES_COUNT_MATCH => 'onVisitedPagesCountMatch', // triggered from conditions depending on page count

--- a/lib/Workflow/EventSubscriber/ChangePublishedStateSubscriber.php
+++ b/lib/Workflow/EventSubscriber/ChangePublishedStateSubscriber.php
@@ -68,7 +68,7 @@ class ChangePublishedStateSubscriber implements EventSubscriberInterface
             && ($event->getSubject() instanceof Concrete || $event->getSubject() instanceof Document);
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             'workflow.completed' => 'onWorkflowCompleted',

--- a/lib/Workflow/EventSubscriber/NotesSubscriber.php
+++ b/lib/Workflow/EventSubscriber/NotesSubscriber.php
@@ -271,7 +271,7 @@ class NotesSubscriber implements EventSubscriberInterface
         return $this->additionalData[self::ADDITIONAL_DATA_NOTES_ADDITIONAL_FIELDS] ?? [];
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             'workflow.completed' => ['onWorkflowCompleted', 1],

--- a/lib/Workflow/EventSubscriber/NotificationSubscriber.php
+++ b/lib/Workflow/EventSubscriber/NotificationSubscriber.php
@@ -199,7 +199,7 @@ class NotificationSubscriber implements EventSubscriberInterface
         $this->enabled = $enabled;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             'workflow.completed' => ['onWorkflowCompleted', 0],


### PR DESCRIPTION
## Changes in this pull request  
Fixes deprecations:
```
Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Workflow\EventSubscriber\NotificationSubscriber" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Workflow\EventSubscriber\ChangePublishedStateSubscriber" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Workflow\EventSubscriber\NotesSubscriber" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\Frontend\RoutingListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\PimcoreContextListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\Frontend\DocumentFallbackListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\PimcoreHeaderListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\Frontend\LocaleListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\TranslationDebugListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\DumpTranslationEntriesListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\Frontend\ElementListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\Frontend\GlobalTemplateVariablesListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\Frontend\HardlinkCanonicalListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\Frontend\BlockStateListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\Frontend\DocumentMetaDataListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\Frontend\DocumentRendererListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\Frontend\StaticPageGeneratorListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\Frontend\ContentTemplateListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\EventedControllerListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\WorkflowManagementListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\SearchBackendListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\ResponseExceptionListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\ResponseHeaderListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\Frontend\EditmodeListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\ResponseStackListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\Frontend\InternalWysiwygHtmlAttributeFilterListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\Frontend\GoogleSearchConsoleVerificationListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\Frontend\OutputTimestampListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\WebDebugToolbarListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\CoreBundle\EventListener\MessengerClearRuntimeCacheListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Targeting\EventListener\VisitedPagesCountListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Targeting\EventListener\TargetingSessionBagListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\AdminBundle\EventListener\AdminSecurityListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\AdminBundle\EventListener\AdminAuthenticationDoubleCheckListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\AdminBundle\EventListener\CsrfProtectionListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\AdminBundle\EventListener\HttpCacheListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\AdminBundle\EventListener\UserPerspectiveListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\AdminBundle\EventListener\UsageStatisticsListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\AdminBundle\EventListener\EnablePreviewTimeSliderListener" now to avoid errors or add an explicit @return annotation to suppress this message.Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderPreparationListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Scheb\TwoFactorBundle\Security\TwoFactor\Event\AuthenticationSuccessEventSuppressor" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Analytics\GoogleTagManager\EventSubscriber\TrackingCodeSubscriber" now to avoid errors or add an explicit @return annotation to suppress this message.

```
and more like this...

## Additional info  

