### PR TITLE
parameters.secret should be longer -> causing issues with JWT library

### DIFF
--- a/.github/ci/files/config/services.yaml
+++ b/.github/ci/files/config/services.yaml
@@ -1,5 +1,5 @@
 parameters:
-    secret: ThisTokenIsNotSoSecretChangeIt
+    secret: ThisTokenIsNotSoSecretChangeItImmediately
 
     # customize the full path to external executables
     # normally they are auto-detected by `which program` or auto-discovered in the configured path in

--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -136,7 +136,7 @@ class Composer
 
         // ensure that there's a random secret defined
         if (strpos($parameters, 'ThisTokenIsNotSoSecretChangeIt')) {
-            $parameters = preg_replace_callback('/ThisTokenIsNotSoSecretChangeIt/', function ($match) {
+            $parameters = preg_replace_callback('/ThisTokenIsNotSoSecretChangeIt(Immediately)?/', function ($match) {
                 // generate a unique token for each occurrence
                 return base64_encode(random_bytes(32));
             }, $parameters);


### PR DESCRIPTION
`Lcobucci\JWT` introduced some changes in v4.2.0 which are causing issues with the current default secret length. 

See also: 
https://github.com/pimcore/demo/pull/345
https://github.com/pimcore/skeleton/pull/114
