### PR TITLE
Revert symfony/contracts version 2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
     "sensio/framework-extra-bundle": "^6.2",
     "sensiolabs/ansi-to-html": "^1.1",
     "symfony-cmf/routing-bundle": "^3.0",
-    "symfony/contracts": "^3.2",
+    "symfony/contracts": "^2.3 || ^3.2",
     "symfony/monolog-bundle": "^3.8",
     "symfony/asset": "^6.1",
     "symfony/cache": "^6.1",


### PR DESCRIPTION
## Changes in this pull request  
Follow up to #13766

## Additional info  
There's a `psr/cache` requirement conflict between `symfony/contracts:3` and `matomo/device-detector`:

- symfony/contracts requires `psr/cache: ^3.0`
- matomo/device-detector requires `psr/cache: ^1.0.1`