### PR TITLE
Revert "[Bug]: Fix getEditables() not returning inherited editables"

### DIFF
--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -500,9 +500,6 @@ abstract class PageSnippet extends Model\Document
     /**
      * @return Editable[]
      */
-    /**
-     * @return Editable[]
-     */
     public function getEditables(): array
     {
         if ($this->editables === null) {

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -500,15 +500,13 @@ abstract class PageSnippet extends Model\Document
     /**
      * @return Editable[]
      */
+    /**
+     * @return Editable[]
+     */
     public function getEditables(): array
     {
         if ($this->editables === null) {
-            $documentEditables = $this->getDao()->getEditables();
-            if ($this->supportsContentMaster() && $this->getContentMasterDocument()) {
-                $contentMasterEditables = $this->getContentMasterDocument()->getDao()->getEditables();
-                $documentEditables = array_merge($contentMasterEditables, $documentEditables);
-            }
-            $this->setEditables($documentEditables);
+            $this->setEditables($this->getDao()->getEditables());
         }
 
         return $this->editables;


### PR DESCRIPTION
Reverts #14028
Content master inheritance does not work. 
Problems in the update.
https://github.com/pimcore/pimcore/blob/2d80865e6b64e65a9b7ec11858f98d9f219a7f8a/models/Document/PageSnippet.php#L132

