### PR TITLE
[Migrations] Make migrations idempotent

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20210531125102.php
+++ b/bundles/CoreBundle/Migrations/Version20210531125102.php
@@ -32,7 +32,9 @@ final class Version20210531125102 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `sites` ADD COLUMN `localizedErrorDocuments` text;');
+        if(!$schema->getTable('sites')->hasColumn('localizedErrorDocuments')) {
+            $this->addSql('ALTER TABLE `sites` ADD COLUMN `localizedErrorDocuments` text;');
+        }
     }
 
     public function down(Schema $schema): void

--- a/bundles/CoreBundle/Migrations/Version20210624085031.php
+++ b/bundles/CoreBundle/Migrations/Version20210624085031.php
@@ -32,11 +32,16 @@ final class Version20210624085031 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE email_log ADD error TEXT NULL');
+        if(!$schema->getTable('email_log')->hasColumn('error')) {
+            $this->addSql('ALTER TABLE email_log ADD error TEXT NULL');
+        }
+
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE email_log DROP error');
+        if ($schema->getTable('email_log')->hasColumn('error')) {
+            $this->addSql('ALTER TABLE email_log DROP error');
+        }
     }
 }

--- a/bundles/CoreBundle/Migrations/Version20211016084043.php
+++ b/bundles/CoreBundle/Migrations/Version20211016084043.php
@@ -29,11 +29,15 @@ final class Version20211016084043 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE gridconfigs ADD setAsFavourite TINYINT(1) NULL');
+        if (!$schema->getTable('gridconfigs')->hasColumn('setAsFavourite')) {
+            $this->addSql('ALTER TABLE gridconfigs ADD setAsFavourite TINYINT(1) NULL');
+        }
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE gridconfigs DROP setAsFavourite');
+        if ($schema->getTable('gridconfigs')->hasColumn('setAsFavourite')) {
+            $this->addSql('ALTER TABLE gridconfigs DROP setAsFavourite');
+        }
     }
 }

--- a/bundles/CoreBundle/Migrations/Version20211221152344.php
+++ b/bundles/CoreBundle/Migrations/Version20211221152344.php
@@ -32,13 +32,18 @@ final class Version20211221152344 extends AbstractMigration
         //disable foreign key checks
         $this->addSql('SET foreign_key_checks = 0');
 
-        $this->addSql('ALTER TABLE `assets_metadata`
-            CHANGE `cid` `cid` int(11) unsigned NOT NULL,
-            ADD CONSTRAINT `fk_assets_metadata_assets`
-            FOREIGN KEY (`cid`)
-            REFERENCES `assets` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;');
+        $this->addSql('ALTER TABLE `assets_metadata` CHANGE `cid` `cid` int(11) unsigned NOT NULL;');
+
+        if(!$schema->getTable('assets_metadata')->hasForeignKey('fk_assets_metadata_assets')) {
+            $this->addSql(
+                'ALTER TABLE `assets_metadata`
+                ADD CONSTRAINT `fk_assets_metadata_assets`
+                FOREIGN KEY (`cid`)
+                REFERENCES `assets` (`id`)
+                ON UPDATE NO ACTION
+                ON DELETE CASCADE;'
+            );
+        }
 
         //enable foreign key checks
         $this->addSql('SET foreign_key_checks = 1');
@@ -46,8 +51,10 @@ final class Version20211221152344 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `assets_metadata`
-            DROP FOREIGN KEY `fk_assets_metadata_assets`,
-            CHANGE `cid` `cid` int(11) NOT NULL;');
+        if ($schema->getTable('assets_metadata')->hasForeignKey('fk_assets_metadata_assets')) {
+            $this->addSql('ALTER TABLE `assets_metadata` DROP FOREIGN KEY `fk_assets_metadata_assets`;');
+        }
+
+        $this->addSql('ALTER TABLE `assets_metadata` CHANGE `cid` `cid` int(11) NOT NULL;');
     }
 }

--- a/bundles/CoreBundle/Migrations/Version20220119082511.php
+++ b/bundles/CoreBundle/Migrations/Version20220119082511.php
@@ -32,22 +32,33 @@ final class Version20220119082511 extends AbstractMigration
         //disable foreign key checks
         $this->addSql('SET foreign_key_checks = 0');
 
-        $this->addSql('ALTER TABLE `gridconfig_favourites` CHANGE `gridConfigId` `gridConfigId` int(11) NOT NULL');
-        $this->addSql('ALTER TABLE `gridconfig_favourites`
-            ADD INDEX `grid_config_id` (`gridConfigId`),
-            ADD CONSTRAINT `fk_gridconfig_favourites_gridconfigs`
-            FOREIGN KEY (`gridConfigId`)
-            REFERENCES `gridconfigs` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;');
+        $this->addSql('ALTER TABLE `gridconfig_favourites` CHANGE `gridConfigId` `gridConfigId` int(11) NOT NULL;');
 
-        $this->addSql('ALTER TABLE `gridconfig_shares`
-            ADD INDEX `grid_config_id` (`gridConfigId`),
-            ADD CONSTRAINT `fk_gridconfig_shares_gridconfigs`
+        if(!$schema->getTable('gridconfig_favourites')->hasIndex('grid_config_id')) {
+            $this->addSql('ALTER TABLE `gridconfig_favourites` ADD INDEX `grid_config_id` (`gridConfigId`);');
+        }
+
+        if (!$schema->getTable('gridconfig_favourites')->hasForeignKey('fk_gridconfig_favourites_gridconfigs')) {
+            $this->addSql('ALTER TABLE `gridconfig_favourites` ADD CONSTRAINT `fk_gridconfig_favourites_gridconfigs`
             FOREIGN KEY (`gridConfigId`)
             REFERENCES `gridconfigs` (`id`)
             ON UPDATE NO ACTION
             ON DELETE CASCADE;');
+        }
+
+        if (!$schema->getTable('gridconfig_shares')->hasIndex('grid_config_id')) {
+            $this->addSql('ALTER TABLE `gridconfig_shares` ADD INDEX `grid_config_id` (`gridConfigId`)');
+        }
+
+        if (!$schema->getTable('gridconfig_shares')->hasForeignKey('fk_gridconfig_shares_gridconfigs')) {
+            $this->addSql(
+                'ALTER TABLE `gridconfig_shares` ADD CONSTRAINT `fk_gridconfig_shares_gridconfigs`
+                FOREIGN KEY (`gridConfigId`)
+                REFERENCES `gridconfigs` (`id`)
+                ON UPDATE NO ACTION
+                ON DELETE CASCADE;'
+            );
+        }
 
         //enable foreign key checks
         $this->addSql('SET foreign_key_checks = 1');
@@ -55,13 +66,22 @@ final class Version20220119082511 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `gridconfig_favourites`
-            DROP INDEX IF EXISTS `grid_config_id`,
-            DROP FOREIGN KEY IF EXISTS `fk_gridconfig_favourites_gridconfigs`,
-            CHANGE `gridConfigId` `gridConfigId` int(11) NULL;');
+        if ($schema->getTable('gridconfig_favourites')->hasIndex('grid_config_id')) {
+            $this->addSql('ALTER TABLE `gridconfig_favourites` DROP INDEX IF EXISTS `grid_config_id`;');
+        }
 
-        $this->addSql('ALTER TABLE `gridconfig_shares`
-            DROP INDEX IF EXISTS `grid_config_id`,
-            DROP FOREIGN KEY IF EXISTS `fk_gridconfig_shares_gridconfigs`;');
+        if ($schema->getTable('gridconfig_favourites')->hasForeignKey('fk_gridconfig_favourites_gridconfigs')) {
+            $this->addSql('ALTER TABLE `gridconfig_favourites` DROP FOREIGN KEY IF EXISTS `fk_gridconfig_favourites_gridconfigs`;');
+        }
+
+        $this->addSql('ALTER TABLE `gridconfig_favourites` CHANGE `gridConfigId` `gridConfigId` int(11) NULL;');
+
+        if ($schema->getTable('gridconfig_shares')->hasIndex('grid_config_id')) {
+            $this->addSql('ALTER TABLE `gridconfig_shares` DROP INDEX IF EXISTS `grid_config_id`;');
+        }
+
+        if ($schema->getTable('gridconfig_shares')->hasForeignKey('fk_gridconfig_favourites_gridconfigs')) {
+            $this->addSql('ALTER TABLE `gridconfig_shares` DROP FOREIGN KEY IF EXISTS `fk_gridconfig_shares_gridconfigs`;');
+        }
     }
 }

--- a/bundles/CoreBundle/Migrations/Version20220120121803.php
+++ b/bundles/CoreBundle/Migrations/Version20220120121803.php
@@ -87,7 +87,7 @@ final class Version20220120121803 extends AbstractMigration
     {
         foreach (['documents_hardlink', 'documents_link', 'documents_page', 'documents_snippet', 'documents_printpage', 'documents_email', 'email_log', 'documents_newsletter', 'documents_editables', 'documents_translations'] as $table) {
             if ($schema->getTable($table)->hasForeignKey('fk_'.$table.'_documents')) {
-                $this->addSql('ALTER TABLE `documents_hardlink` DROP FOREIGN KEY IF EXISTS `fk_'.$table.'_documents`;');
+                $this->addSql('ALTER TABLE `'.$table.'` DROP FOREIGN KEY IF EXISTS `fk_'.$table.'_documents`;');
             }
         }
 

--- a/bundles/CoreBundle/Migrations/Version20220120121803.php
+++ b/bundles/CoreBundle/Migrations/Version20220120121803.php
@@ -32,7 +32,7 @@ final class Version20220120121803 extends AbstractMigration
         //disable foreign key checks
         $this->addSql('SET foreign_key_checks = 0');
 
-        foreach(['documents_hardlink', 'documents_link', 'documents_page', 'documents_snippet', 'documents_printpage', 'documents_email', 'documents_newsletter', 'documents_editables', 'documents_translations'] as $table) {
+        foreach(['documents_hardlink', 'documents_link', 'documents_page', 'documents_snippet', 'documents_printpage', 'documents_email', 'documents_newsletter', 'documents_translations'] as $table) {
             if (!$schema->getTable($table)->hasForeignKey('fk_'.$table.'_documents')) {
                 $this->addSql(
                     'ALTER TABLE `'.$table.'`
@@ -43,6 +43,17 @@ final class Version20220120121803 extends AbstractMigration
                     ON DELETE CASCADE;'
                 );
             }
+        }
+
+        if (!$schema->getTable($table)->hasForeignKey('fk_documents_editables_documents')) {
+            $this->addSql(
+                'ALTER TABLE `documents_editables`
+                ADD CONSTRAINT `fk_documents_editables_documents`
+                FOREIGN KEY (`documentId`)
+                REFERENCES `documents` (`id`)
+                ON UPDATE NO ACTION
+                ON DELETE CASCADE;'
+            );
         }
 
         $this->addSql('ALTER TABLE `email_log` CHANGE `documentId` `documentId` int(11) unsigned NULL;');

--- a/bundles/CoreBundle/Migrations/Version20220120121803.php
+++ b/bundles/CoreBundle/Migrations/Version20220120121803.php
@@ -32,82 +32,41 @@ final class Version20220120121803 extends AbstractMigration
         //disable foreign key checks
         $this->addSql('SET foreign_key_checks = 0');
 
-        $this->addSql('ALTER TABLE `documents_hardlink`
-            ADD CONSTRAINT `fk_documents_hardlink_documents`FOREIGN KEY (`id`)
-            REFERENCES `documents` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;');
+        foreach(['documents_hardlink', 'documents_link', 'documents_page', 'documents_snippet', 'documents_printpage', 'documents_email', 'documents_newsletter', 'documents_editables', 'documents_translations'] as $table) {
+            if (!$schema->getTable($table)->hasForeignKey('fk_'.$table.'_documents')) {
+                $this->addSql(
+                    'ALTER TABLE `'.$table.'`
+                    ADD CONSTRAINT `fk_'.$table.'_documents`
+                    FOREIGN KEY (`id`)
+                    REFERENCES `documents` (`id`)
+                    ON UPDATE NO ACTION
+                    ON DELETE CASCADE;'
+                );
+            }
+        }
 
-        $this->addSql('ALTER TABLE `documents_link`
-            ADD CONSTRAINT `fk_documents_link_documents`
-            FOREIGN KEY (`id`)
-            REFERENCES `documents` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;');
+        $this->addSql('ALTER TABLE `email_log` CHANGE `documentId` `documentId` int(11) unsigned NULL;');
+        if (!$schema->getTable('email_log')->hasForeignKey('fk_email_log_documents')) {
+            $this->addSql(
+                'ALTER TABLE `email_log`
+                ADD CONSTRAINT `fk_email_log_documents`
+                FOREIGN KEY (`documentId`)
+                REFERENCES `documents` (`id`)
+                ON UPDATE NO ACTION
+                ON DELETE CASCADE;'
+            );
+        }
 
-        $this->addSql('ALTER TABLE `documents_page`
-            ADD CONSTRAINT `fk_documents_page_documents`
-            FOREIGN KEY (`id`)
-            REFERENCES `documents` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;');
-
-        $this->addSql('ALTER TABLE `documents_snippet`
-            ADD CONSTRAINT `fk_documents_snippet_documents`
-            FOREIGN KEY (`id`)
-            REFERENCES `documents` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;');
-
-        $this->addSql('ALTER TABLE `documents_printpage`
-            ADD CONSTRAINT `fk_documents_printpage_documents`
-            FOREIGN KEY (`id`)
-            REFERENCES `documents` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;');
-
-        $this->addSql('ALTER TABLE `documents_email`
-            ADD CONSTRAINT `fk_documents_email_documents`
-            FOREIGN KEY (`id`)
-            REFERENCES `documents` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;');
-
-        $this->addSql('ALTER TABLE `email_log`
-            CHANGE `documentId` `documentId` int(11) unsigned NULL,
-            ADD CONSTRAINT `fk_email_log_documents`
-            FOREIGN KEY (`documentId`)
-            REFERENCES `documents` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;');
-
-        $this->addSql('ALTER TABLE `documents_newsletter`
-            ADD CONSTRAINT `fk_documents_newsletter_documents`
-            FOREIGN KEY (`id`)
-            REFERENCES `documents` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;');
-
-        $this->addSql('ALTER TABLE `documents_editables`
-            ADD CONSTRAINT `fk_documents_editables_documents`
-            FOREIGN KEY (`documentId`)
-            REFERENCES `documents` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;');
-
-        $this->addSql('ALTER TABLE `documents_translations`
-            ADD CONSTRAINT `fk_documents_translations_documents`
-            FOREIGN KEY (`id`)
-            REFERENCES `documents` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;');
-
-        $this->addSql('ALTER TABLE `sites`
-            ADD CONSTRAINT `fk_sites_documents`
-            FOREIGN KEY (`rootId`)
-            REFERENCES `documents` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;');
+        if (!$schema->getTable('sites')->hasForeignKey('fk_sites_documents')) {
+            $this->addSql(
+                'ALTER TABLE `sites`
+                ADD CONSTRAINT `fk_sites_documents`
+                FOREIGN KEY (`rootId`)
+                REFERENCES `documents` (`id`)
+                ON UPDATE NO ACTION
+                ON DELETE CASCADE;'
+            );
+        }
 
         //enable foreign key checks
         $this->addSql('SET foreign_key_checks = 1');
@@ -115,28 +74,14 @@ final class Version20220120121803 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `documents_hardlink` DROP FOREIGN KEY IF EXISTS `fk_documents_hardlink_documents`;');
+        foreach (['documents_hardlink', 'documents_link', 'documents_page', 'documents_snippet', 'documents_printpage', 'documents_email', 'email_log', 'documents_newsletter', 'documents_editables', 'documents_translations'] as $table) {
+            if ($schema->getTable($table)->hasForeignKey('fk_'.$table.'_documents')) {
+                $this->addSql('ALTER TABLE `documents_hardlink` DROP FOREIGN KEY IF EXISTS `fk_'.$table.'_documents`;');
+            }
+        }
 
-        $this->addSql('ALTER TABLE `documents_link` DROP FOREIGN KEY IF EXISTS `fk_documents_link_documents`;');
-
-        $this->addSql('ALTER TABLE `documents_page` DROP FOREIGN KEY IF EXISTS `fk_documents_page_documents`;');
-
-        $this->addSql('ALTER TABLE `documents_snippet` DROP FOREIGN KEY IF EXISTS `fk_documents_snippet_documents`;');
-
-        $this->addSql('ALTER TABLE `documents_printpage` DROP FOREIGN KEY IF EXISTS `fk_documents_printpage_documents`;');
-
-        $this->addSql('ALTER TABLE `documents_snippet` DROP FOREIGN KEY IF EXISTS `fk_documents_snippet_documents`;');
-
-        $this->addSql('ALTER TABLE `documents_email` DROP FOREIGN KEY IF EXISTS `fk_documents_email_documents`;');
-
-        $this->addSql('ALTER TABLE `email_log` DROP FOREIGN KEY IF EXISTS `fk_email_log_documents`;');
-
-        $this->addSql('ALTER TABLE `documents_newsletter` DROP FOREIGN KEY IF EXISTS `fk_documents_newsletter_documents`;');
-
-        $this->addSql('ALTER TABLE `documents_editables` DROP FOREIGN KEY IF EXISTS `fk_documents_editables_documents`;');
-
-        $this->addSql('ALTER TABLE `documents_translations` DROP FOREIGN KEY IF EXISTS `fk_documents_translations_documents`;');
-
-        $this->addSql('ALTER TABLE `sites` DROP FOREIGN KEY IF EXISTS `fk_sites_documents`;');
+        if ($schema->getTable('sites')->hasForeignKey('fk_sites_documents')) {
+            $this->addSql('ALTER TABLE `sites` DROP FOREIGN KEY IF EXISTS `fk_sites_documents`;');
+        }
     }
 }

--- a/bundles/CoreBundle/Migrations/Version20220120162621.php
+++ b/bundles/CoreBundle/Migrations/Version20220120162621.php
@@ -122,7 +122,6 @@ final class Version20220120162621 extends AbstractMigration
     public function down(Schema $schema): void
     {
         foreach(['asset', 'document', 'object'] as $elementType) {
-            $this->addSql('ALTER TABLE `users_workspaces_'.$elementType.'` CHANGE `userId` `userId` int(11) NOT NULL DEFAULT \'0\'');
             if ($schema->getTable('users_workspaces_'.$elementType)->hasForeignKey('fk_users_workspaces_'.$elementType.'_'.$elementType.'s')) {
                 $this->addSql('ALTER TABLE `users_workspaces_'.$elementType.'` DROP FOREIGN KEY IF EXISTS `fk_users_workspaces_'.$elementType.'_'.$elementType.'s`');
             }
@@ -130,6 +129,8 @@ final class Version20220120162621 extends AbstractMigration
             if ($schema->getTable('users_workspaces_'.$elementType)->hasForeignKey('fk_users_workspaces_'.$elementType.'_users')) {
                 $this->addSql('ALTER TABLE `users_workspaces_'.$elementType.'` DROP FOREIGN KEY IF EXISTS `fk_users_workspaces_'.$elementType.'_users`');
             }
+
+            $this->addSql('ALTER TABLE `users_workspaces_'.$elementType.'` CHANGE `userId` `userId` int(11) NOT NULL DEFAULT \'0\'');
         }
     }
 }

--- a/bundles/CoreBundle/Migrations/Version20220120162621.php
+++ b/bundles/CoreBundle/Migrations/Version20220120162621.php
@@ -104,7 +104,7 @@ final class Version20220120162621 extends AbstractMigration
             'ALTER TABLE `users_workspaces_object`
             CHANGE `userId` `userId` int(11) unsigned NOT NULL DEFAULT \'0\';');
 
-        if (!$schema->getTable('users_workspaces_document')->hasForeignKey('fk_users_workspaces_object_users')) {
+        if (!$schema->getTable('users_workspaces_object')->hasForeignKey('fk_users_workspaces_object_users')) {
             $this->addSql(
                 'ALTER TABLE `users_workspaces_object`
                 ADD CONSTRAINT `fk_users_workspaces_object_users`

--- a/bundles/CoreBundle/Migrations/Version20220120162621.php
+++ b/bundles/CoreBundle/Migrations/Version20220120162621.php
@@ -89,7 +89,7 @@ final class Version20220120162621 extends AbstractMigration
         }
 
 
-        if (!$schema->getTable('users_workspaces_document')->hasForeignKey('fk_users_workspaces_object_objects')) {
+        if (!$schema->getTable('users_workspaces_object')->hasForeignKey('fk_users_workspaces_object_objects')) {
             $this->addSql(
                 'ALTER TABLE `users_workspaces_object`
                 ADD CONSTRAINT `fk_users_workspaces_object_objects`

--- a/bundles/CoreBundle/Migrations/Version20220120162621.php
+++ b/bundles/CoreBundle/Migrations/Version20220120162621.php
@@ -34,44 +34,86 @@ final class Version20220120162621 extends AbstractMigration
         //disable foreign key checks
         $this->addSql('SET foreign_key_checks = 0');
 
-        $this->addSql('ALTER TABLE `users_workspaces_asset`
-            ADD CONSTRAINT `fk_users_workspaces_asset_assets`
-            FOREIGN KEY (`cid`)
-            REFERENCES `assets` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE,
-            CHANGE `userId` `userId` int(11) unsigned NOT NULL DEFAULT \'0\',
-            ADD CONSTRAINT `fk_users_workspaces_asset_users`
-            FOREIGN KEY (`userId`)
-            REFERENCES `users` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;');
+        if (!$schema->getTable('users_workspaces_asset')->hasForeignKey('fk_users_workspaces_asset_assets')) {
+            $this->addSql(
+                'ALTER TABLE `users_workspaces_asset`
+                ADD CONSTRAINT `fk_users_workspaces_asset_assets`
+                FOREIGN KEY (`cid`)
+                REFERENCES `assets` (`id`)
+                ON UPDATE NO ACTION
+                ON DELETE CASCADE;'
+            );
+        }
 
-        $this->addSql('ALTER TABLE `users_workspaces_document`
-            ADD CONSTRAINT `fk_users_workspaces_document_documents`
-            FOREIGN KEY (`cid`)
-            REFERENCES `documents` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE,
-            CHANGE `userId` `userId` int(11) unsigned NOT NULL DEFAULT \'0\',
-            ADD CONSTRAINT `fk_users_workspaces_document_users`
-            FOREIGN KEY (`userId`)
-            REFERENCES `users` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;;');
+        $this->addSql(
+            'ALTER TABLE `users_workspaces_asset`
+            CHANGE `userId` `userId` int(11) unsigned NOT NULL DEFAULT \'0\';'
+        );
 
-        $this->addSql('ALTER TABLE `users_workspaces_object`
-            ADD CONSTRAINT `fk_users_workspaces_object_objects`
-            FOREIGN KEY (`cid`)
-            REFERENCES `objects` (`o_id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE,
-            CHANGE `userId` `userId` int(11) unsigned NOT NULL DEFAULT \'0\',
-            ADD CONSTRAINT `fk_users_workspaces_object_users`
-            FOREIGN KEY (`userId`)
-            REFERENCES `users` (`id`)
-            ON UPDATE NO ACTION
-            ON DELETE CASCADE;;');
+        if (!$schema->getTable('users_workspaces_asset')->hasForeignKey('fk_users_workspaces_asset_users')) {
+            $this->addSql(
+                'ALTER TABLE `users_workspaces_asset`
+                ADD CONSTRAINT `fk_users_workspaces_asset_users`
+                FOREIGN KEY (`userId`)
+                REFERENCES `users` (`id`)
+                ON UPDATE NO ACTION
+                ON DELETE CASCADE;'
+            );
+        }
+
+
+        if (!$schema->getTable('users_workspaces_document')->hasForeignKey('fk_users_workspaces_document_documents')) {
+            $this->addSql(
+                'ALTER TABLE `users_workspaces_document`
+                ADD CONSTRAINT `fk_users_workspaces_document_documents`
+                FOREIGN KEY (`cid`)
+                REFERENCES `documents` (`id`)
+                ON UPDATE NO ACTION
+                ON DELETE CASCADE;'
+            );
+        }
+
+        $this->addSql(
+            'ALTER TABLE `users_workspaces_document`
+            CHANGE `userId` `userId` int(11) unsigned NOT NULL DEFAULT \'0\';');
+
+        if (!$schema->getTable('users_workspaces_document')->hasForeignKey('fk_users_workspaces_document_users')) {
+            $this->addSql(
+                'ALTER TABLE `users_workspaces_document`
+                ADD CONSTRAINT `fk_users_workspaces_document_users`
+                FOREIGN KEY (`userId`)
+                REFERENCES `users` (`id`)
+                ON UPDATE NO ACTION
+                ON DELETE CASCADE;'
+            );
+        }
+
+
+        if (!$schema->getTable('users_workspaces_document')->hasForeignKey('fk_users_workspaces_object_objects')) {
+            $this->addSql(
+                'ALTER TABLE `users_workspaces_object`
+                ADD CONSTRAINT `fk_users_workspaces_object_objects`
+                FOREIGN KEY (`cid`)
+                REFERENCES `objects` (`o_id`)
+                ON UPDATE NO ACTION
+                ON DELETE CASCADE;'
+            );
+        }
+
+        $this->addSql(
+            'ALTER TABLE `users_workspaces_object`
+            CHANGE `userId` `userId` int(11) unsigned NOT NULL DEFAULT \'0\';');
+
+        if (!$schema->getTable('users_workspaces_document')->hasForeignKey('fk_users_workspaces_object_users')) {
+            $this->addSql(
+                'ALTER TABLE `users_workspaces_object`
+                ADD CONSTRAINT `fk_users_workspaces_object_users`
+                FOREIGN KEY (`userId`)
+                REFERENCES `users` (`id`)
+                ON UPDATE NO ACTION
+                ON DELETE CASCADE;'
+            );
+        }
 
         //enable foreign key checks
         $this->addSql('SET foreign_key_checks = 1');
@@ -79,19 +121,15 @@ final class Version20220120162621 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `users_workspaces_asset`
-                CHANGE `userId` `userId` int(11) NOT NULL DEFAULT \'0\',
-                DROP FOREIGN KEY IF EXISTS `fk_users_workspaces_asset_assets`,
-                DROP FOREIGN KEY IF EXISTS `fk_users_workspaces_asset_users`');
+        foreach(['asset', 'document', 'object'] as $elementType) {
+            $this->addSql('ALTER TABLE `users_workspaces_'.$elementType.'` CHANGE `userId` `userId` int(11) NOT NULL DEFAULT \'0\'');
+            if ($schema->getTable('users_workspaces_'.$elementType)->hasForeignKey('fk_users_workspaces_'.$elementType.'_'.$elementType.'s')) {
+                $this->addSql('ALTER TABLE `users_workspaces_'.$elementType.'` DROP FOREIGN KEY IF EXISTS `fk_users_workspaces_'.$elementType.'_'.$elementType.'s`');
+            }
 
-        $this->addSql('ALTER TABLE `users_workspaces_document`
-                CHANGE `userId` `userId` int(11) NOT NULL DEFAULT \'0\',
-                DROP FOREIGN KEY IF EXISTS `fk_users_workspaces_document_documents`,
-                DROP FOREIGN KEY IF EXISTS `fk_users_workspaces_document_users`');
-
-        $this->addSql('ALTER TABLE `users_workspaces_object`
-                CHANGE `userId` `userId` int(11) NOT NULL DEFAULT \'0\',
-                DROP FOREIGN KEY IF EXISTS `fk_users_workspaces_object_objects`,
-                DROP FOREIGN KEY IF EXISTS `fk_users_workspaces_object_users`');
+            if ($schema->getTable('users_workspaces_'.$elementType)->hasForeignKey('fk_users_workspaces_'.$elementType.'_users')) {
+                $this->addSql('ALTER TABLE `users_workspaces_'.$elementType.'` DROP FOREIGN KEY IF EXISTS `fk_users_workspaces_'.$elementType.'_users`');
+            }
+        }
     }
 }

--- a/bundles/CoreBundle/Migrations/Version20220425082914.php
+++ b/bundles/CoreBundle/Migrations/Version20220425082914.php
@@ -29,11 +29,23 @@ final class Version20220425082914 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `objects` DROP INDEX `type`, ADD INDEX `type_path_classId` (o_type, o_path, o_classId)');
+        if($schema->getTable('objects')->hasIndex('type')) {
+            $this->addSql('ALTER TABLE `objects` DROP INDEX `type`');
+        }
+
+        if (!$schema->getTable('objects')->hasIndex('type_path_classId')) {
+            $this->addSql('ALTER TABLE `objects` ADD INDEX `type_path_classId` (o_type, o_path, o_classId)');
+        }
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `objects` DROP INDEX `type_path_classId`, ADD INDEX `type` (o_type)');
+        if (!$schema->getTable('objects')->hasIndex('type')) {
+            $this->addSql('ALTER TABLE `objects` ADD INDEX `type` (o_type)');
+        }
+
+        if ($schema->getTable('objects')->hasIndex('type_path_classId')) {
+            $this->addSql('ALTER TABLE `objects` DROP INDEX `type_path_classId`');
+        }
     }
 }

--- a/bundles/CoreBundle/Migrations/Version20220718162200.php
+++ b/bundles/CoreBundle/Migrations/Version20220718162200.php
@@ -29,11 +29,15 @@ final class Version20220718162200 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `object_url_slugs` ADD INDEX `fieldname_ownertype_position_objectId` (`fieldname`,`ownertype`,`position`,`objectId`)');
+        if(!$schema->getTable('object_url_slugs')->hasIndex('fieldname_ownertype_position_objectId')) {
+            $this->addSql('ALTER TABLE `object_url_slugs` ADD INDEX `fieldname_ownertype_position_objectId` (`fieldname`,`ownertype`,`position`,`objectId`)');
+        }
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `object_url_slugs` DROP INDEX `fieldname_ownertype_position_objectId`');
+        if ($schema->getTable('object_url_slugs')->hasIndex('fieldname_ownertype_position_objectId')) {
+            $this->addSql('ALTER TABLE `object_url_slugs` DROP INDEX `fieldname_ownertype_position_objectId`');
+        }
     }
 }


### PR DESCRIPTION
Same problem as described in #9024

When migrations get executed and **any** error occurs (or the process gets aborted), the previously executed migrations do not get rolled back automatically (because this is not even possible for `ALTER TABLE` statements because those statements cause implicit commits in the database).

This PR makes all migrations idempotent, this means that all migrations can be executed as often as you want, the result will be always the same.