### PR TITLE
fixes the height of the object preview iframe

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/preview.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/preview.js
@@ -116,5 +116,11 @@ Ext.define('pimcore.object.preview', {
             },
             items: this.paramSelects,
         });
+    },
+
+    setLayoutFrameDimensions: function (width, height) {
+        this.getIframe().setStyle({
+            height: (height - 48) + "px"
+        });
     }
 });


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
In the preview tab of an data object, the iframe height was not correct. This PR fixes this issue.

## Additional info  
You can see the problem in the pimcore demo (https://demo.pimcore.fun/admin/login/deeplink?object_81_object -> click to the preview tab). The footer is not fully shown. You can see that if you put a border to the footer element or if you watch the scollbars (they disappear for a few px).
