### PR TITLE
[Task]: Migration class name not matching the filename

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20220829132224.php
+++ b/bundles/CoreBundle/Migrations/Version20220829132224.php
@@ -22,7 +22,7 @@ use Doctrine\Migrations\AbstractMigration;
 use Pimcore\Config;
 use Pimcore\Model\Tool\SettingsStore;
 
-final class Version20220829110624 extends AbstractMigration
+final class Version20220829132224 extends AbstractMigration
 {
     public function getDescription(): string
     {


### PR DESCRIPTION
## Changes in this pull request  
Resolves 
![image](https://user-images.githubusercontent.com/6014195/190598208-36ddc360-f2b9-481e-8814-35d25f134cff.png)

Followup of #12992

