### PR TITLE
[Bug]: AdvancedManyToMany Document key quoted twice and small tweak

### DIFF
--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -267,16 +267,13 @@ class AdvancedManyToManyRelation extends ManyToManyRelation implements IdRewrite
                 $identifier = 'id';
                 $pathCol = 'path';
                 $typeCol = 'type';
+                
+                $keyCol = 'key';
+                $className = '';
                 if ($targetType == 'object') {
-                    $keyCol = 'key';
                     $className = ', className';
-                } else {
-                    if ($targetType == 'asset') {
-                        $keyCol = 'filename';
-                    } else {
-                        $keyCol = '`key`';
-                    }
-                    $className = '';
+                } elseif ($targetType == 'asset') {
+                    $keyCol = 'filename';
                 }
 
                 $result = $db->fetchAllAssociative(


### PR DESCRIPTION
Follow-up https://github.com/pimcore/pimcore/pull/13816

The [$db->quoteIdentifier($keyCol)](https://github.com/pimcore/pimcore/pull/13816/files#diff-1d0bb2ae86274681b1012717ccb5958660cfdaf177d0c2a3e5f6b1cf039dbf98R286) change without removing the quotes from https://github.com/pimcore/pimcore/blob/c66349e3eca2aa5cfd24444ff8814ba9b107b77e/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php#L277 resulted in having the quote twice
![image](https://user-images.githubusercontent.com/6014195/209830380-a9f4a407-70f2-4e3e-a1d6-68f6cce9e9ee.png)


To reproduce: 
create a many to many relation object field and allow documents


Also tweaked a little bit the code to avoid too many nested else, better "default" values.