### PR TITLE
Increased width and height for fieldcollection type multiselect

### DIFF
--- a/bundles/AdminBundle/public/js/pimcore/object/classes/data/fieldcollections.js
+++ b/bundles/AdminBundle/public/js/pimcore/object/classes/data/fieldcollections.js
@@ -93,8 +93,8 @@ pimcore.object.classes.data.fieldcollections = Class.create(pimcore.object.class
                 value: this.datax.allowedTypes,
                 displayField: "key",
                 valueField: "key",
-                width: 400,
-                height: 100
+                width: 500,
+                height: 200,
             }), {
                 xtype: "checkbox",
                 fieldLabel: t("lazy_loading"),


### PR DESCRIPTION
Scrolling through multiselect is difficult with many fieldcollections.
Only 3 Fieldcollections are visible at a time.

- Increased height from 100px to 200px to be able to see 6 Fieldcollections in select
- Increased width from 400px to 500px for a better general appearance

![image](https://user-images.githubusercontent.com/24526399/216045914-f641d0a6-1802-4afc-8d28-3415e60e2ba8.png)

