### PR TITLE
Send a console error when using deprecated js functions

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/functions.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/functions.js
@@ -85,6 +85,8 @@ function t(key, defaultValue, placeholders) {
  * @deprecated
  */
 function ts(key) {
+    console.error('ts() function is deprecated, use t() instead. It will be removed in Pimcore 11.');
+
     return t(key);
 }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -966,6 +966,8 @@ pimcore.helpers.assetSingleUploadDialog = function (parent, parentType, success,
  * @deprecated
  */
 pimcore.helpers.addCsrfTokenToUrl = function (url) {
+    console.error('pimcore.helpers.addCsrfTokenToUrl() function is deprecated. It will be removed in Pimcore 11.');
+
     // we don't use the CSRF token in the query string
     return url;
 };

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/11_Preparing_for_V11.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/11_Preparing_for_V11.md
@@ -33,4 +33,6 @@
         }
     });
     ```
-    
+- Replace deprecated JS functions
+  - Use t() instead of ts()
+  - Don't use pimcore.helpers.addCsrfTokenToUrl()


### PR DESCRIPTION
When someone still use the ts() function it should be send a console error (so you have also a stack trace).
