### PR TITLE
add loadTemplateFromPath for getting a maintenance page via file path

### DIFF
--- a/bundles/CoreBundle/EventListener/MaintenancePageListener.php
+++ b/bundles/CoreBundle/EventListener/MaintenancePageListener.php
@@ -29,7 +29,7 @@ class MaintenancePageListener
     use ResponseInjectionTrait;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $templateCode = null;
 
@@ -43,15 +43,15 @@ class MaintenancePageListener
     /**
      * @param string $code
      */
-    public function setTemplateCode($code)
+    public function setTemplateCode($code): void
     {
         $this->templateCode = $code;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getTemplateCode()
+    public function getTemplateCode(): ?string
     {
         return $this->templateCode;
     }
@@ -59,7 +59,18 @@ class MaintenancePageListener
     /**
      * @param string $path
      */
-    public function loadTemplateFromResource($path)
+    public function loadTemplateFromPath($path): void
+    {
+        $templateFile = PIMCORE_PROJECT_ROOT . $path;
+        if (file_exists($templateFile)) {
+            $this->setTemplateCode(file_get_contents($templateFile));
+        }
+    }
+
+    /**
+     * @param string $path
+     */
+    public function loadTemplateFromResource($path): void
     {
         $templateFile = $this->kernel->locateResource($path);
         if (file_exists($templateFile)) {
@@ -70,7 +81,7 @@ class MaintenancePageListener
     /**
      * @param RequestEvent $event
      */
-    public function onKernelRequest(RequestEvent $event)
+    public function onKernelRequest(RequestEvent $event): void
     {
         if (!$event->isMainRequest()) {
             return;

--- a/doc/Development_Documentation/20_Extending_Pimcore/15_Maintenance_Mode.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/15_Maintenance_Mode.md
@@ -25,3 +25,13 @@ Pimcore\Bundle\CoreBundle\EventListener\MaintenancePageListener:
     tags:
         - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 620 }
 ```
+
+Use loadTemplateFromPath if the file is located outside a bundle.
+
+```yaml
+Pimcore\Bundle\CoreBundle\EventListener\MaintenancePageListener:
+    calls:
+        - [loadTemplateFromPath, ['/templates/maintenance.html']]
+    tags:
+        - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 620 }
+```


### PR DESCRIPTION
## Changes in this pull request  
Adding loadTemplateFromPath to MaintenancePageListener.php to load a maintenance page via file path. 
loadTemplateFromResource only works if you have bundles and symfony recommends to not have bundles for project code. https://symfony.com/doc/current/bundles.html

## Additional info  
Added this to the documentation.

