### PR TITLE
Fix codeception tests

### DIFF
--- a/tests/Support/Helper/Pimcore.php
+++ b/tests/Support/Helper/Pimcore.php
@@ -85,7 +85,7 @@ class Pimcore extends Module\Symfony
      *
      * @throws \Exception
      */
-    public function grabService(string $serviceId): ?object
+    public function grabService(string $serviceId): object
     {
         if (empty(self::$testServiceContainer)) {
             $container = $this->getContainer();

--- a/tests/Support/Helper/Pimcore.php
+++ b/tests/Support/Helper/Pimcore.php
@@ -328,11 +328,6 @@ class Pimcore extends Module\Symfony
         DataObject\Localizedfield::setGetFallbackValues(true);
     }
 
-    public function makeHtmlSnapshot($name = null)
-    {
-        // TODO: Implement makeHtmlSnapshot() method.
-    }
-
     public function getGroups(): array
     {
         return $this->groups;


### PR DESCRIPTION
## Changes in this pull request  
Follow up to #13764

## Additional info  
- Remove unimplemented Pimcore\Test\Support\Helper::makeHtmlSnapshot()
- Fix `grabService()` return type.
