### PR TITLE
[Bug]: Fix `getEditables()` not returning inherited editables

### DIFF
--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -503,7 +503,11 @@ abstract class PageSnippet extends Model\Document
     public function getEditables(): array
     {
         if ($this->editables === null) {
-            $this->setEditables($this->getDao()->getEditables());
+            $documentEditables = $this->getDao()->getEditables();
+            if ($this->supportsContentMaster() && $contentMasterEditables = $this->getContentMasterDocument()?->getDao()->getEditables()){
+                $documentEditables = array_merge($contentMasterEditables, $documentEditables);
+            }
+            $this->setEditables($documentEditables);
         }
 
         return $this->editables;

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -504,7 +504,8 @@ abstract class PageSnippet extends Model\Document
     {
         if ($this->editables === null) {
             $documentEditables = $this->getDao()->getEditables();
-            if ($this->supportsContentMaster() && $contentMasterEditables = $this->getContentMasterDocument()?->getDao()->getEditables()){
+            if ($this->supportsContentMaster() && $this->getContentMasterDocument()){
+                $contentMasterEditables = $this->getContentMasterDocument()->getDao()->getEditables();
                 $documentEditables = array_merge($contentMasterEditables, $documentEditables);
             }
             $this->setEditables($documentEditables);


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/12762

## Additional info  

Not quite sure if it could be considered as a bug or if it would BC break; on the issue is marked as an improvement for 11.x.
Creating PR for 10.5 for the moment, so in case, it should be easier to switch branch base.
