### PR TITLE
Codeception: Use node.JS LTS version

### DIFF
--- a/.github/workflows/codeception.yml
+++ b/.github/workflows/codeception.yml
@@ -75,9 +75,9 @@ jobs:
             - name: "Checkout code"
               uses: "actions/checkout@v2"
 
-            - uses: "actions/setup-node@v2"
+            - uses: "actions/setup-node@v3"
               with:
-                  node-version: '10'
+                  node-version: 'lts/*'
 
             - name: "Install PHP"
               uses: "shivammathur/setup-php@v2"


### PR DESCRIPTION
Fix the current codeception error

```
Download action repository 'actions/setup-node@v2' (SHA:1f8c6b94b26d0feae1e387ca63ccbdc44d27b561)
Error: Can't use 'tar -xzf' extract archive file: /home/runner/work/_actions/_temp_c63b2b49-c9b8-450d-a937-02d2ec247c94/75fc4526-52e3-444c-9f6a-61b65d75da9c.tar.gz. return code: 2.
```