### PR TITLE
Bugfix Migration:

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20210323082921.php
+++ b/bundles/CoreBundle/Migrations/Version20210323082921.php
@@ -57,7 +57,7 @@ final class Version20210323082921 extends AbstractMigration
 
             foreach ($data as $row) {
                 if (!empty($row['id'])) {
-                    if (!array_key_exists('language',$row) || $row['language'] === null) {
+                    if (!isset($row['language'])) {
                         $row['language'] = '';
                         $this->write("Language of setting id {$row['id']}: {$row['name']} for siteId {$row['siteId']} was NULL, converted to empty string");
                     }

--- a/bundles/CoreBundle/Migrations/Version20210323082921.php
+++ b/bundles/CoreBundle/Migrations/Version20210323082921.php
@@ -57,7 +57,7 @@ final class Version20210323082921 extends AbstractMigration
 
             foreach ($data as $row) {
                 if (!empty($row['id'])) {
-                    if ($row['language'] === null) {
+                    if (!array_key_exists('language',$row) || $row['language'] === null) {
                         $row['language'] = '';
                         $this->write("Language of setting id {$row['id']}: {$row['name']} for siteId {$row['siteId']} was NULL, converted to empty string");
                     }


### PR DESCRIPTION
Fix migration error if language key doesn't exist


[notice] Migrating up to Pimcore\Bundle\CoreBundle\Migrations\Version22020614115124 [error] Migration Pimcore\Bundle\CoreBundle\Migrations\Version20210323082921 failed during Execution. Error: "Warning: Undefined array key "language""

In Version20210323082921.php line 60:

  Warning: Undefined array key "language"
