### PR TITLE
[Bug]: Avoid error of protected property starting with "\0" when removing reference loops

### DIFF
--- a/lib/Tool/Serialize.php
+++ b/lib/Tool/Serialize.php
@@ -102,7 +102,9 @@ final class Serialize
             $propCollection = get_object_vars($clone);
 
             foreach ($propCollection as $name => $propValue) {
-                $clone->$name = self::loopFilterCycles($propValue);
+                if (!str_starts_with($name, "\0")) {
+                    $clone->$name = self::loopFilterCycles($propValue);
+                }
             }
 
             array_splice(self::$loopFilterProcessedObjects, array_search($element, self::$loopFilterProcessedObjects, true), 1);


### PR DESCRIPTION
Same as https://github.com/pimcore/pimcore/pull/13901
but i've forgot to change base branch in 10.6 in that PR

