### PR TITLE
[Fix] adding validation message for wrong upload type

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -15,7 +15,6 @@
 
 namespace Pimcore\Bundle\AdminBundle\Controller\Admin\Asset;
 
-use GuzzleHttp\Psr7\MimeType;
 use Pimcore\Bundle\AdminBundle\Controller\Admin\ElementControllerBase;
 use Pimcore\Bundle\AdminBundle\Controller\Traits\AdminStyleTrait;
 use Pimcore\Bundle\AdminBundle\Controller\Traits\ApplySchedulerDataTrait;
@@ -50,7 +49,6 @@ use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\Mime\MimeTypes;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Validator\Constraints\FileValidator;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -949,7 +949,7 @@ pimcore.helpers.openMemorizedTabs = function () {
     }
 };
 
-pimcore.helpers.assetSingleUploadDialog = function (parent, parentType, success, failure, context) {
+pimcore.helpers.assetSingleUploadDialog = function (parent, parentType, success, failure, context, accept) {
 
     var params = {};
     params['parent' + ucfirst(parentType)] = parent;
@@ -959,7 +959,12 @@ pimcore.helpers.assetSingleUploadDialog = function (parent, parentType, success,
         url += "&context=" + Ext.encode(context);
     }
 
-    pimcore.helpers.uploadDialog(url, 'Filedata', success, failure);
+    if(accept) {
+        url += "&accept=" + accept;
+    }
+
+    // leave the description blank and add accept for upload dialog
+    pimcore.helpers.uploadDialog(url, 'Filedata', success, failure, '', accept);
 };
 
 /**
@@ -972,7 +977,7 @@ pimcore.helpers.addCsrfTokenToUrl = function (url) {
     return url;
 };
 
-pimcore.helpers.uploadDialog = function (url, filename, success, failure, description) {
+pimcore.helpers.uploadDialog = function (url, filename, success, failure, description, accept) {
 
     if (typeof success != "function") {
         success = function () {
@@ -1019,6 +1024,7 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
         buttonConfig: {
             iconCls: 'pimcore_icon_upload'
         },
+        accept: accept,
         listeners: {
             change: function () {
                 uploadForm.getForm().submit({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/image.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/image.js
@@ -16,6 +16,7 @@ pimcore.object.tags.image = Class.create(pimcore.object.tags.abstract, {
 
     type: "image",
     dirty: false,
+    acceptType: 'image/*',
 
     initialize: function (data, fieldConfig) {
         if (data) {
@@ -275,7 +276,7 @@ pimcore.object.tags.image = Class.create(pimcore.object.tags.abstract, {
                 pimcore.helpers.showNotification(t("error"), res, "error",
                     res.response.responseText);
             }
-        }.bind(this), this.context);
+        }.bind(this), this.context, this.acceptType);
     },
 
     addDataFromSelector: function (item) {

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -22,6 +22,7 @@ use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Asset\MetaData\ClassDefinition\Data\Data;
 use Pimcore\Model\Element;
+use Symfony\Component\Validator\Constraints\FileValidator;
 
 /**
  * @method \Pimcore\Model\Asset\Dao getDao()
@@ -499,4 +500,27 @@ class Service extends Model\Element\Service
 
         return $key;
     }
+
+    /**
+     * @param string $mime
+     * @param array $acceptedMimeTypes
+     *
+     * @return bool
+     *
+     */
+    public function validateMimeType(string $mime, array $acceptedMimeTypes) {
+        foreach ($acceptedMimeTypes as $mimeType) {
+            if ($mimeType === $mime) {
+                return true;
+            }
+
+            if ($discrete = strstr($mimeType, '/*', true)) {
+                if (strstr($mime, '/', true) === $discrete) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
 }

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -500,14 +500,8 @@ class Service extends Model\Element\Service
         return $key;
     }
 
-    /**
-     * @param string $mime
-     * @param array $acceptedMimeTypes
-     *
-     * @return bool
-     *
-     */
-    public function validateMimeType(string $mime, array $acceptedMimeTypes) {
+    public function validateMimeType(string $mime, array $acceptedMimeTypes): bool
+    {
         foreach ($acceptedMimeTypes as $mimeType) {
             if ($mimeType === $mime) {
                 return true;

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -22,7 +22,6 @@ use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Asset\MetaData\ClassDefinition\Data\Data;
 use Pimcore\Model\Element;
-use Symfony\Component\Validator\Constraints\FileValidator;
 
 /**
  * @method \Pimcore\Model\Asset\Dao getDao()


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request
Adding validation message for wrong upload type
Resolves #13000 

## Additional info  
See #13000 for description
The mime type wildcard check was taken from https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/Validator/Constraints/FileValidator.php#L226
