### PR TITLE
Ensure timezone is reset if the token is invalid due to a timeout

### DIFF
--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -134,13 +134,16 @@ class Authentication
                 return null;
             }
 
-            $timeZone = date_default_timezone_get();
-            date_default_timezone_set('UTC');
+            try {
+                $timeZone = date_default_timezone_get();
+                date_default_timezone_set('UTC');
 
-            if ($timestamp > time() || $timestamp < (time() - (60 * 60 * 24))) {
-                return null;
+                if ($timestamp > time() || $timestamp < (time() - (60 * 60 * 24))) {
+                    return null;
+                }
+            } finally {
+                date_default_timezone_set($timeZone);
             }
-            date_default_timezone_set($timeZone);
 
             return $user;
         }


### PR DESCRIPTION
`Authentication::authenticateToken()` returns `null` if the token timed out, but it changes the default timezone beforehand and only resets it to its original value *after* the `return`, meaning that it is not reset if the token timed out.

I would expect the default timezone to be the same as before the method was called. This PR ensures that.