### PR TITLE
fix: data object preview generator with url slugs with sites

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -32,6 +32,7 @@ use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data\ManyToManyObjectRelation;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Relations\AbstractRelations;
 use Pimcore\Model\DataObject\ClassDefinition\Data\ReverseObjectRelation;
+use Pimcore\Model\DataObject\ClassDefinition\PreviewGeneratorInterface;
 use Pimcore\Model\Element;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Schedule\Task;
@@ -44,6 +45,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -367,12 +369,13 @@ class DataObjectController extends ElementControllerBase implements KernelContro
      *
      * @param Request $request
      * @param EventDispatcherInterface $eventDispatcher
+     * @param PreviewGeneratorInterface $defaultPreviewGenerator
      *
      * @return JsonResponse
      *
      * @throws \Exception
      */
-    public function getAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
+    public function getAction(Request $request, EventDispatcherInterface $eventDispatcher, PreviewGeneratorInterface $defaultPreviewGenerator): JsonResponse
     {
         $objectId = (int)$request->get('id');
         $objectFromDatabase = DataObject\Concrete::getById($objectId);
@@ -405,8 +408,11 @@ class DataObjectController extends ElementControllerBase implements KernelContro
              *  ------------------------------------------------------------- */
             $objectData['idPath'] = Element\Service::getIdPath($objectFromDatabase);
 
-            $previewGenerator = $objectFromDatabase->getClass()->getPreviewGenerator();
             $linkGeneratorReference = $objectFromDatabase->getClass()->getLinkGeneratorReference();
+            $previewGenerator = $objectFromDatabase->getClass()->getPreviewGenerator();
+            if (empty($previewGenerator) && !empty($linkGeneratorReference)) {
+                $previewGenerator = $defaultPreviewGenerator;
+            }
 
             $objectData['hasPreview'] = false;
             if ($objectFromDatabase->getClass()->getPreviewUrl() || $linkGeneratorReference || $previewGenerator) {
@@ -1972,10 +1978,11 @@ class DataObjectController extends ElementControllerBase implements KernelContro
      * @Route("/preview", name="preview", methods={"GET"})
      *
      * @param Request $request
+     * @param PreviewGeneratorInterface $defaultPreviewGenerator
      *
      * @return Response|RedirectResponse
      */
-    public function previewAction(Request $request)
+    public function previewAction(Request $request, PreviewGeneratorInterface $defaultPreviewGenerator)
     {
         $id = $request->get('id');
         $object = DataObject\Service::getElementFromSession('object', $id);
@@ -1997,22 +2004,35 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 $url = str_replace('%_locale', $this->getAdminUser()->getLanguage(), $url);
             } elseif ($previewService = $object->getClass()->getPreviewGenerator()) {
                 $url = $previewService->generatePreviewUrl($object, array_merge(['preview' => true, 'context' => $this], $request->query->all()));
-            } elseif ($linkGenerator = $object->getClass()->getLinkGenerator()) {
-                $url = $linkGenerator->generate($object, ['preview' => true, 'context' => $this]);
+            } elseif ($object->getClass()->getLinkGenerator()) {
+                $parameters = [
+                    'preview' => true,
+                    'context' => $this
+                ];
+
+                $url = $defaultPreviewGenerator->generatePreviewUrl($object, array_merge($parameters, $request->query->all()));
             }
 
             if (!$url) {
-                return new Response("Preview not available, it seems that there's a problem with this object.");
+                throw new NotFoundHttpException("Cannot render preview due to empty URL");
             }
 
-            // replace all remainaing % signs
+            // replace all remaining % signs
             $url = str_replace('%', '%25', $url);
 
             $urlParts = parse_url($url);
 
-            return $this->redirect($urlParts['path'] . '?pimcore_object_preview=' . $id . '&_dc=' . time() . (isset($urlParts['query']) ? '&' . $urlParts['query'] : ''));
+            $redirectParameters = array_filter([
+                'pimcore_object_preview' => $id,
+                'site' => $request->query->getInt(PreviewGeneratorInterface::PARAMETER_SITE),
+                'dc' => time(),
+            ]);
+
+            $redirectUrl = $urlParts['path'] . '?' . http_build_query($redirectParameters) . (isset($urlParts['query']) ? '&' . $urlParts['query'] : '');
+
+            return $this->redirect($redirectUrl);
         } else {
-            return new Response("Preview not available, it seems that there's a problem with this object.");
+            throw new NotFoundHttpException(sprintf('Expected an object of type "%s", got "%s"', DataObject\Concrete::class, get_debug_type($object)));
         }
     }
 

--- a/bundles/AdminBundle/Resources/config/services.yaml
+++ b/bundles/AdminBundle/Resources/config/services.yaml
@@ -69,3 +69,10 @@ services:
     # Grid Helper Service
     #
     Pimcore\Bundle\AdminBundle\Helper\GridHelperService: ~
+
+
+    #
+    # Default Preview Generator
+    #
+    Pimcore\Model\DataObject\ClassDefinition\PreviewGeneratorInterface:
+        class: Pimcore\Bundle\AdminBundle\Service\PreviewGenerator

--- a/bundles/AdminBundle/Service/PreviewGenerator.php
+++ b/bundles/AdminBundle/Service/PreviewGenerator.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Pimcore\Bundle\AdminBundle\Service;
+
+use Pimcore\Model\DataObject\ClassDefinition\LinkGeneratorInterface;
+use Pimcore\Model\DataObject\ClassDefinition\PreviewGeneratorInterface;
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\Site;
+use Pimcore\Model\Translation;
+use Pimcore\Tool;
+use Pimcore\Translation\Translator;
+use Symfony\Component\Intl\Languages;
+use Symfony\Contracts\Service\Attribute\Required;
+
+class PreviewGenerator implements PreviewGeneratorInterface
+{
+    protected Translator $translator;
+
+    /**
+     * @param Concrete $object
+     * @param array $params
+     * @return string
+     */
+    public function generatePreviewUrl(Concrete $object, array $params): string
+    {
+        $linkGenerator = $object->getClass()->getLinkGenerator();
+
+        if ($linkGenerator instanceof LinkGeneratorInterface) {
+            $filteredParameters = $this->filterParameters($object, $params);
+
+            $locale = $filteredParameters[PreviewGeneratorInterface::PARAMETER_LOCALE] ?? Tool::getDefaultLanguage();
+            $site = array_key_exists(PreviewGeneratorInterface::PARAMETER_SITE, $filteredParameters) ? Site::getById($filteredParameters[PreviewGeneratorInterface::PARAMETER_SITE]) : (new Site\Listing())->current();
+
+            return $linkGenerator->generate($object, [
+                PreviewGeneratorInterface::PARAMETER_LOCALE => $locale,
+                PreviewGeneratorInterface::PARAMETER_SITE => $site
+            ]);
+        }
+
+        throw new \LogicException("No link generator given for element of type {$object->getClassName()}");
+    }
+
+    /**
+     * @param Concrete $object
+     * @param array $parameters
+     * @return array only parameters that are part of the preview generator config and are not empty
+     */
+    protected function filterParameters(Concrete $object, array $parameters): array
+    {
+        $previewConfig = $this->getPreviewConfig($object);
+
+        $filteredParameters = [];
+        foreach ($previewConfig as $config) {
+            $name = $config['name'];
+            $selectedValue = $parameters[$name] ?? $config['defaultValue'];
+
+            if (!empty($selectedValue)) {
+                $filteredParameters[$name] = $selectedValue;
+            }
+        }
+
+        return $filteredParameters;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPreviewConfig(Concrete $object): array
+    {
+        return array_filter([
+            $this->getLocalePreviewConfig($object),
+            $this->getSitePreviewConfig($object),
+        ]);
+    }
+
+    /**
+     * @param Concrete $object
+     * @return array
+     */
+    protected function getLocalePreviewConfig(Concrete $object): array
+    {
+        $user = Tool\Authentication::authenticateSession();
+        $userLocale = $user->getLanguage();
+
+        $locales = [];
+        foreach (Tool::getValidLanguages() as $locale) {
+            $label = Languages::getName($locale, $userLocale);
+            $locales[$label] = $locale;
+        }
+
+        return [
+            'name' => PreviewGeneratorInterface::PARAMETER_LOCALE,
+            'label' => $this->translator->trans('preview_generator_locale', [], Translation::DOMAIN_ADMIN),
+            'values' => $locales,
+            'defaultValue' => in_array($userLocale, Tool::getValidLanguages()) ? $userLocale : Tool::getDefaultLanguage()
+        ];
+    }
+
+    /**
+     * @param Concrete $object
+     * @return array
+     */
+    protected function getSitePreviewConfig(Concrete $object): array
+    {
+        $sites = new Site\Listing();
+        $sites->setOrderKey("mainDomain")->setOrder("ASC");
+
+        $sitesOptions = [];
+
+        foreach ($sites as $site) {
+            $label = $site->getRootDocument()?->getKey();
+            $sitesOptions[$label] = $site->getId();
+        }
+
+        if (empty($sitesOptions)) {
+            return [];
+        }
+
+        return [
+            'name' => PreviewGeneratorInterface::PARAMETER_SITE,
+            'label' => $this->translator->trans('preview_generator_site', [], Translation::DOMAIN_ADMIN),
+            'values' => $sitesOptions,
+            'defaultValue' => current($sitesOptions)
+        ];
+    }
+
+    /**
+     * @internal
+     */
+    #[Required]
+    public function setTranslator(Translator $translator): void
+    {
+        $this->translator = $translator;
+    }
+}

--- a/bundles/CoreBundle/EventListener/Frontend/RoutingListener.php
+++ b/bundles/CoreBundle/EventListener/Frontend/RoutingListener.php
@@ -20,6 +20,7 @@ use Pimcore\Config;
 use Pimcore\Http\Request\Resolver\PimcoreContextResolver;
 use Pimcore\Http\Request\Resolver\SiteResolver;
 use Pimcore\Http\RequestHelper;
+use Pimcore\Model\DataObject\ClassDefinition\PreviewGeneratorInterface;
 use Pimcore\Model\Site;
 use Pimcore\Routing\RedirectHandler;
 use Pimcore\Tool;
@@ -136,20 +137,27 @@ class RoutingListener implements EventSubscriberInterface
      */
     protected function resolveSite(Request $request, $path)
     {
+        $site = null;
+
         // check for a registered site
         // do not initialize a site if it is a "special" admin request
         if (!$this->requestHelper->isFrontendRequestByAdmin($request)) {
             // host name without port incl. X-Forwarded-For handling for trusted proxies
             $host = $request->getHost();
+            $site = Site::getByDomain($host);
+        } elseif ($this->requestHelper->isObjectPreviewRequestByAdmin($request)) {
+            // When rendering an object's preview tab, resolve the site via a parameter
+            $siteId = $request->query->getInt(PreviewGeneratorInterface::PARAMETER_SITE);
+            $site = Site::getById($siteId);
+        }
 
-            if ($site = Site::getByDomain($host)) {
-                $path = $site->getRootPath() . $path;
+        if ($site) {
+            $path = $site->getRootPath() . $path;
 
-                Site::setCurrentSite($site);
+            Site::setCurrentSite($site);
 
-                $this->siteResolver->setSite($request, $site);
-                $this->siteResolver->setSitePath($request, $path);
-            }
+            $this->siteResolver->setSite($request, $site);
+            $this->siteResolver->setSitePath($request, $path);
         }
 
         return $path;

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -1001,5 +1001,7 @@
     "possible_causes": "Possible causes",
     "postal_code_format_error": "Postal code format, e.g. use \"5020 Salzburg, Söllheimer Straße 16\" instead of \"A-5020 Salzburg, Söllheimer Straße 16\"",
     "url-slug-invalid-chars": "Provided invalid character in URL slug",
-    "delete_data_from_it": "This will also delete all data from it."
+    "delete_data_from_it": "This will also delete all data from it.",
+    "preview_generator_site": "Site",
+    "preview_generator_locale": "Locale"
 }

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/56_Preview_Generator.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/56_Preview_Generator.md
@@ -6,7 +6,7 @@ They provide a UI component to pass additional parameters to a URL-generator.
 
 Providers need to implement: `\Pimcore\Model\DataObject\ClassDefinition\PreviewGeneratorInterface`
 
-> As of Pimcore 10.5, a default implementation of a `PreviewGenerator` is provided. You only need to add
+> As of Pimcore 10.6, a default implementation of a `PreviewGenerator` is provided. You only need to add
 > a [link generator](./30_Link_Generator.md). The generated URL will then be used for the preview.
 
 Parameters returned in the `getParams` method will be rendered as a select box. 

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/56_Preview_Generator.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/05_Class_Settings/56_Preview_Generator.md
@@ -6,6 +6,9 @@ They provide a UI component to pass additional parameters to a URL-generator.
 
 Providers need to implement: `\Pimcore\Model\DataObject\ClassDefinition\PreviewGeneratorInterface`
 
+> As of Pimcore 10.5, a default implementation of a `PreviewGenerator` is provided. You only need to add
+> a [link generator](./30_Link_Generator.md). The generated URL will then be used for the preview.
+
 Parameters returned in the `getParams` method will be rendered as a select box. 
 Whatever the user chooses will be passed to the `generatePreviewUrl` method.
 

--- a/lib/Http/RequestHelper.php
+++ b/lib/Http/RequestHelper.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Http;
 
+use Pimcore\Tool\Authentication;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -171,6 +172,20 @@ class RequestHelper
         }
 
         return true;
+    }
+
+    /**
+     * Can be used to check if a user is trying to access the object preview and is allowed to do so.
+     *
+     * @param Request|null $request
+     * @return bool
+     */
+    public function isObjectPreviewRequestByAdmin(Request $request = null): bool
+    {
+        $request = $this->getRequest($request);
+
+        return $request->query->has('pimcore_object_preview')
+            && Authentication::isValidUser(Authentication::authenticateSession($request));
     }
 
     /**

--- a/lib/Routing/Dynamic/DataObjectRouteHandler.php
+++ b/lib/Routing/Dynamic/DataObjectRouteHandler.php
@@ -20,6 +20,7 @@ namespace Pimcore\Routing\Dynamic;
 use Pimcore\Bundle\CoreBundle\EventListener\Frontend\ElementListener;
 use Pimcore\Config;
 use Pimcore\Http\Request\Resolver\SiteResolver;
+use Pimcore\Http\RequestHelper;
 use Pimcore\Model\DataObject;
 use Pimcore\Routing\DataObjectRoute;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -36,19 +37,27 @@ final class DataObjectRouteHandler implements DynamicRouteHandlerInterface
     private $siteResolver;
 
     /**
+     * @var RequestHelper
+     */
+    private $requestHelper;
+
+    /**
      * @var Config
      */
     private $config;
 
     /**
      * @param SiteResolver $siteResolver
+     * @param RequestHelper $requestHelper
      * @param Config $config
      */
     public function __construct(
         SiteResolver $siteResolver,
+        RequestHelper $requestHelper,
         Config $config
     ) {
         $this->siteResolver = $siteResolver;
+        $this->requestHelper = $requestHelper;
         $this->config = $config;
     }
 
@@ -80,9 +89,14 @@ final class DataObjectRouteHandler implements DynamicRouteHandlerInterface
         $slug = DataObject\Data\UrlSlug::resolveSlug($context->getOriginalPath(), $site ? $site->getId() : 0);
         if ($slug) {
             $object = DataObject::getById($slug->getObjectId());
-            if ($object instanceof DataObject\Concrete && $object->isPublished()) {
-                $route = $this->buildRouteForFromSlug($slug, $object);
-                $collection->add($route->getRouteKey(), $route);
+
+            if ($object instanceof DataObject\Concrete) {
+                $doBuildRoute = $object->isPublished() || $this->requestHelper->isObjectPreviewRequestByAdmin($context->getRequest());
+
+                if($doBuildRoute) {
+                    $route = $this->buildRouteForFromSlug($slug, $object);
+                    $collection->add($route->getRouteKey(), $route);
+                }
             }
         }
     }

--- a/models/DataObject/ClassDefinition/PreviewGeneratorInterface.php
+++ b/models/DataObject/ClassDefinition/PreviewGeneratorInterface.php
@@ -19,6 +19,9 @@ use Pimcore\Model\DataObject\Concrete;
 
 interface PreviewGeneratorInterface
 {
+    public const PARAMETER_SITE = "site";
+    public const PARAMETER_LOCALE = "locale";
+
     /**
      * @param Concrete $object
      * @param array $params


### PR DESCRIPTION
- Fixes https://github.com/pimcore/pimcore/issues/11242
- Potentially fixes https://github.com/pimcore/pimcore/issues/7657

## Description
- Adds a default preview generator implementation
- Adds support for sites
- Adds support for locales
- Updates docs about preview generator
- Supports preview for unpublished objects
- Supports preview for objects in unpublished sites (comes in handy if editors want to add/view content already)
- Pre-selects the user's locale if it is available in the system locales
- Improves error messages by actually throwing an error instead of rendering plain text
- Improves error messages by changing the messages to convey more information
- Is automatically used as soon as a link generator is available

> Note that the link-generation itself is still up to the developer.
---
Please peer-review thoroughly before merging.