### PR TITLE
add ability to generate public frontend path even in console

### DIFF
--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -54,7 +54,7 @@ final class Thumbnail
      *
      * @return string
      */
-    public function getPath($deferredAllowed = true, $cacheBuster = false)
+    public function getPath($deferredAllowed = true, $cacheBuster = false, $forceFrontend = false)
     {
         $pathReference = null;
         if ($this->getConfig()) {
@@ -72,7 +72,7 @@ final class Thumbnail
             $pathReference = $this->getPathReference($deferredAllowed);
         }
 
-        $path = $this->convertToWebPath($pathReference);
+        $path = $this->convertToWebPath($pathReference, $forceFrontend);
 
         if ($cacheBuster) {
             $path = $this->addCacheBuster($path, ['cacheBuster' => true], $this->getAsset());

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -320,12 +320,12 @@ trait ImageThumbnailTrait
      *
      * @return string|null
      */
-    protected function convertToWebPath(array $pathReference): ?string
+    protected function convertToWebPath(array $pathReference, $forceFrontend = false): ?string
     {
         $type = $pathReference['type'] ?? null;
         $path = $pathReference['src'] ?? null;
 
-        if (Tool::isFrontend()) {
+        if (Tool::isFrontend() || $forceFrontend) {
             if ($type === 'data-uri') {
                 return $path;
             } elseif ($type === 'deferred') {


### PR DESCRIPTION
This PR gives you the option to get the public image thumbnail path with included frontend_prefixes even when you are in a console command. 

Resolves #12326 

