### PR TITLE
Use hash_equals() rather than direct string comparison for password fields

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Password.php
+++ b/models/DataObject/ClassDefinition/Data/Password.php
@@ -302,7 +302,7 @@ class Password extends Data implements ResourcePersistenceAwareInterface, QueryR
             }
         } else {
             $hash = $this->calculateHash($password);
-            $result = $hash === $objectHash;
+            $result = hash_equals($objectHash, $hash);
         }
 
         return $result;


### PR DESCRIPTION
## Changes in this pull request 

A very small hardening using https://www.php.net/manual/en/function.hash-equals.php instead