### PR TITLE
[Element selector| Auto-size grid columns to field content width

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/asset.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/asset.js
@@ -282,7 +282,16 @@ pimcore.element.selector.asset = Class.create(pimcore.element.selector.abstract,
                 stripeRows: true,
                 viewConfig: {
                     forceFit: true,
-                    markDirty: false
+                    markDirty: false,
+                    listeners: {
+                        refresh: function (dataview) {
+                            Ext.each(dataview.panel.columns, function (column) {
+                                if (column.autoSizeColumn === true) {
+                                    column.autoSize();
+                                }
+                            })
+                        }
+                    }
                 },
                 plugins: ['gridfilters'],
                 selModel: this.getGridSelModel(),

--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/document.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/document.js
@@ -211,7 +211,16 @@ pimcore.element.selector.document = Class.create(pimcore.element.selector.abstra
                 store: this.store,
                 columns: columns,
                 viewConfig: {
-                    forceFit: true
+                    forceFit: true,
+                    listeners: {
+                        refresh: function (dataview) {
+                            Ext.each(dataview.panel.columns, function (column) {
+                                if (column.autoSizeColumn === true) {
+                                    column.autoSize();
+                                }
+                            })
+                        }
+                    }
                 },
                 loadMask: true,
                 columnLines: true,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/object.js
@@ -418,7 +418,7 @@ pimcore.element.selector.object = Class.create(pimcore.element.selector.abstract
                             }
                         })
                     }
-                },
+                }
             },
             cls: 'pimcore_object_grid_panel',
             selModel: this.getGridSelModel(),

--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/object.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/selector/object.js
@@ -409,7 +409,16 @@ pimcore.element.selector.object = Class.create(pimcore.element.selector.abstract
             plugins: ['pimcore.gridfilters'],
             viewConfig: {
                 forceFit: false,
-                xtype: 'patchedgridview'
+                xtype: 'patchedgridview',
+                listeners: {
+                    refresh: function (dataview) {
+                        Ext.each(dataview.panel.columns, function (column) {
+                            if (column.autoSizeColumn === true) {
+                                column.autoSize();
+                            }
+                        })
+                    }
+                },
             },
             cls: 'pimcore_object_grid_panel',
             selModel: this.getGridSelModel(),


### PR DESCRIPTION
Without this PR the columns for the element selector (which is for example used for object search and when clicking the "Search" icon for relation fields), keep their default width wasting all the remaining space:
<img width="1003" alt="Bildschirmfoto 2023-01-13 um 08 57 10" src="https://user-images.githubusercontent.com/8749138/212268156-0a9925d9-229b-4717-a39f-25733dc299ef.png">

With this PR the column width gets automatically adjusted to the field contents:
<img width="1003" alt="Bildschirmfoto 2023-01-13 um 08 57 37" src="https://user-images.githubusercontent.com/8749138/212268160-d8975ab0-67c8-4b8d-ad04-a93aa7d0677e.png">

Or for a single search result:
Before:
<img width="1002" alt="Bildschirmfoto 2023-01-13 um 08 54 35" src="https://user-images.githubusercontent.com/8749138/212268761-8a1c099e-3731-4c9c-a73e-e142b4ae4a33.png">

After
<img width="1004" alt="Bildschirmfoto 2023-01-13 um 08 53 17" src="https://user-images.githubusercontent.com/8749138/212268704-4baae295-e7d7-4928-a2b7-2cc5964cf745.png">


Implementation is the same as in https://github.com/pimcore/pimcore/blob/67654a9eec53ee597573fd1544f6fffbc6160bf5/bundles/AdminBundle/public/js/pimcore/object/folder/search.js#L322-L328