### PR TITLE
[Data Objects] Generate FIELD_NAME constants

### DIFF
--- a/lib/DataObject/ClassBuilder/ClassBuilder.php
+++ b/lib/DataObject/ClassBuilder/ClassBuilder.php
@@ -110,6 +110,7 @@ class ClassBuilder implements ClassBuilderInterface
         $useParts = [];
 
         $cd .= ClassDefinition\Service::buildUseTraitsCode($useParts, $classDefinition->getUseTraits());
+        $cd .= ClassDefinition\Service::buildFieldConstantsCode(...$classDefinition->getFieldDefinitions());
 
         $cd .= $this->propertiesBuilder->buildProperties($classDefinition);
         $cd .= "\n\n";

--- a/lib/DataObject/ClassBuilder/FieldCollectionClassBuilder.php
+++ b/lib/DataObject/ClassBuilder/FieldCollectionClassBuilder.php
@@ -61,6 +61,8 @@ class FieldCollectionClassBuilder implements FieldCollectionClassBuilderInterfac
         $cd .= 'class ' . ucfirst($definition->getKey()) . ' extends ' . $extendClass . $implements . "\n";
         $cd .= '{' . "\n";
 
+        $cd .= ClassDefinition\Service::buildFieldConstantsCode(...$definition->getFieldDefinitions());
+
         $cd .= 'protected string $type = "' . $definition->getKey() . "\";\n";
 
         if (is_array($definition->getFieldDefinitions()) && count($definition->getFieldDefinitions())) {

--- a/lib/DataObject/ClassBuilder/ObjectBrickClassBuilder.php
+++ b/lib/DataObject/ClassBuilder/ObjectBrickClassBuilder.php
@@ -65,6 +65,8 @@ class ObjectBrickClassBuilder implements ObjectBrickClassBuilderInterface
         $cd .= 'class ' . ucfirst($definition->getKey()) . ' extends ' . $extendClass . $implements . "\n";
         $cd .= '{' . "\n";
 
+        $cd .= ClassDefinition\Service::buildFieldConstantsCode(...$definition->getFieldDefinitions());
+
         $cd .= 'protected string $type = "' . $definition->getKey() . "\";\n";
 
         if (is_array($definition->getFieldDefinitions()) && count($definition->getFieldDefinitions())) {

--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -524,4 +524,42 @@ class Service
 
         return '';
     }
+
+    /**
+     * @internal
+     */
+    public static function buildFieldConstantsCode(Data ...$fieldDefinitions): string
+    {
+        $fieldConstants = '';
+        foreach ($fieldDefinitions as $fieldDefinition) {
+            if (!$fieldDefinition instanceof Data\Localizedfields) {
+                $fieldConstants .= static::buildFieldConstantCode($fieldDefinition) . "\n";
+                continue;
+            }
+
+            foreach ($fieldDefinition->getFieldDefinitions() as $localizedFieldDefinition) {
+                $fieldConstants .= static::buildFieldConstantCode($localizedFieldDefinition) . "\n";
+            }
+        }
+
+        return $fieldConstants . "\n";
+    }
+
+    /**
+     * @internal
+     */
+    public static function buildFieldConstantCode(Data $fieldDefinition): string
+    {
+        $nameUpperSnakeCase = static::camelCaseToUpperSnakeCase($fieldDefinition->getName());
+        return 'public const FIELD_' . $nameUpperSnakeCase . ' = \'' . $fieldDefinition->getName() . '\';';
+    }
+
+    /**
+     * @internal
+     */
+    public static function camelCaseToUpperSnakeCase(string $camelCase): string
+    {
+        $snakeCase = ltrim(preg_replace('/[A-Z]+/', '_\\0', $camelCase), '_');
+        return strtoupper($snakeCase);
+    }
 }


### PR DESCRIPTION
These constants can be used in custom logic. For example, when retrieving a field definition.
Resolves #13625