### PR TITLE
Allow null as type and set as null as default

### DIFF
--- a/bundles/CoreBundle/src/EventListener/Frontend/FullPageCacheListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/FullPageCacheListener.php
@@ -51,7 +51,7 @@ class FullPageCacheListener
 
     protected ?string $disableReason = null;
 
-    protected string $defaultCacheKey;
+    protected ?string $defaultCacheKey = null;
 
     public function __construct(
         private VisitorInfoStorageInterface $visitorInfoStorage,


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Full page cache listener throws exception as the defaultCacheKey has no default value and is not initialized. By allowing and setting null, there is no exception and the checks still work.

## Additional info  
```log
php.CRITICAL: Uncaught Error: Typed property Pimcore\Bundle\CoreBundle\EventListener\Frontend\FullPageCacheListener::$defaultCacheKey must not be accessed before initialization {"exception":"[object] (Error(code: 0): Typed property Pimcore\\Bundle\\CoreBundle\\EventListener\\Frontend\\FullPageCacheListener::$defaultCacheKey must not be accessed before initialization at /var/www/pimcore/vendor/pimcore/pimcore/bundles/CoreBundle/src/EventListener/Frontend/FullPageCacheListener.php:328)"}
```
