### PR TITLE
Fix external link detection in link edit panel

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1794,7 +1794,7 @@ pimcore.helpers.editmode.openLinkEditPanel = function (data, callback) {
                 // if it doesn't start with a single "/", we assume it's an external link
                 if (value && !value.startsWith('/') && !'http://'.startsWith(value) && !'https://'.startsWith(value)) {
                     if (!value.match(/^https?:\/\//)) {
-                        el.setValue("http://" + value.replace(/^\/+/, ''));
+                        el.setValue("https://" + value.replace(/^\/+/, ''));
                     }
                     internalTypeField.setValue(null);
                     linkTypeField.setValue("direct");

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1786,12 +1786,13 @@ pimcore.helpers.editmode.openLinkEditPanel = function (data, callback) {
         name: "path",
         width: 520,
         fieldCls: "pimcore_droptarget_input",
+        enableKeyEvents: true,
         listeners: {
-            blur: function (el) {
+            keyup: function (el) {
                 const value = el.getValue();
 
                 // if it doesn't start with a single "/", we assume it's an external link
-                if (!value.match(/^\/[^/]+/)) {
+                if (value && !value.startsWith('/') && !'http://'.startsWith(value) && !'https://'.startsWith(value)) {
                     if (!value.match(/^https?:\/\//)) {
                         el.setValue("http://" + value.replace(/^\/+/, ''));
                     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1799,6 +1799,11 @@ pimcore.helpers.editmode.openLinkEditPanel = function (data, callback) {
                     internalTypeField.setValue(null);
                     linkTypeField.setValue("direct");
                 }
+                // if it starts with "//", we assume it is a protocol-relative URL
+                else if (value.startsWith('//')) {
+                    internalTypeField.setValue(null);
+                    linkTypeField.setValue("direct");
+                }
             }
         }
     });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1786,11 +1786,15 @@ pimcore.helpers.editmode.openLinkEditPanel = function (data, callback) {
         name: "path",
         width: 520,
         fieldCls: "pimcore_droptarget_input",
-        enableKeyEvents: true,
         listeners: {
-            keyup: function (el) {
-                if (el.getValue().match(/^www\./)) {
-                    el.setValue("http://" + el.getValue());
+            blur: function (el) {
+                const value = el.getValue();
+
+                // if it doesn't start with a single "/", we assume it's an external link
+                if (!value.match(/^\/[^/]+/)) {
+                    if (!value.match(/^https?:\/\//)) {
+                        el.setValue("http://" + value.replace(/^\/+/, ''));
+                    }
                     internalTypeField.setValue(null);
                     linkTypeField.setValue("direct");
                 }


### PR DESCRIPTION
Until now, external links in the link edit panel are detected by checking if they start with `www.`, which is not sufficient, because nowadays, many websites don't have a `www` prefix anymore.

From now on, it looks if the value starts with a single `/` (as Pimcore assets/documents/objects are all relative to the host (as far as I know)). Everything else (including protocol-relative URLs like `//google.de`) are considered external.