### PR TITLE
fix: twig sandbox error for "default" filter

### DIFF
--- a/bundles/CoreBundle/Resources/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yaml
@@ -297,7 +297,7 @@ pimcore:
         twig:
             sandbox_security_policy:
                 tags: ['set']
-                filters: ['escape', 'trans']
+                filters: ['escape', 'trans', 'default']
                 functions: ['path', 'asset']
 presta_sitemap:
     # do not add properties by default


### PR DESCRIPTION
resolves #13788 by adding the `default` filter to the `sandbox_security_policy` config.