### PR TITLE
verify path points to file before reading file

### DIFF
--- a/lib/Twig/Extension/AdminExtension.php
+++ b/lib/Twig/Extension/AdminExtension.php
@@ -58,7 +58,7 @@ class AdminExtension extends AbstractExtension
             foreach ([PIMCORE_WEB_ROOT . '/bundles/pimcoreadmin/js/' . $path,
                         PIMCORE_WEB_ROOT . $path,
                     ] as $fullPath) {
-                if (file_exists($fullPath)) {
+                if (is_file($fullPath)) {
                     $scriptContents .= file_get_contents($fullPath) . "\n\n\n";
                     $found = true;
                 }


### PR DESCRIPTION
make sure $fullPath points to a file prior to reading its contents, fixes error exceptions in case of broken configuration

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

fixes error exceptions in case of broken configuration

## Additional info  

