### PR TITLE
[Pimcore admin] Prevent error if saved object does not exist anymore

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1276,6 +1276,10 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     {
         $objectFromDatabase = DataObject\Concrete::getById((int) $request->get('id'));
 
+        if(!$objectFromDatabase instanceof DataObject\Concrete) {
+            return $this->adminJson(['success' => false, 'message' => 'Could not find object']);
+        }
+
         // set the latest available version for editmode
         $object = $this->getLatestVersion($objectFromDatabase);
         $object->setUserModification($this->getAdminUser()->getId());


### PR DESCRIPTION
Actually I do not know how to reproduce the error but we saw some entries like this in the logs:
> request.CRITICAL: Uncaught PHP Exception TypeError: "Pimcore\Bundle\AdminBundle\Controller\Admin\DataObject\DataObjectController::getLatestVersion(): Argument pimcore/pimcore#1 ($object) must be of type Pimcore\Model\DataObject\Concrete, null given, called in /var/www/html/vendor/pimcore/pimcore/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php on line 1280" at /var/www/html/vendor/pimcore/pimcore/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php line 2090

This PR prevents this error.