### PR TITLE
improvement: activate fallback language only if getFallbackValues is set to true

### DIFF
--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -307,7 +307,8 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
             $translated = $this->translator->trans($normalizedId, $parameters, $domain, $locale);
         }
 
-        $lookForFallback = empty($translated);
+        // activate fallback language only if getFallbackValues is set to true
+        $lookForFallback = empty($translated) && \Pimcore\Model\DataObject\Localizedfield::getGetFallbackValues();
         if ($normalizedId != $translated && $translated) {
             return $translated;
         } elseif ($normalizedId == $translated) {


### PR DESCRIPTION
## Changes in this pull request  
When` \Pimcore\Model\DataObject\Localizedfield::getGetFallbackValues()` is set to true the method `Translator->checkForEmptyTranslation()` should not use the fallback values for shared translations.

I added this check to force the `checkForEmptyTranslation` to return the translations id.
