### PR TITLE
Fix; Application logger priority should be always lowercase PSR-3 name

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/LogController.php
+++ b/bundles/AdminBundle/Controller/Admin/LogController.php
@@ -181,18 +181,6 @@ class LogController extends AdminController implements KernelControllerEventInte
     }
 
     /**
-     * @param int $priority
-     *
-     * @return string
-     */
-    private function getPriorityName($priority)
-    {
-        $p = ApplicationLoggerDb::getPriorities();
-
-        return $p[$priority];
-    }
-
-    /**
      * @Route("/log/priority-json", name="pimcore_admin_log_priorityjson", methods={"GET"})
      *
      * @param Request $request

--- a/bundles/AdminBundle/Controller/Admin/LogController.php
+++ b/bundles/AdminBundle/Controller/Admin/LogController.php
@@ -137,7 +137,7 @@ class LogController extends AdminController implements KernelControllerEventInte
                 'pid' => $row['pid'],
                 'message' => $row['message'],
                 'timestamp' => $row['timestamp'],
-                'priority' => $this->getPriorityName($row['priority']),
+                'priority' => $row['priority'],
                 'fileobject' => $fileobject,
                 'relatedobject' => $row['relatedobject'],
                 'relatedobjecttype' => $row['relatedobjecttype'],


### PR DESCRIPTION
## Additional info  
 `$row` gets what is is stored in the table and there the `priority` column is `enum` that only supports the standard PSR-3 name https://github.com/pimcore/pimcore/blob/93e7f2db421e00afd76be3f9fa4f48686a1df830/bundles/InstallBundle/Resources/install.sql#L10



While [getPriorityName](https://github.com/pimcore/pimcore/blob/93e7f2db421e00afd76be3f9fa4f48686a1df830/bundles/AdminBundle/Controller/Admin/LogController.php#L184-L192) tries to convert an `int` (RFC 5424?) to the uppercase eg. WARN


https://github.com/pimcore/pimcore/blob/93e7f2db421e00afd76be3f9fa4f48686a1df830/lib/Log/Handler/ApplicationLoggerDb.php#L87-L109