### PR TITLE
fix: if error_pages undef, exception render uses invalid keys

### DIFF
--- a/bundles/CoreBundle/EventListener/ResponseExceptionListener.php
+++ b/bundles/CoreBundle/EventListener/ResponseExceptionListener.php
@@ -192,8 +192,8 @@ class ResponseExceptionListener implements EventSubscriberInterface
             $localizedErrorDocumentsPaths = $site->getLocalizedErrorDocuments() ?: [];
             $defaultErrorDocumentPath = $site->getErrorDocument();
         } else {
-            $localizedErrorDocumentsPaths = $this->config['documents']['error_pages']['localized'] ?: [];
-            $defaultErrorDocumentPath = $this->config['documents']['error_pages']['default'] ?: '';
+            $localizedErrorDocumentsPaths = $this->config['documents']['error_pages']['localized'] ?? [];
+            $defaultErrorDocumentPath = $this->config['documents']['error_pages']['default'] ?? '';
         }
 
         if (!empty($locale) && array_key_exists($locale, $localizedErrorDocumentsPaths)) {


### PR DESCRIPTION
## Changes in this pull request  
If `error_pages` is undefined, this handler will produce 

```
Warning: Undefined array key "error_pages" in vendor/pimcore/pimcore/bundles/CoreBundle/EventListener/ResponseExceptionListener.php line 195
```