### PR TITLE
Renew o_* references on cloning

### DIFF
--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1331,38 +1331,12 @@ abstract class AbstractObject extends Model\Element\AbstractElement
         parent::__clone();
 
         // renew references when cloning
-        unset($this->o_id);
-        $this->o_id = &$this->id;
-
-        unset($this->o_path);
-        $this->o_path = &$this->path;
-
-        unset($this->o_creationDate);
-        $this->o_creationDate = &$this->creationDate;
-
-        unset($this->o_userOwner);
-        $this->o_userOwner = &$this->userOwner;
-
-        unset($this->o_versionCount);
-        $this->o_versionCount = &$this->versionCount;
-
-        unset($this->o_modificationDate);
-        $this->o_modificationDate = &$this->modificationDate;
-
-        unset($this->o_locked);
-        $this->o_locked = &$this->locked;
-
-        unset($this->o_parent);
-        $this->o_parent = &$this->parent;
-
-        unset($this->o_properties);
-        $this->o_properties = &$this->properties;
-
-        unset($this->o_userModification);
-        $this->o_userModification = &$this->userModification;
-
-        unset($this->o_parentId);
-        $this->o_parentId = &$this->parentId;
+        foreach(['id', 'path', 'creationDate', 'userOwner', 'versionCount', 'modificationDate', 'locked', 'parent', 'properties', 'userModification', 'parentId'] as $referenceField) {
+            $oldValue = $this->$referenceField;
+            unset($this->$referenceField);
+            $this->$referenceField = $oldValue;
+            $this->{'o_'.$referenceField} = &$this->$referenceField;
+        }
 
         $this->o_parent = null;
         // note that o_children is currently needed for the recycle bin

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1331,7 +1331,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
         parent::__clone();
 
         // renew references when cloning
-        unset($this->id);
+        unset($this->o_id);
         $this->o_id = &$this->id;
 
         unset($this->o_path);

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1329,6 +1329,41 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     public function __clone()
     {
         parent::__clone();
+
+        // renew references when cloning
+        unset($this->id);
+        $this->o_id = &$this->id;
+
+        unset($this->o_path);
+        $this->o_path = &$this->path;
+
+        unset($this->o_creationDate);
+        $this->o_creationDate = &$this->creationDate;
+
+        unset($this->o_userOwner);
+        $this->o_userOwner = &$this->userOwner;
+
+        unset($this->o_versionCount);
+        $this->o_versionCount = &$this->versionCount;
+
+        unset($this->o_modificationDate);
+        $this->o_modificationDate = &$this->modificationDate;
+
+        unset($this->o_locked);
+        $this->o_locked = &$this->locked;
+
+        unset($this->o_parent);
+        $this->o_parent = &$this->parent;
+
+        unset($this->o_properties);
+        $this->o_properties = &$this->properties;
+
+        unset($this->o_userModification);
+        $this->o_userModification = &$this->userModification;
+
+        unset($this->o_parentId);
+        $this->o_parentId = &$this->parentId;
+
         $this->o_parent = null;
         // note that o_children is currently needed for the recycle bin
         $this->o_hasSiblings = [];

--- a/tests/Model/DataObject/ObjectTest.php
+++ b/tests/Model/DataObject/ObjectTest.php
@@ -197,6 +197,6 @@ class ObjectTest extends ModelTestCase
 
         $object->setId(123);
 
-        $this->assertEquals(null, $clone->getId(), 'Expected default value saved to version');
+        $this->assertEquals(null, $clone->getId(), 'Setting ID on original object should have no impact on the cloned object');
     }
 }

--- a/tests/Model/DataObject/ObjectTest.php
+++ b/tests/Model/DataObject/ObjectTest.php
@@ -198,5 +198,8 @@ class ObjectTest extends ModelTestCase
         $object->setId(123);
 
         $this->assertEquals(null, $clone->getId(), 'Setting ID on original object should have no impact on the cloned object');
+
+        $otherClone = clone $object;
+        $this->assertEquals(123, $otherClone->getId(), 'Shallow clone should copy the o_* fields');
     }
 }

--- a/tests/Model/DataObject/ObjectTest.php
+++ b/tests/Model/DataObject/ObjectTest.php
@@ -16,6 +16,7 @@
 namespace Pimcore\Tests\Model\DataObject;
 
 use Pimcore\Model\DataObject;
+use Pimcore\Model\Element\Service;
 use Pimcore\Tests\Test\ModelTestCase;
 use Pimcore\Tests\Util\TestHelper;
 
@@ -184,5 +185,18 @@ class ObjectTest extends ModelTestCase
         $latestVersion = end($versions);
 
         $this->assertEquals('default', $latestVersion->getData()->getInputWithDefault(), 'Expected default value saved to version');
+    }
+
+    /**
+     * Verifies that when an object gets cloned, the o_* fields references get renewed
+     */
+    public function testCloning()
+    {
+        $object = TestHelper::createEmptyObject('', false);
+        $clone = Service::cloneMe($object);
+
+        $object->setId(123);
+
+        $this->assertEquals(null, $clone->getId(), 'Expected default value saved to version');
     }
 }


### PR DESCRIPTION
Resolves #12768

Testable with this script:
```php
<?php
$itemMold = new \Pimcore\Model\DataObject\Brand();
$object1 = \Pimcore\Model\Element\Service::cloneMe($itemMold);
$object2 = \Pimcore\Model\Element\Service::cloneMe($itemMold);
$object1->setId(123);
echo '"'.$object2->getId().'" should be ""'.PHP_EOL;

$object3 = clone $object1;
echo '"'.$object3->getId().'" should be "123"'.PHP_EOL;
```