### PR TITLE
Fix fclose(): supplied resource is not a valid stream resource

### DIFF
--- a/models/Asset/Video/Thumbnail/Processor.php
+++ b/models/Asset/Video/Thumbnail/Processor.php
@@ -238,6 +238,11 @@ class Processor
 
                 if ($success) {
                     $source = fopen($converter->getDestinationFile(), 'rb');
+                    if (false === $source) {
+                        $conversionStatus = 'error';
+                        Logger::info('could not open stream resource at path "' . $converter->getDestinationFile() . '" for Video conversion.');
+                        continue;
+                    }
                     Storage::get('thumbnail')->writeStream($converter->getStorageFile(), $source);
                     fclose($source);
                     unlink($converter->getDestinationFile());


### PR DESCRIPTION
This happens quite often on our setup, not sure why, but this fixes the issue.

