### PR TITLE
Added reset option for getChildren on objects. Solves the problem tha…

### DIFF
--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -522,11 +522,16 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     /**
      * @param array $objectTypes
      * @param bool $includingUnpublished
+     * @param bool $resetCache
      *
      * @return DataObject[]
      */
-    public function getChildren(array $objectTypes = [self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_FOLDER], $includingUnpublished = false)
+    public function getChildren(array $objectTypes = [self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_FOLDER], $includingUnpublished = false, bool $resetCache = false)
     {
+        if ($resetCache) {
+            $this->resetChildCache();
+        }
+
         $cacheKey = $this->getListingCacheKey(func_get_args());
 
         if (!isset($this->o_children[$cacheKey])) {
@@ -1452,5 +1457,13 @@ abstract class AbstractObject extends Model\Element\AbstractElement
         }
 
         parent::__wakeup();
+    }
+
+    /**
+     * @return void
+     */
+    private function resetChildCache(): void
+    {
+        $this->o_children = [];
     }
 }

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1135,8 +1135,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     {
         if ($children === null) {
             // unset all cached children
-            $this->o_children = [];
-            $this->o_hasChildren = [];
+            $this->resetChildCache();
         } elseif (is_array($children)) {
             //default cache key
             $cacheKey = $this->getListingCacheKey([$objectTypes, $includingUnpublished]);
@@ -1465,5 +1464,6 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     private function resetChildCache(): void
     {
         $this->o_children = [];
+        $this->o_hasChildren = [];
     }
 }

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -1118,8 +1118,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
     public function setChildrenSortBy($childrenSortBy)
     {
         if ($this->o_childrenSortBy !== $childrenSortBy) {
-            $this->o_children = [];
-            $this->o_hasChildren = [];
+            $this->resetChildCache();
         }
         $this->o_childrenSortBy = $childrenSortBy;
     }


### PR DESCRIPTION
Hey Folks!

There are certain cases in which your're playing around with objects during one (long) reqest.
Storing new Objects and adding new requires to check whether recently created children of an object to clash with names. Therefore all recently (as well as old objects) must be get-able.

We can see here that $object->getChildAmount() increases as expected during creation of multiple children of one parent, but $object->getChildren() is always the same array.
This is caused due to the in-class caching via the $o_children[$cacheKey] variable.

To circumvent this problem I've added the option to manually reset this cache.

  

## Changes in this pull request  
- New private method to reset the $o_children var
- New optional param to reset the cache during fetching of children

## Additional info  

Cheers!
