### PR TITLE
Remove `internal` tag from PimcoreEcommerceFrameworkBundle

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PimcoreEcommerceFrameworkBundle.php
+++ b/bundles/EcommerceFrameworkBundle/PimcoreEcommerceFrameworkBundle.php
@@ -23,9 +23,6 @@ use Pimcore\Extension\Bundle\Traits\StateHelperTrait;
 use Pimcore\Version;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * @internal
- */
 class PimcoreEcommerceFrameworkBundle extends AbstractPimcoreBundle
 {
     use StateHelperTrait;


### PR DESCRIPTION
## Changes in this pull request  
Resolves issues with documentation, deprecations, and Symfony compatibility. This discrepancy between the docs and implementation is sort of similar to #13344.

The Pimcore docs says:

> To load a bundle with the application, it must first be enabled in `config/bundles.php` (see [bundles documentation](https://symfony.com/doc/5.2/bundles.html)).

But doing it the way the Symfony docs suggests (using `::class`) in the array keys will trigger a warning not to use `@internal` classes. 

Because there is no documentation as to why PimcoreEcommerceFrameworkBundle is tagged as `@internal` I guess it was unintentionally made?

Without this change this bundle is the odd one
![image](https://user-images.githubusercontent.com/279826/195562687-da685b02-c571-465a-8cdc-26852c7cfdbf.png)