### PR TITLE
Add missing migration for creating table cache_items

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20201007000000.php
+++ b/bundles/CoreBundle/Migrations/Version20201007000000.php
@@ -30,7 +30,9 @@ final class Version20201007000000 extends AbstractMigration
     public function up(Schema $schema): void
     {
         if (!$schema->hasTable('cache_items')) {
-            $cacheAdapter = new DoctrineDbalAdapter(\Pimcore\Db::get());
+            /** @var \Doctrine\DBAL\Connection $db */
+            $db = \Pimcore\Db::get();
+            $cacheAdapter = new DoctrineDbalAdapter($db);
             $cacheAdapter->createTable();
         }
     }

--- a/bundles/CoreBundle/Migrations/Version20201007000000.php
+++ b/bundles/CoreBundle/Migrations/Version20201007000000.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
+
+/**
+ * @internal
+ */
+final class Version20201007000000 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        if (!$schema->hasTable('cache_items')) {
+            $cacheAdapter = new DoctrineDbalAdapter(\Pimcore\Db::get());
+            $cacheAdapter->createTable();
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS cache_items');
+    }
+}


### PR DESCRIPTION
For an installation from scratch the table `cache_items` gets created in https://github.com/pimcore/pimcore/blob/955d733b826ea588adabe64d52c883ae65ea274b/bundles/InstallBundle/src/Installer.php#L369

Also the `install.sql` refers to this:
https://github.com/pimcore/pimcore/blob/955d733b826ea588adabe64d52c883ae65ea274b/bundles/InstallBundle/dump/install.sql#L73

But when updating an existing Pimcore (we are just updating a system from Pimcore 5 to 10) this does not get executed. This results in errors when the cache gets used, for example during migrations:
```
16:39:52 WARNING   [app] Failed to fetch items: An exception occurred while executing 'SELECT item_id, CASE WHEN item_lifetime IS NULL OR item_lifetime + item_time > ? THEN item_data ELSE NULL END FROM cache_items WHERE item_id IN (?, ?)' with params [1674747592, "\u0000tags\u0000system_resource_columns_object_brick_query_Wein_2", "system_resource_columns_object_brick_query_Wein_2"]:

SQLSTATE[42S02]: Base table or view not found: 1146 Table 'c1_pimcore.cache_items' doesn't exist
[
  "keys" => [
    "\x00tags\x00system_resource_columns_object_brick_query_Wein_2",
    "system_resource_columns_object_brick_query_Wein_2"
  ],
  "exception" => Doctrine\DBAL\Exception\TableNotFoundException^ {
    -driverException: Doctrine\DBAL\Driver\PDO\Exception^ {#1
      -errorCode: 1146
      -sqlState: "42S02"
      #message: "SQLSTATE[42S02]: Base table or view not found: 1146 Table 'c1_pimcore.cache_items' doesn't exist"
      #code: "42S02"
      #file: "/var/www/clients/client1/web1/web/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDO/Exception.php"
      #line: 18
      -previous: PDOException {
        #message: "SQLSTATE[42S02]: Base table or view not found: 1146 Table 'c1_pimcore.cache_items' doesn't exist"
        #code: "42S02"
        #file: "/var/www/clients/client1/web1/web/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php"
        #line: 117
        +errorInfo: [
          "42S02",
          1146,
          "Table 'c1_pimcore.cache_items' doesn't exist"
        ]
        trace: {
          /var/www/clients/client1/web1/web/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:117 { …}
          /var/www/clients/client1/web1/web/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1304 { …}
          /var/www/clients/client1/web1/web/vendor/pimcore/pimcore/lib/Db/PimcoreExtensionsTrait.php:92 { …}
          /var/www/clients/client1/web1/web/vendor/symfony/cache/Adapter/DoctrineDbalAdapter.php:159 { …}
          /var/www/clients/client1/web1/web/vendor/symfony/cache/Traits/AbstractAdapterTrait.php:351 { …}
          /var/www/clients/client1/web1/web/vendor/symfony/cache/Adapter/TagAwareAdapter.php:342 { …}
          /var/www/clients/client1/web1/web/vendor/symfony/cache/Adapter/TagAwareAdapter.php:168 { …}
          /var/www/clients/client1/web1/web/vendor/pimcore/pimcore/lib/Cache/Core/CoreCacheHandler.php:328 { …}
          /var/www/clients/client1/web1/web/vendor/pimcore/pimcore/lib/Cache/Core/CoreCacheHandler.php:304 { …}
          /var/www/clients/client1/web1/web/vendor/pimcore/pimcore/lib/Cache.php:75 { …}
          /var/www/clients/client1/web1/web/vendor/pimcore/pimcore/lib/Model/Dao/AbstractDao.php:71 { …}
          /var/www/clients/client1/web1/web/vendor/pimcore/pimcore/models/DataObject/ClassDefinition/Helper/Dao.php:104 { …}
          /var/www/clients/client1/web1/web/vendor/pimcore/pimcore/models/DataObject/Objectbrick/Definition/Dao.php:146 { …}
          /var/www/clients/client1/web1/web/vendor/pimcore/pimcore/models/DataObject/Objectbrick/Definition.php:372 { …}
          /var/www/clients/client1/web1/web/vendor/pimcore/pimcore/models/DataObject/Objectbrick/Definition.php:204 { …}
          /var/www/clients/client1/web1/web/vendor/pimcore/pimcore/bundles/CoreBundle/Migrations/Version20220318101020.php:49 { …}
          /var/www/clients/client1/web1/web/vendor/pimcore/pimcore/bundles/CoreBundle/Migrations/Version20220318101020.php:33 { …}
          /var/www/clients/client1/web1/web/vendor/doctrine/migrations/lib/Doctrine/Migrations/Version/DbalExecutor.php:167 { …}
          /var/www/clients/client1/web1/web/vendor/doctrine/migrations/lib/Doctrine/Migrations/Version/DbalExecutor.php:102 { …}
          /var/www/clients/client1/web1/web/vendor/doctrine/migrations/lib/Doctrine/Migrations/DbalMigrator.php:112 { …}
          /var/www/clients/client1/web1/web/vendor/doctrine/migrations/lib/Doctrine/Migrations/DbalMigrator.php:76 { …}
          /var/www/clients/client1/web1/web/vendor/doctrine/migrations/lib/Doctrine/Migrations/DbalMigrator.php:162 { …}
          /var/www/clients/client1/web1/web/vendor/doctrine/migrations/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php:210 { …}
          /var/www/clients/client1/web1/web/vendor/symfony/console/Command/Command.php:298 { …}
          /var/www/clients/client1/web1/web/vendor/symfony/console/Application.php:1058 { …}
          /var/www/clients/client1/web1/web/vendor/symfony/framework-bundle/Console/Application.php:96 { …}
          /var/www/clients/client1/web1/web/vendor/symfony/console/Application.php:301 { …}
          /var/www/clients/client1/web1/web/vendor/symfony/framework-bundle/Console/Application.php:82 { …}
          /var/www/clients/client1/web1/web/vendor/symfony/console/Application.php:171 { …}
          /var/www/clients/client1/web1/web/bin/console:26 {
            › $application = new \Pimcore\Console\Application($kernel);
            › $application->run();
            › 
          }
        }
      }
```

This PR creates this table. I did not know which migration date to use so I used one before the first Pimcore 10 migration (or maybe we should use the date of https://github.com/pimcore/pimcore/commit/da4af8150ec9a8b869fe98a8eeaa656932cf16e9). I could not use the current date because the error happens on all migrations which save class definitions.