### PR TITLE
fix sql condition being skipped when exporting objects in grid

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -820,7 +820,7 @@ pimcore.element.helpers.gridColumnConfig = {
         var condition = "";
         var searchQuery = this.searchField ? this.searchField.getValue() : "";
 
-        if (this.sqlFilter) {
+        if (this.sqlFilter || (this.sqlButton && this.sqlButton.pressed)) {
             condition = this.sqlEditor.getValue();
         } else {
             var filterData = this.store.getFilters().items;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -820,7 +820,7 @@ pimcore.element.helpers.gridColumnConfig = {
         var condition = "";
         var searchQuery = this.searchField ? this.searchField.getValue() : "";
 
-        if (this.sqlFilter || (this.sqlButton && this.sqlButton.pressed)) {
+        if (this.sqlFilter) {
             condition = this.sqlEditor.getValue();
         } else {
             var filterData = this.store.getFilters().items;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/gridTabAbstract.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/gridTabAbstract.js
@@ -178,6 +178,7 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
                 }.bind(this),
                 "keydown": function (field, key) {
                     if (key.getKey() == key.ENTER) {
+                        this.sqlFilter = field.getValue();
                         this.updateSqlFilter();
                     }
                 }.bind(this)


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
#13662 

## Additional info  
Resolves issue with skipping sql condition when exporting to csv in grid
