### PR TITLE
Enhance performance for "versioncleanup" maintenance task

### DIFF
--- a/models/Version/Dao.php
+++ b/models/Version/Dao.php
@@ -143,6 +143,8 @@ class Dao extends Model\Dao\AbstractDao
 
                         $versionIds = array_merge($versionIds, $elementVersions);
 
+                        Logger::info($versionInfo['cid'].'(object '.$count.') Vcount '.count($versionIds));
+
                         // call the garbage collector if memory consumption is > 100MB
                         if (memory_get_usage() > 100000000 && ($count % 100 == 0)) {
                             \Pimcore::collectGarbage();

--- a/models/Version/Dao.php
+++ b/models/Version/Dao.php
@@ -146,7 +146,6 @@ class Dao extends Model\Dao\AbstractDao
                         // call the garbage collector if memory consumption is > 100MB
                         if (memory_get_usage() > 100000000 && ($count % 100 == 0)) {
                             \Pimcore::collectGarbage();
-                            sleep(1);
                         }
 
                         if (count($versionIds) > 1000) {

--- a/models/Version/Dao.php
+++ b/models/Version/Dao.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Model\Version;
 
+use Doctrine\DBAL\FetchMode;
 use Pimcore\Db\Helper;
 use Pimcore\Logger;
 use Pimcore\Model;
@@ -131,15 +132,14 @@ class Dao extends Model\Dao\AbstractDao
                 if (isset($elementType['days'])) {
                     // by days
                     $deadline = time() - ($elementType['days'] * 86400);
-                    $tmpVersionIds = $this->db->fetchFirstColumn('SELECT id FROM versions as a WHERE (ctype = ? AND date < ?) AND NOT public AND id NOT IN (' . $ignoreIdsList . ')', [$elementType['elementType'], $deadline]);
+                    $tmpVersionIds = $this->db->fetchFirstColumn('SELECT id FROM versions as a WHERE ctype = ? AND date < ? AND public=0 AND id NOT IN (' . $ignoreIdsList . ')', [$elementType['elementType'], $deadline]);
                     $versionIds = array_merge($versionIds, $tmpVersionIds);
                 } else {
                     // by steps
-                    $versionData = $this->db->executeQuery('SELECT cid, GROUP_CONCAT(id ORDER BY id DESC) AS versions FROM versions WHERE ctype = ? AND NOT public AND id NOT IN (' . $ignoreIdsList . ') GROUP BY cid HAVING COUNT(*) > ? LIMIT 1000', [$elementType['elementType'], $elementType['steps']]);
+                    $versionData = $this->db->executeQuery('SELECT cid FROM versions WHERE ctype = ? AND public=0 AND id NOT IN (' . $ignoreIdsList . ') GROUP BY cid HAVING COUNT(*) > ? LIMIT 1000', [$elementType['elementType'], $elementType['steps']]);
                     while ($versionInfo = $versionData->fetch()) {
                         $count++;
-                        Logger::info($versionInfo['cid'] . '(object ' . $count . ') Vcount ' . count($versionIds));
-                        $elementVersions = \array_slice(explode(',', $versionInfo['versions']), $elementType['steps']);
+                        $elementVersions = $this->db->fetchFirstColumn('SELECT id FROM versions WHERE cid=? AND ctype = ? AND public=0 AND id NOT IN ('.$ignoreIdsList.') ORDER BY id DESC LIMIT '.($elementType['steps'] + 1).', '.PHP_INT_MAX, [$versionInfo['cid'], $elementType['elementType']]);
 
                         $versionIds = array_merge($versionIds, $elementVersions);
 


### PR DESCRIPTION
When using the `x steps` setting for keeping versions, during maintenance there is a quite heavy query being executed in https://github.com/pimcore/pimcore/blob/dc60b60b5ca59e32153f32dd99339381dee2f9d9/models/Version/Dao.php#L138

The main problem is that this query is not [coverable with an index because of the GROUP_CONCAT function](https://dev.mysql.com/doc/refman/8.0/en/group-by-optimization.html).

Another problem is that `NOT public` does not use the index while `public=0` does.

For this reason this PR changes the query to fetch the objects which have more than the configured amount of versions. And then fetches the excess versions within the loop. 

This way we reduced runtime from 12 seconds to 5 seconds with 10M version records.