### PR TITLE
[Asset] Thumbnail <source> tag should have width="" and height="" attributes

### DIFF
--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -206,6 +206,16 @@ final class Thumbnail
             unset($sourceTagAttributes['srcset']);
         }
 
+        if (!isset($options['disableWidthHeightAttributes'])) {
+            if ($thumb->getWidth()) {
+                $sourceTagAttributes['width'] = $thumb->getWidth();
+            }
+
+            if ($thumb->getHeight()) {
+                $sourceTagAttributes['height'] = $thumb->getHeight();
+            }
+        }
+
         $sourceTagAttributes['type'] = $thumb->getMimeType();
 
         $sourceCallback = $options['sourceCallback'] ?? null;


### PR DESCRIPTION
Similar to the `<img>` tag, the `<source>` tags should have set the image dimensions as well, see also: 
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source#picture_with_height_width_attributes_example