### PR TITLE
Fix PhpDoc of `CommitOrderProcessorEvents::SEND_CONFIRMATION_MAILS`

### DIFF
--- a/lib/Event/Ecommerce/CommitOrderProcessorEvents.php
+++ b/lib/Event/Ecommerce/CommitOrderProcessorEvents.php
@@ -46,7 +46,7 @@ final class CommitOrderProcessorEvents
     const POST_COMMIT_ORDER = 'pimcore.ecommerce.commitorderprocessor.postCommitOrder';
 
     /**
-     * @Event("Pimcore\Event\Model\Ecommerce\CommitOrderProcessorEvent")
+     * @Event("Pimcore\Event\Model\Ecommerce\SendConfirmationMailEvent")
      *
      * @var string
      */


### PR DESCRIPTION
It doesn't dispatch a `CommitOrderProcessorEvent` but a `SendConfirmationMailEvent` event, see:

https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/src/CheckoutManager/V7/CommitOrderProcessor.php#L331-L332