### PR TITLE
Fix missing semicolon in nginx config

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/02_Nginx_Configuration.md
@@ -45,7 +45,7 @@ map $uri $static_page_uri {
 
 server {
     listen 80;
-    listen [::]:80
+    listen [::]:80;
     server_name YOUPROJECT.local;
     root /var/www/pimcore/public;
     index index.php;


### PR DESCRIPTION
I copied and pasted nginx configuraton from the documentation and I noticed that it fails because of missing semicolon.