### PR TITLE
Allow getEditables() to return inherited editables by setGetInheritedValues

### DIFF
--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -109,6 +109,31 @@ abstract class PageSnippet extends Model\Document
     protected $inheritedEditables = [];
 
     /**
+     * @var bool
+     */
+    private static $getInheritedValues = false;
+
+    /**
+     * @static
+     *
+     * @param bool $getInheritedValues
+     */
+    public static function setGetInheritedValues($getInheritedValues)
+    {
+        self::$getInheritedValues = $getInheritedValues;
+    }
+
+    /**
+     * @static
+     *
+     * @return bool
+     */
+    public static function getGetInheritedValues()
+    {
+        return self::$getInheritedValues;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function save()
@@ -503,7 +528,15 @@ abstract class PageSnippet extends Model\Document
     public function getEditables(): array
     {
         if ($this->editables === null) {
-            $this->setEditables($this->getDao()->getEditables());
+            $documentEditables = $this->getDao()->getEditables();
+
+            if (self::getGetInheritedValues() && $this->supportsContentMaster() && $this->getContentMasterDocument()){
+                $contentMasterEditables = $this->getContentMasterDocument()->getEditables();
+                $documentEditables = array_merge($contentMasterEditables, $documentEditables);
+                $this->inheritedEditables = $documentEditables;
+            }
+
+            $this->setEditables($documentEditables);
         }
 
         return $this->editables;

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -108,27 +108,14 @@ abstract class PageSnippet extends Model\Document
      */
     protected $inheritedEditables = [];
 
-    /**
-     * @var bool
-     */
-    private static $getInheritedValues = false;
+    private static bool $getInheritedValues = false;
 
-    /**
-     * @static
-     *
-     * @param bool $getInheritedValues
-     */
-    public static function setGetInheritedValues($getInheritedValues)
+    public static function setGetInheritedValues(bool $getInheritedValues): void
     {
         self::$getInheritedValues = $getInheritedValues;
     }
 
-    /**
-     * @static
-     *
-     * @return bool
-     */
-    public static function getGetInheritedValues()
+    public static function getGetInheritedValues(): bool
     {
         return self::$getInheritedValues;
     }


### PR DESCRIPTION
Resolves https://github.com/pimcore/pimcore/issues/12762
Follow-up of https://github.com/pimcore/pimcore/pull/14028 which got reverted

## Additional info  
Some of the changes from the former PR are:
-  adding the possibility to rely on a flag to decide wheter it should return the inherited values or not by `Document\Page::setGetInheritedValues(true);`, instead of changing the default behaviour
- `$this->getContentMasterDocument()->getEditables();` changed from `$this->getContentMasterDocument()->getDao()->getEditables();` which now  enable to recursively get the parent editables
- Added `$this->inheritedEditables = $documentEditables;`, which would optimize a little [getEditable($name)](https://github.com/pimcore/pimcore/blob/5c6bac1a665d8d7b2a437096887cb4469e89dcd1/models/Document/PageSnippet.php#L392) 