### PR TITLE
Fix typo in the docs

### DIFF
--- a/doc/Development_Documentation/18_Tools_and_Features/29_Custom_Reports.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/29_Custom_Reports.md
@@ -47,5 +47,5 @@ pimcore:
 ## Custom JS Class for Report Visualization
 If you need to fully customize the appearance of the report, you can specify a custom java script class that should 
 be used when opening the report in Pimcore Backend. This class can be specified in `Report Class` option and should extend
-the default java script class for the reports which is `pimcore.report.custom.report``. 
+the default java script class for the reports which is `pimcore.report.custom.report`. 
 


### PR DESCRIPTION
The rendering was broken: 
![grafik](https://user-images.githubusercontent.com/424602/207352764-8511b2f4-1689-4b94-8103-51e1cd76d0d5.png)
