### PR TITLE
Add missing config params in facade docs

### DIFF
--- a/lib/Twig/Extension/Templating/Navigation.php
+++ b/lib/Twig/Extension/Templating/Navigation.php
@@ -60,7 +60,7 @@ class Navigation implements RuntimeExtensionInterface
 
     /**
      * Builds a navigation container by passing params
-     * Possible config params are: 'root', 'htmlMenuPrefix', 'pageCallback', 'cache', 'maxDepth', 'active'
+     * Possible config params are: 'root', 'htmlMenuPrefix', 'pageCallback', 'cache', 'cacheLifetime', 'maxDepth', 'active', 'markActiveTrail'
      *
      * @param array $params
      *


### PR DESCRIPTION
This method allows the same config params as [`\Pimcore\Navigation\Builder`](https://github.com/pimcore/pimcore/blob/10.5/lib/Navigation/Builder.php#L83), but two were missing in the docs.