### PR TITLE
Fix Glossary not working with partial pimcore_wysiwyg content

### DIFF
--- a/lib/Tool/Glossary/Processor.php
+++ b/lib/Tool/Glossary/Processor.php
@@ -136,7 +136,7 @@ class Processor
 
         $es->each(function ($parentNode, $i) use ($options, $data) {
             /** @var DomCrawler|null $parentNode */
-            $text = htmlentities($parentNode->text(), ENT_XML1);
+            $text = $parentNode->html();
             if (
                 $parentNode instanceof DomCrawler &&
                 !in_array((string)$parentNode->nodeName(), $this->blockedTags) &&
@@ -158,7 +158,7 @@ class Processor
                 if ($originalText !== $text) {
                     $domNode = $parentNode->getNode(0);
                     $fragment = $domNode->ownerDocument->createDocumentFragment();
-                    $fragment->appendXML($text);
+                    $fragment->appendXML(htmlentities($text, ENT_XML1));
                     $clone = $domNode->cloneNode();
                     $clone->appendChild($fragment);
                     $domNode->parentNode->replaceChild($clone, $domNode);
@@ -166,7 +166,7 @@ class Processor
             }
         });
 
-        $result = $html->html();
+        $result = html_entity_decode($html->html(), ENT_XML1);
         $html->clear();
         unset($html);
 

--- a/tests/Unit/Document/Glossary/GlossaryTest.php
+++ b/tests/Unit/Document/Glossary/GlossaryTest.php
@@ -50,7 +50,7 @@ class GlossaryTest extends TestCase
 
         $expect = '<body><p>This is a Test for the <a class="pimcore_glossary" href="/test">Glossary</a></p></body>';
 
-        $this->assertSame($result, $expect);
+        $this->assertSame($expect, $result);
     }
 
     public function testGlossaryWithHtmlEntities()
@@ -71,7 +71,7 @@ class GlossaryTest extends TestCase
 
         $expect = '<body><p>This is a Test for the&nbsp;<a class="pimcore_glossary" href="/test">Entity</a> &copy;</p></body>';
 
-        $this->assertSame($result, html_entity_decode($expect));
+        $this->assertSame(html_entity_decode($expect), $result);
     }
 
     public function testGlossaryWithHtmlEntities2()
@@ -86,7 +86,7 @@ class GlossaryTest extends TestCase
 
         $expect = '<body><p>Test &nbsp; <a class="pimcore_glossary" href="/test">Eintrag</a> &copy;</p></body>';
 
-        $this->assertSame($result, html_entity_decode($expect));
+        $this->assertSame(html_entity_decode($expect), $result);
     }
 
     public function testGlossaryWithHtml()
@@ -130,7 +130,7 @@ class GlossaryTest extends TestCase
         </div>
     </section>';
 
-        $this->assertSame($result, $expect);
+        $this->assertSame($expect, $result);
     }
 
     public function testGlossaryWithAnotherHtml()
@@ -150,7 +150,7 @@ class GlossaryTest extends TestCase
 
         $expect = '<p><a class="pimcore_glossary" href="/hans">hans</a> &amp; gretl</p>';
 
-        $this->assertSame($result, $expect);
+        $this->assertSame($expect, $result);
     }
 
     public function testGlossaryWithLowerThenAndGreaterThenHtml()
@@ -170,6 +170,6 @@ class GlossaryTest extends TestCase
 
         $expect = '<p><a class="pimcore_glossary" href="/huber">huber</a> &lt;&gt; is the best</p>';
 
-        $this->assertSame($result, $expect);
+        $this->assertSame($expect, $result);
     }
 }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #14184

## Additional info  

