### PR TITLE
Add XLIFF Events

### DIFF
--- a/lib/Event/Model/TranslationXliffEvent.php
+++ b/lib/Event/Model/TranslationXliffEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Event\Model;
+
+use Pimcore\Translation\AttributeSet\AttributeSet;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class TranslationXliffEvent extends Event
+{
+    protected AttributeSet $attributeSet;
+
+    public function __construct(AttributeSet $attributeSet)
+    {
+        $this->attributeSet = $attributeSet;
+    }
+
+    public function getAttributeSet(): AttributeSet
+    {
+        return $this->attributeSet;
+    }
+}

--- a/lib/Event/TranslationEvents.php
+++ b/lib/Event/TranslationEvents.php
@@ -45,4 +45,18 @@ final class TranslationEvents
      * @var string
      */
     const POST_DELETE = 'pimcore.translation.postDelete';
+
+    /**
+     * @Event("Pimcore\Event\Model\TranslationXliffEvent")
+     *
+     * @var string
+     */
+    const XLIFF_ATTRIBUTE_SET_EXPORT = 'pimcore.translation.xliff.attribute_set_export';
+
+    /**
+     * @Event("Pimcore\Event\Model\TranslationXliffEvent")
+     *
+     * @var string
+     */
+    const XLIFF_ATTRIBUTE_SET_IMPORT = 'pimcore.translation.xliff.attribute_set_import';
 }

--- a/lib/Translation/ExportService/Exporter/Xliff12Exporter.php
+++ b/lib/Translation/ExportService/Exporter/Xliff12Exporter.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace Pimcore\Translation\ExportService\Exporter;
 
+use Pimcore\Event\Model\TranslationXliffEvent;
+use Pimcore\Event\TranslationEvents;
 use Pimcore\File;
 use Pimcore\Translation\AttributeSet\AttributeSet;
 use Pimcore\Translation\Escaper\Xliff12Escaper;
@@ -39,8 +41,12 @@ class Xliff12Exporter implements ExporterInterface
     public function export(AttributeSet $attributeSet, string $exportId = null): string
     {
         $exportId = $exportId ?: uniqid();
-
         $exportFile = $this->getExportFilePath($exportId);
+
+        $event = new TranslationXliffEvent($attributeSet);
+        \Pimcore::getEventDispatcher()->dispatch($event, TranslationEvents::XLIFF_ATTRIBUTE_SET_EXPORT);
+
+        $attributeSet = $event->getAttributeSet();
 
         if ($attributeSet->isEmpty()) {
             return $exportFile;

--- a/lib/Translation/ImporterService/Importer/AbstractElementImporter.php
+++ b/lib/Translation/ImporterService/Importer/AbstractElementImporter.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace Pimcore\Translation\ImporterService\Importer;
 
+use Pimcore\Event\Model\TranslationXliffEvent;
+use Pimcore\Event\TranslationEvents;
 use Pimcore\Model\Element;
 use Pimcore\Translation\AttributeSet\Attribute;
 use Pimcore\Translation\AttributeSet\AttributeSet;
@@ -29,6 +31,11 @@ class AbstractElementImporter implements ImporterInterface
     {
         $translationItem = $attributeSet->getTranslationItem();
         $element = $translationItem->getElement();
+
+        $event = new TranslationXliffEvent($attributeSet);
+        \Pimcore::getEventDispatcher()->dispatch($event, TranslationEvents::XLIFF_ATTRIBUTE_SET_IMPORT);
+
+        $attributeSet = $event->getAttributeSet();
 
         if (!$element instanceof Element\ElementInterface || $attributeSet->isEmpty()) {
             return;


### PR DESCRIPTION
This PR allows you to modify the `AttributeSet` in XLIFF Export/Import.

This allows third party bundles to include custom values in the translation process.

Usage Example:

```php
<?php

namespace App\EventListener;

use Pimcore\Event\Model\TranslationXliffEvent;
use Pimcore\Event\TranslationEvents;
use Pimcore\Model\Document;
use Symfony\Component\EventDispatcher\EventSubscriberInterface;

class XliffListener implements EventSubscriberInterface
{
    protected const MY_XLIFF_TYPE = 'my_custom_xliff_type';

    public static function getSubscribedEvents(): array
    {
        return [
            TranslationEvents::XLIFF_ATTRIBUTE_SET_EXPORT => 'export',
            TranslationEvents::XLIFF_ATTRIBUTE_SET_IMPORT => 'import',
        ];
    }

    public function export(TranslationXliffEvent $event): void
    {
        $item = $event->getAttributeSet()->getTranslationItem()->getElement();

        if ($item instanceof Document) {
            $event->getAttributeSet()->addAttribute(self::MY_XLIFF_TYPE, 'item_name', 'item_content', false, []);
        }
    }

    public function import(TranslationXliffEvent $event): void
    {
        $item = $event->getAttributeSet()->getTranslationItem()->getElement();

        foreach ($event->getAttributeSet()->getAttributes() as $attribute) {
            if ($attribute->getType() === self::MY_XLIFF_TYPE) {
                // map attribute to $item
            }
        }
    }
}
```