### PR TITLE
Implement __toString for FileObject class

### DIFF
--- a/lib/Log/FileObject.php
+++ b/lib/Log/FileObject.php
@@ -77,4 +77,9 @@ final class FileObject
     {
         return $this->data;
     }
+    
+    public function __toString(): string
+    {
+        return $this->getFilename();
+    }
 }


### PR DESCRIPTION
Currently to string for appended fileobject will be resembled by empty array in logs (ApplicationLoggerDb handler), with this PR the path to the file will be printed also if not handled by DB handler but by stream/file..

![image](https://user-images.githubusercontent.com/9052094/185958232-8198f404-d045-4b34-8040-51740d17445a.png)
