### PR TITLE
[Bug]: After moving data object the query tables are still filled with inherited data from source location

### DIFF
--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -709,6 +709,9 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
         // the inheritance enabled flag has been changed in the meantime
         if ($this->getClass()->getModificationDate() >= $this->getModificationDate() && $this->getId()) {
             DataObject::disableDirtyDetection();
+        } elseif ($this->getClass()->getAllowInherit() && $this->isFieldDirty('parentId')) {
+            // if inherit is enabled and the data object is moved the query table should be updated
+            DataObject::disableDirtyDetection();
         }
 
         try {


### PR DESCRIPTION
Resolves https://github.com/pimcore/pimcore/issues/13732

