### PR TITLE
Fix translate button doesn't work in DocumentTypes & PredefinedProperties UI 

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/docTypes.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/docTypes.js
@@ -243,11 +243,11 @@ pimcore.settings.document.doctypes = Class.create({
                     handler: function (grid, rowIndex) {
                         var rec = grid.getStore().getAt(rowIndex);
                         try {
-                            pimcore.globalmanager.get("translationadminmanager").activate(rec.data.name);
+                            pimcore.globalmanager.get("translationdomainmanager").activate(rec.data.name);
                         }
                         catch (e) {
-                            pimcore.globalmanager.add("translationadminmanager",
-                                new pimcore.settings.translation.admin(rec.data.name));
+                            pimcore.globalmanager.add("translationdomainmanager",
+                                new pimcore.settings.translation.domain("admin",rec.data.name));
                         }
                     }.bind(this)
                 }]

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
@@ -180,11 +180,10 @@ pimcore.settings.properties.predefined = Class.create({
                     handler: function(grid, rowIndex){
                         var rec = grid.getStore().getAt(rowIndex);
                         try {
-                            pimcore.globalmanager.get("translationadminmanager").activate(rec.data.name);
-                        }
-                        catch (e) {
-                            pimcore.globalmanager.add("translationadminmanager",
-                                                        new pimcore.settings.translation.admin(rec.data.name));
+                            pimcore.globalmanager.get("translationdomainmanager").activate(rec.data.name);
+                        } catch (e) {
+                            pimcore.globalmanager.add("translationdomainmanager",
+                                new pimcore.settings.translation.domain("admin", rec.data.name));
                         }
                     }.bind(this)
                 }]


### PR DESCRIPTION
## Changes in this pull request  
Resolves #13712

## Additional info  

