### PR TITLE
[Elements] Remove non-printable characters from element keys

### DIFF
--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -1114,6 +1114,10 @@ class Service extends Model\AbstractModel
 
         // replace all 4 byte unicode characters
         $key = preg_replace('/[\x{10000}-\x{10FFFF}]/u', '-', $key);
+
+        // replace non-printable characters
+        $key = preg_replace('/[\x00-\x08\x0B\x0C\xC2\xA0\xAD\x0E-\x1F\x7F-\x9F\x{200B}-\x{200D}\x{FEFF}]/u', '', $key);
+
         // replace slashes with a hyphen
         $key = str_replace('/', '-', $key);
 


### PR DESCRIPTION
To reproduce, run command
```php
var_dump(json_encode(\Pimcore\Model\Element\Service::getValidKey("Nivellier\xC2\xADmasse.pdf", 'asset')));
```
It returns `"Nivellier\u00admasse.pdf"`. `\xC2\xAD` is a [soft-hyphen](https://www.compart.com/de/unicode/U+00AD)

When trying to create an asset with this name, there even is a Flysystem error:
`League\Flysystem\CorruptedPathDetected: Corrupted path detected: Nivellier­­masse.pdf in <Pimcore root>vendor/league/flysystem/src/CorruptedPathDetected.php:11` (the soft-hyphen is not visible here but when you copy the filename to an editor, you will see it)

For other element types there is no error but there may be unexpected behaviour.

This PR removes such control characters and other non-printable characters from element keys.