### PR TITLE
[Assets] Support uploading files whose MIME-Type cannot be determined

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -17,6 +17,7 @@ namespace Pimcore\Model;
 
 use Doctrine\DBAL\Exception\DeadlockException;
 use Exception;
+use League\Flysystem\UnableToRetrieveMetadata;
 use function is_array;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
@@ -727,7 +728,11 @@ class Asset extends Element\AbstractElement
 
                 $this->closeStream(); // set stream to null, so that the source stream isn't used anymore after saving
 
-                $mimeType = $storage->mimeType($path);
+                try {
+                    $mimeType = $storage->mimeType($path);
+                } catch(UnableToRetrieveMetadata $e) {
+                    $mimeType = 'unknown';
+                }
                 $this->setMimeType($mimeType);
 
                 // set type

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -731,7 +731,7 @@ class Asset extends Element\AbstractElement
                 try {
                     $mimeType = $storage->mimeType($path);
                 } catch(UnableToRetrieveMetadata $e) {
-                    $mimeType = 'unknown';
+                    $mimeType = 'application/octet-stream';
                 }
                 $this->setMimeType($mimeType);
 


### PR DESCRIPTION
Probably due to change of asset storage to Flysystem it is currently not possible anymore to upload asset files whose MIME-Type cannot be determined. For us this happened with an stp file. You will get
<img width="701" alt="Bildschirmfoto 2022-09-21 um 09 48 42" src="https://user-images.githubusercontent.com/8749138/191446366-c0b55971-5c5d-4a7c-aad5-5b6c6fc3642b.png">

To reproduce you can try to upload a file from https://www.eagleburgmann.com/en/company/download-center/stp-files - obviously this file extension is missing in https://github.com/thephpleague/mime-type-detection/blob/main/src/GeneratedExtensionToMimeTypeMap.php - have tackled this in https://github.com/thephpleague/mime-type-detection/pull/18 - but there will be other file extensions which are also not listed here. Those assets should be possbile to get uploaded as type `unknown` to Pimcore. With this PR this works.