### PR TITLE
Fix usage of `KernelResponseEventInterface` without `KernelControllerEventInterface`

### DIFF
--- a/bundles/CoreBundle/EventListener/EventedControllerListener.php
+++ b/bundles/CoreBundle/EventListener/EventedControllerListener.php
@@ -51,8 +51,9 @@ class EventedControllerListener implements EventSubscriberInterface
         $request = $event->getRequest();
         $controller = $callable[0];
 
+        $request->attributes->set('_event_controller', $controller);
+
         if ($controller instanceof KernelControllerEventInterface) {
-            $request->attributes->set('_event_controller', $controller);
             $controller->onKernelControllerEvent($event);
         }
     }


### PR DESCRIPTION
Purely from looking at the code, I don't think that `KernelResponseEventInterface` is useable without using `KernelControllerEventInterface` too, because `_event_controller` only gets set when the controller implements `KernelControllerEventInterface`, and will be `null`  in `onKernelResponse()` otherwise.

> **Note**
> There's #13368 which cleans `onKernelResponse()` up.