### PR TITLE
Fix migration for creating system user - 

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20220830105212.php
+++ b/bundles/CoreBundle/Migrations/Version20220830105212.php
@@ -30,7 +30,7 @@ final class Version20220830105212 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addSql("INSERT IGNORE INTO users (`parentId`, `name`, `admin`, `active`) VALUES(0, 'system', 1, 1);");
-        $this->addSql("UPDATE users set id = 0 where name = 'system'");
+        $this->addSql("UPDATE users set id = 0 where name = 'system' AND type = 'user'");
     }
 
     public function down(Schema $schema): void

--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -707,9 +707,6 @@ class Installer
 
             $db->executeStatement(implode("\n", $batchQueries));
         }
-
-        // set the id of the system user to 0
-        $db->update('users', ['id' => 0], ['name' => 'system']);
     }
 
     protected function insertDatabaseContents()
@@ -818,6 +815,8 @@ class Installer
             'admin' => 1,
             'active' => 1,
         ]);
+        
+        // set the id of the system user to 0
         $db->update('users', ['id' => 0], ['name' => 'system', 'type' => 'user' ]);
     }
 }

--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -818,6 +818,6 @@ class Installer
             'admin' => 1,
             'active' => 1,
         ]);
-        $db->update('users', ['id' => 0], ['name' => 'system']);
+        $db->update('users', ['id' => 0], ['name' => 'system', 'type' => 'user' ]);
     }
 }


### PR DESCRIPTION
## Changes in this pull request  
Follow up #13001

## Additional info  
Fixes the duplicate entry error when a user folder exists with name `System` and the migration tries to update the rows with name `system` being case insensitive. please see https://github.com/pimcore/pimcore/pull/13001#issuecomment-1234327003