### PR TITLE
[BUG] Asset Upload of advancedManyToManyRelation and manyToManyRelation

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -789,7 +789,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
 
     uploadDialog: function () {
         if (!this.fieldConfig.allowMultipleAssignments || (this.fieldConfig["maxItems"] && this.fieldConfig["maxItems"] >= 1)) {
-            if ((this.store.getData().getSource() || this.store.getData()).count() >= this.fieldConfig.maxItems) {
+            if (this.fieldConfig.maxItems && (this.store.getData().getSource() || this.store.getData()).count() >= this.fieldConfig.maxItems) {
                 Ext.Msg.alert(t("error"), t("limit_reached"));
                 return true;
             }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -452,7 +452,7 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
 
     uploadDialog: function () {
         if (!this.fieldConfig.allowMultipleAssignments || (this.fieldConfig["maxItems"] && this.fieldConfig["maxItems"] >= 1)) {
-            if ((this.store.getData().getSource() || this.store.getData()).count() >= this.fieldConfig.maxItems) {
+            if (this.fieldConfig.maxItems && (this.store.getData().getSource() || this.store.getData()).count() >= this.fieldConfig.maxItems) {
                 Ext.Msg.alert(t("error"), t("limit_reached"));
                 return true;
             }


### PR DESCRIPTION
Fix validation of asset upload of advancedManyToManyRelation and manyToManyRelation (https://github.com/pimcore/pimcore/pull/13543)

If this.fieldConfig.maxItems is not defined (null) then 0 >= null is always true and we get the error message "Limit Reached".

![asset-upload_limit_reached_error](https://user-images.githubusercontent.com/16591421/204580613-d6aeea2a-6ba6-4ee7-8ab7-cc81b9baab4d.png)

