### PR TITLE
[Task][Config]: Fixing a missing case related to the change from yml to yaml

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20221025165133.php
+++ b/bundles/CoreBundle/src/Migrations/Version20221025165133.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Config;
+use Pimcore\Log\Handler\ApplicationLoggerDb;
+
+final class Version20221025165133 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Rename settings.yml to settings.yaml';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->renameSystemFileExtension('yml', 'yaml');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->renameSystemFileExtension('yaml', 'yml');
+    }
+
+    private function renameSystemFileExtension(string $fromExtension, string $toExtension): void
+    {
+        $file = Config::locateConfigFile('system.' . $fromExtension);
+        if (file_exists($file)) {
+            $pathParts = pathinfo($file);
+            rename($file, $pathParts['dirname'] . '/' . $pathParts['filename'] . '.' . $toExtension);
+        }
+    }
+}

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -521,7 +521,7 @@ final class Config implements ArrayAccess
     {
         $fileType = pathinfo($file, PATHINFO_EXTENSION);
         if (file_exists($file)) {
-            if ($fileType == 'yml') {
+            if ($fileType == 'yaml') {
                 $content = Yaml::parseFile($file);
             } else {
                 $content = include($file);


### PR DESCRIPTION
## Changes in this pull request  
Followup https://github.com/pimcore/pimcore/pull/13351

## Additional info  

When saving the pimcore settings, it printed the yaml content in the ajax response (`/admin/settings/set-system`) due to the `include`.
Just providing a quick fix/input, not sure if we should change it to support both yml/yaml and/or change to check mime type