### PR TITLE
Fix: Null can not be used as a standalone type

### DIFF
--- a/models/Asset/WebDAV/File.php
+++ b/models/Asset/WebDAV/File.php
@@ -104,7 +104,7 @@ class File extends DAV\File
      *
      * @return null
      */
-    public function put($data): null
+    public function put($data)
     {
         if ($this->asset->isAllowed('publish')) {
             // read from resource -> default for SabreDAV

--- a/models/Asset/WebDAV/Folder.php
+++ b/models/Asset/WebDAV/Folder.php
@@ -106,7 +106,7 @@ class Folder extends DAV\Collection
      *
      * @return null
      */
-    public function createFile($name, $data = null): null
+    public function createFile($name, $data = null)
     {
         $tmpFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/asset-dav-tmp-file-' . uniqid();
         if (is_resource($data)) {


### PR DESCRIPTION
The standalone null type is only allowed in PHP 8.2
https://php.watch/versions/8.2/null-false-types