### PR TITLE
[Assets] Handle documents with document_page_count=failed same as without document_page_count

### DIFF
--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -58,7 +58,8 @@ class AssetUpdateTasksHandler
 
     private function processDocument(Asset\Document $asset)
     {
-        if (!$asset->getCustomSetting('document_page_count')) {
+        $pageCount = $asset->getCustomSetting('document_page_count');
+        if (!$pageCount || $pageCount === 'failed') {
             $asset->processPageCount();
             $this->saveAsset($asset);
         }

--- a/models/Asset/Document.php
+++ b/models/Asset/Document.php
@@ -17,7 +17,6 @@ namespace Pimcore\Model\Asset;
 
 use Pimcore\Cache;
 use Pimcore\Logger;
-use Pimcore\Messenger\AssetUpdateTasksMessage;
 use Pimcore\Model;
 
 /**

--- a/models/Asset/Document.php
+++ b/models/Asset/Document.php
@@ -17,6 +17,7 @@ namespace Pimcore\Model\Asset;
 
 use Pimcore\Cache;
 use Pimcore\Logger;
+use Pimcore\Messenger\AssetUpdateTasksMessage;
 use Pimcore\Model;
 
 /**
@@ -52,7 +53,6 @@ class Document extends Model\Asset
      */
     public function processPageCount($path = null)
     {
-        $pageCount = null;
         if (!\Pimcore\Document::isAvailable()) {
             Logger::error("Couldn't create image-thumbnail of document " . $this->getRealFullPath() . ' no document adapter is available');
 
@@ -97,11 +97,9 @@ class Document extends Model\Asset
             return new Document\ImageThumbnail(null);
         }
 
-        if (!$this->getCustomSetting('document_page_count')) {
-            Logger::info('Image thumbnail not yet available, processing is done asynchronously.');
+        $pageCount = $this->getCustomSetting('document_page_count');
+        if (!$pageCount || $pageCount === 'failed') {
             $this->addToUpdateTaskQueue();
-
-            return new Document\ImageThumbnail(null);
         }
 
         return new Document\ImageThumbnail($this, $thumbnailName, $page, $deferred);


### PR DESCRIPTION
In https://github.com/pimcore/pimcore/blob/8d9b9cf0fd1ba65ccf7485eb0be0547493ff267f/models/Asset/Document.php#L54-L74 page count of document assets gets calculated.

If this fails, `document_page_count` is set to `failed`. 

In https://github.com/pimcore/pimcore/blob/8d9b9cf0fd1ba65ccf7485eb0be0547493ff267f/models/Asset/Document.php#L106-L111 this property gets used to check of an image thumbnail can be generated.

There are 2 problems:
1. If it initially failed (for whatever reason), the property will only be removed if the asset gets saved. In other words: Even if the cause has been resolved we will never get an image thumbnail for an asset which has `document_page_count=failed` set.
2. Actually the page count is nowhere used to generate the image thumbnail for the document. For this reason with this PR it is tried to generate the thumbnail anyway.

An alternative to the check for `!document_page_count || document_page_count=='failed'` would be to set it to `false`. If you prefer this, please comment.