### PR TITLE
[BUG] Object Grid: Filter for Multiselect field with OptionProvider

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multiselect.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multiselect.js
@@ -81,13 +81,6 @@ pimcore.object.tags.multiselect = Class.create(pimcore.object.tags.abstract, {
     },
 
     getGridColumnFilter: function(field) {
-        if (field.layout.dynamicOptions) {
-            return {
-                type: 'string',
-                dataIndex: field.key
-            };
-        }
-
         var storeData = this.prepareStoreDataAndFilterLabels(field.layout);
 
         var store = Ext.create('Ext.data.JsonStore', {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multiselect.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/multiselect.js
@@ -81,6 +81,13 @@ pimcore.object.tags.multiselect = Class.create(pimcore.object.tags.abstract, {
     },
 
     getGridColumnFilter: function(field) {
+        if (field.layout.dynamicOptions) {
+            return {
+                type: 'string',
+                dataIndex: field.key
+            };
+        }
+
         var storeData = this.prepareStoreDataAndFilterLabels(field.layout);
 
         var store = Ext.create('Ext.data.JsonStore', {

--- a/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -450,7 +450,7 @@ class Multiselect extends Data implements
      */
     public function getFilterConditionExt($value, $operator, $params = [])
     {
-        if ($operator === '=') {
+        if ($operator === '=' || $operator === 'LIKE') {
             $name = $params['name'] ? $params['name'] : $this->name;
 
             $db = \Pimcore\Db::get();
@@ -467,7 +467,9 @@ class Multiselect extends Data implements
                 return $key . ' LIKE ' . implode(' OR ' . $key . ' LIKE ', $values);
             }
 
-            $value = "'%,".$value.",%'";
+            $value = $operator === '='
+                ? "'%,".$value.",%'"
+                : "'%,%".$value."%,%'";
 
             return $key.' LIKE '.$value.' ';
         }


### PR DESCRIPTION
Object Grid: Filter for MultiSelect field with OptionProvider (dynamicOptions = true) is not working.

Result: SQL Query Error 

![Object_Grid_Error_MultiSelect_With_Provider](https://user-images.githubusercontent.com/16591421/202241815-8a6c84a2-1fb3-46fc-b83f-e91c1d99f055.png)

@kjkooistra-youwe: If I remove this code block of your PR https://github.com/pimcore/pimcore/pull/12069 then it will work (for MultiSelect field with OptionProvider) but which influence does it have on your implementation?
  
