### PR TITLE
[Bug] getTotalCount() on listings should return correct count on grouped queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ nbproject
 /tests/_output/
 /tests/_support/_generated/
 /tests/_support/Resources/objects/
+/cache/
+/.htaccess

--- a/doc/Development_Documentation/20_Extending_Pimcore/17_Custom_Persistent_Models.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/17_Custom_Persistent_Models.md
@@ -506,7 +506,7 @@ class Dao extends Listing\Dao\AbstractDao
     public function getTotalCount()
     {
         $queryBuilder = $this->getQueryBuilder();
-        $this->prepareQueryBuilderForTotalCount($queryBuilder);
+        $this->prepareQueryBuilderForTotalCount($queryBuilder, $this->getTableName() . '.id');
 
         $totalCount = $this->db->fetchOne((string) $queryBuilder, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 

--- a/models/Asset/Listing/Dao.php
+++ b/models/Asset/Listing/Dao.php
@@ -101,7 +101,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount()
     {
         $queryBuilder = $this->getQueryBuilder();
-        $this->prepareQueryBuilderForTotalCount($queryBuilder);
+        $this->prepareQueryBuilderForTotalCount($queryBuilder, 'assets.id');
 
         $amount = (int) $this->db->fetchOne((string) $queryBuilder, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 

--- a/models/DataObject/Listing/Dao.php
+++ b/models/DataObject/Listing/Dao.php
@@ -86,7 +86,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount()
     {
         $queryBuilder = $this->getQueryBuilder();
-        $this->prepareQueryBuilderForTotalCount($queryBuilder);
+        $this->prepareQueryBuilderForTotalCount($queryBuilder, $this->getTableName() . '.o_id');
 
         $totalCount = $this->db->fetchOne((string) $queryBuilder, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 

--- a/models/Document/Listing/Dao.php
+++ b/models/Document/Listing/Dao.php
@@ -113,7 +113,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount()
     {
         $queryBuilder = $this->getQueryBuilder();
-        $this->prepareQueryBuilderForTotalCount($queryBuilder);
+        $this->prepareQueryBuilderForTotalCount($queryBuilder, 'documents.id');
 
         $amount = (int) $this->db->fetchOne((string) $queryBuilder, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 

--- a/tests/Model/Asset/ListingTest.php
+++ b/tests/Model/Asset/ListingTest.php
@@ -15,8 +15,10 @@
 
 namespace Pimcore\Tests\Model\Asset;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use Pimcore\Db;
 use Pimcore\Model\Asset;
+use Pimcore\Model\Element\Tag;
 use Pimcore\Tests\Test\ModelTestCase;
 use Pimcore\Tests\Util\TestHelper;
 
@@ -35,12 +37,24 @@ class ListingTest extends ModelTestCase
         $count = $db->fetchOne('SELECT count(*) from assets');
         $this->assertEquals(1, $count, 'expected 1 asset');
 
-        for ($i = 0; $i < 3; $i++) {
-            TestHelper::createImageAsset();
-        }
+        $tagA = TestHelper::createTag('A');
+        $tagB = TestHelper::createTag('B');
 
-        TestHelper::createDocumentAsset();
-        TestHelper::createVideoAsset();
+        $image1 = TestHelper::createImageAsset();
+        TestHelper::assignTag($tagA, $image1);
+        TestHelper::assignTag($tagB, $image1);
+
+        $image2 = TestHelper::createImageAsset();
+
+        $image3 = TestHelper::createImageAsset();
+        TestHelper::assignTag($tagB, $image3);
+
+        $document = TestHelper::createDocumentAsset();
+        TestHelper::assignTag($tagA, $document);
+        TestHelper::assignTag($tagB, $document);
+
+        $video = TestHelper::createVideoAsset();
+        TestHelper::assignTag($tagB, $video);
 
         $count = $db->fetchOne('SELECT count(*) from assets');
         $this->assertEquals(6, $count, 'expected 6 assets');
@@ -69,5 +83,51 @@ class ListingTest extends ModelTestCase
         $this->assertEquals(5, $count, 'expected 5 assets');
         $totalCount = $list->getTotalCount();
         $this->assertEquals(6, $totalCount, 'expected 6 assets');
+
+        // Test: on a grouped query, the ->getTotalCount() should correctly count the number of rows
+        $list = new Asset\Listing();
+        $list->getDao()->onCreateQueryBuilder(function (QueryBuilder $queryBuilder) use ($tagA, $tagB) {
+            $this->joinTags($queryBuilder, $tagA, $tagB);
+        });
+
+        $totalCount = $list->getTotalCount();
+        $this->assertEquals(4, $totalCount, 'expected 4 assets on totalCount of grouped query');
+        $list->load();
+        $count = $list->getCount();
+        $this->assertEquals(4, $count, 'expected 4 assets on grouped query');
+
+        // Test: on a grouped limited query, the ->getTotalCount() should correctly count the number of total rows
+        $list = new Asset\Listing();
+        $list->getDao()->onCreateQueryBuilder(function (QueryBuilder $queryBuilder) use ($tagA, $tagB) {
+            $this->joinTags($queryBuilder, $tagA, $tagB);
+        });
+        $list->setLimit(3);
+
+        $totalCount = $list->getTotalCount();
+        $this->assertEquals(4, $totalCount, 'expected 4 assets on totalCount of grouped limited query');
+        $list->load();
+        $count = $list->getCount();
+        $this->assertEquals(3, $count, 'expected 3 assets on grouped limited query');
+    }
+
+    private function joinTags(QueryBuilder $queryBuilder, Tag ...$tags): void
+    {
+        $expressionBuilder = $queryBuilder->expr();
+        $tagIds = array_map(fn (Tag $tag) => $expressionBuilder->literal($tag->getId()), $tags);
+
+        // Require assets to have one of the tags
+        $queryBuilder
+            ->innerJoin(
+                'assets',
+                'tags_assignment',
+                'ta',
+                $expressionBuilder->and(
+                    $expressionBuilder->in('ta.tagid', $tagIds),
+                    $expressionBuilder->eq('ta.ctype', $expressionBuilder->literal('asset')),
+                    $expressionBuilder->eq('ta.cid', 'assets.id')
+                )
+            )
+            ->groupBy('assets.id')
+        ;
     }
 }


### PR DESCRIPTION
## Error:
When a `GROUP BY` was added to a listing via the `onCreateQueryBuilder` callback, the `$listing->getTotalCount()` returned an incorrect/unexpected row count.

## Steps to reproduce:
```
// A listing we have to retrieve all the assets that have the tag with id 2 and/or the tag with id 7:
$requireOneOfTags = [2, 7];

$listing = (new Asset\Listing())->setCondition('assets.type = ?', ['image']);
$listing->getDao()->onCreateQueryBuilder(function (QueryBuilder $queryBuilder) use ($requireOneOfTags) {
    $expressionBuilder = $queryBuilder->expr();

    // Require assets to have one of the tags
    $queryBuilder
        ->innerJoin(
            'assets',
            'tags_assignment',
            'ta',
            $expressionBuilder->and(
                $expressionBuilder->in('ta.tagid', $requireOneOfTags),
                $expressionBuilder->eq('ta.ctype', $expressionBuilder->literal('asset')),
                $expressionBuilder->eq('ta.cid', 'assets.id')
            )
        )
        ->groupBy('assets.id')
    ;
});

$totalCount = $listing->getTotalCount();
// Executed query:
//     SELECT COUNT(*) FROM assets INNER JOIN tags_assignment ta ON (ta.tagid IN (2, 7)) AND (ta.ctype = 'asset') AND (ta.cid = assets.id) WHERE assets.type = ? GROUP BY assets.id
// Returned data by query
//     For each asset, the amount of tags_assignment
// Returned data by method
//     For the first asset in the rowset, the amount of tags_assignment
// Expected data
//     The number of assets
dump($totalCount); // 1

$realCount = count($listing->getAssets());
dump($realCount); // 3

// After fix:
$totalCount = $listing->getTotalCount();
// Executed query:
//     SELECT COUNT(*) FROM (SELECT * FROM assets INNER JOIN tags_assignment ta ON (ta.tagid IN (2, 7)) AND (ta.ctype = 'asset') AND (ta.cid = assets.id) WHERE assets.type = ? GROUP BY assets.id) as XYZ
// Returned data by query
//     The number of rows that would be returned by the original query = the number of assets
// Returned data by method
//     The number of assets
dump($totalCount); // 3
```

### Background info:
In Pimcore <6.9 we could fix that within the `onCreateQueryBuilder` callback itself as the `COUNT(*)` expression was already added before executing the callback. So our callback method was a bit more complex, checking on the `COUNT(*)` and rewriting that to a `COUNT(DISTINCT assets.id)` whithin the callback itself. However in later versions the callback is executed first and the `COUNT(*)` is attached to the query after the callback - so it's more important to us to fix this within Pimcore itself.