### PR TITLE
Make Tag nullable

### DIFF
--- a/models/Tool/TmpStore.php
+++ b/models/Tool/TmpStore.php
@@ -126,7 +126,7 @@ final class TmpStore extends Model\AbstractModel
             $lifetime = self::getDefaultLifetime();
         }
 
-        return $instance->getDao()->add($id, $data, $tag ?? '', $lifetime);
+        return $instance->getDao()->add($id, $data, $tag, $lifetime);
     }
 
     public static function delete(string $id): void
@@ -172,7 +172,7 @@ final class TmpStore extends Model\AbstractModel
         return $this->tag;
     }
 
-    public function setTag(string $tag): void
+    public function setTag(?string $tag): void
     {
         $this->tag = $tag;
     }

--- a/models/Tool/TmpStore.php
+++ b/models/Tool/TmpStore.php
@@ -36,7 +36,7 @@ final class TmpStore extends Model\AbstractModel
      *
      * @var string
      */
-    protected string $tag;
+    protected ?string $tag = null;
 
     /**
      * @internal
@@ -167,7 +167,7 @@ final class TmpStore extends Model\AbstractModel
         $this->id = $id;
     }
 
-    public function getTag(): string
+    public function getTag(): ?string
     {
         return $this->tag;
     }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Make tag nullable as the update function calls `getTag()` and throws an exception due to the tag not being initialized but should be a string.

## Additional info  
```
messenger.WARNING: Error thrown while handling message Pimcore\Messenger\MaintenanceTaskMessage. Sending for retry #1 using 1000 ms delay. Error: "Handling "Pimcore\Messenger\MaintenanceTaskMessage" failed: Typed property Pimcore\Model\Tool\TmpStore::$tag must not be accessed before initialization" {"class":"Pimcore\\Messenger\\MaintenanceTaskMessage","retryCount":1,"delay":1000,"error":"Handling \"Pimcore\\Messenger\\MaintenanceTaskMessage\" failed: Typed property Pimcore\\Model\\Tool\\TmpStore::$tag must not be accessed before initialization","exception":"[object] (Symfony\\Component\\Messenger\\Exception\\HandlerFailedException(code: 0): Handling \"Pimcore\\Messenger\\MaintenanceTaskMessage\" failed: Typed property Pimcore\\Model\\Tool\\TmpStore::$tag must not be accessed before initialization at /var/www/pimcore/vendor/symfony/messenger/Middleware/HandleMessageMiddleware.php:129)\n[previous exception] [object] (Error(code: 0): Typed property Pimcore\\Model\\Tool\\TmpStore::$tag must not be accessed before initialization at /var/www/pimcore/vendor/pimcore/pimcore/models/Tool/TmpStore.php:172)"}
```
