### PR TITLE
[Bug fix]: handle the case where the ObjectFieldGetter returns a list of objects

### DIFF
--- a/lib/DataObject/GridColumnConfig/Operator/ObjectFieldGetter.php
+++ b/lib/DataObject/GridColumnConfig/Operator/ObjectFieldGetter.php
@@ -91,7 +91,11 @@ final class ObjectFieldGetter extends AbstractOperator
                     if ($o instanceof Concrete) {
                         if ($this->attribute && method_exists($o, $getter)) {
                             $targetValue = $o->$getter();
-                            $newValues[] = $targetValue;
+                            if (is_array($targetValue)) {
+                                $newValues = array_merge($newValues, $targetValue);
+                            } else {
+                                $newValues[] = $targetValue;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Adding check for return value of getter is an array otherwise the returned objects are not accessible in the grid selection by the next operation.
