### PR TITLE
[Bug] Fix search bug in HTTP Errors log

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/httpErrorLog.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/httpErrorLog.js
@@ -102,7 +102,7 @@ pimcore.settings.httpErrorLog = Class.create({
             listeners: {
                 "keydown" : function (field, key) {
                     if (key.getKey() == key.ENTER) {
-                        var val = field.getValue();
+                        const val = field.getValue();
                         this.store.getProxy().extraParams.filter = val ? val : "";
                         this.store.load();
                     }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/httpErrorLog.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/httpErrorLog.js
@@ -102,8 +102,7 @@ pimcore.settings.httpErrorLog = Class.create({
             listeners: {
                 "keydown" : function (field, key) {
                     if (key.getKey() == key.ENTER) {
-                        var input = filterField;
-                        var val = input.getValue();
+                        var val = field.getValue();
                         this.store.getProxy().extraParams.filter = val ? val : "";
                         this.store.load();
                     }


### PR DESCRIPTION
Steps to reproduce:
1. Go to "Marketing -> Search Engine Optimization -> HTTP Errors".
2. Enter anything in the "Filter/Search"-field and hit enter. 
3. Developer tools -> console will reveal that there is an error `Uncaught ReferenceError: filterField is not defined` due to a wrongly named variable.

This PR renames the wrongly named variable and also removes a redundant variable.