### PR TITLE
Workflow fix `docs/` to `doc/` for included and ignored paths

### DIFF
--- a/.github/workflows/codeception.yaml
+++ b/.github/workflows/codeception.yaml
@@ -9,7 +9,7 @@ on:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
         paths-ignore:
-            - 'docs/**'
+            - 'doc/**'
             - 'bundles/**/Resources/public/**'
     push:
         branches:
@@ -17,7 +17,7 @@ on:
             - "[0-9]+.x"
             - "*_actions"
         paths-ignore:
-            - 'docs/**'
+            - 'doc/**'
             - 'bundles/**/Resources/public/**'
 
 env:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,14 +7,14 @@ on:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
         paths:
-            - 'docs/**'
+            - 'doc/**'
     push:
         branches:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
             - "*_actions"
         paths:
-            - 'docs/**'
+            - 'doc/**'
 
 permissions:
   contents: read

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -10,7 +10,7 @@ on:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
         paths-ignore:
-            - 'docs/**'
+            - 'doc/**'
             - 'bundles/**/Resources/public/**'
     push:
         branches:
@@ -18,7 +18,7 @@ on:
             - "[0-9]+.x"
             - "*_actions"
         paths-ignore:
-            - 'docs/**'
+            - 'doc/**'
             - 'bundles/**/Resources/public/**'
 
 env:


### PR DESCRIPTION
## Changes in this pull request  

I think there was an error in previous attempt. Correct path should be [`/pimcore/pimcore/tree/11.x/doc`](https://github.com/pimcore/pimcore/tree/11.x/doc) 😄 