### PR TITLE
Avoid unecessary cast to string in Translator::trans()

### DIFF
--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -92,8 +92,6 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
             $domain = Translation::DOMAIN_DEFAULT;
         }
 
-        $id = (string) $id;
-
         if ($domain === Translation::DOMAIN_ADMIN && !empty($this->adminTranslationMapping)) {
             if (null === $locale) {
                 $locale = $this->getLocale();


### PR DESCRIPTION
## Changes in this pull request  
Incoming parameter to method is typed to `string` and the `trim()` function is [guaranteed to return a string](https://www.php.net/manual/en/function.trim) anyway.


