### PR TITLE
Add source path to ResolveUploadTargetEvent

### DIFF
--- a/bundles/AdminBundle/src/Controller/Admin/Asset/AssetController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/Asset/AssetController.php
@@ -501,7 +501,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
             $this->validateManyToManyRelationAssetType($context, $filename, $sourcePath);
 
-            $event = new ResolveUploadTargetEvent($parentId, $filename, $context);
+            $event = new ResolveUploadTargetEvent($parentId, $filename, $sourcePath, $context);
             \Pimcore::getEventDispatcher()->dispatch($event, AssetEvents::RESOLVE_UPLOAD_TARGET);
             $filename = Element\Service::getValidKey($event->getFilename(), 'asset');
             $parentId = $event->getParentId();

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -173,6 +173,7 @@ Please make sure to set your preferred storage location ***before*** migration. 
   instead of `pimcore_core`. please add option `pimcore_asset_update` to command `bin/console messenger:consume pimcore_core... pimcore_asset_update` to post process assets on update.
   Also run command `bin/console messenger:consume pimcore_core` before the upgrade, so that `AssetUpdateTasksMessage` on the queue gets consumed.
 - [Events] Event `pimcore.element.note.postAdd` has been removed. Use `pimcore.note.postAdd` instead. Note: The event type changed from `ElementEvent` to `ModelEvent`.
+- [Events] Added `$sourcePath` as a mandatory property and its getter and setter methods to `Pimcore\Event\Model\Asset\ResolveUploadTargetEvent`.
 - [Asset] Removed VR Preview. For details please see [#14111](https://github.com/pimcore/pimcore/issues/14111)
 - [Translations] Translations Domains needs to be registered in order to be considered as valid. If you are using custom domains
   for translations (other than `messages` and `admin`), then it is required to register the domain in config below:

--- a/lib/Event/Model/Asset/ResolveUploadTargetEvent.php
+++ b/lib/Event/Model/Asset/ResolveUploadTargetEvent.php
@@ -23,24 +23,38 @@ class ResolveUploadTargetEvent extends Event
 {
     use ArgumentsAwareTrait;
 
+    protected int $parentId;
+
     protected string $filename;
 
-    protected array $context;
+    protected string $sourcePath;
 
-    protected int $parentId;
+    protected array $context;
 
     /**
      * ResolveUploadTargetEvent constructor.
      *
      * @param int $parentId
      * @param string $filename
+     * @param string $sourcePath
      * @param array $context contextual information
      */
-    public function __construct(int $parentId, string $filename, array $context)
+    public function __construct(int $parentId, string $filename, string $sourcePath, array $context)
     {
         $this->parentId = $parentId;
         $this->filename = $filename;
+        $this->sourcePath = $sourcePath;
         $this->context = $context;
+    }
+
+    public function getParentId(): int
+    {
+        return $this->parentId;
+    }
+
+    public function setParentId(int $parentId): void
+    {
+        $this->parentId = $parentId;
     }
 
     public function getFilename(): string
@@ -53,6 +67,16 @@ class ResolveUploadTargetEvent extends Event
         $this->filename = $filename;
     }
 
+    public function getSourcePath(): string
+    {
+        return $this->sourcePath;
+    }
+
+    public function setSourcePath(string $sourcePath): void
+    {
+        $this->sourcePath = $sourcePath;
+    }
+
     public function getContext(): array
     {
         return $this->context;
@@ -61,15 +85,5 @@ class ResolveUploadTargetEvent extends Event
     public function setContext(array $context): void
     {
         $this->context = $context;
-    }
-
-    public function getParentId(): int
-    {
-        return $this->parentId;
-    }
-
-    public function setParentId(int $parentId): void
-    {
-        $this->parentId = $parentId;
     }
 }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

This adds the source path to the `ResolveUploadTargetEvent` in order to allow various validations (e.g. MIME type) during the upload. While it's possible to use `$_FILES['Filedata']['tmp_name']` directly this could be a better way.