### PR TITLE
Remove `@internal` tag from `QueryBuilderHelperTrait`

### DIFF
--- a/lib/Model/Listing/Dao/QueryBuilderHelperTrait.php
+++ b/lib/Model/Listing/Dao/QueryBuilderHelperTrait.php
@@ -18,9 +18,6 @@ namespace Pimcore\Model\Listing\Dao;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Pimcore\Model\DataObject;
 
-/**
- * @internal
- */
 trait QueryBuilderHelperTrait
 {
     /**

--- a/lib/Model/Listing/Dao/QueryBuilderHelperTrait.php
+++ b/lib/Model/Listing/Dao/QueryBuilderHelperTrait.php
@@ -43,6 +43,9 @@ trait QueryBuilderHelperTrait
         }
     }
 
+    /**
+     * @internal
+     */
     private function applyConditionsToQueryBuilder(QueryBuilder $queryBuilder): void
     {
         $condition = $this->model->getCondition();
@@ -74,6 +77,9 @@ trait QueryBuilderHelperTrait
         }
     }
 
+    /**
+     * @internal
+     */
     private function applyGroupByToQueryBuilder(QueryBuilder $queryBuilder): void
     {
         $groupBy = $this->model->getGroupBy();
@@ -82,6 +88,9 @@ trait QueryBuilderHelperTrait
         }
     }
 
+    /**
+     * @internal
+     */
     private function applyOrderByToQueryBuilder(QueryBuilder $queryBuilder): void
     {
         $orderKey = $this->model->getOrderKey();
@@ -109,6 +118,9 @@ trait QueryBuilderHelperTrait
         }
     }
 
+    /**
+     * @internal
+     */
     private function applyLimitToQueryBuilder(QueryBuilder $queryBuilder): void
     {
         $queryBuilder->setFirstResult($this->model->getOffset());


### PR DESCRIPTION
## Changes in this pull request  
Resolves #13344

## Additional info  
Maybe we can tag the private methods of the trait as `@internal`, because they're accessible from the class that uses the trait, if I'm not mistaken.