### PR TITLE
Replace `{@internal}` annotations with `@internal`

### DIFF
--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -22,7 +22,7 @@ use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
 /**
- * {@internal}
+ * @internal
  */
 class Composer
 {

--- a/lib/Model/Paginator/EventSubscriber/PaginateListingSubscriber.php
+++ b/lib/Model/Paginator/EventSubscriber/PaginateListingSubscriber.php
@@ -39,7 +39,7 @@ class PaginateListingSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * {@internal}
+     * @internal
      */
     public static function getSubscribedEvents(): array
     {

--- a/lib/Web2Print/Processor/HeadlessChrome.php
+++ b/lib/Web2Print/Processor/HeadlessChrome.php
@@ -31,7 +31,7 @@ class HeadlessChrome extends Processor
     private $nodePath = '';
 
     /**
-     * {@internal}
+     * @internal
      */
     protected function buildPdf(Document\PrintAbstract $document, $config)
     {
@@ -73,7 +73,7 @@ class HeadlessChrome extends Processor
     }
 
     /**
-     * {@internal}
+     * @internal
      */
     public function getProcessingOptions()
     {
@@ -86,7 +86,7 @@ class HeadlessChrome extends Processor
     }
 
     /**
-     * {@internal}
+     * @internal
      */
     public function getPdfFromString($html, $params = [], $returnFilePath = false)
     {

--- a/lib/Web2Print/Processor/PdfReactor.php
+++ b/lib/Web2Print/Processor/PdfReactor.php
@@ -88,7 +88,7 @@ class PdfReactor extends Processor
     }
 
     /**
-     * {@internal}
+     * @internal
      */
     public function getPdfFromString($html, $params = [], $returnFilePath = false)
     {
@@ -117,7 +117,7 @@ class PdfReactor extends Processor
     }
 
     /**
-     * {@internal}
+     * @internal
      */
     protected function buildPdf(Document\PrintAbstract $document, $config)
     {
@@ -167,7 +167,7 @@ class PdfReactor extends Processor
     }
 
     /**
-     * {@internal}
+     * @internal
      */
     public function getProcessingOptions()
     {

--- a/lib/Web2Print/Processor/WkHtmlToPdf.php
+++ b/lib/Web2Print/Processor/WkHtmlToPdf.php
@@ -84,7 +84,7 @@ class WkHtmlToPdf extends Processor
     }
 
     /**
-     * {@internal}
+     * @internal
      */
     protected function buildPdf(Document\PrintAbstract $document, $config)
     {
@@ -113,7 +113,7 @@ class WkHtmlToPdf extends Processor
     }
 
     /**
-     * {@internal}
+     * @internal
      */
     public function getProcessingOptions()
     {
@@ -143,7 +143,7 @@ class WkHtmlToPdf extends Processor
     }
 
     /**
-     * {@internal}
+     * @internal
      */
     public function getPdfFromString($html, $params = [], $returnFilePath = false)
     {


### PR DESCRIPTION
PhpStorm (at least) doesn't recognize `{@internal}` annotations and doesn't mark usages as such.
So developers extending the classes/calling the methods may not notice it.