### PR TITLE
Fix: Missing return for non-admin users when renaming objects

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1098,7 +1098,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 return $this->adminJson(['success' => false, 'message' => $e->getMessage()]);
             }
         } elseif ($key && $object->isAllowed('rename')) {
-            $this->adminJson($this->renameObject($object, $key));
+            return $this->adminJson($this->renameObject($object, $key));
         } else {
             Logger::debug('prevented update object because of missing permissions.');
         }


### PR DESCRIPTION
Fix https://github.com/pimcore/pimcore/issues/12948

Regression from https://github.com/pimcore/pimcore/pull/11915