### PR TITLE
[Recycle bin] Add date index

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20220906111031.php
+++ b/bundles/CoreBundle/Migrations/Version20220906111031.php
@@ -29,11 +29,11 @@ final class Version20220906111031 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql("ALTER TABLE `recyclebin` ADD INDEX recyclebin_date (`date`)");
+        $this->addSql("ALTER TABLE `recyclebin` ADD INDEX `recyclebin_date` (`date`)");
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `recyclebin` DROP INDEX recyclebin_date');
+        $this->addSql('ALTER TABLE `recyclebin` DROP INDEX `recyclebin_date`');
     }
 }

--- a/bundles/CoreBundle/Migrations/Version20220906111031.php
+++ b/bundles/CoreBundle/Migrations/Version20220906111031.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220906111031 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add date index to recyclebin table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE `recyclebin` ADD INDEX recyclebin_date (`date`)");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE `recyclebin` DROP INDEX recyclebin_date');
+    }
+}

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -400,7 +400,8 @@ CREATE TABLE `recyclebin` (
   `amount` int(3) default NULL,
   `date` int(11) unsigned default NULL,
   `deletedby` varchar(50) DEFAULT NULL,
-  PRIMARY KEY  (`id`)
+  PRIMARY KEY  (`id`),
+  INDEX `recyclebin_date` (`date`)
 ) DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `redirects`;


### PR DESCRIPTION
By default the recycle bin is sorted by `date`, see https://github.com/pimcore/pimcore/blob/2ccdd54162f97b5e89caf1f25fee76bfadf8f972/bundles/AdminBundle/Controller/Admin/RecyclebinController.php#L56

Currently there is no database index covering this. With lots of recycle bin items this may take some time to load the list. This PR adds a database index.