### PR TITLE
[Admin UI] Remove SQL filter functionality in data object grid

### DIFF
--- a/bundles/AdminBundle/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/bundles/AdminBundle/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -820,13 +820,9 @@ pimcore.element.helpers.gridColumnConfig = {
         var condition = "";
         var searchQuery = this.searchField ? this.searchField.getValue() : "";
 
-        if (this.sqlFilter) {
-            condition = this.sqlEditor.getValue();
-        } else {
-            var filterData = this.store.getFilters().items;
-            if (filterData.length > 0) {
-                filters = this.store.getProxy().encodeFilters(filterData);
-            }
+        var filterData = this.store.getFilters().items;
+        if (filterData.length > 0) {
+            filters = this.store.getProxy().encodeFilters(filterData);
         }
 
         var params = {

--- a/bundles/AdminBundle/public/js/pimcore/object/folder/search.js
+++ b/bundles/AdminBundle/public/js/pimcore/object/folder/search.js
@@ -173,7 +173,6 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
 
             this.onlyDirectChildren = response.onlyDirectChildren;
             this.searchFilter = response.searchFilter;
-            this.sqlFilter = response.sqlFilter;
         } else {
             itemsPerPage = this.gridPageSize;
             fields = response;
@@ -394,7 +393,6 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
         config.onlyDirectChildren = this.onlyDirectChildren;
         config.pageSize = this.pagingtoolbar.pageSize;
         config.searchFilter = this.searchField.getValue();
-        config.sqlFilter = this.sqlEditor.getValue();
         config.onlyDirectChildren = this.checkboxOnlyDirectChildren.getValue();
         return config;
     },

--- a/bundles/AdminBundle/public/js/pimcore/object/helpers/gridTabAbstract.js
+++ b/bundles/AdminBundle/public/js/pimcore/object/helpers/gridTabAbstract.js
@@ -164,84 +164,6 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
         return config;
     },
 
-    createSqlEditor: function () {
-        this.sqlEditor = new Ext.form.TextField({
-            xtype: "textfield",
-            width: 500,
-            name: "condition",
-            hidden: !this.sqlFilter,
-            enableKeyEvents: true,
-            value: this.sqlFilter,
-            listeners: {
-                "change": function() {
-                    this.saveColumnConfigButton.show();
-                }.bind(this),
-                "keydown": function (field, key) {
-                    if (key.getKey() == key.ENTER) {
-                        this.updateSqlFilter();
-                    }
-                }.bind(this)
-            }
-        });
-
-        this.updateSqlFilter();
-
-        this.sqlButton = new Ext.Button({
-            iconCls: "pimcore_icon_sql",
-            enableToggle: true,
-            tooltip: t("direct_sql_query"),
-            hidden: !pimcore.currentuser.admin,
-            handler: function (button) {
-
-                this.sqlEditor.setValue("");
-                this.searchField.setValue("");
-
-                // reset base params, because of the condition
-                var proxy = this.store.getProxy();
-                proxy.setExtraParams(
-                    {
-                        class: proxy.extraParams.class,
-                        objectId: proxy.extraParams.objectId,
-                        "fields[]": proxy.extraParams["fields[]"],
-                        language: proxy.extraParams.language
-                    }
-                );
-
-                this.grid.filters.clearFilters();
-                this.grid.getStore().clearFilter();
-
-                this.pagingtoolbar.moveFirst();
-
-                if (button.pressed) {
-                    this.sqlEditor.show();
-                } else {
-                    this.sqlEditor.hide();
-                }
-            }.bind(this)
-        });
-    },
-
-    updateSqlFilter: function() {
-        var proxy = this.store.getProxy();
-        proxy.setExtraParams(
-            {
-                class: proxy.extraParams.class,
-                objectId: proxy.extraParams.objectId,
-                "fields[]": proxy.extraParams["fields[]"],
-                language: proxy.extraParams.language
-            }
-        );
-        proxy.setExtraParam("condition", this.sqlEditor.getValue());
-        if (this.grid && this.grid.filters) {
-            this.grid.getStore().clearFilter();
-            this.grid.filters.clearFilters();
-        }
-
-        if (this.pagingtoolbar) {
-            this.pagingtoolbar.moveFirst();
-        }
-    },
-
     getToolbar: function (fromConfig, save) {
         if (!fromConfig) {
             this.searchQuery = function(field) {
@@ -304,7 +226,6 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
                 }.bind(this)
             });
 
-            this.createSqlEditor();
             this.store.getProxy().setExtraParam("query", this.searchFilter);
 
             this.checkboxOnlyDirectChildren = new Ext.form.Checkbox({
@@ -373,7 +294,6 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
                 this.toolbarFilterInfo,
                 this.clearFilterButton, "->",
                 this.checkboxOnlyDirectChildren, "-",
-                this.sqlEditor, this.sqlButton, "-",
                 this.exportButton, "-",
                 this.columnConfigButton,
                 this.saveColumnConfigButton

--- a/bundles/AdminBundle/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -555,7 +555,6 @@ class DataObjectHelperController extends AdminController
             'availableConfigs' => $availableConfigs,
             'sharedConfigs' => $sharedConfigs,
             'context' => $context,
-            'sqlFilter' => $gridConfig['sqlFilter'] ?? '',
             'searchFilter' => $gridConfig['searchFilter'] ?? '',
         ];
     }

--- a/bundles/CoreBundle/translations/en.extended.json
+++ b/bundles/CoreBundle/translations/en.extended.json
@@ -595,7 +595,6 @@
   "trim": "Trim",
   "server_fileexplorer": "Server File Explorer",
   "add_user": "Add User",
-  "direct_sql_query": "Direct SQL query",
   "use_as_site": "Use as site",
   "remove_site": "Remove Site",
   "edit_site": "Edit Site",

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -79,6 +79,7 @@ Please make sure to set your preferred storage location ***before*** migration. 
 - [Areabricks] The default template location of `AbstractTemplateAreabrick` is now `TEMPLATE_LOCATION_GLOBAL`.
 - [Config] Rename config files from `*.yml` to `*.yaml`. Note that we now use `system.yaml` as config file and not `system.yml`
 - [Childs Compatibility] Removed `getChilds`, `setChilds` and `hasChild` use `getChildren`, `setChildren` and `hasChildren` instead.
+- [DataObjects] Removed sql filter functionality for data object grid
 
 ## 10.5.8
 - [Nginx] Static pages nginx config has been updated to fix the issue for home static page generation. please adapt the following configuration:


### PR DESCRIPTION
Resolves #13224 

For testing: 
- Filter/Search functionality in grid must still work
- Have a look at csv export too
- Should not affect other sql inputs, like the one for reports