### PR TITLE
Move http error log cleanup to seo bundle

### DIFF
--- a/bundles/CoreBundle/config/maintenance.yaml
+++ b/bundles/CoreBundle/config/maintenance.yaml
@@ -19,12 +19,6 @@ services:
         tags:
             - { name: pimcore.maintenance.task, type: cleanuplogfiles }
 
-    Pimcore\Maintenance\Tasks\LogErrorCleanupTask:
-        arguments:
-            - '@doctrine.dbal.default_connection'
-        tags:
-            - { name: pimcore.maintenance.task, type: httperrorlog }
-
     Pimcore\Maintenance\Tasks\CleanupBrickTablesTask:
         arguments:
             - '@logger'

--- a/bundles/SeoBundle/config/services.yaml
+++ b/bundles/SeoBundle/config/services.yaml
@@ -28,3 +28,15 @@ services:
     #
 
     Pimcore\Bundle\SeoBundle\EventListener\ResponseExceptionListener: ~
+
+
+    #
+    # MAINTENANCE TASK
+    #
+
+    Pimcore\Bundle\SeoBundle\Maintenance\LogErrorCleanupTask:
+        arguments:
+            - '@doctrine.dbal.default_connection'
+        tags:
+            - { name: pimcore.maintenance.task, type: httperrorlog }
+

--- a/bundles/SeoBundle/src/Maintenance/LogErrorCleanupTask.php
+++ b/bundles/SeoBundle/src/Maintenance/LogErrorCleanupTask.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
-namespace Pimcore\Maintenance\Tasks;
+namespace Pimcore\Bundle\SeoBundle\Maintenance;
 
 use Doctrine\DBAL\Connection;
 use Pimcore\Maintenance\TaskInterface;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
The http_error_log Table is part of the SeoBundle. Therefore the `LogErrorCleanupTask` fails if the SEO Bundle is not activated. By moving the Maintenance Task to the bundle the task is not executed if the SEO bundle is not activated

## Additional info  
```
app.ERROR: Failed to execute job with ID httperrorlog: PDOException: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'pimcore.http_error_log' doesn't exist in /var/www/pimcore/vendor/doctrine/dbal/src/Driver/PDO/Statement.php:121 Stack trace:
#0 /var/www/pimcore/vendor/doctrine/dbal/src/Driver/PDO/Statement.php(121): PDOStatement->execute(NULL)
#1 /var/www/pimcore/vendor/doctrine/dbal/src/Driver/Middleware/AbstractStatementMiddleware.php(69): Doctrine\DBAL\Driver\PDO\Statement->execute(NULL)
#2 /var/www/pimcore/vendor/doctrine/dbal/src/Logging/Statement.php(98): Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute(NULL)
#3 /var/www/pimcore/vendor/doctrine/dbal/src/Driver/Middleware/AbstractStatementMiddleware.php(69): Doctrine\DBAL\Logging\Statement->execute(NULL)
#4 /var/www/pimcore/vendor/symfony/doctrine-bridge/Middleware/Debug/Statement.php(65): Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute(NULL)
#5 /var/www/pimcore/vendor/doctrine/dbal/src/Connection.php(1196): Symfony\Bridge\Doctrine\Middleware\Debug\Statement->execute()
#6 /var/www/pimcore/vendor/pimcore/pimcore/lib/Maintenance/Tasks/LogErrorCleanupTask.php(44): Doctrine\DBAL\Connection->executeStatement('DELETE FROM htt...', Array)
#7 /var/www/pimcore/vendor/pimcore/pimcore/lib/Maintenance/Executor.php(56): Pimcore\Maintenance\Tasks\LogErrorCleanupTask->execute()
#8 /var/www/pimcore/vendor/pimcore/pimcore/lib/Messenger/Handler/MaintenanceTaskHandler.php(34): Pimcore\Maintenance\Executor->executeTask('httperrorlog')
#9 /var/www/pimcore/vendor/symfony/messenger/Middleware/HandleMessageMiddleware.php(157): Pimcore\Messenger\Handler\MaintenanceTaskHandler->__invoke(Object(Pimcore\Messenger\MaintenanceTaskMessage))
#10 /var/www/pimcore/vendor/symfony/messenger/Middleware/HandleMessageMiddleware.php(96): Symfony\Component\Messenger\Middleware\HandleMessageMiddleware->callHandler(Object(Closure), Object(Pimcore\Messenger\MaintenanceTaskMessage), NULL, NULL)
#11 /var/www/pimcore/vendor/symfony/messenger/Middleware/SendMessageMiddleware.php(77): Symfony\Component\Messenger\Middleware\HandleMessageMiddleware->handle(Object(Symfony\Component\Messenger\Envelope), Object(Symfony\Component\Messenger\Middleware\StackMiddleware))
#12 /var/www/pimcore/vendor/symfony/messenger/Middleware/FailedMessageProcessingMiddleware.php(34): Symfony\Component\Messenger\Middleware\SendMessageMiddleware->handle(Object(Symfony\Component\Messenger\Envelope), Object(Symfony\Component\Messenger\Middleware\StackMiddleware))
#13 /var/www/pimcore/vendor/symfony/messenger/Middleware/DispatchAfterCurrentBusMiddleware.php(68): Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware->handle(Object(Symfony\Component\Messenger\Envelope), Object(Symfony\Component\Messenger\Middleware\StackMiddleware))
#14 /var/www/pimcore/vendor/symfony/messenger/Middleware/RejectRedeliveredMessageMiddleware.php(41): Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware->handle(Object(Symfony\Component\Messenger\Envelope), Object(Symfony\Component\Messenger\Middleware\StackMiddleware))
#15 /var/www/pimcore/vendor/symfony/messenger/Middleware/AddBusNameStampMiddleware.php(37): Symfony\Component\Messenger\Middleware\RejectRedeliveredMessageMiddleware->handle(Object(Symfony\Component\Messenger\Envelope), Object(Symfony\Component\Messenger\Middleware\StackMiddleware))
#16 /var/www/pimcore/vendor/symfony/messenger/MessageBus.php(70): Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware->handle(Object(Symfony\Component\Messenger\Envelope), Object(Symfony\Component\Messenger\Middleware\StackMiddleware))
#17 /var/www/pimcore/vendor/symfony/messenger/TraceableMessageBus.php(38): Symfony\Component\Messenger\MessageBus->dispatch(Object(Symfony\Component\Messenger\Envelope), Array)
#18 /var/www/pimcore/vendor/symfony/messenger/RoutableMessageBus.php(54): Symfony\Component\Messenger\TraceableMessageBus->dispatch(Object(Symfony\Component\Messenger\Envelope), Array)
#19 /var/www/pimcore/vendor/symfony/messenger/Worker.php(161): Symfony\Component\Messenger\RoutableMessageBus->dispatch(Object(Symfony\Component\Messenger\Envelope))
#20 /var/www/pimcore/vendor/symfony/messenger/Worker.php(110): Symfony\Component\Messenger\Worker->handleMessage(Object(Symfony\Component\Messenger\Envelope), 'pimcore_mainten...')
#21 /var/www/pimcore/vendor/symfony/messenger/Command/ConsumeMessagesCommand.php(229): Symfony\Component\Messenger\Worker->run(Array)
#22 /var/www/pimcore/vendor/symfony/console/Command/Command.php(312): Symfony\Component\Messenger\Command\ConsumeMessagesCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#23 /var/www/pimcore/vendor/symfony/console/Application.php(1040): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#24 /var/www/pimcore/vendor/symfony/framework-bundle/Console/Application.php(88): Symfony\Component\Console\Application->doRunCommand(Object(Symfony\Component\Messenger\Command\ConsumeMessagesCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#25 /var/www/pimcore/vendor/symfony/console/Application.php(314): Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand(Object(Symfony\Component\Messenger\Command\ConsumeMessagesCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#26 /var/www/pimcore/vendor/symfony/framework-bundle/Console/Application.php(77): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#27 /var/www/pimcore/vendor/symfony/console/Application.php(168): Symfony\Bundle\FrameworkBundle\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#28 /var/www/pimcore/bin/console(46): Symfony\Component\Console\Application->run()
#29 {main}
...
```
