### PR TITLE
Allow usage of `twig/extra-bundle`

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/DependencyInjection/PimcoreCoreExtension.php
@@ -39,8 +39,6 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
-use Twig\Extra\TwigExtraBundle\TwigExtraBundle;
-use Twig\Extra\String\StringExtension;
 
 /**
  * @internal
@@ -156,7 +154,6 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
         $this->configureGoogleAnalyticsFallbackServiceLocator($container);
         $this->configureSitemaps($container, $config['sitemaps']);
         $this->configureGlossary($container, $config['glossary']);
-        $this->configureTemplating($container);
 
         $container->setParameter('pimcore.workflow', $config['workflows']);
 
@@ -490,14 +487,5 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
     private function configureGlossary(ContainerBuilder $container, array $config)
     {
         $container->setParameter('pimcore.glossary.blocked_tags', $config['blocked_tags']);
-    }
-
-    private function configureTemplating(ContainerBuilder $container): void
-    {
-        // If "twig/extra-bundle" is enabled, it takes care of registering extra Twig extensions,
-        // otherwise we have to do it manually for the ones we need.
-        if (!in_array(TwigExtraBundle::class, $container->getParameter('kernel.bundles'), true)) {
-            $container->register(StringExtension::class, StringExtension::class);
-        }
     }
 }

--- a/bundles/CoreBundle/Resources/config/templating_twig.yaml
+++ b/bundles/CoreBundle/Resources/config/templating_twig.yaml
@@ -82,8 +82,6 @@ services:
     # content was added (e.g. headTitle)
     Twig\DeferredExtension\DeferredExtension: ~
 
-    Twig\Extra\String\StringExtension: ~
-
     Pimcore\Twig\Sandbox\SecurityPolicy:
         arguments:
             $allowedTags: '%pimcore.templating.twig.sandbox_security_policy.tags%'

--- a/composer.json
+++ b/composer.json
@@ -144,6 +144,7 @@
     "symfony/polyfill-intl-icu": "^1.21",
     "symfony/polyfill-php81": "^1.23.0",
     "tijsverkoyen/css-to-inline-styles": "^2.2.3",
+    "twig/extra-bundle": "^3.4.0",
     "twig/twig": "^3.0.4",
     "twig/string-extra": "^3.0.4",
     "rybakit/twig-deferred-extension": "^3.0",

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## 10.6.0
+- [Twig] Pimcore now requires the `twig/extra-bundle` which eases the usage of Twig's "extra" extensions.
+
 ## 10.5.10
 - [DataObject] Deprecated: Loading non-Concrete objects with the Concrete class will not be possible in Pimcore 11.
 

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -49,6 +49,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Twig\Extra\TwigExtraBundle\TwigExtraBundle;
 
 abstract class Kernel extends SymfonyKernel
 {
@@ -393,6 +394,7 @@ abstract class Kernel extends SymfonyKernel
             new FrameworkBundle(),
             new SecurityBundle(),
             new TwigBundle(),
+            new TwigExtraBundle(),
             new MonologBundle(),
             new DoctrineBundle(),
             new DoctrineMigrationsBundle(),


### PR DESCRIPTION
The skeleton (and demo) have the `TwigExtraBundle` as an example in their [`bundles.php`](https://github.com/pimcore/skeleton/blob/11.x/config/bundles.php). But when you install the package and enable the bundle, you get an exception, because Pimcore manually registers the `StringExtension` from the `twig/string-extra`, which makes the `TwigExtraBundle` cry:

> Unable to register extension "Twig\Extra\String\StringExtension" as it is already registered.

To be able, to use the bundle, you currently have to disable it there, like:
```yaml
twig_extra:
    # Note: this is actually enabled. But because Pimcore does it, this bundle cannot do it, too.
    string: false
```

This PR changes it, so that the `StringExtension` is only registered, when the `TwigExtraBundle` is not loaded.

> **Note**
> I would consider this a bug, but it is also a BC break unless we find a way to fix it **and** tell the users who have the configuration `twig_extra: { string: false }` to change it to `true`, because otherwise Pimcore can't use it.