### PR TITLE
[Bug] bugfix update child paths if all children are unpublished

### DIFF
--- a/models/DataObject/AbstractObject/Dao.php
+++ b/models/DataObject/AbstractObject/Dao.php
@@ -162,7 +162,7 @@ class Dao extends Model\Element\Dao
      */
     public function updateChildPaths($oldPath)
     {
-        if ($this->hasChildren(DataObject::$types)) {
+        if ($this->hasChildren(DataObject::$types, true)) {
             //get objects to empty their cache
             $objects = $this->db->fetchFirstColumn('SELECT o_id FROM objects WHERE o_path LIKE ?', [Helper::escapeLike($oldPath) . '%']);
 


### PR DESCRIPTION
If the parent of an object changes the child paths were not correctly updated if all the children were unpublished.
This bug occurred only when changing the the parent via a command not via the UI.

## Changes in this pull request  
In Pimcore\Model\DataObject\AbstractObject\Dao the updateChildPaths() method now also searches for unpublished children.

## Additional info  

This example command reproduces the bug in the demo project:

```
<?php

namespace App\Command;

use Pimcore\Console\AbstractCommand;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;
use Pimcore\Model\DataObject\Car;

class MoveCommand extends AbstractCommand
{
    public function configure()
    {
        $this->setName('app:move-test');
    }

    /**
     * {@inheritdoc}
     */
    public function execute(InputInterface $input, OutputInterface $output)
    {
    
        $sprintBlue = Car::getByPath('/Product Data/Cars/alfa romeo/1900/sprint/blue');
        if ($sprintBlue) {
            $output->writeln("unpublish " . $sprintBlue->getFullPath());
            $sprintBlue->setPublished(false);
            $sprintBlue->save();
        }

        $sprintSilver = Car::getByPath('/Product Data/Cars/alfa romeo/1900/sprint/silver');
        if ($sprintSilver) {
            $output->writeln("unpublish " . $sprintSilver->getFullPath());
            $sprintSilver->setPublished(false);
            $sprintSilver->save();
        }
        
        $sprint = Car::getByPath('/Product Data/Cars/alfa romeo/1900/sprint');
        $target = Car::getByPath('/Product Data/Cars/alfa romeo/2000');
        if ($sprint && $target) {
            $output->writeln("Move the 'alfa romeo/1900/sprint' to 'alfa romeo/2000/sprint'");
            $sprint->setParent($target);
            $sprint->save();
        }
        
        return 0;
    }
}
```

## Workaround

To simulate the correct behavior of the UI it is possible to call this function:
`\Pimcore\Model\Document::setHideUnpublished(false);`
because of the check in [AbstractObject::hasChildren](https://github.com/pimcore/pimcore/blob/11.x/models/DataObject/AbstractObject/Dao.php#L331)