### PR TITLE
Concatenated video thumbnail path leads to an error

### DIFF
--- a/models/Asset/Video.php
+++ b/models/Asset/Video.php
@@ -139,7 +139,7 @@ class Video extends Model\Asset
      */
     private function enrichThumbnailPath($path)
     {
-        $fullPath = rtrim($this->getRealPath(), '/') . $path;
+        $fullPath = $this->getRealPath() . ltrim($path, '/');
 
         if (Tool::isFrontend()) {
             $path = urlencode_ignore_slash($fullPath);

--- a/models/Asset/Video.php
+++ b/models/Asset/Video.php
@@ -139,7 +139,7 @@ class Video extends Model\Asset
      */
     private function enrichThumbnailPath($path)
     {
-        $fullPath = $this->getRealPath() . ltrim($path, '/');
+        $fullPath = rtrim($this->getRealPath(), '/') . '/' . ltrim($path, '/');
 
         if (Tool::isFrontend()) {
             $path = urlencode_ignore_slash($fullPath);


### PR DESCRIPTION
Remove leading slash of the path instead of the RealPath to avoid there is no slash in between of the concatenation.

The function getRealPath() returns `path/of/asset/` with a tailing slash. The trim function removes it. The path has the value `video-thumb__8219__480p/video.mp4`, with no leading slash. Concatenated result is `path/of/assetvideo-thumb__8219__480p/video.mp4` which ends up in an error message "Can't find file".
