### PR TITLE
Fix Error thrown while handling message Pimcore\Messenger\GenerateWeb2PrintPdfMessage

### DIFF
--- a/lib/Messenger/Handler/GenerateWeb2PrintPdfHandler.php
+++ b/lib/Messenger/Handler/GenerateWeb2PrintPdfHandler.php
@@ -17,6 +17,7 @@ namespace Pimcore\Messenger\Handler;
 
 use Pimcore\Config;
 use Pimcore\Messenger\GenerateWeb2PrintPdfMessage;
+use Pimcore\Web2Print\Exception\NotPreparedException;
 use Pimcore\Web2Print\Processor;
 use Psr\Log\LoggerInterface;
 
@@ -46,6 +47,10 @@ class GenerateWeb2PrintPdfHandler
             }
         }
 
-        Processor::getInstance()->startPdfGeneration($documentId);
+        try {
+            Processor::getInstance()->startPdfGeneration($documentId);
+        } catch (NotPreparedException $e) {
+            $this->logger->debug($e->getMessage());
+        }
     }
 }

--- a/lib/Web2Print/Exception/CancelException.php
+++ b/lib/Web2Print/Exception/CancelException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Web2Print\Exception;
+
+class CancelException extends \RuntimeException
+{
+}

--- a/lib/Web2Print/Exception/NotPreparedException.php
+++ b/lib/Web2Print/Exception/NotPreparedException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Web2Print\Exception;
+
+class NotPreparedException extends \RuntimeException
+{
+}

--- a/lib/Web2Print/Processor.php
+++ b/lib/Web2Print/Processor.php
@@ -108,7 +108,7 @@ abstract class Processor
 
         $document = $this->getPrintDocument($documentId);
 
-        $lock = self::getLock($document);
+        $lock = $this->getLock($document);
         // check if there is already a generating process running, wait if so ...
         $lock->acquire(true);
 
@@ -262,8 +262,9 @@ abstract class Processor
             throw new \Exception('Document with id ' . $documentId . ' not found.');
         }
 
-        self::getLock($document)->release();
+        $this->getLock($document)->release();
         Model\Tool\TmpStore::delete($document->getLockKey());
+        @unlink(static::getJobConfigFile($documentId));
     }
 
     /**

--- a/lib/Web2Print/Processor.php
+++ b/lib/Web2Print/Processor.php
@@ -102,6 +102,9 @@ abstract class Processor
     public function startPdfGeneration($documentId)
     {
         $jobConfigFile = $this->loadJobConfigObject($documentId);
+        if (!$jobConfigFile) {
+            return null;
+        }
 
         $document = $this->getPrintDocument($documentId);
 
@@ -173,7 +176,12 @@ abstract class Processor
      */
     protected function loadJobConfigObject($documentId)
     {
-        return json_decode(file_get_contents($this->getJobConfigFile($documentId)));
+        $file = self::getJobConfigFile($documentId);
+        if (file_exists($file)) {
+            return json_decode(file_get_contents($file));
+        }
+
+        return null;
     }
 
     /**
@@ -216,6 +224,9 @@ abstract class Processor
     protected function updateStatus($documentId, $status, $statusUpdate)
     {
         $jobConfig = $this->loadJobConfigObject($documentId);
+        if (!$jobConfig) {
+            return;
+        }
         $jobConfig->status = $status;
         $jobConfig->statusUpdate = $statusUpdate;
         $this->saveJobConfigObjectFile($jobConfig);

--- a/lib/Web2Print/Processor.php
+++ b/lib/Web2Print/Processor.php
@@ -142,7 +142,7 @@ abstract class Processor
         $lock->release();
         Model\Tool\TmpStore::delete($document->getLockKey());
 
-        @unlink($this->getJobConfigFile($documentId));
+        @unlink(static::getJobConfigFile($documentId));
 
         return $pdf;
     }
@@ -164,7 +164,7 @@ abstract class Processor
      */
     protected function saveJobConfigObjectFile($jobConfig)
     {
-        file_put_contents($this->getJobConfigFile($jobConfig->documentId), json_encode($jobConfig));
+        file_put_contents(static::getJobConfigFile($jobConfig->documentId), json_encode($jobConfig));
 
         return true;
     }
@@ -176,7 +176,7 @@ abstract class Processor
      */
     protected function loadJobConfigObject($documentId)
     {
-        $file = self::getJobConfigFile($documentId);
+        $file = static::getJobConfigFile($documentId);
         if (file_exists($file)) {
             return json_decode(file_get_contents($file));
         }

--- a/lib/Web2Print/Processor.php
+++ b/lib/Web2Print/Processor.php
@@ -106,7 +106,7 @@ abstract class Processor
     {
         $jobConfigFile = $this->loadJobConfigObject($documentId);
         if (!$jobConfigFile) {
-            throw new NotPreparedException('PDF Generation is not prepared.');
+            throw new NotPreparedException('PDF Generation for document ' . $documentId . ' is not prepared.');
         }
 
         $document = $this->getPrintDocument($documentId);
@@ -136,7 +136,8 @@ abstract class Processor
             $document->setLastGenerated((time() + 1));
             $document->setLastGenerateMessage('');
             $document->save();
-        } catch (CancelException) {
+        } catch (CancelException $e) {
+            Logger::debug($e->getMessage());
         } catch (\Exception $e) {
             Logger::err((string) $e);
             $document->setLastGenerateMessage($e->getMessage());
@@ -231,7 +232,7 @@ abstract class Processor
     {
         $jobConfig = $this->loadJobConfigObject($documentId);
         if (!$jobConfig) {
-            throw new CancelException('PDF Generation is canceled.');
+            throw new CancelException('PDF Generation for document ' . $documentId . ' is canceled.');
         }
         $jobConfig->status = $status;
         $jobConfig->statusUpdate = $statusUpdate;


### PR DESCRIPTION
```
14:55:35 WARNING   [messenger] Error thrown while handling message Pimcore\Messenger\GenerateWeb2PrintPdfMessage. Sending for retry #1 using 1000 ms delay. Error: "Handling "Pimcore\Messenger\GenerateWeb2PrintPdfMessage" failed: Warning: file_get_contents(/var/www/html/var/tmp/pdf-creation-job-246.json): Failed to open stream: No such file or directory" ["class" => "Pimcore\Messenger\GenerateWeb2PrintPdfMessage","retryCount" => 1,"delay" => 1000,"error" => "Handling "Pimcore\Messenger\GenerateWeb2PrintPdfMessage" failed: Warning: file_get_contents(/var/www/html/var/tmp/pdf-creation-job-246.json): Failed to open stream: No such file or directory","exception" => Symfony\Component\Messenger\Exception\HandlerFailedException^ { …}]
14:55:36 WARNING   [messenger] Error thrown while handling message Pimcore\Messenger\GenerateWeb2PrintPdfMessage. Sending for retry #2 using 2000 ms delay. Error: "Handling "Pimcore\Messenger\GenerateWeb2PrintPdfMessage" failed: Warning: file_get_contents(/var/www/html/var/tmp/pdf-creation-job-246.json): Failed to open stream: No such file or directory" ["class" => "Pimcore\Messenger\GenerateWeb2PrintPdfMessage","retryCount" => 2,"delay" => 2000,"error" => "Handling "Pimcore\Messenger\GenerateWeb2PrintPdfMessage" failed: Warning: file_get_contents(/var/www/html/var/tmp/pdf-creation-job-246.json): Failed to open stream: No such file or directory","exception" => Symfony\Component\Messenger\Exception\HandlerFailedException^ { …}]
14:55:38 WARNING   [messenger] Error thrown while handling message Pimcore\Messenger\GenerateWeb2PrintPdfMessage. Sending for retry #3 using 4000 ms delay. Error: "Handling "Pimcore\Messenger\GenerateWeb2PrintPdfMessage" failed: Warning: file_get_contents(/var/www/html/var/tmp/pdf-creation-job-246.json): Failed to open stream: No such file or directory" ["class" => "Pimcore\Messenger\GenerateWeb2PrintPdfMessage","retryCount" => 3,"delay" => 4000,"error" => "Handling "Pimcore\Messenger\GenerateWeb2PrintPdfMessage" failed: Warning: file_get_contents(/var/www/html/var/tmp/pdf-creation-job-246.json): Failed to open stream: No such file or directory","exception" => Symfony\Component\Messenger\Exception\HandlerFailedException^ { …}]
14:55:42 CRITICAL  [messenger] Error thrown while handling message Pimcore\Messenger\GenerateWeb2PrintPdfMessage. Removing from transport after 3 retries. Error: "Handling "Pimcore\Messenger\GenerateWeb2PrintPdfMessage" failed: Warning: file_get_contents(/var/www/html/var/tmp/pdf-creation-job-246.json): Failed to open stream: No such file or directory" ["class" => "Pimcore\Messenger\GenerateWeb2PrintPdfMessage","retryCount" => 3,"error" => "Handling "Pimcore\Messenger\GenerateWeb2PrintPdfMessage" failed: Warning: file_get_contents(/var/www/html/var/tmp/pdf-creation-job-246.json): Failed to open stream: No such file or directory","exception" => Symfony\Component\Messenger\Exception\HandlerFailedException^ { …}]
```

# Steps to reproduce
1. Open Web2Print Container Document
2. Start Symfony Messenger Worker
3. Click on "PDF generieren" Button
4. Click on "PDF-Erstellung abbrechen" Button
5. Click on "PDF generieren" Button

# Further informations
The Cancel Button doesn't really cancel the generation. Only the lock is removed.
The second generation start overwrite the config file for prepare but the first generation will remove it when it is finished.
You see also the status from the first generation.

Now it will also remove the config file when you click the cancel button. If the updateStatus method doesn't find the config file it throws a CancelException. So the generation do stop and we can catch it without error.

I also created a NotPreparedException and catch it in the messenger in the case when it is canceled before it is started.