### PR TITLE
[Task]: Fix references to `indexservice:process-queue update-index` in doc/comments

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -948,7 +948,7 @@ abstract class AbstractElasticSearch extends Worker\ProductCentricBatchProcessin
      * - data is copied from old index to new index
      *
      * While in reindex
-     * - all index updates are stored into store table only, and transferred with next ecommerce:indexservice:process-queue update-index
+     * - all index updates are stored into store table only, and transferred with next ecommerce:indexservice:process-update-queue
      * - no index structure updates are allowed
      *
      * @throws BadRequest400Exception

--- a/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/09_Findologic.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/05_Index_Service/01_Product_Index_Configuration/09_Findologic.md
@@ -2,7 +2,7 @@
 Basically findologic worker works as described in the [optimized architecture](README.md). But there is an additional 
 speciality with the export: 
 
-Executing `php bin/console ecommerce:indexservice:process-queue update-index` does not write the data directly to 
+Executing `php bin/console ecommerce:indexservice:process-update-queue` does not write the data directly to 
 Findologic, but into an extra table 
 `\Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Worker\DefaultFindologic::EXPORT_TABLE_NAME` 
 (default is `ecommerceframework_productindex_export_findologic`). 


### PR DESCRIPTION
Cleanup of some leftover, since after https://github.com/pimcore/pimcore/pull/6487 the command are changed
https://github.com/pimcore/pimcore/blob/49b11d16c8486971ba6708e717122729e0e33799/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md?plain=1#L609-L610