### PR TITLE
Document/Video ImageThumbnail should return error image if it couldn't be generated

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -1502,6 +1502,10 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }
 
         $stream = $thumb->getStream();
+        if (!$stream) {
+            throw $this->createNotFoundException('Unable to get video thumbnail for video ' . $video->getId());
+        }
+
         $response = new StreamedResponse(function () use ($stream) {
             fpassthru($stream);
         }, 200, [

--- a/models/Asset/Document/ImageThumbnail.php
+++ b/models/Asset/Document/ImageThumbnail.php
@@ -105,20 +105,20 @@ final class ImageThumbnail
                 Logger::error("Couldn't create image-thumbnail of document " . $this->asset->getRealFullPath());
                 Logger::error($e->getMessage());
             }
-
-            if (empty($this->pathReference)) {
-                $this->pathReference = [
-                    'type' => 'error',
-                    'src' => '/bundles/pimcoreadmin/img/filetype-not-supported.svg',
-                ];
-            }
-
-            $event = new GenericEvent($this, [
-                'deferred' => $deferred,
-                'generated' => $generated,
-            ]);
-            \Pimcore::getEventDispatcher()->dispatch($event, AssetEvents::DOCUMENT_IMAGE_THUMBNAIL);
         }
+
+        if (empty($this->pathReference)) {
+            $this->pathReference = [
+                'type' => 'error',
+                'src' => '/bundles/pimcoreadmin/img/filetype-not-supported.svg',
+            ];
+        }
+
+        $event = new GenericEvent($this, [
+            'deferred' => $deferred,
+            'generated' => $generated,
+        ]);
+        \Pimcore::getEventDispatcher()->dispatch($event, AssetEvents::DOCUMENT_IMAGE_THUMBNAIL);
     }
 
     /**

--- a/models/Asset/Document/ImageThumbnail.php
+++ b/models/Asset/Document/ImageThumbnail.php
@@ -81,13 +81,13 @@ final class ImageThumbnail
      */
     public function generate($deferredAllowed = true)
     {
+        $deferred = $deferredAllowed && $this->deferred;
         $generated = false;
 
         if ($this->asset && empty($this->pathReference)) {
             $config = $this->getConfig();
             $cacheFileStream = null;
             $config->setFilenameSuffix('page-' . $this->page);
-            $deferred = $deferredAllowed && $this->deferred;
 
             try {
                 if (!$deferred) {

--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -168,20 +168,20 @@ final class ImageThumbnail
                     }
                 }
             }
-
-            if (empty($this->pathReference)) {
-                $this->pathReference = [
-                    'type' => 'error',
-                    'src' => '/bundles/pimcoreadmin/img/filetype-not-supported.svg',
-                ];
-            }
-
-            $event = new GenericEvent($this, [
-                'deferred' => $deferred,
-                'generated' => $generated,
-            ]);
-            \Pimcore::getEventDispatcher()->dispatch($event, AssetEvents::VIDEO_IMAGE_THUMBNAIL);
         }
+
+        if (empty($this->pathReference)) {
+            $this->pathReference = [
+                'type' => 'error',
+                'src' => '/bundles/pimcoreadmin/img/filetype-not-supported.svg',
+            ];
+        }
+
+        $event = new GenericEvent($this, [
+            'deferred' => $deferred,
+            'generated' => $generated,
+        ]);
+        \Pimcore::getEventDispatcher()->dispatch($event, AssetEvents::VIDEO_IMAGE_THUMBNAIL);
     }
 
     /**


### PR DESCRIPTION
If the `$this->asset` attribute is null it should also set the error image in `$this->pathReference` like in the Image asset Thumbnail class.

The attribute can be null if the dependencies doesn't exist or document hasn't a page count or video hasn't dimensions:
https://github.com/pimcore/pimcore/blob/80a590eb96950e325aac9f58cf7aa0eb3bf93f31/models/Asset/Document.php#L92-L108
https://github.com/pimcore/pimcore/blob/80a590eb96950e325aac9f58cf7aa0eb3bf93f31/models/Asset/Video.php#L166-L182