### PR TITLE
[Task]: Quoting `email_log` columns identifiers

### DIFF
--- a/models/Tool/Email/Log/Dao.php
+++ b/models/Tool/Email/Log/Dao.php
@@ -78,7 +78,8 @@ class Dao extends Model\Dao\AbstractDao
                     $preparedData = self::createJsonLoggingObject($value);
                     $value = json_encode($preparedData);
                 }
-
+                
+                $key = $this->db->quoteIdentifier($key);
                 $data[$key] = $value;
             }
         }


### PR DESCRIPTION
Partially resolves https://github.com/pimcore/pimcore/issues/13392

Not using `Helper::quoteDataIdentifiers`, otherwise it would loop twice