### PR TITLE
[Bug]: Date editable frontend format fallback

### DIFF
--- a/doc/Development_Documentation/03_Documents/01_Editables/10_Date.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/10_Date.md
@@ -5,7 +5,7 @@
 | Name     | Type   | Description                                                                        |
 |----------|--------|------------------------------------------------------------------------------------|
 | `format` | string | A string which describes how to format the date in editmode                       |
-| `outputFormat` | string | A string which describes how to format the date in frontend, [see possible formats](https://carbon.nesbot.com/docs/)   (new in v5.6.4)                 |
+| `outputFormat` | string | A string which describes how to format the date in frontend, [see possible formats](https://www.php.net/manual/en/function.strftime.php#refsect1-function.strftime-parameters)                 |
 | `class`  | string | A CSS class that is added to the surrounding container of this element in editmode |
 
 ## Methods

--- a/models/Document/Editable/Date.php
+++ b/models/Document/Editable/Date.php
@@ -72,18 +72,17 @@ class Date extends Model\Document\Editable implements EditmodeDataInterface
      */
     public function frontend()
     {
-        $format = null;
-
-        if (isset($this->config['outputFormat']) && $this->config['outputFormat']) {
-            $format = $this->config['outputFormat'];
-        } elseif (isset($this->config['format']) && $this->config['format']) {
-            $format = $this->config['format'];
-        } else {
-            $format = 'Y-m-d\TH:i:sO'; // ISO8601
-        }
-
         if ($this->date instanceof \DateTimeInterface) {
-            return $this->date->formatLocalized($format);
+            if (isset($this->config['outputFormat']) && $this->config['outputFormat']) {
+                return $this->date->formatLocalized($this->config['outputFormat']);
+            } else {
+                if (isset($this->config['format']) && $this->config['format']) {
+                    $format = $this->config['format'];
+                } else {
+                    $format = 'Y-m-d\TH:i:sO'; // ISO8601
+                }
+                return $this->date->format($format);
+            }
         }
     }
 


### PR DESCRIPTION
By looking at a wayback version https://web.archive.org/web/20150327045409/https://carbon.nesbot.com/docs/#api-localization of the documentation, it was recommending strftime parameters, latest documentation mentions other parameters
https://pimcore.com/docs/pimcore/current/Development_Documentation/Documents/Editables/Date.html

So the fallback when outputFormat is not set was unlikely used, as there are incompatibilites between the parameters used by these 2 functions, see https://github.com/pimcore/pimcore/pull/14431#issuecomment-1441644584

Test by using this twig code

```twig
    as example<br>
    {{ pimcore_date('myDate1', {
        'format': 'd.m.Y',
        'outputFormat': '%d.%m.%Y'
    }) }}
    <hr/>
    outputFormat empty fallback to format <br>
    {{ pimcore_date('myDate2', {
        'format': 'd.m.Y'
    }) }}
    <hr/>
    fallback to ISO <br>
    {{ pimcore_date('myDate3') }}
```

prior PR
![image](https://user-images.githubusercontent.com/6014195/220879810-64219532-0c9a-496e-9d92-c617d299454c.png)

after
![image](https://user-images.githubusercontent.com/6014195/220881101-6bfea6b5-58e1-47af-9c7c-3c067e72541e.png)
