### PR TITLE
Deprecate `Pimcore\Tool\Authentication::authenticateHttpBasic()`

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -20,6 +20,7 @@
 - [Annotations] Using Annotations `@ResponseHeader` & `@ParamConverter`, `@Template` and 
 rest from [SensioFrameworkExtraBundle](https://symfony.com/bundles/SensioFrameworkExtraBundle/current/index.html#annotations-for-controllers) is deprecated and will not be supported on Pimcore 11. 
 Use `#[ResponseHeader]`,`#[DataObjectParam]` argument, `#[Template]` and other attributes instead.
+- [Authentication] The method `Pimcore\Tool\Authentication::authenticateHttpBasic()` has been deprecated and will be removed in Pimcore 11.
 
 ## 10.5.13
 - [Web2Print] Print document twig expressions are now executed in a sandbox with restrictive security policies (just like Sending mails and Dataobject Text Layouts introduced in 10.5.9).

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -83,12 +83,20 @@ class Authentication
     }
 
     /**
+     * @deprecated
+     *
      * @throws \Exception
      *
      * @return User
      */
     public static function authenticateHttpBasic()
     {
+        trigger_deprecation(
+            'pimcore/pimcore',
+            '10.6',
+            sprintf('%s is deprecated and will be removed in Pimcore 11', __METHOD__),
+        );
+
         // we're using Sabre\HTTP for basic auth
         $request = \Sabre\HTTP\Sapi::getRequest();
         $response = new \Sabre\HTTP\Response();


### PR DESCRIPTION
It seems like this method is not used in Pimcore itself (anymore?) so I propose to deprecate it in Pimcore `10.6` and [remove it in Pimcore `11.0`](https://github.com/pimcore/pimcore/pull/14299).