### PR TITLE
AbstractObject: Remove deprecated attributes

### DIFF
--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -65,8 +65,6 @@ abstract class AbstractObject extends Model\Element\AbstractElement
 
     /**
      * @internal
-     *
-     * @var bool
      */
     protected static bool $disableDirtyDetection = false;
 
@@ -79,145 +77,44 @@ abstract class AbstractObject extends Model\Element\AbstractElement
 
     /**
      * @internal
-     *
-     * @deprecated
-     *
-     * @var int|null
-     */
-    protected ?int $id = null;
-
-    /**
-     * @internal
-     *
-     * @deprecated
-     *
-     * @var int|null
-     */
-    protected ?int $parentId = null;
-
-    /**
-     * @internal
-     *
-     * @deprecated
-     */
-    protected ?Element\AbstractElement $parent = null;
-
-    /**
-     * @internal
-     *
-     * @var string
      */
     protected string $type = 'object';
 
     /**
      * @internal
-     *
-     * @var string|null
      */
     protected ?string $key = null;
 
     /**
      * @internal
-     *
-     * @var string|null
-     */
-    protected ?string $path = null;
-
-    /**
-     * @internal
-     *
-     * @var int
      */
     protected int $index = 0;
-
-    /**
-     * @internal
-     *
-     * @deprecated
-     *
-     * @var int|null
-     */
-    protected ?int $creationDate = null;
-
-    /**
-     * @internal
-     *
-     * @deprecated
-     *
-     * @var int|null
-     */
-    protected ?int $modificationDate = null;
-
-    /**
-     * @internal
-     *
-     * @deprecated
-     */
-    protected ?int $userOwner = null;
-
-    /**
-     * @internal
-     *
-     * @deprecated
-     */
-    protected ?int $userModification = null;
 
     /**
      * Contains a list of sibling documents
      *
      * @internal
      *
-     * @var array
+     * @var array<string, Listing>
      */
     protected array $siblings = [];
 
     /**
      * @internal
      *
-     * @var array
+     * @var array<string, Listing>
      */
     protected array $children = [];
 
     /**
      * @internal
-     *
-     * @deprecated
-     *
-     * @var string
-     */
-    protected ?string $locked = null;
-
-    /**
-     * @internal
-     *
-     * @var string|null
      */
     protected ?string $childrenSortBy = null;
 
     /**
      * @internal
-     *
-     * @var string|null
      */
     protected ?string $childrenSortOrder = null;
-
-    /**
-     * @internal
-     *
-     * @deprecated
-     *
-     * @var int
-     */
-    protected int $versionCount = 0;
-
-    /**
-     * @internal
-     *
-     * @deprecated
-     *
-     * @var array<string, Model\Property>|null
-     */
-    protected ?array $properties = null;
 
     /**
      * {@inheritdoc}

--- a/models/Document.php
+++ b/models/Document.php
@@ -46,8 +46,6 @@ class Document extends Element\AbstractElement
 
     /**
      * @internal
-     *
-     * @var string|null
      */
     protected ?string $fullPathCache = null;
 
@@ -58,17 +56,8 @@ class Document extends Element\AbstractElement
 
     /**
      * @internal
-     *
-     * @var string|null
      */
     protected ?string $key = null;
-
-    /**
-     * @internal
-     *
-     * @var string|null
-     */
-    protected ?string $path = null;
 
     /**
      * @internal
@@ -88,14 +77,14 @@ class Document extends Element\AbstractElement
     /**
      * @internal
      *
-     * @var array
+     * @var array<string, Listing>
      */
     protected array $children = [];
 
     /**
      * @internal
      *
-     * @var array
+     * @var array<string, Listing>
      */
     protected array $siblings = [];
 
@@ -581,7 +570,6 @@ class Document extends Element\AbstractElement
 
     /**
      * Get a list of the children (not recursivly)
-     *
      */
     public function getChildren(bool $includingUnpublished = false): Listing
     {

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -36,22 +36,16 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
 
     /**
      * @internal
-     *
-     * @var Model\Dependency|null
      */
     protected ?Model\Dependency $dependencies = null;
 
     /**
      * @internal
-     *
-     * @var int|null
      */
     protected ?int $__dataVersionTimestamp = null;
 
     /**
      * @internal
-     *
-     * @var string|null
      */
     protected ?string $path = null;
 
@@ -79,15 +73,11 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
 
     /**
      * @internal
-     *
-     * @var int|null
      */
     protected ?int $modificationDate = null;
 
     /**
      * @internal
-     *
-     * @var int
      */
     protected int $versionCount = 0;
 


### PR DESCRIPTION
This attributes already exists in the AbstractElement class. So this attributes are not necessary anymore.