### PR TITLE
[Calculated value fields] In grid view do not strip HTML tags if display type is "HTML"

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/grid.js
@@ -380,9 +380,9 @@ pimcore.object.helpers.grid = Class.create({
 
                 } else {
                     var fieldType = fields[i].type;
-                    var tag = pimcore.object.tags[fieldType];
+                    var tag = new pimcore.object.tags[fieldType](null, fields[i].layout);
                     if (tag) {
-                        var fc = tag.prototype.getGridColumnConfig(field);
+                        var fc = tag.getGridColumnConfig(field);
 
                         if(width === null) {
                             fc.autoSizeColumn = true;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
@@ -99,7 +99,7 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
                 console.log(e);
             }
 
-            if (value) {
+            if (value && this.fieldConfig.elementType !== 'html') {
                 value = value.replace(/\n/g,"<br>");
                 value = strip_tags(value, '<br>');
             }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/calculatedValue.js
@@ -22,7 +22,6 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
 
     },
 
-
     getLayoutEdit: function () {
 
         var input = {


### PR DESCRIPTION
Steps to reproduce:
1. Create calculator which implements `CalculatorClassInterface` and in `compute()` returns
   ```html
   <div style="width:100%">
     <div style="width:300px;background-color:#e0e0e0;padding:3px;border-radius:3px;box-shadow:inset 0 1px 3px rgba(0, 0, 0, .2);">
       <span class="progress-bar-fill" style="width:53%;display:block;height:22px;background-color:#659cef;border-radius:3px;transition:width 500ms ease-in-out;"></span>
     </div>
   </div>
   ```
2. Create data object class with calculated value field and `Type = HTML` and enable `Visible in grid view`
3. Create object of this class
4. open grid

Before this PR you will see:
<img width="327" alt="Bildschirmfoto 2022-09-15 um 09 38 16" src="https://user-images.githubusercontent.com/8749138/190344239-9efdc79f-01cd-46bb-8cf2-890be76d3f85.png">

With this PR you will see:
<img width="328" alt="Bildschirmfoto 2022-09-15 um 09 38 57" src="https://user-images.githubusercontent.com/8749138/190344526-19b32ba0-b7f7-4a3b-a3be-e8804cd179de.png">
