### PR TITLE
Remove deprecated methods `getObject()` and `setObject()`

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -32,6 +32,7 @@
 - Removed `SessionConfiguratorInterface` & `SessionConfigurator` so services with tag `pimcore.session.configurator` will not register session bags anymore.
 - Removed parameter `pimcore.admin.session.attribute_bags`
 - TargetingSessionBagListener - changed the signature of `__construct`.
+- Removed deprecated methods `getObject()` and `setObject()` on the classes `Pimcore\Model\Document\Link` and `Pimcore\Model\DataObject\Data\Link`, please use `getElement()` and `setElement()` instead.
 - Removed deprecated `Pimcore\Db\ConnectionInterface` interface, `Pimcore\Db\Connection` class and `Pimcore\Db\PimcoreExtensionsTrait` trait.
   Column identifiers for the `insert()` and `update()` method data must be self quoted now. You can use the `Pimcore\Db\Helper::quoteDataIdentifiers()` method for that.
 - [Config] `Pimcore\Config\Config` has been removed, see [#12477](https://github.com/pimcore/pimcore/issues/12477). Please use the returned array instead, e.g.

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -348,24 +348,6 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    /**
-     * @deprecated use getElement() instead - will be removed in Pimcore 11
-     *
-     * @return Asset|DataObject|Document|null
-     */
-    public function getObject(): DataObject|Asset|Document|null
-    {
-        return $this->getElement();
-    }
-
-    /**
-     * @deprecated use setElement() instead - will be removed in Pimcore 11
-     */
-    public function setObject(ElementInterface $object): static
-    {
-        return $this->setElement($object);
-    }
-
     public function getHtml(): string
     {
         $attributes = ['rel', 'tabindex', 'accesskey', 'title', 'target', 'class'];

--- a/models/Document/Link.php
+++ b/models/Document/Link.php
@@ -287,42 +287,6 @@ class Link extends Model\Document
         return $this;
     }
 
-    /**
-     * @deprecated use getElement() instead, will be removed in Pimcore 11
-     *
-     * @return Model\Element\ElementInterface|null
-     */
-    public function getObject(): ?Model\Element\ElementInterface
-    {
-        trigger_deprecation(
-            'pimcore/pimcore',
-            '10.0',
-            'The Link::getObject() method is deprecated, use Link::getElement() instead.'
-        );
-
-        return $this->getElement();
-    }
-
-    /**
-     * @param Model\Element\ElementInterface $object
-     *
-     * @return $this
-     *
-     * @deprecated use getElement() instead, will be removed in Pimcore 11
-     */
-    public function setObject(Model\Element\ElementInterface $object): static
-    {
-        trigger_deprecation(
-            'pimcore/pimcore',
-            '10.0',
-            'The Link::setObject() method is deprecated, use Link::setElement() instead.'
-        );
-
-        $this->setElement($object);
-
-        return $this;
-    }
-
     private function setObjectFromId(): ?Model\Element\ElementInterface
     {
         try {

--- a/tests/Model/DataType/BlockTest.php
+++ b/tests/Model/DataType/BlockTest.php
@@ -138,8 +138,9 @@ class BlockTest extends ModelTestCase
 
         $loadedData = $object->getTestblock();
 
+        /** @var Link $loadedLink */
         $loadedLink = $loadedData[0]['blocklink']->getData();
-        $this->assertEquals($targetDocument->getId(), $loadedLink->getObject()->getId());
+        $this->assertEquals($targetDocument->getId(), $loadedLink->getElement()->getId());
 
         $loadedHotspotImage = $loadedData[0]['blockhotspotimage']->getData();
         $this->assertEquals($asset->getId(), $loadedHotspotImage->getImage()->getId());
@@ -188,8 +189,9 @@ class BlockTest extends ModelTestCase
         $object = DataObject::getById($objectRef->getId(), ['force' => true]);
         $loadedData = $object->getLtestblock('de');
 
+        /** @var Link $loadedLink */
         $loadedLink = $loadedData[0]['lblocklink']->getData();
-        $this->assertEquals($targetDocument->getId(), $loadedLink->getObject()->getId());
+        $this->assertEquals($targetDocument->getId(), $loadedLink->getElement()->getId());
 
         $loadedHotspotImage = $loadedData[0]['lblockhotspotimage']->getData();
         $this->assertEquals($asset->getId(), $loadedHotspotImage->getImage()->getId());


### PR DESCRIPTION
The methods were deprecated in 10.0 with this PR https://github.com/pimcore/pimcore/pull/8899