### PR TITLE
Added null/empty check for predefinedMetaDataGroups data array

### DIFF
--- a/bundles/AdminBundle/public/js/pimcore/asset/metadata/grid.js
+++ b/bundles/AdminBundle/public/js/pimcore/asset/metadata/grid.js
@@ -278,9 +278,13 @@ pimcore.asset.metadata.grid = Class.create({
                     xtype: "tbspacer",
                     width: 20
                 });
-                let predefinedMetadataGroups = Ext.Array.map (this.asset.data.predefinedMetaDataGroups, function(predefinedMetadataGroup){
-                    return {text: t(predefinedMetadataGroup), handler: function(){ this.handleAddPredefinedDefinitions(predefinedMetadataGroup); }.bind(this)};
-                }.bind(this));
+
+                let predefinedMetadataGroups = [];
+                if (this.asset.data && this.asset.data.predefinedMetaDataGroups) {
+                    predefinedMetadataGroups = Ext.Array.map (this.asset.data.predefinedMetaDataGroups, function(predefinedMetadataGroup){
+                        return {text: t(predefinedMetadataGroup), handler: function(){ this.handleAddPredefinedDefinitions(predefinedMetadataGroup); }.bind(this)};
+                    }.bind(this));
+                }
 
                 if(predefinedMetadataGroups.length > 0) {
                     predefinedMetadataGroups.unshift('-');


### PR DESCRIPTION
I have configured Azure Blob storage and able to add/update/delete in Azure but when I try to open the asset in Admin panel, I got an error regarding predefinedMetaDataGroups data array.
So, added a null check for the same.

_Would be great if it is merged ASAP.
Thanks_