### PR TITLE
Deprecate `Pimcore\Tool\Authentication::authenticatePlaintext()`

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -20,6 +20,7 @@
 - [Annotations] Using Annotations `@ResponseHeader` & `@ParamConverter`, `@Template` and rest from [SensioFrameworkExtraBundle](https://symfony.com/bundles/SensioFrameworkExtraBundle/current/index.html#annotations-for-controllers) is deprecated and will not be supported on Pimcore 11. Use `#[ResponseHeader]`,`#[DataObjectParam]` argument, `#[Template]` and other attributes instead.
 - [Asset] Deprecated VR Preview. For details please see [#14111](https://github.com/pimcore/pimcore/issues/14111).
 - [Authentication] The method `Pimcore\Tool\Authentication::authenticateHttpBasic()` has been deprecated and will be removed in Pimcore 11.
+- [Authentication] The method `Pimcore\Tool\Authentication::authenticatePlaintext()` has been deprecated and will be removed in Pimcore 11.
 
 ## 10.5.13
 - [Web2Print] Print document twig expressions are now executed in a sandbox with restrictive security policies (just like Sending mails and Dataobject Text Layouts introduced in 10.5.9).

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -25,6 +25,8 @@ use Symfony\Component\HttpFoundation\Request;
 class Authentication
 {
     /**
+     * @deprecated
+     *
      * @param string $username
      * @param string $password
      *
@@ -32,6 +34,12 @@ class Authentication
      */
     public static function authenticatePlaintext($username, $password)
     {
+        trigger_deprecation(
+            'pimcore/pimcore',
+            '10.6',
+            sprintf('%s is deprecated and will be removed in Pimcore 11', __METHOD__),
+        );
+
         /** @var User $user */
         $user = User::getByName($username);
 


### PR DESCRIPTION
This method is not used in Pimcore itself anymore, so I propose to deprecate it in Pimcore 10.6 and [remove it in Pimcore 11](https://github.com/pimcore/pimcore/pull/14359).