### PR TITLE
Translation::getByKeyLocalized(): Remove unnecessary func_get_args()

### DIFF
--- a/models/Translation.php
+++ b/models/Translation.php
@@ -288,12 +288,6 @@ final class Translation extends AbstractModel
      */
     public static function getByKeyLocalized(string $id, string $domain = self::DOMAIN_DEFAULT, bool $create = false, bool $returnIdIfEmpty = false, string $language = null): ?string
     {
-        $args = func_get_args();
-        $domain = $args[1] ?? self::DOMAIN_DEFAULT;
-        $create = $args[2] ?? false;
-        $returnIdIfEmpty = $args[3] ?? false;
-        $language = $args[4] ?? null;
-
         if ($domain == self::DOMAIN_ADMIN) {
             if ($user = Tool\Admin::getCurrentUser()) {
                 $language = $user->getLanguage();


### PR DESCRIPTION
Was introduced by https://github.com/pimcore/pimcore/pull/7800 but the params now uncommented by https://github.com/pimcore/pimcore/pull/13474