### PR TITLE
Remove `cart_readonly_mode` from the docs

### DIFF
--- a/doc/Development_Documentation/10_E-Commerce_Framework/11_Cart_Manager.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/11_Cart_Manager.md
@@ -106,7 +106,6 @@ pimcore_ecommerce_framework:
                     factory_options:
                         cart_class_name: Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart
                         guest_cart_class_name: Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\SessionCart
-                        cart_readonly_mode: deactivated            
         
             default:   
                 price_calculator:
@@ -131,9 +130,6 @@ Following elements are configured:
   adding/removing products and also creates the corresponding price calculator. 
 * **Cart factory service ID**: builds carts when needed and can be configured with cart class name and further options varying
   by factory implementation
-  * Factory option `cart_readonly_mode`, possible values are:
-     * `deactivated`: Cart is never read only (will be default value with Pimcore 10), details see also [Payment Integration](./13_Checkout_Manager/07_Integrating_Payment.md).
-     * `strict` (default value, deprecated, will be removed in Pimcore 10): Cart is read only as soon as payment is pending.  
 * **Price calculator factory service ID + options and modificators**: The price calculator is a framework for calculation
   and modification (shipping costs, discounts, ...) of prices on cart level. Each modification is implemented in a 
   [`CartPriceModificatorInterface` class](https://github.com/pimcore/pimcore/blob/10.x/bundles/EcommerceFrameworkBundle/CartManager/CartPriceModificator/CartPriceModificatorInterface.php). 


### PR DESCRIPTION
The `cart_readonly_mode` option has been removed in Pimcore 10.0, but was still mentioned in the docs.