### PR TITLE
Fix deprecation condition in `Navigation\Builder` class

### DIFF
--- a/lib/Navigation/Builder.php
+++ b/lib/Navigation/Builder.php
@@ -128,8 +128,8 @@ class Builder
      */
     public function getNavigation($activeDocument = null, $navigationRootDocument = null, $htmlMenuIdPrefix = null, $pageCallback = null, $cache = true, ?int $maxDepth = null, ?int $cacheLifetime = null)
     {
-        //TODO Pimcore 11: remove the `if (func_num_args() > 1)` block to remove the BC layer
-        if (func_num_args() > 1) {
+        //TODO Pimcore 11: remove the `if (...)` block to remove the BC layer
+        if (func_num_args() > 1 || ($activeDocument !== null && !is_array($activeDocument))) {
             trigger_deprecation('pimcore/pimcore', '10.5', 'Calling Pimcore\Navigation\Builder::getNavigation() using extra arguments is deprecated and will be removed in Pimcore 11.' .
             'Instead, specify the arguments as an array');
         } else {


### PR DESCRIPTION
I have a case, where `Navigation\Builder::getNavigation()` is called with only one parameter: the active document.
 This currently fails with a `TypeError` instead of triggering a deprecation.