### PR TITLE
[Improvement] Show object type in metainfo dialog and consolidate deeplink for variants

### DIFF
--- a/bundles/AdminBundle/public/js/pimcore/object/object.js
+++ b/bundles/AdminBundle/public/js/pimcore/object/object.js
@@ -922,7 +922,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
             usermodification_name: this.data.general.userModificationFullname,
             userowner: this.data.general.userOwner,
             userowner_name: this.data.general.userOwnerFullname,
-            deeplink: pimcore.helpers.getDeeplink("object", this.data.general.id, "object")
+            deeplink: pimcore.helpers.getDeeplink("object", this.data.general.id, this.data.general.type)
         };
     },
 

--- a/bundles/AdminBundle/public/js/pimcore/object/object.js
+++ b/bundles/AdminBundle/public/js/pimcore/object/object.js
@@ -915,6 +915,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
             parentid: this.data.general.parentId,
             classid: this.data.general.classId,
             "class": this.data.general.className,
+            type: this.data.general.type,
             modificationdate: this.data.general.modificationDate,
             creationdate: this.data.general.creationDate,
             usermodification: this.data.general.userModification,
@@ -945,6 +946,9 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
             }, {
                 name: "class",
                 value: metainfo.class
+            }, {
+                name: "type",
+                value: metainfo.type
             }, {
                 name: "modificationdate",
                 type: "date",


### PR DESCRIPTION
This PR adds the DataObject's type (`object` or `variant`) to the metainfo dialog and consolidates the deeplink to match the documented behavior.

