### PR TITLE
chore: Use more descriptive `str_contains()`/`str_starts_with()`/`str_ends_with()` where possible

### DIFF
--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/LongRunningHelperPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/LongRunningHelperPass.php
@@ -33,7 +33,7 @@ final class LongRunningHelperPass implements CompilerPassInterface
     {
         $helperDefinition = $container->getDefinition(LongRunningHelper::class);
         foreach ($container->getDefinitions() as $serviceId => $definition) {
-            if (strpos($serviceId, 'monolog.handler.') === 0) {
+            if (str_starts_with($serviceId, 'monolog.handler.')) {
                 $class = $container->getParameterBag()->resolveValue($definition->getClass());
                 if (is_a($class, 'Monolog\Handler\BufferHandler', true)
                     || is_a($class, 'Monolog\Handler\FingersCrossedHandler', true)) {

--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/MonologPublicLoggerPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/MonologPublicLoggerPass.php
@@ -29,7 +29,7 @@ final class MonologPublicLoggerPass implements CompilerPassInterface
     {
         $loggerPrefix = 'monolog.logger.';
         $serviceIds = array_filter($container->getServiceIds(), function (string $id) use ($loggerPrefix) {
-            return 0 === strpos($id, $loggerPrefix);
+            return str_starts_with($id, $loggerPrefix);
         });
 
         foreach ($serviceIds as $serviceId) {

--- a/bundles/CoreBundle/src/EventListener/Frontend/EditmodeListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/EditmodeListener.php
@@ -127,7 +127,7 @@ class EditmodeListener implements EventSubscriberInterface
 
         // check for substring as the content type could define attributes (e.g. charset)
         foreach ($this->contentTypes as $ct) {
-            if (false !== strpos($contentType, $ct)) {
+            if (str_contains($contentType, $ct)) {
                 return true;
             }
         }

--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -733,7 +733,7 @@ class Installer
         // remove comments in SQL script
         $dumpFile = preg_replace("/\s*(?!<\")\/\*[^\*]+\*\/(?!\")\s*/", '', $dumpFile);
 
-        if (strpos($file, 'atomic') !== false) {
+        if (str_contains($file, 'atomic')) {
             $db->executeStatement($dumpFile);
         } else {
             // get every command as single part - ; at end of line

--- a/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
@@ -119,7 +119,7 @@ class SearchController extends UserAwareController
 
             foreach ($fields as $f) {
                 $parts = explode('~', $f);
-                if (substr($f, 0, 1) == '~') {
+                if (str_starts_with($f, '~')) {
                     //                    $type = $parts[1];
                     //                    $field = $parts[2];
                     //                    $keyid = $parts[3];

--- a/bundles/StaticRoutesBundle/src/Model/Staticroute.php
+++ b/bundles/StaticRoutesBundle/src/Model/Staticroute.php
@@ -387,7 +387,7 @@ final class Staticroute extends AbstractModel
 
         $tmpReversePattern = $this->getReverse();
         foreach ($urlParams as $key => $param) {
-            if (strpos($tmpReversePattern, '%' . $key) !== false) {
+            if (str_contains($tmpReversePattern, '%' . $key)) {
                 $parametersInReversePattern[$key] = $param;
 
                 // we need to replace the found variable to that it cannot match again a placeholder

--- a/bundles/XliffBundle/src/Escaper/Xliff12Escaper.php
+++ b/bundles/XliffBundle/src/Escaper/Xliff12Escaper.php
@@ -51,7 +51,7 @@ class Xliff12Escaper
                             $part = '<ph id="' . $count . '">' . $this->encodeData($part) . '</ph>';
 
                             $count++;
-                        } elseif (strpos($tag[1], '/') === false) {
+                        } elseif (!str_contains($tag[1], '/')) {
                             $openTags[$count] = ['tag' => $tagName, 'id' => $count];
                             $part = '<bpt id="' . $count . '">' . $this->encodeData($part) . '</bpt>';
 

--- a/lib/Helper/Mail.php
+++ b/lib/Helper/Mail.php
@@ -164,7 +164,7 @@ CSS;
         $emailLog->setSentDate(time());
 
         $subject = $mail->getSubjectRendered();
-        if (0 === strpos($subject, '=?')) {
+        if (str_starts_with($subject, '=?')) {
             $mbIntEnc = mb_internal_encoding();
             mb_internal_encoding($mail->getTextCharset());
             $subject = mb_decode_mimeheader($subject);
@@ -233,12 +233,12 @@ CSS;
             foreach ($matches[0] as $key => $value) {
                 $path = $matches[2][$key];
 
-                if (strpos($path, '//') === 0) {
+                if (str_starts_with($path, '//')) {
                     $absolutePath = 'http:' . $path;
-                } elseif (strpos($path, '/') === 0) {
+                } elseif (str_starts_with($path, '/')) {
                     $absolutePath = preg_replace('@^' . $replacePrefix . '(/(.*))?$@', '/$2', $path);
                     $absolutePath = $hostUrl . $absolutePath;
-                } elseif (strpos($path, 'file://') === 0) {
+                } elseif (str_starts_with($path, 'file://')) {
                     continue;
                 } else {
                     $absolutePath = $hostUrl . "/$path";
@@ -260,10 +260,10 @@ CSS;
             foreach ($parts as $key => $v) {
                 $v = trim($v);
                 // ignore absolute urls
-                if (strpos($v, 'http://') === 0 ||
-                    strpos($v, 'https://') === 0 ||
-                    strpos($v, '//') === 0 ||
-                    strpos($v, 'file://') === 0
+                if (str_starts_with($v, 'http://') ||
+                    str_starts_with($v, 'https://') ||
+                    str_starts_with($v, '//') ||
+                    str_starts_with($v, 'file://')
                 ) {
                     continue;
                 }
@@ -305,7 +305,7 @@ CSS;
                             $fileContent = file_get_contents($fileInfo['filePathNormalized']);
                         }
                     }
-                } elseif (strpos($path, 'http') === 0) {
+                } elseif (str_starts_with($path, 'http')) {
                     $fileContent = \Pimcore\Tool::getHttpData($path);
                     $fileInfo = [
                         'fileUrlNormalized' => $path,

--- a/lib/Http/ResponseHelper.php
+++ b/lib/Http/ResponseHelper.php
@@ -60,7 +60,7 @@ class ResponseHelper
             return false;
         }
 
-        if (false !== strpos((string)$response->getContent(), '<html')) {
+        if (str_contains((string)$response->getContent(), '<html')) {
             return true;
         }
 

--- a/lib/HttpKernel/BundleLocator/BundleLocator.php
+++ b/lib/HttpKernel/BundleLocator/BundleLocator.php
@@ -69,7 +69,7 @@ class BundleLocator implements BundleLocatorInterface
             $namespace = $reflectionClass->getNamespaceName();
 
             foreach ($bundles as $bundle) {
-                if (0 === strpos($namespace, $bundle->getNamespace())) {
+                if (str_starts_with($namespace, $bundle->getNamespace())) {
                     return $bundle;
                 }
             }

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -344,15 +344,15 @@ class Imagick extends Adapter
         $profiles = $this->resource->getImageProfiles('icc', true);
 
         if (isset($profiles['icc'])) {
-            if (strpos($profiles['icc'], 'RGB') !== false) {
+            if (str_contains($profiles['icc'], 'RGB')) {
                 // no need to process (s)RGB images
                 return $this;
             }
 
-            // Workaround for ImageMagick (e.g. 6.9.10-23) bug, that let's it crash immediately if the tagged colorspace is
+            // Workaround for ImageMagick (e.g. 6.9.10-23) bug, that lets it crash immediately if the tagged colorspace is
             // different from the colorspace of the embedded icc color profile
             // If that is the case we just ignore the color profiles
-            if (strpos($profiles['icc'], 'CMYK') !== false && $imageColorspace !== \Imagick::COLORSPACE_CMYK) {
+            if (str_contains($profiles['icc'], 'CMYK') && $imageColorspace !== \Imagick::COLORSPACE_CMYK) {
                 return $this;
             }
         }

--- a/lib/Maintenance/Tasks/CleanupBrickTablesTask.php
+++ b/lib/Maintenance/Tasks/CleanupBrickTablesTask.php
@@ -55,7 +55,7 @@ class CleanupBrickTablesTask implements TaskInterface
             foreach ($tableNames as $tableName) {
                 $tableName = current($tableName);
 
-                if (strpos($tableName, 'object_brick_localized_query_') === 0) {
+                if (str_starts_with($tableName, 'object_brick_localized_query_')) {
                     continue;
                 }
 

--- a/lib/Maintenance/Tasks/CleanupFieldcollectionTablesTask.php
+++ b/lib/Maintenance/Tasks/CleanupFieldcollectionTablesTask.php
@@ -78,7 +78,7 @@ class CleanupFieldcollectionTablesTask implements TaskInterface
 
                 $isLocalized = false;
 
-                if (strpos($classId, 'localized_') === 0) {
+                if (str_starts_with($classId, 'localized_')) {
                     $isLocalized = true;
                     $classId = substr($classId, strlen('localized_'));
                 }

--- a/lib/Maintenance/Tasks/DbCleanupBrokenViewsTask.php
+++ b/lib/Maintenance/Tasks/DbCleanupBrokenViewsTask.php
@@ -47,7 +47,7 @@ class DbCleanupBrokenViewsTask implements TaskInterface
                 try {
                     $createStatement = $this->db->fetchAssociative('SHOW FIELDS FROM '.$name);
                 } catch (\Exception $e) {
-                    if (strpos($e->getMessage(), 'references invalid table') !== false) {
+                    if (str_contains($e->getMessage(), 'references invalid table')) {
                         $this->logger->error('view '.$name.' seems to be a broken one, it will be removed');
                         $this->logger->error('error message was: '.$e->getMessage());
 

--- a/lib/Migrations/FilteredMigrationsRepository.php
+++ b/lib/Migrations/FilteredMigrationsRepository.php
@@ -73,9 +73,8 @@ final class FilteredMigrationsRepository implements \Doctrine\Migrations\Migrati
         }
 
         $filteredMigrations = [];
-        $items = $migrations->getItems();
-        foreach ($items as $migration) {
-            if (strpos(get_class($migration->getMigration()), $this->prefix) === 0) {
+        foreach ($migrations->getItems() as $migration) {
+            if (str_starts_with(get_class($migration->getMigration()), $this->prefix)) {
                 $filteredMigrations[] = $migration;
             }
         }

--- a/lib/Migrations/FilteredTableMetadataStorage.php
+++ b/lib/Migrations/FilteredTableMetadataStorage.php
@@ -71,9 +71,8 @@ final class FilteredTableMetadataStorage implements MetadataStorage
         }
 
         $filteredMigrations = [];
-        $items = $migrations->getItems();
-        foreach ($items as $migration) {
-            if (strpos((string)$migration->getVersion(), $this->prefix) === 0) {
+        foreach ($migrations->getItems() as $migration) {
+            if (str_starts_with((string)$migration->getVersion(), $this->prefix)) {
                 $filteredMigrations[] = $migration;
             }
         }

--- a/lib/Navigation/Page/Url.php
+++ b/lib/Navigation/Page/Url.php
@@ -77,7 +77,7 @@ class Url extends Page
 
         $fragment = $this->getFragment();
         if (null !== $fragment) {
-            if ('#' === substr($uri, -1)) {
+            if (str_ends_with($uri, '#')) {
                 return $uri . $fragment;
             }
 

--- a/lib/Navigation/Renderer/AbstractRenderer.php
+++ b/lib/Navigation/Renderer/AbstractRenderer.php
@@ -365,7 +365,7 @@ abstract class AbstractRenderer implements RendererInterface
                 $val = $this->_normalizeId($val);
             }
 
-            if (strpos($val, '"') !== false) {
+            if (str_contains($val, '"')) {
                 $xhtml .= " $key='$val'";
             } else {
                 $xhtml .= " $key=\"$val\"";
@@ -392,7 +392,7 @@ abstract class AbstractRenderer implements RendererInterface
             }
         }
 
-        if (strstr($value, '[')) {
+        if (str_contains($value, '[')) {
             if ('[]' == substr($value, -2)) {
                 $value = substr($value, 0, strlen($value) - 2);
             }

--- a/lib/Navigation/Renderer/AbstractRenderer.php
+++ b/lib/Navigation/Renderer/AbstractRenderer.php
@@ -393,7 +393,7 @@ abstract class AbstractRenderer implements RendererInterface
         }
 
         if (str_contains($value, '[')) {
-            if ('[]' == substr($value, -2)) {
+            if (str_ends_with($value, '[]')) {
                 $value = substr($value, 0, strlen($value) - 2);
             }
             $value = trim($value, ']');

--- a/lib/Navigation/Renderer/AbstractRenderer.php
+++ b/lib/Navigation/Renderer/AbstractRenderer.php
@@ -343,7 +343,7 @@ abstract class AbstractRenderer implements RendererInterface
         foreach ($attribs as $key => $val) {
             $key = htmlspecialchars($key, ENT_COMPAT, 'UTF-8');
 
-            if (('on' == substr($key, 0, 2)) || ('constraints' == $key)) {
+            if ('constraints' === $key || str_starts_with($key, 'on')) {
                 // Don't escape event attributes; _do_ substitute double quotes with singles
                 if (!is_scalar($val)) {
                     // non-scalar data should be cast to JSON first

--- a/lib/Routing/Dynamic/DocumentRouteHandler.php
+++ b/lib/Routing/Dynamic/DocumentRouteHandler.php
@@ -276,7 +276,7 @@ final class DocumentRouteHandler implements DynamicRouteHandlerInterface
         // only do redirecting with GET requests
         if ($context->getRequest()->getMethod() === 'GET') {
             if (($this->config['documents']['allow_trailing_slash'] ?? null) === 'no') {
-                if ($redirectTargetUrl !== '/' && substr($redirectTargetUrl, -1) === '/') {
+                if ($redirectTargetUrl !== '/' && str_ends_with($redirectTargetUrl, '/')) {
                     $redirectTargetUrl = rtrim($redirectTargetUrl, '/');
                 }
             }

--- a/lib/Routing/Element/Router.php
+++ b/lib/Routing/Element/Router.php
@@ -79,7 +79,7 @@ class Router implements RouterInterface, RequestMatcherInterface, VersatileGener
             $path = $element->getFullPath();
             $needsHostname = self::ABSOLUTE_URL === $referenceType || self::NETWORK_PATH === $referenceType;
 
-            if (strpos($path, '://') !== false) {
+            if (str_contains($path, '://')) {
                 $host = parse_url($path, PHP_URL_HOST);
                 $scheme = parse_url($path, PHP_URL_SCHEME);
                 $path = parse_url($path, PHP_URL_PATH);

--- a/lib/Tool/Console.php
+++ b/lib/Tool/Console.php
@@ -266,7 +266,7 @@ final class Console
         /**
          * mod_php seems to lose the environment variables if we do not set them manually before the child process is started
          */
-        if (strpos(php_sapi_name(), 'apache') !== false) {
+        if (str_contains(php_sapi_name(), 'apache')) {
             foreach (['APP_ENV'] as $envVarName) {
                 if ($envValue = $_SERVER[$envVarName] ?? $_SERVER['REDIRECT_' . $envVarName] ?? null) {
                     putenv($envVarName . '='.$envValue);

--- a/lib/Tool/Frontend.php
+++ b/lib/Tool/Frontend.php
@@ -29,7 +29,7 @@ final class Frontend
         $inSite = true;
 
         if ($site && $site->getRootDocument() instanceof Document\Page) {
-            if (strpos($document->getRealFullPath(), $site->getRootDocument()->getRealFullPath() . '/') !== 0) {
+            if (!str_starts_with($document->getRealFullPath(), $site->getRootDocument()->getRealFullPath() . '/')) {
                 $inSite = false;
             }
         }

--- a/lib/Tool/Text.php
+++ b/lib/Tool/Text.php
@@ -118,11 +118,11 @@ class Text
                             $cleanedStyle = preg_replace('#[ ]+#', '', $styleAttr[1]);
                             $styles = explode(';', $cleanedStyle);
                             foreach ($styles as $style) {
-                                if (strpos(trim($style), 'width') === 0) {
+                                if (str_starts_with(trim($style), 'width')) {
                                     if (preg_match('/([0-9]+)(px)/i', $style, $match)) {
                                         $config['width'] = $match[1];
                                     }
-                                } elseif (strpos(trim($style), 'height') === 0) {
+                                } elseif (str_starts_with(trim($style), 'height')) {
                                     if (preg_match('/([0-9]+)(px)/i', $style, $match)) {
                                         $config['height'] = $match[1];
                                     }

--- a/lib/Tool/Text.php
+++ b/lib/Tool/Text.php
@@ -68,7 +68,7 @@ class Text
                         } elseif ($element instanceof Document) {
                             // get parameters
                             preg_match('/href="([^"]+)*"/', $oldTag, $oldHref);
-                            if ($oldHref[1] && (strpos($oldHref[1], '?') !== false || strpos($oldHref[1], '#') !== false)) {
+                            if ($oldHref[1] && (str_contains($oldHref[1], '?') || str_contains($oldHref[1], '#'))) {
                                 $urlParts = parse_url($oldHref[1]);
                                 if (array_key_exists('query', $urlParts) && !empty($urlParts['query'])) {
                                     $path .= '?' . $urlParts['query'];

--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -222,7 +222,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
         $normalizedId = $id;
 
         //translate only plural form(seperated by pipe "|") with count param
-        if (isset($parameters['%count%']) && $translated && strpos($normalizedId, '|') !== false) {
+        if (isset($parameters['%count%']) && $translated && str_contains($normalizedId, '|')) {
             $normalizedId = $id = $translated;
             $translated = $this->translator->trans($normalizedId, $parameters, $domain, $locale);
         }

--- a/lib/Twig/Extension/Templating/HeadStyle.php
+++ b/lib/Twig/Extension/Templating/HeadStyle.php
@@ -327,7 +327,7 @@ class HeadStyle extends AbstractExtension implements RuntimeExtensionInterface
                     continue;
                 }
                 if ('media' == $key) {
-                    if (false === strpos($value, ',')) {
+                    if (!str_contains($value, ',')) {
                         if (!in_array($value, $this->_mediaTypes)) {
                             continue;
                         }

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -404,7 +404,7 @@ EOT;
              *
              * @see http://foone.org/apng/
              */
-            $isAnimated = strpos(substr($fileContent, 0, strpos($fileContent, 'IDAT')), 'acTL') !== false;
+            $isAnimated = str_contains(substr($fileContent, 0, strpos($fileContent, 'IDAT')), 'acTL');
         }
 
         return $isAnimated;

--- a/models/DataObject/ClassDefinition/Data/Numeric.php
+++ b/models/DataObject/ClassDefinition/Data/Numeric.php
@@ -359,7 +359,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
                 throw new Model\Element\ValidationException('Value exceeds PHP_INT_MAX please use an input data type instead of numeric!');
             }
 
-            if ($this->getInteger() && strpos((string) $data, '.') !== false) {
+            if ($this->getInteger() && str_contains((string)$data, '.')) {
                 throw new Model\Element\ValidationException('Value in field [ '.$this->getName().' ] is not an integer');
             }
 
@@ -432,7 +432,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
             return $value;
         }
 
-        if (strpos($value, '.') === false) {
+        if (!str_contains($value, '.')) {
             return (int) $value;
         }
 

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -297,7 +297,7 @@ class QuantityValue extends AbstractQuantityValue
                 throw new Model\Element\ValidationException('Value exceeds PHP_INT_MAX please use an input data type instead of numeric!');
             }
 
-            if ($this->getInteger() && strpos((string) $value, '.') !== false) {
+            if ($this->getInteger() && str_contains((string)$value, '.')) {
                 throw new Model\Element\ValidationException('Value in field [ '.$this->getName().' ] is not an integer');
             }
 
@@ -323,7 +323,7 @@ class QuantityValue extends AbstractQuantityValue
             return $value;
         }
 
-        if (strpos($value, '.') === false) {
+        if (!str_contains($value, '.')) {
             return (int) $value;
         }
 

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -805,7 +805,7 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
                 $actualValue = $row[$column];
                 if (isset($likes[$column])) {
                     $expectedValue = $likes[$column];
-                    if (strpos($actualValue, $expectedValue) !== 0) {
+                    if (!str_starts_with($actualValue, $expectedValue)) {
                         return false;
                     }
                 } elseif ($actualValue != $expectedValue) {

--- a/models/DataObject/Data/ObjectMetadata.php
+++ b/models/DataObject/Data/ObjectMetadata.php
@@ -71,7 +71,7 @@ class ObjectMetadata extends Model\AbstractModel implements DataObject\OwnerAwar
      */
     public function __call(string $method, array $args)
     {
-        if (substr($method, 0, 3) == 'get') {
+        if (str_starts_with($method, 'get')) {
             $key = substr($method, 3, strlen($method) - 3);
 
             $idx = array_searchi($key, $this->columns);
@@ -84,7 +84,7 @@ class ObjectMetadata extends Model\AbstractModel implements DataObject\OwnerAwar
             throw new \Exception("Requested data $key not available");
         }
 
-        if (substr($method, 0, 3) == 'set') {
+        if (str_starts_with($method, 'set')) {
             $key = substr($method, 3, strlen($method) - 3);
             $idx = array_searchi($key, $this->columns);
 

--- a/models/DataObject/Data/StructuredTable.php
+++ b/models/DataObject/Data/StructuredTable.php
@@ -54,7 +54,7 @@ class StructuredTable implements OwnerAwareFieldInterface
      */
     public function __call(string $name, array $arguments)
     {
-        if (substr($name, 0, 3) == 'get') {
+        if (str_starts_with($name, 'get')) {
             $key = strtolower(substr($name, 3, strlen($name) - 3));
 
             $parts = explode('__', $key);
@@ -75,7 +75,7 @@ class StructuredTable implements OwnerAwareFieldInterface
             throw new \Exception("Requested data $key not available");
         }
 
-        if (substr($name, 0, 3) == 'set') {
+        if (str_starts_with($name, 'set')) {
             $key = strtolower(substr($name, 3, strlen($name) - 3));
 
             $parts = explode('__', $key);

--- a/models/DataObject/Data/UrlSlug.php
+++ b/models/DataObject/Data/UrlSlug.php
@@ -257,7 +257,7 @@ class UrlSlug implements OwnerAwareFieldInterface
                 $fd = $classDefinition->getFieldDefinition($this->getFieldname());
             } elseif ($this->getOwnertype() === 'localizedfield') {
                 $ownerName = $this->getOwnername();
-                if (strpos($ownerName, '~') !== false) {
+                if (str_contains($ownerName, '~')) {
                     // this is a localized field inside a field collection or objectbrick
                     $parts = explode('~', $this->getOwnername());
                     $type = trim($parts[0], '/');

--- a/models/DataObject/Listing.php
+++ b/models/DataObject/Listing.php
@@ -99,7 +99,7 @@ class Listing extends Model\Listing\AbstractListing implements PaginateListingIn
      */
     public function addFilterByField(string $field, string $operator, float|array|int|string $data): static
     {
-        if (strpos($operator, '?') === false) {
+        if (!str_contains($operator, '?')) {
             $operator .= ' ?';
         }
 

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -335,7 +335,7 @@ class Service extends Model\Element\Service
                 } elseif (count($keyParts) > 1) {
                     // brick
                     $brickType = $keyParts[0];
-                    if (strpos($brickType, '?') !== false) {
+                    if (str_contains($brickType, '?')) {
                         $brickDescriptor = substr($brickType, 1);
                         $brickDescriptor = json_decode($brickDescriptor, true);
                         $brickType = $brickDescriptor['containerKey'];
@@ -1821,7 +1821,7 @@ class Service extends Model\Element\Service
                     $brickDescriptor = null;
                     $innerContainer = null;
 
-                    if (strpos($brickType, '?') !== false) {
+                    if (str_contains($brickType, '?')) {
                         $brickDescriptor = substr($brickType, 1);
                         $brickDescriptor = json_decode($brickDescriptor, true);
                         $innerContainer = $brickDescriptor['innerContainer'] ?? 'localizedfields';

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -275,7 +275,7 @@ class Service extends Model\Element\Service
      */
     public static function isHelperGridColumnConfig(string $field): bool
     {
-        return strpos($field, '#') === 0;
+        return str_starts_with($field, '#');
     }
 
     /**
@@ -318,7 +318,7 @@ class Service extends Model\Element\Service
 
                 $def = $object->getClass()->getFieldDefinition($key, $context);
 
-                if (strpos($key, '#') === 0) {
+                if (str_starts_with($key, '#')) {
                     if (!$haveHelperDefinition) {
                         $helperDefinitions = self::getHelperDefinitions();
                         $haveHelperDefinition = true;
@@ -327,7 +327,7 @@ class Service extends Model\Element\Service
                         $context['fieldname'] = $key;
                         $data[$key] = self::calculateCellValue($object, $helperDefinitions, $key, $context);
                     }
-                } elseif (strpos($key, '~') === 0) {
+                } elseif (str_starts_with($key, '~')) {
                     $type = $keyParts[1];
                     if ($type === 'classificationstore') {
                         $data[$key] = self::getStoreValueForObject($object, $key, $requestedLanguage);
@@ -423,7 +423,7 @@ class Service extends Model\Element\Service
                     }
 
                     // because the key for the classification store has not a direct getter, you have to check separately if the data is inheritable
-                    if (strpos($key, '~') === 0 && empty($data[$key])) {
+                    if (str_starts_with($key, '~') && empty($data[$key])) {
                         $type = $keyParts[1];
 
                         if ($type === 'classificationstore') {
@@ -679,7 +679,7 @@ class Service extends Model\Element\Service
     {
         $keyParts = explode('~', $key);
 
-        if (strpos($key, '~') === 0) {
+        if (str_starts_with($key, '~')) {
             $type = $keyParts[1];
             if ($type === 'classificationstore') {
                 $field = $keyParts[2];
@@ -1708,7 +1708,7 @@ class Service extends Model\Element\Service
 
         $key = $field['key'];
         $title = $field['label'];
-        if (strpos($key, '#') === 0) {
+        if (str_starts_with($key, '#')) {
             if (isset($helperDefinitions[$key])) {
                 if ($helperDefinitions[$key]->attributes) {
                     return $helperDefinitions[$key]->attributes->label ? $helperDefinitions[$key]->attributes->label : $title;
@@ -1716,7 +1716,7 @@ class Service extends Model\Element\Service
 
                 return $title;
             }
-        } elseif (substr($key, 0, 1) == '~') {
+        } elseif (str_starts_with($key, '~')) {
             $fieldParts = explode('~', $key);
             $type = $fieldParts[1];
 
@@ -1780,7 +1780,7 @@ class Service extends Model\Element\Service
 
                         return (string) $cellValue;
                     }
-                } elseif (substr($field, 0, 1) == '~') {
+                } elseif (str_starts_with($field, '~')) {
                     $type = $fieldParts[1];
 
                     if ($type == 'classificationstore') {

--- a/models/Document.php
+++ b/models/Document.php
@@ -730,11 +730,10 @@ class Document extends Element\AbstractElement
                     if ($hardlinkTarget) {
                         $hardlinkPath = preg_replace('@^' . preg_quote(Site::getCurrentSite()->getRootPath(), '@') . '@', '', $hardlink->getRealFullPath());
 
-                        $link = preg_replace('@^' . preg_quote($hardlinkTarget->getRealFullPath(), '@') . '@',
-                            $hardlinkPath, $this->getRealFullPath());
+                        $link = preg_replace('@^' . preg_quote($hardlinkTarget->getRealFullPath(), '@') . '@', $hardlinkPath, $this->getRealFullPath());
                     }
 
-                    if (strpos($this->getRealFullPath(), Site::getCurrentSite()->getRootDocument()->getRealFullPath()) === false && strpos($link, $hardlinkPath) === false) {
+                    if (!str_contains($link, $hardlinkPath) && !str_contains($this->getRealFullPath(), Site::getCurrentSite()->getRootDocument()->getRealFullPath())) {
                         $link = null;
                     }
                 }

--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -208,7 +208,7 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
         $url = $this->data['path'] ?? '';
 
         if (strlen($this->data['parameters'] ?? '') > 0) {
-            $url .= (strpos($url, '?') !== false ? '&' : '?') . htmlspecialchars(str_replace('?', '', $this->getParameters()));
+            $url .= (str_contains($url, '?') ? '&' : '?') . htmlspecialchars(str_replace('?', '', $this->getParameters()));
         }
 
         if (strlen($this->data['anchor'] ?? '') > 0) {

--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -142,8 +142,8 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
             $attribs = [];
             foreach ($availableAttribs as $key => $value) {
                 if ((is_string($value) || is_numeric($value))
-                    && (strpos($key, 'data-') === 0 ||
-                        strpos($key, 'aria-') === 0 ||
+                    && (str_starts_with($key, 'data-') ||
+                        str_starts_with($key, 'aria-') ||
                         in_array($key, $allowedAttributes))) {
                     if (!empty($this->data[$key]) && !empty($this->config[$key])) {
                         $attribs[] = $key.'="'. htmlspecialchars($this->data[$key]) .' '. htmlspecialchars($this->config[$key]) .'"';

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -595,7 +595,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
 
         $wmode = '?wmode=transparent';
         $seriesPrefix = '';
-        if (strpos($youtubeId, 'PL') === 0) {
+        if (str_starts_with($youtubeId, 'PL')) {
             $wmode = '';
             $seriesPrefix = 'videoseries?list=';
         }

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -537,7 +537,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
         $youtubeId = '';
         if ($this->type === self::TYPE_YOUTUBE) {
             if ($youtubeId = $this->id) {
-                if (strpos($youtubeId, '//') !== false) {
+                if (str_contains($youtubeId, '//')) {
                     $parts = parse_url($this->id);
                     if (array_key_exists('query', $parts)) {
                         parse_str($parts['query'], $vars);
@@ -548,7 +548,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
                     }
 
                     //get youtube id if form urls like  http://www.youtube.com/embed/youtubeId
-                    if (strpos($this->id, 'embed') !== false) {
+                    if (str_contains($this->id, 'embed')) {
                         $explodedPath = explode('/', $parts['path']);
                         $youtubeId = $explodedPath[array_search('embed', $explodedPath) + 1];
                     }

--- a/models/Document/Hardlink/Wrapper.php
+++ b/models/Document/Hardlink/Wrapper.php
@@ -107,7 +107,7 @@ trait Wrapper
         $result = parent::getProperty($name, $asContainer);
         if ($result instanceof Document) {
             $hardLink = $this->getHardLinkSource();
-            if (strpos($result->getRealFullPath(), $hardLink->getSourceDocument()->getRealFullPath() . '/') === 0
+            if (str_starts_with($result->getRealFullPath(), $hardLink->getSourceDocument()->getRealFullPath() . '/')
                 || $hardLink->getSourceDocument()->getRealFullPath() === $result->getRealFullPath()
             ) {
                 $c = Service::wrap($result);

--- a/models/Site/Dao.php
+++ b/models/Site/Dao.php
@@ -68,7 +68,7 @@ class Dao extends Model\Dao\AbstractDao
                     $siteDomains = unserialize($site['domains']);
                     if (is_array($siteDomains) && count($siteDomains) > 0) {
                         foreach ($siteDomains as $siteDomain) {
-                            if (strpos($siteDomain, '*') !== false) {
+                            if (str_contains($siteDomain, '*')) {
                                 $siteDomain = str_replace('.*', '*', $siteDomain); // backward compatibility
                                 $wildcardDomains[$siteDomain] = $site['id'];
                             }

--- a/tests/Model/LazyLoading/AbstractLazyLoadingTest.php
+++ b/tests/Model/LazyLoading/AbstractLazyLoadingTest.php
@@ -131,7 +131,7 @@ class AbstractLazyLoadingTest extends ModelTestCase
         }
 
         foreach ($needle as $item) {
-            $this->assertEquals($expected, strpos($string, $item) !== false, $messagePrefix . "Check if '$item' is occuring in serialized data.");
+            $this->assertEquals($expected, str_contains($string, $item), $messagePrefix . "Check if '$item' is occuring in serialized data.");
         }
     }
 

--- a/tests/Service/Element/VersionTest.php
+++ b/tests/Service/Element/VersionTest.php
@@ -133,17 +133,17 @@ class VersionTest extends TestCase
         $sourceObjectFromDb = Unittest::getById($sourceObject->getId(), ['force' => true]);
 
         $targetObjects = $sourceObject->getMultihref();
-        $this->assertEquals(1, count($targetObjects), 'expected one target');
+        $this->assertCount(1, $targetObjects, 'expected one target');
 
         $targetObject = $targetObjects[0];
         $this->assertEquals($randomText, $targetObject->getInput(), 'random text does not match');
 
         $latestVersion1 = $this->getNewestVersion($sourceObject->getId());
         $content = stream_get_contents($latestVersion1->getFileStream());
-        $this->assertTrue(strpos($content, $randomText) === false, "random text shouldn't be there");
+        $this->assertStringNotContainsString($randomText, $content, "random text shouldn't be there");
 
         $multihref = $sourceObjectFromDb->getMultihref();
-        $this->assertEquals(1, count($multihref), 'expected 1 target element');
+        $this->assertCount(1, $multihref, 'expected 1 target element');
     }
 
     // Save a new object and check if the storagetype is set to fs


### PR DESCRIPTION
This is some cleanup that uses the modern and more descriptive `str_contains()`/`str_starts_with()`/`str_ends_with()` functions where possible.