### PR TITLE
[Search] Search within a word

### DIFF
--- a/bundles/AdminBundle/src/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/src/Controller/Searchadmin/SearchController.php
@@ -421,22 +421,22 @@ class SearchController extends AdminController
      */
     protected function filterQueryParam(string $query)
     {
-        if ($query == '*') {
+        if ($query === '*') {
             $query = '';
         }
 
-        $query = str_replace('&quot;', '"', $query);
-        $query = str_replace('%', '*', $query);
-        $query = str_replace('@', '#', $query);
+        $query = str_replace(['&quot;', '%', '@'], ['"', '*', '#'], $query);
         $query = preg_replace("@([^ ])\-@", '$1 ', $query);
 
         $query = str_replace(['<', '>', '(', ')', '~'], ' ', $query);
 
         // it is not allowed to have * behind another *
-        $query = preg_replace('#[*]+#', '*', $query);
+        $query = preg_replace('#\*+#', '*', $query);
 
         // no boolean operators at the end of the query
         $query = rtrim($query, '+- ');
+
+        $query = preg_replace('/([\p{L}\p{Nd}_]+)([\s\)]|$)/u', '$1*$2', $query);
 
         return $query;
     }

--- a/bundles/AdminBundle/src/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/src/Controller/Searchadmin/SearchController.php
@@ -430,6 +430,7 @@ class SearchController extends AdminController
 
         $query = str_replace(['<', '>', '(', ')', '~'], ' ', $query);
 
+        // expand search terms with * to get prefix search. Terms within quotes do not get expanded to allow for exact searches
         $query = preg_replace('/(?!\B"[^"]*)([\p{L}\p{Nd}_]+)(?![^"]*"\B)/u', '$1*', $query);
 
         // it is not allowed to have * behind another *

--- a/bundles/AdminBundle/src/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/src/Controller/Searchadmin/SearchController.php
@@ -430,22 +430,13 @@ class SearchController extends AdminController
 
         $query = str_replace(['<', '>', '(', ')', '~'], ' ', $query);
 
+        $query = preg_replace('/(?!\B"[^"]*)([\p{L}\p{Nd}_]+)(?![^"]*"\B)/u', '$1*', $query);
+
         // it is not allowed to have * behind another *
         $query = preg_replace('#\*+#', '*', $query);
 
         // no boolean operators at the end of the query
         $query = rtrim($query, '+- ');
-
-        $terms = str_getcsv($query, ' ');
-        $fulltextSearchTerms = array_map(static function ($term) {
-            if(str_contains($term, ' ')) {
-                // term was wrapped in quotes -> do not change
-                return '"'.$term.'"';
-            }
-
-            return preg_replace('/([\p{L}\p{Nd}_]+)([\s\)]|$)/u', '$1*$2', $term);
-        }, $terms);
-        $query = implode(' ', $fulltextSearchTerms);
 
         return $query;
     }

--- a/bundles/AdminBundle/src/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/src/Controller/Searchadmin/SearchController.php
@@ -436,7 +436,16 @@ class SearchController extends AdminController
         // no boolean operators at the end of the query
         $query = rtrim($query, '+- ');
 
-        $query = preg_replace('/([\p{L}\p{Nd}_]+)([\s\)]|$)/u', '$1*$2', $query);
+        $terms = str_getcsv($query, ' ');
+        $fulltextSearchTerms = array_map(static function ($term) {
+            if(str_contains($term, ' ')) {
+                // term was wrapped in quotes -> do not change
+                return '"'.$term.'"';
+            }
+
+            return preg_replace('/([\p{L}\p{Nd}_]+)([\s\)]|$)/u', '$1*$2', $term);
+        }, $terms);
+        $query = implode(' ', $fulltextSearchTerms);
 
         return $query;
     }


### PR DESCRIPTION
The backend search uses MySQL's fulltext search in boolean mode. By default the search is done exactly as requested - assuming the user knows the technical details about [available search operators](https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html). Often this is not the case as users are domain experts but not necessarily IT experts.

This leads to the problem that when somebody has a product "Ring with 5 diamonds" and searches for "diamond", he will not find it because MySQL does an exact search on a word basis and the word "diamond" does not appear on the product (assuming it neither does appear on any other data object field of this object).

With this PR the search will automatically append `*` to search terms and thus above object will get found. To execute an exact search, you can use a quoted string like `"diamond"` to only find objects which contain the word `diamond` but not `diamonds`. This behaviour is more convenient to users and it works like on most other applications like Google (where partial matching is default and only if quotes get used, the exact search term gets used).

PS: There is no problem with performance as prefix searches are covered with the index in the same way as exact searches.