### PR TITLE
[Object bricks] Sort brick names in generated code for container class

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20221129084031.php
+++ b/bundles/CoreBundle/Migrations/Version20221129084031.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Model\DataObject\Objectbrick\Definition\Listing;
+
+final class Version20221129084031 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Updates object brick definition files';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->regenerateObjectBricks();
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->regenerateObjectBricks();
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private function regenerateObjectBricks()
+    {
+        $list = new Listing();
+        foreach ($list->load() as $brickDefinition) {
+            $this->write(sprintf('Saving object brick: %s', $brickDefinition->getKey()));
+            $brickDefinition->save();
+        }
+    }
+}

--- a/lib/DataObject/ClassBuilder/ObjectBrickContainerClassBuilder.php
+++ b/lib/DataObject/ClassBuilder/ObjectBrickContainerClassBuilder.php
@@ -25,7 +25,7 @@ class ObjectBrickContainerClassBuilder implements ObjectBrickContainerClassBuild
         $className = $definition->getContainerClassName($classDefinition->getName(), $fieldName);
         $namespace = $definition->getContainerNamespace($classDefinition->getName(), $fieldName);
 
-        sort($brickKeys);
+        natcasesort($brickKeys);
 
         $cd = '<?php';
 

--- a/lib/DataObject/ClassBuilder/ObjectBrickContainerClassBuilder.php
+++ b/lib/DataObject/ClassBuilder/ObjectBrickContainerClassBuilder.php
@@ -25,6 +25,8 @@ class ObjectBrickContainerClassBuilder implements ObjectBrickContainerClassBuild
         $className = $definition->getContainerClassName($classDefinition->getName(), $fieldName);
         $namespace = $definition->getContainerNamespace($classDefinition->getName(), $fieldName);
 
+        sort($brickKeys);
+
         $cd = '<?php';
 
         $cd .= "\n\n";


### PR DESCRIPTION
Steps to reproduce:

1. Create data object class `Test` with object brick container field `bricks`
2. Create object brick `Abc`, allow it for object brick container field from 1.
3. Create object brick `Def`, allow it for object brick container field from 1.
4. Check `var/classes/DataObject/Test/Bricks.php` it will contain `protected $brickGetters = ['Def','Abc'];`
5. Save object brick `Abc` again (without changing any settings)

Check `var/classes/DataObject/Test/Bricks.php` again, now it will contain `protected $brickGetters = ['Abc', 'Def'];`

Always the last saved object brick will get listed first. This is caused by https://github.com/pimcore/pimcore/blob/a5ab3e591c4dfb71d1b007b8f6a5ba12f088cece/lib/DataObject/ClassBuilder/PHPObjectBrickContainerClassDumper.php#L31-L46
As `$containerDefinition[$cl['classname']]` is an associative array, the order of the added items is as they have been added. For the currently saved object brick the data is added in
https://github.com/pimcore/pimcore/blob/a5ab3e591c4dfb71d1b007b8f6a5ba12f088cece/lib/DataObject/ClassBuilder/PHPObjectBrickContainerClassDumper.php#L31-L33
While for all other existing bricks the data is added in https://github.com/pimcore/pimcore/blob/a5ab3e591c4dfb71d1b007b8f6a5ba12f088cece/lib/DataObject/ClassBuilder/PHPObjectBrickContainerClassDumper.php#L38-L45

This may or may not be a problem depending on deployment strategy. When you have those Brick container classes in Git, they get changed and may prevent the deployment from running (if there is a check for changed files on the server).

The same problem exists for the `pimcore:deployment:classes-rebuild` command. As this calls brick code generation in a loop in https://github.com/pimcore/pimcore/blob/a5ab3e591c4dfb71d1b007b8f6a5ba12f088cece/bundles/CoreBundle/src/Command/ClassesDefinitionsBuildCommand.php#L66-L71
At the end the the alphabetically last one will get listed first in the `$brickGetters` attribute in the object brick container class.

This PR changes this behaviour so that the bricks get sorted by name when the PHP code gets generated. So in above example it will always be `protected $brickGetters = ['Abc', 'Def'];` - regardless which brick got saved last.