### PR TITLE
Fallback for region specific languages in admin translations

### DIFF
--- a/bundles/AdminBundle/src/Controller/Admin/MiscController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/MiscController.php
@@ -99,12 +99,22 @@ class MiscController extends AdminController
 
         $translations = [];
 
+        $fallbackLanguages = [];
+        if (null !== \Locale::getRegion($language)) {
+            // if language is region specific, add the primary language as fallback
+            $fallbackLanguages[] = \Locale::getPrimaryLanguage($language);
+        }
+        if ($language != 'en') {
+            // add en as a fallback
+            $fallbackLanguages[] = 'en';
+        }
+
         foreach (['admin', 'admin_ext'] as $domain) {
             $translations = array_merge($translations, $translator->getCatalogue($language)->all($domain));
-            if ($language != 'en') {
-                // add en as a fallback
-                $translator->lazyInitialize($domain, 'en');
-                foreach ($translator->getCatalogue('en')->all($domain) as $key => $value) {
+
+            foreach ($fallbackLanguages as $fallbackLanguage) {
+                $translator->lazyInitialize($domain, $fallbackLanguage);
+                foreach ($translator->getCatalogue($fallbackLanguage)->all($domain) as $key => $value) {
                     if (empty($translations[$key])) {
                         $translations[$key] = $value;
                     }

--- a/bundles/AdminBundle/src/Controller/Admin/MiscController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/MiscController.php
@@ -99,12 +99,19 @@ class MiscController extends AdminController
 
         $translations = [];
 
+        // add en as a fallback
+        $fallbackLanguages = ['en'];
+        if (null !== \Locale::getRegion($language)) {
+            // if language is region specific, prepend the primary language as a fallback
+            array_unshift($fallbackLanguages, \Locale::getPrimaryLanguage($language));
+        }
+
         foreach (['admin', 'admin_ext'] as $domain) {
             $translations = array_merge($translations, $translator->getCatalogue($language)->all($domain));
-            if ($language != 'en') {
-                // add en as a fallback
-                $translator->lazyInitialize($domain, 'en');
-                foreach ($translator->getCatalogue('en')->all($domain) as $key => $value) {
+
+            foreach ($fallbackLanguages as $fallbackLanguage) {
+                $translator->lazyInitialize($domain, $fallbackLanguage);
+                foreach ($translator->getCatalogue($fallbackLanguage)->all($domain) as $key => $value) {
                     if (empty($translations[$key])) {
                         $translations[$key] = $value;
                     }

--- a/bundles/AdminBundle/src/Controller/Admin/MiscController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/MiscController.php
@@ -99,19 +99,12 @@ class MiscController extends AdminController
 
         $translations = [];
 
-        // add en as a fallback
-        $fallbackLanguages = ['en'];
-        if (null !== \Locale::getRegion($language)) {
-            // if language is region specific, prepend the primary language as a fallback
-            array_unshift($fallbackLanguages, \Locale::getPrimaryLanguage($language));
-        }
-
         foreach (['admin', 'admin_ext'] as $domain) {
             $translations = array_merge($translations, $translator->getCatalogue($language)->all($domain));
-
-            foreach ($fallbackLanguages as $fallbackLanguage) {
-                $translator->lazyInitialize($domain, $fallbackLanguage);
-                foreach ($translator->getCatalogue($fallbackLanguage)->all($domain) as $key => $value) {
+            if ($language != 'en') {
+                // add en as a fallback
+                $translator->lazyInitialize($domain, 'en');
+                foreach ($translator->getCatalogue('en')->all($domain) as $key => $value) {
                     if (empty($translations[$key])) {
                         $translations[$key] = $value;
                     }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #14092 

This PR allows to use country/region specific languages in Pimcore backend for admin translations.

**Test setup:**

config/packages/pimcore_admin.yaml:
```
pimcore_admin:
    admin_languages:
        - de_CH
        - en
```

translations/admin.de_CH.yaml:
```
app:
    testlabel: "test-label de"
```

Admin user's locale is listed in his/her profile ("German (Switzerland)"), Pimcore admin backend is translated (from generic "de" translations). ExtJS numeric fields accept the dot (.) as decimal separator. App specific admin translations can be provided both in "admin.de.yaml" as well as in "admin.de_CH.yaml".
     