### PR TITLE
change dialog rendering to use default overwrite logic when using inheritance

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/area_abstract.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/area_abstract.js
@@ -45,6 +45,7 @@ pimcore.document.area_abstract = Class.create(pimcore.document.editable, {
                                 } else {
                                     editablesInBox[editableName].render();
                                 }
+                                editablesInBox[editableName].setInherited(editablesInBox[editableName].inherited);
                             });
                         }, 200);
                     }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
This PR fixes that inherited elements in dialogs never have their inherited property changed.

This behavior occurs when using translations with inheritance.

1. To reproduce, add any brick that uses `getEditableDialogBoxConfiguration()` to a page.
2. Copy and Paste (Inheritance) as a new language variant.
3. In the translated page, overwrite the element from step 1 and try to edit any setting in the dialog.
4. After this fix, the inherited property gets set to false and changes are persisted.

Resolves #13431

## Additional info  
I fixed this for a customer, so I haven't tested if it actually resolves the issue above, but it most likely will.
