### PR TITLE
[Task]: WebMozarts v2 - fetchItems() missing `$output` parameter

### DIFF
--- a/lib/Console/Traits/ParallelizationBase.php
+++ b/lib/Console/Traits/ParallelizationBase.php
@@ -37,7 +37,7 @@ if (trait_exists('\Webmozarts\Console\Parallelization\Parallelization')) {
         {
             $this->runBeforeFirstCommand($input, $output);
 
-            $items = $this->fetchItems($input);
+            $items = $this->fetchItems($input, $output);
 
             //Method executed before executing all the items
             if (method_exists($this, 'runBeforeBatch')) {


### PR DESCRIPTION
Encountered this problem in 11.x when trying to `php bin/console ecommerce:indexservice:process-update-queue`

follow-up of changes of https://github.com/pimcore/pimcore/pull/13480, https://github.com/pimcore/pimcore/pull/13216
