### PR TITLE
Fix preGetData missing language param for Data\Wysiwyg

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -343,6 +343,7 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
         return Text::wysiwygText($data, [
                 'object' => $container,
                 'context' => $this,
+                'language' => $params['language'],
             ]);
     }
 

--- a/models/DataObject/ClassDefinition/Data/Wysiwyg.php
+++ b/models/DataObject/ClassDefinition/Data/Wysiwyg.php
@@ -343,7 +343,7 @@ class Wysiwyg extends Data implements ResourcePersistenceAwareInterface, QueryRe
         return Text::wysiwygText($data, [
                 'object' => $container,
                 'context' => $this,
-                'language' => $params['language'],
+                'language' => $params['language'] ?? null,
             ]);
     }
 


### PR DESCRIPTION
Without this PR a link generator won't be able to know for which language to generate the link in the WYSIWYG for.

Only a `context` is passed, but it does not contain the current language/index from the LocalizedField.
![image](https://user-images.githubusercontent.com/9052094/208437818-c329b3d8-78b6-4e1d-874b-5fdfa98fe8ba.png)

Maybe for future versions, it would be better to use `_locale` for links as recommended by Symfony.

Also see https://github.com/pimcore/pimcore/blob/11.x/models/DataObject/Localizedfield.php#L502
