### PR TITLE
Remove checking of non-existing request attribute

### DIFF
--- a/bundles/CoreBundle/EventListener/EventedControllerListener.php
+++ b/bundles/CoreBundle/EventListener/EventedControllerListener.php
@@ -63,12 +63,7 @@ class EventedControllerListener implements EventSubscriberInterface
     public function onKernelResponse(ResponseEvent $event)
     {
         $request = $event->getRequest();
-        $eventedController = $request->attributes->get('_evented_controller');
         $eventController = $request->attributes->get('_event_controller');
-
-        if (!$eventedController && !$eventController) {
-            return;
-        }
 
         if ($eventController instanceof KernelResponseEventInterface) {
             $eventController->onKernelResponseEvent($event);


### PR DESCRIPTION
This is a remainder of the `EventedControllerInterface` from Pimcore 6. It was replaced by `KernelControllerEventInterface` and `KernelResponseEventInterface` but this code part was apparently forgotten to remove.

---

By the way... are you sure the `KernelResponseEventInterface` is working correctly? As far as I can see it only gets called, when the controller also implements the `KernelControllerEventInterface` (which e.g. the `Pimcore\Bundle\AdminBundle\Controller\Admin\IndexController` does not), because only then the `_event_controller` request attribute gets set.

/edit: see #13369