### PR TITLE
Fix new PhpStan errors

### DIFF
--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -558,7 +558,7 @@ class Installer
         }
 
         // see Symfony's cache:clear command
-        $oldCacheDir = substr($cacheDir, 0, -1) . ('~' === substr($cacheDir, -1) ? '+' : '~');
+        $oldCacheDir = substr($cacheDir, 0, -1) . '~';
 
         $filesystem = new Filesystem();
         if ($filesystem->exists($oldCacheDir)) {

--- a/composer.json
+++ b/composer.json
@@ -171,8 +171,8 @@
   "require-dev": {
     "codeception/codeception": "^4.1.12",
     "codeception/phpunit-wrapper": "^9",
-    "phpstan/phpstan": "^1.8.1",
-    "phpstan/phpstan-symfony": "^1.2.2",
+    "phpstan/phpstan": "^1.8.3",
+    "phpstan/phpstan-symfony": "^1.2.13",
     "phpunit/phpunit": "^9.3",
     "spiritix/php-chrome-html2pdf": "^1.6",
     "elasticsearch/elasticsearch": "^7.11",

--- a/lib/Twig/Extension/Templating/HeadStyle.php
+++ b/lib/Twig/Extension/Templating/HeadStyle.php
@@ -385,7 +385,7 @@ class HeadStyle extends AbstractExtension implements RuntimeExtensionInterface
             . $escapeStart . $indent . $item->content . PHP_EOL . $escapeEnd
             . '</style>';
 
-        if (null == $escapeStart && null == $escapeEnd) {
+        if (null === $escapeStart) {
             if (str_replace(' ', '', $item->attributes['conditional']) === '!IE') {
                 $html = '<!-->' . $html . '<!--';
             }

--- a/models/DataObject/ClassDefinition/Data/InputQuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/InputQuantityValue.php
@@ -96,13 +96,11 @@ class InputQuantityValue extends QuantityValue
     public function getDataFromEditmode($data, $object = null, $params = [])
     {
         if ($data['value'] || $data['unit']) {
-            if ($data['unit']) {
-                if ($data['unit'] == -1 || $data['unit'] == null || empty($data['unit'])) {
-                    return $this->getNewDataObject($data['value'], null);
-                }
-
-                return $this->getNewDataObject($data['value'], $data['unit']);
+            if ($data['unit'] == -1 || empty($data['unit'])) {
+                return $this->getNewDataObject($data['value'], null);
             }
+
+            return $this->getNewDataObject($data['value'], $data['unit']);
         }
 
         return null;

--- a/models/DataObject/ClassDefinition/Data/InputQuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/InputQuantityValue.php
@@ -96,7 +96,7 @@ class InputQuantityValue extends QuantityValue
     public function getDataFromEditmode($data, $object = null, $params = [])
     {
         if ($data['value'] || $data['unit']) {
-            if ($data['unit'] == -1 || empty($data['unit'])) {
+            if (empty($data['unit']) || $data['unit'] == -1) {
                 return $this->getNewDataObject($data['value'], null);
             }
 

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -610,7 +610,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
     public function getDataFromEditmode($data, $object = null, $params = [])
     {
         if (strlen($data['value']) > 0 || $data['unit']) {
-            if ($data['unit'] == -1 || $data['unit'] == null || empty($data['unit'])) {
+            if ($data['unit'] == -1 || empty($data['unit'])) {
                 return new Model\DataObject\Data\QuantityValue($data['value'], null);
             }
 

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -610,7 +610,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
     public function getDataFromEditmode($data, $object = null, $params = [])
     {
         if (strlen($data['value']) > 0 || $data['unit']) {
-            if ($data['unit'] == -1 || empty($data['unit'])) {
+            if (empty($data['unit']) || $data['unit'] == -1) {
                 return new Model\DataObject\Data\QuantityValue($data['value'], null);
             }
 

--- a/models/Tool/CustomReport/Adapter/Sql.php
+++ b/models/Tool/CustomReport/Adapter/Sql.php
@@ -117,17 +117,10 @@ class Sql extends AbstractAdapter
         }
 
         if (!empty($config['where'])) {
-            $whereParts = [];
-            if (!empty($config['where'])) {
-                if (strpos(strtoupper(trim($config['where'])), 'WHERE') === 0) {
-                    $config['where'] = preg_replace('/^\s*WHERE\s*/', '', $config['where']);
-                }
-                $whereParts[] = '(' . str_replace("\n", ' ', $config['where']) . ')';
+            if (strpos(strtoupper(trim($config['where'])), 'WHERE') === 0) {
+                $config['where'] = preg_replace('/^\s*WHERE\s*/', '', $config['where']);
             }
-
-            if ($whereParts) {
-                $sql .= ' WHERE ' . implode(' AND ', $whereParts);
-            }
+            $sql .= ' WHERE (' . str_replace("\n", ' ', $config['where']) . ')';
         }
 
         if (!empty($config['groupby']) && !$ignoreSelectAndGroupBy) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -256,7 +256,7 @@ parameters:
 			path: models/Document/Hardlink/Wrapper/Snippet.php
 
 		-
-			message: "#^Parameter \\#1 \\$children of method Pimcore\\\\Model\\\\DataObject\\\\AbstractObject\\:\\:setChildren\\(\\) expects array\\<Pimcore\\\\Model\\\\DataObject\\>\\|null, array\\<Pimcore\\\\Model\\\\Element\\\\ElementInterface\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$children of method Pimcore\\\\Model\\\\DataObject\\\\AbstractObject\\:\\:setChildren\\(\\) expects array\\<Pimcore\\\\Model\\\\Asset\\|Pimcore\\\\Model\\\\DataObject\\|Pimcore\\\\Model\\\\Document\\>\\|null, array\\<Pimcore\\\\Model\\\\Element\\\\ElementInterface\\> given\\.$#"
 			count: 1
 			path: models/Element/Service.php
 


### PR DESCRIPTION
The new PhpStan version 1.8.3 find new errors
```
------ -------------------------------------------------------------------------------- 
  Line   bundles/InstallBundle/Installer.php                                             
 ------ -------------------------------------------------------------------------------- 
  561    Strict comparison using === between '~' and 'e' will always evaluate to false.  
 ------ -------------------------------------------------------------------------------- 

 ------ --------------------------------------------- 
  Line   lib/Twig/Extension/Templating/HeadStyle.php  
 ------ --------------------------------------------- 
  388    Right side of && is always true.             
 ------ --------------------------------------------- 

 ------ ------------------------------------------------------------------- 
  Line   models/DataObject/ClassDefinition/Data/InputQuantityValue.php      
 ------ ------------------------------------------------------------------- 
  100    Offset 'unit' on array in empty() always exists and is not falsy.  
 ------ ------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------- 
  Line   models/DataObject/ClassDefinition/Data/QuantityValue.php           
 ------ ------------------------------------------------------------------- 
  613    Offset 'unit' on array in empty() always exists and is not falsy.  
 ------ ------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   models/Element/Service.php                                                                                                                                                                                                      
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
         Ignored error pattern #^Parameter \#1 \$children of method Pimcore\\Model\\DataObject\\AbstractObject\:\:setChildren\(\) expects array<Pimcore\\Model\\DataObject>\|null, array<Pimcore\\Model\\Element\\ElementInterface>      
         given\.$# in path /var/www/html/models/Element/Service.php was not matched in reported errors.                                                                                                                                  
  713    Parameter #1 $children of method Pimcore\Model\DataObject\AbstractObject::setChildren() expects array<Pimcore\Model\Asset|Pimcore\Model\DataObject|Pimcore\Model\Document>|null, array<Pimcore\Model\Element\ElementInterface>  
         given.                                                                                                                                                                                                                          
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------- 
  Line   models/Tool/CustomReport/Adapter/Sql.php                            
 ------ -------------------------------------------------------------------- 
  121    Offset 'where' on array in empty() always exists and is not falsy.  
  128    If condition is always true.                                        
 ------ -------------------------------------------------------------------- 
```