### PR TITLE
fix deadlock while saving assets concurrently

### DIFF
--- a/models/Asset/Dao.php
+++ b/models/Asset/Dao.php
@@ -128,7 +128,11 @@ class Dao extends Model\Element\Dao
         }
 
         // metadata
-        $this->db->delete('assets_metadata', ['cid' => $this->model->getId()]);
+        $dataExists = $this->db->fetchOne('SELECT `name` FROM assets_metadata WHERE cid = ? LIMIT 1', [$this->model->getId()]);
+        if($dataExists) {
+            $this->db->delete('assets_metadata', ['cid' => $this->model->getId()]);
+        }
+
         /** @var array $metadata */
         $metadata = $this->model->getMetadata(null, null, false, true);
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
The PR resolves issues while concurrently saving assets, due to the gap lock created while storing assets metadata

## Additional info  

