### PR TITLE
Log error and return null when ffmpeg couldn't read dimensions/duration

### DIFF
--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -69,27 +69,18 @@ class AssetUpdateTasksHandler
 
     private function processVideo(Asset\Video $asset): void
     {
-        try {
-            $asset->setCustomSetting('duration', $asset->getDurationFromBackend());
-        } catch (\Exception $e) {
-            Logger::err('Unable to get duration of video: ' . $asset->getId());
-
-            throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
+        if ($duration = $asset->getDurationFromBackend()) {
+            $asset->setCustomSetting('duration', $duration);
+        } else {
+            $asset->removeCustomSetting('duration');
         }
 
-        try {
-            $dimensions = $asset->getDimensionsFromBackend();
-            if ($dimensions) {
-                $asset->setCustomSetting('videoWidth', $dimensions['width']);
-                $asset->setCustomSetting('videoHeight', $dimensions['height']);
-            } else {
-                $asset->removeCustomSetting('videoWidth');
-                $asset->removeCustomSetting('videoHeight');
-            }
-        } catch (\Exception $e) {
-            Logger::err('Unable to get dimensions of video: ' . $asset->getId());
-
-            throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
+        if ($dimensions = $asset->getDimensionsFromBackend()) {
+            $asset->setCustomSetting('videoWidth', $dimensions['width']);
+            $asset->setCustomSetting('videoHeight', $dimensions['height']);
+        } else {
+            $asset->removeCustomSetting('videoWidth');
+            $asset->removeCustomSetting('videoHeight');
         }
 
         $asset->handleEmbeddedMetaData(true);

--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -86,7 +86,9 @@ class AssetUpdateTasksHandler
         $asset->handleEmbeddedMetaData(true);
         $this->saveAsset($asset);
 
-        $asset->getImageThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->generate(false);
+        if ($asset->getCustomSetting('videoWidth') && $asset->getCustomSetting('videoHeight')) {
+            $asset->getImageThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->generate(false);
+        }
     }
 
     private function processImage(Asset\Image $image): void

--- a/lib/Video/Adapter.php
+++ b/lib/Video/Adapter.php
@@ -217,15 +217,11 @@ abstract class Adapter
 
     /**
      * @return float|null
-     *
-     * @throws \Exception
      */
     abstract public function getDuration();
 
     /**
-     * @return array
-     *
-     * @throws \Exception
+     * @return array|null
      */
     abstract public function getDimensions();
 }

--- a/lib/Video/Adapter.php
+++ b/lib/Video/Adapter.php
@@ -224,6 +224,8 @@ abstract class Adapter
 
     /**
      * @return array
+     *
+     * @throws \Exception
      */
     abstract public function getDimensions();
 }

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -15,7 +15,6 @@
 
 namespace Pimcore\Video\Adapter;
 
-use Pimcore\File;
 use Pimcore\Logger;
 use Pimcore\Tool\Console;
 use Pimcore\Video\Adapter;
@@ -193,8 +192,10 @@ class Ffmpeg extends Adapter
             } else {
                 // create an error log file
                 if (file_exists($this->getConversionLogFile()) && filesize($this->getConversionLogFile())) {
-                    copy($this->getConversionLogFile(),
-                        str_replace('.log', '.error.log', $this->getConversionLogFile()));
+                    copy(
+                        $this->getConversionLogFile(),
+                        str_replace('.log', '.error.log', $this->getConversionLogFile())
+                    );
                 }
             }
         } else {
@@ -214,13 +215,12 @@ class Ffmpeg extends Adapter
             $timeOffset = 5;
         }
 
-        $realTargetPath = null;
-
         $cmd = [
             self::getFfmpegCli(),
             '-ss', $timeOffset, '-i', realpath($this->file),
             '-vcodec', 'png', '-vframes', 1, '-vf', 'scale=iw*sar:ih',
-            str_replace('/', DIRECTORY_SEPARATOR, $file), ];
+            str_replace('/', DIRECTORY_SEPARATOR, $file),
+        ];
         Console::addLowProcessPriority($cmd);
         $process = new Process($cmd);
         $process->run();
@@ -257,19 +257,24 @@ class Ffmpeg extends Adapter
      */
     public function getDuration()
     {
-        $output = $this->getVideoInfo();
+        try {
+            $output = $this->getVideoInfo();
 
-        // get total video duration
-        $result = preg_match("/Duration: (\d\d):(\d\d):(\d\d\.\d+),/", $output, $matches);
+            // get total video duration
+            $result = preg_match('/Duration: (\d\d):(\d\d):(\d\d\.\d+),/', $output, $matches);
 
-        if ($result) {
-            // calculate duration in seconds
-            $duration = ((int)$matches[1] * 3600) + ((int)$matches[2] * 60) + (float)$matches[3];
+            if ($result) {
+                // calculate duration in seconds
+                $duration = ((int)$matches[1] * 3600) + ((int)$matches[2] * 60) + (float)$matches[3];
 
-            return $duration;
+                return $duration;
+            }
+            throw new \Exception(
+                'Could not read duration with FFMPEG Adapter. File: ' . $this->file . '. Output: ' . $output
+            );
+        } catch (\Exception $e) {
+            Logger::error($e->getMessage());
         }
-
-        Logger::error('Could not read duration with FFMPEG Adapter. File: ' . $this->file . '. Output: ' . $output);
 
         return null;
     }
@@ -279,16 +284,22 @@ class Ffmpeg extends Adapter
      */
     public function getDimensions()
     {
-        $output = $this->getVideoInfo();
+        try {
+            $output = $this->getVideoInfo();
 
-        if (preg_match('/ ([0-9]+x[0-9]+)[, ]/', $output, $matches)) {
-            $dimensionRaw = $matches[1];
-            list($width, $height) = explode('x', $dimensionRaw);
+            if (preg_match('/ ([0-9]+x[0-9]+)[, ]/', $output, $matches)) {
+                $dimensionRaw = $matches[1];
+                list($width, $height) = explode('x', $dimensionRaw);
 
-            return ['width' => $width, 'height' => $height];
+                return ['width' => $width, 'height' => $height];
+            }
+
+            throw new \Exception(
+                'Could not read dimensions with FFMPEG Adapter. File: ' . $this->file . '. Output: ' . $output
+            );
+        } catch (\Exception $e) {
+            Logger::error($e->getMessage());
         }
-
-        Logger::error('Could not read dimensions with FFMPEG Adapter. File: ' . $this->file . '. Output: ' . $output);
 
         return null;
     }

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -276,16 +276,23 @@ class Ffmpeg extends Adapter
 
     /**
      * @return array
+     *
+     * @throws \Exception
      */
     public function getDimensions()
     {
         $output = $this->getVideoInfo();
 
-        preg_match('/ ([0-9]+x[0-9]+)[, ]/', $output, $matches);
-        $durationRaw = $matches[1];
-        list($width, $height) = explode('x', $durationRaw);
+        if (preg_match('/ ([0-9]+x[0-9]+)[, ]/', $output, $matches)) {
+            $durationRaw = $matches[1];
+            list($width, $height) = explode('x', $durationRaw);
 
-        return ['width' => $width, 'height' => $height];
+            return ['width' => $width, 'height' => $height];
+        }
+
+        throw new \Exception(
+            'Could not read dimensions from FFMPEG. Maybe not supported FFMPEG version. Output from FFMPEG: ' . $output
+        );
     }
 
     public function destroy()

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -269,9 +269,7 @@ class Ffmpeg extends Adapter
             return $duration;
         }
 
-        Logger::error(
-            'Could not read duration with FFMPEG Adapter. Maybe not supported FFMPEG version. Output from FFMPEG: ' . $output
-        );
+        Logger::error('Could not read duration with FFMPEG Adapter. File: ' . $this->file . '. Output: ' . $output);
 
         return null;
     }
@@ -290,9 +288,7 @@ class Ffmpeg extends Adapter
             return ['width' => $width, 'height' => $height];
         }
 
-        Logger::error(
-            'Could not read dimensions with FFMPEG Adapter. Maybe not supported FFMPEG version. Output from FFMPEG: ' . $output
-        );
+        Logger::error('Could not read dimensions with FFMPEG Adapter. File: ' . $this->file . '. Output: ' . $output);
 
         return null;
     }

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -254,8 +254,6 @@ class Ffmpeg extends Adapter
 
     /**
      * @return float|null
-     *
-     * @throws \Exception
      */
     public function getDuration()
     {
@@ -271,28 +269,32 @@ class Ffmpeg extends Adapter
             return $duration;
         }
 
+        Logger::error(
+            'Could not read duration with FFMPEG Adapter. Maybe not supported FFMPEG version. Output from FFMPEG: ' . $output
+        );
+
         return null;
     }
 
     /**
-     * @return array
-     *
-     * @throws \Exception
+     * @return array|null
      */
     public function getDimensions()
     {
         $output = $this->getVideoInfo();
 
         if (preg_match('/ ([0-9]+x[0-9]+)[, ]/', $output, $matches)) {
-            $durationRaw = $matches[1];
-            list($width, $height) = explode('x', $durationRaw);
+            $dimensionRaw = $matches[1];
+            list($width, $height) = explode('x', $dimensionRaw);
 
             return ['width' => $width, 'height' => $height];
         }
 
-        throw new \Exception(
-            'Could not read dimensions from FFMPEG. Maybe not supported FFMPEG version. Output from FFMPEG: ' . $output
+        Logger::error(
+            'Could not read dimensions with FFMPEG Adapter. Maybe not supported FFMPEG version. Output from FFMPEG: ' . $output
         );
+
+        return null;
     }
 
     public function destroy()

--- a/models/Asset/Video.php
+++ b/models/Asset/Video.php
@@ -187,8 +187,6 @@ class Video extends Model\Asset
      * @param string|null $filePath
      *
      * @return float|null
-     *
-     * @throws \Exception
      */
     public function getDurationFromBackend(?string $filePath = null)
     {
@@ -210,8 +208,6 @@ class Video extends Model\Asset
      * @internal
      *
      * @return array|null
-     *
-     * @throws \Exception
      */
     public function getDimensionsFromBackend()
     {


### PR DESCRIPTION
See https://github.com/pimcore/pimcore/issues/13038

Exceptions are already catched and logged in the messanger handler:
https://github.com/pimcore/pimcore/blob/b3f3111ce0a781069f6289e03fcfe5e974a98c29/lib/Messenger/Handler/AssetUpdateTasksHandler.php#L80-L93