### PR TITLE
[Bug]: Fieldcollection default value not set

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/input.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/input.js
@@ -18,9 +18,10 @@ pimcore.object.tags.input = Class.create(pimcore.object.tags.abstract, {
 
     initialize: function (data, fieldConfig) {
 
-        this.data = "";
 
-        if (data) {
+        this.data = null;
+
+        if (data !== null && typeof data !== "undefined") {
             this.data = data;
         }
         this.fieldConfig = fieldConfig;
@@ -28,7 +29,10 @@ pimcore.object.tags.input = Class.create(pimcore.object.tags.abstract, {
 
     applyDefaultValue: function() {
         this.defaultValue = null;
-        if ((typeof this.data === "undefined" || !this.data) && this.fieldConfig.defaultValue && this.context.type === "classificationstore") {
+        if ((typeof this.data === "undefined" || this.data === null) &&
+            this.fieldConfig.defaultValue &&
+            (this.context.type === "classificationstore" || this.context.containerType === "fieldcollection")
+        ) {
             this.data = this.fieldConfig.defaultValue;
             this.defaultValue = this.fieldConfig.defaultValue;
         }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #14190

## Additional info  
I was not able to reproduce this issue for the numeric field, however the input field was originally restricted only for classificationstore context
