### PR TITLE
Make editmodeImagePreview available for YouTube videos

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -295,11 +295,11 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         } elseif ($this->type === self::TYPE_ASSET) {
             return $this->getAssetCode($inAdmin);
         } elseif ($this->type === self::TYPE_YOUTUBE) {
-            return $this->getYoutubeCode();
+            return $this->getYoutubeCode($inAdmin);
         } elseif ($this->type === self::TYPE_VIMEO) {
-            return $this->getVimeoCode();
+            return $this->getVimeoCode($inAdmin);
         } elseif ($this->type === self::TYPE_DAILYMOTION) {
-            return $this->getDailymotionCode();
+            return $this->getDailymotionCode($inAdmin);
         } elseif ($this->type === 'url') {
             return $this->getUrlCode();
         }
@@ -615,7 +615,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
     /**
      * @return string
      */
-    private function getYoutubeCode()
+    private function getYoutubeCode($inAdmin = false)
     {
         if (!$this->id) {
             return $this->getEmptyCode();
@@ -629,9 +629,9 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
             return $this->getEmptyCode();
         }
         
-        if ($this->editmode === true && isset($config['editmodeImagePreview']) && $config['editmodeImagePreview'] === true) {
+        if ($inAdmin && isset($config['editmodeImagePreview']) && $config['editmodeImagePreview'] === true) {
             return '<div id="pimcore_video_' . $this->getName() . '" class="pimcore_editable_video '. ($config['class'] ?? '') .'">
-                <img src="https://img.youtube-nocookie.com/vi/' . $youtubeId . '/0.jpg">
+                <img src="https://img.youtube.com/vi/' . $youtubeId . '/0.jpg">
             </div>';
         }
 
@@ -716,7 +716,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
     /**
      * @return string
      */
-    private function getVimeoCode()
+    private function getVimeoCode($inAdmin = false)
     {
         if (!$this->id) {
             return $this->getEmptyCode();
@@ -735,6 +735,12 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         }
 
         if (ctype_digit($vimeoId)) {
+            if ($inAdmin && isset($config['editmodeImagePreview']) && $config['editmodeImagePreview'] === true) {
+                return '<div id="pimcore_video_' . $this->getName() . '" class="pimcore_editable_video '. ($config['class'] ?? '') .'">
+                    <img src="https://vumbnail.com/' . $vimeoId . '.jpg">
+                </div>';
+            }
+
             $width = '100%';
             if (array_key_exists('width', $config)) {
                 $width = $config['width'];
@@ -795,7 +801,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
     /**
      * @return string
      */
-    private function getDailymotionCode()
+    private function getDailymotionCode($inAdmin = false)
     {
         if (!$this->id) {
             return $this->getEmptyCode();
@@ -814,6 +820,11 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         }
 
         if ($dailymotionId) {
+            if ($inAdmin && isset($config['editmodeImagePreview']) && $config['editmodeImagePreview'] === true) {
+                return '<div id="pimcore_video_' . $this->getName() . '" class="pimcore_editable_video '. ($config['class'] ?? '') .'">
+                    <img src="https://www.dailymotion.com/thumbnail/video/' . $dailymotionId . '">
+                </div>';
+            }
             $width = $config['width'] ?? '100%';
 
             $height = $config['height'] ?? '300';

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -449,12 +449,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         return $this->getConfig()['height'] ?? 300;
     }
 
-    /**
-     * @param bool $inAdmin
-     *
-     * @return string
-     */
-    private function getAssetCode($inAdmin = false)
+    private function getAssetCode(bool $inAdmin = false): string
     {
         $asset = Asset::getById($this->id);
         $config = $this->getConfig();
@@ -612,10 +607,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         return $youtubeId;
     }
 
-    /**
-     * @return string
-     */
-    private function getYoutubeCode($inAdmin = false)
+    private function getYoutubeCode(bool $inAdmin = false): string
     {
         if (!$this->id) {
             return $this->getEmptyCode();
@@ -713,10 +705,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         return $code;
     }
 
-    /**
-     * @return string
-     */
-    private function getVimeoCode($inAdmin = false)
+    private function getVimeoCode(bool $inAdmin = false): string
     {
         if (!$this->id) {
             return $this->getEmptyCode();
@@ -798,10 +787,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         return $this->getEmptyCode();
     }
 
-    /**
-     * @return string
-     */
-    private function getDailymotionCode($inAdmin = false)
+    private function getDailymotionCode(bool $inAdmin = false): string
     {
         if (!$this->id) {
             return $this->getEmptyCode();

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -628,6 +628,12 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         if (!$youtubeId) {
             return $this->getEmptyCode();
         }
+        
+        if ($this->editmode === true && isset($config['editmodeImagePreview']) && $config['editmodeImagePreview'] === true) {
+            return '<div id="pimcore_video_' . $this->getName() . '" class="pimcore_editable_video '. ($config['class'] ?? '') .'">
+                <img src="https://img.youtube-nocookie.com/vi/' . $youtubeId . '/0.jpg">
+            </div>';
+        }
 
         $width = '100%';
         if (array_key_exists('width', $config)) {


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
The config `editmodeImagePreview` for the video editable was not working for YouTube videos. I made it working in this pull request. 

## Additional info  
I'm not sure if you see this as a bug fix or as a feature/improvement. But, in our case, this solves a bug in loading the editor in the admin panel, so that's why I submitted this pull request in 10.5. 