### PR TITLE
Consider class_overrides for Doc-Blocks to get code completion correct

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -39,7 +39,7 @@ trait Relation
                 $class[] = '\Pimcore\Model\Document' . $strArray;
             } elseif (is_array($documentTypes)) {
                 foreach ($documentTypes as $item) {
-                    $class[] = sprintf('\Pimcore\Model\Document\%s', ucfirst($item['documentTypes']) . $strArray);
+                    $class[] = $this->getMappedClassName('\Pimcore\Model\Document\\' . ucfirst($item['documentTypes']), $strArray);
                 }
             }
         }
@@ -51,7 +51,7 @@ trait Relation
                 $class[] = '\Pimcore\Model\Asset' . $strArray;
             } elseif (is_array($assetTypes)) {
                 foreach ($assetTypes as $item) {
-                    $class[] = sprintf('\Pimcore\Model\Asset\%s', ucfirst($item['assetTypes']) . $strArray);
+                    $class[] = $this->getMappedClassName('\Pimcore\Model\Asset\\' . ucfirst($item['assetTypes']), $strArray);
                 }
             }
         }
@@ -63,12 +63,27 @@ trait Relation
                 $class[] = '\Pimcore\Model\DataObject\AbstractObject' . $strArray;
             } elseif (is_array($classes)) {
                 foreach ($classes as $item) {
-                    $class[] = sprintf('\Pimcore\Model\DataObject\%s', ucfirst($item['classes']) . $strArray);
+                    $class[] = $this->getMappedClassName('\Pimcore\Model\DataObject\\' . ucfirst($item['classes']), $strArray);
                 }
             }
         }
 
         return $class;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getMappedClassName(string $className,string $strArray)
+    {
+        try{
+            $className = \Pimcore::getContainer()->get('pimcore.model.factory')->getClassNameFor($className);
+            if($className[0] != '\\'){
+                $className = '\\'.$className;
+            }
+        }catch (\Exception $e){ //no class override
+        }
+        return $className . $strArray;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -81,7 +81,6 @@ trait Relation
         } finally {
             return $className;
         }
-        return $className;
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -51,7 +51,7 @@ trait Relation
                 $class[] = '\Pimcore\Model\Asset' . $strArray;
             } elseif (is_array($assetTypes)) {
                 foreach ($assetTypes as $item) {
-                    $class[] = $this->getMappedClassName('\Pimcore\Model\Asset\\' . ucfirst($item['assetTypes']), $strArray);
+                    $class[] = $this->getMappedClassName('\Pimcore\Model\Asset\\' . ucfirst($item['assetTypes'])) . $strArray;
                 }
             }
         }

--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -39,7 +39,7 @@ trait Relation
                 $class[] = '\Pimcore\Model\Document' . $strArray;
             } elseif (is_array($documentTypes)) {
                 foreach ($documentTypes as $item) {
-                    $class[] = $this->getMappedClassName('\Pimcore\Model\Document\\' . ucfirst($item['documentTypes']), $strArray);
+                    $class[] = $this->getMappedClassName('\Pimcore\Model\Document\\' . ucfirst($item['documentTypes'])) . $strArray;
                 }
             }
         }

--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -63,7 +63,7 @@ trait Relation
                 $class[] = '\Pimcore\Model\DataObject\AbstractObject' . $strArray;
             } elseif (is_array($classes)) {
                 foreach ($classes as $item) {
-                    $class[] = $this->getMappedClassName('\Pimcore\Model\DataObject\\' . ucfirst($item['classes']), $strArray);
+                    $class[] = $this->getMappedClassName('\Pimcore\Model\DataObject\\' . ucfirst($item['classes'])) . $strArray;
                 }
             }
         }

--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -78,8 +78,8 @@ trait Relation
             if ($className[0] !== '\\') {
                 $className = '\\' . $className;
             }
-        } catch (\Exception) {
-            //no class override
+        } finally {
+            return $className;
         }
         return $className;
     }

--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -71,19 +71,17 @@ trait Relation
         return $class;
     }
 
-    /**
-     * @return string
-     */
-    protected function getMappedClassName(string $className,string $strArray)
+    protected function getMappedClassName(string $className): string
     {
-        try{
+        try {
             $className = \Pimcore::getContainer()->get('pimcore.model.factory')->getClassNameFor($className);
-            if($className[0] != '\\'){
-                $className = '\\'.$className;
+            if ($className[0] !== '\\') {
+                $className = '\\' . $className;
             }
-        }catch (\Exception $e){ //no class override
+        } catch (\Exception) {
+            //no class override
         }
-        return $className . $strArray;
+        return $className;
     }
 
     /**


### PR DESCRIPTION
Currently class_overrwrites are not considered in the DocBlocks so the Code completion is not correct and PHPStand... complains quite often that the code is not correct (because the return types don't consider the class_overrides).

This PR fixes the the Doc-Blocks. 
So e.g instead of "\Pimcore\Model\DataObject\Car" it would return "\App\Model\DataObject\Car" if it is mapped this way.