### PR TITLE
BC layer for tests support classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -172,8 +172,7 @@
   },
   "autoload": {
     "files": [
-      "lib/helper-functions.php",
-      "tests/class_aliases.php"
+      "lib/helper-functions.php"
     ],
     "psr-4": {
       "Pimcore\\Model\\": "models",
@@ -198,7 +197,8 @@
       "Pimcore\\Tests\\": "tests"
     },
     "files": [
-      "src/Kernel.php"
+      "src/Kernel.php",
+      "tests/class_aliases.php"
     ]
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -172,7 +172,8 @@
   },
   "autoload": {
     "files": [
-      "lib/helper-functions.php"
+      "lib/helper-functions.php",
+      "tests/class_aliases.php"
     ],
     "psr-4": {
       "Pimcore\\Model\\": "models",

--- a/tests/Support/Helper/DataType/TestDataHelper.php
+++ b/tests/Support/Helper/DataType/TestDataHelper.php
@@ -1128,7 +1128,7 @@ class TestDataHelper extends AbstractTestDataHelper
      * @param int $seed
      * @param array $returnParams
      */
-    public function assertVideo(Concrete $object, $field, $seed = 1, $returnParams)
+    public function assertVideo(Concrete $object, $field, $seed, $returnParams)
     {
         $getter = 'get' . ucfirst($field);
 

--- a/tests/class_aliases.php
+++ b/tests/class_aliases.php
@@ -33,11 +33,6 @@ $classAliases = [
     '\Pimcore\Tests\Support\Test\TestCase' => '\Pimcore\Tests\Test\TestCase',
     '\Pimcore\Tests\Support\Util\Autoloader' => '\Pimcore\Tests\Util\Autoloader',
     '\Pimcore\Tests\Support\Util\TestHelper' => '\Pimcore\Tests\Util\TestHelper',
-    '\Pimcore\Tests\Support\CacheTester' => '\Pimcore\Tests\CacheTester',
-    '\Pimcore\Tests\Support\EcommerceTester' => '\Pimcore\Tests\EcommerceTester',
-    '\Pimcore\Tests\Support\ModelTester' => '\Pimcore\Tests\ModelTester',
-    '\Pimcore\Tests\Support\ServiceTester' => '\Pimcore\Tests\ServiceTester',
-    '\Pimcore\Tests\Support\UnitTester' => '\Pimcore\Tests\UnitTester',
 ];
 
 foreach ($classAliases as $class => $alias) {

--- a/tests/class_aliases.php
+++ b/tests/class_aliases.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+//BC layer for Test Support clasess. Remove in Pimcore 12
+$classAliases = [
+    '\Pimcore\Tests\Support\Helper\DataType\Calculator' => '\Pimcore\Tests\Helper\DataType\Calculator',
+    '\Pimcore\Tests\Support\Helper\DataType\TestDataHelper' => '\Pimcore\Tests\Helper\DataType\TestDataHelper',
+    '\Pimcore\Tests\Support\Helper\Document\TestDataHelper' => '\Pimcore\Tests\Helper\Document\TestDataHelper',
+    '\Pimcore\Tests\Support\Helper\Element\PropertiesTestHelper' => '\Pimcore\Tests\Helper\Element\PropertiesTestHelper',
+    '\Pimcore\Tests\Support\Helper\AbstractDefinitionHelper' => '\Pimcore\Tests\Helper\AbstractDefinitionHelper',
+    '\Pimcore\Tests\Support\Helper\AbstractTestDataHelper' => '\Pimcore\Tests\Helper\AbstractTestDataHelper',
+    '\Pimcore\Tests\Support\Helper\ClassManager' => '\Pimcore\Tests\Helper\ClassManager',
+    '\Pimcore\Tests\Support\Helper\Ecommerce' => '\Pimcore\Tests\Helper\Ecommerce',
+    '\Pimcore\Tests\Support\Helper\Model' => '\Pimcore\Tests\Helper\Model',
+    '\Pimcore\Tests\Support\Helper\Pimcore' => '\Pimcore\Tests\Helper\Pimcore',
+    '\Pimcore\Tests\Support\Helper\Unit' => '\Pimcore\Tests\Helper\Unit',
+    '\Pimcore\Tests\Support\Test\DataType\AbstractDataTypeTestCase' => '\Pimcore\Tests\Test\DataType\AbstractDataTypeTestCase',
+    '\Pimcore\Tests\Support\Test\AbstractPropertiesTest' => '\Pimcore\Tests\Test\AbstractPropertiesTest',
+    '\Pimcore\Tests\Support\Test\EcommerceTestCase' => '\Pimcore\Tests\Test\EcommerceTestCase',
+    '\Pimcore\Tests\Support\Test\ModelTestCase' => '\Pimcore\Tests\Test\ModelTestCase',
+    '\Pimcore\Tests\Support\Test\TestCase' => '\Pimcore\Tests\Test\TestCase',
+    '\Pimcore\Tests\Support\Util\Autoloader' => '\Pimcore\Tests\Util\Autoloader',
+    '\Pimcore\Tests\Support\Util\TestHelper' => '\Pimcore\Tests\Util\TestHelper',
+    '\Pimcore\Tests\Support\CacheTester' => '\Pimcore\Tests\CacheTester',
+    '\Pimcore\Tests\Support\EcommerceTester' => '\Pimcore\Tests\EcommerceTester',
+    '\Pimcore\Tests\Support\ModelTester' => '\Pimcore\Tests\ModelTester',
+    '\Pimcore\Tests\Support\ServiceTester' => '\Pimcore\Tests\ServiceTester',
+    '\Pimcore\Tests\Support\UnitTester' => '\Pimcore\Tests\UnitTester',
+];
+
+foreach ($classAliases as $class => $alias) {
+    if (!class_exists($alias, false)) {
+        class_alias($class, $alias);
+    }
+}


### PR DESCRIPTION
## Changes in this pull request  
Follow up to #13415

## Additional info  
Tests support classes are moved to new namepaces with codeception 5 directory structure change, so adding BC layer for old namespaces.
