### PR TITLE
Video Editable: Fix undefined array key "v"

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -591,7 +591,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
                     if (array_key_exists('query', $parts)) {
                         parse_str($parts['query'], $vars);
 
-                        if ($vars['v']) {
+                        if (isset($vars['v']) && $vars['v']) {
                             $youtubeId = $vars['v'];
                         }
                     }


### PR DESCRIPTION
Fixes `Warning: Undefined array key "v"` when using a YouTube URL like `https://youtu.be/ajqOIVOztwE?rel=0`.