### PR TITLE
improvement: add cause element to duplicate full path exception

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -670,6 +670,7 @@ class Asset extends Element\AbstractElement
             if ($duplicate instanceof Asset && $duplicate->getId() != $this->getId()) {
                 $duplicateFullPathException = new DuplicateFullPathException('Duplicate full path [ ' . $this->getRealFullPath() . ' ] - cannot save asset');
                 $duplicateFullPathException->setDuplicateElement($duplicate);
+                $duplicateFullPathException->setCauseElement($this);
 
                 throw $duplicateFullPathException;
             }

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -881,6 +881,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             if ($duplicate instanceof self && $duplicate->getId() != $this->getId()) {
                 $duplicateFullPathException = new DuplicateFullPathException('Duplicate full path [ '.$this->getRealFullPath().' ] - cannot save object');
                 $duplicateFullPathException->setDuplicateElement($duplicate);
+                $duplicateFullPathException->setCauseElement($this);
 
                 throw $duplicateFullPathException;
             }

--- a/models/Document.php
+++ b/models/Document.php
@@ -504,6 +504,7 @@ class Document extends Element\AbstractElement
             if ($duplicate instanceof Document && $duplicate->getId() != $this->getId()) {
                 $duplicateFullPathException = new DuplicateFullPathException('Duplicate full path [ ' . $this->getRealFullPath() . ' ] - cannot save document');
                 $duplicateFullPathException->setDuplicateElement($duplicate);
+                $duplicateFullPathException->setCauseElement($this);
 
                 throw $duplicateFullPathException;
             }

--- a/models/Element/DuplicateFullPathException.php
+++ b/models/Element/DuplicateFullPathException.php
@@ -17,6 +17,7 @@ namespace Pimcore\Model\Element;
 
 class DuplicateFullPathException extends \Exception
 {
+    private ?ElementInterface $causeElement = null;
     private ?ElementInterface $duplicateElement = null;
 
     public function setDuplicateElement(?ElementInterface $duplicateElement): void
@@ -27,5 +28,15 @@ class DuplicateFullPathException extends \Exception
     public function getDuplicateElement(): ?ElementInterface
     {
         return $this->duplicateElement;
+    }
+
+    public function setCauseElement(?ElementInterface $causeElement): void
+    {
+        $this->causeElement = $causeElement;
+    }
+
+    public function getCauseElement(): ?ElementInterface
+    {
+        return $this->causeElement;
     }
 }


### PR DESCRIPTION
When saving an element, chances are, a `DuplicateFullPatchException` is thrown. If the exception is handled programmatically, it's useful to have access to the cause of the execption (e.g., the element on which `save()` was called).

This PR adds the corresponding setters and calls them where necessary. The developer may then call `getCauseElement()` to access the element that caused the exception.