### PR TITLE
Fix Symfony deprecations - rest

### DIFF
--- a/bundles/AdminBundle/Security/User/UserProvider.php
+++ b/bundles/AdminBundle/Security/User/UserProvider.php
@@ -50,9 +50,11 @@ class UserProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      *
-     * @param User $user
+     * @param UserInterface $user
+     *
+     * @return UserInterface
      */
-    public function refreshUser(UserInterface $user)
+    public function refreshUser(UserInterface $user)//: UserInterface
     {
         if (!$user instanceof User) {
             // user is not supported - we only support pimcore users
@@ -77,8 +79,10 @@ class UserProvider implements UserProviderInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
-    public function supportsClass($class)
+    public function supportsClass($class)//: bool
     {
         return $class === User::class;
     }

--- a/bundles/CoreBundle/Resources/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yaml
@@ -9,6 +9,7 @@ framework:
         enabled: true
     router:
         strict_requirements: ~
+        utf8: true
     form: ~
     csrf_protection: ~
     validation: { enable_annotations: true }
@@ -50,6 +51,7 @@ framework:
         default_bus: messenger.bus.pimcore-core
         buses:
             messenger.bus.pimcore-core:
+        reset_on_message: true
 
 # Twig Configuration
 twig:

--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
     "symfony/messenger": "^5.4.0",
     "symfony/mime": "^5.2.0",
     "symfony/monolog-bridge": "^5.2.0",
-    "symfony/notifier": "^5.2.0",
+    "symfony/notifier": "^5.4.0",
     "symfony/options-resolver": "^5.2.0",
     "symfony/password-hasher": "^5.3",
     "symfony/process": "^5.2.0",

--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
     "symfony/filesystem": "^5.2.0",
     "symfony/finder": "^5.2.0",
     "symfony/form": "^5.2.0",
-    "symfony/framework-bundle": "^5.3.0",
+    "symfony/framework-bundle": "^5.4.0",
     "symfony/http-client": "^5.2.0",
     "symfony/http-foundation": "^5.3.0",
     "symfony/http-kernel": "^5.3",

--- a/lib/Log/ApplicationLogger.php
+++ b/lib/Log/ApplicationLogger.php
@@ -137,8 +137,10 @@ class ApplicationLogger implements LoggerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = [])// : void
     {
         if (!isset($context['component']) || is_null($context['component'])) {
             $context['component'] = $this->component;
@@ -256,64 +258,80 @@ class ApplicationLogger implements LoggerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
-    public function emergency($message, array $context = [])
+    public function emergency($message, array $context = [])// : void
     {
         $this->handleLog('emergency', $message, func_get_args());
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
-    public function critical($message, array $context = [])
+    public function critical($message, array $context = [])// : void
     {
         $this->handleLog('critical', $message, func_get_args());
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
-    public function error($message, array $context = [])
+    public function error($message, array $context = [])// : void
     {
         $this->handleLog('error', $message, func_get_args());
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
-    public function alert($message, array $context = [])
+    public function alert($message, array $context = [])// : void
     {
         $this->handleLog('alert', $message, func_get_args());
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
-    public function warning($message, array $context = [])
+    public function warning($message, array $context = [])// : void
     {
         $this->handleLog('warning', $message, func_get_args());
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
-    public function notice($message, array $context = [])
+    public function notice($message, array $context = [])// : void
     {
         $this->handleLog('notice', $message, func_get_args());
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
-    public function info($message, array $context = [])
+    public function info($message, array $context = [])// : void
     {
         $this->handleLog('info', $message, func_get_args());
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
-    public function debug($message, array $context = [])
+    public function debug($message, array $context = [])// : void
     {
         $this->handleLog('debug', $message, func_get_args());
     }

--- a/lib/Routing/Element/Router.php
+++ b/lib/Routing/Element/Router.php
@@ -59,7 +59,8 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
      *
      * @return array
      */
-    public function setContext(RequestContext $context)
+    #[\ReturnTypeWillChange]
+    public function setContext(RequestContext $context)//: array
     {
         $this->context = $context;
     }

--- a/lib/Routing/Element/Router.php
+++ b/lib/Routing/Element/Router.php
@@ -56,6 +56,8 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
 
     /**
      * {@inheritdoc}
+     *
+     * @return array
      */
     public function setContext(RequestContext $context)
     {
@@ -84,6 +86,8 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getRouteDebugMessage($name, array $parameters = [])// : string
     {
@@ -97,6 +101,8 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function generate(string $name, array $parameters = [], int $referenceType = self::ABSOLUTE_PATH)// : string
     {
@@ -184,16 +190,20 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
 
     /**
      * {@inheritdoc}
+     *
+     * @return array
      */
-    public function matchRequest(Request $request)
+    public function matchRequest(Request $request)// : array
     {
         throw new ResourceNotFoundException(sprintf('No routes found for "%s".', $request->getPathInfo()));
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @return array
      */
-    public function match($pathinfo)
+    public function match($pathinfo)// : array
     {
         throw new ResourceNotFoundException(sprintf('No routes found for "%s".', $pathinfo));
     }

--- a/lib/Routing/Element/Router.php
+++ b/lib/Routing/Element/Router.php
@@ -56,11 +56,8 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
 
     /**
      * {@inheritdoc}
-     *
-     * @return array
      */
-    #[\ReturnTypeWillChange]
-    public function setContext(RequestContext $context)//: array
+    public function setContext(RequestContext $context)
     {
         $this->context = $context;
     }

--- a/lib/Routing/Loader/AnnotatedRouteControllerLoader.php
+++ b/lib/Routing/Loader/AnnotatedRouteControllerLoader.php
@@ -27,7 +27,7 @@ class AnnotatedRouteControllerLoader extends BaseAnnotatedRouteControllerLoader
     /**
      * {@inheritdoc}
      */
-    protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method)
+    protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method): string
     {
         $routeName = parent::getDefaultRouteName($class, $method);
 

--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
 use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -76,8 +77,10 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
-    public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null)
+    public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null)//: string
     {
         $id = trim($id);
 
@@ -135,8 +138,10 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
-    public function getLocale()
+    public function getLocale()//: string
     {
         if ($this->translator instanceof LocaleAwareInterface) {
             return $this->translator->getLocale();
@@ -147,6 +152,8 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
 
     /**
      * {@inheritdoc}
+     *
+     * @return MessageCatalogueInterface
      */
     public function getCatalogue(string $locale = null)// : MessageCatalogueInterface
     {

--- a/lib/Workflow/MarkingStore/DataObjectSplittedStateMarkingStore.php
+++ b/lib/Workflow/MarkingStore/DataObjectSplittedStateMarkingStore.php
@@ -61,6 +61,8 @@ class DataObjectSplittedStateMarkingStore implements MarkingStoreInterface
     /**
      * {@inheritdoc}
      *
+     * @return Marking
+     *
      * @throws LogicException
      */
     public function getMarking($subject)// : Marking

--- a/lib/Workflow/MarkingStore/StateTableMarkingStore.php
+++ b/lib/Workflow/MarkingStore/StateTableMarkingStore.php
@@ -36,6 +36,8 @@ class StateTableMarkingStore implements MarkingStoreInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return Marking
      */
     public function getMarking($subject)// : Marking
     {


### PR DESCRIPTION
## Changes in this pull request  
Fixes deprecations:
```
Since symfony/framework-bundle 5.1: Not setting the "framework.router.utf8" configuration option is deprecated, it will default to "true" in version 6.0.

Since symfony/framework-bundle 5.4: Not setting the "framework.messenger.reset_on_message" configuration option is deprecated, it will default to "true" in version 6.0.

Method "Symfony\Cmf\Component\Routing\VersatileGeneratorInterface::getRouteDebugMessage()" might add "string" as a native return type declaration in the future. Do the same in implementation "Pimcore\Routing\Element\Router" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Routing\Generator\UrlGeneratorInterface::generate()" might add "string" as a native return type declaration in the future. Do the same in implementation "Pimcore\Routing\Element\Router" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Routing\Matcher\RequestMatcherInterface::matchRequest()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Routing\Element\Router" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Routing\Matcher\UrlMatcherInterface::match()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pimcore\Routing\Element\Router" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface::getMarking()" might add "Marking" as a native return type declaration in the future. Do the same in implementation "Pimcore\Workflow\MarkingStore\StateTableMarkingStore" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface::getMarking()" might add "Marking" as a native return type declaration in the future. Do the same in implementation "Pimcore\Workflow\MarkingStore\DataObjectSplittedStateMarkingStore" now to avoid errors or add an explicit @return annotation to suppress this message.

Pimcore\Log\ApplicationLogger:
Method "Psr\Log\LoggerInterface::log()" might add "void" as a native return type declaration in the future. Do the same in implementation "Pimcore\Log\ApplicationLogger" now to avoid errors or add an explicit @return annotation to suppress this message.
Method "Psr\Log\LoggerInterface::critical()" might add "void" as a native return type declaration in the future. Do the same in implementation "Pimcore\Log\ApplicationLogger" now to avoid errors or add an explicit @return annotation to suppress this message.
Method "Psr\Log\LoggerInterface::error()" might add "void" as a native return type declaration in the future. Do the same in implementation "Pimcore\Log\ApplicationLogger" now to avoid errors or add an explicit @return annotation to suppress this message.
Method "Psr\Log\LoggerInterface::alert()" might add "void" as a native return type declaration in the future. Do the same in implementation "Pimcore\Log\ApplicationLogger" now to avoid errors or add an explicit @return annotation to suppress this message.
Method "Psr\Log\LoggerInterface::warning()" might add "void" as a native return type declaration in the future. Do the same in implementation "Pimcore\Log\ApplicationLogger" now to avoid errors or add an explicit @return annotation to suppress this message.
Method "Psr\Log\LoggerInterface::notice()" might add "void" as a native return type declaration in the future. Do the same in implementation "Pimcore\Log\ApplicationLogger" now to avoid errors or add an explicit @return annotation to suppress this message.
Method "Psr\Log\LoggerInterface::info()" might add "void" as a native return type declaration in the future. Do the same in implementation "Pimcore\Log\ApplicationLogger" now to avoid errors or add an explicit @return annotation to suppress this message.
Method "Psr\Log\LoggerInterface::debug()" might add "void" as a native return type declaration in the future. Do the same in implementation "Pimcore\Log\ApplicationLogger" now to avoid errors or add an explicit @return annotation to suppress this message.

Translator:
Method "Symfony\Contracts\Translation\TranslatorInterface::trans()" might add "string" as a native return type declaration in the future. Do the same in implementation "Pimcore\Translation\Translator" now to avoid errors or add an explicit @return annotation to suppress this message.
Method "Symfony\Contracts\Translation\LocaleAwareInterface::getLocale()" might add "string" as a native return type declaration in the future. Do the same in implementation "Pimcore\Translation\Translator" now to avoid errors or add an explicit @return annotation to suppress this message.
Method "Symfony\Component\Translation\TranslatorBagInterface::getCatalogue()" might add "MessageCatalogueInterface" as a native return type declaration in the future. Do the same in implementation "Pimcore\Translation\Translator" now to avoid errors or add an explicit @return annotation to suppress this message.

Pimcore\Bundle\AdminBundle\Security\User\UserProvider:
Method "Symfony\Component\Security\Core\User\UserProviderInterface::refreshUser()" might add "UserInterface" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\AdminBundle\Security\User\UserProvider" now to avoid errors or add an explicit @return annotation to suppress this message.
Method "Symfony\Component\Security\Core\User\UserProviderInterface::supportsClass()" might add "bool" as a native return type declaration in the future. Do the same in implementation "Pimcore\Bundle\AdminBundle\Security\User\UserProvider" now to avoid errors or add an explicit @return annotation to suppress this message.

User Deprecated: Method "Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader::getDefaultRouteName()" might add "string" as a native return type declaration in the future. Do the same in child class "Pimcore\Routing\Loader\AnnotatedRouteControllerLoader" now to avoid errors or add an explicit @return annotation to suppress this message.
```

## Additional info  
This one is left, we can't change it without a BC break:
```
Since symfony/dependency-injection 5.1: The "Psr\Container\ContainerInterface" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it. It is being referenced by the "Pimcore\Model\DataObject\QuantityValue\UnitConversionService" service.
```