### PR TITLE
Fix allowed types for blocks

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/class.js
@@ -489,8 +489,8 @@ pimcore.object.classes.klass = Class.create({
     },
 
     getRestrictionsFromParent: function (node) {
-        if(node.data.editor.type == "localizedfields") {
-            return "localizedfields";
+        if(in_array(node.data.editor.type, ['localizedfields', 'block'])) {
+            return node.data.editor.type;
         } else {
             if(node.parentNode && node.parentNode.getDepth() > 0) {
                 var parentType = this.getRestrictionsFromParent(node.parentNode);


### PR DESCRIPTION
For adding data fields below layout components (like fieldsets) within blocks, `allowedIn` is not considered properly. Therefore it was allowed to add for example field collections to blocks (which is not supported). 

![image](https://user-images.githubusercontent.com/8792145/214550193-79b8b997-a433-4ed4-b9aa-501206c999d1.png)

This should fix that...


fixed #14072