### PR TITLE
[Fix] adding itemid for working reset

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/time.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/time.js
@@ -78,46 +78,50 @@ pimcore.object.classes.data.time = Class.create(pimcore.object.classes.data.data
                 items: [
                     {
                         xtype: "numberfield",
+                        itemId: 'increment',
                         fieldLabel: t("increment"),
                         width: 200,
                         name: "increment",
                         value: datax.increment ? datax.increment : 15
                     },
                     {
-                    xtype: 'timefield',
-                    itemId: 'minTime',
-                    fieldLabel: t('min_value'),
-                    format: pimcore.object.classes.data.time.prototype.dateFormat,
-                    editable: false,
-                    width: 200,
-                    value: datax.minValue,
-                    componentCls: "object_field",
-                    name: 'minValue',
-                    listeners: {
-                        change: onMinMaxValueChange
+                        xtype: 'timefield',
+                        itemId: 'minTime',
+                        fieldLabel: t('min_value'),
+                        format: pimcore.object.classes.data.time.prototype.dateFormat,
+                        editable: false,
+                        width: 200,
+                        value: datax.minValue,
+                        componentCls: "object_field",
+                        name: 'minValue',
+                        listeners: {
+                            change: onMinMaxValueChange
+                        }
+                    },
+                    {
+                        xtype: 'timefield',
+                        itemId: 'maxTime',
+                        fieldLabel: t('max_value'),
+                        format: pimcore.object.classes.data.time.prototype.dateFormat,
+                        editable: false,
+                        width: 200,
+                        value: datax.maxValue,
+                        componentCls: "object_field",
+                        name: 'maxValue',
+                        listeners: {
+                            change: onMinMaxValueChange
+                        }
+                    },
+                    {
+                        xtype: 'button',
+                        text: t('reset'),
+                        handler: function() {
+                            minmaxSet.getComponent('increment').setValue(15);
+                            minmaxSet.getComponent('minTime').setValue(null);
+                            minmaxSet.getComponent('maxTime').setValue(null);
+                        }
                     }
-                },{
-                    xtype: 'timefield',
-                    itemId: 'maxTime',
-                    fieldLabel: t('max_value'),
-                    format: pimcore.object.classes.data.time.prototype.dateFormat,
-                    editable: false,
-                    width: 200,
-                    value: datax.maxValue,
-                    componentCls: "object_field",
-                    name: 'maxValue',
-                    listeners: {
-                        change: onMinMaxValueChange
-                    }
-                },{
-                    xtype: 'button',
-                    text: t('reset'),
-                    handler: function() {
-                        minmaxSet.getComponent('increment').reset();
-                        minmaxSet.getComponent('minTime').reset();
-                        minmaxSet.getComponent('maxTime').reset();
-                    }
-                }]
+                ]
             });
 
             specificItems = [minmaxSet];


### PR DESCRIPTION
## Changes in this pull request  
adding itemId for increment and setting the default values in reset function
Resolves #13358 

## Additional info  
Resets the min and max time to null, and the increment back to 15.
Apparently the reset function on this components did not work anymore
