### PR TITLE
[Improvement] Replaced `method_exists` with `VarExporterInterface` check

### DIFF
--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace Pimcore\Model\DataObject\ClassDefinition;
 
+use Pimcore\Loader\ImplementationLoader\LoaderInterface;
+use Pimcore\Logger;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data\EncryptedField;
-use Pimcore\Logger;
-use Pimcore\Loader\ImplementationLoader\LoaderInterface;
-use Pimcore\Tool;
 use Pimcore\Model\DataObject\ClassDefinition\Data\VarExporterInterface;
+use Pimcore\Tool;
 
 class Service
 {

--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -16,11 +16,12 @@ declare(strict_types=1);
 
 namespace Pimcore\Model\DataObject\ClassDefinition;
 
-use Pimcore\Loader\ImplementationLoader\LoaderInterface;
+use Pimcore\Tool;
 use Pimcore\Logger;
 use Pimcore\Model\DataObject;
+use Pimcore\Loader\ImplementationLoader\LoaderInterface;
 use Pimcore\Model\DataObject\ClassDefinition\Data\EncryptedField;
-use Pimcore\Tool;
+use Pimcore\Model\DataObject\ClassDefinition\Data\VarExporterInterface;
 
 class Service
 {
@@ -63,7 +64,7 @@ class Service
 
     private static function removeDynamicOptionsFromLayoutDefinition(mixed &$layout): void
     {
-        if (method_exists($layout, 'resolveBlockedVars')) {
+        if ($layout instanceof VarExporterInterface) {
             $blockedVars = $layout->resolveBlockedVars();
             foreach ($blockedVars as $blockedVar) {
                 if (isset($layout->{$blockedVar})) {
@@ -345,7 +346,7 @@ class Service
                 } else {
                     //for BC reasons
                     $blockedVars = [];
-                    if (method_exists($item, 'resolveBlockedVars')) {
+                    if ($item instanceof VarExporterInterface) {
                         $blockedVars = $item->resolveBlockedVars();
                     }
                     self::removeDynamicOptionsFromArray($array, $blockedVars);

--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace Pimcore\Model\DataObject\ClassDefinition;
 
-use Pimcore\Tool;
-use Pimcore\Logger;
 use Pimcore\Model\DataObject;
-use Pimcore\Loader\ImplementationLoader\LoaderInterface;
 use Pimcore\Model\DataObject\ClassDefinition\Data\EncryptedField;
+use Pimcore\Logger;
+use Pimcore\Loader\ImplementationLoader\LoaderInterface;
+use Pimcore\Tool;
 use Pimcore\Model\DataObject\ClassDefinition\Data\VarExporterInterface;
 
 class Service


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #13863

