### PR TITLE
[Bug][11]: Xliff import strict types/ SimpleXML issue

### DIFF
--- a/lib/Translation/ImportDataExtractor/Xliff12DataExtractor.php
+++ b/lib/Translation/ImportDataExtractor/Xliff12DataExtractor.php
@@ -46,7 +46,7 @@ class Xliff12DataExtractor implements ImportDataExtractorInterface
         $target = $file['target-language'];
 
         // see https://en.wikipedia.org/wiki/IETF_language_tag
-        $target = str_replace('-', '_', $target->__toString());
+        $target = str_replace('-', '_', (string)$target);
         if (!Tool::isValidLanguage($target)) {
             $target = \Locale::getPrimaryLanguage($target);
         }

--- a/lib/Translation/ImportDataExtractor/Xliff12DataExtractor.php
+++ b/lib/Translation/ImportDataExtractor/Xliff12DataExtractor.php
@@ -46,7 +46,7 @@ class Xliff12DataExtractor implements ImportDataExtractorInterface
         $target = $file['target-language'];
 
         // see https://en.wikipedia.org/wiki/IETF_language_tag
-        $target = str_replace('-', '_', $target);
+        $target = str_replace('-', '_', $target->__toString());
         if (!Tool::isValidLanguage($target)) {
             $target = \Locale::getPrimaryLanguage($target);
         }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #13718

## Additional info  
Due the `declare(strict_types=1);` , this `$target` being a `SimpleXml` type breaks the str_replace which works only `string|array`
![image](https://user-images.githubusercontent.com/6014195/205698279-ac6cc9a2-1706-490f-841c-edb7cf5be458.png)

