### PR TITLE
[Version preview] Prevent E_DEPRECATED error when having input field = null

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Extension/Text.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Text.php
@@ -50,7 +50,7 @@ trait Text
     /**
      * @see Data::getVersionPreview
      *
-     * @param string $data
+     * @param string|null $data
      * @param null|Model\DataObject\AbstractObject $object
      * @param array $params
      *
@@ -58,6 +58,6 @@ trait Text
      */
     public function getVersionPreview($data, $object = null, $params = [])
     {
-        return htmlspecialchars($data, ENT_QUOTES, 'UTF-8');
+        return htmlspecialchars((string)$data, ENT_QUOTES, 'UTF-8');
     }
 }


### PR DESCRIPTION
All fields get initialized with `null`. For text fields in object preview this causes an 
> E_DEPRECATED: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated 
in PHP 8.1 because https://github.com/pimcore/pimcore/blob/03508497d3fcb22d8c44f0d56e487136159912a2/models/DataObject/ClassDefinition/Data/Extension/Text.php#L61 then calls `htmlspecialchars(null)`.