### PR TITLE
[Bug]: ReadOnly layout for Float number classification store key cause javascript exception "Layout run failed"

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/numeric.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/numeric.js
@@ -139,6 +139,8 @@ pimcore.object.tags.numeric = Class.create(pimcore.object.tags.abstract, {
         var input = {
             fieldLabel: this.fieldConfig.title,
             name: this.fieldConfig.name,
+            labelWidth: 100,
+            width: 175,
             componentCls: this.getWrapperClassNames(),
         };
 


### PR DESCRIPTION
resolves #13377 