### PR TITLE
[Bug]: versions 500 error when field collection is removed

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/fieldcollection.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/fieldcollection.js
@@ -189,7 +189,7 @@ pimcore.object.fieldcollection = Class.create({
 
     addFieldComplete: function (button, value, object) {
 
-        var isValidName = /^[a-zA-Z]+$/;
+        var isValidName = /^[a-zA-Z][a-zA-Z0-9]*$/;
 
         if (button == "ok" && value.length > 2 && isValidName.test(value) && !in_arrayi(value, this.forbiddenNames)) {
             Ext.Ajax.request({

--- a/models/DataObject/Fieldcollection.php
+++ b/models/DataObject/Fieldcollection.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Model\DataObject;
 
+use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Element\DirtyIndicatorInterface;
@@ -362,6 +363,18 @@ class Fieldcollection extends Model\AbstractModel implements \Iterator, DirtyInd
                     if ($fieldValue instanceof Localizedfield) {
                         $fieldValue->loadLazyData();
                     }
+                }
+            }
+        }
+    }
+
+    public function __wakeup()
+    {
+        if (is_array($this->items)) {
+            foreach ($this->items as $key => $item) {
+                if ($item instanceof \__PHP_Incomplete_Class) {
+                    unset($this->items[$key]);
+                    Logger::error('fieldcollection item ' . $key . ' does not exist anymore');
                 }
             }
         }

--- a/models/DataObject/Fieldcollection.php
+++ b/models/DataObject/Fieldcollection.php
@@ -34,7 +34,7 @@ class Fieldcollection extends Model\AbstractModel implements \Iterator, DirtyInd
     /**
      * @internal
      *
-     * @var TItem[]
+     * @var array<TItem|\__PHP_Incomplete_Class>
      */
     protected $items = [];
 

--- a/models/DataObject/Objectbrick.php
+++ b/models/DataObject/Objectbrick.php
@@ -319,8 +319,6 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
 
     public function __wakeup()
     {
-        $brickGetter = null;
-
         // for backwards compatibility
         if ($this->object) {
             $this->objectId = $this->object->getId();
@@ -339,7 +337,7 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
             foreach ($this->items as $key => $item) {
                 if ($item instanceof \__PHP_Incomplete_Class) {
                     unset($this->items[$key]);
-                    Logger::error('brick ' . $brickGetter . ' does not exist anymore');
+                    Logger::error('brick item ' . $key . ' does not exist anymore');
                 }
             }
         }


### PR DESCRIPTION
Resolves https://github.com/pimcore/pimcore/issues/13749
Alternative to https://github.com/pimcore/pimcore/pull/13932

It should be possible to set a number to the fieldcollection name (like in objectbricks).
Also the logging in the objectbricks __wakeup method is wrong.