### PR TITLE
[Improvement]: CheckMaxPixels only if image, improve code redundancy

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -300,7 +300,7 @@ class Asset extends Element\AbstractElement
                         $isRewindable = @rewind($data['stream']);
                         $dest = fopen($tmpFile, 'w+', false, File::getContext());
                         stream_copy_to_stream($data['stream'], $dest);
-                        $mimeTypeGuessData = MimeTypes::getDefault()->guessMimeType($tmpFile);
+                        $mimeTypeGuessData = $tmpFile;
 
                         if (!$isRewindable) {
                             $data['stream'] = $dest;

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -282,26 +282,25 @@ class Asset extends Element\AbstractElement
         // (tree) is generated immediately after creating an image
         $class = Asset::class;
         if (array_key_exists('filename', $data) && (array_key_exists('data', $data) || array_key_exists('sourcePath', $data) || array_key_exists('stream', $data))) {
+            $mimeType = 'directory';
+            $mimeTypeGuessData = null;
             if (array_key_exists('data', $data) || array_key_exists('stream', $data)) {
                 $tmpFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/asset-create-tmp-file-' . uniqid() . '.' . File::getFileExtension($data['filename']);
+                $mimeTypeGuessData = $tmpFile;
                 if (array_key_exists('data', $data)) {
                     File::put($tmpFile, $data['data']);
-                    self::checkMaxPixels($tmpFile, $data);
-                    $mimeType = MimeTypes::getDefault()->guessMimeType($tmpFile);
                     unlink($tmpFile);
                 } else {
                     $streamMeta = stream_get_meta_data($data['stream']);
                     if (file_exists($streamMeta['uri'])) {
                         // stream is a local file, so we don't have to write a tmp file
-                        self::checkMaxPixels($streamMeta['uri'], $data);
-                        $mimeType = MimeTypes::getDefault()->guessMimeType($streamMeta['uri']);
+                        $mimeTypeGuessData = $streamMeta['uri'];
                     } else {
                         // write a tmp file because the stream isn't a pointer to the local filesystem
                         $isRewindable = @rewind($data['stream']);
                         $dest = fopen($tmpFile, 'w+', false, File::getContext());
                         stream_copy_to_stream($data['stream'], $dest);
-                        self::checkMaxPixels($tmpFile, $data);
-                        $mimeType = MimeTypes::getDefault()->guessMimeType($tmpFile);
+                        $mimeTypeGuessData = MimeTypes::getDefault()->guessMimeType($tmpFile);
 
                         if (!$isRewindable) {
                             $data['stream'] = $dest;
@@ -311,21 +310,24 @@ class Asset extends Element\AbstractElement
                         }
                     }
                 }
+                $mimeType = MimeTypes::getDefault()->guessMimeType($mimeTypeGuessData);
             } else {
-                if (is_dir($data['sourcePath'])) {
-                    $mimeType = 'directory';
-                } else {
-                    self::checkMaxPixels($data['sourcePath'], $data);
-                    $mimeType = MimeTypes::getDefault()->guessMimeType($data['sourcePath']);
+                if (!is_dir($data['sourcePath'])) {
+                    $mimeTypeGuessData = $data['sourcePath'];
                     if (is_file($data['sourcePath'])) {
                         $data['stream'] = fopen($data['sourcePath'], 'rb', false, File::getContext());
                     }
+                    $mimeType = MimeTypes::getDefault()->guessMimeType($mimeTypeGuessData);
                 }
-
                 unset($data['sourcePath']);
             }
 
             $type = self::getTypeFromMimeMapping($mimeType, $data['filename']);
+            // only check maxpixels if it is an image
+            if($type === 'image' && $mimeTypeGuessData) {
+                self::checkMaxPixels($mimeTypeGuessData, $data);
+            }
+
             $class = '\\Pimcore\\Model\\Asset\\' . ucfirst($type);
             if (array_key_exists('type', $data)) {
                 unset($data['type']);
@@ -350,15 +352,15 @@ class Asset extends Element\AbstractElement
         // this check is intentionally done in Asset::create() because in Asset::update() it would result
         // in an additional download from remote storage if configured, so in terms of performance
         // this is the more efficient way
-        $maxPixels = (int) Pimcore::getContainer()->getParameter('pimcore.config')['assets']['image']['max_pixels'];
+        $maxPixels = (int)Pimcore::getContainer()->getParameter('pimcore.config')['assets']['image']['max_pixels'];
         if ($size = @getimagesize($localPath)) {
-            $imagePixels = (int) ($size[0] * $size[1]);
+            $imagePixels = (int)($size[0] * $size[1]);
             if ($imagePixels > $maxPixels) {
                 Logger::error("Image to be created {$localPath} (temp. path) exceeds max pixel size of {$maxPixels}, you can change the value in config pimcore.assets.image.max_pixels");
 
                 $diff = sqrt(1 + ($maxPixels / $imagePixels));
-                $suggestion_0 = (int) round($size[0] / $diff, -2, PHP_ROUND_HALF_DOWN);
-                $suggestion_1 = (int) round($size[1] / $diff, -2, PHP_ROUND_HALF_DOWN);
+                $suggestion_0 = (int)round($size[0] / $diff, -2, PHP_ROUND_HALF_DOWN);
+                $suggestion_1 = (int)round($size[1] / $diff, -2, PHP_ROUND_HALF_DOWN);
 
                 $mp = $maxPixels / 1_000_000;
                 // unlink file before throwing exception


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #14228 

## Additional info  
Restructure mimetype and maxpixel code for less redundancy
