### PR TITLE
fix: video in object cannot be edited

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -2001,7 +2001,7 @@ pimcore.helpers.editmode.openLinkEditPanel = function (data, callback) {
 
 pimcore.helpers.editmode.openVideoEditPanel = function (data, callback) {
 
-    const allowedTypes = data.allowedTypes;
+    const allowedTypes = data.allowedTypes || [];
     var window = null;
     var form = null;
     var fieldPath = new Ext.form.TextField({


### PR DESCRIPTION
Specifically, if the class definition does not restrict the video type, the `allowedTypes` variable is **not** defined. Yet, it is followed by the call `allowedTypes.includes...` somewhere further down. This causes a JS exception, which means the user cannot edit the video due to the edit dialog not opening.

Caused by https://github.com/pimcore/pimcore/pull/12445
Similar to https://github.com/pimcore/pimcore/pull/12733, but the JS equivalent

<img width="909" alt="image" src="https://user-images.githubusercontent.com/57256630/186335211-055ce97a-0f4b-4c90-9092-8c4926dd2d26.png">
