### PR TITLE
remove classificationstore groupConfig runtime cache instead of setting null

### DIFF
--- a/models/DataObject/Classificationstore/GroupConfig.php
+++ b/models/DataObject/Classificationstore/GroupConfig.php
@@ -369,8 +369,12 @@ final class GroupConfig extends Model\AbstractModel
     private function removeCache(): void
     {
         // Remove runtime cache
-        RuntimeCache::set(self::getCacheKey($this->getId()), null);
-        RuntimeCache::set(self::getCacheKey($this->getStoreId(), $this->getName()), null);
+        if (RuntimeCache::getInstance()->offsetExists(self::getCacheKey($this->getId()))) {
+            RuntimeCache::getInstance()->offsetUnset(self::getCacheKey($this->getId()));
+        }
+        if (RuntimeCache::getInstance()->offsetExists(self::getCacheKey($this->getStoreId(), $this->getName()))) {
+            RuntimeCache::getInstance()->offsetUnset(self::getCacheKey($this->getStoreId(), $this->getName()));
+        }
 
         // Remove persisted cache
         Cache::remove(self::getCacheKey($this->getId()));


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  

## Changes in this pull request  
Resolves the issue when after saving groupConfig, retrieving returns null due to setting runtime cache to null instead of removing it. This is already fixed in keyConfig https://github.com/pimcore/pimcore/blob/5a46f38754309b7337b7617160214c298e230d8d/models/DataObject/Classificationstore/KeyConfig.php#L417

## Additional info  
How to reproduce:

```
$groupId = 1; //create a classification group and get the id here
$config = \Pimcore\Model\DataObject\Classificationstore\GroupConfig::getById($groupId);
p_r("Retrieve Group Config", $config);
$config->save();
p_r("After Save Group Config", $config);
$configAfterSave = \Pimcore\Model\DataObject\Classificationstore\GroupConfig::getById($groupId);
p_r("Again retrieve Group Config", $configAfterSave); //here it returns null
```