### PR TITLE
fix(ecommerce): undefined array key in filter definition

### DIFF
--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectRelation.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectRelation.php
@@ -47,7 +47,7 @@ class MultiSelectRelation extends AbstractFilterType
         }
 
         foreach ($values as $v) {
-            if (empty($availableRelations) || isset($availableRelations[$v['value']]) && $availableRelations[$v['value']] === true) {
+            if (empty($availableRelations) || (isset($availableRelations[$v['value']]) && $availableRelations[$v['value']] === true)) {
                 $objects[$v['value']] = DataObject::getById($v['value']);
             }
         }

--- a/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectRelation.php
+++ b/bundles/EcommerceFrameworkBundle/FilterService/FilterType/MultiSelectRelation.php
@@ -47,7 +47,7 @@ class MultiSelectRelation extends AbstractFilterType
         }
 
         foreach ($values as $v) {
-            if (empty($availableRelations) || $availableRelations[$v['value']] === true) {
+            if (empty($availableRelations) || isset($availableRelations[$v['value']]) && $availableRelations[$v['value']] === true) {
                 $objects[$v['value']] = DataObject::getById($v['value']);
             }
         }


### PR DESCRIPTION
## How to reproduce
Add a filter of the type FilterMultiRelation to a filter definition and define available relations. If any of the available values is not found in the available relations, an array key is undefined exception will be thrown as the ID of the object is not a key in the available relations.

## Changes in this pull request  
Added a check if the array key is defined, before checking the value of it.