### PR TITLE
JS Error in properties tab when we try to add property without type

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/properties.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/properties.js
@@ -642,7 +642,7 @@ pimcore.element.properties = Class.create({
         }
 
         // check for empty key & type
-        if (key.length < 2 || type.length < 1) {
+        if (key.length < 2 || !type ||type.length < 1) {
             Ext.MessageBox.alert(t("error"), t("name_and_key_must_be_defined"));
             return;
         }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Added missing "check" in if condition before trying to access length, to avoid calling on null.
Attached screenshot to ensure everything is clear.

## Additional info  

![image](https://user-images.githubusercontent.com/17313784/199962277-b6174d07-6792-4c2a-8dc3-738d3297703f.png)
