### PR TITLE
[Task]: Encode `path` column in Users > Workspaces

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/workspace/asset.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/workspace/asset.js
@@ -34,6 +34,7 @@ pimcore.settings.user.workspace.asset = Class.create({
         var typesColumns = [
             {text: t("path"), width: 200, sortable: false, dataIndex: 'path',
                         editor: new Ext.form.TextField({}),
+                        renderer: Ext.util.Format.htmlEncode,
                         tdCls: "pimcore_property_droptarget"
             }
         ];

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/workspace/document.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/workspace/document.js
@@ -35,7 +35,8 @@ pimcore.settings.user.workspace.document = Class.create({
         var typesColumns = [
             {text: t("path"), width: 200, sortable: false, dataIndex: 'path',
                     editor: new Ext.form.TextField({}),
-                tdCls: "pimcore_property_droptarget"
+                    renderer: Ext.util.Format.htmlEncode,
+                    tdCls: "pimcore_property_droptarget"
             }
         ];
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/workspace/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/workspace/object.js
@@ -36,6 +36,7 @@ pimcore.settings.user.workspace.object = Class.create({
         var typesColumns = [
             {text: t("path"), width: 200, sortable: false, dataIndex: 'path',
                                 editor: new Ext.form.TextField({}),
+                                renderer: Ext.util.Format.htmlEncode,
                                 tdCls: "pimcore_property_droptarget"
             }
         ];


### PR DESCRIPTION
## Changes in this pull request  
Just for best practice purposes, any invalid typed `path` doesn't get saved anyways when not matching to any existing and valid element.

Potentially it could be improved by allowing the same regex rules as defined [here](https://github.com/pimcore/pimcore/blob/b7d67edaaebeb366b5ddfcfc5983a1e20e139c53/models/Element/Service.php#L1098-L1132) 

