### PR TITLE
[Task] Follow up native params and return type hints

### DIFF
--- a/bundles/AdminBundle/src/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/Asset/AssetController.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Pimcore

--- a/bundles/AdminBundle/src/Controller/Admin/Asset/AssetHelperController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/Asset/AssetHelperController.php
@@ -233,7 +233,7 @@ class AssetHelperController extends AdminController
 
         if (empty($gridConfig)) {
             $availableFields = $this->getDefaultGridFields(
-                $request->get('no_system_columns'),
+                $request->get('no_system_columns', false),
                 [], //maybe required for types other than metadata
                 $context,
                 $types);

--- a/bundles/AdminBundle/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/DataObject/DataObjectController.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Pimcore

--- a/bundles/AdminBundle/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -370,10 +370,10 @@ class DataObjectHelperController extends AdminController
 
         if (empty($gridConfig)) {
             $availableFields = $this->getDefaultGridFields(
-                $request->get('no_system_columns'),
+                $request->get('no_system_columns', false),
                 $class,
                 $gridType,
-                $request->get('no_brick_columns'),
+                $request->get('no_brick_columns', false),
                 $fields,
                 $context,
                 $objectId,

--- a/bundles/AdminBundle/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -410,7 +410,7 @@ class DataObjectHelperController extends AdminController
                                     $keyFieldDef = json_decode($keyDef->getDefinition(), true);
                                     if ($keyFieldDef) {
                                         $keyFieldDef = \Pimcore\Model\DataObject\Classificationstore\Service::getFieldDefinitionFromJson($keyFieldDef, $keyDef->getType());
-                                        $fieldConfig = $this->getFieldGridConfig($keyFieldDef, $gridType, $sc['position'], true, null, $class, $objectId);
+                                        $fieldConfig = $this->getFieldGridConfig($keyFieldDef, $gridType, (string)$sc['position'], true, null, $class, $objectId);
                                         if ($fieldConfig) {
                                             $fieldConfig['key'] = $key;
                                             $fieldConfig['label'] = '#' . $keyFieldDef->getTitle();
@@ -452,7 +452,7 @@ class DataObjectHelperController extends AdminController
                             }
 
                             if ($fd !== null) {
-                                $fieldConfig = $this->getFieldGridConfig($fd, $gridType, $sc['position'], true, $keyPrefix, $class, $objectId);
+                                $fieldConfig = $this->getFieldGridConfig($fd, $gridType, (string)$sc['position'], true, $keyPrefix, $class, $objectId);
                                 if (!empty($fieldConfig)) {
                                     if (isset($sc['width'])) {
                                         $fieldConfig['width'] = $sc['width'];
@@ -482,7 +482,7 @@ class DataObjectHelperController extends AdminController
                                 }
 
                                 if (!empty($fd)) {
-                                    $fieldConfig = $this->getFieldGridConfig($fd, $gridType, $sc['position'], true, null, $class, $objectId);
+                                    $fieldConfig = $this->getFieldGridConfig($fd, $gridType, (string)$sc['position'], true, null, $class, $objectId);
                                     if (!empty($fieldConfig)) {
                                         if (isset($sc['width'])) {
                                             $fieldConfig['width'] = $sc['width'];

--- a/bundles/AdminBundle/src/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/Document/DocumentController.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Pimcore

--- a/bundles/AdminBundle/src/Controller/Admin/Document/DocumentControllerBase.php
+++ b/bundles/AdminBundle/src/Controller/Admin/Document/DocumentControllerBase.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Pimcore

--- a/bundles/AdminBundle/src/Controller/Admin/ElementController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/ElementController.php
@@ -62,7 +62,7 @@ class ElementController extends AdminController
      */
     public function unlockElementAction(Request $request): Response
     {
-        Element\Editlock::unlock($request->get('id'), $request->get('type'));
+        Element\Editlock::unlock((int)$request->get('id'), $request->get('type'));
 
         return $this->adminJson(['success' => true]);
     }

--- a/bundles/AdminBundle/src/EventListener/UsageStatisticsListener.php
+++ b/bundles/AdminBundle/src/EventListener/UsageStatisticsListener.php
@@ -104,7 +104,7 @@ class UsageStatisticsListener implements EventSubscriberInterface
                 $value = json_decode($value);
                 if (is_array($value)) {
                     array_walk_recursive($value, function (&$item, $key) {
-                        if (strpos($key, 'pass') !== false) {
+                        if (strpos((string)$key, 'pass') !== false) {
                             $item = '*************';
                         }
                     });

--- a/bundles/AdminBundle/src/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/src/Helper/GridHelperService.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Pimcore
  *

--- a/bundles/AdminBundle/src/Security/Authenticator/AdminLoginAuthenticator.php
+++ b/bundles/AdminBundle/src/Security/Authenticator/AdminLoginAuthenticator.php
@@ -58,7 +58,7 @@ class AdminLoginAuthenticator extends AdminAbstractAuthenticator implements Auth
             return $response;
         }
 
-        $event = new LoginRedirectEvent(self::PIMCORE_ADMIN_LOGIN, ['perspective' => strip_tags($request->get('perspective'))]);
+        $event = new LoginRedirectEvent(self::PIMCORE_ADMIN_LOGIN, ['perspective' => strip_tags($request->get('perspective', '') )]);
         $this->dispatcher->dispatch($event, AdminEvents::LOGIN_REDIRECT);
 
         $url = $this->router->generate($event->getRouteName(), $event->getRouteParams());

--- a/bundles/CoreBundle/src/EventListener/Frontend/ElementListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/ElementListener.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Pimcore

--- a/bundles/EcommerceFrameworkBundle/src/CoreExtensions/ObjectData/IndexFieldSelection.php
+++ b/bundles/EcommerceFrameworkBundle/src/CoreExtensions/ObjectData/IndexFieldSelection.php
@@ -18,21 +18,21 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\CoreExtensions\ObjectData;
 
 class IndexFieldSelection
 {
-    public string $tenant;
+    public ?string $tenant = null;
 
     public string $field;
 
     /**
-     * @var string|string[]
+     * @var string|string[]|null
      */
-    public string|array $preSelect;
+    public string|array|null $preSelect;
 
     /**
-     * @param string $tenant
+     * @param string|null $tenant
      * @param string $field
      * @param string|string[] $preSelect
      */
-    public function __construct(string $tenant, string $field, array|string $preSelect)
+    public function __construct(?string $tenant, string $field, array|string|null $preSelect)
     {
         $this->field = $field;
         $this->preSelect = $preSelect;
@@ -58,9 +58,9 @@ class IndexFieldSelection
     }
 
     /**
-     * @return string|string[]
+     * @return string|string[]|null
      */
-    public function getPreSelect(): array|string
+    public function getPreSelect(): array|string|null
     {
         return $this->preSelect;
     }
@@ -70,7 +70,7 @@ class IndexFieldSelection
         $this->tenant = $tenant;
     }
 
-    public function getTenant(): string
+    public function getTenant(): ?string
     {
         return $this->tenant;
     }

--- a/bundles/EcommerceFrameworkBundle/src/Environment.php
+++ b/bundles/EcommerceFrameworkBundle/src/Environment.php
@@ -150,7 +150,7 @@ class Environment implements EnvironmentInterface
         $this->currentAssortmentSubTenant = null;
         $this->currentCheckoutTenant = null;
         $this->currentTransientCheckoutTenant = null;
-        $this->useGuestCart = false;
+        $this->useGuestCart = null;
     }
 
     public function setDefaultCurrency(Currency $currency)

--- a/bundles/EcommerceFrameworkBundle/src/Model/Currency.php
+++ b/bundles/EcommerceFrameworkBundle/src/Model/Currency.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Pimcore

--- a/bundles/EcommerceFrameworkBundle/src/PriceSystem/Price.php
+++ b/bundles/EcommerceFrameworkBundle/src/PriceSystem/Price.php
@@ -30,7 +30,7 @@ class Price implements PriceInterface
 
     private Decimal $netAmount;
 
-    private string $taxEntryCombinationMode = TaxEntry::CALCULATION_MODE_COMBINE;
+    private ?string $taxEntryCombinationMode = TaxEntry::CALCULATION_MODE_COMBINE;
 
     private bool $minPrice;
 
@@ -122,7 +122,7 @@ class Price implements PriceInterface
     /**
      * {@inheritdoc}
      */
-    public function getTaxEntryCombinationMode(): string
+    public function getTaxEntryCombinationMode(): ?string
     {
         return $this->taxEntryCombinationMode;
     }
@@ -162,7 +162,7 @@ class Price implements PriceInterface
     /**
      * {@inheritdoc}
      */
-    public function setTaxEntryCombinationMode(string $taxEntryCombinationMode): void
+    public function setTaxEntryCombinationMode(?string $taxEntryCombinationMode = null): void
     {
         $this->taxEntryCombinationMode = $taxEntryCombinationMode;
     }

--- a/bundles/EcommerceFrameworkBundle/src/PriceSystem/PriceInterface.php
+++ b/bundles/EcommerceFrameworkBundle/src/PriceSystem/PriceInterface.php
@@ -75,9 +75,9 @@ interface PriceInterface
     /**
      * Returns tax entry combination mode needed for tax calculation
      *
-     * @return string
+     * @return string|null
      */
-    public function getTaxEntryCombinationMode(): string;
+    public function getTaxEntryCombinationMode(): ?string;
 
     /**
      * Sets gross amount of price. If $recalc is set to true, corresponding net price
@@ -113,9 +113,9 @@ interface PriceInterface
     /**
      * Sets $taxEntryCombinationMode for price.
      *
-     * @param string $taxEntryCombinationMode
+     * @param string|null $taxEntryCombinationMode
      *
      * @return void
      */
-    public function setTaxEntryCombinationMode(string $taxEntryCombinationMode): void;
+    public function setTaxEntryCombinationMode(?string $taxEntryCombinationMode = null): void;
 }

--- a/bundles/EcommerceFrameworkBundle/src/PricingManager/Rule.php
+++ b/bundles/EcommerceFrameworkBundle/src/PricingManager/Rule.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Pimcore

--- a/bundles/EcommerceFrameworkBundle/src/Tracking/AbstractProductData.php
+++ b/bundles/EcommerceFrameworkBundle/src/Tracking/AbstractProductData.php
@@ -26,9 +26,9 @@ abstract class AbstractProductData extends AbstractData
 
     protected array $categories;
 
-    protected string $variant;
+    protected ?string $variant = null;
 
-    protected int $position;
+    protected int $position = 0;
 
     protected float $price;
 
@@ -89,7 +89,7 @@ abstract class AbstractProductData extends AbstractData
         return $this;
     }
 
-    public function getVariant(): string
+    public function getVariant(): ?string
     {
         return $this->variant;
     }

--- a/bundles/EcommerceFrameworkBundle/src/Tracking/AbstractProductData.php
+++ b/bundles/EcommerceFrameworkBundle/src/Tracking/AbstractProductData.php
@@ -61,6 +61,9 @@ abstract class AbstractProductData extends AbstractData
         return $this->brand;
     }
 
+    /**
+     * @return $this
+     */
     public function setBrand(?string $brand = null): static
     {
         $this->brand = $brand;

--- a/bundles/EcommerceFrameworkBundle/src/Tracking/AbstractProductData.php
+++ b/bundles/EcommerceFrameworkBundle/src/Tracking/AbstractProductData.php
@@ -22,7 +22,7 @@ abstract class AbstractProductData extends AbstractData
 
     protected string $name;
 
-    protected string $brand;
+    protected ?string $brand = null;
 
     protected array $categories;
 
@@ -56,12 +56,12 @@ abstract class AbstractProductData extends AbstractData
         return $this;
     }
 
-    public function getBrand(): string
+    public function getBrand(): ?string
     {
         return $this->brand;
     }
 
-    public function setBrand(string $brand): static
+    public function setBrand(?string $brand = null): static
     {
         $this->brand = $brand;
 

--- a/bundles/EcommerceFrameworkBundle/src/Tracking/ProductAction.php
+++ b/bundles/EcommerceFrameworkBundle/src/Tracking/ProductAction.php
@@ -20,7 +20,7 @@ class ProductAction extends AbstractProductData
 {
     protected int $quantity = 1;
 
-    protected string $coupon;
+    protected string $coupon = '';
 
     public function getQuantity(): float|int
     {

--- a/composer.json
+++ b/composer.json
@@ -152,7 +152,7 @@
   "require-dev": {
     "codeception/codeception": "^5.0.3",
     "codeception/phpunit-wrapper": "^9",
-    "phpstan/phpstan": "1.9.x-dev",
+    "phpstan/phpstan": "1.9.2",
     "phpstan/phpstan-symfony": "^1.2.14",
     "phpunit/phpunit": "^9.3",
     "spiritix/php-chrome-html2pdf": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -152,7 +152,7 @@
   "require-dev": {
     "codeception/codeception": "^5.0.3",
     "codeception/phpunit-wrapper": "^9",
-    "phpstan/phpstan": "^1.9",
+    "phpstan/phpstan": "1.9.x-dev",
     "phpstan/phpstan-symfony": "^1.2.14",
     "phpunit/phpunit": "^9.3",
     "spiritix/php-chrome-html2pdf": "^1.6",

--- a/lib/DataObject/ClassBuilder/FieldDefinitionPropertiesBuilder.php
+++ b/lib/DataObject/ClassBuilder/FieldDefinitionPropertiesBuilder.php
@@ -24,8 +24,8 @@ class FieldDefinitionPropertiesBuilder implements FieldDefinitionPropertiesBuild
     {
         $cd = '';
 
-        $cd .= 'protected $o_classId = "' . $classDefinition->getId(). "\";\n";
-        $cd .= 'protected $o_className = "'.$classDefinition->getName().'"'.";\n";
+        $cd .= 'protected ?string $o_classId = "' . $classDefinition->getId(). "\";\n";
+        $cd .= 'protected ?string $o_className = "'.$classDefinition->getName().'"'.";\n";
 
         if (is_array($classDefinition->getFieldDefinitions()) && count($classDefinition->getFieldDefinitions())) {
             foreach ($classDefinition->getFieldDefinitions() as $key => $def) {

--- a/lib/DataObject/ClassBuilder/FieldDefinitionPropertiesBuilder.php
+++ b/lib/DataObject/ClassBuilder/FieldDefinitionPropertiesBuilder.php
@@ -24,8 +24,8 @@ class FieldDefinitionPropertiesBuilder implements FieldDefinitionPropertiesBuild
     {
         $cd = '';
 
-        $cd .= 'protected ?string $o_classId = "' . $classDefinition->getId(). "\";\n";
-        $cd .= 'protected ?string $o_className = "'.$classDefinition->getName().'"'.";\n";
+        $cd .= 'protected $o_classId = "' . $classDefinition->getId(). "\";\n";
+        $cd .= 'protected $o_className = "'.$classDefinition->getName().'"'.";\n";
 
         if (is_array($classDefinition->getFieldDefinitions()) && count($classDefinition->getFieldDefinitions())) {
             foreach ($classDefinition->getFieldDefinitions() as $key => $def) {

--- a/lib/Event/Traits/ResponseAwareTrait.php
+++ b/lib/Event/Traits/ResponseAwareTrait.php
@@ -61,6 +61,6 @@ trait ResponseAwareTrait
      */
     public function hasResponse(): bool
     {
-        return null !== $this->response;
+        return isset($this->response);
     }
 }

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -325,7 +325,6 @@ class Imagick extends Adapter
             for ($i = 0; $i < $width; $i++) {
                 for ($j = 0; $j < $height; $j++) {
                     $pixel = $this->resource->getImagePixelColor($i, $j);
-                    // @phpstan-ignore-next-line - phpstan expects bool, but actually doc says int
                     $color = $pixel->getColor(1); // get the real alpha not just 1/0
                     if ($color['a'] < 1) { // if there's an alpha pixel, return true
                         return true;

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -325,6 +325,7 @@ class Imagick extends Adapter
             for ($i = 0; $i < $width; $i++) {
                 for ($j = 0; $j < $height; $j++) {
                     $pixel = $this->resource->getImagePixelColor($i, $j);
+                    // @phpstan-ignore-next-line - phpstan expects bool, but actually doc says int
                     $color = $pixel->getColor(1); // get the real alpha not just 1/0
                     if ($color['a'] < 1) { // if there's an alpha pixel, return true
                         return true;

--- a/lib/Navigation/Renderer/AbstractRenderer.php
+++ b/lib/Navigation/Renderer/AbstractRenderer.php
@@ -210,13 +210,16 @@ abstract class AbstractRenderer implements RendererInterface
      *
      * @return array
      */
-    public function findActive(Container $container, int $minDepth = null, int $maxDepth = -1): array
+    public function findActive(Container $container, int $minDepth = null, int $maxDepth = null): array
     {
         if (!is_int($minDepth)) {
             $minDepth = $this->getMinDepth();
         }
         if ((!is_int($maxDepth) || $maxDepth < 0) && null !== $maxDepth) {
             $maxDepth = $this->getMaxDepth();
+        }
+        if(is_null($maxDepth)) {
+            $maxDepth = -1;
         }
 
         $found = null;

--- a/lib/Navigation/Renderer/Breadcrumbs.php
+++ b/lib/Navigation/Renderer/Breadcrumbs.php
@@ -68,9 +68,9 @@ class Breadcrumbs extends AbstractRenderer
     /**
      * Partial view script to use for rendering menu
      *
-     * @var string|array
+     * @var string|array|null
      */
-    protected string|array $_template;
+    protected string|array|null $_template = null;
 
     // Accessors:
 
@@ -110,12 +110,12 @@ class Breadcrumbs extends AbstractRenderer
         return $this->_linkLast;
     }
 
-    public function getTemplate(): array|string
+    public function getTemplate(): array|string|null
     {
         return $this->_template;
     }
 
-    public function setTemplate(array|string $template): static
+    public function setTemplate(array|string|null $template): static
     {
         $this->_template = $template;
 

--- a/lib/Navigation/Renderer/Breadcrumbs.php
+++ b/lib/Navigation/Renderer/Breadcrumbs.php
@@ -115,6 +115,9 @@ class Breadcrumbs extends AbstractRenderer
         return $this->_template;
     }
 
+    /**
+     * @return $this
+     */
     public function setTemplate(array|string|null $template): static
     {
         $this->_template = $template;

--- a/lib/Routing/RedirectHandler.php
+++ b/lib/Routing/RedirectHandler.php
@@ -242,12 +242,16 @@ final class RedirectHandler implements LoggerAwareInterface
         }
 
         $cacheKey = 'system_route_redirect';
-        if (($this->redirects = Cache::load($cacheKey)) === false) {
+        $valueFromCache = Cache::load($cacheKey);
+        $this->redirects = $valueFromCache === false ? null : $valueFromCache;
+        if (!isset($this->redirects)) {
             // acquire lock to avoid concurrent redirect cache warm-up
             $this->lock->acquire(true);
 
             //check again if redirects are cached to avoid re-warming cache
-            if (($this->redirects = Cache::load($cacheKey)) === false) {
+            $valueFromCache = Cache::load($cacheKey);
+            $this->redirects = $valueFromCache === false ? null : $valueFromCache;
+            if (!isset($this->redirects)) {
                 try {
                     $list = new Redirect\Listing();
                     $list->setCondition('active = 1 AND regex = 1');

--- a/lib/Tool/Glossary/Processor.php
+++ b/lib/Tool/Glossary/Processor.php
@@ -94,20 +94,22 @@ class Processor
         ];
 
         foreach ($data as $entry) {
+            $linkTarget = $entry['linkTarget'] ?? '';
+            $linkTargetTrimmed = rtrim((string)$linkTarget, ' /');
             if ($document instanceof Document) {
                 // check if the current document is the target link (id check)
-                if ($entry['linkType'] == 'internal' && $document->getId() == $entry['linkTarget']) {
+                if ($entry['linkType'] == 'internal' && $document->getId() == $linkTarget) {
                     continue;
                 }
 
                 // check if the current document is the target link (path check)
-                if ($document->getFullPath() == rtrim($entry['linkTarget'], ' /')) {
+                if ($document->getFullPath() == $linkTargetTrimmed) {
                     continue;
                 }
             }
 
             // check if the current URI is the target link (path check)
-            if ($uri === rtrim($entry['linkTarget'], ' /')) {
+            if ($uri === $linkTargetTrimmed) {
                 continue;
             }
 

--- a/lib/Twig/Extension/Templating/HeadScript.php
+++ b/lib/Twig/Extension/Templating/HeadScript.php
@@ -93,7 +93,7 @@ class HeadScript extends CacheBusterAware implements RuntimeExtensionInterface
      * Capture type and/or attributes (used for hinting during capture)
      * @var bool
      */
-    protected bool $_captureLock;
+    protected bool $_captureLock = false;
 
     protected ?string $_captureScriptType = null;
 

--- a/lib/Web2Print/Processor/PdfReactor.php
+++ b/lib/Web2Print/Processor/PdfReactor.php
@@ -88,7 +88,7 @@ class PdfReactor extends Processor
     /**
      * @internal
      */
-    public function getPdfFromString(string $html, array $params = [], bool $returnFilePath = false): bool|string
+    public function getPdfFromString(string $html, array $params = [], bool $returnFilePath = false): string
     {
         $pdfreactor = $this->getClient();
 
@@ -117,7 +117,7 @@ class PdfReactor extends Processor
     /**
      * @internal
      */
-    protected function buildPdf(Document\PrintAbstract $document, object $config): bool|string
+    protected function buildPdf(Document\PrintAbstract $document, object $config): string
     {
         $this->includeApi();
 

--- a/lib/helper-functions.php
+++ b/lib/helper-functions.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Pimcore

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Pimcore

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -1142,8 +1142,12 @@ final class ClassDefinition extends Model\AbstractModel
 
     public function getPreviewGenerator(): ?ClassDefinition\PreviewGeneratorInterface
     {
-        /** @var ClassDefinition\PreviewGeneratorInterface $interface */
-        $interface = DataObject\ClassDefinition\Helper\PreviewGeneratorResolver::resolveGenerator($this->getPreviewGeneratorReference());
+        $interface = null;
+
+        if($this->getPreviewGeneratorReference()) {
+            /** @var ClassDefinition\PreviewGeneratorInterface $interface */
+            $interface = DataObject\ClassDefinition\Helper\PreviewGeneratorResolver::resolveGenerator($this->getPreviewGeneratorReference());
+        }
 
         return $interface;
     }

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Pimcore
@@ -44,7 +43,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     public string $style;
 
-    public array $permissions;
+    public array|string $permissions;
 
     public string $datatype = 'data';
 
@@ -172,7 +171,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         return $this->mandatory;
     }
 
-    public function getPermissions(): array
+    public function getPermissions(): array|string
     {
         return $this->permissions;
     }
@@ -198,7 +197,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         return $this;
     }
 
-    public function setPermissions(array $permissions): static
+    public function setPermissions(array|string $permissions): static
     {
         $this->permissions = $permissions;
 

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -43,9 +43,9 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
     /**
      * @internal
      *
-     * @var string|null
+     * @var array|string|null
      */
-    public ?string $visibleFields = null;
+    public array|string|null $visibleFields = null;
 
     /**
      * @internal
@@ -645,7 +645,7 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
         return $this;
     }
 
-    public function getVisibleFields(): ?string
+    public function getVisibleFields(): array|string|null
     {
         return $this->visibleFields;
     }

--- a/models/DataObject/ClassDefinition/Data/Localizedfields.php
+++ b/models/DataObject/ClassDefinition/Data/Localizedfields.php
@@ -153,7 +153,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
     public ?array $permissionEdit = null;
 
     /**
-     * @param mixed $data
+     * @param mixed $localizedField
      * @param null|DataObject\Concrete $object
      * @param array $params
      *
@@ -162,16 +162,16 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
      * @see Data::getDataForEditmode
      *
      */
-    public function getDataForEditmode(mixed $data, DataObject\Concrete $object = null, array $params = []): array
+    public function getDataForEditmode(mixed $localizedField, DataObject\Concrete $object = null, array $params = []): array
     {
         $fieldData = [];
         $metaData = [];
 
-        if (!$data instanceof DataObject\Localizedfield) {
+        if (!$localizedField instanceof DataObject\Localizedfield) {
             return [];
         }
 
-        $result = $this->doGetDataForEditMode($data, $object, $fieldData, $metaData, 1, $params);
+        $result = $this->doGetDataForEditMode($localizedField, $object, $fieldData, $metaData, 1, $params);
 
         // replace the real data with the data for the editmode
         foreach ($result['data'] as $language => &$data) {
@@ -185,7 +185,7 @@ class Localizedfields extends Data implements CustomResourcePersistingInterface,
                     $childData->setContextualData($ownerType, $ownerName, $index, $language, null, null, $fieldDefinition);
                     $value = $fieldDefinition->getDataForEditmode($childData, $object, $params);
                 } else {
-                    $value = $fieldDefinition->getDataForEditmode($value, $object, array_merge($params, $data->getDao()->getFieldDefinitionParams($fieldDefinition->getName(), $language)));
+                    $value = $fieldDefinition->getDataForEditmode($value, $object, array_merge($params, $localizedField->getDao()->getFieldDefinitionParams($fieldDefinition->getName(), $language)));
                 }
             }
         }

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -82,9 +82,9 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
     /**
      * @internal
      *
-     * @var string|null
+     * @var array|string|null
      */
-    public ?string $visibleFields = null;
+    public array|string|null $visibleFields = null;
 
     /**
      * @internal
@@ -782,7 +782,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
         return $this;
     }
 
-    public function getVisibleFields(): ?string
+    public function getVisibleFields(): ?array
     {
         return $this->visibleFields;
     }

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -782,7 +782,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
         return $this;
     }
 
-    public function getVisibleFields(): ?array
+    public function getVisibleFields(): array|null|string
     {
         return $this->visibleFields;
     }

--- a/models/DataObject/ClassDefinition/Data/Numeric.php
+++ b/models/DataObject/ClassDefinition/Data/Numeric.php
@@ -440,7 +440,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
      */
     public function getVersionPreview(mixed $data, DataObject\Concrete $object = null, array $params = []): string
     {
-        return $data;
+        return $data ?? '';
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Layout.php
+++ b/models/DataObject/ClassDefinition/Layout.php
@@ -97,9 +97,9 @@ class Layout implements Model\DataObject\ClassDefinition\Data\VarExporterInterfa
     /**
      * @internal
      *
-     * @var array
+     * @var array|string
      */
-    public array $permissions;
+    public array|string $permissions;
 
     /**
      * @internal
@@ -150,7 +150,7 @@ class Layout implements Model\DataObject\ClassDefinition\Data\VarExporterInterfa
         return $this->collapsible;
     }
 
-    public function getPermissions(): array
+    public function getPermissions(): array|string
     {
         return $this->permissions;
     }
@@ -212,7 +212,7 @@ class Layout implements Model\DataObject\ClassDefinition\Data\VarExporterInterfa
         return $this;
     }
 
-    public function setPermissions(array $permissions): static
+    public function setPermissions(array|string $permissions): static
     {
         $this->permissions = $permissions;
 

--- a/models/DataObject/ClassDefinition/Layout/Text.php
+++ b/models/DataObject/ClassDefinition/Layout/Text.php
@@ -44,7 +44,7 @@ class Text extends Model\DataObject\ClassDefinition\Layout implements Model\Data
      *
      * @var string
      */
-    public string $renderingClass;
+    public string $renderingClass = '';
 
     /**
      * @internal
@@ -107,9 +107,13 @@ class Text extends Model\DataObject\ClassDefinition\Layout implements Model\Data
      */
     public function enrichLayoutDefinition(?Concrete $object, array $context = []): static
     {
-        $renderer = Model\DataObject\ClassDefinition\Helper\DynamicTextResolver::resolveRenderingClass(
-            $this->getRenderingClass()
-        );
+        $renderer = null;
+        $class = $this->getRenderingClass();
+        if(!empty($class)) {
+            $renderer = Model\DataObject\ClassDefinition\Helper\DynamicTextResolver::resolveRenderingClass(
+                $class
+            );
+        }
 
         $context['fieldname'] = $this->getName();
         $context['layout'] = $this;

--- a/models/DataObject/Classificationstore/GroupConfig.php
+++ b/models/DataObject/Classificationstore/GroupConfig.php
@@ -59,7 +59,7 @@ final class GroupConfig extends Model\AbstractModel
      *
      * @var string
      */
-    protected string $description;
+    protected string $description = '';
 
     protected ?int $creationDate = null;
 

--- a/models/DataObject/Classificationstore/KeyGroupRelation.php
+++ b/models/DataObject/Classificationstore/KeyGroupRelation.php
@@ -40,7 +40,7 @@ final class KeyGroupRelation extends Model\AbstractModel
      *
      * @var string
      */
-    protected string $description;
+    protected string $description = '';
 
     /**
      * Field definition

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -385,7 +385,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
         return $this;
     }
 
-    public function getClass(): ClassDefinition
+    public function getClass(): ?ClassDefinition
     {
         if (!$this->o_class) {
             $this->setClass(ClassDefinition::getById($this->getClassId()));

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -517,11 +517,11 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
      *
      * @param string $fieldName
      * @param bool $forOwner
-     * @param string $remoteClassId
+     * @param string|null $remoteClassId
      *
      * @return array
      */
-    public function getRelationData(string $fieldName, bool $forOwner, string $remoteClassId): array
+    public function getRelationData(string $fieldName, bool $forOwner, ?string $remoteClassId = null): array
     {
         $relationData = $this->getDao()->getRelationData($fieldName, $forOwner, $remoteClassId);
 

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -75,16 +75,16 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
     /**
      * @internal
      *
-     * @var string
+     * @var string|null
      */
-    protected $o_classId;
+    protected ?string $o_classId = null;
 
     /**
      * @internal
      *
-     * @var string
+     * @var string|null
      */
-    protected $o_className;
+    protected ?string $o_className = null;
 
     /**
      * @internal
@@ -385,7 +385,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
         return $this;
     }
 
-    public function getClass(): ?ClassDefinition
+    public function getClass(): ClassDefinition
     {
         if (!$this->o_class) {
             $this->setClass(ClassDefinition::getById($this->getClassId()));
@@ -394,7 +394,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
         return $this->o_class;
     }
 
-    public function getClassId(): string
+    public function getClassId(): ?string
     {
         return $this->o_classId;
     }
@@ -409,7 +409,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
         return $this;
     }
 
-    public function getClassName(): string
+    public function getClassName(): ?string
     {
         return $this->o_className;
     }

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -77,14 +77,14 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
      *
      * @var string|null
      */
-    protected ?string $o_classId = null;
+    protected $o_classId = null;
 
     /**
      * @internal
      *
      * @var string|null
      */
-    protected ?string $o_className = null;
+    protected $o_className = null;
 
     /**
      * @internal
@@ -396,7 +396,10 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
 
     public function getClassId(): ?string
     {
-        return $this->o_classId;
+        if(isset($this->o_classId)) {
+            return (string)$this->o_classId;
+        }
+        return null;
     }
 
     /**

--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -74,7 +74,7 @@ class Dao extends Model\DataObject\AbstractObject\Dao
         return $relations;
     }
 
-    public function getRelationData(string $field, bool $forOwner, string $remoteClassId): array
+    public function getRelationData(string $field, bool $forOwner, ?string $remoteClassId = null): array
     {
         $id = $this->model->getId();
         if ($remoteClassId) {

--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -39,7 +39,16 @@ class Dao extends Model\DataObject\AbstractObject\Dao
 
     public function init()
     {
-        $this->inheritanceHelper = new DataObject\Concrete\Dao\InheritanceHelper($this->model->getClassId());
+        return;
+    }
+
+    protected function getInheritanceHelper() {
+
+        if(!$this->inheritanceHelper) {
+            $this->inheritanceHelper = new DataObject\Concrete\Dao\InheritanceHelper($this->model->getClassId());
+        }
+
+        return $this->inheritanceHelper;
     }
 
     /**
@@ -281,7 +290,7 @@ class Dao extends Model\DataObject\AbstractObject\Dao
 
         // get data for query table
         $data = [];
-        $this->inheritanceHelper->resetFieldsToCheck();
+        $this->getInheritanceHelper()->resetFieldsToCheck();
         $oldData = $this->db->fetchAssociative('SELECT * FROM object_query_' . $this->model->getClassId() . ' WHERE oo_id = ?', [$this->model->getId()]);
 
         $inheritanceEnabled = $this->model->getClass()->getAllowInherit();
@@ -352,7 +361,7 @@ class Dao extends Model\DataObject\AbstractObject\Dao
                                 }
 
                                 if ($doInsert) {
-                                    $this->inheritanceHelper->addRelationToCheck($key, $fd, array_keys($insertData));
+                                    $this->getInheritanceHelper()->addRelationToCheck($key, $fd, array_keys($insertData));
                                 }
                             } else {
                                 $oldDataValue = $oldData[$key] ?? null;
@@ -360,7 +369,7 @@ class Dao extends Model\DataObject\AbstractObject\Dao
                                 if ($isEmpty && $oldDataValue == $parentDataValue) {
                                     // do nothing, ... value is still empty and parent data is equal to current data in query table
                                 } elseif ($oldDataValue != $insertData) {
-                                    $this->inheritanceHelper->addRelationToCheck($key, $fd);
+                                    $this->getInheritanceHelper()->addRelationToCheck($key, $fd);
                                 }
                             }
                         } else {
@@ -371,7 +380,7 @@ class Dao extends Model\DataObject\AbstractObject\Dao
                                     if ($isEmpty && $oldDataValue == $parentDataValue) {
                                         // do nothing, ... value is still empty and parent data is equal to current data in query table
                                     } elseif ($oldDataValue != $insertDataValue) {
-                                        $this->inheritanceHelper->addFieldToCheck($insertDataKey, $fd);
+                                        $this->getInheritanceHelper()->addFieldToCheck($insertDataKey, $fd);
                                     }
                                 }
                             } else {
@@ -381,7 +390,7 @@ class Dao extends Model\DataObject\AbstractObject\Dao
                                     // do nothing, ... value is still empty and parent data is equal to current data in query table
                                 } elseif ($oldDataValue != $insertData) {
                                     // data changed, do check and update
-                                    $this->inheritanceHelper->addFieldToCheck($key, $fd);
+                                    $this->getInheritanceHelper()->addFieldToCheck($key, $fd);
                                 }
                             }
                         }
@@ -400,12 +409,12 @@ class Dao extends Model\DataObject\AbstractObject\Dao
 
     public function saveChildData()
     {
-        $this->inheritanceHelper->doUpdate($this->model->getId(), false, [
+        $this->getInheritanceHelper()->doUpdate($this->model->getId(), false, [
             'inheritanceRelationContext' => [
                 'ownerType' => 'object',
             ],
         ]);
-        $this->inheritanceHelper->resetFieldsToCheck();
+        $this->getInheritanceHelper()->resetFieldsToCheck();
     }
 
     /**

--- a/models/DataObject/QuantityValue/Unit.php
+++ b/models/DataObject/QuantityValue/Unit.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Pimcore

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -596,7 +596,7 @@ class Service extends Model\Element\Service
         return $languageAllowed;
     }
 
-    public static function getLayoutPermissions(string $classId, array $permissionSet): ?array
+    public static function getLayoutPermissions(string $classId, ?array $permissionSet = null): ?array
     {
         $layoutPermissions = null;
 
@@ -1645,7 +1645,9 @@ class Service extends Model\Element\Service
         }
 
         if ($object instanceof Concrete) {
-            self::doResetDirtyMap($object, $object->getClass());
+            if(($class = $object->getClass()) !== null) {
+                self::doResetDirtyMap($object, $class);
+            }
         }
     }
 

--- a/models/Document/Dao.php
+++ b/models/Document/Dao.php
@@ -274,14 +274,17 @@ class Dao extends Model\Element\Dao
 
         foreach ($propertiesRaw as $propertyRaw) {
             try {
+                $id = $this->model->getId();
                 $property = new Model\Property();
                 $property->setType($propertyRaw['type']);
-                $property->setCid($this->model->getId());
+                if(isset($id)) {
+                    $property->setCid($id);
+                }
                 $property->setName($propertyRaw['name']);
                 $property->setCtype('document');
                 $property->setDataFromResource($propertyRaw['data']);
                 $property->setInherited(true);
-                if ($propertyRaw['cid'] == $this->model->getId()) {
+                if ($propertyRaw['cid'] == $id) {
                     $property->setInherited(false);
                 }
                 $property->setInheritable(false);

--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Pimcore

--- a/models/Document/Editable/Select.php
+++ b/models/Document/Editable/Select.php
@@ -66,9 +66,7 @@ class Select extends Model\Document\Editable
      */
     public function setDataFromResource(mixed $data): static
     {
-        if(is_string($data)) {
-            $this->text = $data;
-        }
+        $this->text = (string)$data;
 
         return $this;
     }

--- a/models/Document/Editable/Select.php
+++ b/models/Document/Editable/Select.php
@@ -66,7 +66,9 @@ class Select extends Model\Document\Editable
      */
     public function setDataFromResource(mixed $data): static
     {
-        $this->text = $data;
+        if(is_string($data)) {
+            $this->text = $data;
+        }
 
         return $this;
     }

--- a/models/Document/Service/Dao.php
+++ b/models/Document/Service/Dao.php
@@ -37,7 +37,7 @@ class Dao extends Model\Dao\AbstractDao
         );
     }
 
-    public function getTranslationSourceId(Document $document): int
+    public function getTranslationSourceId(Document $document): mixed
     {
         $sourceId = $this->db->fetchOne('SELECT sourceId FROM documents_translations WHERE id = ?', [$document->getId()]);
         if (!$sourceId) {

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -276,9 +276,12 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
     {
         $this->getProperties();
 
+        $id = $this->getId();
         $property = new Model\Property();
         $property->setType($type);
-        $property->setCid($this->getId());
+        if(isset($id)) {
+            $property->setCid($id);
+        }
         $property->setName($name);
         $property->setCtype(Service::getElementType($this));
         $property->setData($data);

--- a/models/Element/AdminStyle.php
+++ b/models/Element/AdminStyle.php
@@ -29,9 +29,9 @@ class AdminStyle
 {
     protected string|bool|null $elementCssClass = '';
 
-    protected string|bool|null $elementIcon;
+    protected string|bool|null $elementIcon = null;
 
-    protected string|bool|null $elementIconClass;
+    protected string|bool|null $elementIconClass = null;
 
     protected ?array $elementQtipConfig = null;
 

--- a/models/Element/Editlock.php
+++ b/models/Element/Editlock.php
@@ -28,7 +28,7 @@ use Pimcore\Tool\Session;
  */
 final class Editlock extends Model\AbstractModel
 {
-    protected int $id;
+    protected ?int $id = null;
 
     protected int $cid;
 
@@ -114,7 +114,7 @@ final class Editlock extends Model\AbstractModel
         return $this->cid;
     }
 
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -131,9 +131,9 @@ final class Editlock extends Model\AbstractModel
         return $this;
     }
 
-    public function setId(int $id): static
+    public function setId(?int $id): static
     {
-        $this->id = (int) $id;
+        $this->id = $id;
 
         return $this;
     }

--- a/models/User.php
+++ b/models/User.php
@@ -54,7 +54,7 @@ final class User extends User\UserRole
 
     protected bool $allowDirtyClose = false;
 
-    protected ?string $contentLanguages = null;
+    protected ?string $contentLanguages = '';
 
     protected ?string $activePerspective = null;
 
@@ -66,9 +66,9 @@ final class User extends User\UserRole
 
     protected int $lastLogin;
 
-    protected string $keyBindings;
+    protected ?string $keyBindings = null;
 
-    protected array $twoFactorAuthentication;
+    protected array $twoFactorAuthentication = [];
 
     public function getPassword(): ?string
     {

--- a/models/Version.php
+++ b/models/Version.php
@@ -50,7 +50,7 @@ final class Version extends AbstractModel
 
     protected ?User $user = null;
 
-    protected string $note;
+    protected string $note = '';
 
     protected int $date;
 


### PR DESCRIPTION
Follow-up https://github.com/pimcore/pimcore/pull/13474

- [x] PdfReactor processor
https://github.com/pimcore/pimcore/blob/8d831bac31c3a6d97e7c563c4322ae87841a8698/lib/Web2Print/Processor.php#L153
- [x] Ecommerce Environment
I see `useGuestCart` is [nullable ](https://github.com/pimcore/pimcore/commit/3df0381dc02275d6dbde96e8246983c1d90ea56f) now, then it should be `null` like the other properties as well when clearing, also [this change ](https://github.com/pimcore/demo/blob/922243c3c9acb7f6b39985553120a2bb52c0cd26/src/Ecommerce/Overrides/Environment.php#L40-L41)would be missing after merging https://github.com/pimcore/demo/pull/376 
- [x] this line got fixed by Blankse in the [phpStan repo ](https://github.com/phpstan/phpstan-src/pull/2020) and could be removed again https://github.com/pimcore/pimcore/blob/631a52073541777720403653f987bd62f1ac881f/lib/Image/Adapter/Imagick.php#L328 - will be resolved with a follow up task: https://github.com/pimcore/pimcore/issues/13688