### PR TITLE
Bump "codeception/module-symfony" dev requirement to 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -151,6 +151,7 @@
   },
   "require-dev": {
     "codeception/codeception": "^5.0.3",
+    "codeception/module-symfony": "^3.1.0",
     "codeception/phpunit-wrapper": "^9",
     "phpstan/phpstan": "1.9.2",
     "phpstan/phpstan-symfony": "^1.2.14",


### PR DESCRIPTION
## Changes in this pull request  
Older version not supported on Symfony 6

Please see https://github.com/pimcore/pimcore/pull/13762

## Additional info  

- [ ] Rebase after merging changes from https://github.com/pimcore/pimcore/pull/13762 into 11.x branch.
