### PR TITLE
Remove deprecated JS functions

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/functions.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/functions.js
@@ -81,15 +81,6 @@ function t(key, defaultValue, placeholders) {
     }
 }
 
-/**
- * @deprecated
- */
-function ts(key) {
-    console.error('ts() function is deprecated, use t() instead. It will be removed in Pimcore 11.');
-
-    return t(key);
-}
-
 Math.sec = function(x) {
     return 1 / Math.cos(x);
 };

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -962,16 +962,6 @@ pimcore.helpers.assetSingleUploadDialog = function (parent, parentType, success,
     pimcore.helpers.uploadDialog(url, 'Filedata', success, failure);
 };
 
-/**
- * @deprecated
- */
-pimcore.helpers.addCsrfTokenToUrl = function (url) {
-    console.error('pimcore.helpers.addCsrfTokenToUrl() function is deprecated. It will be removed in Pimcore 11.');
-
-    // we don't use the CSRF token in the query string
-    return url;
-};
-
 pimcore.helpers.uploadDialog = function (url, filename, success, failure, description) {
 
     if (typeof success != "function") {

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,8 +1,8 @@
 # Upgrade Notes
 ## 11.0.0
-
 - [Image Optimizer] Removed all the Image Optimizer services (e.g. PngCrushOptimizer, JpegoptimOptimizer etc.) as image optimization is done by the new package spatie/image-optimizer. 
-  
+- Removed deprecated JS functions (`ts()` and `pimcore.helpers.addCsrfTokenToUrl()`)
+
 ## 10.5.0
 - [Sessions] Changed default value for `symfony.session.cookie_secure` to `auto`
 - [Listings] `JsonListing` class is deprecated. Please use `CallableFilterListingInterface`, `FilterListingTrait` and `CallableOrderListingInterface`, `OrderListingTrait` instead.


### PR DESCRIPTION
Follow up to https://github.com/pimcore/pimcore/pull/12771 for Pimcore 11

