### PR TITLE
chore: Remove unnecessary casts

### DIFF
--- a/bundles/SeoBundle/src/Model/Redirect.php
+++ b/bundles/SeoBundle/src/Model/Redirect.php
@@ -283,11 +283,7 @@ final class Redirect extends AbstractModel
 
     public function setSourceSite(?int $sourceSite): static
     {
-        if ($sourceSite) {
-            $this->sourceSite = $sourceSite;
-        } else {
-            $this->sourceSite = null;
-        }
+        $this->sourceSite = $sourceSite;
 
         return $this;
     }
@@ -299,11 +295,7 @@ final class Redirect extends AbstractModel
 
     public function setTargetSite(?int $targetSite): static
     {
-        if ($targetSite) {
-            $this->targetSite = $targetSite;
-        } else {
-            $this->targetSite = null;
-        }
+        $this->targetSite = $targetSite;
 
         return $this;
     }

--- a/lib/Navigation/Renderer/AbstractRenderer.php
+++ b/lib/Navigation/Renderer/AbstractRenderer.php
@@ -105,11 +105,7 @@ abstract class AbstractRenderer implements RendererInterface
      */
     public function setMinDepth(int $minDepth = null): static
     {
-        if (null !== $minDepth) {
-            $this->_minDepth = $minDepth;
-        } else {
-            $this->_minDepth = null;
-        }
+        $this->_minDepth = $minDepth;
 
         return $this;
     }
@@ -130,11 +126,7 @@ abstract class AbstractRenderer implements RendererInterface
      */
     public function setMaxDepth(int $maxDepth = null): static
     {
-        if (null !== $maxDepth) {
-            $this->_maxDepth = $maxDepth;
-        } else {
-            $this->_maxDepth = null;
-        }
+        $this->_maxDepth = $maxDepth;
 
         return $this;
     }

--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -281,8 +281,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
                         $t->setKey($id);
 
                         // add all available languages
-                        $availableLanguages = Translation::getValidLanguages();
-                        foreach ($availableLanguages as $language) {
+                        foreach (Translation::getValidLanguages() as $language) {
                             $t->addTranslation($language, '');
                         }
                     }

--- a/lib/Twig/Extension/Templating/Placeholder/ContainerService.php
+++ b/lib/Twig/Extension/Templating/Placeholder/ContainerService.php
@@ -93,11 +93,7 @@ class ContainerService
      */
     public function createContainer(string $key, array $value = []): Container
     {
-        $key = $key;
-
-        $this->_items[$this->currentIndex][$key] = new Container($value);
-
-        return $this->_items[$this->currentIndex][$key];
+        return $this->_items[$this->currentIndex][$key] = new Container($value);
     }
 
     /**
@@ -109,14 +105,7 @@ class ContainerService
      */
     public function getContainer(string $key): Container
     {
-        $key = $key;
-        if (isset($this->_items[$this->currentIndex][$key])) {
-            return $this->_items[$this->currentIndex][$key];
-        }
-
-        $container = $this->createContainer($key);
-
-        return $container;
+        return $this->_items[$this->currentIndex][$key] ?? $this->createContainer($key);
     }
 
     /**
@@ -128,10 +117,7 @@ class ContainerService
      */
     public function containerExists(string $key): bool
     {
-
-        $return = array_key_exists($key, $this->_items[$this->currentIndex]);
-
-        return $return;
+        return array_key_exists($key, $this->_items[$this->currentIndex]);
     }
 
     /**
@@ -158,7 +144,6 @@ class ContainerService
      */
     public function deleteContainer(string $key): bool
     {
-
         if (isset($this->_items[$this->currentIndex][$key])) {
             unset($this->_items[$this->currentIndex][$key]);
 

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -342,7 +342,6 @@ class Ffmpeg extends Adapter
 
     public function setVideoBitrate(int $videoBitrate): static
     {
-
         $videoBitrate = (int) ceil($videoBitrate / 2) * 2;
 
         parent::setVideoBitrate($videoBitrate);
@@ -356,7 +355,6 @@ class Ffmpeg extends Adapter
 
     public function setAudioBitrate(int $audioBitrate): static
     {
-
         $audioBitrate = (int) ceil($audioBitrate / 2) * 2;
 
         parent::setAudioBitrate($audioBitrate);

--- a/models/Asset/Listing.php
+++ b/models/Asset/Listing.php
@@ -48,10 +48,6 @@ class Listing extends Model\Listing\AbstractListing implements PaginateListingIn
         return $this->setData($assets);
     }
 
-    /**
-     *
-     * Methods for AdapterInterface
-     */
     public function count(): int
     {
         return $this->getTotalCount();

--- a/models/DataObject/Data/GeoCoordinates.php
+++ b/models/DataObject/Data/GeoCoordinates.php
@@ -51,7 +51,6 @@ class GeoCoordinates implements OwnerAwareFieldInterface
 
     public function setLongitude(float $longitude): static
     {
-
         if ($this->longitude != $longitude) {
             $this->longitude = $longitude;
             $this->markMeDirty();

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -607,10 +607,6 @@ abstract class PageSnippet extends Model\Document
 
     public function setMissingRequiredEditable(?bool $missingRequiredEditable): static
     {
-        if ($missingRequiredEditable !== null) {
-            $missingRequiredEditable = $missingRequiredEditable;
-        }
-
         $this->missingRequiredEditable = $missingRequiredEditable;
 
         return $this;

--- a/tests/Support/Helper/DataType/TestDataHelper.php
+++ b/tests/Support/Helper/DataType/TestDataHelper.php
@@ -728,7 +728,6 @@ class TestDataHelper extends AbstractTestDataHelper
         $value = $object->$getter();
         $this->assertInstanceOf(DataObject\Data\RgbaColor::class, $value);
 
-        $seed = (int) $seed;
         $expectedBase = $seed % 200;
 
         $this->assertEquals($expectedBase, $value->getR());
@@ -1305,7 +1304,6 @@ class TestDataHelper extends AbstractTestDataHelper
 
     public function fillRgbaColor(Concrete $object, string $field, int $seed = 1): void
     {
-        $seed = (int) $seed;
         $value = $seed % 200;
         $value = new DataObject\Data\RgbaColor($value, $value + 1, $value + 2, $value + 3);
 


### PR DESCRIPTION
Now that we have improved parameter/return types, we can get rid of many unnecessary casts.