### PR TITLE
Link::getObject()/setObject() - Trigger deprecations, Add Upgrade note

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -334,6 +334,7 @@ framework:
 - Removed `\Pimcore\Tool::getValidCacheKey/()`, use `preg_replace('/[^a-zA-Z0-9]/', '_', $key)` instead.
 - Removed `\Pimcore\Tool::isValidPath/()`, use `\Pimcore\Model\Element\Service::isValidPath()` instead.
 - Deprecated `\Pimcore\Model\Element\Service::getSaveCopyName()`, use `getSafeCopyName()` instead.
+- Deprecated methods `getObject()` and `setObject()` on the classes `\Pimcore\Model\Document\Link` and `\Pimcore\Model\DataObject\Data\Link`, use `getElement()` and `setElement()` instead.
 - Using dynamic modules, controllers and actions in static routes (e.g. `%controller`) does not work anymore.
 - Removed `\Pimcore\Controller\Config\ConfigNormalizer`.
 - Removed `pimcore_action()` Twig extension. Use Twig `render()` instead.

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -520,6 +520,12 @@ class Link implements OwnerAwareFieldInterface
      */
     public function getObject()
     {
+        trigger_deprecation(
+            'pimcore/pimcore',
+            '10.0',
+            'The Link::getObject() method is deprecated, use Link::getElement() instead.'
+        );
+
         return $this->getElement();
     }
 
@@ -530,6 +536,12 @@ class Link implements OwnerAwareFieldInterface
      */
     public function setObject($object)
     {
+        trigger_deprecation(
+            'pimcore/pimcore',
+            '10.0',
+            'The Link::setObject() method is deprecated, use Link::setElement() instead.'
+        );
+
         return $this->setElement($object);
     }
 

--- a/tests/Model/DataType/BlockTest.php
+++ b/tests/Model/DataType/BlockTest.php
@@ -147,8 +147,9 @@ class BlockTest extends ModelTestCase
 
         $loadedData = $object->getTestblock();
 
+        /** @var Link $loadedLink */
         $loadedLink = $loadedData[0]['blocklink']->getData();
-        $this->assertEquals($targetDocument->getId(), $loadedLink->getObject()->getId());
+        $this->assertEquals($targetDocument->getId(), $loadedLink->getElement()->getId());
 
         $loadedHotspotImage = $loadedData[0]['blockhotspotimage']->getData();
         $this->assertEquals($asset->getId(), $loadedHotspotImage->getImage()->getId());
@@ -197,8 +198,9 @@ class BlockTest extends ModelTestCase
         $object = DataObject::getById($objectRef->getId(), ['force' => true]);
         $loadedData = $object->getLtestblock('de');
 
+        /** @var Link $loadedLink */
         $loadedLink = $loadedData[0]['lblocklink']->getData();
-        $this->assertEquals($targetDocument->getId(), $loadedLink->getObject()->getId());
+        $this->assertEquals($targetDocument->getId(), $loadedLink->getElement()->getId());
 
         $loadedHotspotImage = $loadedData[0]['lblockhotspotimage']->getData();
         $this->assertEquals($asset->getId(), $loadedHotspotImage->getImage()->getId());


### PR DESCRIPTION
The methods were deprecated in 10.0 with this PR https://github.com/pimcore/pimcore/pull/8899
Related to https://github.com/pimcore/pimcore/pull/14244