### PR TITLE
Fix hasChildren/hasSiblings type-hints and default value

### DIFF
--- a/bundles/AdminBundle/config/pimcore/routing.yaml
+++ b/bundles/AdminBundle/config/pimcore/routing.yaml
@@ -5,13 +5,6 @@ _pimcore_admin:
     options:
         expose: true
 
-_pimcore_reports:
-    resource: "../../src/Controller/Reports/"
-    type:     annotation
-    prefix:   /admin/reports
-    options:
-        expose: true
-
 _pimcore_gdpr:
     resource: "../../src/Controller/GDPR/"
     type:     annotation

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -353,7 +353,11 @@ abstract class AbstractObject extends Model\Element\AbstractElement
      * Returns a list of the children objects
      */
     public function getChildren(
-        array $objectTypes = [self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_VARIANT, self::OBJECT_TYPE_FOLDER],
+        array $objectTypes = [
+            self::OBJECT_TYPE_OBJECT,
+            self::OBJECT_TYPE_VARIANT,
+            self::OBJECT_TYPE_FOLDER
+        ],
         bool $includingUnpublished = false
     ): Listing {
         $cacheKey = $this->getListingCacheKey(func_get_args());
@@ -396,7 +400,11 @@ abstract class AbstractObject extends Model\Element\AbstractElement
      * Get a list of the sibling objects
      */
     public function getSiblings(
-        array $objectTypes = [self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_VARIANT, self::OBJECT_TYPE_FOLDER],
+        array $objectTypes = [
+            self::OBJECT_TYPE_OBJECT,
+            self::OBJECT_TYPE_VARIANT,
+            self::OBJECT_TYPE_FOLDER
+        ],
         bool $includingUnpublished = false
     ): Listing {
         $cacheKey = $this->getListingCacheKey(func_get_args());
@@ -879,7 +887,11 @@ abstract class AbstractObject extends Model\Element\AbstractElement
      */
     public function setChildren(
         ?Listing $children,
-        array $objectTypes = [self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_VARIANT, self::OBJECT_TYPE_FOLDER],
+        array $objectTypes = [
+            self::OBJECT_TYPE_OBJECT,
+            self::OBJECT_TYPE_VARIANT,
+            self::OBJECT_TYPE_FOLDER
+        ],
         bool $includingUnpublished = false
     ): static {
         if ($children === null) {

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -427,7 +427,11 @@ abstract class AbstractObject extends Model\Element\AbstractElement
      * Returns true if the object has at least one sibling
      */
     public function hasSiblings(
-        array $objectTypes = [self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_VARIANT, self::OBJECT_TYPE_FOLDER],
+        array $objectTypes = [
+            self::OBJECT_TYPE_OBJECT,
+            self::OBJECT_TYPE_VARIANT,
+            self::OBJECT_TYPE_FOLDER
+        ],
         ?bool $includingUnpublished = null
     ): bool {
         return $this->getDao()->hasSiblings($objectTypes, $includingUnpublished);

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -382,8 +382,12 @@ abstract class AbstractObject extends Model\Element\AbstractElement
      *
      */
     public function hasChildren(
-        array $objectTypes = [self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_VARIANT, self::OBJECT_TYPE_FOLDER],
-        bool $includingUnpublished = null
+        array $objectTypes = [
+            self::OBJECT_TYPE_OBJECT,
+            self::OBJECT_TYPE_VARIANT,
+            self::OBJECT_TYPE_FOLDER
+        ],
+        ?bool $includingUnpublished = null
     ): bool {
         return $this->getDao()->hasChildren($objectTypes, $includingUnpublished);
     }
@@ -424,7 +428,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
      */
     public function hasSiblings(
         array $objectTypes = [self::OBJECT_TYPE_OBJECT, self::OBJECT_TYPE_VARIANT, self::OBJECT_TYPE_FOLDER],
-        bool $includingUnpublished = null
+        ?bool $includingUnpublished = null
     ): bool {
         return $this->getDao()->hasSiblings($objectTypes, $includingUnpublished);
     }

--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Model\DataObject\AbstractObject;
 
+use Doctrine\DBAL\Exception;
 use Pimcore\Db;
 use Pimcore\Db\Helper;
 use Pimcore\Logger;
@@ -289,13 +290,16 @@ class Dao extends Model\Element\Dao
     /**
      * Quick test if there are children
      *
-     * @param array $objectTypes
-     * @param bool|null $includingUnpublished
-     * @param Model\User|null $user
-     *
-     * @return bool
+     * @throws Exception
      */
-    public function hasChildren(array $objectTypes = [DataObject::OBJECT_TYPE_OBJECT, DataObject::OBJECT_TYPE_VARIANT, DataObject::OBJECT_TYPE_FOLDER], bool $includingUnpublished = null, User $user = null): bool
+    public function hasChildren(
+        array $objectTypes = [
+            DataObject::OBJECT_TYPE_OBJECT,
+            DataObject::OBJECT_TYPE_VARIANT,
+            DataObject::OBJECT_TYPE_FOLDER],
+        ?bool $includingUnpublished = null,
+        ?User $user = null
+    ): bool
     {
         if (!$this->model->getId()) {
             return false;
@@ -342,12 +346,16 @@ class Dao extends Model\Element\Dao
     /**
      * Quick test if there are siblings
      *
-     * @param array $objectTypes
-     * @param bool|null $includingUnpublished
-     *
-     * @return bool
+     * @throws Exception
      */
-    public function hasSiblings(array $objectTypes = [DataObject::OBJECT_TYPE_OBJECT, DataObject::OBJECT_TYPE_VARIANT, DataObject::OBJECT_TYPE_FOLDER], bool $includingUnpublished = null): bool
+    public function hasSiblings(
+        array $objectTypes = [
+            DataObject::OBJECT_TYPE_OBJECT,
+            DataObject::OBJECT_TYPE_VARIANT,
+            DataObject::OBJECT_TYPE_FOLDER
+        ],
+        ?bool $includingUnpublished = null
+    ): bool
     {
         if (!$this->model->getParentId()) {
             return false;

--- a/models/Document.php
+++ b/models/Document.php
@@ -571,7 +571,7 @@ class Document extends Element\AbstractElement
     /**
      * Returns true if the document has at least one child
      */
-    public function hasChildren(bool $includingUnpublished = null): bool
+    public function hasChildren(?bool $includingUnpublished = null): bool
     {
         return $this->getDao()->hasChildren($includingUnpublished);
     }

--- a/models/Document.php
+++ b/models/Document.php
@@ -571,7 +571,7 @@ class Document extends Element\AbstractElement
     /**
      * Returns true if the document has at least one child
      */
-    public function hasChildren(bool $includingUnpublished = false): bool
+    public function hasChildren(bool $includingUnpublished = null): bool
     {
         return $this->getDao()->hasChildren($includingUnpublished);
     }

--- a/models/Document.php
+++ b/models/Document.php
@@ -607,7 +607,7 @@ class Document extends Element\AbstractElement
     /**
      * Returns true if the document has at least one sibling
      */
-    public function hasSiblings(bool $includingUnpublished = null): bool
+    public function hasSiblings(?bool $includingUnpublished = null): bool
     {
         return $this->getDao()->hasSiblings($includingUnpublished);
     }

--- a/models/Document/Dao.php
+++ b/models/Document/Dao.php
@@ -321,13 +321,8 @@ class Dao extends Model\Element\Dao
 
     /**
      * Quick check if there are children.
-     *
-     * @param bool|null $includingUnpublished
-     * @param Model\User|null $user
-     *
-     * @return bool
      */
-    public function hasChildren(bool $includingUnpublished = null, User $user = null): bool
+    public function hasChildren(?bool $includingUnpublished = null, ?User $user = null): bool
     {
         if (!$this->model->getId()) {
             return false;
@@ -367,7 +362,7 @@ class Dao extends Model\Element\Dao
      *
      * @return int
      */
-    public function getChildAmount(User $user = null): int
+    public function getChildAmount(?User $user = null): int
     {
         if (!$this->model->getId()) {
             return 0;
@@ -397,7 +392,7 @@ class Dao extends Model\Element\Dao
      *
      * @return bool
      */
-    public function hasSiblings(bool $includingUnpublished = null): bool
+    public function hasSiblings(?bool $includingUnpublished = null): bool
     {
         if (!$this->model->getParentId()) {
             return false;

--- a/models/Document/Hardlink.php
+++ b/models/Document/Hardlink.php
@@ -194,7 +194,7 @@ class Hardlink extends Document
     /**
      * {@inheritdoc}
      */
-    public function hasChildren(bool $includingUnpublished = null): bool
+    public function hasChildren(?bool $includingUnpublished = null): bool
     {
         return count($this->getChildren($includingUnpublished)) > 0;
     }

--- a/models/Document/Hardlink.php
+++ b/models/Document/Hardlink.php
@@ -194,7 +194,7 @@ class Hardlink extends Document
     /**
      * {@inheritdoc}
      */
-    public function hasChildren(bool $includingUnpublished = false): bool
+    public function hasChildren(bool $includingUnpublished = null): bool
     {
         return count($this->getChildren($includingUnpublished)) > 0;
     }

--- a/models/Document/Hardlink.php
+++ b/models/Document/Hardlink.php
@@ -191,12 +191,9 @@ class Hardlink extends Document
         return $this->children[$cacheKey];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function hasChildren(?bool $includingUnpublished = null): bool
     {
-        return count($this->getChildren($includingUnpublished)) > 0;
+        return count($this->getChildren((bool)$includingUnpublished)) > 0;
     }
 
     /**

--- a/models/Document/Hardlink/Wrapper.php
+++ b/models/Document/Hardlink/Wrapper.php
@@ -156,7 +156,7 @@ trait Wrapper
         return $this->children[$cacheKey];
     }
 
-    public function hasChildren(bool $includingUnpublished = null): bool
+    public function hasChildren(?bool $includingUnpublished = null): bool
     {
         $hardLink = $this->getHardLinkSource();
 

--- a/models/Document/Hardlink/Wrapper.php
+++ b/models/Document/Hardlink/Wrapper.php
@@ -156,7 +156,7 @@ trait Wrapper
         return $this->children[$cacheKey];
     }
 
-    public function hasChildren(bool $includingUnpublished = false): bool
+    public function hasChildren(bool $includingUnpublished = null): bool
     {
         $hardLink = $this->getHardLinkSource();
 


### PR DESCRIPTION
## Changes in this pull request  
follow up to #13474

## Additional info  
When a folder has only unpublished documents then it doesn't show children on tree.

Steps to reproduce:
1. Add folder under /Documents
2. Add new unpublished document under new folder
3. Reload folder => no children.
