### PR TITLE
Remove disable shutdown call

### DIFF
--- a/bundles/GlossaryBundle/src/DependencyInjection/PimcoreGlossaryExtension.php
+++ b/bundles/GlossaryBundle/src/DependencyInjection/PimcoreGlossaryExtension.php
@@ -25,10 +25,6 @@ final class PimcoreGlossaryExtension extends ConfigurableExtension
 {
     public function loadInternal(array $config, ContainerBuilder $container): void
     {
-        // on container build the shutdown handler shouldn't be called
-        // for details please see https://github.com/pimcore/pimcore/issues/4709
-        \Pimcore::disableShutdown();
-
         $loader = new YamlFileLoader(
             $container,
             new FileLocator(__DIR__ . '/../../config')

--- a/bundles/StaticRoutesBundle/src/DependencyInjection/PimcoreStaticRoutesExtension.php
+++ b/bundles/StaticRoutesBundle/src/DependencyInjection/PimcoreStaticRoutesExtension.php
@@ -25,10 +25,6 @@ final class PimcoreStaticRoutesExtension extends ConfigurableExtension
 {
     public function loadInternal(array $config, ContainerBuilder $container): void
     {
-        // on container build the shutdown handler shouldn't be called
-        // for details please see https://github.com/pimcore/pimcore/issues/4709
-        \Pimcore::disableShutdown();
-
         $loader = new YamlFileLoader(
             $container,
             new FileLocator(__DIR__ . '/../../config')

--- a/bundles/WordExportBundle/src/DependencyInjection/PimcoreWordExportExtension.php
+++ b/bundles/WordExportBundle/src/DependencyInjection/PimcoreWordExportExtension.php
@@ -25,10 +25,6 @@ final class PimcoreWordExportExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
-        // on container build the shutdown handler shouldn't be called
-        // for details please see https://github.com/pimcore/pimcore/issues/4709
-        \Pimcore::disableShutdown();
-
         $loader = new YamlFileLoader(
             $container,
             new FileLocator(__DIR__ . '/../../config')

--- a/bundles/XliffBundle/src/DependencyInjection/PimcoreXliffExtension.php
+++ b/bundles/XliffBundle/src/DependencyInjection/PimcoreXliffExtension.php
@@ -27,10 +27,6 @@ final class PimcoreXliffExtension extends ConfigurableExtension
 {
     protected function loadInternal(array $config, ContainerBuilder $container): void
     {
-        // on container build the shutdown handler shouldn't be called
-        // for details please see https://github.com/pimcore/pimcore/issues/4709
-        \Pimcore::disableShutdown();
-
         $loader = new YamlFileLoader(
             $container,
             new FileLocator(__DIR__ . '/../../config')


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Follow up to bundle extraction
Removing ` \Pimcore::disableShutdown();` from bundle Extensions as the call is not needed
