### PR TITLE
[Task]: Mime type check on Profile Avatar upload

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -27,6 +27,7 @@ use Pimcore\Model\User;
 use Pimcore\Tool;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Google\GoogleAuthenticatorInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
@@ -795,6 +796,13 @@ class UserController extends AdminController implements KernelControllerEventInt
 
         if ($userObj->isAdmin() && !$this->getAdminUser()->isAdmin()) {
             throw $this->createAccessDeniedHttpException('Only admin users are allowed to modify admin users');
+        }
+
+        //Check if uploaded file is an image
+        $avatarFile = $request->files->get('Filedata');
+
+        if (!$avatarFile instanceof UploadedFile || !str_starts_with($avatarFile->getMimeType(), 'image/')) {
+            throw new \Exception('Unsupported file format.');
         }
 
         $userObj->setImage($_FILES['Filedata']['tmp_name']);

--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -21,6 +21,7 @@ use Pimcore\Bundle\AdminBundle\Controller\AdminController;
 use Pimcore\Bundle\AdminBundle\HttpFoundation\JsonResponse;
 use Pimcore\Controller\KernelControllerEventInterface;
 use Pimcore\Logger;
+use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Element;
 use Pimcore\Model\User;

--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -801,7 +801,9 @@ class UserController extends AdminController implements KernelControllerEventInt
         //Check if uploaded file is an image
         $avatarFile = $request->files->get('Filedata');
 
-        if (!$avatarFile instanceof UploadedFile || !str_starts_with($avatarFile->getMimeType(), 'image/')) {
+        $assetType = Asset::getTypeFromMimeMapping($avatarFile->getMimeType(), $avatarFile);
+
+        if (!$avatarFile instanceof UploadedFile || $assetType !== 'image') {
             throw new \Exception('Unsupported file format.');
         }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/profile/panel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/profile/panel.js
@@ -250,6 +250,9 @@ pimcore.settings.profile.panel = Class.create({
                                 Ext.getCmp("pimcore_profile_delete_image_" + this.currentUser.id).setVisible(true);
                                 pimcore.helpers.reloadUserImage(this.currentUser.id);
                                 this.currentUser.hasImage = true;
+                            }.bind(this),
+                            function () {
+                                Ext.MessageBox.alert(t('error'), t("unsupported_filetype"));
                             }.bind(this)
                         );
                     }.bind(this)

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/user/user/settings.js
@@ -177,6 +177,9 @@ pimcore.settings.user.user.settings = Class.create({
                                 Ext.getCmp("pimcore_user_delete_image_" + this.currentUser.id).setVisible(true);
                                 pimcore.helpers.reloadUserImage(this.currentUser.id);
                                 this.currentUser.hasImage = true;
+                            }.bind(this),
+                            function () {
+                                Ext.MessageBox.alert(t('error'), t("unsupported_filetype"));
                             }.bind(this)
                         );
                     }.bind(this)


### PR DESCRIPTION
If one tries to upload any other file format, it wouldn't show any alert message, so added this check to make it stricter.
Leaving it to a more generic `image` because i am not sure if by specifying the formats could lead to some "behaviour change"

