### PR TITLE
[EcommerceFramework] Fix buildOption() in IndexFieldSelectionCombo on cache write

### DIFF
--- a/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionCombo.php
+++ b/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionCombo.php
@@ -46,7 +46,7 @@ class IndexFieldSelectionCombo extends Select
     {
         $options = [];
 
-        if (!headers_sent && \Pimcore::getContainer()->has(PimcoreEcommerceFrameworkExtension::SERVICE_ID_FACTORY)) {
+        if (!headers_sent() && \Pimcore::getContainer()->has(PimcoreEcommerceFrameworkExtension::SERVICE_ID_FACTORY)) {
             try {
                 $indexService = Factory::getInstance()->getIndexService();
                 $indexColumns = $indexService->getIndexAttributes(true);

--- a/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionCombo.php
+++ b/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionCombo.php
@@ -46,7 +46,7 @@ class IndexFieldSelectionCombo extends Select
     {
         $options = [];
 
-        if (\Pimcore::getContainer()->has(PimcoreEcommerceFrameworkExtension::SERVICE_ID_FACTORY)) {
+        if (!headers_sent && \Pimcore::getContainer()->has(PimcoreEcommerceFrameworkExtension::SERVICE_ID_FACTORY)) {
             try {
                 $indexService = Factory::getInstance()->getIndexService();
                 $indexColumns = $indexService->getIndexAttributes(true);


### PR DESCRIPTION
This PR resolves errors during cache write of documents with relations to objects which have fields of type `IndexFieldSelectionCombo` in its class definitions (i.e. FilterDefinition of EcommerceFramework).

If you think there is a better way to solve it, feedback is welcome!

  ### Short exception trace
```
Failed to start the session because headers have already been sent by "/home/myproject/www/vendor/symfony/http-foundation/Response.php" 
...Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage->getBag('ecommerceframew...') 
...Pimcore\Bundle\EcommerceFrameworkBundle\Environment->getCurrentAssortmentTenant() 
...Pimcore\Bundle\EcommerceFrameworkBundle\CoreExtensions\ClassDefinition\IndexFieldSelectionCombo->buildOptions() #9 
...Pimcore\Model\Element\Service::getElementById('object', 611362) #23 /home/myproject/www/vendor/pimcore/pimcore/models/Document/Editable/Relation.php(137): 
...Pimcore\Cache\Core\CoreCacheHandler->prepareCacheTags('document_1660', Object(App\Entity\Document\Page), Array) 
...Pimcore\Cache\Core\CoreCacheHandler->writeSaveQueue()
...Pimcore::shutdown() 
```

### Full exception trace:

`[2022-10-17T09:57:41.971360+02:00] pimcore.ERROR: RuntimeException: Failed to start the session because headers have already been sent by "/home/myproject/www/vendor/symfony/http-foundation/Response.php" at line 381. in /home/myproject/www/vendor/symfony/http-foundation/Session/Storage/NativeSessionStorage.php:145 Stack trace: #0 /home/myproject/www/vendor/symfony/http-foundation/Session/Storage/NativeSessionStorage.php(352): Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage->start() #1 /home/myproject/www/vendor/symfony/http-foundation/Session/Session.php(261): Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage->getBag('ecommerceframew...') #2 /home/myproject/www/vendor/pimcore/pimcore/bundles/EcommerceFrameworkBundle/SessionEnvironment.php(153): Symfony\Component\HttpFoundation\Session\Session->getBag('ecommerceframew...') #3 /home/myproject/www/vendor/pimcore/pimcore/bundles/EcommerceFrameworkBundle/SessionEnvironment.php(91): Pimcore\Bundle\EcommerceFrameworkBundle\SessionEnvironment->getSessionBag() #4 /home/myproject/www/vendor/pimcore/pimcore/bundles/EcommerceFrameworkBundle/Environment.php(241): Pimcore\Bundle\EcommerceFrameworkBundle\SessionEnvironment->load() #5 /home/myproject/www/vendor/pimcore/pimcore/bundles/EcommerceFrameworkBundle/IndexService/IndexService.php(275): Pimcore\Bundle\EcommerceFrameworkBundle\Environment->getCurrentAssortmentTenant() #6 /home/myproject/www/vendor/pimcore/pimcore/bundles/EcommerceFrameworkBundle/IndexService/IndexService.php(183): Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\IndexService->resolveTenantWorker(NULL) #7 /home/myproject/www/vendor/pimcore/pimcore/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionCombo.php(52): Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\IndexService->getIndexAttributes(true) #8 /home/myproject/www/vendor/pimcore/pimcore/bundles/EcommerceFrameworkBundle/CoreExtensions/ClassDefinition/IndexFieldSelectionCombo.php(42): Pimcore\Bundle\EcommerceFrameworkBundle\CoreExtensions\ClassDefinition\IndexFieldSelectionCombo->buildOptions() #9 /home/myproject/www/vendor/pimcore/pimcore/models/DataObject/ClassDefinition/Helper/VarExport.php(57): Pimcore\Bundle\EcommerceFrameworkBundle\CoreExtensions\ClassDefinition\IndexFieldSelectionCombo->__construct() #10 /home/myproject/www/var/classes/fieldcollections/SimilarityField.php(48): Pimcore\Model\DataObject\ClassDefinition\Data::__set_state(Array) #11 /home/myproject/www/vendor/pimcore/pimcore/models/DataObject/Fieldcollection/Definition.php(109): include('/home/myproject/www...') #12 /home/myproject/www/vendor/pimcore/pimcore/models/DataObject/ClassDefinition/Data/Fieldcollections.php(364): Pimcore\Model\DataObject\Fieldcollection\Definition::getByKey('SimilarityField') #13 /home/myproject/www/vendor/pimcore/pimcore/models/DataObject/ClassDefinition/Data.php(299): Pimcore\Model\DataObject\ClassDefinition\Data\Fieldcollections->setAllowedTypes(Array) #14 /home/myproject/www/vendor/pimcore/pimcore/models/DataObject/ClassDefinition/Helper/VarExport.php(58): Pimcore\Model\DataObject\ClassDefinition\Data->setValues(Array) #15 /home/myproject/www/var/classes/definition_FilterDefinition.php(1308): Pimcore\Model\DataObject\ClassDefinition\Data::__set_state(Array) #16 /home/myproject/www/vendor/pimcore/pimcore/models/DataObject/ClassDefinition.php(305): include('/home/myproject/www...') #17 /home/myproject/www/vendor/pimcore/pimcore/models/DataObject/Concrete.php(407): Pimcore\Model\DataObject\ClassDefinition::getById('EF_FD') #18 /home/myproject/www/vendor/pimcore/pimcore/models/DataObject/Concrete/Dao.php(148): Pimcore\Model\DataObject\Concrete->getClass() #19 /home/myproject/www/vendor/pimcore/pimcore/models/DataObject/Concrete/Dao.php(63): Pimcore\Model\DataObject\Concrete\Dao->getData() #20 /home/myproject/www/vendor/pimcore/pimcore/models/DataObject/AbstractObject.php(401): Pimcore\Model\DataObject\Concrete\Dao->getById(611362) #21 /home/myproject/www/vendor/pimcore/pimcore/models/Element/Service.php(519): Pimcore\Model\DataObject\AbstractObject::getById(611362, Array) #22 /home/myproject/www/vendor/pimcore/pimcore/models/Document/Editable/Relation.php(164): Pimcore\Model\Element\Service::getElementById('object', 611362) #23 /home/myproject/www/vendor/pimcore/pimcore/models/Document/Editable/Relation.php(137): Pimcore\Model\Document\Editable\Relation->setElement() #24 /home/myproject/www/vendor/pimcore/pimcore/models/Document/PageSnippet/Dao.php(55): Pimcore\Model\Document\Editable\Relation->setDataFromResource(Array) #25 /home/myproject/www/vendor/pimcore/pimcore/models/Document/PageSnippet.php(506): Pimcore\Model\Document\PageSnippet\Dao->getEditables() #26 /home/myproject/www/vendor/pimcore/pimcore/models/Document/PageSnippet.php(241): Pimcore\Model\Document\PageSnippet->getEditables() #27 /home/myproject/www/vendor/pimcore/pimcore/lib/Cache/Core/CoreCacheHandler.php(472): Pimcore\Model\Document\PageSnippet->getCacheTags(Array) #28 /home/myproject/www/vendor/pimcore/pimcore/lib/Cache/Core/CoreCacheHandler.php(907): Pimcore\Cache\Core\CoreCacheHandler->prepareCacheTags('document_1660', Object(App\Entity\Document\Page), Array) #29 /home/myproject/www/vendor/pimcore/pimcore/lib/Cache/Core/CoreCacheHandler.php(960): Pimcore\Cache\Core\CoreCacheHandler->writeSaveQueue() #30 /home/myproject/www/vendor/pimcore/pimcore/lib/Cache.php(200): Pimcore\Cache\Core\CoreCacheHandler->shutdown(false) #31 /home/myproject/www/vendor/pimcore/pimcore/lib/Pimcore.php(259): Pimcore\Cache::shutdown() #32 /home/myproject/www/vendor/pimcore/pimcore/lib/Kernel.php(328): Pimcore::shutdown() #33 [internal function]: Pimcore\Kernel->Pimcore\{closure}() #34 {main} [] []
`