### PR TITLE
[Data objects] Support exporting empty class

### DIFF
--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -56,7 +56,7 @@ class Service
     public static function generateClassDefinitionJson($class)
     {
         $class = clone $class;
-        if($class->layoutDefinitions) {
+        if($class->layoutDefinitions instanceof Layout) {
             self::removeDynamicOptionsFromLayoutDefinition($class->layoutDefinitions);
         }
 

--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -56,7 +56,9 @@ class Service
     public static function generateClassDefinitionJson($class)
     {
         $class = clone $class;
-        self::removeDynamicOptionsFromLayoutDefinition($class->layoutDefinitions);
+        if($class->layoutDefinitions) {
+            self::removeDynamicOptionsFromLayoutDefinition($class->layoutDefinitions);
+        }
 
         self::setDoRemoveDynamicOptions(true);
         $data = json_decode(json_encode($class));


### PR DESCRIPTION
Steps to reproduce bug:

1. Create data object class without any layout or data elements. Save.
2. Export class

You will get the error `Uncaught PHP Exception TypeError: "method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given" at /var/www/html/vendor/pimcore/pimcore/models/DataObject/ClassDefinition/Service.php line 77 `

With this PR the class definition JSON will get exported.