### PR TITLE
[Bug]: Adding a new variant of an object which is using ClassificationStore Selects crashes

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -378,12 +378,16 @@ class Select extends Data implements
     }
 
     /**
-     * @param string|null $data
+     * @param array|string|null $data
      *
      * @return bool
      */
     public function isEmpty($data)
     {
+        if (is_array($data)) {
+            return count($data) < 1;
+        }
+
         return strlen((string) $data) < 1;
     }
 

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -388,7 +388,7 @@ class Select extends Data implements
             return count($data) < 1;
         }
 
-        return strlen((string) $data) < 1;
+        return (string) $data === '';
     }
 
     /**


### PR DESCRIPTION
## Bug
If a user in Pimcore admin is adding a new variant of an object which is using ClassificationStore Selects it crashes due to a conversion error.
- Parent (and therefore the variants) must use ClassificationStore
- At least one Select field must be used
- (select values are being set via custom data provider - this might be optional)

## Changes in this pull request  
Changes the "isEmpty" check for Select type such as arrays are being treated correctly.

Resolves the issue of users in admin are not able to add new variants thought the interface.

## Additional info  

