### PR TITLE
Fix object bricks control menu for grouped bricks

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
@@ -110,7 +110,7 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
                     continue;
                 }
 
-                if(this.fieldConfig.allowedTypes.length > 0 && this.fieldConfig.allowedTypes.indexOf(elementData.key) === -1) {
+                if (elementData.leaf === true && this.fieldConfig.allowedTypes.length > 0 && this.fieldConfig.allowedTypes.indexOf(elementData.key) === -1) {
                     continue;
                 }
 


### PR DESCRIPTION
Recently this feature got merged: https://github.com/pimcore/pimcore/pull/12084 .
While itself being a nice feature, it introduced a bug to the control menu for adding (a) new object brick(s) to an object.

Before:
![image](https://user-images.githubusercontent.com/7099583/181390704-3e43439a-a064-40c4-bfce-3dca910026f1.png)

After:
![image](https://user-images.githubusercontent.com/7099583/181390818-b6f71c37-9c87-4699-abf6-ad966e1b4163.png)

This does only affect grouped elements, as they don't have the `key`-property and their children do.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [x] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  

