### PR TITLE
[Bug]: Data from localized field in block is not deleted 

### DIFF
--- a/lib/DataObject/BlockDataMarshaller/Localizedfields.php
+++ b/lib/DataObject/BlockDataMarshaller/Localizedfields.php
@@ -87,6 +87,8 @@ class Localizedfields implements MarshallerInterface
             foreach ($value as $language => $items) {
                 $result[$language] = [];
                 foreach ($items as $key => $normalizedData) {
+                    if (!isset($childDefs[$key])) continue;
+
                     $childDef = $childDefs[$key];
 
                     if ($this->marshallerService->supportsFielddefinition('block', $childDef->getFieldtype())) {


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #13807

## Additional info  
Data which are stored in DB but are not longer registered as a field in the class definition are initially skipped. After saving/updating the DAO are these fields removed from DB.
