### PR TITLE
LogErrorCleanupTask: fixed query

### DIFF
--- a/lib/Maintenance/Tasks/LogErrorCleanupTask.php
+++ b/lib/Maintenance/Tasks/LogErrorCleanupTask.php
@@ -45,6 +45,8 @@ class LogErrorCleanupTask implements TaskInterface
         // it's allowed to store the IP for 7 days for security reasons (DoS, ...)
         $limit = time() - (6 * 86400);
 
-        $this->db->executeStatement('DELETE FROM http_error_log WHERE `date` < :limit', [$limit]);
+        $this->db->executeStatement('DELETE FROM http_error_log WHERE `date` < :limit', [
+            'limit' => $limit,
+        ]);
     }
 }


### PR DESCRIPTION
regression of #12123
Fixes the following error: 

```
09:17:07 ERROR     [app] Failed to execute job with ID httperrorlog: Doctrine\DBAL\Exception\DriverException {-driverException: Doctrine\DBAL\Driver\PDO\Exception {#1 …}#message: """  An exception occurred while executing 'DELETE FROM http_error_log WHERE `date` < :limit' with params [1658222227]:\n  \n  SQLSTATE[HY093]: Invalid parameter number: parameter was not defined  """#code: 0#file: "/var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php"#line: 128-previous: Doctrine\DBAL\Driver\PDO\Exception {#1 …}trace: {/var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:128 { …}/var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:182 { …}/var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:159 { …}/var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:2226 { …}/var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1538 { …}/var/www/html/vendor/pimcore/pimcore/lib/Maintenance/Tasks/LogErrorCleanupTask.php:48 { …}/var/www/html/vendor/pimcore/pimcore/lib/Maintenance/Executor.php:81 { …}/var/www/html/vendor/pimcore/pimcore/lib/Messenger/Handler/MaintenanceTaskHandler.php:33 { …}/var/www/html/vendor/symfony/messenger/Middleware/HandleMessageMiddleware.php:95 { …}/var/www/html/vendor/symfony/messenger/Middleware/SendMessageMiddleware.php:73 { …}/var/www/html/vendor/symfony/messenger/Middleware/FailedMessageProcessingMiddleware.php:34 { …}/var/www/html/vendor/symfony/messenger/Middleware/DispatchAfterCurrentBusMiddleware.php:68 { …}/var/www/html/vendor/symfony/messenger/Middleware/RejectRedeliveredMessageMiddleware.php:48 { …}/var/www/html/vendor/symfony/messenger/Middleware/AddBusNameStampMiddleware.php:37 { …}/var/www/html/vendor/symfony/messenger/MessageBus.php:77 { …}/var/www/html/vendor/symfony/messenger/RoutableMessageBus.php:54 { …}/var/www/html/vendor/symfony/messenger/Worker.php:158 { …}/var/www/html/vendor/symfony/messenger/Worker.php:107 { …}/var/www/html/vendor/symfony/messenger/Command/ConsumeMessagesCommand.php:225 { …}/var/www/html/vendor/symfony/console/Command/Command.php:298 { …}/var/www/html/vendor/symfony/console/Application.php:1042 { …}/var/www/html/vendor/symfony/framework-bundle/Console/Application.php:96 { …}/var/www/html/vendor/symfony/console/Application.php:299 { …}/var/www/html/vendor/symfony/framework-bundle/Console/Application.php:82 { …}/var/www/html/vendor/symfony/console/Application.php:171 { …}/var/www/html/bin/console:48 {› $application = new \Pimcore\Console\Application($kernel);› $application->run();› } …}} ["id" => "httperrorlog","exception" => Doctrine\DBAL\Exception\DriverException { …}]
```