### PR TITLE
[Bug]: Overriding "From" in newsletter for test mail does not work

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/EmailController.php
+++ b/bundles/AdminBundle/Controller/Admin/EmailController.php
@@ -391,23 +391,6 @@ class EmailController extends AdminController
 
         $mail = new Mail();
 
-        if ($from = $request->get('from')) {
-            $addressArray = \Pimcore\Helper\Mail::parseEmailAddressField($from);
-            if ($addressArray) {
-                //use the first address only
-                list($cleanedFromAddress) = $addressArray;
-                $mail->from(new Address($cleanedFromAddress['email'], $cleanedFromAddress['name'] ?? ''));
-            }
-        }
-
-        $toAddresses = \Pimcore\Helper\Mail::parseEmailAddressField($request->get('to'));
-        foreach ($toAddresses as $cleanedToAddress) {
-            $mail->addTo($cleanedToAddress['email'], $cleanedToAddress['name'] ?? '');
-        }
-
-        $mail->subject($request->get('subject'));
-        $mail->setIgnoreDebugMode(true);
-
         if ($request->get('emailType') == 'text') {
             $mail->text($request->get('content'));
         } elseif ($request->get('emailType') == 'html') {
@@ -431,6 +414,23 @@ class EmailController extends AdminController
                 throw new \Exception('Email document not found!');
             }
         }
+
+        if ($from = $request->get('from')) {
+            $addressArray = \Pimcore\Helper\Mail::parseEmailAddressField($from);
+            if ($addressArray) {
+                //use the first address only
+                list($cleanedFromAddress) = $addressArray;
+                $mail->from(new Address($cleanedFromAddress['email'], $cleanedFromAddress['name'] ?? ''));
+            }
+        }
+
+        $toAddresses = \Pimcore\Helper\Mail::parseEmailAddressField($request->get('to'));
+        foreach ($toAddresses as $cleanedToAddress) {
+            $mail->addTo($cleanedToAddress['email'], $cleanedToAddress['name'] ?? '');
+        }
+
+        $mail->subject($request->get('subject'));
+        $mail->setIgnoreDebugMode(true);
 
         $mail->send();
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/13004

## Additional info  
Just swapped the order of these 2 blocks (the one that defines the content and the from/to/subject setters).
The problem is caused by `$mail->setDocument($doc)` which calls  [setDocumentSettings()](https://github.com/pimcore/pimcore/blob/7702e75426a53a63c21f6fb2049c48841e2a028c/lib/Mail.php#L419) and loads the `from/to/subject` fields with the predefined ones in document Settings, in this case it was "overwriting" the value passed in the test mail form.