### PR TITLE
Composer: Make some static methods useable for Package Events too

### DIFF
--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -34,7 +34,7 @@ class Composer
     ];
 
     /**
-     * @param Event $event
+     * @param Event|PackageEvent $event
      *
      * @return string
      */
@@ -161,7 +161,7 @@ class Composer
      *
      * @internal
      */
-    protected static function executeCommand(Event $event, $consoleDir, array $cmd, $timeout = 900, $writeBuffer = true)
+    protected static function executeCommand(Event|PackageEvent $event, $consoleDir, array $cmd, $timeout = 900, $writeBuffer = true)
     {
         $command = [static::getPhp(false)];
         $command = array_merge($command, static::getPhpArguments());
@@ -230,7 +230,7 @@ class Composer
         return $arguments;
     }
 
-    protected static function getOptions(Event $event)
+    protected static function getOptions(Event|PackageEvent $event)
     {
         $options = array_merge(static::$options, $event->getComposer()->getPackage()->getExtra());
 
@@ -243,7 +243,7 @@ class Composer
         return $options;
     }
 
-    protected static function getConsoleDir(Event $event, $actionName)
+    protected static function getConsoleDir(Event|PackageEvent $event, $actionName)
     {
         $options = static::getOptions($event);
         if (!static::hasDirectory($event, 'bin-dir', $options['bin-dir'], $actionName)) {
@@ -253,7 +253,7 @@ class Composer
         return $options['bin-dir'];
     }
 
-    protected static function hasDirectory(Event $event, $configName, $path, $actionName)
+    protected static function hasDirectory(Event|PackageEvent $event, $configName, $path, $actionName)
     {
         if (!is_dir($path)) {
             $event->getIO()->write(sprintf('The %s (%s) specified in composer.json was not found in %s, can not %s.', $configName, $path, getcwd(), $actionName));


### PR DESCRIPTION
The static methods hasDirectory, getConsoleDir, getOptions and executeCommand could now be used for PackageEvents too.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

