### PR TITLE
[Task]: Add parameter types getGetter/getSetterCode

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -94,6 +94,7 @@ Please make sure to set your preferred storage location ***before*** migration. 
   - Removed `dontCheckEnabled` config support from Areablock editable.
 - [Codeception] Bumped `codeception/codeception` version to ^5.0. Now, Pimcore is using a new directory structure for tests (Codeception 5 directory structure). For details, please see [#13415](https://github.com/pimcore/pimcore/pull/13415)
 - `Element\Service::getValidKey()` strips all control/unassigned, invalid and some more special (e.g. tabs, line-breaks, form-feed & vertical whitespace) characters.
+- [Data Objects]: Removed setter functions for calculated values, since they weren´t used anyway.
 
 
 ## 10.5.8

--- a/lib/DataObject/ClassBuilder/ObjectBrickContainerClassBuilder.php
+++ b/lib/DataObject/ClassBuilder/ObjectBrickContainerClassBuilder.php
@@ -76,11 +76,12 @@ class ObjectBrickContainerClassBuilder implements ObjectBrickContainerClassBuild
 
             $cd .= "}\n\n";
 
+            $typeDeclaration = '\\Pimcore\\Model\\DataObject\\Objectbrick\\Data\\' . ucfirst($brickKey);
             $cd .= '/**' . "\n";
-            $cd .= '* @param \\Pimcore\\Model\\DataObject\\Objectbrick\\Data\\' . ucfirst($brickKey) . ' $' . $brickKey . "\n";
+            $cd .= '* @param ' . $typeDeclaration  . ' $' . $brickKey . "\n";
             $cd .= '* @return $this' . "\n";
             $cd .= '*/' . "\n";
-            $cd .= 'public function set' . ucfirst($brickKey) . '(' . '$' . $brickKey . '): static' . "\n";
+            $cd .= 'public function set' . ucfirst($brickKey) . '(' . $typeDeclaration . ' $' . $brickKey . '): static' . "\n";
             $cd .= '{' . "\n";
             $cd .= "\t" . '$this->' . $brickKey . ' = ' . '$' . $brickKey . ";\n";
             $cd .= "\t" . 'return $this' . ";\n";

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -1014,7 +1014,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         $code .= '* Get ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
         $code .= '* @return ' . $this->getPhpdocReturnType() . "\n";
         $code .= '*/' . "\n";
-        $code .= 'public function get' . ucfirst($key) . '($language = null)' . $typeDeclaration . "\n";
+        $code .= 'public function get' . ucfirst($key) . '(?string $language = null)' . $typeDeclaration . "\n";
         $code .= '{' . "\n";
 
         $code .= "\t" . '$data = $this->getLocalizedfields()->getLocalizedValue("' . $key . '", $language);' . "\n";
@@ -1067,7 +1067,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         $code .= '* @param ' . $this->getPhpdocInputType() . ' $' . $key . "\n";
         $code .= '* @return $this' . "\n";
         $code .= '*/' . "\n";
-        $code .= 'public function set' . ucfirst($key) . ' (' . $typeDeclaration . '$' . $key . ', $language = null): static' . "\n";
+        $code .= 'public function set' . ucfirst($key) . ' (' . $typeDeclaration . '$' . $key . ', ?string $language = null): static' . "\n";
         $code .= '{' . "\n";
 
         if ($this->supportsDirtyDetection()) {
@@ -1092,7 +1092,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
             $code .= "\t" . '$hideUnpublished = \\Pimcore\\Model\\DataObject\\Concrete::getHideUnpublished();' . "\n";
             $code .= "\t" . '\\Pimcore\\Model\\DataObject\\Concrete::setHideUnpublished(false);' . "\n";
-            $code .= "\t" . '$currentData = $this->get' . ucfirst($this->getName()) . '($language);' . "\n";
+            $code .= "\t" . '$currentData = $this->get' . ucfirst($this->getName()) . '(string $language);' . "\n";
             $code .= "\t" . '\\Pimcore\\Model\\DataObject\\Concrete::setHideUnpublished($hideUnpublished);' . "\n";
 
             if ($class instanceof DataObject\ClassDefinition && $class->getAllowInherit()) {

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -1092,7 +1092,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
             $code .= "\t" . '$hideUnpublished = \\Pimcore\\Model\\DataObject\\Concrete::getHideUnpublished();' . "\n";
             $code .= "\t" . '\\Pimcore\\Model\\DataObject\\Concrete::setHideUnpublished(false);' . "\n";
-            $code .= "\t" . '$currentData = $this->get' . ucfirst($this->getName()) . '(string $language);' . "\n";
+            $code .= "\t" . '$currentData = $this->get' . ucfirst($this->getName()) . '($language);' . "\n";
             $code .= "\t" . '\\Pimcore\\Model\\DataObject\\Concrete::setHideUnpublished($hideUnpublished);' . "\n";
 
             if ($class instanceof DataObject\ClassDefinition && $class->getAllowInherit()) {

--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -510,7 +510,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
         $code .= '* @param ' . $this->getPhpdocInputType() . ' $' . $key . "\n";
         $code .= '* @return $this' . "\n";
         $code .= '*/' . "\n";
-        $code .= 'public function set' . ucfirst($key) . '(' . '$' . $key . ', ?string $language = null): static' . "\n";
+        $code .= 'public function set' . ucfirst($key) . '(' . $this->getParameterTypeDeclaration() . ' $' . $key . ', ?string $language = null): static' . "\n";
         $code .= '{' . "\n";
         $code .= "\t" . 'return $this;' . "\n";
         $code .= "}\n\n";

--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -328,7 +328,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
         $code .= '* Get ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
         $code .= '* @return ' . $this->getPhpdocReturnType() . "\n";
         $code .= '*/' . "\n";
-        $code .= 'public function get' . ucfirst($key) . '($language = null): ' . $this->getReturnTypeDeclaration() . "\n";
+        $code .= 'public function get' . ucfirst($key) . '(?string $language = null): ' . $this->getReturnTypeDeclaration() . "\n";
         $code .= '{' . "\n";
         $code .= "\t" . 'if (!$language) {' . "\n";
         $code .= "\t\t" . 'try {' . "\n";
@@ -384,7 +384,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
         $code .= '* Set ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
         $code .= '* @return ' . $this->getPhpdocReturnType() . "\n";
         $code .= '*/' . "\n";
-        $code .= 'public function get' . ucfirst($key) . '($language = null): ' . $this->getReturnTypeDeclaration() . "\n";
+        $code .= 'public function get' . ucfirst($key) . '(?string $language = null): ' . $this->getReturnTypeDeclaration() . "\n";
         $code .= '{' . "\n";
 
         $code .= "\t" . '$brickDefinition = DataObject\Objectbrick\Definition::getByKey("' . $brickClass->getKey() . '");' . "\n";
@@ -510,7 +510,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
         $code .= '* @param ' . $this->getPhpdocInputType() . ' $' . $key . "\n";
         $code .= '* @return $this' . "\n";
         $code .= '*/' . "\n";
-        $code .= 'public function set' . ucfirst($key) . '(' . '$' . $key . ', $language = null): static' . "\n";
+        $code .= 'public function set' . ucfirst($key) . '(' . '$' . $key . ', ?string $language = null): static' . "\n";
         $code .= '{' . "\n";
         $code .= "\t" . 'return $this;' . "\n";
         $code .= "}\n\n";

--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -436,12 +436,18 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
     {
         $key = $this->getName();
 
+        if ($this instanceof DataObject\ClassDefinition\Data\TypeDeclarationSupportInterface && $this->getParameterTypeDeclaration()) {
+            $typeDeclaration = $this->getParameterTypeDeclaration() . ' ';
+        } else {
+            $typeDeclaration = '';
+        }
+
         $code = '/**' . "\n";
         $code .= '* Set ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
         $code .= '* @param ' . $this->getPhpdocInputType() . ' $' . $key . "\n";
         $code .= '* @return $this' . "\n";
         $code .= '*/' . "\n";
-        $code .= 'public function set' . ucfirst($key) . '(' . '$' . $key . '): static' . "\n";
+        $code .= 'public function set' . ucfirst($key) . '(' . $typeDeclaration . '$' . $key . '): static' . "\n";
         $code .= '{' . "\n";
 
         $code .= "\t" . 'return $this;' . "\n";
@@ -457,13 +463,19 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
     {
         $key = $this->getName();
 
+        if ($this instanceof DataObject\ClassDefinition\Data\TypeDeclarationSupportInterface && $this->getParameterTypeDeclaration()) {
+            $typeDeclaration = $this->getParameterTypeDeclaration() . ' ';
+        } else {
+            $typeDeclaration = '';
+        }
+
         $code = '';
         $code .= '/**' . "\n";
         $code .= '* Set ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
         $code .= '* @param ' . $this->getPhpdocInputType() . ' $' . $key . "\n";
         $code .= '* @return $this' . "\n";
         $code .= '*/' . "\n";
-        $code .= 'public function set' . ucfirst($key) . '(' . '$' . $key . '): static' . "\n";
+        $code .= 'public function set' . ucfirst($key) . '(' . $typeDeclaration . '$' . $key . '): static' . "\n";
         $code .= '{' . "\n";
         $code .= "\t" . 'return $this;' . "\n";
         $code .= "}\n\n";
@@ -478,12 +490,18 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
     {
         $key = $this->getName();
 
+        if ($this instanceof DataObject\ClassDefinition\Data\TypeDeclarationSupportInterface && $this->getParameterTypeDeclaration()) {
+            $typeDeclaration = $this->getParameterTypeDeclaration() . ' ';
+        } else {
+            $typeDeclaration = '';
+        }
+
         $code = '/**' . "\n";
         $code .= '* Get ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
         $code .= '* @param ' . $this->getPhpdocInputType() . ' $' . $key . "\n";
         $code .= '* @return $this' . "\n";
         $code .= '*/' . "\n";
-        $code .= 'public function set' . ucfirst($key) . '(' . '$' . $key . '): static' . "\n";
+        $code .= 'public function set' . ucfirst($key) . '(' . $typeDeclaration . '$' . $key . '): static' . "\n";
         $code .= '{' . "\n";
         $code .= "\t" . 'return $this;' . "\n";
         $code .= "}\n\n";
@@ -505,12 +523,18 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
             $classname = $class->getName();
         }
 
+        if ($this instanceof DataObject\ClassDefinition\Data\TypeDeclarationSupportInterface && $this->getParameterTypeDeclaration()) {
+            $typeDeclaration = $this->getParameterTypeDeclaration() . ' ';
+        } else {
+            $typeDeclaration = '';
+        }
+
         $code = '/**' . "\n";
         $code .= '* Set ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
         $code .= '* @param ' . $this->getPhpdocInputType() . ' $' . $key . "\n";
         $code .= '* @return $this' . "\n";
         $code .= '*/' . "\n";
-        $code .= 'public function set' . ucfirst($key) . '(' . $this->getParameterTypeDeclaration() . ' $' . $key . ', ?string $language = null): static' . "\n";
+        $code .= 'public function set' . ucfirst($key) . '(' . $typeDeclaration . '$' . $key . ', ?string $language = null): static' . "\n";
         $code .= '{' . "\n";
         $code .= "\t" . 'return $this;' . "\n";
         $code .= "}\n\n";

--- a/models/DataObject/ClassDefinition/Data/CalculatedValue.php
+++ b/models/DataObject/ClassDefinition/Data/CalculatedValue.php
@@ -434,26 +434,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
      */
     public function getSetterCode($class)
     {
-        $key = $this->getName();
-
-        if ($this instanceof DataObject\ClassDefinition\Data\TypeDeclarationSupportInterface && $this->getParameterTypeDeclaration()) {
-            $typeDeclaration = $this->getParameterTypeDeclaration() . ' ';
-        } else {
-            $typeDeclaration = '';
-        }
-
-        $code = '/**' . "\n";
-        $code .= '* Set ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '* @param ' . $this->getPhpdocInputType() . ' $' . $key . "\n";
-        $code .= '* @return $this' . "\n";
-        $code .= '*/' . "\n";
-        $code .= 'public function set' . ucfirst($key) . '(' . $typeDeclaration . '$' . $key . '): static' . "\n";
-        $code .= '{' . "\n";
-
-        $code .= "\t" . 'return $this;' . "\n";
-        $code .= "}\n\n";
-
-        return $code;
+        return '';
     }
 
     /**
@@ -461,26 +442,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
      */
     public function getSetterCodeObjectbrick($brickClass)
     {
-        $key = $this->getName();
-
-        if ($this instanceof DataObject\ClassDefinition\Data\TypeDeclarationSupportInterface && $this->getParameterTypeDeclaration()) {
-            $typeDeclaration = $this->getParameterTypeDeclaration() . ' ';
-        } else {
-            $typeDeclaration = '';
-        }
-
-        $code = '';
-        $code .= '/**' . "\n";
-        $code .= '* Set ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '* @param ' . $this->getPhpdocInputType() . ' $' . $key . "\n";
-        $code .= '* @return $this' . "\n";
-        $code .= '*/' . "\n";
-        $code .= 'public function set' . ucfirst($key) . '(' . $typeDeclaration . '$' . $key . '): static' . "\n";
-        $code .= '{' . "\n";
-        $code .= "\t" . 'return $this;' . "\n";
-        $code .= "}\n\n";
-
-        return $code;
+        return '';
     }
 
     /**
@@ -488,25 +450,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
      */
     public function getSetterCodeFieldcollection($fieldcollectionDefinition)
     {
-        $key = $this->getName();
-
-        if ($this instanceof DataObject\ClassDefinition\Data\TypeDeclarationSupportInterface && $this->getParameterTypeDeclaration()) {
-            $typeDeclaration = $this->getParameterTypeDeclaration() . ' ';
-        } else {
-            $typeDeclaration = '';
-        }
-
-        $code = '/**' . "\n";
-        $code .= '* Get ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '* @param ' . $this->getPhpdocInputType() . ' $' . $key . "\n";
-        $code .= '* @return $this' . "\n";
-        $code .= '*/' . "\n";
-        $code .= 'public function set' . ucfirst($key) . '(' . $typeDeclaration . '$' . $key . '): static' . "\n";
-        $code .= '{' . "\n";
-        $code .= "\t" . 'return $this;' . "\n";
-        $code .= "}\n\n";
-
-        return $code;
+        return '';
     }
 
     /**
@@ -514,32 +458,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
      */
     public function getSetterCodeLocalizedfields($class)
     {
-        $key = $this->getName();
-        if ($class instanceof DataObject\Objectbrick\Definition) {
-            $classname = 'Objectbrick\\Data\\' . ucfirst($class->getKey());
-        } elseif ($class instanceof DataObject\Fieldcollection\Definition) {
-            $classname = 'Fieldcollection\\Data\\' . ucfirst($class->getKey());
-        } else {
-            $classname = $class->getName();
-        }
-
-        if ($this instanceof DataObject\ClassDefinition\Data\TypeDeclarationSupportInterface && $this->getParameterTypeDeclaration()) {
-            $typeDeclaration = $this->getParameterTypeDeclaration() . ' ';
-        } else {
-            $typeDeclaration = '';
-        }
-
-        $code = '/**' . "\n";
-        $code .= '* Set ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '* @param ' . $this->getPhpdocInputType() . ' $' . $key . "\n";
-        $code .= '* @return $this' . "\n";
-        $code .= '*/' . "\n";
-        $code .= 'public function set' . ucfirst($key) . '(' . $typeDeclaration . '$' . $key . ', ?string $language = null): static' . "\n";
-        $code .= '{' . "\n";
-        $code .= "\t" . 'return $this;' . "\n";
-        $code .= "}\n\n";
-
-        return $code;
+        return '';
     }
 
     /**
@@ -578,7 +497,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
      */
     public function getParameterTypeDeclaration(): ?string
     {
-        return '?\\' . DataObject\Data\CalculatedValue::class;
+        return '';
     }
 
     /**
@@ -594,7 +513,7 @@ class CalculatedValue extends Data implements QueryResourcePersistenceAwareInter
      */
     public function getPhpdocInputType(): ?string
     {
-        return '\\' . DataObject\Data\CalculatedValue::class . '|null';
+        return '';
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Table.php
+++ b/models/DataObject/ClassDefinition/Data/Table.php
@@ -814,7 +814,7 @@ class Table extends Data implements ResourcePersistenceAwareInterface, QueryReso
         $code .= '* Get ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
         $code .= '* @return ' . $this->getPhpdocReturnType() . "\n";
         $code .= '*/' . "\n";
-        $code .= 'public function get' . ucfirst($key) . ' ($language = null)' . $typeDeclaration . "\n";
+        $code .= 'public function get' . ucfirst($key) . ' (?string $language = null)' . $typeDeclaration . "\n";
         $code .= '{' . "\n";
 
         $code .= "\t" . '$data = $this->getLocalizedfields()->getLocalizedValue("' . $key . '", $language);' . "\n";

--- a/tests/Model/DataObject/ClassDefinitionTest.php
+++ b/tests/Model/DataObject/ClassDefinitionTest.php
@@ -145,26 +145,6 @@ public function setQuantityValue(?\Pimcore\Model\DataObject\Data\QuantityValue $
     /**
      * Verifies that the setter code gets created properly
      */
-    public function testCalculatedValueSetterCode()
-    {
-        $expectedSetterCode =
-            '/**
-* Set calculatedValue - calculatedValue
-* @param \Pimcore\Model\DataObject\Data\CalculatedValue|null $calculatedValue
-* @return $this
-*/
-public function setCalculatedValue($calculatedValue): static
-{
-	return $this;
-}
-
-';
-        $this->testSetterCode('calculatedValue', $expectedSetterCode);
-    }
-
-    /**
-     * Verifies that the setter code gets created properly
-     */
     public function testLocalizedFieldSetterCode()
     {
         $expectedSetterCode =

--- a/tests/Support/Test/DataType/AbstractDataTypeTestCase.php
+++ b/tests/Support/Test/DataType/AbstractDataTypeTestCase.php
@@ -165,13 +165,6 @@ abstract class AbstractDataTypeTestCase extends TestCase
         $valueFromCalculator = $this->testObject->getCalculatedValue();
         $this->assertEquals($value, $valueFromCalculator, 'calculated value does not match');
 
-        // now call the setter and retry, shouldn't have any effect
-        $newValue = uniqid();
-        $this->testObject->setCalculatedValue($newValue);
-
-        $valueFromCalculator = $this->testObject->getCalculatedValue();
-        $this->assertEquals($value, $valueFromCalculator, 'calculated value does not match');
-
         //check if it got written to the query table
 
         $this->testObject->save();
@@ -194,13 +187,6 @@ abstract class AbstractDataTypeTestCase extends TestCase
         ]);
 
         $this->testObject->setFirstname('Jane');
-
-        $value = $this->testObject->getCalculatedValueExpression();
-        $this->assertEquals('Jane some calc', $value, 'calculated value does not match');
-
-        // now call the setter and retry, shouldn't have any effect
-        $newValue = uniqid();
-        $this->testObject->setCalculatedValueExpression($newValue);
 
         $value = $this->testObject->getCalculatedValueExpression();
         $this->assertEquals('Jane some calc', $value, 'calculated value does not match');


### PR DESCRIPTION
Add types for all parameters, including $language parameter
Removed setter functions for `CalculatedValue`, since they are not used, change return values for getPhpdocInputType/getParameterTypeDeclaration accordingly