### PR TITLE
[BUG][DataObjects]: Renaming DataObjects doesn´t work

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1078,10 +1078,10 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
             try {
                 $isIndexUpdate = isset($values['indices']);
-                $indexUpdate = is_int($values['indices']) ? $values['indices'] : $values['indices'][$object->getId()];
 
                 if ($isIndexUpdate) {
                     // Ensure the update sort index is already available in the postUpdate eventListener
+                    $indexUpdate = is_int($values['indices']) ? $values['indices'] : $values['indices'][$object->getId()];
                     $object->setIndex($indexUpdate);
                 }
 


### PR DESCRIPTION
Currently renaming an object is not possible
line 1080 checks if the array has an indices key, but then it is immediately used it anyway

fix:
moved the setting of the $indexUpdate variable down into the if condition, so no error is thrown and it's set for the functions that need it