### PR TITLE
[Docs] Performance: Mention command pimcore:cache:warming

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/09_Performance_Guide.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/09_Performance_Guide.md
@@ -237,6 +237,8 @@ framework:
                 provider: 'redis://localhost'
 ```
 
+Beware that element data gets added to the cache on first request of the data. To warm-up the cache after clearing the cache (e.g. caused by a deployment), execute `bin/console pimcore:cache:warming` so users experience optimal performance even on first access of an element.
+
 #### Benchmarks:
 On running command, `ab -n 100 -c 20 http://localhost/en/shop/Products/Cars~c390`
 


### PR DESCRIPTION
In some situations it might be a good idea to warm-up the cache to get good performance even on first access of elements in Pimcore admin area.