### PR TITLE
Site event handling

### DIFF
--- a/lib/Event/Model/SiteEvent.php
+++ b/lib/Event/Model/SiteEvent.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Pimcore\Event\Model;
+
+use Pimcore\Event\Traits\ArgumentsAwareTrait;
+use Pimcore\Model\Element\ElementInterface;
+use Pimcore\Model\Site;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class SiteEvent extends Event implements ElementEventInterface
+{
+    use ArgumentsAwareTrait;
+
+    /** @var Site */
+    protected $site;
+
+    /**
+     * @param Site $site
+     */
+    public function __construct(Site $site)
+    {
+        $this->site = $site;
+    }
+
+    /**
+     * @return Site
+     */
+    public function getSite(): Site
+    {
+        return $this->site;
+    }
+
+    /**
+     * @param Site $site
+     */
+    public function setSite(Site $site): void
+    {
+        $this->site = $site;
+    }
+
+    /**
+     * @return ElementInterface|Site
+     */
+    public function getElement()
+    {
+        return $this->getSite();
+    }
+}

--- a/lib/Event/SiteEvents.php
+++ b/lib/Event/SiteEvents.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Pimcore\Event;
+
+final class SiteEvents
+{
+    /**
+     * Arguments:
+     *  - saveVersionOnly | is set if method saveVersion() was called instead of save()
+     *  - oldPath | the old full path in case the path has changed
+     *
+     * @Event("Pimcore\Event\Model\SiteEvent")
+     *
+     * @var string
+     */
+    const POST_UPDATE = 'pimcore.site.postUpdate';
+}

--- a/models/Site.php
+++ b/models/Site.php
@@ -16,16 +16,22 @@
 namespace Pimcore\Model;
 
 use Pimcore\Cache\RuntimeCache;
+use Pimcore\Event\DocumentEvents;
+use Pimcore\Event\Model\SiteEvent;
+use Pimcore\Event\SiteEvents;
+use Pimcore\Event\Traits\RecursionBlockingEventDispatchHelperTrait;
 use Pimcore\Logger;
 use Pimcore\Model\Exception\NotFoundException;
 
 /**
  * @method \Pimcore\Model\Site\Dao getDao()
  * @method void delete()
- * @method void save()
+ *
  */
 final class Site extends AbstractModel
 {
+    use RecursionBlockingEventDispatchHelperTrait;
+
     /**
      * @var Site|null
      */
@@ -472,5 +478,21 @@ final class Site extends AbstractModel
     public function getCreationDate()
     {
         return $this->creationDate;
+    }
+
+    /**
+     * @return void
+     */
+    public function save()
+    {
+        $this->__call(__FUNCTION__, []);
+
+        // additional parameters (e.g. "versionNote" for the version note)
+        $params = [];
+        if (func_num_args() && is_array(func_get_arg(0))) {
+            $params = func_get_arg(0);
+        }
+        $preEvent = new SiteEvent($this, $params);
+        $this->dispatchEvent($preEvent, SiteEvents::POST_UPDATE);
     }
 }

--- a/models/Site.php
+++ b/models/Site.php
@@ -16,7 +16,6 @@
 namespace Pimcore\Model;
 
 use Pimcore\Cache\RuntimeCache;
-use Pimcore\Event\DocumentEvents;
 use Pimcore\Event\Model\SiteEvent;
 use Pimcore\Event\SiteEvents;
 use Pimcore\Event\Traits\RecursionBlockingEventDispatchHelperTrait;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #13139 

## Additional info  
Add new SiteEvent to hook into post site updates. For example we would like to reindex our Elasticsearch after a Site is saved

