### PR TITLE
[Task]: Remove superfluous null coalescing in Application Logger Processor

### DIFF
--- a/lib/Log/Processor/ApplicationLoggerProcessor.php
+++ b/lib/Log/Processor/ApplicationLoggerProcessor.php
@@ -68,7 +68,7 @@ class ApplicationLoggerProcessor
             return $record;
         }
 
-        $relatedObject = $record['context']['relatedObject'] ?? null;
+        $relatedObject = $record['context']['relatedObject'];
         $relatedObjectType = $record['context']['relatedObjectType'] ?? null;
 
         if (null !== $relatedObject && is_object($relatedObject)) {


### PR DESCRIPTION
## Changes in this pull request  
The `!isset` on line 62 and the `return` already ensure that it would be never `null` on line 71.
https://github.com/pimcore/pimcore/blob/1dab58c6dda0e96eb1f4a2d71444a2d77db819d4/lib/Log/Processor/ApplicationLoggerProcessor.php#L62-L71

Stumbled upon this issue when working on monolog 3 https://github.com/pimcore/pimcore/actions/runs/3444228582/jobs/5746609556