### PR TITLE
[Workflows] Add option to define what to do with unsaved changes when applying a transition

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
@@ -989,9 +989,9 @@ pimcore.elementservice.getWorkflowActionsButton = function(workflows, elementTyp
             };
 
             if (elementEditor.isDirty()) {
-                if (transition.saveBehavior === 'warn') {
+                if (transition.unsavedChangesBehaviour === 'warn') {
                     pimcore.helpers.showNotification(t("error"), t("workflow_transition_unsaved_data"), "error");
-                } else if (transition.saveBehavior === 'save') {
+                } else if (transition.unsavedChangesBehaviour === 'save') {
                     elementEditor.save(null, null, null, function () {
                         applyWorkflow(workflow, transition, elementEditor, elementId, elementType);
                     });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
@@ -994,13 +994,7 @@ pimcore.elementservice.getWorkflowActionsButton = function(workflows, elementTyp
                     iconCls: transition.iconCls,
                     handler: function (workflow, transition) {
 
-                        transition.isGlobalAction = false;
-                        if (transition.notes) {
-                            new pimcore.workflow.transitionPanel(elementType, elementId, elementEditor, workflow.name, transition);
-                        } else {
-                            pimcore.workflow.transitions.perform(elementType, elementId, elementEditor, workflow.name, transition);
-                        }
-
+                        pimcore.elementservice.workflowActionsButtonHandler(workflow, transition, elementEditor, elementId, elementType);
 
                     }.bind(this, workflow, transition)
                 });
@@ -1015,13 +1009,7 @@ pimcore.elementservice.getWorkflowActionsButton = function(workflows, elementTyp
                     iconCls: transition.iconCls,
                     handler: function (workflow, transition) {
 
-                        transition.isGlobalAction = true;
-                        if (transition.notes) {
-                            new pimcore.workflow.transitionPanel(elementType, elementId, elementEditor, workflow.name, transition);
-                        } else {
-                            pimcore.workflow.transitions.perform(elementType, elementId, elementEditor, workflow.name, transition);
-                        }
-
+                        pimcore.elementservice.workflowActionsButtonHandler(workflow, transition, elementEditor, elementId, elementType);
 
                     }.bind(this, workflow, transition)
                 });
@@ -1042,6 +1030,35 @@ pimcore.elementservice.getWorkflowActionsButton = function(workflows, elementTyp
 
     return false;
 };
+
+pimcore.elementservice.workflowActionsButtonHandler = function (workflow, transition, elementEditor, elementId, elementType) {
+    if(elementEditor.isDirty()) {
+        if (transition.saveBehavior === 'warning') {
+
+            pimcore.helpers.showNotification(t("error"), t("workflow_transition_unsaved_data"), "error");
+
+        } else if(transition.saveBehavior === 'save') {
+
+            elementEditor.save(null, null, null, function() {
+                pimcore.elementservice.workflowTransitionSave(workflow, transition, elementEditor, elementId, elementType);
+            });
+
+        } else {
+            pimcore.elementservice.workflowTransitionSave(workflow, transition, elementEditor, elementId, elementType);
+        }
+    } else {
+        pimcore.elementservice.workflowTransitionSave(workflow, transition, elementEditor, elementId, elementType);
+    }
+};
+
+pimcore.elementservice.workflowTransitionSave = function (workflow, transition, elementEditor, elementId, elementType) {
+    transition.isGlobalAction = false;
+    if (transition.notes) {
+        new pimcore.workflow.transitionPanel(elementType, elementId, elementEditor, workflow.name, transition);
+    } else {
+        pimcore.workflow.transitions.perform(elementType, elementId, elementEditor, workflow.name, transition);
+    }
+}
 
 
 pimcore.elementservice.replaceAsset = function (id, callback) {

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -21,6 +21,7 @@ use Pimcore\Targeting\Storage\TargetingStorageInterface;
 use Pimcore\Workflow\EventSubscriber\ChangePublishedStateSubscriber;
 use Pimcore\Workflow\EventSubscriber\NotificationSubscriber;
 use Pimcore\Workflow\Notification\NotificationEmailService;
+use Pimcore\Workflow\Transition;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -1932,6 +1933,13 @@ final class Configuration implements ConfigurationInterface
                                                         ->values([ChangePublishedStateSubscriber::NO_CHANGE, ChangePublishedStateSubscriber::FORCE_UNPUBLISHED, ChangePublishedStateSubscriber::FORCE_PUBLISHED, ChangePublishedStateSubscriber::SAVE_VERSION])
                                                         ->defaultValue(ChangePublishedStateSubscriber::NO_CHANGE)
                                                         ->info('Change published state of element while transition (only available for documents and data objects).')
+                                                    ->end()
+                                                    ->enumNode('saveBehavior')
+                                                        ->values([Transition::OPTIONS_SAVEBEHAVIOR_SAVE,
+                                                                  Transition::OPTIONS_SAVEBEHAVIOR_NOT_SAVE,
+                                                                  Transition::OPTIONS_SAVEBEHAVIOR_WARNING])
+                                                        ->defaultValue(Transition::OPTIONS_SAVEBEHAVIOR_WARNING)
+                                                        ->info('Set saving behavior for workflow transitions: save data before transition, do not save (standard behavior) or show warning popup.')
                                                     ->end()
                                                 ->end()
                                             ->end()

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -1939,7 +1939,7 @@ final class Configuration implements ConfigurationInterface
                                                                   Transition::UNSAVED_CHANGES_BEHAVIOUR_WARN,
                                                                   Transition::UNSAVED_CHANGES_BEHAVIOUR_IGNORE])
                                                         ->defaultValue(Transition::UNSAVED_CHANGES_BEHAVIOUR_WARN)
-                                                        ->info('Set saving behavior for workflow transitions: save data before transition, do not save (standard behavior) or show warning popup.')
+                                                        ->info('Behaviour when workflow transition gets applied but there are unsaved changes')
                                                     ->end()
                                                 ->end()
                                             ->end()

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -1934,11 +1934,11 @@ final class Configuration implements ConfigurationInterface
                                                         ->defaultValue(ChangePublishedStateSubscriber::NO_CHANGE)
                                                         ->info('Change published state of element while transition (only available for documents and data objects).')
                                                     ->end()
-                                                    ->enumNode('saveBehavior')
-                                                        ->values([Transition::OPTIONS_SAVEBEHAVIOR_SAVE,
-                                                                  Transition::OPTIONS_SAVEBEHAVIOR_NOT_SAVE,
-                                                                  Transition::OPTIONS_SAVEBEHAVIOR_WARNING])
-                                                        ->defaultValue(Transition::OPTIONS_SAVEBEHAVIOR_WARNING)
+                                                    ->enumNode('unsavedChangesBehaviour')
+                                                        ->values([Transition::UNSAVED_CHANGES_BEHAVIOUR_SAVE,
+                                                                  Transition::UNSAVED_CHANGES_BEHAVIOUR_WARN,
+                                                                  Transition::UNSAVED_CHANGES_BEHAVIOUR_IGNORE])
+                                                        ->defaultValue(Transition::UNSAVED_CHANGES_BEHAVIOUR_WARN)
                                                         ->info('Set saving behavior for workflow transitions: save data before transition, do not save (standard behavior) or show warning popup.')
                                                     ->end()
                                                 ->end()

--- a/bundles/CoreBundle/Resources/translations/de.json
+++ b/bundles/CoreBundle/Resources/translations/de.json
@@ -788,7 +788,6 @@
     "workflow_actions": "Aktionen",
     "workflow_notes_requred_field_message": "\"%s\" ist erforderlich.",
     "workflow_transition_applied_successfully": "Aktion erfolgreich angewendet",
-    "workflow_transition_unsaved_data": "Sie haben nicht gespeicherte Daten. Bitte speichern Sie die Änderungen, bevor Sie den Workflow-Übergang anwenden.",
     "workflow_change_email_notification_subject": "Workflow-Aktualisierung für %s in Workflow '%s'",
     "workflow_change_email_notification_text": "Für %s mit der ID %s wurde die Aktion \"%s\" im Ablauf '%s' ausgelöst.",
     "workflow_change_email_notification_deeplink": "Deep Link zum Element.",

--- a/bundles/CoreBundle/Resources/translations/de.json
+++ b/bundles/CoreBundle/Resources/translations/de.json
@@ -788,6 +788,7 @@
     "workflow_actions": "Aktionen",
     "workflow_notes_requred_field_message": "\"%s\" ist erforderlich.",
     "workflow_transition_applied_successfully": "Aktion erfolgreich angewendet",
+    "workflow_transition_unsaved_data": "Sie haben nicht gespeicherte Daten. Bitte speichern Sie die Änderungen, bevor Sie den Workflow-Übergang anwenden.",
     "workflow_change_email_notification_subject": "Workflow-Aktualisierung für %s in Workflow '%s'",
     "workflow_change_email_notification_text": "Für %s mit der ID %s wurde die Aktion \"%s\" im Ablauf '%s' ausgelöst.",
     "workflow_change_email_notification_deeplink": "Deep Link zum Element.",

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -818,6 +818,7 @@
     "workflow_actions": "Actions",
     "workflow_notes_requred_field_message": "\"%s\" is a required field.",
     "workflow_transition_applied_successfully": "Action applied successfully",
+    "workflow_transition_unsaved_data": "You have unsaved data. Please, save changes before changing apply workflow transition.",
     "workflow_change_email_notification_subject": "Workflow update for %s in workflow '%s'",
     "workflow_change_email_notification_text": "For %s with ID %s the action \"%s\" was triggered in workflow '%s'.",
     "workflow_change_email_notification_deeplink": "Deeplink to the element.",

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -818,7 +818,7 @@
     "workflow_actions": "Actions",
     "workflow_notes_requred_field_message": "\"%s\" is a required field.",
     "workflow_transition_applied_successfully": "Action applied successfully",
-    "workflow_transition_unsaved_data": "You have unsaved data. Please, save changes before changing apply workflow transition.",
+    "workflow_transition_unsaved_data": "Your data changes have not been saved yet. Please, save changes before applying workflow transition.",
     "workflow_change_email_notification_subject": "Workflow update for %s in workflow '%s'",
     "workflow_change_email_notification_text": "For %s with ID %s the action \"%s\" was triggered in workflow '%s'.",
     "workflow_change_email_notification_deeplink": "Deeplink to the element.",

--- a/doc/Development_Documentation/07_Workflow_Management/01_Configuration_Details/README.md
+++ b/doc/Development_Documentation/07_Workflow_Management/01_Configuration_Details/README.md
@@ -265,7 +265,10 @@ pimcore:
                                 mailPath:             '@PimcoreCore/Workflow/NotificationEmail/notificationEmail.html.twig'
 
                         # Change published state of element while transition (only available for documents and data objects).
-                        changePublishedState: no_change # One of "no_change"; "force_unpublished"; "force_published", "save_version" (since Pimcore 6.6.0)
+                        changePublishedState: no_change # One of "no_change", "force_unpublished", "force_published", "save_version"
+                        
+                        # behaviour when transition gets applied but there are unsaved changes
+                        unsavedChangesBehaviour: warn # One of "warn", "save", "ignore"
 
             # Actions which will be added to actions button independently of the current workflow place.
             globalActions:

--- a/lib/Workflow/ActionsButtonService.php
+++ b/lib/Workflow/ActionsButtonService.php
@@ -55,7 +55,7 @@ class ActionsButtonService
                 'iconCls' => $transition->getIconClass(),
                 'objectLayout' => $transition->getObjectLayout(),
                 'notes' => $notes,
-                'saveBehavior' => $transition->getOptions()['saveBehavior']
+                'saveBehavior' => $transition->getOptions()['unsavedChangesBehaviour']
             ];
         }
 

--- a/lib/Workflow/ActionsButtonService.php
+++ b/lib/Workflow/ActionsButtonService.php
@@ -55,6 +55,7 @@ class ActionsButtonService
                 'iconCls' => $transition->getIconClass(),
                 'objectLayout' => $transition->getObjectLayout(),
                 'notes' => $notes,
+                'saveBehavior' => $transition->getOptions()['saveBehavior']
             ];
         }
 

--- a/lib/Workflow/ActionsButtonService.php
+++ b/lib/Workflow/ActionsButtonService.php
@@ -55,7 +55,7 @@ class ActionsButtonService
                 'iconCls' => $transition->getIconClass(),
                 'objectLayout' => $transition->getObjectLayout(),
                 'notes' => $notes,
-                'saveBehavior' => $transition->getOptions()['saveBehavior']
+                'unsavedChangesBehaviour' => $transition->getOptions()['saveBehavior']
             ];
         }
 

--- a/lib/Workflow/Transition.php
+++ b/lib/Workflow/Transition.php
@@ -25,6 +25,10 @@ class Transition extends \Symfony\Component\Workflow\Transition implements Notes
     use NotesAwareTrait;
     use NotificationTrait;
 
+    public const OPTIONS_SAVEBEHAVIOR_SAVE = 'save';
+    public const OPTIONS_SAVEBEHAVIOR_NOT_SAVE = 'not_save';
+    public const OPTIONS_SAVEBEHAVIOR_WARNING = 'warning';
+
     /**
      * @var array
      */

--- a/lib/Workflow/Transition.php
+++ b/lib/Workflow/Transition.php
@@ -25,9 +25,9 @@ class Transition extends \Symfony\Component\Workflow\Transition implements Notes
     use NotesAwareTrait;
     use NotificationTrait;
 
-    public const OPTIONS_SAVEBEHAVIOR_SAVE = 'save';
-    public const OPTIONS_SAVEBEHAVIOR_NOT_SAVE = 'not_save';
-    public const OPTIONS_SAVEBEHAVIOR_WARNING = 'warning';
+    public const UNSAVED_CHANGES_BEHAVIOUR_SAVE = 'save';
+    public const UNSAVED_CHANGES_BEHAVIOUR_IGNORE = 'ignore';
+    public const UNSAVED_CHANGES_BEHAVIOUR_WARN = 'warn';
 
     /**
      * @var array


### PR DESCRIPTION
As discussed in #7660 it is an inconvenient workflow when you want to do some changes to a data object and afterwards apply a workflow transition. Currently you have to save the object first and then apply the workflow. If you miss the saving, currently the transition is tried to be applied without the just made changes.

This PR adds a new option `unsavedChangesBehaviour` for each transition with the possible values:
- `warn`: Show warning message that the object has not been saved yet. Do not apply transition.
- `save`: Save the object implicitly and apply workflow transition
- `ignore`: Do not save the object and apply workflow transition (this is current behaviour)

Default is `warn`.

Resolves #7660.