### PR TITLE
Task: Removed aliases related to deprecated Pimcore\Db\Connection

### DIFF
--- a/bundles/CoreBundle/config/aliases.yaml
+++ b/bundles/CoreBundle/config/aliases.yaml
@@ -3,8 +3,6 @@ services:
         public: true
 
     # aliases enabling autowiring for type hints to our own implementations
-    Pimcore\Db\Connection: '@database_connection'
-    Pimcore\Db\ConnectionInterface: '@database_connection'
     Pimcore\Kernel: '@kernel'
 
     Symfony\Bridge\Twig\Extension\WebLinkExtension: '@twig.extension.weblink'


### PR DESCRIPTION
## Changes in this pull request  
Follow-up of https://github.com/pimcore/pimcore/issues/12466


