### PR TITLE
Revert "[Bug]: Avoid error of protected property starting with "\0" when removing reference loops"

### DIFF
--- a/lib/Tool/Serialize.php
+++ b/lib/Tool/Serialize.php
@@ -102,9 +102,7 @@ final class Serialize
             $propCollection = get_object_vars($clone);
 
             foreach ($propCollection as $name => $propValue) {
-                if (!str_starts_with($name, "\0")) {
-                    $clone->$name = self::loopFilterCycles($propValue);
-                }
+                $clone->$name = self::loopFilterCycles($propValue);
             }
 
             array_splice(self::$loopFilterProcessedObjects, array_search($element, self::$loopFilterProcessedObjects, true), 1);


### PR DESCRIPTION
Reverts pimcore/pimcore#13901

Merged in 10.6 instead of 10.5.x