### PR TITLE
Invalidate only given file instead of resetting the whole opcache

### DIFF
--- a/lib/File.php
+++ b/lib/File.php
@@ -132,8 +132,8 @@ class File
     {
         $return = self::put($path, $data);
 
-        if (function_exists('opcache_reset')) {
-            opcache_reset();
+        if (\function_exists('opcache_invalidate')) {
+            opcache_invalidate($path);
         }
 
         return $return;


### PR DESCRIPTION
I don't think it's necessary to invalidate the whole opcache when `Pimcore\File::putPhpFile()` is called. It should be sufficient to invalidate only the specified file.