### PR TITLE
fix: getting value.value if value is an object

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/country.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/country.js
@@ -24,7 +24,7 @@ pimcore.object.tags.country = Class.create(pimcore.object.tags.select, {
 
     getGridColumnConfig:function (field) {
         var renderer = function (key, value, metaData, record) {
-            if (value) {
+            if (value && Ext.isObject(value)) {
                 value = value.value;
             }
             this.applyPermissionStyle(key, value, metaData, record);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #13341

## Additional info  
value.value returns undefined if the original value is not an object. e.g. when loading an advanced many-to-many object relation, the value is the countryCode itself.
