### PR TITLE
[Docs / Wysiwyg fields] Fix wysiwyg editor example config

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/wysiwyg.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/wysiwyg.js
@@ -190,7 +190,7 @@ pimcore.object.tags.wysiwyg = Class.create(pimcore.object.tags.abstract, {
         }
 
         if(this.fieldConfig.toolbarConfig) {
-            var useNativeJson = Ext.USE_NATIVE_JSON;
+            const useNativeJson = Ext.USE_NATIVE_JSON;
             Ext.USE_NATIVE_JSON = false;
             var elementCustomConfig = Ext.decode(this.fieldConfig.toolbarConfig);
             Ext.USE_NATIVE_JSON = useNativeJson;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/wysiwyg.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/wysiwyg.js
@@ -190,7 +190,10 @@ pimcore.object.tags.wysiwyg = Class.create(pimcore.object.tags.abstract, {
         }
 
         if(this.fieldConfig.toolbarConfig) {
+            var useNativeJson = Ext.USE_NATIVE_JSON;
+            Ext.USE_NATIVE_JSON = false;
             var elementCustomConfig = Ext.decode(this.fieldConfig.toolbarConfig);
+            Ext.USE_NATIVE_JSON = useNativeJson;
             eConfig = mergeObject(eConfig, elementCustomConfig);
         }
 

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/95_Text_Types.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/95_Text_Types.md
@@ -71,8 +71,8 @@ It's possible to pass a custom CKEditor config object to the wysiwyg editor.
 
 ```
 {
-  "toolbarGroups": [{ "name": "links" }],
-  "enterMode": 2
+  toolbarGroups: [{ "name": "links" }],
+  enterMode: CKEDITOR.ENTER_BR
 }
 ```
 

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/95_Text_Types.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/95_Text_Types.md
@@ -71,20 +71,20 @@ It's possible to pass a custom CKEditor config object to the wysiwyg editor.
 
 ```
 {
-  toolbarGroups : [ { name: 'links' }],
-  enterMode: CKEDITOR.CKEDITOR.ENTER_BR,
+  "toolbarGroups": [{ "name": "links" }],
+  "enterMode": 2
 }
 ```
 
 While most configuration parameters define which features shall be available when using the wysiwyg editor the `enterMode` defines the following behaviour:
-* `CKEDITOR.CKEDITOR.ENTER_P` (default)
+* `CKEDITOR.ENTER_P` (constant value = 1) (default)
   * Pressing `enter` key adds a paragraph `<p></p>` tag at the cursor position
   * content gets always wrapped in `<p>` tags, even if you just enter one line
   * When setting the field's content via its setter method, the `<p>` tags do not get automatically added. When you later open the object in the admin panel and save the object, the `<p>` tags get added. This can be misleading because the content of the field changed although the field has not been touched.
-* `CKEDITOR.CKEDITOR.ENTER_BR` 
+* `CKEDITOR.ENTER_BR` (constant value = 2)
   * Pressing `enter` key adds a `<br>` tag at the cursor position
-* `CKEDITOR.CKEDITOR.ENTER_DIV`
-  * same as `CKEDITOR.CKEDITOR.ENTER_P` but paragraphs get wrapped in `<div>` tags
+* `CKEDITOR.ENTER_DIV` (constant value = 3)
+  * same as `CKEDITOR.ENTER_P` but paragraphs get wrapped in `<div>` tags
 
 More examples and config options for the toolbar and toolbarGroups can be found at 
 [http://docs.ckeditor.com/#!/guide/dev_toolbar](http://docs.ckeditor.com/#!/guide/dev_toolbar). 

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/95_Text_Types.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/95_Text_Types.md
@@ -77,13 +77,13 @@ It's possible to pass a custom CKEditor config object to the wysiwyg editor.
 ```
 
 While most configuration parameters define which features shall be available when using the wysiwyg editor the `enterMode` defines the following behaviour:
-* `CKEDITOR.ENTER_P` (constant value = 1) (default)
+* `CKEDITOR.ENTER_P` (default)
   * Pressing `enter` key adds a paragraph `<p></p>` tag at the cursor position
   * content gets always wrapped in `<p>` tags, even if you just enter one line
   * When setting the field's content via its setter method, the `<p>` tags do not get automatically added. When you later open the object in the admin panel and save the object, the `<p>` tags get added. This can be misleading because the content of the field changed although the field has not been touched.
-* `CKEDITOR.ENTER_BR` (constant value = 2)
+* `CKEDITOR.ENTER_BR`
   * Pressing `enter` key adds a `<br>` tag at the cursor position
-* `CKEDITOR.ENTER_DIV` (constant value = 3)
+* `CKEDITOR.ENTER_DIV`
   * same as `CKEDITOR.ENTER_P` but paragraphs get wrapped in `<div>` tags
 
 More examples and config options for the toolbar and toolbarGroups can be found at 

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/95_Text_Types.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/95_Text_Types.md
@@ -86,8 +86,8 @@ While most configuration parameters define which features shall be available whe
 * `CKEDITOR.ENTER_DIV`
   * same as `CKEDITOR.ENTER_P` but paragraphs get wrapped in `<div>` tags
 
-More examples and config options for the toolbar and toolbarGroups can be found at 
-[http://docs.ckeditor.com/#!/guide/dev_toolbar](http://docs.ckeditor.com/#!/guide/dev_toolbar). 
+More examples and config options for the toolbar and toolbarGroups can be found in
+[CKeditor toolbar documentation](http://docs.ckeditor.com/#!/guide/dev_toolbar) or you can use the [CKeditor configurator](https://ckeditor.com/latest/samples/toolbarconfigurator) to create a custom toolbar configuration. 
 
 Please refer to the [CKeditor 4.0 Documentation](http://docs.ckeditor.com/).
 


### PR DESCRIPTION
Since Pimcore 10 the example editor config in https://pimcore.com/docs/pimcore/current/Development_Documentation/Objects/Object_Classes/Data_Types/Text_Types.html#page_Editor-Configuration does not work anymore. The reason is that in https://github.com/pimcore/pimcore/blob/1be12b0493bc9153783c8d85210f9863637aec3c/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/wysiwyg.js#L193 `Ext.decode()` gets used - but the difference with Pimcore 10 is that in this function
```javascript
try {
            // check USE_NATIVE_JSON here so it can be changed if needed
            if (hasNative && Ext.USE_NATIVE_JSON) {
                return JSON.parse(json);
            }
            return doDecode(json);
        } catch (e) {
            if (safe) {
                return null;
            }
            Ext.raise({
                sourceClass: "Ext.JSON",
                sourceMethod: "decode",
                msg: "You're trying to decode an invalid JSON String: " + json
            });
        }
```

`Ext.USE_NATIVE_JSON` is `true` whereas in Pimcore 6 it was `false`. Thus in Pimcore 6 the `doDecode()` function was used which is much more tolerant. The native `JSON.parse()` is really picky. Back to the docs example:
```markdown
{
  toolbarGroups : [ { name: 'links' }],
  enterMode: CKEDITOR.CKEDITOR.ENTER_BR,
}
```
This does not work for the following reasons:
- JSON attributes need to be quoted
- trailing comma after `enterMode` not allowed
- `CKEDITOR.CKEDITOR.ENTER_BR` got renamed to `CKEDITOR.ENTER_BR`
- constants cannot be resolved(!)

Especially the last point is really bad because you cannot use the generated configurations from [the linked CKEditor configuration docs](https://ckeditor.com/docs/ckeditor4/latest/features/toolbar.html) or the [CKEditor configurator](https://ckeditor.com/latest/samples/toolbarconfigurator). Because of this this PR does not only fix the docs but disables `Ext.USE_NATIVE_JSON` for this.