### PR TITLE
Remove useless exception handling in Area(Block)::buildInfoObject()

### DIFF
--- a/models/Document/Editable/Area.php
+++ b/models/Document/Editable/Area.php
@@ -129,14 +129,10 @@ class Area extends Model\Document\Editable
     {
         $config = $this->getConfig();
         // create info object and assign it to the view
-        try {
-            $info = new Area\Info();
-            $info->setId($config['type']);
-            $info->setEditable($this);
-            $info->setIndex(0);
-        } catch (\Exception $e) {
-            $info = null;
-        }
+        $info = new Area\Info();
+        $info->setId($config['type']);
+        $info->setEditable($this);
+        $info->setIndex(0);
 
         $params = [];
         if (isset($config['params']) && is_array($config['params']) && array_key_exists($config['type'], $config['params'])) {

--- a/models/Document/Editable/Area.php
+++ b/models/Document/Editable/Area.php
@@ -135,14 +135,12 @@ class Area extends Model\Document\Editable
         $info->setIndex(0);
 
         $params = [];
-        if (isset($config['params']) && is_array($config['params']) && array_key_exists($config['type'], $config['params'])) {
-            if (is_array($config['params'][$config['type']])) {
-                $params = $config['params'][$config['type']];
-            }
+        if (is_array($config['params'][$config['type']] ?? null)) {
+            $params = $config['params'][$config['type']];
         }
 
-        if (isset($config['globalParams'])) {
-            $params = array_merge($config['globalParams'], (array)$params);
+        if (is_array($config['globalParams'] ?? null)) {
+            $params = array_merge($config['globalParams'], $params);
         }
 
         $info->setParams($params);

--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -216,6 +216,7 @@ class Areablock extends Model\Document\Editable implements BlockInterface
      */
     public function buildInfoObject(): Area\Info
     {
+        $config = $this->getConfig();
         // create info object and assign it to the view
         $info = new Area\Info();
         $info->setId($this->currentIndex ? $this->currentIndex['type'] : null);
@@ -223,16 +224,12 @@ class Areablock extends Model\Document\Editable implements BlockInterface
         $info->setIndex($this->current);
 
         $params = [];
-
-        $config = $this->getConfig();
-        if (isset($config['params']) && is_array($config['params']) && array_key_exists($this->currentIndex['type'], $config['params'])) {
-            if (is_array($config['params'][$this->currentIndex['type']])) {
-                $params = $config['params'][$this->currentIndex['type']];
-            }
+        if (is_array($config['params'][$this->currentIndex['type']] ?? null)) {
+            $params = $config['params'][$this->currentIndex['type']];
         }
 
-        if (isset($config['globalParams'])) {
-            $params = array_merge($config['globalParams'], (array)$params);
+        if (is_array($config['globalParams'] ?? null)) {
+            $params = array_merge($config['globalParams'], $params);
         }
 
         $info->setParams($params);

--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -218,14 +218,9 @@ class Areablock extends Model\Document\Editable implements BlockInterface
     {
         // create info object and assign it to the view
         $info = new Area\Info();
-
-        try {
-            $info->setId($this->currentIndex ? $this->currentIndex['type'] : null);
-            $info->setEditable($this);
-            $info->setIndex($this->current);
-        } catch (\Exception $e) {
-            Logger::err((string) $e);
-        }
+        $info->setId($this->currentIndex ? $this->currentIndex['type'] : null);
+        $info->setEditable($this);
+        $info->setIndex($this->current);
 
         $params = [];
 


### PR DESCRIPTION
The exception handling in `Area(Block)::buildInfoObject()` was rather useless.

In `Area`, `$info` was set to `null` in case of an error, but later `$info->setParams(...)` gets called, which would crash.

In `Areablock`, an error was logged if one of the first three setters failed (which is rather unlikely), and I think it'll be better to fail hard in this case.

---

I also simplified the code to determine the `$params` a bit.