### PR TITLE
[BUG][DataObjects]: Pass condition variables types in ClassDefinition listing DAO

### DIFF
--- a/models/DataObject/ClassDefinition/Listing/Dao.php
+++ b/models/DataObject/ClassDefinition/Listing/Dao.php
@@ -34,7 +34,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         $classes = [];
 
-        $classesRaw = $this->db->fetchFirstColumn('SELECT id FROM classes' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $classesRaw = $this->db->fetchFirstColumn('SELECT id FROM classes' . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
 
         foreach ($classesRaw as $classRaw) {
             if ($class = DataObject\ClassDefinition::getById($classRaw)) {


### PR DESCRIPTION
Not passing the condition variable types will cause an SQL error if the `ClassDefinition` listing is filtered like so:
`$classDefinitions->addConditionParam("id IN (?)", [['my_class_id']]);`