### PR TITLE
[Data objects] Version preview for blocks

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -479,7 +479,7 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
      */
     public function getVersionPreview(mixed $data, DataObject\Concrete $object = null, array $params = []): string
     {
-        return 'not supported';
+        return $this->getDiffVersionPreview($data, $object, $params)['html'];
     }
 
     /**
@@ -505,15 +505,43 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
      * @param DataObject\Concrete|null $object
      * @param array $params
      *
-     * @return string
+     * @return array
      */
-    public function getDiffVersionPreview(?array $data, Concrete $object = null, array $params = []): string
+    public function getDiffVersionPreview(?array $data, Concrete $object = null, array $params = []): array
     {
-        if ($data) {
-            return 'not supported';
+        $html = '';
+        if (is_array($data)) {
+            $html = '<table>';
+
+            foreach ($data as $index => $item) {
+                if (!is_array($item)) {
+                    continue;
+                }
+
+                $html .= '<tr><th><b>'.$index.'</b></th><th>&nbsp;</th><th>&nbsp;</th></tr>';
+
+                foreach($this->getFieldDefinitions() as $fieldDefinition) {
+                    $title = !empty($fieldDefinition->title) ? $fieldDefinition->title : $fieldDefinition->getName();
+                    $html .= '<tr><td>&nbsp;</td><td>'.$title.'</td><td>';
+
+                    $blockElement = $item[$fieldDefinition->getName()];
+                    if($blockElement instanceof DataObject\Data\BlockElement) {
+                        $html .= $fieldDefinition->getVersionPreview($blockElement->getData(), $object, $params);
+                    } else {
+                        $html .= 'invalid data';
+                    }
+                    $html .= '</td></tr>';
+                }
+            }
+
+            $html .= '</table>';
         }
 
-        return '';
+        $value = [];
+        $value['html'] = $html;
+        $value['type'] = 'html';
+
+        return $value;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -242,7 +242,7 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
      */
     public function getVersionPreview(mixed $data, DataObject\Concrete $object = null, array $params = []): string
     {
-        return 'FIELDCOLLECTIONS';
+        return $this->getDiffVersionPreview($data, $object, $params)['html'];
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -242,7 +242,7 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
      */
     public function getVersionPreview(mixed $data, DataObject\Concrete $object = null, array $params = []): string
     {
-        return $this->getDiffVersionPreview($data, $object, $params)['html'];
+        return 'FIELDCOLLECTIONS';
     }
 
     /**


### PR DESCRIPTION
Currently blocks do not have a version preview. It just looks like this:
<img width="754" alt="Bildschirmfoto 2022-11-22 um 11 25 48" src="https://user-images.githubusercontent.com/8749138/203290336-7ebb1983-eb4f-45d9-9f18-08a373bfe24d.png">

This PR adds this feature, version preview looks like this:

Block:
<img width="1176" alt="Bildschirmfoto 2022-11-22 um 10 30 02" src="https://user-images.githubusercontent.com/8749138/203288826-2ad67043-8886-4253-8dbc-6cb710d37812.png">

It is actually based on https://github.com/pimcore/pimcore/blob/8d831bac31c3a6d97e7c563c4322ae87841a8698/models/DataObject/ClassDefinition/Data/Fieldcollections.php#L552-L583

In fact `Fieldcollections::getDiffVersionPreview()` is not used for version comparison in Pimcore backend but to provide a uniform interface to get the version preview, I have applied this to `Block::getVersionPreview()`, `Block::getDiffVersionPreview()` and `Fieldcollections::getVersionPreview()`.

An alternative would be to put all version display logic from https://github.com/pimcore/pimcore/blob/11.x/bundles/AdminBundle/templates/admin/data_object/data_object/preview_version.html.twig into the corresponding `getVersionPreview()` methods? But this is for another PR...