### PR TITLE
Fix: Check::state is int instead of string

### DIFF
--- a/bundles/CoreBundle/Command/RequirementsCheckCommand.php
+++ b/bundles/CoreBundle/Command/RequirementsCheckCommand.php
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class RequirementsCheckCommand extends AbstractCommand
 {
-    /** @var array $levelsToDisplay */
+    /** @var int[] $levelsToDisplay */
     protected $levelsToDisplay = [];
 
     /**

--- a/bundles/CoreBundle/Command/RequirementsCheckCommand.php
+++ b/bundles/CoreBundle/Command/RequirementsCheckCommand.php
@@ -76,9 +76,6 @@ class RequirementsCheckCommand extends AbstractCommand
 
     /**
      * @param Requirements\Check[] $checks
-     * @param string $title
-     *
-     * @return void
      */
     protected function display(array $checks, string $title = ''): void
     {
@@ -95,12 +92,7 @@ class RequirementsCheckCommand extends AbstractCommand
         }
     }
 
-    /**
-     * @param string $state
-     *
-     * @return string
-     */
-    protected function displayState(string $state): string
+    protected function displayState(int $state): string
     {
         switch ($state) {
             case Requirements\Check::STATE_OK:

--- a/lib/Tool/Requirements/Check.php
+++ b/lib/Tool/Requirements/Check.php
@@ -139,9 +139,9 @@ final class Check implements \ArrayAccess
     /**
      * @param string $offset
      *
-     * @return string|int
+     * @return string|int|null
      */
-    public function offsetGet($offset): string|int
+    public function offsetGet($offset): string|int|null
     {
         return $this->{'get'.$offset}();
     }

--- a/lib/Tool/Requirements/Check.php
+++ b/lib/Tool/Requirements/Check.php
@@ -37,7 +37,7 @@ final class Check implements \ArrayAccess
     public $link;
 
     /**
-     * @var string
+     * @var int
      */
     public $state;
 
@@ -91,7 +91,7 @@ final class Check implements \ArrayAccess
     }
 
     /**
-     * @return string
+     * @return int
      */
     public function getState()
     {
@@ -99,7 +99,7 @@ final class Check implements \ArrayAccess
     }
 
     /**
-     * @param string $state
+     * @param int $state
      */
     public function setState($state)
     {
@@ -139,16 +139,16 @@ final class Check implements \ArrayAccess
     /**
      * @param string $offset
      *
-     * @return string
+     * @return string|int
      */
-    public function offsetGet($offset): string
+    public function offsetGet($offset): string|int
     {
         return $this->{'get'.$offset}();
     }
 
     /**
      * @param string $offset
-     * @param string $value
+     * @param string|int $value
      */
     public function offsetSet($offset, $value): void
     {

--- a/lib/Tool/Requirements/Check.php
+++ b/lib/Tool/Requirements/Check.php
@@ -49,7 +49,7 @@ final class Check implements \ArrayAccess
     /**
      * @param array{name: string, link?: string, state: int, message?: string} $data
      */
-    public function __construct(array $data = [])
+    public function __construct(array $data)
     {
         foreach ($data as $key => $value) {
             $this->$key = $value;

--- a/lib/Tool/Requirements/Check.php
+++ b/lib/Tool/Requirements/Check.php
@@ -32,7 +32,7 @@ final class Check implements \ArrayAccess
     public $name;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $link;
 
@@ -42,7 +42,7 @@ final class Check implements \ArrayAccess
     public $state;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $message;
 
@@ -75,7 +75,7 @@ final class Check implements \ArrayAccess
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLink()
     {

--- a/lib/Tool/Requirements/Check.php
+++ b/lib/Tool/Requirements/Check.php
@@ -47,9 +47,7 @@ final class Check implements \ArrayAccess
     public $message;
 
     /**
-     * Check constructor.
-     *
-     * @param array $data
+     * @param array{name: string, link?: string, state: int, message?: string} $data
      */
     public function __construct(array $data = [])
     {


### PR DESCRIPTION
See error in https://github.com/pimcore/pimcore/pull/13408

```
In RequirementsCheckCommand.php line 98:
                                                                               
  Pimcore\Bundle\CoreBundle\Command\RequirementsCheckCommand::displayState():  
   Argument #1 ($state) must be of type string, int given, called in /home/runner/work/pimcore/pimcore/bundles/CoreBundle/src/Command/RequirementsCheckCommand.php on line 89   
```