### PR TITLE
Consider overridden/custom types for doc blocks to achieve correct code completion

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -44,9 +44,9 @@ trait Relation
                     $types[] = $this->getClassName('document', $item['documentTypes']);
                 }
             } else {
-                $types[] = Page::class;
-                $types[] = Snippet::class;
-                $types[] = Document::class;
+                $types[] = '\\' . Page::class;
+                $types[] = '\\' . Snippet::class;
+                $types[] = '\\' . Document::class;
             }
         }
 
@@ -57,7 +57,7 @@ trait Relation
                     $types[] = $this->getClassName('asset', $item['assetTypes']);
                 }
             } else {
-                $types[] = Asset::class;
+                $types[] = '\\' . Asset::class;
             }
         }
 
@@ -68,11 +68,9 @@ trait Relation
                     $types[] = $this->getClassName('object', $item['classes']);
                 }
             } else {
-                $types[] = AbstractObject::class;
+                $types[] = '\\' . AbstractObject::class;
             }
         }
-
-        $types = array_map(static fn (string $type): string => u($type)->ensureStart('\\')->toString(), $types);
 
         if ($asArray) {
             $types = array_map(static fn (string $type): string => $type . '[]', $types);
@@ -93,13 +91,13 @@ trait Relation
 
         if ($typeLoader) {
             try {
-                return $typeLoader->getClassNameFor($shortName);
+                return u($typeLoader->getClassNameFor($shortName))->ensureStart('\\');
             } catch (UnsupportedException) {
                 // try next
             }
 
             try {
-                return $typeLoader->build($shortName)::class;
+                return u($typeLoader->build($shortName)::class)->ensureStart('\\');
             } catch (UnsupportedException) {
                 // try next
             }
@@ -107,13 +105,13 @@ trait Relation
 
         $factory = \Pimcore::getContainer()->get('pimcore.model.factory');
         $className = match ($type) {
-            'asset' => 'Pimcore\Model\Asset\\' . ucfirst($shortName),
-            'document' => 'Pimcore\Model\Document\\' . ucfirst($shortName),
-            'object' => 'Pimcore\Model\DataObject\\' . ucfirst($shortName),
+            'asset' => '\Pimcore\Model\Asset\\' . ucfirst($shortName),
+            'document' => '\Pimcore\Model\Document\\' . ucfirst($shortName),
+            'object' => '\Pimcore\Model\DataObject\\' . ucfirst($shortName),
         };
 
         try {
-            return $factory->getClassNameFor($className);
+            return u($factory->getClassNameFor($className))->ensureStart('\\');
         } catch (UnsupportedException) {
             return $className;
         }

--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -39,7 +39,7 @@ trait Relation
                 $class[] = '\Pimcore\Model\Document' . $strArray;
             } elseif (is_array($documentTypes)) {
                 foreach ($documentTypes as $item) {
-                    $class[] = sprintf('\Pimcore\Model\Document\%s', ucfirst($item['documentTypes']) . $strArray);
+                    $class[] = $this->getMappedClassName('\Pimcore\Model\Document\\' . ucfirst($item['documentTypes'])) . $strArray;
                 }
             }
         }
@@ -51,7 +51,7 @@ trait Relation
                 $class[] = '\Pimcore\Model\Asset' . $strArray;
             } elseif (is_array($assetTypes)) {
                 foreach ($assetTypes as $item) {
-                    $class[] = sprintf('\Pimcore\Model\Asset\%s', ucfirst($item['assetTypes']) . $strArray);
+                    $class[] = $this->getMappedClassName('\Pimcore\Model\Asset\\' . ucfirst($item['assetTypes'])) . $strArray;
                 }
             }
         }
@@ -63,12 +63,24 @@ trait Relation
                 $class[] = '\Pimcore\Model\DataObject\AbstractObject' . $strArray;
             } elseif (is_array($classes)) {
                 foreach ($classes as $item) {
-                    $class[] = sprintf('\Pimcore\Model\DataObject\%s', ucfirst($item['classes']) . $strArray);
+                    $class[] = $this->getMappedClassName('\Pimcore\Model\DataObject\\' . ucfirst($item['classes'])) . $strArray;
                 }
             }
         }
 
         return $class;
+    }
+
+    protected function getMappedClassName(string $className): string
+    {
+        try {
+            $className = \Pimcore::getContainer()->get('pimcore.model.factory')->getClassNameFor($className);
+            if ($className[0] !== '\\') {
+                $className = '\\' . $className;
+            }
+        } finally {
+            return $className;
+        }
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -91,12 +91,6 @@ trait Relation
             } catch (UnsupportedException) {
                 // try next
             }
-
-            try {
-                return u($typeLoader->build($shortName)::class)->ensureStart('\\');
-            } catch (UnsupportedException) {
-                // try next
-            }
         }
 
         $factory = \Pimcore::getContainer()->get('pimcore.model.factory');

--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -44,9 +44,9 @@ trait Relation
                     $types[] = $this->getClassName('document', $item['documentTypes']);
                 }
             } else {
-                $types[] = '\\' . Page::class;
-                $types[] = '\\' . Snippet::class;
-                $types[] = '\\' . Document::class;
+                $types[] = Page::class;
+                $types[] = Snippet::class;
+                $types[] = Document::class;
             }
         }
 
@@ -57,7 +57,7 @@ trait Relation
                     $types[] = $this->getClassName('asset', $item['assetTypes']);
                 }
             } else {
-                $types[] = '\\' . Asset::class;
+                $types[] = Asset::class;
             }
         }
 
@@ -68,9 +68,11 @@ trait Relation
                     $types[] = $this->getClassName('object', $item['classes']);
                 }
             } else {
-                $types[] = '\\' . AbstractObject::class;
+                $types[] = AbstractObject::class;
             }
         }
+
+        $types = array_map(static fn (string $type): string => u($type)->ensureStart('\\')->toString(), $types);
 
         if ($asArray) {
             $types = array_map(static fn (string $type): string => $type . '[]', $types);
@@ -91,13 +93,13 @@ trait Relation
 
         if ($typeLoader) {
             try {
-                return u($typeLoader->getClassNameFor($shortName))->ensureStart('\\');
+                return $typeLoader->getClassNameFor($shortName);
             } catch (UnsupportedException) {
                 // try next
             }
 
             try {
-                return u($typeLoader->build($shortName)::class)->ensureStart('\\');
+                return $typeLoader->build($shortName)::class;
             } catch (UnsupportedException) {
                 // try next
             }
@@ -105,13 +107,13 @@ trait Relation
 
         $factory = \Pimcore::getContainer()->get('pimcore.model.factory');
         $className = match ($type) {
-            'asset' => '\Pimcore\Model\Asset\\' . ucfirst($shortName),
-            'document' => '\Pimcore\Model\Document\\' . ucfirst($shortName),
-            'object' => '\Pimcore\Model\DataObject\\' . ucfirst($shortName),
+            'asset' => 'Pimcore\Model\Asset\\' . ucfirst($shortName),
+            'document' => 'Pimcore\Model\Document\\' . ucfirst($shortName),
+            'object' => 'Pimcore\Model\DataObject\\' . ucfirst($shortName),
         };
 
         try {
-            return u($factory->getClassNameFor($className))->ensureStart('\\');
+            return $factory->getClassNameFor($className);
         } catch (UnsupportedException) {
             return $className;
         }

--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -16,11 +16,6 @@
 namespace Pimcore\Model\DataObject\ClassDefinition\Data\Extension;
 
 use Pimcore\Loader\ImplementationLoader\Exception\UnsupportedException;
-use Pimcore\Model\Asset;
-use Pimcore\Model\DataObject\AbstractObject;
-use Pimcore\Model\Document;
-use Pimcore\Model\Document\Page;
-use Pimcore\Model\Document\Snippet;
 use Pimcore\Model\Document\TypeDefinition\Loader\TypeLoader as DocumentTypeLoader;
 use function Symfony\Component\String\u;
 
@@ -35,48 +30,49 @@ trait Relation
      */
     protected function getPhpDocClassString($asArray = false)
     {
-        $types = [];
+        // init
+        $class = [];
+        $strArray = $asArray ? '[]' : '';
 
         // add documents
         if ($this->getDocumentsAllowed()) {
-            if ($documentTypes = $this->getDocumentTypes()) {
+            $documentTypes = $this->getDocumentTypes();
+            if (count($documentTypes) == 0) {
+                $class[] = '\Pimcore\Model\Document\Page' . $strArray;
+                $class[] = '\Pimcore\Model\Document\Snippet' . $strArray;
+                $class[] = '\Pimcore\Model\Document' . $strArray;
+            } elseif (is_array($documentTypes)) {
                 foreach ($documentTypes as $item) {
-                    $types[] = $this->getClassName('document', $item['documentTypes']);
+                    $class[] = $this->getClassName('document', $item['documentTypes']) . $strArray;
                 }
-            } else {
-                $types[] = '\\' . Page::class;
-                $types[] = '\\' . Snippet::class;
-                $types[] = '\\' . Document::class;
             }
         }
 
-        // add assets
+        // add asset
         if ($this->getAssetsAllowed()) {
-            if ($assetTypes = $this->getAssetTypes()) {
+            $assetTypes = $this->getAssetTypes();
+            if (count($assetTypes) == 0) {
+                $class[] = '\Pimcore\Model\Asset' . $strArray;
+            } elseif (is_array($assetTypes)) {
                 foreach ($assetTypes as $item) {
-                    $types[] = $this->getClassName('asset', $item['assetTypes']);
+                    $class[] = $this->getClassName('asset', $item['assetTypes']) . $strArray;
                 }
-            } else {
-                $types[] = '\\' . Asset::class;
             }
         }
 
         // add objects
         if ($this->getObjectsAllowed()) {
-            if ($classes = $this->getClasses()) {
+            $classes = $this->getClasses();
+            if (count($classes) === 0) {
+                $class[] = '\Pimcore\Model\DataObject\AbstractObject' . $strArray;
+            } elseif (is_array($classes)) {
                 foreach ($classes as $item) {
-                    $types[] = $this->getClassName('object', $item['classes']);
+                    $class[] = $this->getClassName('object', $item['classes']) . $strArray;
                 }
-            } else {
-                $types[] = '\\' . AbstractObject::class;
             }
         }
 
-        if ($asArray) {
-            $types = array_map(static fn (string $type): string => $type . '[]', $types);
-        }
-
-        return $types;
+        return $class;
     }
 
     /**


### PR DESCRIPTION
This is a continuation of #14233 from @ctippler, adding support for custom document types, as requested by @mattamon.

It also includes a partly backport of #13934 to minimize conflicts when `10.6` gets merged into `v11.x`.