### PR TITLE
[Docs] 07_Users_and_Roles.md - permisions to move elements in tree

### DIFF
--- a/doc/Development_Documentation/22_Administration_of_Pimcore/07_Users_and_Roles.md
+++ b/doc/Development_Documentation/22_Administration_of_Pimcore/07_Users_and_Roles.md
@@ -97,6 +97,8 @@ role `myRole` and thereby inherits all workspace settings from the role.
 In case the editor has his own workspace settings on `/home/myPath`, these permissions are added to permissions from any 
 role they incorporate. A permission granted by any role can not be rescinded for a single user.
 
+Example: If you want to allow to move elements in tree then it is necessary to grant the create and settings access.
+
 
 It is also possible to restrict access to localized fields on a language-level. By default, a user can view and edit 
 (as long as they also have sufficient object permissions) all localized fields. This can now be restricted to a subset of 


### PR DESCRIPTION
Question: At the moment it is necessary to grant the **create** and **settings** access to move elements in tree. Is this correct or a bug?

If correct then we should add it to the documentation (already in this PR) otherwise we have to change the implementation!  

Why the question?

```
// check new parent's permission
if(!newParent.data.permissions.create){
        Ext.MessageBox.alert(' ', t('element_cannot_be_moved'));
        return false;
}
```

## Changes in this pull request  
Resolves #

## Additional info  

