### PR TITLE
[Data objects] Catch error when loading data object whose latest version is not accessible

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -381,7 +381,11 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
         // set the latest available version for editmode
         $draftVersion = null;
-        $object = $this->getLatestVersion($objectFromDatabase, $draftVersion);
+        try {
+            $object = $this->getLatestVersion($objectFromDatabase, $draftVersion);
+        } catch(\Exception $e) {
+            $object = $objectFromDatabase;
+        }
 
         // check for lock
         if ($object->isAllowed('save') || $object->isAllowed('publish') || $object->isAllowed('unpublish') || $object->isAllowed('delete')) {


### PR DESCRIPTION
Steps to reproduce:

1. Create object
2. Save object or let auto-draft version be created
3. Remove the version file from the storage (e.g. from `<Pimcore root>/var/versions/...`)
4. In Pimcore backend, try to open the object.

Result: There will be an error like 
`Version: cannot read version data with storage type: fs`
and the object does not get opened.

With this PR the object will get opened and the problem that the latest version cannot be loaded is ignored.