### PR TITLE
[Bug]: Fix problem in grid configuration with invisble block

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/classTree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/classTree.js
@@ -192,7 +192,7 @@ pimcore.object.helpers.classTree = Class.create({
 
         newNode = fn();
 
-        if (con.children) {
+        if (con.children && newNode) {
             for (var i = 0; i < con.children.length; i++) {
                 this.recursiveAddNode(con.children[i], newNode, brickDescriptor, config);
             }


### PR DESCRIPTION
If you create a class with a block that is invisible and has visible fields inside the grid configuration fails because it tries to add the subfields to non existing invisible block node