### PR TITLE
[Classification store search window] Support finding group collection / groups / keys by translation

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -276,13 +276,14 @@ class ClassificationstoreController extends AdminController implements KernelCon
 
         $searchfilter = $request->get('searchfilter');
         if ($searchfilter) {
-            $searchFilterCondition = 'name LIKE '.$db->quote('%'.$searchfilter.'%').' OR description LIKE '.$db->quote('%'.$searchfilter.'%');
+            $searchFilterConditions = [];
 
-            foreach($this->getTranslatedSearchFilterTerms($searchfilter) as $searchFilterTerm) {
-                $searchFilterCondition .= ' OR name LIKE '.$db->quote('%'.$searchFilterTerm.'%').' OR description LIKE '.$db->quote('%'.$searchFilterTerm.'%');
+            $searchTerms = array_merge([$searchfilter], $this->getTranslatedSearchFilterTerms($searchfilter));
+            foreach($searchTerms as $searchFilterTerm) {
+                $searchFilterConditions[] = 'name LIKE '.$db->quote('%'.$searchFilterTerm.'%').' OR description LIKE '.$db->quote('%'.$searchFilterTerm.'%');
             }
 
-            $conditionParts[] = '('.$searchFilterCondition.')';
+            $conditionParts[] = '('.implode(' OR ', $searchFilterConditions).')';
         }
 
         $storeId = $request->get('storeId');
@@ -431,13 +432,14 @@ class ClassificationstoreController extends AdminController implements KernelCon
 
         $searchfilter = $request->get('searchfilter');
         if ($searchfilter) {
-            $searchFilterCondition = 'name LIKE ' . $db->quote('%' . $searchfilter . '%') . ' OR description LIKE ' . $db->quote('%'. $searchfilter . '%');
+            $searchFilterConditions = [];
 
-            foreach ($this->getTranslatedSearchFilterTerms($searchfilter) as $searchFilterTerm) {
-                $searchFilterCondition .= ' OR name LIKE '.$db->quote('%'.$searchFilterTerm.'%').' OR description LIKE '.$db->quote('%'.$searchFilterTerm.'%');
+            $searchTerms = array_merge([$searchfilter], $this->getTranslatedSearchFilterTerms($searchfilter));
+            foreach ($searchTerms as $searchFilterTerm) {
+                $searchFilterConditions[] = 'name LIKE '.$db->quote('%'.$searchFilterTerm.'%').' OR description LIKE '.$db->quote('%'.$searchFilterTerm.'%');
             }
 
-            $conditionParts[] = '('.$searchFilterCondition.')';
+            $conditionParts[] = '('.implode(' OR ', $searchFilterConditions).')';
         }
 
         if ($request->get('storeId')) {
@@ -774,17 +776,16 @@ class ClassificationstoreController extends AdminController implements KernelCon
 
         $searchfilter = $request->get('searchfilter');
         if ($searchfilter) {
-            $searchFilterCondition = Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS.'.name LIKE '.$db->quote('%'.$searchfilter.'%')
-                .' OR '.Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS.'.name LIKE '.$db->quote('%'.$searchfilter.'%')
-                .' OR '.Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS.'.description LIKE '.$db->quote('%'.$searchfilter.'%');
+            $searchFilterConditions = [];
 
-            foreach ($this->getTranslatedSearchFilterTerms($searchfilter) as $searchFilterTerm) {
-                $searchFilterCondition .= ' OR '.Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS.'.name LIKE '.$db->quote('%'.$searchFilterTerm.'%')
+            $searchTerms = array_merge([$searchfilter], $this->getTranslatedSearchFilterTerms($searchfilter));
+            foreach ($searchTerms as $searchFilterTerm) {
+                $searchFilterConditions[] = Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS.'.name LIKE '.$db->quote('%'.$searchFilterTerm.'%')
                     .' OR '.Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS.'.name LIKE '.$db->quote('%'.$searchFilterTerm.'%')
                     .' OR '.Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS.'.description LIKE '.$db->quote('%'.$searchFilterTerm.'%');
             }
 
-            $conditionParts[] = '('.$searchFilterCondition.')';
+            $conditionParts[] = '('.implode(' OR ', $searchFilterConditions).')';
         }
 
         $condition = implode(' AND ', $conditionParts);

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -278,14 +278,8 @@ class ClassificationstoreController extends AdminController implements KernelCon
         if ($searchfilter) {
             $searchFilterCondition = 'name LIKE '.$db->quote('%'.$searchfilter.'%').' OR description LIKE '.$db->quote('%'.$searchfilter.'%');
 
-            $user = Admin::getCurrentUser();
-            if ($user instanceof User) {
-                $translationListing = new Listing();
-                $translationListing->setDomain(Translation::DOMAIN_ADMIN);
-                $translationListing->setCondition('language=? AND text LIKE ?', [$user->getLanguage(), '%'.$searchfilter.'%']);
-                foreach ($translationListing as $translation) {
-                    $searchFilterCondition .= ' OR name LIKE '.$db->quote('%'.$translation->getKey().'%').' OR description LIKE '.$db->quote('%'.$translation->getKey().'%');
-                }
+            foreach($this->getTranslatedSearchFilterTerms($searchfilter) as $searchFilterTerm) {
+                $searchFilterCondition .= ' OR name LIKE '.$db->quote('%'.$searchFilterTerm.'%').' OR description LIKE '.$db->quote('%'.$searchFilterTerm.'%');
             }
 
             $conditionParts[] = '('.$searchFilterCondition.')';
@@ -439,14 +433,8 @@ class ClassificationstoreController extends AdminController implements KernelCon
         if ($searchfilter) {
             $searchFilterCondition = 'name LIKE ' . $db->quote('%' . $searchfilter . '%') . ' OR description LIKE ' . $db->quote('%'. $searchfilter . '%');
 
-            $user = Admin::getCurrentUser();
-            if ($user instanceof User) {
-                $translationListing = new Listing();
-                $translationListing->setDomain(Translation::DOMAIN_ADMIN);
-                $translationListing->setCondition('language=? AND text LIKE ?', [$user->getLanguage(), '%'.$searchfilter.'%']);
-                foreach($translationListing as $translation) {
-                    $searchFilterCondition .= ' OR name LIKE ' . $db->quote('%' .$translation->getKey() . '%') . ' OR description LIKE ' . $db->quote('%'.$translation->getKey() . '%');
-                }
+            foreach ($this->getTranslatedSearchFilterTerms($searchfilter) as $searchFilterTerm) {
+                $searchFilterCondition .= ' OR name LIKE '.$db->quote('%'.$searchFilterTerm.'%').' OR description LIKE '.$db->quote('%'.$searchFilterTerm.'%');
             }
 
             $conditionParts[] = '('.$searchFilterCondition.')';
@@ -790,16 +778,10 @@ class ClassificationstoreController extends AdminController implements KernelCon
                 .' OR '.Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS.'.name LIKE '.$db->quote('%'.$searchfilter.'%')
                 .' OR '.Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS.'.description LIKE '.$db->quote('%'.$searchfilter.'%');
 
-            $user = Admin::getCurrentUser();
-            if ($user instanceof User) {
-                $translationListing = new Listing();
-                $translationListing->setDomain(Translation::DOMAIN_ADMIN);
-                $translationListing->setCondition('language=? AND text LIKE ?', [$user->getLanguage(), '%'.$searchfilter.'%']);
-                foreach ($translationListing as $translation) {
-                    $searchFilterCondition .= ' OR '.Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS.'.name LIKE '.$db->quote('%'.$translation->getKey().'%')
-                        .' OR '.Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS.'.name LIKE '.$db->quote('%'.$translation->getKey().'%')
-                        .' OR '.Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS.'.description LIKE '.$db->quote('%'.$translation->getKey().'%');
-                }
+            foreach ($this->getTranslatedSearchFilterTerms($searchfilter) as $searchFilterTerm) {
+                $searchFilterCondition .= ' OR '.Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS.'.name LIKE '.$db->quote('%'.$searchFilterTerm.'%')
+                    .' OR '.Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS.'.name LIKE '.$db->quote('%'.$searchFilterTerm.'%')
+                    .' OR '.Classificationstore\KeyConfig\Dao::TABLE_NAME_KEYS.'.description LIKE '.$db->quote('%'.$searchFilterTerm.'%');
             }
 
             $conditionParts[] = '('.$searchFilterCondition.')';
@@ -1629,5 +1611,25 @@ class ClassificationstoreController extends AdminController implements KernelCon
             'searchRelationsAction',
         ];
         $this->checkActionPermission($event, 'classes', $unrestrictedActions);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getTranslatedSearchFilterTerms(string $searchTerm): array {
+        $terms = [];
+
+        $user = Admin::getCurrentUser();
+        if ($user instanceof User) {
+            $translationListing = new Listing();
+            $translationListing->setDomain(Translation::DOMAIN_ADMIN);
+            $translationListing->setCondition('language=? AND text LIKE ?', [$user->getLanguage(), '%'.$searchTerm.'%']);
+
+            foreach ($translationListing as $translation) {
+                $terms[] = $translation->getKey();
+            }
+        }
+
+        return $terms;
     }
 }


### PR DESCRIPTION
Steps to reproduce:

1. Create classification store
2. Create classification store group collection "Group Collection ABC"
3. Create classification store group "Group ABC", assign it to "Group Collection ABC"
4. Create classification store key / field "Field ABC", assign it to "Field ABC"
5. In translations for domain `admin` add the following translations:
    - key: Group Collection ABC, translation DE: Gruppensammlung ABC
    - key: Group ABC, translation DE: Gruppe ABC
    - key: Field ABC, translation DE: Feld ABC
6. Create class with classification store container, assign the just created store
7. Change user language to DE
8. Create object, click the "+" icon to search for classification store items
9. Search for "gruppe" -> nothing found (although we initially saw an item with name=Gruppe ABC)
10. Search for "gruppensammlung" -> same problem
11. Search for "feld" -> same problem

When you have a classification store with thousands of groups, e.g. for ETIM classification it is very difficult for users to find a certain group.

With this PR also the translated names and descriptions of the group collection / groups / keys get searched. This way all of above search terms will return the corresponding items.