### PR TITLE
[Bug]: Adds Video Thumbnail support in PublicServices when using Flysystem

### DIFF
--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -106,6 +106,8 @@ class PublicServicesController extends Controller
 
                             if ($storage->fileExists($storagePath)) {
                                 $thumbnailStream = $storage->readStream($storagePath);
+                                $mime = $storage->mimeType($storagePath);
+                                $fileSize = $storage->fileSize($storagePath);
                             }
                         } else {
                             $time = 1;
@@ -163,9 +165,6 @@ class PublicServicesController extends Controller
                                 $requestedFile = preg_replace('/\.' . $actualFileExtension . '$/', '.' . $requestedFileExtension, $pathReference['src']);
                                 $storage->writeStream($requestedFile, $thumbnailStream);
                             }
-                        }else{
-                            $mime = $storage->mimeType($storagePath);
-                            $fileSize = $storage->fileSize($storagePath);
                         }
                         // set appropriate caching headers
                         // see also: https://github.com/pimcore/pimcore/blob/1931860f0aea27de57e79313b2eb212dcf69ef13/.htaccess#L86-L86

--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -162,9 +162,11 @@ class PublicServicesController extends Controller
                                 $requestedFile = preg_replace('/\.' . $actualFileExtension . '$/', '.' . $requestedFileExtension, $pathReference['src']);
                                 $storage->writeStream($requestedFile, $thumbnailStream);
                             }
-                        }elseif ($thumbnailType =='video' && $storagePath){
+                        }elseif ($thumbnailType =='video' && isset($storagePath)){
                             $mime = $storage->mimeType($storagePath);
                             $fileSize = $storage->fileSize($storagePath);
+                        }else{
+                            throw new \Exception('Cannot determine mime type and file size of '.$thumbnailType.' thumbnail, see logs for details.');
                         }
                         // set appropriate caching headers
                         // see also: https://github.com/pimcore/pimcore/blob/1931860f0aea27de57e79313b2eb212dcf69ef13/.htaccess#L86-L86

--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -78,7 +78,7 @@ class PublicServicesController extends Controller
                             TmpStore::delete($deferredConfigId);
 
                             if (!$thumbnailConfig instanceof $thumbnailConfigClass) {
-                                throw new \Exception('Deferred thumbnail config file doesn\'t contain a valid //'.$thumbnailConfigClass.' object');
+                                throw new \Exception('Deferred thumbnail config file doesn\'t contain a valid '.$thumbnailConfigClass.' object');
                             }
                         } elseif ($this->getParameter('pimcore.config')['assets'][$thumbnailType]['thumbnails']['status_cache']) {
                             // Delete Thumbnail Name from Cache so the next call can generate a new TmpStore entry
@@ -105,8 +105,6 @@ class PublicServicesController extends Controller
 
                             if ($storage->fileExists($storagePath)) {
                                 $thumbnailStream = $storage->readStream($storagePath);
-                                $mime = $storage->mimeType($storagePath);
-                                $fileSize = $storage->fileSize($storagePath);
                             }
                         } else {
                             $time = 1;
@@ -164,6 +162,9 @@ class PublicServicesController extends Controller
                                 $requestedFile = preg_replace('/\.' . $actualFileExtension . '$/', '.' . $requestedFileExtension, $pathReference['src']);
                                 $storage->writeStream($requestedFile, $thumbnailStream);
                             }
+                        }elseif ($thumbnailType =='video' && $storagePath){
+                            $mime = $storage->mimeType($storagePath);
+                            $fileSize = $storage->fileSize($storagePath);
                         }
                         // set appropriate caching headers
                         // see also: https://github.com/pimcore/pimcore/blob/1931860f0aea27de57e79313b2eb212dcf69ef13/.htaccess#L86-L86

--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -65,9 +65,8 @@ class PublicServicesController extends Controller
                     $thumbnailStream = null;
 
                     // just check if the thumbnail exists -> throws exception otherwise
-                    $thumbnailConfigClass = 'Pimcore\Model\Asset\\' . ucfirst($thumbnailType) . '\\Thumbnail\Config';
-                    $thumbnailConfig = new $thumbnailConfigClass();
-                    $thumbnailConfig = $thumbnailConfig::getByName($thumbnailName);
+                    $thumbnailConfigClass = 'Pimcore\\Model\\Asset\\' . ucfirst($thumbnailType) . '\\Thumbnail\Config';
+                    $thumbnailConfig = $thumbnailConfigClass::getByName($thumbnailName);
 
                     if (!$thumbnailConfig) {
                         // check if there's an item in the TmpStore

--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -66,8 +66,8 @@ class PublicServicesController extends Controller
                     try {
                         $storage = Storage::get('thumbnail');
 
-                        $videoThumbnail = $asset->getThumbnail('content', ['mp4']);
-                        $storagePath = urldecode($videoThumbnail['formats']['mp4']);
+                        $videoThumbnail = $asset->getThumbnail($thumbnailName, [$requestedFileExtension]);
+                        $storagePath = urldecode($videoThumbnail['formats'][$requestedFileExtension]);
 
                         if ($storage->fileExists($storagePath)) {
                             $thumbnailStream = $storage->readStream($storagePath);

--- a/bundles/CoreBundle/Resources/config/routing.yml
+++ b/bundles/CoreBundle/Resources/config/routing.yml
@@ -15,10 +15,11 @@ _pimcore_service_common_files_apple_touch_icon:
         filename: 'apple\-touch\-icon.*'
 
 _pimcore_service_thumbnail:
-    path: '{prefix}image-thumb__{assetId}__{thumbnailName}/{filename}'
+    path: '{prefix}{type}-thumb__{assetId}__{thumbnailName}/{filename}'
     defaults: { _controller: Pimcore\Bundle\CoreBundle\Controller\PublicServicesController::thumbnailAction}
     requirements:
         prefix: '.*'
+        type: 'video|image'
         assetId: '\d+'
         thumbnailName: '[a-zA-Z0-9_\-]+'
         filename: '.*'

--- a/tests/Model/Asset/AssetThumbnailCacheTest.php
+++ b/tests/Model/Asset/AssetThumbnailCacheTest.php
@@ -90,6 +90,7 @@ class AssetThumbnailCacheTest extends TestCase
             'assetId' => $asset->getId(),
             'thumbnailName' => $thumbnailName,
             'filename' => $asset->getFilename(),
+            'type' => 'image'
         ]);
         $response = $controller->thumbnailAction($subRequest);
 

--- a/tests/Model/Asset/AssetThumbnailCacheTest.php
+++ b/tests/Model/Asset/AssetThumbnailCacheTest.php
@@ -110,6 +110,7 @@ class AssetThumbnailCacheTest extends TestCase
             'assetId' => $asset->getId(),
             'thumbnailName' => $thumbnailName,
             'filename' => $asset->getFilename(),
+            'type' => 'image'
         ]);
         $response = $controller->thumbnailAction($subRequest);
         $this->assertNotNull($asset->getDao()->getCachedThumbnailModificationDate($thumbnailName, $asset->getFilename()));


### PR DESCRIPTION
## Changes in this pull request  
Alternative solution of a problem reported in https://github.com/pimcore/pimcore/pull/13291

## Additional info  
Having thumbnail in cloud storage with flysystem and a video editable on a public page, the video thumbnail won't work because the file eg. `/566/video-thumb__566__content/abcedf_10s_5MB.mp4` wouldn't be served by the Public Service Controller, throwing routing problems or 404 not found. 
This is because `video-thumb` was not covered, so it was just displaying the video image cover (which was working fine due the prefix as `image-thumb`) but couldn't play.