### PR TITLE
[Bug]: Avoid error of protected property starting with "\0" when removing reference loops

### DIFF
--- a/lib/Tool/Serialize.php
+++ b/lib/Tool/Serialize.php
@@ -102,8 +102,9 @@ final class Serialize
             $propCollection = get_object_vars($clone);
 
             foreach ($propCollection as $name => $propValue) {
-                $name = trim($name);
-                $clone->$name = self::loopFilterCycles($propValue);
+                if (!str_starts_with($name, "\0")) {
+                    $clone->$name = self::loopFilterCycles($propValue);
+                }
             }
 
             array_splice(self::$loopFilterProcessedObjects, array_search($element, self::$loopFilterProcessedObjects, true), 1);

--- a/lib/Tool/Serialize.php
+++ b/lib/Tool/Serialize.php
@@ -102,7 +102,9 @@ final class Serialize
             $propCollection = get_object_vars($clone);
 
             foreach ($propCollection as $name => $propValue) {
-                $clone->$name = self::loopFilterCycles($propValue);
+                if(is_array($propValue) || (is_object($propValue))){
+                    $clone->$name = self::loopFilterCycles($propValue);
+                }
             }
 
             array_splice(self::$loopFilterProcessedObjects, array_search($element, self::$loopFilterProcessedObjects, true), 1);

--- a/lib/Tool/Serialize.php
+++ b/lib/Tool/Serialize.php
@@ -102,9 +102,8 @@ final class Serialize
             $propCollection = get_object_vars($clone);
 
             foreach ($propCollection as $name => $propValue) {
-                if(is_array($propValue) || (is_object($propValue))){
-                    $clone->$name = self::loopFilterCycles($propValue);
-                }
+                $name = trim($name);
+                $clone->$name = self::loopFilterCycles($propValue);
             }
 
             array_splice(self::$loopFilterProcessedObjects, array_search($element, self::$loopFilterProcessedObjects, true), 1);


### PR DESCRIPTION
There are events if the propvalue is 0 (for never-published documents of Pimcore 6 after upgrading to Pimcore X for example). Prevent errors like 'Cannot access property starting with "\0"' here.

## Changes in this pull request  
Resolves recent comment in #11801

## Additional info  
To reproduce the bug create a pimcore 6.9.6, create a document without ever publishing it, update to Pimcore 10.5.9+ and try to open it.
