### PR TITLE
Use TEMPLATE_LOCATION_GLOBAL by default

### DIFF
--- a/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/02_Bricks.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/02_Bricks.md
@@ -72,10 +72,10 @@ The template location defines the base path which will be used to find your temp
 locations. `<bundlePath>` is the filesystem path of the bundle the brick resides in, `<brickId>` the ID of the brick 
 as registered on the areabrick manager (see below).
 
-| Location | Path                                           |
-|----------|------------------------------------------------|
-| global   | `templates/areas/<brickId>`                    |
-| bundle   | `<bundlePath>/Resources/views/Areas/<brickId>` |
+| Location | Path                                                                                                                                                                                    |
+|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| global   | `templates/areas/<brickId>/`                                                                                                                                                            |
+| bundle   | `<bundlePath>/Resources/views/areas/<brickId>/` for legacy (Symfony <= 4) bundle strucure<br>or<br>`<bundlePath>/templates/areas/<brickId>/` for modern (Symfony >= 5) bundle structure |
 
 Depending on the template location, the following files will be used. You can always completely control locations by 
 implementing the methods for templates and icon yourself (see `AreabrickInterface`):

--- a/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/02_Bricks.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/02_Bricks.md
@@ -136,11 +136,6 @@ class Iframe extends AbstractTemplateAreabrick
     {
         return 'Embed contents from other URL (websites) via iframe';
     }
-
-    public function getTemplateLocation()
-    {
-        return static::TEMPLATE_LOCATION_GLOBAL;
-    }
     
     public function needsReload(): bool
     {

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -71,6 +71,7 @@ Please make sure to set your preferred storage location ***before*** migration. 
 - [Email] Bumped `league/html-to-markdown` to ^5.1.
 - [DataObjects] Changed `$objectTypes` default value to include variants in certain scenarios.
 - [Elements]: Removed deprecated `getTotalCount()` method
+- [Areabricks] The default template location of `AbstractTemplateAreabrick` is now `TEMPLATE_LOCATION_GLOBAL`.
 
 ## 10.5.0
 - [Class Definitions] Resolving classes or services will no longer catch exceptions in Pimcore 11. Remove invalid references from class definitions.

--- a/lib/Extension/Document/Areabrick/AbstractTemplateAreabrick.php
+++ b/lib/Extension/Document/Areabrick/AbstractTemplateAreabrick.php
@@ -18,10 +18,14 @@ namespace Pimcore\Extension\Document\Areabrick;
 /**
  * Base brick with template autoloading capabilities.
  *
- * Depending on the result of getTemplateLocation and getTemplateSuffix the tag handler builds the following references:
+ * Depending on the result of getTemplateLocation() and getTemplateSuffix() the tag handler builds the
+ * following references:
  *
- * - <currentBundle>:Areas/<brickId>/(view|edit).<suffix>
- * - Areas/<brickId>/(view|edit).<suffix> -> resolves to app/Resources
+ * - @<bundle>/[A|a]reas/<brickId>/view.<suffix>
+ *      -> resolves to <bundle>/templates/[A|a]reas/<brickId>/view.<suffix> (Symfony >= 5 structure)
+ *         or <bundle>/Resources/views/[A|a]reas/<brickId>/view.<suffix> (Symfony <= 4 structure)
+ * - areas/<brickId>/view.<suffix>
+ *      -> resolves to <project>/templates/areas/<brickId>/view.<suffix>
  */
 abstract class AbstractTemplateAreabrick extends AbstractAreabrick
 {

--- a/lib/Extension/Document/Areabrick/AbstractTemplateAreabrick.php
+++ b/lib/Extension/Document/Areabrick/AbstractTemplateAreabrick.php
@@ -39,7 +39,7 @@ abstract class AbstractTemplateAreabrick extends AbstractAreabrick implements Te
      */
     public function getTemplateLocation()
     {
-        return static::TEMPLATE_LOCATION_BUNDLE;
+        return static::TEMPLATE_LOCATION_GLOBAL;
     }
 
     /**

--- a/lib/Extension/Document/Areabrick/AbstractTemplateAreabrick.php
+++ b/lib/Extension/Document/Areabrick/AbstractTemplateAreabrick.php
@@ -23,7 +23,7 @@ namespace Pimcore\Extension\Document\Areabrick;
  * - <currentBundle>:Areas/<brickId>/(view|edit).<suffix>
  * - Areas/<brickId>/(view|edit).<suffix> -> resolves to app/Resources
  */
-abstract class AbstractTemplateAreabrick extends AbstractAreabrick implements TemplateAreabrickInterface
+abstract class AbstractTemplateAreabrick extends AbstractAreabrick
 {
     /**
      * {@inheritdoc}

--- a/lib/Extension/Document/Areabrick/TemplateAreabrickInterface.php
+++ b/lib/Extension/Document/Areabrick/TemplateAreabrickInterface.php
@@ -20,9 +20,9 @@ namespace Pimcore\Extension\Document\Areabrick;
  * Depending on the result of getTemplateLocation() and getTemplateSuffix() the tag handler builds the
  * following references:
  *
- * - @<bundle>/[A|a]reas/<brickId>/view.<suffix>
- *      -> resolves to <bundle>/templates/[A|a]reas/<brickId>/view.<suffix> (Symfony >= 5 structure)
- *         or <bundle>/Resources/views/[A|a]reas/<brickId>/view.<suffix> (Symfony <= 4 structure)
+ * - @<bundle>/areas/<brickId>/view.<suffix>
+ *      -> resolves to <bundle>/templates/areas/<brickId>/view.<suffix> (Symfony >= 5 structure)
+ *         or <bundle>/Resources/views/areas/<brickId>/view.<suffix> (Symfony <= 4 structure)
  * - areas/<brickId>/view.<suffix>
  *      -> resolves to <project>/templates/areas/<brickId>/view.<suffix>
  */

--- a/lib/Extension/Document/Areabrick/TemplateAreabrickInterface.php
+++ b/lib/Extension/Document/Areabrick/TemplateAreabrickInterface.php
@@ -16,11 +16,15 @@
 namespace Pimcore\Extension\Document\Areabrick;
 
 /**
- * Bricks implementing this interface auto-resolve view templates if hasTemplate properties are set.
- * Depending on the result of getTemplateLocation and getTemplateSuffix the tag handler builds the following references:
+ * Bricks implementing this interface auto-resolve view templates if hasTemplate() properties are set.
+ * Depending on the result of getTemplateLocation() and getTemplateSuffix() the tag handler builds the
+ * following references:
  *
- * - <currentBundle>:Areas/<brickId>/(view|edit).<suffix>
- * - Areas/<brickId>/(view|edit).<suffix> -> resolves to app/Resources
+ * - @<bundle>/[A|a]reas/<brickId>/view.<suffix>
+ *      -> resolves to <bundle>/templates/[A|a]reas/<brickId>/view.<suffix> (Symfony >= 5 structure)
+ *         or <bundle>/Resources/views/[A|a]reas/<brickId>/view.<suffix> (Symfony <= 4 structure)
+ * - areas/<brickId>/view.<suffix>
+ *      -> resolves to <project>/templates/areas/<brickId>/view.<suffix>
  */
 interface TemplateAreabrickInterface extends AreabrickInterface
 {
@@ -31,7 +35,7 @@ interface TemplateAreabrickInterface extends AreabrickInterface
     const TEMPLATE_SUFFIX_TWIG = 'html.twig';
 
     /**
-     * Determines if template should be auto-located in area bundle or in app/Resources
+     * Determines if template should be auto-located in bundle or in project
      *
      * @return string
      */


### PR DESCRIPTION
> **Warning**
> This is breaking

Since Symfony 4 there's no more `AppBundle`, thus I think the default template location in `AbstractTemplateAreabrick::getTemplateLocation()` should be `TEMPLATE_LOCATION_GLOBAL`, so you don't have to override it when creating a brick (except when you create a bundle, of course :wink:).

I also fixed/improved the PhpDoc and refactored the template resolution in `EditableHandler` a bit.