### PR TITLE
Fieldcollection/Objectbrick/CustomLayout/Bulk Export: Cleanup BlockedVars and Dynamic Options like ClassDefinition

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
@@ -1776,20 +1776,18 @@ class ClassController extends AdminController implements KernelControllerEventIn
         foreach ($list as $item) {
             if ($item['type'] == 'fieldcollection') {
                 $fieldCollection = DataObject\Fieldcollection\Definition::getByKey($item['name']);
-                $key = $fieldCollection->getKey();
                 $fieldCollectionJson = json_decode(DataObject\ClassDefinition\Service::generateFieldCollectionJson($fieldCollection));
-                $fieldCollectionJson->key = $key;
+                $fieldCollectionJson->key = $item['name'];
                 $result['fieldcollection'][] = $fieldCollectionJson;
             } elseif ($item['type'] == 'class') {
                 $class = DataObject\ClassDefinition::getByName($item['name']);
-                $data = json_decode(json_encode($class));
-                unset($data->fieldDefinitions);
+                $data = json_decode(DataObject\ClassDefinition\Service::generateClassDefinitionJson($class));
+                $data->name = $item['name'];
                 $result['class'][] = $data;
             } elseif ($item['type'] == 'objectbrick') {
                 $objectBrick = DataObject\Objectbrick\Definition::getByKey($item['name']);
-                $key = $objectBrick->getKey();
                 $objectBrickJson = json_decode(DataObject\ClassDefinition\Service::generateObjectBrickJson($objectBrick));
-                $objectBrickJson->key = $key;
+                $objectBrickJson->key = $item['name'];
                 $result['objectbrick'][] = $objectBrickJson;
             } elseif ($item['type'] == 'customlayout') {
                 /** @var DataObject\ClassDefinition\CustomLayout $customLayout */

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
@@ -1769,29 +1769,32 @@ class ClassController extends AdminController implements KernelControllerEventIn
 
         foreach ($list as $item) {
             if ($item['type'] == 'fieldcollection') {
-                $fieldCollection = DataObject\Fieldcollection\Definition::getByKey($item['name']);
-                $fieldCollectionJson = json_decode(DataObject\ClassDefinition\Service::generateFieldCollectionJson($fieldCollection));
-                $fieldCollectionJson->key = $item['name'];
-                $result['fieldcollection'][] = $fieldCollectionJson;
+                if ($fieldCollection = DataObject\Fieldcollection\Definition::getByKey($item['name'])) {
+                    $fieldCollectionJson = json_decode(DataObject\ClassDefinition\Service::generateFieldCollectionJson($fieldCollection));
+                    $fieldCollectionJson->key = $item['name'];
+                    $result['fieldcollection'][] = $fieldCollectionJson;
+                }
             } elseif ($item['type'] == 'class') {
-                $class = DataObject\ClassDefinition::getByName($item['name']);
-                $data = json_decode(DataObject\ClassDefinition\Service::generateClassDefinitionJson($class));
-                $data->name = $item['name'];
-                $result['class'][] = $data;
+                if ($class = DataObject\ClassDefinition::getByName($item['name'])) {
+                    $data = json_decode(DataObject\ClassDefinition\Service::generateClassDefinitionJson($class));
+                    $data->name = $item['name'];
+                    $result['class'][] = $data;
+                }
             } elseif ($item['type'] == 'objectbrick') {
-                $objectBrick = DataObject\Objectbrick\Definition::getByKey($item['name']);
-                $objectBrickJson = json_decode(DataObject\ClassDefinition\Service::generateObjectBrickJson($objectBrick));
-                $objectBrickJson->key = $item['name'];
-                $result['objectbrick'][] = $objectBrickJson;
+                if ($objectBrick = DataObject\Objectbrick\Definition::getByKey($item['name'])) {
+                    $objectBrickJson = json_decode(DataObject\ClassDefinition\Service::generateObjectBrickJson($objectBrick));
+                    $objectBrickJson->key = $item['name'];
+                    $result['objectbrick'][] = $objectBrickJson;
+                }
             } elseif ($item['type'] == 'customlayout') {
-                /** @var DataObject\ClassDefinition\CustomLayout $customLayout */
-                $customLayout = DataObject\ClassDefinition\CustomLayout::getById($item['name']);
-                $classId = $customLayout->getClassId();
-                $class = DataObject\ClassDefinition::getById($classId);
-                $customLayoutJson = json_decode(DataObject\ClassDefinition\Service::generateCustomLayoutJson($customLayout));
-                $customLayoutJson->name = $customLayout->getName();
-                $customLayoutJson->className = $class->getName();
-                $result['customlayout'][] = $customLayoutJson;
+                if ($customLayout = DataObject\ClassDefinition\CustomLayout::getById($item['name'])) {
+                    $classId = $customLayout->getClassId();
+                    $class = DataObject\ClassDefinition::getById($classId);
+                    $customLayoutJson = json_decode(DataObject\ClassDefinition\Service::generateCustomLayoutJson($customLayout));
+                    $customLayoutJson->name = $customLayout->getName();
+                    $customLayoutJson->className = $class->getName();
+                    $result['customlayout'][] = $customLayoutJson;
+                }
             }
         }
 

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
@@ -718,13 +718,7 @@ class ClassController extends AdminController implements KernelControllerEventIn
             $customLayout = DataObject\ClassDefinition\CustomLayout::getById($id);
             if ($customLayout) {
                 $name = $customLayout->getName();
-                $customLayoutData = [
-                    'description' => $customLayout->getDescription(),
-                    'layoutDefinitions' => $customLayout->getLayoutDefinitions(),
-                    'default' => $customLayout->getDefault() ?: 0,
-                ];
-
-                $json = json_encode($customLayoutData, JSON_PRETTY_PRINT);
+                $json = DataObject\ClassDefinition\Service::generateCustomLayoutJson($customLayout);
 
                 $response = new Response($json);
                 $response->headers->set('Content-type', 'application/json');
@@ -1794,9 +1788,10 @@ class ClassController extends AdminController implements KernelControllerEventIn
                 $customLayout = DataObject\ClassDefinition\CustomLayout::getById($item['name']);
                 $classId = $customLayout->getClassId();
                 $class = DataObject\ClassDefinition::getById($classId);
-                $customLayout = $customLayout->getObjectVars();
-                $customLayout['className'] = $class->getName();
-                $result['customlayout'][] = $customLayout;
+                $customLayoutJson = json_decode(DataObject\ClassDefinition\Service::generateCustomLayoutJson($customLayout));
+                $customLayoutJson->name = $customLayout->getName();
+                $customLayoutJson->className = $class->getName();
+                $result['customlayout'][] = $customLayoutJson;
             }
         }
 

--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -63,11 +63,7 @@ class Service
         self::setDoRemoveDynamicOptions(true);
         $data = json_decode(json_encode($class));
         self::setDoRemoveDynamicOptions(false);
-        unset($data->name);
-        unset($data->creationDate);
-        unset($data->userOwner);
-        unset($data->userModification);
-        unset($data->fieldDefinitions);
+        unset($data->name, $data->creationDate, $data->userOwner, $data->userModification, $data->fieldDefinitions);
 
         return json_encode($data, JSON_PRETTY_PRINT);
     }
@@ -177,10 +173,16 @@ class Service
     public static function generateFieldCollectionJson($fieldCollection)
     {
         $fieldCollection = clone $fieldCollection;
-        $fieldCollection->setKey(null);
-        $fieldCollection->setFieldDefinitions([]);
+        if ($fieldCollection->layoutDefinitions instanceof Layout) {
+            self::removeDynamicOptionsFromLayoutDefinition($fieldCollection->layoutDefinitions);
+        }
 
-        return json_encode($fieldCollection, JSON_PRETTY_PRINT);
+        self::setDoRemoveDynamicOptions(true);
+        $data = json_decode(json_encode($fieldCollection));
+        self::setDoRemoveDynamicOptions(false);
+        unset($data->key, $data->fieldDefinitions);
+
+        return json_encode($data, JSON_PRETTY_PRINT);
     }
 
     /**
@@ -226,8 +228,6 @@ class Service
     public static function generateObjectBrickJson($objectBrick)
     {
         $objectBrick = clone $objectBrick;
-        $objectBrick->setKey(null);
-        $objectBrick->setFieldDefinitions([]);
 
         // set classname attribute to the real class name not to the class ID
         // this will allow to import the brick on a different instance with identical class names but different class IDs
@@ -245,7 +245,15 @@ class Service
             }
         }
 
-        return json_encode($objectBrick, JSON_PRETTY_PRINT);
+        if ($objectBrick->layoutDefinitions instanceof Layout) {
+            self::removeDynamicOptionsFromLayoutDefinition($objectBrick->layoutDefinitions);
+        }
+        self::setDoRemoveDynamicOptions(true);
+        $data = json_decode(json_encode($objectBrick));
+        self::setDoRemoveDynamicOptions(false);
+        unset($data->key, $data->fieldDefinitions);
+
+        return json_encode($data, JSON_PRETTY_PRINT);
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -256,6 +256,22 @@ class Service
         return json_encode($data, JSON_PRETTY_PRINT);
     }
 
+    public static function generateCustomLayoutJson(CustomLayout $customLayout): string
+    {
+        if ($layoutDefinitions = $customLayout->getLayoutDefinitions()) {
+            self::removeDynamicOptionsFromLayoutDefinition($layoutDefinitions);
+        }
+        self::setDoRemoveDynamicOptions(true);
+        $data = [
+            'description' => $customLayout->getDescription(),
+            'layoutDefinitions' => json_decode(json_encode($layoutDefinitions)),
+            'default' => $customLayout->getDefault() ?: 0,
+        ];
+        self::setDoRemoveDynamicOptions(false);
+
+        return json_encode($data, JSON_PRETTY_PRINT);
+    }
+
     /**
      * @param DataObject\Objectbrick\Definition $objectBrick
      * @param string $json


### PR DESCRIPTION
In Fieldcollection/Objectbrick/CustomLayout/Bulk exports are the deprecated "childs" Attributes and all unnecessary attributes (like the dynamic options). This should be removed like in the class definition export.