### PR TITLE
DynamicTextLabelInterface: params type should be an array

### DIFF
--- a/bundles/AdminBundle/src/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/DataObject/ClassController.php
@@ -1302,7 +1302,7 @@ class ClassController extends AdminController implements KernelControllerEventIn
 
         $forObjectEditor = $request->get('forObjectEditor');
 
-        $context = null;
+        $context = [];
         $layoutDefinitions = [];
         $groups = [];
         $definitions = [];

--- a/models/DataObject/ClassDefinition/Data/LayoutDefinitionEnrichmentInterface.php
+++ b/models/DataObject/ClassDefinition/Data/LayoutDefinitionEnrichmentInterface.php
@@ -27,7 +27,7 @@ interface LayoutDefinitionEnrichmentInterface
      *
      *
      * @param Concrete|null $object
-     * @param array $context additional contextual data like fieldname etc.
+     * @param array<string, mixed> $context additional contextual data like fieldname etc.
      *
      * @return $this
      *

--- a/models/DataObject/ClassDefinition/Layout/DynamicTextLabelInterface.php
+++ b/models/DataObject/ClassDefinition/Layout/DynamicTextLabelInterface.php
@@ -22,6 +22,7 @@ interface DynamicTextLabelInterface
 {
     /**
      * @param string $data as provided in the class definition
+     * @param array<string, mixed> $params
      */
     public function renderLayoutText(string $data, ?Concrete $object, array $params): string;
 }

--- a/models/DataObject/ClassDefinition/Layout/DynamicTextLabelInterface.php
+++ b/models/DataObject/ClassDefinition/Layout/DynamicTextLabelInterface.php
@@ -22,10 +22,6 @@ interface DynamicTextLabelInterface
 {
     /**
      * @param string $data as provided in the class definition
-     * @param Concrete|null $object
-     * @param mixed $params
-     *
-     * @return string
      */
-    public function renderLayoutText(string $data, ?Concrete $object, mixed $params): string;
+    public function renderLayoutText(string $data, ?Concrete $object, array $params): string;
 }

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1370,7 +1370,7 @@ class Service extends Model\Element\Service
      *
      * @param Model\DataObject\ClassDefinition\Data|Model\DataObject\ClassDefinition\Layout|null $layout
      * @param Concrete|null $object
-     * @param array $context additional contextual data
+     * @param array<string, mixed> $context additional contextual data
      *
      * @internal
      */


### PR DESCRIPTION
See the usage in the Text layout class:
https://github.com/pimcore/pimcore/blob/9f214972ae0cd1bbf560a030e32c80090e8e37d2/models/DataObject/ClassDefinition/Layout/Text.php#L108-L122