### PR TITLE
[Reverse relation] Support configuration of visible fields

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -28,7 +28,6 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
 {
     /**
      * @internal
-     *
      */
     public ?string $ownerClassName = null;
 
@@ -73,7 +72,9 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
                     return null;
                 }
                 $class = DataObject\ClassDefinition::getById($this->ownerClassId);
-                $this->ownerClassName = $class->getName();
+                if($class instanceof DataObject\ClassDefinition) {
+                    $this->ownerClassName = $class->getName();
+                }
             } catch (\Exception $e) {
                 Logger::error($e->getMessage());
             }
@@ -178,11 +179,6 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
         return [];
     }
 
-    public function isOptimizedAdminLoading(): bool
-    {
-        return true;
-    }
-
     public function preGetData(mixed $container, array $params = []): array
     {
         return $this->load($container);
@@ -199,5 +195,15 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
     public function getFieldType(): string
     {
         return 'reverseObjectRelation';
+    }
+    /**
+     * @inheritdoc
+     */
+    public function getClasses(): array
+    {
+        if($this->ownerClassId) {
+            return Model\Element\Service::fixAllowedTypes([$this->ownerClassId], 'classes');
+        }
+        return [];
     }
 }

--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -202,7 +202,7 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
     public function getClasses(): array
     {
         if($this->ownerClassId) {
-            return Model\Element\Service::fixAllowedTypes([$this->ownerClassId], 'classes');
+            return Model\Element\Service::fixAllowedTypes([$this->ownerClassName], 'classes');
         }
         return [];
     }


### PR DESCRIPTION
For (advanced) many-to-many object relations you can configure the fields to be shown for the relation field grid in the editing panel.
This PR adds the same for reverse relations:

<img width="433" alt="Снимок экрана 2022-11-14 в 16 00 57" src="https://user-images.githubusercontent.com/8749138/201679533-b542065b-772c-410d-a082-323abf789407.png">
<img width="1319" alt="Снимок экрана 2022-11-15 в 15 06 37" src="https://user-images.githubusercontent.com/8749138/201927075-ba0e53a2-e7ee-4f43-86fe-6fa1a77c35a9.png">

