### PR TITLE
[Bug]: Fix video editable height configuration problem with percentage values and improving error rendering

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -576,11 +576,17 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         // If contains at least one digit (0-9), then assume it is a value that can be calculated,
         // otherwise it is likely be `auto`,`inherit`,etc..
         if (preg_match('/[\d]/', $width)){
+
+            // when is numeric, therefore is without length units or %, then is px
+            if (is_numeric($width)) {
+                $width .= 'px';
+            }
             $width = 'calc(' . $width . ' - 1px)';
         }
 
         $height = $this->getHeight();
         if (preg_match('/[\d]/', $height)){
+
             if (is_numeric($height)) {
                 $height .= 'px';
             }

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -573,8 +573,15 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
     private function getErrorCode($message = '')
     {
         $width = $this->getWidth();
-        if (strpos($this->getWidth(), '%') === false) {
-            $width = ((int)$this->getWidth() - 1) . 'px';
+        // If contains at least one digit (0-9), then assume it is a value that can be calculated,
+        // otherwise it is likely be `auto`,`inherit`,etc..
+        if (preg_match('/[\d]/', $width)){
+            $width = 'calc(' . $width . ' - 1px)';
+        }
+
+        $height = $this->getHeight();
+        if (preg_match('/[\d]/', $height)){
+            $height = 'calc(' . $height . ' - 1px)';
         }
 
         // only display error message in debug mode
@@ -584,7 +591,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
         $code = '
         <div id="pimcore_video_' . $this->getName() . '" class="pimcore_editable_video">
-            <div class="pimcore_editable_video_error" style="text-align:center; width: ' . $width . '; height: ' . ($this->getHeight() - 1) . 'px; border:1px solid #000; background: url(/bundles/pimcoreadmin/img/filetype-not-supported.svg) no-repeat center center #fff;">
+            <div class="pimcore_editable_video_error" style="text-align:center; width: ' . $width . '; height: ' . $height . '; border:1px solid #000; background: url(/bundles/pimcoreadmin/img/filetype-not-supported.svg) no-repeat center center #fff;">
                 ' . $message . '
             </div>
         </div>';

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -581,6 +581,9 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
         $height = $this->getHeight();
         if (preg_match('/[\d]/', $height)){
+            if (is_numeric($height)) {
+                $height .= 'px';
+            }
             $height = 'calc(' . $height . ' - 1px)';
         }
 

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -577,7 +577,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         // otherwise it is likely be `auto`,`inherit`,etc..
         if (preg_match('/[\d]/', $width)){
 
-            // when is numeric, therefore is without length units or %, then is px
+            // when is numeric, assume there are no length units nor %, and considering the value as pixels
             if (is_numeric($width)) {
                 $width .= 'px';
             }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #13472

Update: i was trying to reproduce the error again and found out that this twig template in Demo may be the culprit
https://github.com/pimcore/demo/blob/686e91e30c430d54487a66c8558cb6ea5c2051b5/templates/areas/video/view.html.twig#L9
![image](https://user-images.githubusercontent.com/6014195/199747555-f634214e-d9c9-425d-8097-8f48fece5eaf.png)

The `auto` value in the twig template isn't complying with the valid values
https://github.com/pimcore/pimcore/blob/747b0d7761fdd8a933de5fdd8e3a7990336589e2/doc/Development_Documentation/03_Documents/01_Editables/38_Video.md?plain=1#L16

and it does not actually work with percentage as stated because of ` ($this->getHeight() - 1) . 'px`