### PR TITLE
Markdown & URL fixes in 01_Develop_for_Pimcore.md

### DIFF
--- a/doc/Development_Documentation/00_Overview/01_Develop_for_Pimcore.md
+++ b/doc/Development_Documentation/00_Overview/01_Develop_for_Pimcore.md
@@ -1,35 +1,37 @@
 # Develop for Pimcore
 
-Start contributing to Pimcore and become an official Community Developer - we are thankful for your support. 
-For details on how to contribute have a look at your [Contributing Guide](https://github.com/pimcore/pimcore/blob/11.x/CONTRIBUTING.md). 
+Start contributing to Pimcore and become an official Community Developer - we are thankful for your support.
+For details on how to contribute have a look at your [Contributing Guide](https://github.com/pimcore/pimcore/blob/11.x/CONTRIBUTING.md).
 
-#### TL;DR
-Fork us on [GitHub](https://github.com/pimcore/pimcore) and contribute code with pull requests ;-). 
+## TL;DR
 
- 
-#### Bug Fixes
-Please create a pull request including a step by step description to reproduce the problem. 
+Fork us on [GitHub](https://github.com/pimcore/pimcore) and contribute code with pull requests ;-).
 
-#### Contribute Features
-Contact the core-team on our [Gitter channel](https://gitter.im/pimcore/pimcore) before you start developing, 
-so we can coordinate feature development and avoid parallel development of similar features. 
-Don't forget about the documentation for your new feature! 
+### Bug Fixes
 
-#### Security Vulnerabilities
-Please use [this form](https://pimcorehq.wufoo.com/forms/pimcore-security-report/).
+Please create a pull request including a step by step description to reproduce the problem.
 
+### Contribute Features
+
+Contact the core-team on our [Gitter channel](https://gitter.im/pimcore/pimcore) before you start developing,
+so we can coordinate feature development and avoid parallel development of similar features.
+Don't forget about the documentation for your new feature!
+
+### Security Vulnerabilities
+
+Please use [this process to report any vulnerability](https://github.com/pimcore/pimcore/blob/11.x/SECURITY.md) you find.
 
 ## PSRs (PHP-FIG) & Standards in General
-Pimcore is an active member of the [PHP-FIG](http://www.php-fig.org/) and committed to standards and interoperability, therefore we always try to implement the latest standards.
-At the moment Pimcore implements the following PSRs: 
+
+Pimcore is an active member of the [PHP-FIG](https://www.php-fig.org/) and committed to standards and interoperability, therefore we always try to implement the latest standards.
+At the moment Pimcore implements the following PSRs:
+
 * PSR-1 (Basic Coding Standard)
 * PSR-2 (Coding Style Guide)
 * PSR-3 (Logger Interface)
-* PSR-4 (Autoloading Standard) 
+* PSR-4 (Autoloading Standard)
 * PSR-6 (Caching)
 
-Please also keep that in mind when contributing to Pimcore. 
+Please also keep that in mind when contributing to Pimcore.
 
-For further information please have a look at [http://www.php-fig.org/](http://www.php-fig.org/)
- 
- 
+For further information please have a look at [www.php-fig.org](https://www.php-fig.org/)


### PR DESCRIPTION
## Changes in this pull request  
- pimcorehq.wufoo.com no longer exists
- linted with [DavidAnson/markdownlint](https://github.com/DavidAnson/markdownlint)
