### PR TITLE
[Bug] listing getTotalCount() column already exists

### DIFF
--- a/lib/Model/Listing/Dao/QueryBuilderHelperTrait.php
+++ b/lib/Model/Listing/Dao/QueryBuilderHelperTrait.php
@@ -131,7 +131,7 @@ trait QueryBuilderHelperTrait
         }
 
         if ($this->isQueryBuilderPartInUse($queryBuilder, 'groupBy') || $this->isQueryBuilderPartInUse($queryBuilder, 'having')) {
-            $queryBuilder->select(!empty($originalSelect) ? $originalSelect : '*');
+            $queryBuilder->select(!empty($originalSelect) ? $originalSelect : $identifierColumn);
 
             // Rewrite to 'SELECT COUNT(*) FROM (' . $queryBuilder . ') XYZ'
             $innerQuery = (string)$queryBuilder;


### PR DESCRIPTION
Adding multiple joins to a listing via onCreateQueryBuilder causes PDOException: SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'cid'").

Caused by the subquery retrieving `*`, while join queries may contain the same column. Fixed by using the identifier column introduced in https://github.com/pimcore/pimcore/pull/12854