### PR TITLE
Remove temporary files which got created by File::getLocalTempFilePath()

### DIFF
--- a/lib/File.php
+++ b/lib/File.php
@@ -240,7 +240,7 @@ class File
             $fileExtension ?: 'tmp'
         );
 
-        register_shutdown_function(function() use ($filePath) {
+        register_shutdown_function(static function() use ($filePath) {
             if(file_exists($filePath)) {
                 unlink($filePath);
             }

--- a/lib/File.php
+++ b/lib/File.php
@@ -245,6 +245,8 @@ class File
                 unlink($filePath);
             }
         });
+
+        return $filePath;
     }
 
     /**

--- a/lib/File.php
+++ b/lib/File.php
@@ -234,11 +234,17 @@ class File
 
     public static function getLocalTempFilePath(?string $fileExtension = null): string
     {
-        return sprintf('%s/temp-file-%s.%s',
+        $filePath = sprintf('%s/temp-file-%s.%s',
             PIMCORE_SYSTEM_TEMP_DIRECTORY,
             uniqid() . '-' .  bin2hex(random_bytes(15)),
             $fileExtension ?: 'tmp'
         );
+
+        register_shutdown_function(function() use ($filePath) {
+            if(file_exists($filePath)) {
+                unlink($filePath);
+            }
+        });
     }
 
     /**

--- a/lib/Helper/TemporaryFileHelperTrait.php
+++ b/lib/Helper/TemporaryFileHelperTrait.php
@@ -65,7 +65,7 @@ trait TemporaryFileHelperTrait
             $fileExtension = File::getFileExtension($streamMeta['uri']);
         }
 
-        $tmpFilePath = File::getLocalTempFilePath($fileExtension);
+        $tmpFilePath = File::getLocalTempFilePath($fileExtension, $keep);
 
         $dest = fopen($tmpFilePath, 'wb', false, File::getContext());
         if (!$dest) {
@@ -74,12 +74,6 @@ trait TemporaryFileHelperTrait
 
         stream_copy_to_stream($src, $dest);
         fclose($dest);
-
-        if (!$keep) {
-            /** @var LongRunningHelper $longRunningHelper */
-            $longRunningHelper = Pimcore::getContainer()->get(LongRunningHelper::class);
-            $longRunningHelper->addTmpFilePath($tmpFilePath);
-        }
 
         return $tmpFilePath;
     }

--- a/lib/Helper/TemporaryFileHelperTrait.php
+++ b/lib/Helper/TemporaryFileHelperTrait.php
@@ -79,9 +79,6 @@ trait TemporaryFileHelperTrait
             /** @var LongRunningHelper $longRunningHelper */
             $longRunningHelper = Pimcore::getContainer()->get(LongRunningHelper::class);
             $longRunningHelper->addTmpFilePath($tmpFilePath);
-            register_shutdown_function(static function () use ($tmpFilePath) {
-                @unlink($tmpFilePath);
-            });
         }
 
         return $tmpFilePath;

--- a/lib/Image/Optimizer.php
+++ b/lib/Image/Optimizer.php
@@ -51,9 +51,6 @@ class Optimizer implements ImageOptimizerInterface
                         'optimizer' => $optimizer,
                     ];
                 } catch (ImageOptimizationFailedException $ex) {
-                    if (file_exists($tmpFilePath)) {
-                        unlink($tmpFilePath);
-                    }
                 }
             }
         }
@@ -75,10 +72,6 @@ class Optimizer implements ImageOptimizerInterface
         // cleanup
         foreach ($optimizedImages as $tmpFile) {
             unlink($tmpFile['path']);
-        }
-
-        if (is_file($workingPath)) {
-            unlink($workingPath);
         }
     }
 

--- a/models/Asset/Document/ImageThumbnail.php
+++ b/models/Asset/Document/ImageThumbnail.php
@@ -146,7 +146,6 @@ final class ImageThumbnail
                     $converter->saveImage($tempFile, $this->page);
                     $storage->write($cacheFilePath, file_get_contents($tempFile));
                 } finally {
-                    unlink($tempFile);
                     $lock->release();
                 }
             } else {

--- a/models/Asset/Folder.php
+++ b/models/Asset/Folder.php
@@ -206,7 +206,6 @@ class Folder extends Model\Asset
                 if (filesize($localFile) > 0) {
                     $storage->write($cacheFilePath, file_get_contents($localFile));
                 }
-                unlink($localFile);
 
                 return $storage->readStream($cacheFilePath);
             }

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -194,7 +194,6 @@ class Image extends Model\Asset
             $imagick->writeImage($tmpFile);
             $imageBase64 = base64_encode(file_get_contents($tmpFile));
             $imagick->destroy();
-            unlink($tmpFile);
 
             $svg = <<<EOT
 <?xml version="1.0" encoding="utf-8"?>

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -434,8 +434,6 @@ class Processor
                     }
                 }
 
-                unlink($tmpFsPath);
-
                 $generated = true;
 
                 $isImageOptimizersEnabled = PimcoreConfig::getSystemConfiguration('assets')['image']['thumbnails']['image_optimizers']['enabled'];

--- a/models/Asset/Video/ImageThumbnail.php
+++ b/models/Asset/Video/ImageThumbnail.php
@@ -143,7 +143,6 @@ final class ImageThumbnail
                         $converter->saveImage($tempFile, $timeOffset);
                         $generated = true;
                         $storage->write($cacheFilePath, file_get_contents($tempFile));
-                        unlink($tempFile);
                     }
 
                     $lock->release();

--- a/models/User.php
+++ b/models/User.php
@@ -570,7 +570,6 @@ final class User extends User\UserRole
                 $image->save($targetFile, 'png');
 
                 $storage->write($this->getThumbnailImageStoragePath(), file_get_contents($targetFile));
-                unlink($targetFile);
             }
 
             return $storage->readStream($this->getThumbnailImageStoragePath());


### PR DESCRIPTION
On a lot of places https://github.com/pimcore/pimcore/blob/19ef4b24b8bc8151fd000f07016da5269b54cb9a/lib/File.php#L203 gets called. And after using the temporary file for processing the file gets deleted. But there are 2 problems with this:

1. You always have to remember deleting the file, otherwise there will be loads of old temp files remaining on the hard disk.
2. Even if you remember to call `unlink()` you have to be careful in case of exceptions.

Some examples which this PR fixes:
https://github.com/pimcore/pimcore/blob/19ef4b24b8bc8151fd000f07016da5269b54cb9a/models/Asset/Image/Thumbnail/Processor.php#L414-L428
If the `$storage->writeStream($storagePath, $stream);` throws an exception, the temporary file from `$tmpFsPath` will not get deleted.

In https://github.com/pimcore/pimcore/blob/19ef4b24b8bc8151fd000f07016da5269b54cb9a/lib/Image/Optimizer.php#L41-L44 and https://github.com/pimcore/pimcore/blob/19ef4b24b8bc8151fd000f07016da5269b54cb9a/lib/Image/Optimizer.php#L74-L76 it is not immediately obvious that the latter cleans up the temporary file of `$tmpFilePath`. Not easy to maintain this with future changes.

So either we should wrap all the usages of `File::getLocalTempFilePath()` with `try {} finally {}` to cleanup even if an exception occured. But this has the same problem that we have to remember cleaning up. Or we use the lazy approach of this PR, then we can simply use `File::getLocalTempFilePath()` and the cleanup will be done automatically.