### PR TITLE
[Bug]: Set `login_screen_custom_image` default to empty string to avoid `twig_matches` error

### DIFF
--- a/bundles/AdminBundle/DependencyInjection/Configuration.php
+++ b/bundles/AdminBundle/DependencyInjection/Configuration.php
@@ -123,7 +123,7 @@ final class Configuration implements ConfigurationInterface
                         ->defaultNull()
                     ->end()
                     ->scalarNode('login_screen_custom_image')
-                        ->defaultNull()
+                        ->defaultValue('')
                     ->end()
                 ->end()
             ->end()


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/13939, https://github.com/pimcore/skeleton/issues/130

## Additional info  
Related and alternative fix to https://github.com/pimcore/skeleton/pull/131
