### PR TITLE
Bugfix: Get image Thumbnail Admin Action

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -1331,7 +1331,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     public function getImageThumbnailAction(Request $request)
     {
         $fileinfo = $request->get('fileinfo');
-        $image = Asset\Image::getById((int)$request->get('id'));
+        $image = Asset::getById((int)$request->get('id'));
 
         if (!$image) {
             throw $this->createNotFoundException('Asset not found');

--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -1331,7 +1331,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     public function getImageThumbnailAction(Request $request)
     {
         $fileinfo = $request->get('fileinfo');
-        $image = Asset::getById((int)$request->get('id'));
+        $image = Asset\Image::getById((int)$request->get('id'));
 
         if (!$image) {
             throw $this->createNotFoundException('Asset not found');

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -254,7 +254,7 @@ class Asset extends Element\AbstractElement
                 $asset->getDao()->getById($id);
                 $className = 'Pimcore\\Model\\Asset\\' . ucfirst($asset->getType());
 
-                if (get_class($asset) !== $className) {
+                if (self::getModelFactory()->supportsClassName($className)) {
                     /** @var Asset $asset */
                     $asset = self::getModelFactory()->build($className);
                     $asset->getDao()->getById($id);


### PR DESCRIPTION
- Call getById from Asset instead of Asset\Image to not break class model overrides

## Steps to reproduce
- Overwrite the Pimcore\Model\Asset\Image in your config.yaml models -> class_overrides as described here:
https://pimcore.com/docs/pimcore/current/Development_Documentation/Extending_Pimcore/Overriding_Models.html
- Upload a new Asset in the DAM and click directly on the uploaded image (No reload)
- getImageThumbnailAction gets the image
- The image is an instance of Pimcore\Model\Asset\Image instead of your own overwritten class

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Change how a image will be loaded in the imageThumbnailAction

## Additional info  
The Pimcore\Model\Asset getById method which is being called in the Pimcore\Bundle\AdminBundle\Controller\Admin\Asset\AssetContoller getImageThumbnailAction creates a new static instance.

https://github.com/pimcore/pimcore/blob/87ec1423edc77b5c78a05709146ecc092c055ce8/models/Asset.php#L250-L261

This will break class model overrides in this case. To avoid this the method should be called from the Asset itself instead of Asset\Image
