### PR TITLE
Fix: Do not cast resources to string

### DIFF
--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -252,7 +252,7 @@ class Processor
                 }
 
                 if (is_resource($fileSystemPath)) {
-                    $fileSystemPath = self::getLocalFileFromStream((string)$fileSystemPath);
+                    $fileSystemPath = self::getLocalFileFromStream($fileSystemPath);
                 }
 
                 if (!file_exists($fileSystemPath)) {

--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -155,7 +155,7 @@ final class ImageThumbnail
                         $this->pathReference = Image\Thumbnail\Processor::process(
                             $this->asset,
                             $this->getConfig(),
-                            (string)$cacheFileStream,
+                            $cacheFileStream,
                             $deferred,
                             $generated
                         );


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.6`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.6` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #13720 

## Additional info  
Casting resources to string will result e.g.  in the following string "Resource id #90"
