### PR TITLE
Task: Fix parameter's order in Chromium::convert()

### DIFF
--- a/lib/Image/Chromium.php
+++ b/lib/Image/Chromium.php
@@ -46,7 +46,7 @@ class Chromium
     /**
      * @throws \Exception
      */
-    public static function convert(string $url, string $outputFile, ?string $sessionId = null, ?string $sessionName = null, string $windowSize = '1280,1024'): bool
+    public static function convert(string $url, string $outputFile, ?string $sessionName = null,  ?string $sessionId = null, string $windowSize = '1280,1024'): bool
     {
         $binary = self::getChromiumBinary();
         if (!$binary) {


### PR DESCRIPTION
Follow-up https://github.com/pimcore/pimcore/pull/13909

## Additional info  
It was likely meant to be `name` and `id`, see 
https://github.com/pimcore/pimcore/blob/055c69ea1f4ddfab694d59fd2b134905e94a8756/bundles/AdminBundle/src/Controller/Admin/Document/DocumentController.php#L1161
https://github.com/pimcore/pimcore/blob/055c69ea1f4ddfab694d59fd2b134905e94a8756/lib/Image/Chromium.php#L67
