### PR TITLE
[Task]: Remove application_logging permissions from core installer

### DIFF
--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -718,7 +718,6 @@ class Installer
             'userModification' => 1,
         ]));
         $userPermissions = [
-            'application_logging',
             'assets',
             'classes',
             'clear_cache',


### PR DESCRIPTION
Follow up to #12530

Removed the permission since it should only be installed by the corresponding bundle.