### PR TITLE
[Reverse object relation] Do not allow to search for folders

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/reverseObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/reverseObjectRelation.js
@@ -318,17 +318,16 @@ pimcore.object.tags.reverseObjectRelation = Class.create(pimcore.object.tags.man
         allowedClasses.push(record.data.text);
 
 
-        pimcore.helpers.itemselector(true, this.addDataFromSelector.bind(this), {
-            type: ["object"],
-            subtype: [
-                {
+        pimcore.helpers.itemselector(true, this.addDataFromSelector.bind(this),
+            {
+                type: ["object"],
+                subtype: {
                     object: ["object", "variant"]
+                },
+                specific: {
+                    classes: allowedClasses
                 }
-            ],
-            specific: {
-                classes: allowedClasses
-            }
-        },
+            },
             {
                 context: Ext.apply({scope: "objectEditor"}, this.getContext())
             });


### PR DESCRIPTION
Steps to reproduce bug:
1. Create data object class `A`
2. Create data object class `B` with a many-to-many object relation `relation` to `A`
3. Edit class `A` -> add reverse relation field to `B.relation`
4. Create folder `/test`
5. Create object of `A` named `Object of A`
6. Create object of `B` named `Object of B` inside `/test` and assign `Object of A` to `relation`
7. open / reload `Object of A` (`Object of B` should be shown in the reverse relation). Click the Search icon for the reverse relation. It will allow you to filter for subtype `folder` - and the worst: It will even find something, in this case `/` and `/test`

This PR fixes this - similar to https://github.com/pimcore/pimcore/blob/efeecaaaa542489aadb934cf47de70eee0062be1/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyObjectRelation.js#L708-L710