### PR TITLE
docker-compose: rename service php-fpm to just `php` and use new tag names

### DIFF
--- a/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md
+++ b/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md
@@ -32,7 +32,7 @@ After finishing, shutdown docker containers and cleanup volumes with `docker-com
 
 This will run all tests.
 ```
-docker-compose exec php-fpm vendor/bin/codecept run -c . -vvv
+docker-compose exec php vendor/bin/codecept run -c . -vvv
 ```
 
 #### Only run a specific suite
@@ -40,7 +40,7 @@ docker-compose exec php-fpm vendor/bin/codecept run -c . -vvv
 Only runs the `Model` tests. For a list of suites see the list below.
 
 ```
-docker-compose exec php-fpm vendor/bin/codecept run -c . Model -vvv
+docker-compose exec php vendor/bin/codecept run -c . Model -vvv
 ```
 
 #### Only run a specific test group
@@ -49,7 +49,7 @@ This can be a subset of a suite. You also have the option to provide a comma-sep
 For an overview of available groups see the table below.
 
 ```
-docker-compose exec php-fpm vendor/bin/codecept run -c . Model -vvv -g dataTypeLocal
+docker-compose exec php vendor/bin/codecept run -c . Model -vvv -g dataTypeLocal
 ```
 
 
@@ -59,7 +59,7 @@ For Redis, the `PIMCORE_TEST_REDIS_DSN` option is mandatory. If not using the Re
 to a value that does not conflict to any other Redis DBs on your system.
 
 ```
-docker-compose exec php-fpm vendor/bin/codecept run -c . Cache
+docker-compose exec php vendor/bin/codecept run -c . Cache
 ```
 
 

--- a/tests/bin/docker-compose.yml
+++ b/tests/bin/docker-compose.yml
@@ -14,9 +14,9 @@ services:
             MYSQL_USER: pimcore
             MYSQL_PASSWORD: pimcore
 
-    php-fpm:
+    php:
 #        user: '1000:1000' # set to your uid:gid
-        image: pimcore/pimcore:PHP8.1-fpm
+        image: pimcore/pimcore:php8.1-latest
         environment:
             PHP_IDE_CONFIG: "serverName=localhost"
             COMPOSER_HOME: /var/www/html

--- a/tests/bin/init-tests.sh
+++ b/tests/bin/init-tests.sh
@@ -3,9 +3,9 @@
 docker-compose down -v --remove-orphans
 docker-compose up -d
 
-docker-compose exec php-fpm .github/ci/scripts/setup-pimcore-environment.sh
-docker-compose exec php-fpm composer update
+docker-compose exec php .github/ci/scripts/setup-pimcore-environment.sh
+docker-compose exec php composer update
 
 printf "\n\n\n================== \n"
-printf "Run 'docker-compose exec php-fpm vendor/bin/codecept run -vv' to re-run the tests.\n"
+printf "Run 'docker-compose exec php vendor/bin/codecept run -vv' to re-run the tests.\n"
 printf "Run 'docker-compose down -v --remove-orphans' to shutdown container and cleanup.\n\n"


### PR DESCRIPTION
See also: 

https://github.com/pimcore/demo/pull/369
https://github.com/pimcore/skeleton/pull/122