### PR TITLE
[Bugfix]: KeyConfig cache issue

### DIFF
--- a/models/DataObject/Classificationstore/KeyConfig.php
+++ b/models/DataObject/Classificationstore/KeyConfig.php
@@ -415,8 +415,8 @@ final class KeyConfig extends Model\AbstractModel
     private function removeCache(): void
     {
         // Remove runtime cache
-        RuntimeCache::set(self::getCacheKey($this->getId()), null);
-        RuntimeCache::set(self::getCacheKey($this->getStoreId(), $this->getName()), null);
+        RuntimeCache::getInstance()->offsetUnset(self::getCacheKey($this->getId()));
+        RuntimeCache::getInstance()->offsetUnset(self::getCacheKey($this->getStoreId(), $this->getName()));
 
         // Remove persisted cache
         Cache::remove(self::getCacheKey($this->getId()));


### PR DESCRIPTION
There is an issue when you get KeyConfig by name, it is saved in Runtime Cache. When you do some action on that object and save it, Runtime Cache sets cache key value to null instead of deleting it. So when you want to get that KeyConfig by name again, you get null (database is not contacted again because value in cache exists, even though it is not correct).