### PR TITLE
[Task]: Remove empty Submenu when building menu

### DIFF
--- a/bundles/AdminBundle/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/public/js/pimcore/helpers.js
@@ -3232,6 +3232,12 @@ pimcore.helpers.buildMenu = function(items) {
             continue;
         }
 
+        // if the submenu has no items, remove the submenu itself
+        if(items[i].menu.items.length === 0){
+            items.splice(i, 1);
+            continue;
+        }
+        
         pimcore.helpers.buildMenu(items[i].menu.items);
         items[i].menu = Ext.create('pimcore.menu.menu', items[i].menu);
     }


### PR DESCRIPTION
## Changes in this pull request  
Followup of the menu building introduced in https://github.com/pimcore/pimcore/pull/13811

## Notes
Found this case here https://github.com/pimcore/pimcore/pull/13967#discussion_r1064886252 but with this PR, i am moving the logic in the helper.js to make it recursive