### PR TITLE
Removed HTML encoding of the notification content.

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/notification/helper.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/notification/helper.js
@@ -77,7 +77,7 @@ pimcore.notification.helper.showNotifications = function (notifications) {
         var notification = Ext.create('Ext.window.Toast', {
             iconCls: 'pimcore_icon_' + row.type,
             title: Ext.util.Format.htmlEncode(row.title),
-            html: Ext.util.Format.htmlEncode(row.message),
+            html: row.message,
             autoShow: true,
             width: 400,
             height: 150,
@@ -137,7 +137,7 @@ pimcore.notification.helper.openDetailsWindow = function (id, title, message, ty
         modal: true,
         iconCls: 'pimcore_icon_' + type,
         title: Ext.util.Format.htmlEncode(title),
-        html: Ext.util.Format.htmlEncode(message),
+        html: message,
         autoShow: true,
         width: 700,
         height: 350,


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
HTML encoding of the notification content was removed.

## Additional info  
`Ext.util.Format.htmlEncode()` blocks using the HTML markup in the notification content: e.g. there is no way to put the link.
