### PR TITLE
chore: Use short list syntax everywhere

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -24,6 +24,7 @@ $config->setRules([
     '@PSR1'                  => true,
     '@PSR2'                  => true,
     'array_syntax'           => ['syntax' => 'short'],
+    'list_syntax'            => ['syntax' => 'short'],
 
     'header_comment'         => [
         'comment_type' => 'PHPDoc',

--- a/bundles/CoreBundle/src/Command/ThumbnailsImageCommand.php
+++ b/bundles/CoreBundle/src/Command/ThumbnailsImageCommand.php
@@ -164,7 +164,7 @@ class ThumbnailsImageCommand extends AbstractCommand
 
     protected function runSingleCommand(string $item, InputInterface $input, OutputInterface $output): void
     {
-        list($assetId, $thumbnailConfigName) = explode('~~~', $item, 2);
+        [$assetId, $thumbnailConfigName] = explode('~~~', $item, 2);
 
         $image = Image::getById((int) $assetId);
         if (!$image) {

--- a/bundles/CoreBundle/src/Command/ThumbnailsVideoCommand.php
+++ b/bundles/CoreBundle/src/Command/ThumbnailsVideoCommand.php
@@ -105,7 +105,7 @@ class ThumbnailsVideoCommand extends AbstractCommand
         // disable versioning
         Version::disable();
 
-        list($assetId, $thumbnailConfigName) = explode('~~~', $item, 2);
+        [$assetId, $thumbnailConfigName] = explode('~~~', $item, 2);
 
         $video = Asset\Video::getById((int) $assetId);
         if (!$video) {

--- a/bundles/XliffBundle/src/ImportDataExtractor/Xliff12DataExtractor.php
+++ b/bundles/XliffBundle/src/ImportDataExtractor/Xliff12DataExtractor.php
@@ -54,7 +54,7 @@ class Xliff12DataExtractor implements ImportDataExtractorInterface
             throw new \Exception(sprintf('invalid language %s', $file['target-language']));
         }
 
-        list($type, $id) = explode('-', (string)$file['original']);
+        [$type, $id] = explode('-', (string)$file['original']);
 
         $translationItem = $this->translationItemResolver->resolve($type, $id);
 
@@ -69,7 +69,7 @@ class Xliff12DataExtractor implements ImportDataExtractorInterface
         }
 
         foreach ($file->body->{'trans-unit'} as $transUnit) {
-            list($type, $name) = explode(Xliff12Exporter::DELIMITER, (string)$transUnit['id']);
+            [$type, $name] = explode(Xliff12Exporter::DELIMITER, (string)$transUnit['id']);
 
             if (!isset($transUnit->target)) {
                 continue;

--- a/bundles/XliffBundle/src/ImporterService/Importer/DataObjectImporter.php
+++ b/bundles/XliffBundle/src/ImporterService/Importer/DataObjectImporter.php
@@ -38,7 +38,7 @@ class DataObjectImporter extends AbstractElementImporter
         }
 
         if ($attribute->getType() === Attribute::TYPE_BRICK_LOCALIZED_FIELD) {
-            list($brickField, $brick, $field) = explode(DataObjectDataExtractor::BRICK_DELIMITER, $attribute->getName());
+            [$brickField, $brick, $field] = explode(DataObjectDataExtractor::BRICK_DELIMITER, $attribute->getName());
 
             $brickGetter = null;
             $brickContainerGetter = 'get' . ucfirst($brickField);
@@ -58,7 +58,7 @@ class DataObjectImporter extends AbstractElementImporter
         }
 
         if ($attribute->getType() === Attribute::TYPE_BLOCK_IN_LOCALIZED_FIELD) {
-            list($blockName, $blockIndex, $fieldname, $sourceLanguage) = explode(DataObjectDataExtractor::BLOCK_DELIMITER, $attribute->getName());
+            [$blockName, $blockIndex, $fieldname, $sourceLanguage] = explode(DataObjectDataExtractor::BLOCK_DELIMITER, $attribute->getName());
             /** @var array $originalBlockData */
             $originalBlockData = $element->{'get' . $blockName}($sourceLanguage);
             $originalBlockItem = $originalBlockData[$blockIndex] ?? null;
@@ -81,7 +81,7 @@ class DataObjectImporter extends AbstractElementImporter
         }
 
         if ($attribute->getType() === Attribute::TYPE_BLOCK) {
-            list($blockName, $blockIndex, $dummy, $fieldname) = explode(DataObjectDataExtractor::BLOCK_DELIMITER, $attribute->getName());
+            [$blockName, $blockIndex, $dummy, $fieldname] = explode(DataObjectDataExtractor::BLOCK_DELIMITER, $attribute->getName());
             /** @var array $blockData */
             $blockData = $element->{'get' . $blockName}();
             $blockItem = $blockData[$blockIndex];
@@ -95,7 +95,7 @@ class DataObjectImporter extends AbstractElementImporter
         }
 
         if ($attribute->getType() === Attribute::TYPE_FIELD_COLLECTION_LOCALIZED_FIELD) {
-            list($fieldCollectionField, $index, $field) = explode(DataObjectDataExtractor::FIELD_COLLECTIONS_DELIMITER, $attribute->getName());
+            [$fieldCollectionField, $index, $field] = explode(DataObjectDataExtractor::FIELD_COLLECTIONS_DELIMITER, $attribute->getName());
 
             /** @var DataObject\Fieldcollection|null $fieldCollection */
             $fieldCollection = $element->{'get' . $fieldCollectionField}();

--- a/lib/DataObject/FielddefinitionMarshaller/Traits/RgbaColorTrait.php
+++ b/lib/DataObject/FielddefinitionMarshaller/Traits/RgbaColorTrait.php
@@ -43,7 +43,7 @@ trait RgbaColorTrait
         if (is_array($value)) {
             $rgb = $value['value'];
             $a = $value['value2'];
-            list($r, $g, $b) = sscanf($rgb, '%02x%02x%02x');
+            [$r, $g, $b] = sscanf($rgb, '%02x%02x%02x');
             $a = hexdec($a);
 
             return [

--- a/lib/Image/Adapter/GD.php
+++ b/lib/Image/Adapter/GD.php
@@ -38,7 +38,7 @@ class GD extends Adapter
         }
 
         // set dimensions
-        list($width, $height) = getimagesize($this->path);
+        [$width, $height] = getimagesize($this->path);
         $this->setWidth($width);
         $this->setHeight($height);
 
@@ -218,7 +218,7 @@ class GD extends Adapter
     {
         $this->preModify();
 
-        list($r, $g, $b) = $this->colorhex2colorarray($color);
+        [$r, $g, $b] = $this->colorhex2colorarray($color);
 
         // just imagefill() on the existing image doesn't work, so we have to create a new image, fill it and then merge
         // the source image with the background-image together
@@ -245,7 +245,7 @@ class GD extends Adapter
 
         if (is_file($image)) {
             $backgroundImage = imagecreatefromstring(file_get_contents($image));
-            list($backgroundImageWidth, $backgroundImageHeight) = getimagesize($image);
+            [$backgroundImageWidth, $backgroundImageHeight] = getimagesize($image);
 
             $newImg = $this->createImage($this->getWidth(), $this->getHeight());
 
@@ -304,7 +304,7 @@ class GD extends Adapter
         $image = PIMCORE_PROJECT_ROOT . '/' . $image;
 
         if (is_file($image)) {
-            list($oWidth, $oHeight) = getimagesize($image);
+            [$oWidth, $oHeight] = getimagesize($image);
 
             if ($origin === 'top-right') {
                 $x = $this->getWidth() - $oWidth - $x;

--- a/lib/Model/Dao/PimcoreLocationAwareConfigDao.php
+++ b/lib/Model/Dao/PimcoreLocationAwareConfigDao.php
@@ -59,7 +59,7 @@ abstract class PimcoreLocationAwareConfigDao implements DaoInterface
             return self::$cache[$this->settingsStoreScope][$id]['data'];
         }
 
-        list($data, $this->dataSource) = $this->locationAwareConfigRepository->loadConfigByKey($id);
+        [$data, $this->dataSource] = $this->locationAwareConfigRepository->loadConfigByKey($id);
 
         if ($data) {
             self::$cache[$this->settingsStoreScope][$id] = [

--- a/lib/Tool/Authentication.php
+++ b/lib/Tool/Authentication.php
@@ -123,8 +123,7 @@ class Authentication
         $timestamp = null;
 
         try {
-            $decrypted = self::tokenDecrypt($token);
-            list($timestamp, $username) = $decrypted;
+            [$timestamp, $username] = self::tokenDecrypt($token);
         } catch (CryptoException $e) {
             return null;
         }

--- a/lib/Tool/Text/Csv.php
+++ b/lib/Tool/Text/Csv.php
@@ -35,7 +35,7 @@ class Csv
         if ($count < 10) {
             throw new \Exception('You must provide at least ten lines in your sample data');
         }
-        list($quote, $delim) = $this->guessQuoteAndDelim($data);
+        [$quote, $delim] = $this->guessQuoteAndDelim($data);
         if (!$quote) {
             $quote = '"';
         }

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -280,7 +280,7 @@ class Ffmpeg extends Adapter
 
             if (preg_match('/ ([0-9]+x[0-9]+)[, ]/', $output, $matches)) {
                 $dimensionRaw = $matches[1];
-                list($width, $height) = explode('x', $dimensionRaw);
+                [$width, $height] = explode('x', $dimensionRaw);
 
                 return ['width' => $width, 'height' => $height];
             }

--- a/models/DataObject/ClassDefinition/Data/RgbaColor.php
+++ b/models/DataObject/ClassDefinition/Data/RgbaColor.php
@@ -76,7 +76,7 @@ class RgbaColor extends Data implements
     public function getDataFromResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?Model\DataObject\Data\RgbaColor
     {
         if (is_array($data) && isset($data[$this->getName() . '__rgb']) && isset($data[$this->getName() . '__a'])) {
-            list($r, $g, $b) = sscanf($data[$this->getName() . '__rgb'], '%02x%02x%02x');
+            [$r, $g, $b] = sscanf($data[$this->getName() . '__rgb'], '%02x%02x%02x');
             $a = hexdec($data[$this->getName() . '__a']);
             $data = new Model\DataObject\Data\RgbaColor($r, $g, $b, $a);
         }
@@ -142,7 +142,7 @@ class RgbaColor extends Data implements
     {
         if ($data) {
             $data = trim($data, '# ');
-            list($r, $g, $b, $a) = sscanf($data, '%02x%02x%02x%02x');
+            [$r, $g, $b, $a] = sscanf($data, '%02x%02x%02x%02x');
             $color = new Model\DataObject\Data\RgbaColor($r, $g, $b, $a);
 
             return $color;

--- a/models/DataObject/Data/RgbaColor.php
+++ b/models/DataObject/Data/RgbaColor.php
@@ -142,10 +142,10 @@ class RgbaColor implements OwnerAwareFieldInterface
         $length = strlen($hexValue);
         if ($length == 6 || $length == 8) {
             if ($length == 6) {
-                list($r, $g, $b) = sscanf($hexValue, '%02x%02x%02x');
+                [$r, $g, $b] = sscanf($hexValue, '%02x%02x%02x');
                 $a = 255;
             } else {
-                list($r, $g, $b, $a) = sscanf($hexValue, '%02x%02x%02x%02x');
+                [$r, $g, $b, $a] = sscanf($hexValue, '%02x%02x%02x%02x');
             }
             $this->setR($r);
             $this->setG($g);

--- a/models/Notification/Service/NotificationServiceFilterParser.php
+++ b/models/Notification/Service/NotificationServiceFilterParser.php
@@ -75,12 +75,12 @@ class NotificationServiceFilterParser
 
             switch ($type) {
                 case self::TYPE_STRING:
-                    list($key, $value) = $this->parseString($item);
+                    [$key, $value] = $this->parseString($item);
                     $result[$key] = $value;
 
                     break;
                 case self::TYPE_DATE:
-                    list($key, $value) = $this->parseDate($item);
+                    [$key, $value] = $this->parseDate($item);
                     $result[$key] = $value;
 
                     break;

--- a/tests/Model/DataType/ObjectAwareFieldsTest.php
+++ b/tests/Model/DataType/ObjectAwareFieldsTest.php
@@ -58,7 +58,7 @@ class ObjectAwareFieldsTest extends AbstractLazyLoadingTest
         $object->setInput($object->getInput() + 1);
         $object->saveVersion();
 
-        list($databaseObject, $latestObjectVersion) = $this->reloadObject($object->getId());
+        [$databaseObject, $latestObjectVersion] = $this->reloadObject($object->getId());
 
         $this->assertEquals($latestObjectVersion->getLocalizedfields()->getObject()->getInput(), $latestObjectVersion->getInput(), 'Object reference in localized field is not right.');
     }
@@ -85,7 +85,7 @@ class ObjectAwareFieldsTest extends AbstractLazyLoadingTest
         $object->setInput($object->getInput() + 1);
         $object->saveVersion();
 
-        list($databaseObject, $latestObjectVersion) = $this->reloadObject($object->getId());
+        [$databaseObject, $latestObjectVersion] = $this->reloadObject($object->getId());
 
         $fieldCollectionItems = $latestObjectVersion->getFieldcollection()->getItems();
         foreach ($fieldCollectionItems as $item) {
@@ -110,7 +110,7 @@ class ObjectAwareFieldsTest extends AbstractLazyLoadingTest
         $object->setInput($object->getInput() + 1);
         $object->saveVersion();
 
-        list($databaseObject, $latestObjectVersion) = $this->reloadObject($object->getId());
+        [$databaseObject, $latestObjectVersion] = $this->reloadObject($object->getId());
 
         $brickItems = $latestObjectVersion->getBricks()->getItems();
         foreach ($brickItems as $item) {


### PR DESCRIPTION
This is just some cleanup that uses the more modern short list syntax `[...] = ...` instead of `list(...) = ...`.