### PR TITLE
Image Thumbnail: Fix undefined getName() method when no config is set

### DIFF
--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -216,10 +216,12 @@ trait ImageThumbnailTrait
             $asset = $this->getAsset();
             $dimensions = [];
 
-            $thumbnail = $asset->getDao()->getCachedThumbnail($config->getName(), $this->getFilename());
-            if ($thumbnail && $thumbnail['width'] && $thumbnail['height']) {
-                $dimensions['width'] = $thumbnail['width'];
-                $dimensions['height'] = $thumbnail['height'];
+            if ($config) {
+                $thumbnail = $asset->getDao()->getCachedThumbnail($config->getName(), $this->getFilename());
+                if ($thumbnail && $thumbnail['width'] && $thumbnail['height']) {
+                    $dimensions['width'] = $thumbnail['width'];
+                    $dimensions['height'] = $thumbnail['height'];
+                }
             }
 
             if (empty($dimensions) && $this->exists()) {


### PR DESCRIPTION
After update from 10.4 to 10.5 we get following error:
![image](https://user-images.githubusercontent.com/998558/180222174-67206928-1e2f-40dd-b631-10f54e58cb3e.png)

Code:
```
{{ pimcore_image('image').frontend|raw }}
```

Regression from https://github.com/pimcore/pimcore/pull/12461