### PR TITLE
[PHP] Prevent deprecated error "Passing null to parameter #1 ($string) of type string is deprecated

### DIFF
--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -640,7 +640,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
                 }
             }
 
-            return htmlspecialchars($data->getValue() . $unit, ENT_QUOTES, 'UTF-8');
+            return htmlspecialchars((string)$data->getValue() . $unit, ENT_QUOTES, 'UTF-8');
         }
 
         return '';

--- a/models/DataObject/ClassDefinition/Data/Select.php
+++ b/models/DataObject/ClassDefinition/Data/Select.php
@@ -321,7 +321,7 @@ class Select extends Data implements
      */
     public function getVersionPreview($data, $object = null, $params = [])
     {
-        return htmlspecialchars($data, ENT_QUOTES, 'UTF-8');
+        return htmlspecialchars((string)$data, ENT_QUOTES, 'UTF-8');
     }
 
     /**


### PR DESCRIPTION
In `getVersionPreview()` method of some field types `htmlspecialchars()` gets called. Nowadays this triggers the deprecation error `Passing null to parameter #1 ($string) of type string is deprecated` if called with `null`. This PR casts the provided `$data` to a string to prevent this error, in analogy to https://github.com/pimcore/pimcore/blob/a837b3375ac230c537520db1b4fc79fcbabb1e49/models/DataObject/ClassDefinition/Data/Extension/Text.php#L61