### PR TITLE
Fix Error with GeneratePagePreviewMessage, when Page is deleted

### DIFF
--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -650,10 +650,10 @@ class Service extends Model\Element\Service
      */
     public static function generatePagePreview($id, $request = null, $hostUrl = null)
     {
-        $success = false;
-
-        /** @var Page $doc */
-        $doc = Document::getById($id);
+        $doc = Document\Page::getById($id);
+        if (!$doc) {
+            return false;
+        }
         if (!$hostUrl) {
             $hostUrl = Config::getSystemConfiguration('documents')['preview_url_prefix'];
             if (empty($hostUrl)) {
@@ -684,10 +684,10 @@ class Service extends Model\Element\Service
 
                 unlink($tmpFile);
 
-                $success = true;
+                return true;
             }
         }
 
-        return $success;
+        return false;
     }
 }


### PR DESCRIPTION
We get many of this errors:
```
15:05:56 WARNING   [messenger] Error thrown while handling message Pimcore\Messenger\GeneratePagePreviewMessage. Sending for retry #1 using 1000 ms delay. Error: "Handling "Pimcore\Messenger\GeneratePagePreviewMessage" failed: Call to a member function getRealFullPath() on null" ["class" => "Pimcore\Messenger\GeneratePagePreviewMessage","retryCount" => 1,"delay" => 1000,"error" => "Handling "Pimcore\Messenger\GeneratePagePreviewMessage" failed: Call to a member function getRealFullPath() on null","exception" => Symfony\Component\Messenger\Exception\HandlerFailedException { …}]
```