### PR TITLE
Fix: Return all possible types and subtypes for mime type

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -528,13 +528,13 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }
 
         // check if there is a requested type and if matches the asset type of the uploaded file
-        $type = $request->get('type');
-        if ($type) {
+        $uploadAssetType = $request->get('uploadAssetType');
+        if ($uploadAssetType) {
             $mimetype = MimeTypes::getDefault()->guessMimeType($sourcePath);
             $assetType = Asset::getTypeFromMimeMapping($mimetype, $filename);
 
-            if ($type !== $assetType) {
-                throw new \Exception("Mime type does not match with asset type: $type");
+            if ($uploadAssetType !== $assetType) {
+                throw new \Exception("Mime type $mimetype does not match with asset type: $uploadAssetType");
             }
         }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/image.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/image.js
@@ -252,7 +252,7 @@ pimcore.document.editables.image = Class.create(pimcore.document.editable, {
                 pimcore.helpers.showNotification(t("error"), res, "error",
                     res.response.responseText);
             }
-        }.bind(this), [] ,this.getType());
+        }.bind(this), [], "image");
     },
 
     onNodeOver: function(target, dd, e, data) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -949,7 +949,7 @@ pimcore.helpers.openMemorizedTabs = function () {
     }
 };
 
-pimcore.helpers.assetSingleUploadDialog = function (parent, parentType, success, failure, context, type) {
+pimcore.helpers.assetSingleUploadDialog = function (parent, parentType, success, failure, context, uploadAssetType) {
 
     var params = {};
     params['parent' + ucfirst(parentType)] = parent;
@@ -959,8 +959,8 @@ pimcore.helpers.assetSingleUploadDialog = function (parent, parentType, success,
         url += "&context=" + Ext.encode(context);
     }
 
-    if(type) {
-        url += "&type=" + type;
+    if(uploadAssetType) {
+        url += "&uploadAssetType=" + uploadAssetType;
     }
 
     pimcore.helpers.uploadDialog(url, 'Filedata', success, failure);

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
@@ -14,7 +14,7 @@
 pimcore.registerNS("pimcore.object.tags.hotspotimage");
 pimcore.object.tags.hotspotimage = Class.create(pimcore.object.tags.image, {
 
-    type: "hotspotimage",
+    type: "image",
     data: null,
 
     marginTop: 10,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/hotspotimage.js
@@ -14,7 +14,7 @@
 pimcore.registerNS("pimcore.object.tags.hotspotimage");
 pimcore.object.tags.hotspotimage = Class.create(pimcore.object.tags.image, {
 
-    type: "image",
+    type: "hotspotimage",
     data: null,
 
     marginTop: 10,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/image.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/image.js
@@ -275,7 +275,7 @@ pimcore.object.tags.image = Class.create(pimcore.object.tags.abstract, {
                 pimcore.helpers.showNotification(t("error"), res, "error",
                     res.response.responseText);
             }
-        }.bind(this), this.context, this.type);
+        }.bind(this), this.context, "image");
     },
 
     addDataFromSelector: function (item) {


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #14003 

## Additional info  
`getTypeFromMimeMapping` does not return all subtypes for a mime type e.g. it return image for an hotspot image.
`getTypeFromMimeMapping` has now a third parameter which is the mapping itself which can be changed
