### PR TITLE
Restricted the option to set pages as content master document to each other

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/DocumentControllerBase.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/DocumentControllerBase.php
@@ -351,7 +351,7 @@ abstract class DocumentControllerBase extends AdminController implements KernelC
         $doc = Model\Document\PageSnippet::getById((int) $request->get('id'));
         if ($doc instanceof Model\Document\PageSnippet) {
             $doc->setEditables([]);
-            $doc->setContentMasterDocumentId($request->get('contentMasterDocumentPath'));
+            $doc->setContentMasterDocumentId($request->get('contentMasterDocumentPath'),true);
             $doc->saveVersion();
         }
 

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -416,7 +416,7 @@ abstract class PageSnippet extends Model\Document
      *
      * @throws \Exception
      */
-    public function setContentMasterDocumentId($contentMasterDocumentId, bool $validate=false)
+    public function setContentMasterDocumentId($contentMasterDocumentId/*, bool $validate*/)
     {
         // this is that the path is automatically converted to ID => when setting directly from admin UI
         if (!is_numeric($contentMasterDocumentId) && !empty($contentMasterDocumentId)) {
@@ -431,17 +431,16 @@ abstract class PageSnippet extends Model\Document
         }
 
         // Don't set the content master document if the document is already part of the master document chain
-        if($contentMasterDocumentId && $validate) {
+        if ($contentMasterDocumentId) {
+            $validate = \func_get_args ()[1] ?? false;
             $maxDepth = 20;
             $currentContentMasterDocument = Document::getById ($contentMasterDocumentId);
-
-            while ($currentContentMasterDocument && $maxDepth-- > 0) {
+            do {
                 if ($currentContentMasterDocument->getId () === $this->getId ()) {
                     throw new \Exception('This document is already part of the master document chain, please choose a different one.');
                 }
-
-                $currentContentMasterDocument = $currentContentMasterDocument->getContentMasterDocument();
-            }
+                $currentContentMasterDocument = $currentContentMasterDocument->getContentMasterDocument ();
+            } while ($currentContentMasterDocument && $maxDepth-- > 0 && $validate);
         }
 
 

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -412,12 +412,11 @@ abstract class PageSnippet extends Model\Document
 
     /**
      * @param int|string|null $contentMasterDocumentId
-     *
      * @return $this
      *
      * @throws \Exception
      */
-    public function setContentMasterDocumentId($contentMasterDocumentId)
+    public function setContentMasterDocumentId($contentMasterDocumentId, bool $validate=false)
     {
         // this is that the path is automatically converted to ID => when setting directly from admin UI
         if (!is_numeric($contentMasterDocumentId) && !empty($contentMasterDocumentId)) {
@@ -431,9 +430,20 @@ abstract class PageSnippet extends Model\Document
             $contentMasterDocument = null;
         }
 
-        if ($contentMasterDocumentId && $contentMasterDocumentId == $this->getId()) {
-            throw new \Exception('You cannot use the current document as a master document, please choose a different one.');
+        // Don't set the content master document if the document is already part of the master document chain
+        if($contentMasterDocumentId && $validate) {
+            $maxDepth = 20;
+            $currentContentMasterDocument = Document::getById ($contentMasterDocumentId);
+
+            while ($currentContentMasterDocument && $maxDepth-- > 0) {
+                if ($currentContentMasterDocument->getId () === $this->getId ()) {
+                    throw new \Exception('This document is already part of the master document chain, please choose a different one.');
+                }
+
+                $currentContentMasterDocument = $currentContentMasterDocument->getContentMasterDocument();
+            }
         }
+
 
         $this->contentMasterDocumentId = $contentMasterDocumentId;
 
@@ -468,7 +478,7 @@ abstract class PageSnippet extends Model\Document
     public function setContentMasterDocument($document)
     {
         if ($document instanceof self) {
-            $this->setContentMasterDocumentId($document->getId());
+            $this->setContentMasterDocumentId($document->getId(),true);
         } else {
             $this->setContentMasterDocumentId(null);
         }

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -244,7 +244,7 @@ class Service extends Model\Element\Service
 
         if ($enableInheritance && ($new instanceof Document\PageSnippet) && $new->supportsContentMaster()) {
             $new->setEditables([]);
-            $new->setContentMasterDocumentId($source->getId());
+            $new->setContentMasterDocumentId($source->getId(),true);
         }
 
         if ($language) {

--- a/tests/Model/Document/DocumentTest.php
+++ b/tests/Model/Document/DocumentTest.php
@@ -235,13 +235,24 @@ class DocumentTest extends ModelTestCase
         $this->assertNull($childEditable);
 
         // set master document
-        $child->setContentMasterDocumentId($this->testPage->getId());
+        $child->setContentMasterDocumentId($this->testPage->getId(),true);
         $child->save();
         $child = Page::getById($child->getId(), ['force' => true]);
 
         // now the value should get inherited
         $childEditable = $child->getEditable('headline');
         $this->assertEquals('test', $childEditable->getValue());
+
+        // Don't set the master document if the document is already a part of the master document chain
+        $testFirstPage = TestHelper::createEmptyDocumentPage ();
+        $testSecondPage = TestHelper::createEmptyDocumentPage ();
+        $testFirstPage->setContentMasterDocumentId($testSecondPage->getId(), true);
+        $testFirstPage->setPublished (true);
+        $testFirstPage->save();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("This document is already part of the master document chain, please choose a different one.");
+        $testSecondPage->setContentMasterDocumentId($testFirstPage->getId (), true);
     }
 
     public function testLink()


### PR DESCRIPTION
Restricted the option to set pages as content master document to each other

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #12765 

## Additional info  

