### PR TITLE
Fix overflowing name and description on document area on hover

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/editmode.css
+++ b/bundles/AdminBundle/Resources/public/css/editmode.css
@@ -245,6 +245,11 @@ input.cke_dialog_ui_input_tel {
     line-height: 38px;
     font-size: 10px;
     padding-left: 10px;
+
+    /* Hide overflowing text where surrounding area is too narrow to display it */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .pimcore_block_button_plus,


### PR DESCRIPTION
## Changes in this pull request  
Before:
![image](https://user-images.githubusercontent.com/279826/194878298-0c690d96-a931-4554-8a12-d85c80936c20.png)
![image](https://user-images.githubusercontent.com/279826/194878452-7fbaa5fa-5674-4619-be3a-4a2387ec8ce9.png)

----

After:
![image](https://user-images.githubusercontent.com/279826/194878613-b10bc941-091d-45cc-891f-0eb3cbc2b121.png)
![image](https://user-images.githubusercontent.com/279826/194878579-6e951fd8-7f74-4b0d-bbab-32502b35e013.png)


