### PR TITLE
fix: allow textareas to be nullable from admin

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Textarea.php
+++ b/models/DataObject/ClassDefinition/Data/Textarea.php
@@ -254,6 +254,10 @@ class Textarea extends Data implements ResourcePersistenceAwareInterface, QueryR
      */
     public function getDataFromEditmode($data, $object = null, $params = [])
     {
+        if ($data === '') {
+            return null;
+        }
+        
         return $data;
     }
 

--- a/models/DataObject/ClassDefinition/Data/Textarea.php
+++ b/models/DataObject/ClassDefinition/Data/Textarea.php
@@ -250,7 +250,7 @@ class Textarea extends Data implements ResourcePersistenceAwareInterface, QueryR
      * @param null|Model\DataObject\Concrete $object
      * @param mixed $params
      *
-     * @return string
+     * @return string|null
      */
     public function getDataFromEditmode($data, $object = null, $params = [])
     {


### PR DESCRIPTION
## Changes in this pull request  

Makes textareas nullable. Currently, once you edit it, it can never go back to `null`.

