### PR TITLE
Concrete::getById() must return only Concrete objects

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,7 +1,7 @@
 # Upgrade Notes
 
 ## 10.5.10
-- [DataObject] Deprecated: Loading none Concrete objects with the Concrete class will not possible in Pimcore 11.
+- [DataObject] Deprecated: Loading non-Concrete objects with the Concrete class will not be possible in Pimcore 11.
 
 ## 10.5.8
 - [Twig] Sending mails and Dataobject Text Layouts, which allow rendering user controlled twig templates are now executed in a sandbox with restrictive security policies for tags, filters, functions.

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## 10.5.10
+- [DataObject] Deprecated: Loading none Concrete objects with the Concrete class will not possible in Pimcore 11.
+
 ## 10.5.8
 - [Twig] Sending mails and Dataobject Text Layouts, which allow rendering user controlled twig templates are now executed in a sandbox with restrictive security policies for tags, filters, functions.
          Please use following configuration to allow more in template rendering:

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -520,7 +520,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             trigger_deprecation(
                 'pimcore/pimcore',
                 '10.5',
-                'Loading none Concrete objects with via the Concrete class will not possible in Pimcore 11'
+                'Loading none Concrete objects with the Concrete class will not possible in Pimcore 11'
             );
 
             return true;

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -516,7 +516,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
      */
     protected static function typeMatch(AbstractObject $object)
     {
-        return in_array(static::class, [Concrete::class, __CLASS__], true) || $object instanceof static;
+        return static::class === __CLASS__ || $object instanceof static;
     }
 
     /**

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -520,13 +520,13 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             trigger_deprecation(
                 'pimcore/pimcore',
                 '10.5',
-                'Loading none Concrete objects with the Concrete class will not possible in Pimcore 11'
+                'Loading non-Concrete objects with the Concrete class will not be possible in Pimcore 11'
             );
 
             return true;
         }
 
-        return static::class === __CLASS__ || $object instanceof static;
+        return static::class === self::class || $object instanceof static;
     }
 
     /**

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -516,6 +516,16 @@ abstract class AbstractObject extends Model\Element\AbstractElement
      */
     protected static function typeMatch(AbstractObject $object)
     {
+        if (static::class === Concrete::class && !$object instanceof static) {
+            trigger_deprecation(
+                'pimcore/pimcore',
+                '10.5',
+                'Loading none Concrete objects with via the Concrete class will not possible in Pimcore 11'
+            );
+
+            return true;
+        }
+
         return static::class === __CLASS__ || $object instanceof static;
     }
 


### PR DESCRIPTION
Concrete::getById() returns also Folder objects. But this is wrong because the return type is static|null