### PR TITLE
[Installer] Fix eventually occurring 'too many connections' problem

### DIFF
--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -635,6 +635,11 @@ class Installer
 
         $db->executeQuery('SET FOREIGN_KEY_CHECKS=1;');
 
+        // close connections and wait a bit for closing them ... in order to avoid too many connections error
+        // when installing demos
+        $db->close();
+        sleep(10);
+
         return $errors;
     }
 

--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -635,10 +635,9 @@ class Installer
 
         $db->executeQuery('SET FOREIGN_KEY_CHECKS=1;');
 
-        // close connections and wait a bit for closing them ... in order to avoid too many connections error
+        // close connections and collection garbage ... in order to avoid too many connections error
         // when installing demos
-        $db->close();
-        sleep(20);
+        \Pimcore::collectGarbage();
 
         return $errors;
     }

--- a/bundles/InstallBundle/Installer.php
+++ b/bundles/InstallBundle/Installer.php
@@ -638,7 +638,7 @@ class Installer
         // close connections and wait a bit for closing them ... in order to avoid too many connections error
         // when installing demos
         $db->close();
-        sleep(10);
+        sleep(20);
 
         return $errors;
     }


### PR DESCRIPTION
During install (especially with installation packages and when doctrine/orm is in place) eventually 'too many connections' problem occurred. This PR fixes it by collecting garbage and closing db connections. 