### PR TITLE
Fix twig example code to actually use a comment as intended

### DIFF
--- a/doc/Development_Documentation/02_MVC/02_Template/02_Template_Extensions/00_Placeholder.md
+++ b/doc/Development_Documentation/02_MVC/02_Template/02_Template_Extensions/00_Placeholder.md
@@ -13,7 +13,7 @@ echo out.
 ```twig
 {% do pimcore_placeholder('foo').set("Some text for later") %}
 
-{% outputs "Some text for later" %}
+{# outputs "Some text for later" #}
 {{ pimcore_placeholder('foo') }}
 ```
 


### PR DESCRIPTION
I am not absolutely if this change is correct, as I currently do not really understand what should be happening in this example. But my guess would be that the changed passage should be a twig comment. The way it is written now it was confusing to me.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info  

