### PR TITLE
[Docs] Image\Thumbnail getHTML() will get escaped without "|raw"

### DIFF
--- a/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
+++ b/doc/Development_Documentation/04_Assets/03_Working_with_Thumbnails/01_Image_Thumbnails.md
@@ -52,7 +52,7 @@ Same in Twig:
 
 {# preferred alternative - let Pimcore create the whole image tag #}
 {# including high-res alternatives (srcset) or media queries, if configured #}
-{{ image.thumbnail('myThumbnailName').html }}
+{{ image.thumbnail('myThumbnailName').html|raw }}
 ```
 
 ## Explanation of the Transformations
@@ -99,7 +99,7 @@ You can configure the generated markup with the following options:
 ## Usage Examples
 ```twig
 /* Use directly on the asset object */
-{{ pimcore_asset_by_path('/path/to/image.jpg').thumbnail('myThumbnail').html }}
+{{ pimcore_asset_by_path('/path/to/image.jpg').thumbnail('myThumbnail').html|raw }}
 
 /* ... with some additional options */
 {{ pimcore_asset_by_path('/path/to/image.jpg').thumbnail('myThumbnail').html({ 
@@ -107,7 +107,7 @@ You can configure the generated markup with the following options:
         data-test: "my value"
     },
     disableImgTag: true
-}) }}
+})|raw }}
 
 /* Use with the image tag in documents */
 <div>
@@ -130,7 +130,7 @@ You can configure the generated markup with the following options:
 /* Use from an object-field */
 /* where "myThumbnail" is the name of the thumbnail configuration in settings -> thumbnails */
 {% if myObject.myImage %}
-   {{ myObject.myImage.thumbnail('myThumbnail').html }}
+   {{ myObject.myImage.thumbnail('myThumbnail').html|raw }}
 {% endif %}
 
  
@@ -139,7 +139,7 @@ You can configure the generated markup with the following options:
  
 
 /* Use directly on the asset object using dynamic configuration */
-{{ pimcore_asset_by_path('/path/to/image.jpg').thumbnail({'width': 500, 'format': 'png'}).html }}
+{{ pimcore_asset_by_path('/path/to/image.jpg').thumbnail({'width': 500, 'format': 'png'}).html|raw}}
 ```
 
 ## Advanced Examples
@@ -211,7 +211,7 @@ $webpThumbnail->getHtml();
         'non-standard': 'HTML attributes',
         'another': 'one'
     }
-}) }}
+})|raw }}
   
 /* same with a thumbnail definition */
 {{ image.thumbnail('exampleScaleWidth').html({
@@ -219,15 +219,15 @@ $webpThumbnail->getHtml();
         'class': 'thumbnail-class',
     },
     'data-my-name': 'my value',
-}) }}
+})|raw }}
   
 /* disable the automatically added width & height attributes */
-{{ image.thumbnail('exampleScaleWidth').html({}, ['width', 'height']) }}
+{{ image.thumbnail('exampleScaleWidth').html({}, ['width', 'height'])|raw }}
 
 /* add alt text */
-{{ image.thumbnail('exampleScaleWidth').html({'alt': 'top priority alt text'}) }}
+{{ image.thumbnail('exampleScaleWidth').html({'alt': 'top priority alt text'})|raw }}
 /* OR */
-{{ image.thumbnail('exampleScaleWidth').html({'defaultalt': 'default alt, if not set in image'}) }}
+{{ image.thumbnail('exampleScaleWidth').html({'defaultalt': 'default alt, if not set in image'})|raw }}
     
 
 /* Output only <img> element wihout <picture> and <source> around it */
@@ -246,7 +246,7 @@ By default, the images are lazy loading. This can be changed by setting the valu
     'imgAttributes': {
         'loading': 'eager',
     }
-}) }}
+})|raw }}
     
 
 ````  


### PR DESCRIPTION
Without `|raw` the generated HTML code will get escaped and thus the code will get displayed in the browser instead of the image.