### PR TITLE
Fix issue with trying to get cart with empty id when setting values

### DIFF
--- a/bundles/EcommerceFrameworkBundle/CartManager/AbstractCartItem.php
+++ b/bundles/EcommerceFrameworkBundle/CartManager/AbstractCartItem.php
@@ -102,7 +102,7 @@ abstract class AbstractCartItem extends \Pimcore\Model\AbstractModel implements 
      */
     public function setProduct(CheckoutableInterface $product, bool $fireModified = true)
     {
-        if ($this->productId !== $product->getId() && $this->getCart() && !$this->isLoading && $fireModified) {
+        if ($this->productId !== $product->getId() && !$this->isLoading && $this->getCart() && $fireModified) {
             $this->getCart()->modified();
         }
         $this->product = $product;
@@ -179,7 +179,7 @@ abstract class AbstractCartItem extends \Pimcore\Model\AbstractModel implements 
      */
     public function setProductId($productId)
     {
-        if ($this->productId !== $productId && $this->getCart() && !$this->isLoading) {
+        if ($this->productId !== $productId && !$this->isLoading && $this->getCart()) {
             $this->getCart()->modified();
         }
         $this->productId = $productId;


### PR DESCRIPTION
Fix issue with trying to get cart with empty id when setting values from Dao.

The logic at this line will result in an "raw" array based on the table column-order where productId comes before cartId.
This means we will call the function CartItem::setProductId() that will call self::getCart() and acctualy perform an SQL-query with an empty cartId. 

https://github.com/pimcore/pimcore/blob/10.5/bundles/EcommerceFrameworkBundle/CartManager/CartItem/Dao.php#L68 

Before (cart containing 44 items - our use-case can have 200+ items):
![bild](https://user-images.githubusercontent.com/817312/188285093-3da15fb6-cd1c-4e43-ab26-23b13a0e9e79.png)

After (gone ):
![bild](https://user-images.githubusercontent.com/817312/188285136-b5d269f5-7923-43a9-92ba-bb1c18c47bd1.png)


## Changes in this pull request  
Switching logic order of if-statment in bundles/EcommerceFrameworkBundle/CartManager/AbstractCartItem.php
