### PR TITLE
#13401: Add Import/Export Quantity value unit definitions support

### DIFF
--- a/bundles/CoreBundle/config/services.yaml
+++ b/bundles/CoreBundle/config/services.yaml
@@ -107,6 +107,7 @@ services:
 
     Pimcore\Model\DataObject\QuantityValue\UnitConversionService:
         public: true
+    Pimcore\Model\DataObject\QuantityValue\Service: ~
 
     Pimcore\Model\DataObject\QuantityValue\QuantityValueConverterInterface:
         public: true

--- a/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
+++ b/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 /**
  * Pimcore
  *

--- a/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
+++ b/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 /**
  * Pimcore
  *

--- a/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
+++ b/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
@@ -28,7 +28,8 @@ class QuantityValueCommand extends AbstractCommand
 {
     use DryRun;
 
-    public function __construct(private Service $service){
+    public function __construct(private Service $service)
+    {
         parent::__construct();
     }
 

--- a/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
+++ b/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
@@ -50,7 +50,6 @@ class QuantityValueCommand extends AbstractCommand
     /**
      * Validate and return path to JSON file
      *
-     * @return string
      */
     protected function getPath(): string
     {
@@ -78,9 +77,6 @@ class QuantityValueCommand extends AbstractCommand
         return $content;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $path = $this->getPath();

--- a/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
+++ b/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Command\Definition\Import;
+
+use Pimcore\Console\AbstractCommand;
+use Pimcore\Console\Traits\DryRun;
+use Pimcore\Model\DataObject\QuantityValue\Service;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class QuantityValueCommand extends AbstractCommand
+{
+    use DryRun;
+
+    public function configure(): void
+    {
+        $this
+            ->setName('pimcore:definition:import:units')
+            ->setAliases(['definition:import:units'])
+            ->setDescription('Import quantity value units from a JSON export')
+            ->addArgument(
+                'path',
+                InputArgument::REQUIRED,
+                'Path to quantity value unit JSON export file')
+            ->addOption(
+                'override',
+                'o',
+                InputOption::VALUE_NEGATABLE,
+                'Override the existing unit definition'
+            );
+
+        $this->configureDryRunOption();
+    }
+
+    /**
+     * Validate and return path to JSON file
+     *
+     * @return string
+     */
+    protected function getPath(): string
+    {
+        $path = $this->input->getArgument('path');
+        if (!file_exists($path) || !is_readable($path)) {
+            throw new \InvalidArgumentException('File does not exist');
+        }
+
+        return $path;
+    }
+
+    /**
+     * Load JSON data from file
+     */
+    protected function getJson(string $path): string
+    {
+        $content = file_get_contents($path);
+
+        // try to decode json here as we want to fail early if file is no valid JSON
+        $json = json_decode($content);
+        if (null === $json) {
+            throw new \InvalidArgumentException('JSON could not be decoded');
+        }
+
+        return $content;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $path = $this->getPath();
+        $json = $this->getJson($path);
+        $override = $this->input->getOption('override') ?? false;
+        $result = false;
+        if ($this->isDryRun()) {
+            $this->output->writeln($this->prefixDryRun(sprintf('Skipping the unit definition import from %s', $path)));
+            $result = true;
+        } else {
+            $this->output->writeln(sprintf('Importing quantity value unit definitions from %s', $path));
+            $result = Service::importDefinitionFromJson($json, $override);
+        }
+
+        if ($result) {
+            $this->output->writeln('Successfully imported definitions');
+
+            return 0;
+        } else {
+            $this->output->writeln('<error>ERROR:</error> Failed to import definitions');
+
+            return 1;
+        }
+    }
+}

--- a/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
+++ b/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
@@ -24,6 +24,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'pimcore:definition:import:units',
+    description: 'Import quantity value units from a JSON export',
+    aliases: ['definition:import:units']
+)]
 class QuantityValueCommand extends AbstractCommand
 {
     use DryRun;
@@ -35,9 +40,6 @@ class QuantityValueCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setName('pimcore:definition:import:units')
-            ->setAliases(['definition:import:units'])
-            ->setDescription('Import quantity value units from a JSON export')
             ->addArgument(
                 'path',
                 InputArgument::REQUIRED,

--- a/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
+++ b/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
@@ -19,6 +19,7 @@ namespace Pimcore\Bundle\CoreBundle\Command\Definition\Import;
 use Pimcore\Console\AbstractCommand;
 use Pimcore\Console\Traits\DryRun;
 use Pimcore\Model\DataObject\QuantityValue\Service;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
+++ b/bundles/CoreBundle/src/Command/Definition/Import/QuantityValueCommand.php
@@ -28,7 +28,11 @@ class QuantityValueCommand extends AbstractCommand
 {
     use DryRun;
 
-    public function configure(): void
+    public function __construct(private Service $service){
+        parent::__construct();
+    }
+
+    protected function configure(): void
     {
         $this
             ->setName('pimcore:definition:import:units')
@@ -52,7 +56,7 @@ class QuantityValueCommand extends AbstractCommand
      * Validate and return path to JSON file
      *
      */
-    protected function getPath(): string
+    private function getPath(): string
     {
         $path = $this->input->getArgument('path');
         if (!file_exists($path) || !is_readable($path)) {
@@ -65,7 +69,7 @@ class QuantityValueCommand extends AbstractCommand
     /**
      * Load JSON data from file
      */
-    protected function getJson(string $path): string
+    private function getJson(string $path): string
     {
         $content = file_get_contents($path);
 
@@ -89,7 +93,7 @@ class QuantityValueCommand extends AbstractCommand
             $result = true;
         } else {
             $this->output->writeln(sprintf('Importing quantity value unit definitions from %s', $path));
-            $result = Service::importDefinitionFromJson($json, $override);
+            $result = $this->service->importDefinitionFromJson($json, $override);
         }
 
         if ($result) {

--- a/models/DataObject/QuantityValue/Service.php
+++ b/models/DataObject/QuantityValue/Service.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 /**
  * Pimcore
  *

--- a/models/DataObject/QuantityValue/Service.php
+++ b/models/DataObject/QuantityValue/Service.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 /**
  * Pimcore
  *

--- a/models/DataObject/QuantityValue/Service.php
+++ b/models/DataObject/QuantityValue/Service.php
@@ -20,7 +20,7 @@ use Pimcore\Model\Translation;
 
 class Service
 {
-    public static function importDefinitionFromJson(string $json, bool $override = false): bool
+    public function importDefinitionFromJson(string $json, bool $override = false): bool
     {
         try {
             $unitsArray = json_decode($json, true);
@@ -54,7 +54,7 @@ class Service
         return true;
     }
 
-    public static function generateDefinitionJson(): string|false
+    public function generateDefinitionJson(): string|false
     {
         $list = new Unit\Listing();
         $list->setOrderKey(['baseunit', 'factor', 'abbreviation']);

--- a/models/DataObject/QuantityValue/Service.php
+++ b/models/DataObject/QuantityValue/Service.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Pimcore
  *
@@ -8,8 +9,8 @@
  * Full copyright and license information is available in
  * LICENSE.md which is distributed with this source code.
  *
- * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
- * @license    http://www.pimcore.org/license     GPLv3 and PCL
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
 namespace Pimcore\Model\DataObject\QuantityValue;

--- a/models/DataObject/QuantityValue/Service.php
+++ b/models/DataObject/QuantityValue/Service.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Model\DataObject\QuantityValue;
+
+use Pimcore\Model\Translation;
+
+class Service
+{
+    public static function importDefinitionFromJson(string $json, bool $override = false): bool
+    {
+        try {
+            $unitsArray = json_decode($json, true);
+            $baseUnits = array_column($unitsArray, 'baseunit');
+            $units = []; //array of units to be imported;
+            foreach ($unitsArray as $unitArray) {
+                if ($unit = Unit::getById($unitArray['id'])) {
+                    if ($override) { // override the existing unit definition
+                        $unit->delete();
+                    } else { //skip the import if delete flag is not set
+                        continue;
+                    }
+                }
+                $unit = new Unit();
+                $unit->setValues($unitArray, true);
+                // we need to organize the units such that parent row are inserted before child row in db
+                // to avoid the foreign key constraint error
+                if (in_array($unitArray['id'], $baseUnits)) {
+                    array_unshift($units, $unit);
+                } else {
+                    array_push($units, $unit);
+                }
+            }
+            foreach ($units as $unit) {
+                $unit->save();
+            }
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static function generateDefinitionJson(): string|false
+    {
+        $list = new Unit\Listing();
+        $list->setOrderKey(['baseunit', 'factor', 'abbreviation']);
+        $list->setOrder(['ASC', 'ASC', 'ASC']);
+
+        $result = [];
+        $units = $list->getUnits();
+        foreach ($units as &$unit) {
+            try {
+                if ($unit->getAbbreviation()) {
+                    $unit->setAbbreviation(Translation::getByKeyLocalized($unit->getAbbreviation(), Translation::DOMAIN_ADMIN,
+                        true, true));
+                }
+                if ($unit->getLongname()) {
+                    $unit->setLongname(Translation::getByKeyLocalized($unit->getLongname(), Translation::DOMAIN_ADMIN, true,
+                        true));
+                }
+                $result[] = $unit->getObjectVars();
+            } catch (\Exception $e) {
+                return false;
+            }
+        }
+
+        return json_encode($result, JSON_PRETTY_PRINT);
+    }
+}


### PR DESCRIPTION
Adds the support for importing/exporting quantity value unit definition in pimcore.
1. Added Commands:
    * `pimcore:definition:import:units` => Imports the quantity value units from a JSON Export.
3. Added UI Buttons:
    * Import
    * Export
![Screenshot from 2023-01-25 00-50-16](https://user-images.githubusercontent.com/59438412/214490068-47714903-2674-4188-82e8-153330e1d5ce.png)