### PR TITLE
[BUG] fix condition problem if user can modify all languages (lEdit is null…

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectActionsTrait.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectActionsTrait.php
@@ -187,10 +187,10 @@ trait DataObjectActionsTrait
         $user = Tool\Admin::getCurrentUser();
         $languagePermissions = [];
         if (!$user->isAdmin()) {
-            $languagePermissions = $object->getPermissions('lEdit', $user);
+            $languagePermissionsData = $object->getPermissions('lEdit', $user);
 
-            if ($languagePermissions['lEdit']) {
-                $languagePermissions = explode(',', $languagePermissions['lEdit']);
+            if ($languagePermissionsData['lEdit']) {
+                $languagePermissions = explode(',', $languagePermissionsData['lEdit']);
             }
         }
 


### PR DESCRIPTION
hey,

the commit https://github.com/pimcore/pimcore/pull/13785/commits/131c8d09ee603bc20cb8e55af419542d12f11c2e breaks grid inline editing for users who have permission for all languages in localization fields.

because if condition here is "true" because array from DB is not empty https://github.com/pimcore/pimcore/blob/11.x/bundles/AdminBundle/src/Controller/Admin/DataObject/DataObjectActionsTrait.php#L260


## Changes in this pull request  
Resolves #


## Additional info  
![image](https://user-images.githubusercontent.com/16688055/212715793-81202751-6e80-4c9f-a586-a0670fbe1a43.png)

