### PR TITLE
[Task]: Quoting `key` column identifier in `ecommerceframework_cartcheckoutdata`

### DIFF
--- a/bundles/EcommerceFrameworkBundle/src/CartManager/CartCheckoutData/Dao.php
+++ b/bundles/EcommerceFrameworkBundle/src/CartManager/CartCheckoutData/Dao.php
@@ -16,6 +16,7 @@
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData;
 
 use Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData;
+use Pimcore\Db\Helper;
 use Pimcore\Model\Exception\NotFoundException;
 
 /**
@@ -90,9 +91,9 @@ class Dao extends \Pimcore\Model\Dao\AbstractDao
         }
 
         try {
-            $this->db->insert(self::TABLE_NAME, $data);
+            $this->db->insert(self::TABLE_NAME, Helper::quoteDataIdentifiers($this->db, $data));
         } catch (\Exception $e) {
-            $this->db->update(self::TABLE_NAME, $data, ['key' => $this->db->quote($this->model->getKey()), 'cartId' => $this->db->quote($this->model->getCartId())]);
+            $this->db->update(self::TABLE_NAME, Helper::quoteDataIdentifiers($this->db, $data), ['key' => $this->db->quote($this->model->getKey()), 'cartId' => $this->db->quote($this->model->getCartId())]);
         }
     }
 


### PR DESCRIPTION
## Changes in this pull request  
Partially resolves https://github.com/pimcore/pimcore/issues/13392


## To reproduce
Without this PR, it will crash when trying to checkout the cart (after filling billing and accepting terms)
![image](https://user-images.githubusercontent.com/6014195/200908363-9e304057-f529-402b-893b-f3695c34ed46.png)



