### PR TITLE
[PhpStan] Fix: InMemory::plainText() expects non-empty-string, string given

### DIFF
--- a/lib/Targeting/Storage/Cookie/JWTCookieSaveHandler.php
+++ b/lib/Targeting/Storage/Cookie/JWTCookieSaveHandler.php
@@ -41,6 +41,9 @@ class JWTCookieSaveHandler extends AbstractCookieSaveHandler
      */
     private $logger;
 
+    /**
+     * @param non-empty-string $secret
+     */
     public function __construct(
         string $secret,
         array $options = [],


### PR DESCRIPTION
```
 ------ -----------------------------------------------------------------------------------------------
  Line   lib/Targeting/Storage/Cookie/JWTCookieSaveHandler.php
 ------ -----------------------------------------------------------------------------------------------
  54     Parameter #1 $contents of static method Lcobucci\JWT\Signer\Key\InMemory::plainText() expects
         non-empty-string, string given.
 ------ -----------------------------------------------------------------------------------------------
```