### PR TITLE
[Static Page Generator] Fix json request to a non document route saves wrong content

### DIFF
--- a/bundles/CoreBundle/EventListener/Frontend/StaticPageGeneratorListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/StaticPageGeneratorListener.php
@@ -131,6 +131,10 @@ class StaticPageGeneratorListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
+        if ($request->isXmlHttpRequest()) {
+            return;
+        }
+
         if (!$event->isMainRequest()) {
             return;
         }

--- a/doc/Development_Documentation/19_Development_Tools_and_Details/20_Static_Page_Generator.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/20_Static_Page_Generator.md
@@ -89,3 +89,16 @@ pimcore:
 |----------------|---------------------------------------------------------------|
 | enabled        | Set it true to enable Static Page Router                      |
 | route_pattern  | Regular expression to match routes for static page rendering  |
+
+## Static Page Generation with Ajax Request
+The static pages with XMLHttpRequest fetches the data and displays it on the page, just like a standard document page. 
+However, if you are using the Fetch API to request the data, then must add the `XMLHttpRequest` header as shown below, 
+otherwise the sub-request will replace the content of the generated static page.
+
+```js
+fetch('/test/page', {
+    headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+    }
+})
+```


### PR DESCRIPTION
## Changes in this pull request  
Resolves #12840

## Additional info  
if using fetch, then need to set XMLHttpRequest header:
```js
fetch('/test/page', {
    headers: {
        'X-Requested-With': 'XMLHttpRequest',
    }
})
```

