### PR TITLE
Update thumbnail forwarding path for docs

### DIFF
--- a/doc/Development_Documentation/04_Assets/07_Restricting_Public_Asset_Access.md
+++ b/doc/Development_Documentation/04_Assets/07_Restricting_Public_Asset_Access.md
@@ -171,7 +171,7 @@ class MyAssetController extends FrontendController
 
                 try {
                     $parameters = $matcher->matchRequest($request);
-                    return $this->forward('PimcoreCoreBundle:PublicServices:thumbnail', $parameters);
+                    return $this->forward('Pimcore\Bundle\CoreBundle\Controller\PublicServicesController::thumbnailAction', $parameters);
                 } catch (\Exception $e) {
                     // nothing to do
                 }


### PR DESCRIPTION
Thumbnail forwarding path is updated to match and work with forward for protected asset access

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Documentation updated for thumbnail forwarding protected assets

## Additional info  

