### PR TITLE
Update Ghostscript.php / fix double escape

### DIFF
--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -158,10 +158,10 @@ class Ghostscript extends Adapter
 
         // Adding permit-file-read flag to prevent issue with Ghostscript's SAFER mode which is enabled by default as of version 9.50.
         if (version_compare($this->getVersion(), '9.50', '>=')) {
-            $command .= " --permit-file-read='" . escapeshellcmd($localFile) . "'";
+            $command .= " --permit-file-read=" . escapeshellarg($localFile);
         }
 
-        $command .= " -c '(" . escapeshellcmd($localFile) . ") (r) file runpdfbegin pdfpagecount = quit'";
+        $command .= " -c " . escapeshellarg("(" . $localFile . ") (r) file runpdfbegin pdfpagecount = quit");
 
         Console::addLowProcessPriority($command);
 


### PR DESCRIPTION
Use `escapeshellarg()` instead of `escapeshellcmd()` and escape the whole argument. 
With the `escapeshellcmd()` command the file path is escaped but it's already between single quotes  '', so it's double escaped and fails because of the SAFER mode.
=> only fails if the path or file have specials characters...

From php.net:
Warning: escapeshellcmd() should be used on the whole command string, and it still allows the attacker to pass arbitrary number of arguments. For escaping a single argument escapeshellarg() should be used instead. 
https://www.php.net/manual/en/function.escapeshellcmd.php

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
