### PR TITLE
[Improvement] Pass additionalData to transition events

### DIFF
--- a/doc/Development_Documentation/07_Workflow_Management/09_Working_with_PHP_API.md
+++ b/doc/Development_Documentation/07_Workflow_Management/09_Working_with_PHP_API.md
@@ -66,3 +66,70 @@ In addition to the Symfony events, Pimcore provides two additional events for gl
 - `pimcore.workflow.postGlobalAction`
 See [WorkflowEvents](https://github.com/pimcore/pimcore/blob/10.x/lib/Event/WorkflowEvents.php) for details. 
 
+### Using Additional Data in Events
+
+If additional data fields are defined in the transition configuration, it's possible to retrieve those data on event listener functions.
+
+See following example how to interact with additional data on transition events.
+
+Let's first define an additional field in the workflow configuration.
+
+```yaml
+transitions:
+    close_product:
+        from: open
+        to: closed
+        options:
+            label: close product
+            notes:
+                commentEnabled: 1
+                commentRequired: 1
+                additionalFields:
+                    -
+                        name: mySelect
+                        title: please select a type
+                        fieldType: select
+                        fieldTypeSettings:
+                            options:
+                                -
+                                    key: Option A
+                                    value: a
+                                -
+                                    key: Option B
+                                    value: b
+                                -
+                                    key: Option C
+                                    value: c
+```
+
+Then, we should define the transition event on `services.yaml`.
+
+```yaml
+services:
+    App\EventListener\WorkflowsEventListener:
+        tags:        
+            - { name: kernel.event_listener, event: workflow.projectWorkflow.transition.close_product, method: onCloseProduct }
+```
+
+The additional data will be then available in the transition event
+
+```php
+<?php
+
+namespace App\EventListener;
+
+use Symfony\Component\Workflow\Event\TransitionEvent;
+
+class WorkflowsEventListener
+{
+    public function onCloseProduct(TransitionEvent $event)
+    {
+        $context = $event->getContext();
+        $additionalData = $context["additional"];
+        
+        $mySelectValue = $additionalData["mySelect"];;
+        
+        // do something with the value
+    }
+}
+```

--- a/lib/Workflow/Manager.php
+++ b/lib/Workflow/Manager.php
@@ -256,7 +256,7 @@ class Manager
     {
         $this->notesSubscriber->setAdditionalData($additionalData);
 
-        $marking = $workflow->apply($subject, $transition);
+        $marking = $workflow->apply($subject, $transition, $additionalData);
 
         $this->notesSubscriber->setAdditionalData([]);
 


### PR DESCRIPTION
If we pass additionalData to the workflow "apply" method, those data are passed to the various transition and place events in the "context" variable (as it is just working now for the "GlobalActionEvent") that is currently unused.

This is necessary to have the possibility to use additionalData in the various workflow events.

## Changes in this pull request  
The $additionalData variable is passed to the "apply" method of the workflow as third argument, which is the "context"
On cascade, the context will be passed to all the workflow events (e.g the TransitionEvent) so that it's possible to use the additionalData selected by the user in those events to guide some decisions 

