### PR TITLE
[Feature][Notes] Make user-created notes deletable

### DIFF
--- a/bundles/AdminBundle/public/js/pimcore/element/notes.js
+++ b/bundles/AdminBundle/public/js/pimcore/element/notes.js
@@ -173,6 +173,22 @@ pimcore.element.notes = Class.create({
                 }]
             });
 
+            columns.push({
+                xtype: 'actioncolumn',
+                menuText: t('delete'),
+                width: 30,
+                items: [{
+                    tooltip: t('delete'),
+                    icon: '/bundles/pimcoreadmin/img/flat-color-icons/delete.svg',
+                    handler: function (grid, rowIndex) {
+                        this.store.removeAt(rowIndex);
+                    }.bind(this),
+                    isDisabled: function (view, rowIndex, colIndex, item, record) {
+                        return !record.data.isDeletable;
+                    },
+                }]
+            });
+
             var plugins = ['pimcore.gridfilters'];
 
             this.grid = new Ext.grid.GridPanel({

--- a/bundles/AdminBundle/src/Controller/Admin/ElementController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/ElementController.php
@@ -185,6 +185,26 @@ class ElementController extends AdminController
     {
         $this->checkPermission('notes_events');
 
+        if ($request->query->get('xaction') === 'destroy') {
+            $deleteData = $this->decodeJson((string) $request->request->get('data'));
+            $deleteId   = $deleteData['id'] ?? null;
+            $deleteNote = $deleteId ? Element\Note::getById($deleteId) : null;
+
+            if (!$deleteNote) {
+                throw $this->createNotFoundException();
+            }
+
+            if (!$deleteNote->getIsDeletable()) {
+                throw $this->createAccessDeniedHttpException();
+            }
+            
+            $deleteNote->delete();
+
+            return $this->adminJson([
+                'success' => true,
+            ]);
+        }
+
         $list = new Element\Note\Listing();
 
         $list->setLimit($request->get('limit'));
@@ -310,6 +330,7 @@ class ElementController extends AdminController
         $note->setTitle($request->get('title'));
         $note->setDescription($request->get('description'));
         $note->setType($request->get('type'));
+        $note->setIsDeletable(true);
         $note->save();
 
         return $this->adminJson([

--- a/bundles/CoreBundle/src/Migrations/Version20221010134556.php
+++ b/bundles/CoreBundle/src/Migrations/Version20221010134556.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20221010134556 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds isDeletable column to notes table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $notes = $schema->getTable('notes');
+
+        if (!$notes->hasColumn('isDeletable')) {
+            $this->addSql('ALTER TABLE `notes` ADD COLUMN `isDeletable` TINYINT(1) NOT NULL DEFAULT 0');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $notes = $schema->getTable('notes');
+
+        if ($notes->hasColumn('isDeletable')) {
+            $this->addSql('ALTER TABLE `notes` DROP COLUMN `isDeletable`');
+        }
+    }
+}

--- a/models/Element/Note.php
+++ b/models/Element/Note.php
@@ -83,6 +83,13 @@ final class Note extends Model\AbstractModel
     /**
      * @internal
      *
+     * @var bool|null
+     */
+    protected $isDeletable;
+
+    /**
+     * @internal
+     *
      * @var array
      */
     protected $data = [];
@@ -337,5 +344,25 @@ final class Note extends Model\AbstractModel
     public function getUser()
     {
         return $this->user;
+    }
+
+    /**
+     * @param bool|null $isDeletable
+     *
+     * @return $this
+     */
+    public function setIsDeletable($isDeletable)
+    {
+        $this->isDeletable = (bool) $isDeletable;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsDeletable()
+    {
+        return (bool) $this->isDeletable;
     }
 }

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -1374,6 +1374,7 @@ class Service extends Model\AbstractModel
             'date' => $note->getDate(),
             'title' => Pimcore::getContainer()->get(TranslatorInterface::class)->trans($note->getTitle(), [], 'admin'),
             'description' => $note->getDescription(),
+            'isDeletable' => $note->getIsDeletable(),
         ];
 
         // prepare key-values


### PR DESCRIPTION
## Changes in this pull request

Resolves #3396

With this pull request, user-created notes will be deletable.  
With `$note->setIsDeletable(true)` the note can also be changed to deletable via PHP API.  

DB-Changes: Adds a column `isDeletable TINYINT(1) DEFAULT 0` to the `notes` table.