### PR TITLE
Fix: User type

### DIFF
--- a/lib/Event/Admin/Login/LoginFailedEvent.php
+++ b/lib/Event/Admin/Login/LoginFailedEvent.php
@@ -50,7 +50,7 @@ class LoginFailedEvent extends Event
         return $default;
     }
 
-    public function getUser(): User
+    public function getUser(): ?User
     {
         return $this->user;
     }

--- a/lib/Event/Admin/Login/LoginFailedEvent.php
+++ b/lib/Event/Admin/Login/LoginFailedEvent.php
@@ -23,7 +23,7 @@ class LoginFailedEvent extends Event
 {
     protected array $credentials;
 
-    protected User $user;
+    protected ?User $user = null;
 
     public function __construct(array $credentials)
     {


### PR DESCRIPTION
Fixes error `Typed property Pimcore\Event\Admin\Login\LoginFailedEvent::$user must not be accessed before initialization`