### PR TITLE
[Bug]: RGBA Color doesn't work if user language is german

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/colorpicker-overrides.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/colorpicker-overrides.js
@@ -93,6 +93,13 @@ pimcore.helpers.colorpicker = {
                 if (me.colorPicker) {
                     me.colorPicker.setColor(c);
                 }
+            },
+
+            /**
+             * Deactivate the alpha decimal formatting, see https://github.com/pimcore/pimcore/issues/13304
+             */
+            getAlphaDecimalFormat: function () {
+                return null;
             }
         });
 


### PR DESCRIPTION
Fix https://github.com/pimcore/pimcore/issues/13304