### PR TITLE
[Predefined Asset Metadata] Prevent creation of predefined item with same name

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers/generic-grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers/generic-grid.js
@@ -51,6 +51,7 @@ pimcore.helpers.grid.buildDefaultStore = function (url, fields, itemsPerPage, cu
         listeners: {
             exception: function(proxy, response, operation){
                 pimcore.helpers.showNotification(t("error"), t(operation.getError()), "error");
+                store.load();
             }
         }
     });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers/generic-grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers/generic-grid.js
@@ -27,8 +27,7 @@ pimcore.helpers.grid.buildDefaultStore = function (url, fields, itemsPerPage, cu
         type: 'ajax',
         reader: {
             type: 'json',
-            rootProperty: 'data',
-            messageProperty: 'message'
+            rootProperty: 'data'
         },
         writer: {
             type: 'json',
@@ -47,13 +46,17 @@ pimcore.helpers.grid.buildDefaultStore = function (url, fields, itemsPerPage, cu
             read: 'POST',
             update: 'POST',
             destroy: 'POST'
-        },
+        }/*,
         listeners: {
             exception: function(proxy, response, operation){
-                pimcore.helpers.showNotification(t("error"), t(operation.getError()), "error");
-                store.load();
+                Ext.MessageBox.show({
+                    title: 'REMOTE EXCEPTION',
+                    msg: operation.getError(),
+                    icon: Ext.MessageBox.ERROR,
+                    buttons: Ext.Msg.OK
+                });
             }
-        }
+        }*/
     });
 
     var config = {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers/generic-grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers/generic-grid.js
@@ -27,7 +27,8 @@ pimcore.helpers.grid.buildDefaultStore = function (url, fields, itemsPerPage, cu
         type: 'ajax',
         reader: {
             type: 'json',
-            rootProperty: 'data'
+            rootProperty: 'data',
+            messageProperty: 'message'
         },
         writer: {
             type: 'json',
@@ -46,17 +47,12 @@ pimcore.helpers.grid.buildDefaultStore = function (url, fields, itemsPerPage, cu
             read: 'POST',
             update: 'POST',
             destroy: 'POST'
-        }/*,
+        },
         listeners: {
             exception: function(proxy, response, operation){
-                Ext.MessageBox.show({
-                    title: 'REMOTE EXCEPTION',
-                    msg: operation.getError(),
-                    icon: Ext.MessageBox.ERROR,
-                    buttons: Ext.Msg.OK
-                });
+                pimcore.helpers.showNotification(t("error"), t(operation.getError()), "error");
             }
-        }*/
+        }
     });
 
     var config = {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/metadata/predefined.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/metadata/predefined.js
@@ -81,6 +81,12 @@ pimcore.settings.metadata.predefined = Class.create({
             }
         );
 
+        this.store.getProxy().getReader().setMessageProperty('message');
+        this.store.getProxy().on('exception', function (proxy, response, operation) {
+            pimcore.helpers.showNotification(t("error"), t(operation.getError()), "error");
+            store.load();
+        });
+
         this.store.addListener('exception', function(proxy, mode, action, options, response) {
             Ext.Msg.show({
                 title: t("error"),

--- a/models/Metadata/Predefined.php
+++ b/models/Metadata/Predefined.php
@@ -143,7 +143,6 @@ final class Predefined extends Model\AbstractModel
     public static function create()
     {
         $type = new self();
-        $type->save();
 
         return $type;
     }

--- a/models/Metadata/Predefined/Listing.php
+++ b/models/Metadata/Predefined/Listing.php
@@ -109,23 +109,23 @@ class Listing extends JsonListing implements CallableFilterListingInterface, Cal
     {
         $list = new self();
 
-        $definitions = array_filter($list->load(), function ($item) use ($key, $language, $targetSubtype) {
+        foreach($list->load() as $item) {
             if ($item->getName() != $key) {
-                return false;
+                continue;
             }
 
             if ($language && $language != $item->getLanguage()) {
-                return false;
+                continue;
             }
 
             if ($targetSubtype && $targetSubtype != $item->getTargetSubtype()) {
-                return false;
+                continue;
             }
 
-            return true;
-        });
+            return $item;
+        }
 
-        return $definitions[0] ?? null;
+        return null;
     }
 
     /**


### PR DESCRIPTION
Steps to reproduce:

1. Create predefined asset meta data (e.g. simply keep default name `New Definition`)
2. Create another predefined asset meta data with same name as for 1.
3. Close predefined meta data panel and reopen it

Expected result:
Only one item should exist because the names are unique according to https://github.com/pimcore/pimcore/blob/e8173ce9655519d57f3878804648d03fbe9a4c05/bundles/AdminBundle/Controller/Admin/SettingsController.php#L207-L210

When creating duplicate, an error message should be shown.

Actual result:
In https://github.com/pimcore/pimcore/blob/e8173ce9655519d57f3878804648d03fbe9a4c05/bundles/AdminBundle/Controller/Admin/SettingsController.php#L203 an empty predefined meta data item gets created and saved to the database
https://github.com/pimcore/pimcore/blob/e8173ce9655519d57f3878804648d03fbe9a4c05/models/Metadata/Predefined.php#L146

The actual check if there is another item with the same name is only done afterwards https://github.com/pimcore/pimcore/blob/e8173ce9655519d57f3878804648d03fbe9a4c05/bundles/AdminBundle/Controller/Admin/SettingsController.php#L207-L210

This then recognizes the existence of a duplicate and returns the `rule_violation`. But the user does not get notified of this error.
Moreover after reloading the predefined meta data panel, there is a PHP error in https://github.com/pimcore/pimcore/blob/e8173ce9655519d57f3878804648d03fbe9a4c05/models/Metadata/Predefined.php#L372 because the `type` has not been set for the duplicate. And thus you cannot even remove this empty duplicate via UI.

This PR adjusts `Predefined::create()` to not save the item because in this moment it is completely empty anyway and cannot be loaded. Maybe it was designed differently as the comment https://github.com/pimcore/pimcore/blob/e8173ce9655519d57f3878804648d03fbe9a4c05/bundles/AdminBundle/Controller/Admin/SettingsController.php#L202 says that the type gets saved - but in fact it does not.

Additionally this PR show an error window in case of a server-side error.