### PR TITLE
Unit::setBaseunit() must allow string and null

### DIFF
--- a/models/DataObject/QuantityValue/Unit.php
+++ b/models/DataObject/QuantityValue/Unit.php
@@ -167,7 +167,7 @@ class Unit extends Model\AbstractModel
         return $this->abbreviation;
     }
 
-    public function setBaseunit(Unit|int $baseunit): static
+    public function setBaseunit(Unit|string|null $baseunit): static
     {
         if ($baseunit instanceof self) {
             $baseunit = $baseunit->getId();


### PR DESCRIPTION
You get errors if you try to load a unit with baseunit.