### PR TITLE
Fix max height of grouped brick menu

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
@@ -691,8 +691,7 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.area_abstra
     },
 
     getTypeMenu: function (scope, element, insertPosition) {
-        let menu = [];
-        let groupMenu;
+        const menu = [];
         const limits = this.config["limits"] || {};
 
         if (typeof this.config.group != "undefined") {
@@ -700,7 +699,7 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.area_abstra
             const maxHeight = Ext.getBody().getViewSize().height;
             for (let g = 0; g < groups.length; g++) {
                 if (groups[g].length > 0) {
-                    groupMenu = {
+                    let groupMenu = {
                         text: t(groups[g]),
                         iconCls: "pimcore_icon_area",
                         hideOnClick: false,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
@@ -694,10 +694,10 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.area_abstra
         let menu = [];
         let groupMenu;
         const limits = this.config["limits"] || {};
-        const maxHeight = Ext.getBody().getViewSize().height;
 
         if (typeof this.config.group != "undefined") {
             const groups = Object.keys(this.config.group);
+            const maxHeight = Ext.getBody().getViewSize().height;
             for (let g = 0; g < groups.length; g++) {
                 if (groups[g].length > 0) {
                     groupMenu = {
@@ -730,7 +730,7 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.area_abstra
             }
         } else {
             for (let i = 0; i < this.config.types.length; i++) {
-                let type = this.config.types[i].type;
+                const type = this.config.types[i].type;
                 if (typeof limits[type] == "undefined" ||
                     typeof this.brickTypeUsageCounter[type] == "undefined" || this.brickTypeUsageCounter[type] < limits[type]) {
                     menu.push(this.getMenuConfigForBrick(this.config.types[i], scope, element, insertPosition));

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/areablock.js
@@ -691,37 +691,45 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.area_abstra
     },
 
     getTypeMenu: function (scope, element, insertPosition) {
-        var menu = [];
-        var groupMenu;
-        var limits = this.config["limits"] || {};
+        let menu = [];
+        let groupMenu;
+        const limits = this.config["limits"] || {};
+        const maxHeight = Ext.getBody().getViewSize().height;
 
-        if(typeof this.config.group != "undefined") {
-            var groups = Object.keys(this.config.group);
-            for (var g=0; g<groups.length; g++) {
-                if(groups[g].length > 0) {
+        if (typeof this.config.group != "undefined") {
+            const groups = Object.keys(this.config.group);
+            for (let g = 0; g < groups.length; g++) {
+                if (groups[g].length > 0) {
                     groupMenu = {
                         text: t(groups[g]),
                         iconCls: "pimcore_icon_area",
                         hideOnClick: false,
-                        menu: []
+                        menu: {
+                            xtype: 'menu',
+                            items: []
+                        }
                     };
 
-                    for (var i=0; i<this.config.types.length; i++) {
-                        if(in_array(this.config.types[i].type,this.config.group[groups[g]])) {
+                    for (let i = 0; i < this.config.types.length; i++) {
+                        if (in_array(this.config.types[i].type,this.config.group[groups[g]])) {
                             let type = this.config.types[i].type;
                             if (typeof limits[type] == "undefined" ||
                                 typeof this.brickTypeUsageCounter[type] == "undefined" || this.brickTypeUsageCounter[type] < limits[type]) {
-                                    groupMenu.menu.push(this.getMenuConfigForBrick(this.config.types[i], scope, element, insertPosition));
+                                    groupMenu.menu.items.push(this.getMenuConfigForBrick(this.config.types[i], scope, element, insertPosition));
                             }
                         }
                     }
-                    if(groupMenu.menu.length) {
+                    if (groupMenu.menu.items.length) {
+                        // One item has a height of 32px
+                        if (groupMenu.menu.items.length * 32 > maxHeight) {
+                            groupMenu.menu.height = maxHeight;
+                        }
                         menu.push(groupMenu);
                     }
                 }
             }
         } else {
-            for (var i=0; i<this.config.types.length; i++) {
+            for (let i = 0; i < this.config.types.length; i++) {
                 let type = this.config.types[i].type;
                 if (typeof limits[type] == "undefined" ||
                     typeof this.brickTypeUsageCounter[type] == "undefined" || this.brickTypeUsageCounter[type] < limits[type]) {


### PR DESCRIPTION
Followup to https://github.com/pimcore/pimcore/pull/13626

Still not working after this PR unfortunately. It only works at the beginning of a document. But if the document is long and I want to insert something at the end there are no scroll buttons. 

I think the fix only works for the brick menu without groups. We have all bricks in groups, so I found this solution to fix this.