### PR TITLE
Refactor `Relation::getPhpDocClassString()`

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -577,7 +577,7 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
      */
     protected function getPhpdocType(): string
     {
-        return implode(' | ', $this->getPhpDocClassString(true));
+        return $this->getPhpDocClassString(true);
     }
 
     public function normalize(mixed $value, array $params = []): ?array

--- a/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
@@ -652,7 +652,7 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
      */
     protected function getPhpdocType(): string
     {
-        return implode(' | ', $this->getPhpDocClassString(true));
+        return $this->getPhpDocClassString(true);
     }
 
     public function normalize(mixed $value, array $params = []): ?array

--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -500,7 +500,7 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
      */
     protected function getPhpdocType(): string
     {
-        return implode(' | ', $this->getPhpDocClassString(false));
+        return $this->getPhpDocClassString(false);
     }
 
     public function normalize(mixed $value, array $params = []): ?array

--- a/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/AbstractRelations.php
@@ -64,9 +64,7 @@ abstract class AbstractRelations extends Data implements
     public ?string $pathFormatterClass = null;
 
     /**
-     * @return array[
-     *  'classes' => string,
-     * ]
+     * @return array<array{classes: string}>
      */
     public function getClasses(): array
     {


### PR DESCRIPTION
While working on #12645 I refactored `Relation::getPhpDocClassString()` a bit. It returns now a `string`, as the name says. The rest is just cleanup.