### PR TITLE
[Installer] Fix creating "system" user

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20220830105212.php
+++ b/bundles/CoreBundle/Migrations/Version20220830105212.php
@@ -16,7 +16,7 @@ final class Version20220830105212 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql("INSERT IGNORE INTO users (`parentId`, `name`, `admin`, `active`) VALUES(0, 'system', 'admin', 'active');");
+        $this->addSql("INSERT IGNORE INTO users (`parentId`, `name`, `admin`, `active`) VALUES(0, 'system', 1, 1);");
         $this->addSql("UPDATE users set id = 0 where name = 'system'");
     }
 

--- a/bundles/CoreBundle/Migrations/Version20220830105212.php
+++ b/bundles/CoreBundle/Migrations/Version20220830105212.php
@@ -22,6 +22,6 @@ final class Version20220830105212 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql("DELETE FROM users WHERE `id` = 0");
+        //no need to delete system user entry
     }
 }

--- a/bundles/CoreBundle/Migrations/Version20220830105212.php
+++ b/bundles/CoreBundle/Migrations/Version20220830105212.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220830105212 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("INSERT IGNORE INTO users (`parentId`, `name`, `admin`, `active`) VALUES(0, 'system', 'admin', 'active');");
+        $this->addSql("UPDATE users set id = 0 where name = 'system'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("DELETE FROM users WHERE `id` = 0");
+    }
+}

--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -613,7 +613,7 @@ class Installer
 
             try {
                 //create a system user with id 0
-                $this->insertSystemUser();
+                $this->insertSystemUser($db);
 
                 if (empty($dataFiles) || !$this->importDatabaseDataDump) {
                     // empty installation
@@ -810,10 +810,8 @@ class Installer
         }
     }
 
-    protected function insertSystemUser()
+    protected function insertSystemUser(Connection $db)
     {
-        $db = \Pimcore\Db::get();
-
         $db->insert('users', [
             'parentId' => 0,
             'name' => 'system',

--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -810,7 +810,7 @@ class Installer
         }
     }
 
-    protected function insertSystemUser(Connection $db)
+    protected function insertSystemUser(Connection $db): void
     {
         $db->insert('users', [
             'parentId' => 0,

--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -612,6 +612,9 @@ class Installer
             $dataFiles = $this->getDataFiles();
 
             try {
+                //create a system user with id 0
+                $this->insertSystemUser();
+
                 if (empty($dataFiles) || !$this->importDatabaseDataDump) {
                     // empty installation
                     $this->insertDatabaseContents();
@@ -756,15 +759,6 @@ class Installer
             'o_userOwner' => 1,
             'o_userModification' => 1,
         ]);
-
-        $db->insert('users', [
-            'parentId' => 0,
-            'name' => 'system',
-            'admin' => 1,
-            'active' => 1,
-        ]);
-        $db->update('users', ['id' => 0], ['name' => 'system']);
-
         $userPermissions = [
             ['key' => 'application_logging'],
             ['key' => 'assets'],
@@ -814,5 +808,18 @@ class Installer
         foreach ($userPermissions as $up) {
             $db->insert('users_permission_definitions', $up);
         }
+    }
+
+    protected function insertSystemUser()
+    {
+        $db = \Pimcore\Db::get();
+
+        $db->insert('users', [
+            'parentId' => 0,
+            'name' => 'system',
+            'admin' => 1,
+            'active' => 1,
+        ]);
+        $db->update('users', ['id' => 0], ['name' => 'system']);
     }
 }


### PR DESCRIPTION
## Changes in this pull request  
Always create a system user with `id = 0`, irrespective of data dump provided.

## Additional info  

