### PR TITLE
[Assets] Skip Thumbs.db when importing zip asset -> Follow-up of #14353

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -2347,7 +2347,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             for ($i = $offset; $i < ($offset + $limit); $i++) {
                 $path = $zip->getNameIndex($i);
 
-                if (str_starts_with($path, '__MACOSX/') || $path === 'Thumbs.db') {
+                if (str_starts_with($path, '__MACOSX/') || str_ends_with($path, '/Thumbs.db')) {
                     continue;
                 }
 

--- a/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/Controller/Admin/Asset/AssetController.php
@@ -2347,7 +2347,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             for ($i = $offset; $i < ($offset + $limit); $i++) {
                 $path = $zip->getNameIndex($i);
 
-                if (str_starts_with($path, '__MACOSX/')) {
+                if (str_starts_with($path, '__MACOSX/') || $path === 'Thumbs.db') {
                     continue;
                 }
 


### PR DESCRIPTION
Follow-up of #14353 which did not work for Thumbs.db files in sub folders.