### PR TITLE
[Bug] Passing object to `DataObjectParamResolver` doesn´t work

### DIFF
--- a/bundles/CoreBundle/Request/ParamConverter/DataObjectParamResolver.php
+++ b/bundles/CoreBundle/Request/ParamConverter/DataObjectParamResolver.php
@@ -72,7 +72,7 @@ class DataObjectParamResolver implements ArgumentValueResolverInterface
         }
 
         /** @var Concrete|null $object */
-        $object = $class::getById($value);
+        $object = $value instanceof AbstractObject ? $value : $class::getById($value);
         if (!$object) {
             throw new NotFoundHttpException(sprintf('Invalid data object ID given for parameter "%s".', $param));
         } elseif (


### PR DESCRIPTION
E.g. used/done here https://github.com/pimcore/demo/blob/ce3356edf293e3f802a96ccfbf9aa326bd244a96/src/Controller/ProductController.php#L57

Noticed while testing https://github.com/pimcore/pimcore/pull/14274