### PR TITLE
[Assets] Skip Thumbs.db when importing zip asset

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -2347,7 +2347,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             for ($i = $offset; $i < ($offset + $limit); $i++) {
                 $path = $zip->getNameIndex($i);
 
-                if (str_starts_with($path, '__MACOSX/')) {
+                if (str_starts_with($path, '__MACOSX/') || $path === 'Thumbs.db') {
                     continue;
                 }
 


### PR DESCRIPTION
In analogy of #12161 this PR skips Windows' `Thumbs.db` when importing zip file to assets. These files are especially annoying when you upload a zip file with a folder hierarchy, then in every subfolder Windows adds a `Thumbs.db`. 
The same is also done by MacOS when extracting zip files.