### PR TITLE
extract text from pdfs via ghostscript

### DIFF
--- a/lib/Document/Adapter/LibreOffice.php
+++ b/lib/Document/Adapter/LibreOffice.php
@@ -186,7 +186,13 @@ class LibreOffice extends Ghostscript
             // for per page extraction we have to convert the document to PDF and extract the text via ghostscript
             return parent::getText($page, $asset);
         }
-        if (self::isFileTypeSupported($asset->getFilename())) {
+
+        // if asset is pdf extract via ghostscript
+        if (parent::isFileTypeSupported($asset->getFilename())) {
+            return parent::getText(null, $asset);
+        }
+
+        if ($this->isFileTypeSupported($asset->getFilename())) {
             // if we want to get the text of the whole document, we can use libreoffices text export feature
             $cmd = [self::getLibreOfficeCli(), '--headless', '--nologo', '--nofirststartwizard', '--norestore', '--convert-to', 'txt:Text', '--outdir',  PIMCORE_SYSTEM_TEMP_DIRECTORY, $asset->getLocalFile()];
             Console::addLowProcessPriority($cmd);


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #6289

## Additional info  
With the official Pimcore Docker image, the Text extraction from (large) PDF Assets is running into a timeout from libreoffice. 

```
pimcore.ERROR: Symfony\Component\Process\Exception\ProcessTimedOutException: The process "'/usr/bin/nice' '-n' '19' '/usr/bin/soffice' '--headless' '--nologo' '--nofirststartwizard' '--norestore' '--convert-to' 'txt:Text' '--outdir' '/var/www/pimcore/var/tmp' '/var/www/pimcore/var/tmp/temp-file-62d84df67e98b-a811104cd38790ea88e09bfa7869bc.pdf'" exceeded the timeout of 240 seconds.
```

In #6289 it is mentioned that ghostscript has precedence over libreoffice, but since [these changes](https://github.com/pimcore/pimcore/commit/f4c7b218) #9517, that is no longer true.