### PR TITLE
documentation: add example for predefinedDataTemplate image config

### DIFF
--- a/doc/Development_Documentation/03_Documents/01_Editables/14_Image.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/14_Image.md
@@ -189,6 +189,27 @@ All dimensions are in percent and therefore independent from the image size, you
         {% endif %}
     </p>
 </div>
+
+
+{# Predefined Data Templates; use "hotspot" instead of the "marker" key to add templates for hotspots #}
+{{ pimcore_image("image", {
+    'thumbnail': 'my-thumbnail',
+    'predefinedDataTemplates': {
+        'marker': [
+            {
+                'menuName': 'Menu Name',
+                'name': 'Config Name',
+                'data': [
+                    {
+                        'name': 'my textfield',
+                        'type': 'textfield',
+                    }
+                ]
+            }
+        ]
+    }
+}) }}
+
 ```
 
 `getHotspots` output:


### PR DESCRIPTION
Feature was introduced in https://github.com/pimcore/pimcore/pull/2554.