### PR TITLE
Cleanup `Pimcore\Tool\Authentication::refreshUser()`

### DIFF
--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -23,7 +23,6 @@ use Pimcore\Logger;
 use Pimcore\Model\User;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
@@ -122,37 +121,19 @@ class Authentication
     {
         $user = $token->getUser();
 
-        $userNotFoundByProvider = false;
-        $userClass = $user::class;
-
-        if (!$provider instanceof UserProviderInterface) {
-            throw new \InvalidArgumentException(sprintf('User provider "%s" must implement "%s".', get_debug_type($provider), UserProviderInterface::class));
-        }
-
-        if (!$provider->supportsClass($userClass)) {
+        if (!$provider->supportsClass($user::class)) {
             return null;
         }
 
         try {
-            $refreshedUser = $provider->refreshUser($user);
-            $newToken = clone $token;
-            $newToken->setUser($refreshedUser);
-            $token->setUser($refreshedUser);
+            $token->setUser($provider->refreshUser($user));
 
             return $token;
-        } catch (UnsupportedUserException) {
-            // let's try the next user provider
         } catch (UserNotFoundException $e) {
             Logger::warning('Username could not be found in the selected user provider.', ['username' => $e->getUserIdentifier(), 'provider' => $provider::class]);
 
-            $userNotFoundByProvider = true;
-        }
-
-        if ($userNotFoundByProvider) {
             return null;
         }
-
-        throw new \RuntimeException(sprintf('There is no user provider for user "%s". Shouldn\'t the "supportsClass()" method of your user provider return true for this classname?', $userClass));
     }
 
     public static function authenticateToken(string $token, bool $adminRequired = false): ?User


### PR DESCRIPTION
`Pimcore\Tool\Authentication::refreshUser()` was [copied from Symfony](https://github.com/symfony/symfony/blob/090033332fa4eb5e7475111136b1cce260edffa4/src/Symfony/Component/Security/Http/Firewall/ContextListener.php#L189) where it operates in a loop, but that is not the case here, so we can simplify some things.