### PR TITLE
[Docs] Link to preview generators

### DIFF
--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/55_Preview.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/55_Preview.md
@@ -2,7 +2,7 @@
 
 > **DEPRECATED FEATURE**  
 >
-> **Please use [preview generators](./56_Preview_Generator.md) instead, which are more powerful and flexibel and 
+> **Please use [preview generators](./56_Preview_Generator.md) instead, which are more powerful and flexible and 
 offer the same functionality. The preview tab is automatically displayed when a link generator is defined 
 on the data object class.**
 

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/55_Preview.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/55_Preview.md
@@ -2,7 +2,7 @@
 
 > **DEPRECATED FEATURE**  
 >
-> **Please use [link generators](./30_Link_Generator.md) instead, which are more powerful and flexibel and 
+> **Please use [preview generators](./56_Preview_Generator.md) instead, which are more powerful and flexibel and 
 offer the same functionality. The preview tab is automatically displayed when a link generator is defined 
 on the data object class.**
 


### PR DESCRIPTION
Preview URL is deprecated but the alternative is not *link* generator but *preview* generator.