### PR TITLE
[Bug] Unique check on pretty urls is not considering sites

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Document/PageController.php
+++ b/bundles/AdminBundle/Controller/Admin/Document/PageController.php
@@ -30,6 +30,7 @@ use Pimcore\Model\Element;
 use Pimcore\Model\Redirect;
 use Pimcore\Model\Schedule\Task;
 use Pimcore\Templating\Renderer\EditableRenderer;
+use Pimcore\Tool\Frontend;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -293,8 +294,24 @@ class PageController extends DocumentControllerBase
         ]);
 
         if ($list->getTotalCount() > 0) {
-            $success = false;
-            $message[] = 'URL path already exists.';
+            $checkDocument = Document::getById($docId);
+            $checkSite     = Frontend::getSiteForDocument($checkDocument);
+            $checkSiteId   = empty($checkSite) ? 0 : $checkSite->getId();
+
+            foreach ($list as $document) {
+                if (empty($document)) {
+                    continue;
+                }
+
+                $site   = Frontend::getSiteForDocument($document);
+                $siteId = empty($site) ? 0 : $site->getId();
+
+                if ($siteId === $checkSiteId) {
+                    $success   = false;
+                    $message[] = 'URL path already exists.';
+                    break;
+                }
+            }
         }
 
         return $this->adminJson([


### PR DESCRIPTION
Resolves #7219

How to reproduce the issue:
1. Create two documents in two different site roots
2. Save document 1 with a pretty url
3. Set the same pretty url inside document 2
4. You'll get an error "URL path already exists.", although it should be possible to have the same pretty url in two different sites

## Additional info 
This also works for documents without sites. So you can have the same pretty url without a site and within a site.

