### PR TITLE
[Bug]: 10.5.13 In Classification Store and Detailed Configuration of the key, in "Select" fields you can save values out of the dictionary 

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/calculatedValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/calculatedValue.js
@@ -67,6 +67,7 @@ pimcore.object.classes.data.calculatedValue = Class.create(pimcore.object.classe
             name: 'calculatorType',
             displayField: 'name',
             valueField: 'value',
+            forceSelection: true,
             store: [
                 { value: 'class', name: t('calculatedValue_calculatortype_class') },
                 { value: 'expression', name: t('calculatedValue_calculatortype_expression') },

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/input.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/input.js
@@ -150,6 +150,7 @@ pimcore.object.classes.data.input = Class.create(pimcore.object.classes.data.dat
                     name: 'regexflags',
                     triggerAction: "all",
                     selectOnFocus: true,
+                    forceSelection: true,
                     store: new Ext.data.ArrayStore({
                         fields: [
                             'value',

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/inputQuantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/inputQuantityValue.js
@@ -71,6 +71,7 @@ pimcore.object.classes.data.inputQuantityValue = Class.create(pimcore.object.cla
                 editable: true,
                 typeAhead: true,
                 selectOnFocus: true,
+                forceSelection: true,
                 fieldLabel: t('default_unit'),
                 store: this.store,
                 value: this.datax.defaultUnit,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/quantityValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/data/quantityValue.js
@@ -77,6 +77,7 @@ pimcore.object.classes.data.quantityValue = Class.create(pimcore.object.classes.
                 editable: true,
                 typeAhead: true,
                 selectOnFocus: true,
+                forceSelection: true,
                 fieldLabel: t('default_unit'),
                 store: this.store,
                 value: this.datax.defaultUnit,


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #13949

## Additional info  
fix: prevent user from typing free values in some ComboBox fields
