### PR TITLE
[Web2Print > Headless Chrome] Use Pimcore's standard way to find node executable

### DIFF
--- a/lib/Web2Print/Processor/HeadlessChrome.php
+++ b/lib/Web2Print/Processor/HeadlessChrome.php
@@ -20,8 +20,10 @@ use Pimcore\Event\DocumentEvents;
 use Pimcore\Event\Model\PrintConfigEvent;
 use Pimcore\Logger;
 use Pimcore\Model\Document;
+use Pimcore\Tool\Console;
 use Pimcore\Web2Print\Processor;
 use Spiritix\Html2Pdf\Converter;
+use Spiritix\Html2Pdf\ConverterException;
 use Spiritix\Html2Pdf\Input\StringInput;
 use Spiritix\Html2Pdf\Output\FileOutput;
 use Spiritix\Html2Pdf\Output\StringOutput;
@@ -108,6 +110,8 @@ class HeadlessChrome extends Processor
         $converter = new Converter($input, $output);
         if ($this->nodePath) {
             $converter->setNodePath($this->nodePath);
+        } else {
+            $converter->setNodePath(Console::getExecutable('node'));
         }
         $converter->setOptions($params);
 


### PR DESCRIPTION
By default the headless chrome processor just uses the application `node` in https://github.com/spiritix/php-chrome-html2pdf/blob/ca4925b589cffa161e3a79650a3a403ffc89c655/src/Spiritix/Html2Pdf/Converter.php#L58

In some environments this may not be set. Actually there is a `HeadlessChrome::setNodePath()` in https://github.com/pimcore/pimcore/blob/e3c005abf4760d96f32bf5f743aa7fc4f6290cfd/lib/Web2Print/Processor/HeadlessChrome.php#L147-L152 but this does not seem to get used somewhere.
And anyway imho it would be a better way to support the standard way of Pimcore to set application binary paths via [config settings](https://github.com/pimcore/skeleton/blob/10.2/config/services.yaml). 

So this PR keeps support for the `HeadlessChrome::setNodePath()` for BC reasons. But if no `nodePath` has been set, it uses the default `Tool::getExecutable()` method.