### PR TITLE
[Data objects] Advanced relations: Render "number" meta fields with correct decimal separator

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -155,10 +155,14 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
             var renderer = null;
             var listeners = null;
 
-            if (this.fieldConfig.columns[i].type == "number" && !readOnly) {
-                cellEditor = function() {
-                    return new Ext.form.NumberField({});
-                }.bind();
+            if (this.fieldConfig.columns[i].type == "number") {
+                if(!readOnly) {
+                    cellEditor = function () {
+                        return new Ext.form.NumberField({});
+                    }.bind();
+                }
+
+                renderer = Ext.util.Format.numberRenderer();
             } else if (this.fieldConfig.columns[i].type == "text" && !readOnly) {
                 cellEditor = function() {
                     return new Ext.form.TextField({});

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -113,10 +113,14 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
             var renderer = null;
             var listeners = null;
 
-            if (this.fieldConfig.columns[i].type == "number" && !readOnly) {
-                cellEditor = function () {
-                    return new Ext.form.NumberField({});
-                };
+            if (this.fieldConfig.columns[i].type == "number") {
+                if(!readOnly) {
+                    cellEditor = function () {
+                        return new Ext.form.NumberField({});
+                    };
+                }
+
+                renderer = Ext.util.Format.numberRenderer();
             } else if (this.fieldConfig.columns[i].type == "text" && !readOnly) {
                 cellEditor = function () {
                     return new Ext.form.TextField({});


### PR DESCRIPTION
Steps to reproduce:

1. Assure current user's language is `English`
2. Create class with advanced many-to-many (object) relation field. To this add meta column `test` of type `number`
3. Create object of this class, assign the object itself to the relation, in meta column `test` write `1.23`
4. Change language of currently logged in user to `German`
5. Open object again

Expected behaviour: In column `test` the value should be `1,23` (because in Germany comma is used as decimal separator).

Actual behaviour: You will see `1.23` (with dot as decimal separator).

This PR applies the correct locale renderer for number fields.