### PR TITLE
HeadlessChrome: modify config via event listener

### DIFF
--- a/lib/Event/DocumentEvents.php
+++ b/lib/Event/DocumentEvents.php
@@ -167,6 +167,10 @@ final class DocumentEvents
      *  - reactorConfig | configuration which is passed to PDFReactor
      *  - document | Pimcore document that is converted
      *
+     * HeadlessChrome:
+     *  - params | puppeteer PDF options (see also https://pptr.dev/api/puppeteer.pdfoptions/)
+     *  - html | HTML passed to puppeteer
+     *
      * @Event("Pimcore\Event\Model\PrintConfigEvent")
      *
      * @var string

--- a/lib/Web2Print/Processor/HeadlessChrome.php
+++ b/lib/Web2Print/Processor/HeadlessChrome.php
@@ -38,7 +38,6 @@ class HeadlessChrome extends Processor
         $web2printConfig = Config::getWeb2PrintConfig();
         $web2printConfig = $web2printConfig->get('headlessChromeSettings');
         $web2printConfig = json_decode($web2printConfig, true);
-        $web2printConfig = array_merge($web2printConfig, ($config->headlessChromeSettings ?? []));
 
         $params = ['document' => $document];
         $this->updateStatus($document->getId(), 10, 'start_html_rendering');
@@ -92,6 +91,16 @@ class HeadlessChrome extends Processor
     public function getPdfFromString($html, $params = [], $returnFilePath = false)
     {
         $params = $params ?: $this->getDefaultOptions();
+
+        $event = new PrintConfigEvent($this, [
+            'params' => $params,
+            'html' => $html,
+        ]);
+
+        \Pimcore::getEventDispatcher()->dispatch($event, DocumentEvents::PRINT_MODIFY_PROCESSING_CONFIG);
+
+        ['html' => $html, 'params' => $params] = $event->getArguments();
+
         $input = new StringInput();
         $input->setHtml($html);
 

--- a/lib/Web2Print/Processor/HeadlessChrome.php
+++ b/lib/Web2Print/Processor/HeadlessChrome.php
@@ -38,6 +38,7 @@ class HeadlessChrome extends Processor
         $web2printConfig = Config::getWeb2PrintConfig();
         $web2printConfig = $web2printConfig->get('headlessChromeSettings');
         $web2printConfig = json_decode($web2printConfig, true);
+        $web2printConfig = array_merge($web2printConfig, ($config->headlessChromeSettings ?? []));
 
         $params = ['document' => $document];
         $this->updateStatus($document->getId(), 10, 'start_html_rendering');


### PR DESCRIPTION
## Changes in this pull request  

When generating a PDF based on a Document in `\Pimcore\Web2Print\Processor::startPdfGeneration`, a `pimcore.document.print.prePdfGeneration` is dispatched (line 125). The payload (a `\Pimcore\Event\Model\DocumentEvent`) is then passed (line 127) as `$config` to `\Pimcore\Web2Print\Processor::buildPdf`.

Currently, the implementation of `buildPdf()` in `\Pimcore\Web2Print\Processor\HeadlessChrome` does not use the argument `$config`, rendering any changes to the job config in the event listener useless. This PR addresses this issue by merging the global Web2Print options with the options passed in that event.

## Additional info  

Since there still is [a 10.5.x milestone](https://github.com/pimcore/pimcore/milestone/183) and the change is a bugfix, this PR targets `10.5`.

A sample listener might look as follows:

```php
<?php

namespace App\EventListener\Document;

use Pimcore\Event\Model\DocumentEvent;

class ConfigListener
{
    public function setParams(DocumentEvent $event): void
    {
        $jobConfig = $event->getArgument('jobConfig');

        $jobConfig->headlessChromeSettings = [
            'marginTop' => '0mm',
            'marginRight' => '0mm',
            'marginBottom' => '0mm',
            'marginLeft' => '0mm',
        ];

        $event->setArgument('jobConfig', $jobConfig);
    }
}
```