### PR TITLE
Fixes missing class reference in built Listing classes

### DIFF
--- a/lib/DataObject/ClassBuilder/ListingClassBuilder.php
+++ b/lib/DataObject/ClassBuilder/ListingClassBuilder.php
@@ -39,6 +39,8 @@ class ListingClassBuilder implements ListingClassBuilderInterface
         $cd .= "\n\n";
         $cd .= 'namespace Pimcore\\Model\\DataObject\\'.ucfirst($classDefinition->getName()).';';
         $cd .= "\n\n";
+        $cd .= 'use Pimcore\\Model;';
+        $cd .= "\n";
         $cd .= 'use Pimcore\\Model\\DataObject;';
         $cd .= "\n\n";
         $cd .= "/**\n";


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves "Undefined class 'ElementInterface'" in class definition files at `var/classes/DataObject/ClassName/Listing.php`

![image](https://user-images.githubusercontent.com/279826/184841158-4b9bffc8-d48d-47e8-9ecc-1855d23a60c1.png)


## After this change

![image](https://user-images.githubusercontent.com/279826/184841297-f9cd40a2-03bf-4c80-a78a-65d09ca344e0.png)
