### PR TITLE
fix: always call Process::setTimeout()

### DIFF
--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -241,9 +241,7 @@ final class Console
         $cmd = self::buildPhpScriptCmd($script, $arguments);
         self::addLowProcessPriority($cmd);
         $process = new Process($cmd);
-        if ($timeout) {
-            $process->setTimeout($timeout);
-        }
+        $process->setTimeout($timeout);
         $process->start();
 
         if (!empty($outputFile)) {


### PR DESCRIPTION
Process has default timeout of 60s which can be omitted if setting it to null. Pimcore doesn't call setTimeout() unless and defaults to null. This means by default every process has a 60sec timeout and you can't unset it, you can only set it really high

