### PR TITLE
[Fix] moving "allowToCreateNewObject" option out of class context scope

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/manyToManyObjectRelation.js
@@ -192,18 +192,19 @@ pimcore.object.classes.data.manyToManyObjectRelation = Class.create(pimcore.obje
 
         this.specificPanel.add({
             xtype: "checkbox",
+            boxLabel: t("enable_text_selection"),
+            name: "enableTextSelection",
+            value: this.datax.enableTextSelection
+        });
+
+        this.specificPanel.add({
+            xtype: "checkbox",
             boxLabel: t("allow_to_create_new_object"),
             name: "allowToCreateNewObject",
             value: this.datax.allowToCreateNewObject
         });
 
         if(this.context == 'class') {
-            this.specificPanel.add({
-                xtype: "checkbox",
-                boxLabel: t("enable_text_selection"),
-                name: "enableTextSelection",
-                value: this.datax.enableTextSelection
-            });
             this.specificPanel.add({
                 xtype: "checkbox",
                 boxLabel: t("enable_admin_async_load"),

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/manyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/manyToManyObjectRelation.js
@@ -190,18 +190,19 @@ pimcore.object.classes.data.manyToManyObjectRelation = Class.create(pimcore.obje
         });
         this.specificPanel.add(this.fieldSelect);
 
+        this.specificPanel.add({
+            xtype: "checkbox",
+            boxLabel: t("allow_to_create_new_object"),
+            name: "allowToCreateNewObject",
+            value: this.datax.allowToCreateNewObject
+        });
+
         if(this.context == 'class') {
             this.specificPanel.add({
                 xtype: "checkbox",
                 boxLabel: t("enable_text_selection"),
                 name: "enableTextSelection",
                 value: this.datax.enableTextSelection
-            });
-            this.specificPanel.add({
-                xtype: "checkbox",
-                boxLabel: t("allow_to_create_new_object"),
-                name: "allowToCreateNewObject",
-                value: this.datax.allowToCreateNewObject
             });
             this.specificPanel.add({
                 xtype: "checkbox",


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request 
Moving the "allowToCreateNewObject" option outside of class scope.
Resolves #13495

## Additional info  
"allowToCreateNewObject" can now be disabled in fieldcollections or objectbricks
