### PR TITLE
[Tests] docker compose should use debug image as stated in the docs

### DIFF
--- a/tests/bin/docker-compose.yml
+++ b/tests/bin/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
     php:
 #        user: '1000:1000' # set to your uid:gid
-        image: pimcore/pimcore:php8.1-latest
+        image: pimcore/pimcore:php8.1-debug-latest
         environment:
             PHP_IDE_CONFIG: "serverName=localhost"
             COMPOSER_HOME: /var/www/html


### PR DESCRIPTION
Docs say: 
> The docker images are based on the debug images, thus it is also possible to debug the tests using xdebug. Make sure, that path mappings are applied correctly though





https://pimcore.com/docs/pimcore/current/Development_Documentation/Development_Tools_and_Details/Testing/Core_Tests.html