### PR TITLE
FullPageCacheListener kernel.request handler needs to be executed aft…

### DIFF
--- a/bundles/CoreBundle/config/event_listeners.yaml
+++ b/bundles/CoreBundle/config/event_listeners.yaml
@@ -128,7 +128,7 @@ services:
     Pimcore\Bundle\CoreBundle\EventListener\Frontend\FullPageCacheListener:
         public: true
         tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 610 }
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 120 }
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: -120 }
             - { name: kernel.event_listener, event: kernel.response, method: stopPropagationCheck, priority: 100 }
 


### PR DESCRIPTION
…er session was initialized

Follow-up to #12294
