### PR TITLE
fix: mailto not working anymore when editing links

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1790,17 +1790,9 @@ pimcore.helpers.editmode.openLinkEditPanel = function (data, callback) {
         listeners: {
             keyup: function (el) {
                 const value = el.getValue();
+                const pathRegex = new RegExp('^((\\/)|((\\/[^\\/]+)+(\\/)?))$');
 
-                // if it doesn't start with a single "/", we assume it's an external link
-                if (value && !value.startsWith('/') && !'http://'.startsWith(value) && !'https://'.startsWith(value)) {
-                    if (!value.match(/^https?:\/\//)) {
-                        el.setValue("https://" + value.replace(/^\/+/, ''));
-                    }
-                    internalTypeField.setValue(null);
-                    linkTypeField.setValue("direct");
-                }
-                // if it starts with "//", we assume it is a protocol-relative URL
-                else if (value.startsWith('//')) {
+                if(value && !value.match(pathRegex)) {
                     internalTypeField.setValue(null);
                     linkTypeField.setValue("direct");
                 }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1790,7 +1790,7 @@ pimcore.helpers.editmode.openLinkEditPanel = function (data, callback) {
         listeners: {
             keyup: function (el) {
                 const value = el.getValue();
-                const pathRegex = new RegExp('^((\\/)|((\\/[^\\/]+)+(\\/)?))$');
+                const pathRegex = new RegExp('^((/)|((/[^/]+)+(/)?))$');
 
                 if(value && !value.match(pathRegex)) {
                     internalTypeField.setValue(null);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1790,7 +1790,7 @@ pimcore.helpers.editmode.openLinkEditPanel = function (data, callback) {
         listeners: {
             keyup: function (el) {
                 const value = el.getValue();
-                const pathRegex = new RegExp('^((/)|((/[^/]+)+(/)?))$');
+                const pathRegex = new RegExp('^(/|(/[^/]+)+/?)$');
 
                 if(value && !value.match(pathRegex)) {
                     internalTypeField.setValue(null);


### PR DESCRIPTION
We had a project on `10.5.3` and updated to `10.5.7`, in which https://github.com/pimcore/pimcore/pull/13172 was introduced. This resulted in our client creating a new ticket, because prio to the mentioned PR, it was possible to have `mailto`'s in the `Path` field. Now, with the mentioned PR merged, `https://` will get prepended.

This PR removes all of the magic, ultimately, checking if the `Path` value is _not_, in fact, a _path_ to set the required values.