### PR TITLE
Bugfix(ClassificationStore): KeyConfig

### DIFF
--- a/models/DataObject/Classificationstore/KeyConfig.php
+++ b/models/DataObject/Classificationstore/KeyConfig.php
@@ -415,8 +415,12 @@ final class KeyConfig extends Model\AbstractModel
     private function removeCache(): void
     {
         // Remove runtime cache
-        RuntimeCache::getInstance()->offsetUnset(self::getCacheKey($this->getId()));
-        RuntimeCache::getInstance()->offsetUnset(self::getCacheKey($this->getStoreId(), $this->getName()));
+        if (RuntimeCache::getInstance()->offsetExists(self::getCacheKey($this->getId()))) {
+            RuntimeCache::getInstance()->offsetUnset(self::getCacheKey($this->getId()));
+        }
+        if (RuntimeCache::getInstance()->offsetExists(self::getCacheKey($this->getStoreId(), $this->getName()))) {
+            RuntimeCache::getInstance()->offsetUnset(self::getCacheKey($this->getStoreId(), $this->getName()));
+        }
 
         // Remove persisted cache
         Cache::remove(self::getCacheKey($this->getId()));


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
 ## Changes in this pull request  
This PR fixes an error that occurs when creating or adding a KeyConfig because the cache is cleared on save without "testing" if the cache key exists.

## Reproduction
```php
// get a KeyConfig by name
$keyConfig = Classificationstore\KeyConfig::getByName($name, $storeId);
// make changes and save
$keyConfig->save();
// exception will be thrown
```

## Additional info  
None.
