### PR TITLE
[Assets] Do not change modification date when processing asset dimensions

### DIFF
--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -51,6 +51,7 @@ class AssetUpdateTasksHandler
     private function saveAsset(Asset $asset)
     {
         Version::disable();
+        $asset->markFieldDirty('modificationDate'); // prevent modificationDate from being changed
         $asset->save();
         Version::enable();
     }


### PR DESCRIPTION
When setting the modification date for an asset manually, it gets reset to current date by https://github.com/pimcore/pimcore/blob/06f7e798555c04af9e4e573352ef4f8a241f0271/lib/Messenger/Handler/AssetUpdateTasksHandler.php#L55

This is caused by https://github.com/pimcore/pimcore/blob/06f7e798555c04af9e4e573352ef4f8a241f0271/models/Element/AbstractElement.php#L298-L302

You can reproduce the error with the following script:
```php
$newAsset = new \Pimcore\Model\Asset();
$newAsset->setFilename("myAsset.png");
$newAsset->setData(file_get_contents("some-file.png"));
$newAsset->setModificationDate(123);
$newAsset->save()
```

Saving the asset triggers an `AssetUpdateTasksMessage` in
https://github.com/pimcore/pimcore/blob/06f7e798555c04af9e4e573352ef4f8a241f0271/models/Asset.php#L551-L555
and
https://github.com/pimcore/pimcore/blob/06f7e798555c04af9e4e573352ef4f8a241f0271/models/Asset.php#L1677-L1682

When this gets processed by the `messenger:consume` command in the background, the `modificationDate` gets set to the current date. 

Consequences:
- Latest version of the asset is not marked as published
- Modification Date is simply wrong - not only when manually setting it via `setModificationDate` but also if the `AssetUpdateTasksMessage` is not being processed within the same second as the asset got actually modified

With this PR the `modificationDate` does not get changed by `AssetUpdateTasksHandler` anymore.