### PR TITLE
PhpStan: Remove ignored error pattern from baseline file

### DIFF
--- a/lib/Tool/Text/Csv.php
+++ b/lib/Tool/Text/Csv.php
@@ -24,10 +24,6 @@ namespace Pimcore\Tool\Text;
 class Csv
 {
     /**
-     * @param string $data
-     *
-     * @return \stdClass
-     *
      * @throws \Exception
      */
     public function detect(string $data): \stdClass
@@ -60,10 +56,6 @@ class Csv
     }
 
     /**
-     * @param string $data
-     *
-     * @return string
-     *
      * @phpstan-return non-empty-string
      */
     protected function guessLinefeed(string $data): string
@@ -79,10 +71,10 @@ class Csv
             return "$cr$lf";
         }
         if ($count_cr == 0 && $count_lf > 0) {
-            return (string)$lf;
+            return $lf;
         }
         if ($count_lf == 0 && $count_cr > 0) {
-            return (string)$cr;
+            return $cr;
         }
 
         // sane default: cr+lf
@@ -98,7 +90,7 @@ class Csv
         $patterns[] = '/(?:^|\n)(["\']).*?(\2)(?:$|\n)/';
 
         foreach ($patterns as $pattern) {
-            if ($nummatches = preg_match_all($pattern, $data, $matches)) {
+            if (preg_match_all($pattern, $data, $matches)) {
                 if ($matches) {
                     break;
                 }
@@ -125,6 +117,9 @@ class Csv
         return [$quote, $delim];
     }
 
+    /**
+     * @phpstan-param non-empty-string $linefeed
+     */
     protected function guessDelim(string $data, string $linefeed, string $quotechar): bool|string
     {
         $charcount = count_chars($data, 1);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -136,11 +136,6 @@ parameters:
 			path: lib/Tool/Serialize.php
 
 		-
-			message: "#^Parameter \\#1 \\$separator of function explode expects non\\-empty\\-string, string given\\.$#"
-			count: 1
-			path: lib/Tool/Text/Csv.php
-
-		-
 			message: "#^Negated boolean expression is always true\\.$#"
 			count: 1
 			path: models/Asset/Video/ImageThumbnail.php


### PR DESCRIPTION
```
------ ----------------------------------------------------------------------- 
  Line   lib/Tool/Text/Csv.php                                                  
 ------ ----------------------------------------------------------------------- 
         Ignored error pattern #^Parameter \#1 \$separator of function explode  
         expects non\-empty\-string, string given\.$# in path                   
         /home/runner/work/pimcore/pimcore/lib/Tool/Text/Csv.php was not        
         matched in reported errors.                                            
 ------ ----------------------------------------------------------------------- 


Error:  [ERROR] Found 1 error                                                    
```