### PR TITLE
[Bug]: strip_tags needs empty string as default value, cannot handle null

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/LoginController.php
+++ b/bundles/AdminBundle/Controller/Admin/LoginController.php
@@ -242,7 +242,7 @@ class LoginController extends AdminController implements BruteforceProtectedCont
 
         if (preg_match('/(document|asset|object)_([0-9]+)_([a-z]+)/', $queryString, $deeplink)) {
             $deeplink = $deeplink[0];
-            $perspective = strip_tags($request->get('perspective'));
+            $perspective = strip_tags($request->get('perspective', ''));
 
             if (strpos($queryString, 'token')) {
                 $event = new LoginRedirectEvent('pimcore_admin_login', [

--- a/bundles/AdminBundle/Controller/Admin/TagsController.php
+++ b/bundles/AdminBundle/Controller/Admin/TagsController.php
@@ -42,7 +42,7 @@ class TagsController extends AdminController
     {
         try {
             $tag = new Tag();
-            $tag->setName(strip_tags($request->get('text')));
+            $tag->setName(strip_tags($request->get('text', '')));
             $tag->setParentId((int)$request->get('parentId'));
             $tag->save();
 
@@ -91,7 +91,7 @@ class TagsController extends AdminController
                 $tag->setParentId((int)$parentId);
             }
             if ($request->get('text')) {
-                $tag->setName(strip_tags($request->get('text')));
+                $tag->setName(strip_tags($request->get('text', '')));
             }
 
             $tag->save();
@@ -113,7 +113,7 @@ class TagsController extends AdminController
     {
         $showSelection = $request->get('showSelection') == 'true';
         $assignmentCId = (int)$request->get('assignmentCId');
-        $assignmentCType = strip_tags($request->get('assignmentCType'));
+        $assignmentCType = strip_tags($request->get('assignmentCType', ''));
 
         $recursiveChildren = false;
         $assignedTagIds = [];
@@ -209,7 +209,7 @@ class TagsController extends AdminController
     public function loadTagsForElementAction(Request $request)
     {
         $assginmentCId = (int)$request->get('assignmentCId');
-        $assginmentCType = strip_tags($request->get('assignmentCType'));
+        $assginmentCType = strip_tags($request->get('assignmentCType', ''));
 
         $assignedTagArray = [];
         if ($assginmentCId && $assginmentCType) {
@@ -233,7 +233,7 @@ class TagsController extends AdminController
     public function addTagToElementAction(Request $request)
     {
         $assginmentCId = (int)$request->get('assignmentElementId');
-        $assginmentCType = strip_tags($request->get('assignmentElementType'));
+        $assginmentCType = strip_tags($request->get('assignmentElementType', ''));
         $tagId = (int)$request->get('tagId');
 
         $tag = Tag::getById($tagId);
@@ -256,7 +256,7 @@ class TagsController extends AdminController
     public function removeTagFromElementAction(Request $request)
     {
         $assginmentCId = (int)$request->get('assignmentElementId');
-        $assginmentCType = strip_tags($request->get('assignmentElementType'));
+        $assginmentCType = strip_tags($request->get('assignmentElementType', ''));
         $tagId = (int)$request->get('tagId');
 
         $tag = Tag::getById($tagId);
@@ -280,7 +280,7 @@ class TagsController extends AdminController
     public function getBatchAssignmentJobsAction(Request $request, EventDispatcherInterface $eventDispatcher)
     {
         $elementId = (int)$request->get('elementId');
-        $elementType = strip_tags($request->get('elementType'));
+        $elementType = strip_tags($request->get('elementType', ''));
 
         $idList = [];
         switch ($elementType) {
@@ -423,7 +423,7 @@ class TagsController extends AdminController
      */
     public function doBatchAssignmentAction(Request $request)
     {
-        $cType = strip_tags($request->get('elementType'));
+        $cType = strip_tags($request->get('elementType', ''));
         $assignedTags = json_decode($request->get('assignedTags'));
         $elementIds = json_decode($request->get('childrenIds'));
         $doCleanupTags = $request->get('removeAndApply') == 'true';

--- a/bundles/AdminBundle/Security/Authenticator/AdminAbstractAuthenticator.php
+++ b/bundles/AdminBundle/Security/Authenticator/AdminAbstractAuthenticator.php
@@ -116,7 +116,7 @@ abstract class AdminAbstractAuthenticator extends AbstractAuthenticator implemen
         } else {
             $url = $this->router->generate('pimcore_admin_index', [
                 '_dc' => time(),
-                'perspective' => strip_tags($request->get('perspective')),
+                'perspective' => strip_tags($request->get('perspective', '')),
             ]);
         }
 

--- a/bundles/AdminBundle/Security/Authenticator/AdminLoginAuthenticator.php
+++ b/bundles/AdminBundle/Security/Authenticator/AdminLoginAuthenticator.php
@@ -57,7 +57,7 @@ class AdminLoginAuthenticator extends AdminAbstractAuthenticator implements Auth
             return $response;
         }
 
-        $event = new LoginRedirectEvent(self::PIMCORE_ADMIN_LOGIN, ['perspective' => strip_tags($request->get('perspective'))]);
+        $event = new LoginRedirectEvent(self::PIMCORE_ADMIN_LOGIN, ['perspective' => strip_tags($request->get('perspective', ''))]);
         $this->dispatcher->dispatch($event, AdminEvents::LOGIN_REDIRECT);
 
         $url = $this->router->generate($event->getRouteName(), $event->getRouteParams());

--- a/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
+++ b/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
@@ -331,7 +331,7 @@ class AdminAuthenticator extends AbstractGuardAuthenticator implements LoggerAwa
         } else {
             $url = $this->router->generate('pimcore_admin_index', [
                 '_dc' => time(),
-                'perspective' => strip_tags($request->get('perspective')),
+                'perspective' => strip_tags($request->get('perspective', '')),
             ]);
         }
 

--- a/doc/Development_Documentation/10_E-Commerce_Framework/09_Working_with_Prices/07_Vouchers.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/09_Working_with_Prices/07_Vouchers.md
@@ -48,7 +48,7 @@ A voucher token is always applied to a cart. To do so, use following snippet.
 ```php
 <?php
 
-if($token = strip_tags($request->get('voucher-code'))) {
+if($token = strip_tags($request->get('voucher-code', ''))) {
     try {
         $success = $cart->addVoucherToken($token);
         if($success) {

--- a/doc/Development_Documentation/10_E-Commerce_Framework/09_Working_with_Prices/07_Vouchers.md
+++ b/doc/Development_Documentation/10_E-Commerce_Framework/09_Working_with_Prices/07_Vouchers.md
@@ -48,10 +48,10 @@ A voucher token is always applied to a cart. To do so, use following snippet.
 ```php
 <?php
 
-if($token = strip_tags($request->get('voucher-code', ''))) {
+if ($token = strip_tags($request->get('voucher-code', ''))) {
     try {
         $success = $cart->addVoucherToken($token);
-        if($success) {
+        if ($success) {
             $this->addFlash('success', $translator->trans('cart.voucher-code-added'));
         } else {
             $this->addFlash('danger', $translator->trans('cart.voucher-code-cound-not-be-added'));
@@ -100,7 +100,7 @@ See an sample snippet to display the voucher information to the customer:
 ```twig
 <form method="post" action="{{ path('shop-cart-apply-voucher') }}" class="card p-2 mb-4">
 
-    {% if(cart.pricingManagerTokenInformationDetails | length > 0) %}
+    {% if (cart.pricingManagerTokenInformationDetails | length > 0) %}
 
         <ul class="list-group pb-3">
 


### PR DESCRIPTION
Resolves https://github.com/pimcore/pimcore/issues/13723
Alternative for https://github.com/pimcore/pimcore/pull/13756

Target branch 10.5 and all strip_tags with `$request->get()`