### PR TITLE
Fix `property_exists(): Passing null to parameter #2 ($property) of type string is deprecated`

### DIFF
--- a/models/DataObject/Traits/ObjectVarTrait.php
+++ b/models/DataObject/Traits/ObjectVarTrait.php
@@ -44,7 +44,7 @@ trait ObjectVarTrait
     }
 
     /**
-     * @param string $var
+     * @param string|null $var
      *
      * @return mixed
      */

--- a/models/DataObject/Traits/ObjectVarTrait.php
+++ b/models/DataObject/Traits/ObjectVarTrait.php
@@ -50,7 +50,7 @@ trait ObjectVarTrait
      */
     public function getObjectVar($var)
     {
-        if (!property_exists($this, $var)) {
+        if (!$var || !property_exists($this, $var)) {
             return null;
         }
 


### PR DESCRIPTION
Fixes:

> Deprecated: property_exists(): Passing null to parameter #2 ($property) of type string is deprecated in /var/www/pimcore/vendor/pimcore/pimcore/models/DataObject/Traits/ObjectVarTrait.php on line 53