### PR TITLE
[Session] Do not register session bag if session already started

### DIFF
--- a/bundles/AdminBundle/EventListener/AdminSessionBagListener.php
+++ b/bundles/AdminBundle/EventListener/AdminSessionBagListener.php
@@ -52,6 +52,12 @@ class AdminSessionBagListener implements EventSubscriberInterface
         }
 
         $session = $event->getRequest()->getSession();
+
+        //do not reigster bags, if session is already started
+        if ($session->isStarted()) {
+           return;
+        }
+
         $this->configure($session);
     }
 

--- a/bundles/AdminBundle/EventListener/AdminSessionBagListener.php
+++ b/bundles/AdminBundle/EventListener/AdminSessionBagListener.php
@@ -53,7 +53,7 @@ class AdminSessionBagListener implements EventSubscriberInterface
 
         $session = $event->getRequest()->getSession();
 
-        //do not reigster bags, if session is already started
+        //do not register bags, if session is already started
         if ($session->isStarted()) {
            return;
         }

--- a/bundles/EcommerceFrameworkBundle/EventListener/SessionBagListener.php
+++ b/bundles/EcommerceFrameworkBundle/EventListener/SessionBagListener.php
@@ -66,7 +66,7 @@ class SessionBagListener implements EventSubscriberInterface
 
         $session = $event->getRequest()->getSession();
 
-        //do not reigster bags, if session is already started
+        //do not register bags, if session is already started
         if ($session->isStarted()) {
             return;
         }

--- a/bundles/EcommerceFrameworkBundle/EventListener/SessionBagListener.php
+++ b/bundles/EcommerceFrameworkBundle/EventListener/SessionBagListener.php
@@ -65,6 +65,12 @@ class SessionBagListener implements EventSubscriberInterface
         }
 
         $session = $event->getRequest()->getSession();
+
+        //do not reigster bags, if session is already started
+        if ($session->isStarted()) {
+            return;
+        }
+
         $this->configure($session);
     }
 

--- a/lib/Targeting/EventListener/TargetingSessionBagListener.php
+++ b/lib/Targeting/EventListener/TargetingSessionBagListener.php
@@ -57,6 +57,12 @@ class TargetingSessionBagListener implements EventSubscriberInterface
         }
 
         $session = $event->getRequest()->getSession();
+
+        //do not reigster bags, if session is already started
+        if ($session->isStarted()) {
+            return;
+        }
+
         $this->configure($session);
     }
 

--- a/lib/Targeting/EventListener/TargetingSessionBagListener.php
+++ b/lib/Targeting/EventListener/TargetingSessionBagListener.php
@@ -58,7 +58,7 @@ class TargetingSessionBagListener implements EventSubscriberInterface
 
         $session = $event->getRequest()->getSession();
 
-        //do not reigster bags, if session is already started
+        //do not register bags, if session is already started
         if ($session->isStarted()) {
             return;
         }


### PR DESCRIPTION
e.g. in case of SessionConfigurators already registering bags - follow up to #12746

## Additional info  
In prod mode, the exceptions are thrown "Cannot register a bag when the session is already started." in Session bag listeners.
