### PR TITLE
[Asset] Remove deprecated `marshal()/unmarshal()` methods for metadata

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -160,6 +160,7 @@ Please make sure to set your preferred storage location ***before*** migration. 
 - [Ecommerce][Product Interfaces] Changed return type-hints of `CheckoutableInterface` methods `getOSPrice`, `getOSPriceInfo`, `getOSAvailabilityInfo`, `getPriceSystemName`, `getAvailabilitySystemName`, `getPriceSystemImplementation`, `getAvailabilitySystemImplementation` to be non-nullable.
 - [Elements] Removed the deprecated `Pimcore\Model\Element\Service::getType()`, use `Pimcore\Model\Element\Service::getElementType()` instead.
 - [DataObjects] Method `Concrete::getClass()` throws NotFoundException if class is not found for an object.
+- [Asset] Removed the deprecated `marshal()/unmarshal()` methods for metadata, use `normalize()/denormalize()` methods instead.
 - [Asset] Asset/Asset Thumbnail Update messages are now routed to different queue
   instead of `pimcore_core`. please add option `pimcore_asset_update` to command `bin/console messenger:consume pimcore_core... pimcore_asset_update` to post process assets on update.
   Also run command `bin/console messenger:consume pimcore_core` before the upgrade, so that `AssetUpdateTasksMessage` on the queue gets consumed.

--- a/models/Asset/MetaData/ClassDefinition/Data/Asset.php
+++ b/models/Asset/MetaData/ClassDefinition/Data/Asset.php
@@ -41,35 +41,6 @@ class Asset extends Data
         return $element;
     }
 
-    /**
-     * @param mixed $value
-     * @param array $params
-     *
-     * @return string
-     *
-     * @deprecated use denormalize() instead, will be removed in Pimcore 11
-     */
-    public function unmarshal(mixed $value, array $params = []): mixed
-    {
-        trigger_deprecation(
-            'pimcore/pimcore',
-            '10.4',
-            sprintf('%s is deprecated, please use denormalize() instead. It will be removed in Pimcore 11.', __METHOD__)
-        );
-
-        $element = null;
-        if (is_numeric($value)) {
-            $element = Service::getElementById('asset', $value);
-        }
-        if ($element) {
-            $value = $element->getRealFullPath();
-        } else {
-            $value = '';
-        }
-
-        return $value;
-    }
-
     public function transformGetterData(mixed $data, array $params = []): mixed
     {
         if (is_numeric($data)) {

--- a/models/Asset/MetaData/ClassDefinition/Data/Data.php
+++ b/models/Asset/MetaData/ClassDefinition/Data/Data.php
@@ -24,44 +24,6 @@ abstract class Data implements DataDefinitionInterface, NormalizerInterface
     use SimpleNormalizerTrait;
 
     /**
-     * @param mixed $value
-     * @param array $params
-     *
-     * @return mixed
-     *
-     * @deprecated use normalize() instead, will be removed in Pimcore 11
-     */
-    public function marshal(mixed $value, array $params = []): mixed
-    {
-        trigger_deprecation(
-            'pimcore/pimcore',
-            '10.4',
-            sprintf('%s is deprecated, please use normalize() instead. It will be removed in Pimcore 11.', __METHOD__)
-        );
-
-        return $this->normalize($value, $params);
-    }
-
-    /**
-     * @param mixed $value
-     * @param array $params
-     *
-     * @return mixed
-     *
-     * @deprecated use denormalize() instead, will be removed in Pimcore 11
-     */
-    public function unmarshal(mixed $value, array $params = []): mixed
-    {
-        trigger_deprecation(
-            'pimcore/pimcore',
-            '10.4',
-            sprintf('%s is deprecated, please use denormalize() instead. It will be removed in Pimcore 11.', __METHOD__)
-        );
-
-        return $this->denormalize($value, $params);
-    }
-
-    /**
      * @return string
      */
     public function __toString()

--- a/models/Asset/MetaData/ClassDefinition/Data/DataObject.php
+++ b/models/Asset/MetaData/ClassDefinition/Data/DataObject.php
@@ -42,35 +42,6 @@ class DataObject extends Data
         return $element;
     }
 
-    /**
-     * @param mixed $value
-     * @param array $params
-     *
-     * @return string
-     *
-     * @deprecated use denormalize() instead, will be removed in Pimcore 11
-     */
-    public function unmarshal(mixed $value, array $params = []): mixed
-    {
-        trigger_deprecation(
-            'pimcore/pimcore',
-            '10.4',
-            sprintf('%s is deprecated, please use denormalize() instead. It will be removed in Pimcore 11.', __METHOD__)
-        );
-
-        $element = null;
-        if (is_numeric($value)) {
-            $element = Service::getElementById('object', $value);
-        }
-        if ($element) {
-            $value = $element->getRealFullPath();
-        } else {
-            $value = '';
-        }
-
-        return $value;
-    }
-
     public function transformGetterData(mixed $data, array $params = []): mixed
     {
         if (is_numeric($data)) {

--- a/models/Asset/MetaData/ClassDefinition/Data/Document.php
+++ b/models/Asset/MetaData/ClassDefinition/Data/Document.php
@@ -41,35 +41,6 @@ class Document extends Data
         return $element;
     }
 
-    /**
-     * @param mixed $value
-     * @param array $params
-     *
-     * @return string
-     *
-     * @deprecated use denormalize() instead, will be removed in Pimcore 11
-     */
-    public function unmarshal(mixed $value, array $params = []): mixed
-    {
-        trigger_deprecation(
-            'pimcore/pimcore',
-            '10.4',
-            sprintf('%s is deprecated, please use denormalize() instead. It will be removed in Pimcore 11.', __METHOD__)
-        );
-
-        $element = null;
-        if (is_numeric($value)) {
-            $element = Service::getElementById('document', $value);
-        }
-        if ($element) {
-            $value = $element->getRealFullPath();
-        } else {
-            $value = '';
-        }
-
-        return $value;
-    }
-
     public function transformGetterData(mixed $data, array $params = []): mixed
     {
         if (is_numeric($data)) {


### PR DESCRIPTION
Followup to https://github.com/pimcore/pimcore/pull/11596