### PR TITLE
Fix data object csv export

### DIFF
--- a/bundles/AdminBundle/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1420,7 +1420,10 @@ class DataObjectHelperController extends AdminController
         return $this->adminJson(['success' => true]);
     }
 
-    public function encodeFunc($value): string
+    /**
+     * @param array{fieldName: string, data: string} $value
+     */
+    public function encodeFunc(array $value): string
     {
         $value = $value['data'];
         $value = str_replace('"', '""', $value);

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1818,17 +1818,9 @@ class Service extends Model\Element\Service
     }
 
     /**
-     * @param string $fallbackLanguage
-     * @param string $field
-     * @param DataObject\Concrete $object
-     * @param string $requestedLanguage
-     * @param array $helperDefinitions
-     *
-     * @return mixed
-     *
      * @internal
      */
-    protected static function getCsvFieldData(string $fallbackLanguage, string $field, Concrete $object, string $requestedLanguage, array $helperDefinitions): mixed
+    protected static function getCsvFieldData(string $fallbackLanguage, string $field, Concrete $object, string $requestedLanguage, array $helperDefinitions): string
     {
         //check if field is systemfield
         $systemFieldMap = [
@@ -1844,7 +1836,7 @@ class Service extends Model\Element\Service
         if (in_array($field, array_keys($systemFieldMap))) {
             $getter = $systemFieldMap[$field];
 
-            return $object->$getter();
+            return (string) $object->$getter();
         } else {
             //check if field is standard object field
             $fieldDefinition = $object->getClass()->getFieldDefinition($field);
@@ -1970,7 +1962,7 @@ class Service extends Model\Element\Service
             }
         }
 
-        return null;
+        return '';
     }
 
     /**

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -538,7 +538,7 @@ class Service extends Model\Element\Service
         return $config;
     }
 
-    public static function calculateCellValue(AbstractObject $object, array $helperDefinitions, string $key, array $context = []): array|\stdClass|null
+    public static function calculateCellValue(AbstractObject $object, array $helperDefinitions, string $key, array $context = []): mixed
     {
         $config = static::getConfigForHelperDefinition($helperDefinitions, $key, $context);
         if (!$config) {
@@ -1855,7 +1855,7 @@ class Service extends Model\Element\Service
                             $cellValue = implode(',', $cellValue);
                         }
 
-                        return $cellValue;
+                        return (string) $cellValue;
                     }
                 } elseif (substr($field, 0, 1) == '~') {
                     $type = $fieldParts[1];


### PR DESCRIPTION
Following error if you want to export data object with ID column:
`str_replace(): Argument #3 ($subject) must be of type array|string, int given`

If you use a char counter operator you get following error:
`Pimcore\\Model\\DataObject\\Service::calculateCellValue(): Return value must be of type stdClass|array|null, int returned`