### PR TITLE
[Docs] Mention migrating document editable naming strategy

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
@@ -28,7 +28,7 @@ Update your project folder structure as per [Symfony Flex](https://symfony.com/d
 You can use `./bin/console migration:controller-reference` to migrate your existing Documents, Static routes and Document Types to the new controller references in the format: `AppBundle\Controller\FooController::barAction`.
 
 ### Check document editable naming strategy
-If `bin/console debug:config pimcore documents.editables.naming_strategy` returns `legacy`, [migrate element naming](https://github.com/pimcore/pimcore/blob/6.9/doc/Development_Documentation/03_Documents/13_Editable_Naming_Strategies.md#migration-to-the-nested-naming-strategy), otherwise all your document editables will lose its data.
+If `bin/console debug:config pimcore documents.editables.naming_strategy` returns `legacy`, [migrate editable naming](https://github.com/pimcore/pimcore/blob/6.9/doc/Development_Documentation/03_Documents/13_Editable_Naming_Strategies.md#migration-to-the-nested-naming-strategy), otherwise all your document editables will lose its data.
 
 ### Migrate versions to be compatible with Pimcore X
 Documents:

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
@@ -17,7 +17,7 @@
 - If you're using REST Webservices or the PHP templating engine,
   upgrade to [Datahub](https://github.com/pimcore/data-hub) and [Twig templates](https://twig.symfony.com/doc/3.x/)
   or consider using our [LTS offering](https://pimcore.com/en/services/lts) which brings back this functionality as optional commercial bundles. 
-- In case you did not adapt to the new editable naming strategy since Pimcore 5, you need to do this in Pimcore 6 before updating to Pimcore X. Follow [this guide](https://pimcore.com/docs/pimcore/6.9/Development_Documentation/Documents/Editable_Naming_Strategies.html)
+- In case `bin/console debug:config pimcore documents.editables.naming_strategy` returns `legacy`, you did not adapt to the new editable naming strategy since Pimcore 5. Please migrate in Pimcore 6 before updating to Pimcore X, otherwise all your document editables will lose their data. Follow [this guide](https://pimcore.com/docs/pimcore/6.9/Development_Documentation/Documents/Editable_Naming_Strategies.html)
 
 ## IMPORTANT CHANGES TO DO PRIOR THE UPDATE! (TO DO WITH PHP < 8.0)
 
@@ -26,9 +26,6 @@ Update your project folder structure as per [Symfony Flex](https://symfony.com/d
 
 ### Migrate legacy module/controller/action configurations to new controller references
 You can use `./bin/console migration:controller-reference` to migrate your existing Documents, Static routes and Document Types to the new controller references in the format: `AppBundle\Controller\FooController::barAction`.
-
-### Check document editable naming strategy
-If `bin/console debug:config pimcore documents.editables.naming_strategy` returns `legacy`, [migrate editable naming](https://github.com/pimcore/pimcore/blob/6.9/doc/Development_Documentation/03_Documents/13_Editable_Naming_Strategies.md#migration-to-the-nested-naming-strategy), otherwise all your document editables will lose its data.
 
 ### Migrate versions to be compatible with Pimcore X
 Documents:

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/07_Updating_Pimcore/10_V6_to_V10.md
@@ -27,6 +27,9 @@ Update your project folder structure as per [Symfony Flex](https://symfony.com/d
 ### Migrate legacy module/controller/action configurations to new controller references
 You can use `./bin/console migration:controller-reference` to migrate your existing Documents, Static routes and Document Types to the new controller references in the format: `AppBundle\Controller\FooController::barAction`.
 
+### Check document editable naming strategy
+If `bin/console debug:config pimcore documents.editables.naming_strategy` returns `legacy`, [migrate element naming](https://github.com/pimcore/pimcore/blob/6.9/doc/Development_Documentation/03_Documents/13_Editable_Naming_Strategies.md#migration-to-the-nested-naming-strategy), otherwise all your document editables will lose its data.
+
 ### Migrate versions to be compatible with Pimcore X
 Documents:
 If you wish to carry forward Document version files from 6.x to Pimcore X, then it is required run command `pimcore:documents:migrate-elements` to migrate deprecated property `elements` to `editables`. (only relevant for versions created before 6.7)
@@ -97,7 +100,7 @@ mv app/AppKernel.php src/Kernel.php
 ### Add .env environment file
 Add [.env](https://github.com/pimcore/skeleton/blob/10.2/.env) file to project root, if not exists already.
 
-### Migrate Php templates to Twig
+### Migrate PHP templates to Twig
 Since Pimcore X supports only Symfony 5, which dropped the support for Php templates, it is required to update your php templates to Twig. 
 
 If you are using enterprise edition, then it is still possible to support Php templates by installing `pimcore/php-templating-engine-bundle`.


### PR DESCRIPTION
Pimcore 6 supported the Pimcore 5 (or 4?) document editable naming strategy with the config
```yaml
pimcore:
    documents:
        editables:
            naming_strategy: legacy
```

Pimcore 10 does not. So let's advise people to at least check if they already have migrated - because afterwards the `pimcore:documents:migrate-naming-strategy` command does not exist anymore.

PS: As https://github.com/pimcore/pimcore/pull/13713#issuecomment-1332100284 already added this to the docs, this PR now only adds the command to check if the project uses legacy naming strategy.