### PR TITLE
fix: include documents without navigation name as invisible in navigation builder

### DIFF
--- a/lib/Navigation/Builder.php
+++ b/lib/Navigation/Builder.php
@@ -407,7 +407,7 @@ class Builder
                 continue;
             }
 
-            if (($child instanceof Document\Folder || $child instanceof Document\Page || $child instanceof Document\Link) && $child->getProperty('navigation_name')) {
+            if ($child instanceof Document\Folder || $child instanceof Document\Page || $child instanceof Document\Link) {
                 $path = $child->getFullPath();
                 if ($child instanceof Document\Link) {
                     $path = $child->getHref();
@@ -429,7 +429,7 @@ class Builder
                 $page->setRelation($child->getProperty('navigation_relation'));
                 $page->setDocument($child);
 
-                if ($child->getProperty('navigation_exclude') || !$child->getPublished()) {
+                if (trim((string)$child->getProperty('navigation_name')) === '' || $child->getProperty('navigation_exclude') || !$child->getPublished()) {
                     $page->setVisible(false);
                 }
 


### PR DESCRIPTION
## Changes in this pull request  
Error: when overriding the navigation label via a pageCallback, documents without a configured navigation_name were still excluded from the navigation
Resolved by: including all documents, but marking the ones without a navigation_name as invisible by default

## Background info  
We used the NavigationBuilder to create a secondary menu/sitemap where the customer wanted to have a different label being displayed. Therefore we used the pageCallback, but documents/links without a configured navigation_name were still missing from the result.

Moving this "do I have a label?" check to the `setVisible(false)` gives the developer more flexibility using the pageCallback.
