### PR TITLE
fix: Fixing localStorage overflow caused by unlimited logging of activityLog entries. Introduced sliding window of max 4000 items.

### DIFF
--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -50,8 +50,11 @@ class SearchController extends AdminController
      * @return JsonResponse
      *
      * @todo: $conditionTypeParts could be undefined
+     *
      * @todo: $conditionSubtypeParts could be undefined
+     *
      * @todo: $conditionClassnameParts could be undefined
+     *
      * @todo: $data could be undefined
      */
     public function findAction(Request $request, EventDispatcherInterface $eventDispatcher, GridHelperService $gridHelperService)

--- a/bundles/CoreBundle/Resources/public/js/targeting.js
+++ b/bundles/CoreBundle/Resources/public/js/targeting.js
@@ -293,6 +293,19 @@
 
         User.prototype.save = function () {
             if (util.featureDetect('localStorage')) {
+                // Ensure activityLog doesn't eat up all the local storage.
+                // It is assumed 10MB of localStorage group space, activityLog
+                // entries can vastly vary in size e.g. for pageView entries due
+                // to the saved URL.
+                // For now 0.5 KB per log entry are assumed. Using a
+                // conservative 20% of the assumed available space as limit
+                // allows us to fill 2MB of storage which equals about 4000
+                // activityLog entries.
+                const activityLogLimit = 4000;
+                if (this.data.activityLog.length > activityLogLimit) {
+                    util.logger.canLog('info') && console.info('[TARGETING] ' + this.data.activityLog.length + ' acitvityLog items exceed limit of ' + activityLogLimit + '. Evicting excess.', this);
+                    this.data.activityLog = this.data.activityLog.slice(0, activityLogLimit);
+                }
                 localStorage.setItem("_ptg.user", JSON.stringify(this.data));
             }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  
fix: Fixing localStorage overflow caused by unlimited logging of activityLog entries. Introduced sliding window of max 4000 items.

## Changes in this pull request  
Resolves #

## Additional info  

