### PR TITLE
Fix link to the ExtJS docs

### DIFF
--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/03_Layout_Elements/README.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/03_Layout_Elements/README.md
@@ -25,5 +25,5 @@ Please read this [page](./01_Dynamic_Text_Labels.md) for further details.
 Please read this [page](./02_Preview_Iframe.md) for further details.
 
 Pimcore uses Ext JS layout components for all object layout elements. For a deeper understanding of the layout elements, 
-please have a look at the [Ext JS documentation pages](http://docs.sencha.com/extjs/6.0/6.0.1-classic/) and 
+please have a look at the [Ext JS documentation pages](https://docs.sencha.com/extjs/7.0.0/classic/Ext.html) and 
 [examples](http://www.sencha.com/products/js/).


### PR DESCRIPTION
> **Note**: 
Apart from that: the `Edit on GitHub` link is broken, because it points to the `10.x` branch, which doesn't exist anymore.