### PR TITLE
[Assets] When uploading new version of asset, show notification if file is too big

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1024,7 +1024,12 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
             iconCls: 'pimcore_icon_upload'
         },
         listeners: {
-            change: function () {
+            change: function (fileUploadField) {
+                if(fileUploadField.fileInputEl.dom.files[0].size > pimcore.settings["upload_max_filesize"]) {
+                    pimcore.helpers.showNotification(t("error"), t("file_is_bigger_that_upload_limit") + " " + fileUploadField.fileInputEl.dom.files[0].name, "error");
+                    return;
+                }
+
                 uploadForm.getForm().submit({
                     url: url,
                     params: {


### PR DESCRIPTION
While for uploading new asset files (e.g. via tree context menu) there is a check for max file size, this is not done when updating an existing asset file via "Upload new version" button:
<img width="309" alt="Bildschirmfoto 2023-02-14 um 13 04 47" src="https://user-images.githubusercontent.com/8749138/218733283-bb3c9f92-d3cd-4d22-87da-38d05b012c72.png">

Currently, when you upload a too big file, you will only see a CSRF token error. This is caused by PHP discarding all input parameters for a request which is bigger than `post_max_size`. 

The same is valid when new asset files get uploaded via compatibility mode:
<img width="547" alt="Bildschirmfoto 2023-02-14 um 13 06 57" src="https://user-images.githubusercontent.com/8749138/218733702-4028524a-abd2-4140-9ad7-f8ad0ccd120b.png">