### PR TITLE
AdvancedManyToManyObjectRelation: Cast to boolean

### DIFF
--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -742,7 +742,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
      */
     public function setEnableBatchEdit($enableBatchEdit)
     {
-        $this->enableBatchEdit = $enableBatchEdit;
+        $this->enableBatchEdit = (bool) $enableBatchEdit;
     }
 
     /**
@@ -1008,7 +1008,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
      */
     public function setAllowMultipleAssignments($allowMultipleAssignments)
     {
-        $this->allowMultipleAssignments = $allowMultipleAssignments;
+        $this->allowMultipleAssignments = (bool) $allowMultipleAssignments;
 
         return $this;
     }


### PR DESCRIPTION
Boolean attributes should be cast to boolean in the setters to support old fielddefinitions with null values.

Followup to https://github.com/pimcore/pimcore/pull/12999

See codeception error in https://github.com/pimcore/customer-data-framework/pull/336