### PR TITLE
add deprecation warning for class resolver exceptions

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,7 +1,7 @@
 # Upgrade Notes
 
 ## 10.5.0
-- [Class Definitions] Resolving classes or services will no longer catch exceptions in Pimcore 11. Remove invalid any references from class definitions.
+- [Class Definitions] Resolving classes or services will no longer catch exceptions in Pimcore 11. Remove invalid references from class definitions.
 - [Sessions] Changed default value for `symfony.session.cookie_secure` to `auto`
 - [Listings] `JsonListing` class is deprecated. Please use `CallableFilterListingInterface`, `FilterListingTrait` and `CallableOrderListingInterface`, `OrderListingTrait` instead.
   For examples please see existing classes, e.g. `Pimcore\Model\Document\DocType\Listing`.

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,6 +1,7 @@
 # Upgrade Notes
 
 ## 10.5.0
+- [Class Definitions] Resolving classes or services will no longer catch exceptions in Pimcore 11. Remove invalid any references from class definitions.
 - [Sessions] Changed default value for `symfony.session.cookie_secure` to `auto`
 - [Listings] `JsonListing` class is deprecated. Please use `CallableFilterListingInterface`, `FilterListingTrait` and `CallableOrderListingInterface`, `OrderListingTrait` instead.
   For examples please see existing classes, e.g. `Pimcore\Model\Document\DocType\Listing`.

--- a/models/DataObject/ClassDefinition/Helper/ClassResolver.php
+++ b/models/DataObject/ClassDefinition/Helper/ClassResolver.php
@@ -50,6 +50,12 @@ abstract class ClassResolver
                 return self::$cache[$class];
             } catch (\Throwable $e) {
                 Logger::error((string) $e);
+
+                trigger_deprecation(
+                    'pimcore/pimcore',
+                    '10.5',
+                    'Resolving classes will no longer catch exceptions in Pimcore 11. Remove any invalid services from class definitions.'
+                );
             }
         }
 

--- a/models/DataObject/ClassDefinition/Helper/ClassResolver.php
+++ b/models/DataObject/ClassDefinition/Helper/ClassResolver.php
@@ -54,7 +54,7 @@ abstract class ClassResolver
                 trigger_deprecation(
                     'pimcore/pimcore',
                     '10.5',
-                    'Resolving classes will no longer catch exceptions in Pimcore 11. Remove any invalid services from class definitions.'
+                    sprintf('Resolving classes or services will no longer catch exceptions in Pimcore 11. Remove invalid reference %s from class definitions.', $class)
                 );
             }
         }


### PR DESCRIPTION
The `ClassResolver` in Pimcore 11 [will no longer catch exceptions](https://github.com/pimcore/pimcore/pull/12742). This PR adds the deprecation warning for Pimcore 10.