### PR TITLE
[Bug]: strip_tags needs empty string as default value, cannot handle null

### DIFF
--- a/bundles/AdminBundle/src/Controller/Admin/LoginController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/LoginController.php
@@ -233,7 +233,7 @@ class LoginController extends AdminController implements KernelControllerEventIn
 
         if (preg_match('/(document|asset|object)_([0-9]+)_([a-z]+)/', $queryString, $deeplink)) {
             $deeplink = $deeplink[0];
-            $perspective = strip_tags($request->get('perspective'));
+            $perspective = strip_tags($request->get('perspective', '')); // strip_tags needs empty string as default value
 
             if (strpos($queryString, 'token')) {
                 $event = new LoginRedirectEvent('pimcore_admin_login', [

--- a/bundles/AdminBundle/src/Security/Authenticator/AdminAbstractAuthenticator.php
+++ b/bundles/AdminBundle/src/Security/Authenticator/AdminAbstractAuthenticator.php
@@ -121,7 +121,7 @@ abstract class AdminAbstractAuthenticator extends AbstractAuthenticator implemen
         } else {
             $url = $this->router->generate('pimcore_admin_index', [
                 '_dc' => time(),
-                'perspective' => strip_tags($request->get('perspective')),
+                'perspective' => strip_tags($request->get('perspective', '')), // strip_tags needs empty string as default value
             ]);
         }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.6`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.6` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #13723 

## Additional info  
strip_tags cannot handle null values

