### PR TITLE
Fixed object relations loading

### DIFF
--- a/models/DataObject/Fieldcollection/Data/AbstractData.php
+++ b/models/DataObject/Fieldcollection/Data/AbstractData.php
@@ -18,11 +18,13 @@ namespace Pimcore\Model\DataObject\Fieldcollection\Data;
 use Pimcore\Model;
 use Pimcore\Model\DataObject\ClassDefinition\Data\LazyLoadingSupportInterface;
 use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Localizedfield;
+use Pimcore\Model\DataObject\ObjectAwareFieldInterface;
 
 /**
  * @method Dao getDao()
  */
-abstract class AbstractData extends Model\AbstractModel implements Model\DataObject\LazyLoadedFieldsInterface, Model\Element\ElementDumpStateInterface, Model\Element\DirtyIndicatorInterface
+abstract class AbstractData extends Model\AbstractModel implements Model\DataObject\LazyLoadedFieldsInterface, Model\Element\ElementDumpStateInterface, Model\Element\DirtyIndicatorInterface, ObjectAwareFieldInterface
 {
     use Model\Element\ElementDumpStateTrait;
     use Model\DataObject\Traits\LazyLoadedRelationTrait;
@@ -118,6 +120,10 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
     {
         $this->objectId = $object ? $object->getId() : null;
         $this->object = $object;
+
+        if (property_exists($this, 'localizedfields') && $this->localizedfields instanceof Localizedfield) {
+            $this->localizedfields->setObject($object, false);
+        }
 
         return $this;
     }

--- a/models/DataObject/Objectbrick/Data/AbstractData.php
+++ b/models/DataObject/Objectbrick/Data/AbstractData.php
@@ -20,13 +20,15 @@ use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data\LazyLoadingSupportInterface;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Exception\InheritanceParentNotFoundException;
+use Pimcore\Model\DataObject\Localizedfield;
+use Pimcore\Model\DataObject\ObjectAwareFieldInterface;
 
 /**
  * @method Dao getDao()
  * @method void save(Concrete $object, $params = [])
  * @method array getRelationData($field, $forOwner, $remoteClassId)
  */
-abstract class AbstractData extends Model\AbstractModel implements Model\DataObject\LazyLoadedFieldsInterface, Model\Element\ElementDumpStateInterface, Model\Element\DirtyIndicatorInterface
+abstract class AbstractData extends Model\AbstractModel implements Model\DataObject\LazyLoadedFieldsInterface, Model\Element\ElementDumpStateInterface, Model\Element\DirtyIndicatorInterface, ObjectAwareFieldInterface
 {
     use Model\DataObject\Traits\LazyLoadedRelationTrait;
     use Model\Element\ElementDumpStateTrait;
@@ -197,6 +199,10 @@ abstract class AbstractData extends Model\AbstractModel implements Model\DataObj
     {
         $this->objectId = $object ? $object->getId() : null;
         $this->object = $object;
+
+        if (property_exists($this, 'localizedfields') && $this->localizedfields instanceof Localizedfield) {
+            $this->localizedfields->setObject($object, false);
+        }
 
         return $this;
     }

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -34,6 +34,7 @@ use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\ObjectAwareFieldInterface;
 use Pimcore\Model\Dependency;
 use Pimcore\Model\Document;
 use Pimcore\Model\Element\DeepCopy\MarshalMatcher;
@@ -875,6 +876,13 @@ class Service extends Model\AbstractModel
             if ($data instanceof Model\AbstractModel) {
                 $properties = $data->getObjectVars();
                 foreach ($properties as $name => $value) {
+
+                    //do not renew object reference of ObjectAwareFieldInterface - as object might point to a
+                    //specific version of the object and must not be reloaded with DB version of object
+                    if(($data instanceof ObjectAwareFieldInterface || $data instanceof DataObject\Localizedfield) && $name === 'object') {
+                        continue;
+                    }
+
                     $data->setObjectVar($name, self::renewReferences($value, false, $name), true);
                 }
             } else {

--- a/tests/Model/DataType/ObjectAwareFieldsTest.php
+++ b/tests/Model/DataType/ObjectAwareFieldsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Pimcore\Tests\Model\DataType;
+
+use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Fieldcollection;
+use Pimcore\Model\DataObject\Unittest;
+use Pimcore\Tests\Model\LazyLoading\AbstractLazyLoadingTest;
+use Pimcore\Model\DataObject\Objectbrick\Data\LazyLoadingLocalizedTest;
+use Pimcore\Model\DataObject\LazyLoading;
+use Pimcore\Tests\Util\TestHelper;
+
+class ObjectAwareFieldsTest extends AbstractLazyLoadingTest
+{
+
+    private function reloadObject(int $id): array {
+        //reload object from database
+        $databaseObject = AbstractObject::getById($id, true);
+
+        //load latest version of object
+        $latestVersion = $databaseObject->getLatestVersion();
+        $this->assertNotNull($latestVersion, 'Latest version could not be loaded.');
+
+        $latestObjectVersion = $latestVersion->loadData();
+        $this->assertNotNull($latestObjectVersion, 'Object from latest version could not be loaded.');
+
+        $this->assertNotEquals($databaseObject->getInput(), $latestObjectVersion->getInput(), 'Object versions are not different');
+
+        return [$databaseObject, $latestObjectVersion];
+    }
+
+    public function testLocalizedField(): void {
+        /**
+         * @var Unittest $object
+         */
+        $object = TestHelper::createEmptyObject();
+
+        $object->setInput('1');
+        $object->setLinput('some localized input');
+        $object->save();
+
+        //create new unpublished version of object
+        $object = Concrete::getById($object->getId(), true);
+        $object->setInput($object->getInput() + 1);
+        $object->saveVersion();
+
+        list($databaseObject, $latestObjectVersion) = $this->reloadObject($object->getId());
+
+        $this->assertEquals($latestObjectVersion->getLocalizedfields()->getObject()->getInput(), $latestObjectVersion->getInput(), 'Object reference in localized field is not right.');
+    }
+
+    public function testLocalizedFieldInFieldCollection(): void {
+        /**
+         * @var Unittest $object
+         */
+        $object = TestHelper::createEmptyObject();
+
+        $object->setInput('1');
+
+        $items = new Fieldcollection();
+        $item = new FieldCollection\Data\Unittestfieldcollection();
+        $item->setLinput('textEN', 'en');
+        $items->add($item);
+        $object->setFieldcollection($items);
+        $object->save();
+
+        //create new unpublished version of object
+        $object = Concrete::getById($object->getId(), true);
+        $object->getFieldcollection();
+        $object->setInput($object->getInput() + 1);
+        $object->saveVersion();
+
+        list($databaseObject, $latestObjectVersion) = $this->reloadObject($object->getId());
+
+        $fieldCollectionItems = $latestObjectVersion->getFieldcollection()->getItems();
+        foreach($fieldCollectionItems as $item) {
+            $this->assertEquals($item->getObject()->getInput(), $latestObjectVersion->getInput(), 'Object reference in field collection is not right.');
+            $this->assertEquals($item->getLocalizedFields()->getObject()->getInput(), $latestObjectVersion->getInput(), 'Object reference in localized field in field collection is not right.');
+        }
+
+    }
+
+    public function testLocalizedFieldInObjectBrick(): void {
+
+        /**
+         * @var LazyLoading $object
+         */
+        $object = $this->createDataObject();
+        $brick = new LazyLoadingLocalizedTest($object);
+        $brick->setLInput(uniqid());
+        $object->getBricks()->setLazyLoadingLocalizedTest($brick);
+        $object->setInput('1');
+
+        $object->save();
+
+        //create new unpublished version of object
+        $object = Concrete::getById($object->getId(), true);
+        $object->getBricks();
+        $object->setInput($object->getInput() + 1);
+        $object->saveVersion();
+
+        list($databaseObject, $latestObjectVersion) = $this->reloadObject($object->getId());
+
+        $brickItems = $latestObjectVersion->getBricks()->getItems();
+        foreach($brickItems as $item) {
+            $this->assertEquals($item->getObject()->getInput(), $latestObjectVersion->getInput(), 'Object reference in object brick is not right.');
+            $this->assertEquals($item->getLocalizedFields()->getObject()->getInput(), $latestObjectVersion->getInput(), 'Object reference in localized field in object brick is not right.');
+        }
+
+    }
+
+}

--- a/tests/_support/Helper/Model.php
+++ b/tests/_support/Helper/Model.php
@@ -82,6 +82,7 @@ class Model extends AbstractDefinitionHelper
             $rootPanel = (new \Pimcore\Model\DataObject\ClassDefinition\Layout\Tabpanel())->setName('Layout');
             $rootPanel->addChild($panel);
 
+            $panel->addChild($this->createDataChild('input'));
             $panel->addChild($this->createDataChild('manyToManyObjectRelation', 'objects')
                 ->setClasses(['RelationTest'])
             );


### PR DESCRIPTION
Relations of field collections, object bricks and localized fields need to point to the actual object version, not the version stored in DB. Otherwise there are some strange issues when saving elements or loading them from cache. 

That means, they must be set when loading the data object and must not be overwritten with values got with `getById`. 

This PR fixes #13736

Related to #12588
Might need to be reconsidered with #13874
