### PR TITLE
[Improvement] edit not editable advanced relation columns

### DIFF
--- a/bundles/AdminBundle/public/js/pimcore/object/classes/data/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/public/js/pimcore/object/classes/data/advancedManyToManyObjectRelation.js
@@ -184,6 +184,13 @@ pimcore.object.classes.data.advancedManyToManyObjectRelation = Class.create(pimc
 
         this.specificPanel.add({
             xtype: "checkbox",
+            boxLabel: t("allow_editing_columns_when_not_editable"),
+            name: "allowEditingColumnsWhenNotEditable",
+            value: this.datax.allowEditingColumnsWhenNotEditable
+        });
+
+        this.specificPanel.add({
+            xtype: "checkbox",
             boxLabel: t("allow_multiple_assignments"),
             name: "allowMultipleAssignments",
             value: this.datax.allowMultipleAssignments
@@ -408,6 +415,7 @@ pimcore.object.classes.data.advancedManyToManyObjectRelation = Class.create(pimc
                     remoteOwner: source.datax.remoteOwner,
                     classes: source.datax.classes,
                     enableBatchEdit: source.datax.enableBatchEdit,
+                    allowEditingColumnsWhenNotEditable: source.datax.allowEditingColumnsWhenNotEditable,
                     allowMultipleAssignments: source.datax.allowMultipleAssignments,
                     allowToCreateNewObject: source.datax.allowToCreateNewObject,
                     optimizedAdminLoading: source.datax.optimizedAdminLoading,

--- a/bundles/AdminBundle/public/js/pimcore/object/classes/data/advancedManyToManyRelation.js
+++ b/bundles/AdminBundle/public/js/pimcore/object/classes/data/advancedManyToManyRelation.js
@@ -371,6 +371,13 @@ pimcore.object.classes.data.advancedManyToManyRelation = Class.create(pimcore.ob
 
         this.specificPanel.add({
             xtype: "checkbox",
+            boxLabel: t("allow_editing_columns_when_not_editable"),
+            name: "allowEditingColumnsWhenNotEditable",
+            value: this.datax.allowEditingColumnsWhenNotEditable
+        });
+
+        this.specificPanel.add({
+            xtype: "checkbox",
             boxLabel: t("allow_multiple_assignments"),
             name: "allowMultipleAssignments",
             value: this.datax.allowMultipleAssignments
@@ -602,6 +609,7 @@ pimcore.object.classes.data.advancedManyToManyRelation = Class.create(pimcore.ob
                     documentTypes: source.datax.documentTypes,
                     pathFormatterClass: source.datax.pathFormatterClass,
                     enableBatchEdit: source.datax.enableBatchEdit,
+                    allowEditingColumnsWhenNotEditable: source.datax.allowEditingColumnsWhenNotEditable,
                     allowMultipleAssignments: source.datax.allowMultipleAssignments,
                     optimizedAdminLoading: source.datax.optimizedAdminLoading
                 });

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -853,6 +853,7 @@
     "batch_edit_field_selected": "Batch edit selected field",
     "batch_append_selected_to": "Append data to selected",
     "enable_batch_edit_columns": "Enable Batch Edit for Columns",
+    "allow_editing_columns_when_not_editable": "Allow editing columns when not editable",
     "delete_all": "Delete All",
     "open_linked_element": "Open linked Element",
     "mark_as_read": "Mark as read",

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -79,6 +79,13 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
      *
      * @var bool
      */
+    public $allowEditingColumnsWhenNotEditable =  false;
+
+    /**
+     * @internal
+     *
+     * @var bool
+     */
     public $allowMultipleAssignments = false;
 
     /**
@@ -747,6 +754,22 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
     public function setEnableBatchEdit($enableBatchEdit)
     {
         $this->enableBatchEdit = $enableBatchEdit;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAllowEditingColumnsWhenNotEditable()
+    {
+        return $this->allowEditingColumnsWhenNotEditable;
+    }
+
+    /**
+     * @param bool $allowEditingColumnsWhenNotEditable
+     */
+    public function setAllowEditingColumnsWhenNotEditable(bool $allowEditingColumnsWhenNotEditable)
+    {
+        $this->allowEditingColumnsWhenNotEditable = $allowEditingColumnsWhenNotEditable;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -79,6 +79,13 @@ class AdvancedManyToManyRelation extends ManyToManyRelation implements IdRewrite
      *
      * @var bool
      */
+    public $allowEditingColumnsWhenNotEditable = false;
+
+    /**
+     * @internal
+     *
+     * @var bool
+     */
     public $allowMultipleAssignments;
 
     /**
@@ -1060,6 +1067,22 @@ class AdvancedManyToManyRelation extends ManyToManyRelation implements IdRewrite
     public function setEnableBatchEdit($enableBatchEdit)
     {
         $this->enableBatchEdit = $enableBatchEdit;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAllowEditingColumnsWhenNotEditable()
+    {
+        return $this->allowEditingColumnsWhenNotEditable;
+    }
+
+    /**
+     * @param bool $allowEditingColumnsWhenNotEditable
+     */
+    public function setAllowEditingColumnsWhenNotEditable(bool $allowEditingColumnsWhenNotEditable)
+    {
+        $this->allowEditingColumnsWhenNotEditable = $allowEditingColumnsWhenNotEditable;
     }
 
     /**


### PR DESCRIPTION
Allow editing columns of advanced many to many (object) relation fields when not editable is enabled by providing a new option: Allow editing columns when not editable

This allows the columns to be used as configuration, while the user is unable to add or (re)move rows. Rows can be added by administrators or via event listeners, for example.