### PR TITLE
[Tags] Enhance tag UI

### DIFF
--- a/bundles/AdminBundle/public/js/pimcore/element/selector/abstract.js
+++ b/bundles/AdminBundle/public/js/pimcore/element/selector/abstract.js
@@ -103,7 +103,10 @@ pimcore.element.selector.abstract = Class.create({
                 items: [tree.getLayout()],
                 title: t('filter_tags'),
                 tbar: [considerAllChildTags],
-                iconCls: "pimcore_icon_element_tags"
+                iconCls: "pimcore_icon_element_tags",
+                resizable: {
+                    dynamic: true
+                }
             });
         }
 

--- a/bundles/AdminBundle/public/js/pimcore/element/tag/assignment.js
+++ b/bundles/AdminBundle/public/js/pimcore/element/tag/assignment.js
@@ -79,13 +79,14 @@ pimcore.element.tag.assignment = Class.create({
                 store: gridStore,
                 columnLines: true,
                 stripeRows: true,
+                resizable: true,
                 columns: {
                     items: [
                         {
                             text: t("name"),
                             dataIndex: 'path',
                             sortable: true,
-                            width: 400
+                            flex: 1
                         },
                         {
                             xtype: 'actioncolumn',

--- a/bundles/AdminBundle/public/js/pimcore/element/tag/tree.js
+++ b/bundles/AdminBundle/public/js/pimcore/element/tag/tree.js
@@ -232,10 +232,18 @@ pimcore.element.tag.tree = Class.create({
         var user = pimcore.globalmanager.get("user");
 
         var menu = new Ext.menu.Menu();
-        var hasEntries = false;
+
+        if(index === 0) {
+            menu.add(new Ext.menu.Item({
+                text: t('reload'),
+                iconCls: "pimcore_icon_reload",
+                handler: function (tree) {
+                    this.tree.getStore().reload();
+                }.bind(this)
+            }));
+        }
 
         if (this.allowAdd && user.isAllowed("tags_configuration")) {
-            hasEntries = true;
             menu.add(new Ext.menu.Item({
                 text: t('add'),
                 iconCls: "pimcore_icon_add",
@@ -246,7 +254,6 @@ pimcore.element.tag.tree = Class.create({
         }
 
         if (this.allowDelete && user.isAllowed("tags_configuration") && index !== 0) {
-            hasEntries = true;
             menu.add(new Ext.menu.Item({
                 text: t('delete'),
                 iconCls: "pimcore_icon_delete",
@@ -270,7 +277,6 @@ pimcore.element.tag.tree = Class.create({
         }
 
         if (this.allowRename && user.isAllowed("tags_configuration") && index !== 0) {
-            hasEntries = true;
             menu.add(new Ext.menu.Item({
                 text: t('rename'),
                 iconCls: "pimcore_icon_key pimcore_icon_overlay_go",
@@ -310,7 +316,7 @@ pimcore.element.tag.tree = Class.create({
             }));
         }
 
-        if (hasEntries) {
+        if (menu.items.getCount() > 0) {
             menu.showAt(e.pageX, e.pageY);
         }
 


### PR DESCRIPTION
This PR brings:
- resizable "assigned tags" panel when assigning tags to elements (otherwise long tag paths may not be visible)
- use full panel width for assigned element tags (before the tag path column was hard-coded to 400px)
- add context menu item to "All Tags" in tag tree to reload tag tree

Tag assignment panel before:
<img width="1032" alt="Bildschirmfoto 2022-12-20 um 07 52 57" src="https://user-images.githubusercontent.com/8749138/208602231-622250bd-5dbe-4503-be2f-e57297c6a644.png">

Tag assignment panel after:
<img width="1294" alt="Bildschirmfoto 2022-12-20 um 07 52 09" src="https://user-images.githubusercontent.com/8749138/208602259-17f2ff8c-1ae8-4a60-a512-ccc52281e89f.png">
(I manually adjusted tag tree panel size - initially it is equally wide as before)