### PR TITLE
[Fix] getting value.value if value is an object

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/country.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/country.js
@@ -24,7 +24,7 @@ pimcore.object.tags.country = Class.create(pimcore.object.tags.select, {
 
     getGridColumnConfig:function (field) {
         var renderer = function (key, value, metaData, record) {
-            if (value) {
+            if (value && Ext.isObject(value)) {
                 value = value.value;
             }
             this.applyPermissionStyle(key, value, metaData, record);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/country.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/country.js
@@ -57,3 +57,4 @@ pimcore.object.tags.country = Class.create(pimcore.object.tags.select, {
         };
     }
 });
+

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/country.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/country.js
@@ -57,4 +57,3 @@ pimcore.object.tags.country = Class.create(pimcore.object.tags.select, {
         };
     }
 });
-


### PR DESCRIPTION
## Changes in this pull request  
Adding additional object check
Resolves #13341 

## Additional info  
value.value returns undefined if the original value is not an object. e.g. when loading an advanced many-to-many object relation, the value is the countryCode itself.
