### PR TITLE
Fix SessionNotFoundException: There is currently no session available

### DIFF
--- a/bundles/EcommerceFrameworkBundle/EventListener/Frontend/TrackingCodeFlashMessageListener.php
+++ b/bundles/EcommerceFrameworkBundle/EventListener/Frontend/TrackingCodeFlashMessageListener.php
@@ -21,8 +21,10 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Tracking\TrackingManager;
 use Pimcore\Http\Request\Resolver\PimcoreContextResolver;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -74,7 +76,7 @@ class TrackingCodeFlashMessageListener implements EventSubscriberInterface
 
         // Check FlashBag cookie exists to avoid autostart session by accessing the FlashBag.
         $flashBagCookie = (bool)$request->cookies->get(self::FLASH_MESSAGE_BAG_KEY);
-        $session = $this->requestStack->getSession();
+        $session = $this->getSession();
         if ($flashBagCookie && $session instanceof Session) {
             $trackedCodes = $session->getFlashBag()->get(self::FLASH_MESSAGE_BAG_KEY);
 
@@ -97,7 +99,7 @@ class TrackingCodeFlashMessageListener implements EventSubscriberInterface
     {
         $response = $event->getResponse();
         $request = $event->getRequest();
-        $session = $this->requestStack->getSession();
+        $session = $this->getSession();
 
         /**
          * If tracking codes are forwarded as FlashMessage, then set a cookie which is checked in subsequent request for successful handshake
@@ -113,5 +115,16 @@ class TrackingCodeFlashMessageListener implements EventSubscriberInterface
         } elseif ($request->cookies->has(self::FLASH_MESSAGE_BAG_KEY)) {
             $response->headers->clearCookie(self::FLASH_MESSAGE_BAG_KEY);
         }
+    }
+
+    private function getSession(): ?SessionInterface
+    {
+        try {
+            $session = $this->requestStack->getSession();
+        } catch (SessionNotFoundException) {
+            $session = null;
+        }
+
+        return $session;
     }
 }


### PR DESCRIPTION
After update from 10.4 to 10.5 we get an error when we try to generate a web2print pdf via command.
Regression from https://github.com/pimcore/pimcore/pull/12241

```
14:44:01 ERROR     [pimcore] Symfony\Component\HttpFoundation\Exception\SessionNotFoundException: There is currently no session available. in /var/www/html/vendor/symfony/http-foundation/RequestStack.php:126
Stack trace:
#0 /var/www/html/vendor/pimcore/pimcore/bundles/EcommerceFrameworkBundle/EventListener/Frontend/TrackingCodeFlashMessageListener.php(100): Symfony\Component\HttpFoundation\RequestStack->getSession()
#1 /var/www/html/vendor/symfony/event-dispatcher/Debug/WrappedListener.php(117): Pimcore\Bundle\EcommerceFrameworkBundle\EventListener\Frontend\TrackingCodeFlashMessageListener->onKernelResponse(Object(Symfony\Component\HttpKernel\Event\ResponseEvent), 'kernel.response', Object(Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher))
#2 /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php(230): Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke(Object(Symfony\Component\HttpKernel\Event\ResponseEvent), 'kernel.response', Object(Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher))
#3 /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php(59): Symfony\Component\EventDispatcher\EventDispatcher->callListeners(Array, 'kernel.response', Object(Symfony\Component\HttpKernel\Event\ResponseEvent))
#4 /var/www/html/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php(154): Symfony\Component\EventDispatcher\EventDispatcher->dispatch(Object(Symfony\Component\HttpKernel\Event\ResponseEvent), 'kernel.response')
#5 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(185): Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch(Object(Symfony\Component\HttpKernel\Event\ResponseEvent), 'kernel.response')
#6 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(173): Symfony\Component\HttpKernel\HttpKernel->filterResponse(Object(Symfony\Component\HttpFoundation\Response), Object(Symfony\Component\HttpFoundation\Request), 2)
#7 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(74): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 2)
#8 /var/www/html/vendor/symfony/http-kernel/HttpCache/SubRequestHandler.php(86): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 2, false)
#9 /var/www/html/vendor/symfony/http-kernel/Fragment/InlineFragmentRenderer.php(80): Symfony\Component\HttpKernel\HttpCache\SubRequestHandler::handle(Object(Symfony\Component\HttpKernel\HttpKernel), Object(Symfony\Component\HttpFoundation\Request), 2, false)
#10 /var/www/html/vendor/symfony/http-kernel/Fragment/FragmentHandler.php(85): Symfony\Component\HttpKernel\Fragment\InlineFragmentRenderer->render('/_fragment?_pat...', Object(Symfony\Component\HttpFoundation\Request), Array)
#11 /var/www/html/vendor/symfony/http-kernel/DependencyInjection/LazyLoadingFragmentHandler.php(49): Symfony\Component\HttpKernel\Fragment\FragmentHandler->render(Object(Symfony\Component\HttpKernel\Controller\ControllerReference), 'inline', Array)
#12 /var/www/html/vendor/symfony/twig-bridge/Extension/HttpKernelRuntime.php(46): Symfony\Component\HttpKernel\DependencyInjection\LazyLoadingFragmentHandler->render(Object(Symfony\Component\HttpKernel\Controller\ControllerReference), 'inline', Array)
#13 /var/www/html/vendor/pimcore/pimcore/lib/Templating/Renderer/ActionRenderer.php(58): Symfony\Bridge\Twig\Extension\HttpKernelRuntime->renderFragment(Object(Symfony\Component\HttpKernel\Controller\ControllerReference), Array)
#14 /var/www/html/vendor/pimcore/pimcore/lib/Templating/Renderer/IncludeRenderer.php(150): Pimcore\Templating\Renderer\ActionRenderer->render(Object(Symfony\Component\HttpKernel\Controller\ControllerReference), Array)
#15 /var/www/html/vendor/pimcore/pimcore/lib/Templating/Renderer/IncludeRenderer.php(125): Pimcore\Templating\Renderer\IncludeRenderer->renderAction(Object(Pimcore\Model\Document\Printpage), Array)
#16 /var/www/html/vendor/pimcore/pimcore/lib/Twig/Extension/Templating/Inc.php(62): Pimcore\Templating\Renderer\IncludeRenderer->render(Object(Pimcore\Model\Document\Printpage), Array, false, true)
#17 /var/www/html/var/cache/dev/twig/50/50adbe9f0dc024c0ebf26c2ffad2a58a7a2e11c74c05fd285c3c4cef561d43cd.php(78): Pimcore\Twig\Extension\Templating\Inc->__invoke(Object(Pimcore\Model\Document\Printpage))
#18 /var/www/html/vendor/twig/twig/src/Template.php(171): __TwigTemplate_206a786b58717f1f5994bc95511d563445ad1d48121c217565dc6c6cdaad0ec4->block_content(Array, Array)
#19 /var/www/html/var/cache/dev/twig/ff/ff5df2943337bf748d1ffdfa44460619bfa82b29586cb8ee1505855bffbeef57.php(101): Twig\Template->displayBlock('content', Array, Array)
#20 /var/www/html/vendor/twig/twig/src/Template.php(394): __TwigTemplate_c4249635ef6e765039632ef464c8c9d93eecaa8ff5a0425e3ce8352b8fb4da0f->doDisplay(Array, Array)
#21 /var/www/html/vendor/twig/twig/src/Template.php(367): Twig\Template->displayWithErrorHandling(Array, Array)
#22 /var/www/html/var/cache/dev/twig/50/50adbe9f0dc024c0ebf26c2ffad2a58a7a2e11c74c05fd285c3c4cef561d43cd.php(48): Twig\Template->display(Array, Array)
#23 /var/www/html/vendor/twig/twig/src/Template.php(394): __TwigTemplate_206a786b58717f1f5994bc95511d563445ad1d48121c217565dc6c6cdaad0ec4->doDisplay(Array, Array)
#24 /var/www/html/vendor/twig/twig/src/Template.php(367): Twig\Template->displayWithErrorHandling(Array, Array)
#25 /var/www/html/vendor/twig/twig/src/Template.php(379): Twig\Template->display(Array)
#26 /var/www/html/vendor/twig/twig/src/TemplateWrapper.php(40): Twig\Template->render(Array, Array)
#27 /var/www/html/vendor/twig/twig/src/Environment.php(277): Twig\TemplateWrapper->render(Array)
#28 /var/www/html/vendor/symfony/framework-bundle/Controller/AbstractController.php(258): Twig\Environment->render('web2print/conta...', Array)
#29 /var/www/html/vendor/pimcore/pimcore/lib/Controller/Controller.php(81): Symfony\Bundle\FrameworkBundle\Controller\AbstractController->renderView('web2print/conta...', Array)
#30 /var/www/html/vendor/symfony/framework-bundle/Controller/AbstractController.php(266): Pimcore\Controller\Controller->renderView('web2print/conta...', Array)
#31 /var/www/html/vendor/pimcore/pimcore/lib/Controller/Controller.php(43): Symfony\Bundle\FrameworkBundle\Controller\AbstractController->render('web2print/conta...', Array, NULL)
#32 /var/www/html/src/Controller/Web2printController.php(86): Pimcore\Controller\Controller->render('web2print/conta...', Array)
#33 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(152): App\Controller\Web2printController->containerAction(Object(Symfony\Component\HttpFoundation\Request))
#34 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(74): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 2)
#35 /var/www/html/vendor/symfony/http-kernel/HttpCache/SubRequestHandler.php(86): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 2, false)
#36 /var/www/html/vendor/symfony/http-kernel/Fragment/InlineFragmentRenderer.php(80): Symfony\Component\HttpKernel\HttpCache\SubRequestHandler::handle(Object(Symfony\Component\HttpKernel\HttpKernel), Object(Symfony\Component\HttpFoundation\Request), 2, false)
#37 /var/www/html/vendor/pimcore/pimcore/lib/Document/Renderer/DocumentRenderer.php(145): Symfony\Component\HttpKernel\Fragment\InlineFragmentRenderer->render('/_fragment?_pat...', Object(Symfony\Component\HttpFoundation\Request), Array)
#38 /var/www/html/vendor/pimcore/pimcore/models/Document/Service.php(92): Pimcore\Document\Renderer\DocumentRenderer->render(Object(Pimcore\Model\Document\Printcontainer), Array, Array, Array)
#39 /var/www/html/vendor/pimcore/pimcore/models/Document/PrintAbstract.php(128): Pimcore\Model\Document\Service::render(Object(Pimcore\Model\Document\Printcontainer), Array, true)
#40 /var/www/html/vendor/pimcore/pimcore/lib/Web2Print/Processor/PdfReactor.php(132): Pimcore\Model\Document\PrintAbstract->renderDocument(Array)
#41 /var/www/html/vendor/pimcore/pimcore/lib/Web2Print/Processor.php(121): Pimcore\Web2Print\Processor\PdfReactor->buildPdf(Object(Pimcore\Model\Document\Printcontainer), Object(stdClass))
#42 /var/www/html/vendor/pimcore/pimcore/lib/Web2Print/Processor.php(92): Pimcore\Web2Print\Processor->startPdfGeneration(75)
#43 /var/www/html/src/Command/PdfReactorCommand.php(34): Pimcore\Web2Print\Processor->preparePdfGeneration(75, Array)
#44 /var/www/html/vendor/symfony/console/Command/Command.php(298): App\Command\PdfReactorCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#45 /var/www/html/vendor/symfony/console/Application.php(1042): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#46 /var/www/html/vendor/symfony/framework-bundle/Console/Application.php(96): Symfony\Component\Console\Application->doRunCommand(Object(App\Command\PdfReactorCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#47 /var/www/html/vendor/symfony/console/Application.php(299): Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand(Object(App\Command\PdfReactorCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#48 /var/www/html/vendor/symfony/framework-bundle/Console/Application.php(82): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#49 /var/www/html/vendor/symfony/console/Application.php(171): Symfony\Bundle\FrameworkBundle\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#50 /var/www/html/bin/console(48): Symfony\Component\Console\Application->run()
#51 {main}
```

## Steps to reproduce

1. Checkout a pimcore demo
3. Create following command "src/Command/PdfReactorCommand.php"
```
<?php

namespace App\Command;

use Pimcore\Console\AbstractCommand;
use Pimcore\Model\Tool\SettingsStore;
use Pimcore\Web2Print\Processor;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;

class PdfReactorCommand extends AbstractCommand
{
    protected function configure(): void
    {
        $this->setName('app:pdf-reactor');
    }

    /**
     * @param InputInterface $input
     * @param OutputInterface $output
     *
     * @return int
     *
     * @throws \Exception
     */
    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        SettingsStore::set(
            'web_to_print',
            '{"enableInDefaultView":true,"generalTool":"pdfreactor","generalDocumentSaveMode":"default","pdfreactorProtocol":"http","pdfreactorServer":"pdfreactor","pdfreactorServerPort":"9423","pdfreactorBaseUrl":"http:\\/\\/web","pdfreactorApiKey":"","pdfreactorLicence":"","pdfreactorEnableLenientHttpsMode":false,"pdfreactorEnableDebugMode":false}',
            'string',
            'pimcore_web_to_print'
        );
        if (Processor::getInstance()->preparePdfGeneration(75, ['disableBackgroundExecution' => true])) {
            $output->writeln('<info>Pimcore can generate a PDF</info>');
            return 0;
        }

        $output->writeln('<error>Pimcore can not generate a PDF</error>');
        return 1;
    }
}

```
5. Execute the command
`php bin/console app:pdf-reactor`
