### PR TITLE
Improvement: Adds PRE_COPY event to the copy-contents-action

### DIFF
--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -187,6 +187,13 @@ class Service extends Model\Element\Service
             throw new \Exception('Source and target have to be the same type');
         }
 
+        // triggers actions before asset cloning
+        $event = new AssetEvent($source, [
+            'target_element' => $target,
+        ]);
+        \Pimcore::getEventDispatcher()->dispatch($event, AssetEvents::PRE_COPY);
+        $target = $event->getArgument('target_element');
+
         if (!$source instanceof Asset\Folder) {
             $target->setStream($source->getStream());
             $target->setCustomSettings($source->getCustomSettings());

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -258,6 +258,12 @@ class Service extends Model\Element\Service
             throw new \Exception('Source and target have to be the same type');
         }
 
+        // triggers actions before object cloning
+        $event = new DataObjectEvent($source, [
+            'target_element' => $target,
+        ]);
+        \Pimcore::getEventDispatcher()->dispatch($event, DataObjectEvents::PRE_COPY);
+
         //load all in case of lazy loading fields
         self::loadAllObjectFields($source);
 

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -263,6 +263,7 @@ class Service extends Model\Element\Service
             'target_element' => $target,
         ]);
         \Pimcore::getEventDispatcher()->dispatch($event, DataObjectEvents::PRE_COPY);
+        $target = $event->getArgument('target_element');
 
         //load all in case of lazy loading fields
         self::loadAllObjectFields($source);

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -248,6 +248,13 @@ class Service extends Model\Element\Service
             throw new \Exception('Source and target have to be the same type');
         }
 
+        // triggers actions before document cloning
+        $event = new DocumentEvent($source, [
+            'target_element' => $target,
+        ]);
+        \Pimcore::getEventDispatcher()->dispatch($event, DocumentEvents::PRE_COPY);
+        $target = $event->getArgument('target_element');
+
         if ($source instanceof Document\PageSnippet) {
             /** @var PageSnippet $target */
             $target->setEditables($source->getEditables());


### PR DESCRIPTION
## Changes in this pull request  

Resolves #14397

## Additional info  

In the issue-ticket is more details available, but in general the copy-contents-action ("Paste > Copy contents only here") action is not dispatching any event. This pull-request introduces the same event as in the other copy-actions (paste) so we can have an event-listener for that action.

If possible this would also be an idea for earlier versions. I think it should be rather easy to integrate.

If I am missing something in the code, I am happy to add or extend it.

Thanks!
