### PR TITLE
[Documents] Editable Dialog Box - Add description support

### DIFF
--- a/bundles/AdminBundle/public/js/pimcore/document/editables/area_abstract.js
+++ b/bundles/AdminBundle/public/js/pimcore/document/editables/area_abstract.js
@@ -110,10 +110,20 @@ pimcore.document.area_abstract = Class.create(pimcore.document.editable, {
                         html: templateEl.innerHTML
                     };
                 } else {
+                    var templateHTML = templateEl.innerHTML;
+                    if (editablesInBox[config['name']]['config'] 
+                        && editablesInBox[config['name']]['config']['description']) {
+                        
+                        var descriptionHTML = '<div style="font-size: 14px; margin-bottom: 10px;">'
+                          + editablesInBox[config['name']]['config']['description']
+                          + '</div>';
+
+                        templateHTML = descriptionHTML + templateHTML;
+                    }
                     return {
                         xtype: 'fieldset',
                         title: config['label'] ?? config['name'],
-                        html: templateEl.innerHTML
+                        html: templateHTML
                     };
                 }
             }

--- a/bundles/AdminBundle/public/js/pimcore/document/editables/area_abstract.js
+++ b/bundles/AdminBundle/public/js/pimcore/document/editables/area_abstract.js
@@ -101,23 +101,25 @@ pimcore.document.area_abstract = Class.create(pimcore.document.editable, {
             let templateId = 'template__' + editablesInBox[config['name']].getId();
             var templateEl = document.getElementById(templateId);
             if(templateEl) {
+                var templateHTML = templateEl.innerHTML;
+
+                if (config['description']) {
+                    var descriptionHTML = '<div style="font-size: 14px; margin-bottom: 10px;">'
+                        + config['description']
+                        + '</div>';
+
+                    templateHTML = descriptionHTML + templateHTML;
+                }
+
                 if(typeof editablesInBox[config['name']]['renderInDialogBox'] === "function") {
                     if (editablesInBox[config['name']]['config']) {
                         editablesInBox[config['name']]['config']['label'] = config['label'] ?? config['name'];
                     }
                     return {
                         xtype: 'container',
-                        html: templateEl.innerHTML
+                        html: templateHTML
                     };
                 } else {
-                    var templateHTML = templateEl.innerHTML;
-                    if (config['description']) {
-                        var descriptionHTML = '<div style="font-size: 14px; margin-bottom: 10px;">'
-                          + config['description']
-                          + '</div>';
-
-                        templateHTML = descriptionHTML + templateHTML;
-                    }
                     return {
                         xtype: 'fieldset',
                         title: config['label'] ?? config['name'],

--- a/bundles/AdminBundle/public/js/pimcore/document/editables/area_abstract.js
+++ b/bundles/AdminBundle/public/js/pimcore/document/editables/area_abstract.js
@@ -111,11 +111,9 @@ pimcore.document.area_abstract = Class.create(pimcore.document.editable, {
                     };
                 } else {
                     var templateHTML = templateEl.innerHTML;
-                    if (editablesInBox[config['name']]['config'] 
-                        && editablesInBox[config['name']]['config']['description']) {
-                        
+                    if (config['description']) {
                         var descriptionHTML = '<div style="font-size: 14px; margin-bottom: 10px;">'
-                          + editablesInBox[config['name']]['config']['description']
+                          + config['description']
                           + '</div>';
 
                         templateHTML = descriptionHTML + templateHTML;

--- a/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/02_Bricks.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/02_Areablock/02_Bricks.md
@@ -278,6 +278,7 @@ class WysiwygWithImages extends AbstractAreabrick implements EditableDialogBoxIn
                 'type' => 'checkbox',
                 'name' => 'myDialogCheckbox',
                 'label' => 'This is the checkbox label',
+                'description' => 'This is a description for myDialogCheckbox' // descriptions are optional
             ],
             [
                 'type' => 'date',


### PR DESCRIPTION
## Changes in this pull request  
Resolves #9656

This PR extends the editable dialog box config with a `description`.  

## Additional info  

Sometimes an editables label isn't enough to properly describe what it will be used for. With a description above a more detailed explanation can be achieved.

```php
(new EditableDialogBoxConfiguration())->setItems([
    [
        'type' => 'input',
        'name' => 'SEO Headline',
        'config' => [
            'description' => 'This headline is used for search engine blah blah.',
            // With custom HTML
            // 'description' => '<b>This is now bold</b>',
        ],
    ],
]);
```
![image](https://user-images.githubusercontent.com/20670106/194408448-66cb6d4e-fcfb-4cc9-9a6f-1c38f2dabdd2.png)