### PR TITLE
replace lrm characters with - for getValidKey

### DIFF
--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -1114,6 +1114,8 @@ class Service extends Model\AbstractModel
 
         // replace all 4 byte unicode characters
         $key = preg_replace('/[\x{10000}-\x{10FFFF}]/u', '-', $key);
+        // replace left to right marker characters ( lrm )
+        $key = preg_replace('/(\x{200e}|\x{200f})/u', '-', $key);
         // replace slashes with a hyphen
         $key = str_replace('/', '-', $key);
 


### PR DESCRIPTION
If you have a string with left to right marker character you get an invalid key

reproduce
create string with lrm character $imagename

$prod_image_folder = new Asset\Folder();
$img_key = Service::getValidKey($imagename , 'asset');
$prod_image_folder->setKey(Service::getValidKey(img_key , 'asset'));
$prod_image_folder->setParentId(1);
$prod_image_folder->save();

you get a flysystem error because key is not valid in file system

