### PR TITLE
Bug fix: handle the case where the 'containerType' of context is not set

### DIFF
--- a/models/DataObject/Localizedfield/Dao.php
+++ b/models/DataObject/Localizedfield/Dao.php
@@ -76,7 +76,7 @@ class Dao extends Model\Dao\AbstractDao
     {
         $context = $this->model->getContext();
         if ($context) {
-            $containerType = $context['containerType'];
+            $containerType = $context['containerType'] ?? null;
             if ($containerType == 'objectbrick') {
                 $containerKey = $context['containerKey'];
 


### PR DESCRIPTION
handle null pointer in the case where the 'containerType' of context is not set
