### PR TITLE
Fix styling for inherited fields with label top

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/admin.css
+++ b/bundles/AdminBundle/Resources/public/css/admin.css
@@ -1143,6 +1143,10 @@ span.warning {
     margin-right: 10px;
 }
 
+.object_field > .x-form-item-label-top > .x-form-item-label-inner {
+    display: inline-block;
+}
+
 .object_field_panel {
     padding: 0;
 }

--- a/bundles/AdminBundle/Resources/public/extjs/css/PimcoreApp-all_1.css
+++ b/bundles/AdminBundle/Resources/public/extjs/css/PimcoreApp-all_1.css
@@ -2131,10 +2131,6 @@ td.x-frame-mc {
     height: 1px;
 }
 
-.x-form-item-label-top > .x-form-item-label-inner {
-    display: table-cell;
-}
-
 .x-form-item-label-top-side-error:after {
     display: table-cell;
     content: '';

--- a/bundles/AdminBundle/Resources/public/extjs/css/PimcoreApp-all_1.css
+++ b/bundles/AdminBundle/Resources/public/extjs/css/PimcoreApp-all_1.css
@@ -2131,6 +2131,10 @@ td.x-frame-mc {
     height: 1px;
 }
 
+.x-form-item-label-top > .x-form-item-label-inner {
+    display: table-cell;
+}
+
 .x-form-item-label-top-side-error:after {
     display: table-cell;
     content: '';


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
With the current styling, the label is moved to the right and the field is not the full width (as seen in screenshot 1) if the label position is set to top. This is because of the `display: table-cell` styling. 

Old:
![CleanShot 2022-09-23 at 16 37 29](https://user-images.githubusercontent.com/32356549/191988575-77f9c353-ac62-40d9-8b5c-40832d2c9697.png)

New:
![CleanShot 2022-09-23 at 16 42 56](https://user-images.githubusercontent.com/32356549/191988581-a9b3a017-3372-4d2e-a7df-a9af6121aabe.png)
