### PR TITLE
Add missing `Pimcore\Tool\Authentication::handleUnserializeCallback()`

### DIFF
--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -95,7 +95,7 @@ class Authentication
     {
         $token = null;
         $prevUnserializeHandler = ini_set('unserialize_callback_func', __CLASS__.'::handleUnserializeCallback');
-        $prevErrorHandler = set_error_handler(function ($type, $msg, $file, $line, $context = []) use (&$prevErrorHandler) {
+        $prevErrorHandler = set_error_handler(static function ($type, $msg, $file, $line, $context = []) use (&$prevErrorHandler) {
             if (__FILE__ === $file) {
                 throw new \ErrorException($msg, 0x37313BC, $type, $file, $line);
             }
@@ -116,6 +116,14 @@ class Authentication
         }
 
         return $token;
+    }
+
+    /**
+     * @internal
+     */
+    public static function handleUnserializeCallback(string $class): never
+    {
+        throw new \ErrorException('Class not found: '.$class, 0x37313BC);
     }
 
     protected static function refreshUser(TokenInterface $token, UserProvider $provider): ?TokenInterface

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -95,7 +95,7 @@ class Authentication
     {
         $token = null;
         $prevUnserializeHandler = ini_set('unserialize_callback_func', __CLASS__.'::handleUnserializeCallback');
-        $prevErrorHandler = set_error_handler(static function ($type, $msg, $file, $line, $context = []) use (&$prevErrorHandler) {
+        $prevErrorHandler = set_error_handler(static function (int $type, string $msg, string $file, int $line, array $context = []) use (&$prevErrorHandler) {
             if (__FILE__ === $file) {
                 throw new \ErrorException($msg, 0x37313BC, $type, $file, $line);
             }


### PR DESCRIPTION
#13909 added `Authentication::safelyUnserialize()`, which [refers to](https://github.com/symfony/symfony/blob/090033332fa4eb5e7475111136b1cce260edffa4/src/Symfony/Component/Security/Http/Firewall/ContextListener.php#L257) `Authentication::handleUnserializeCallback()` which is missing.

