### PR TITLE
[Bug] fix updating glossary entries fails

### DIFF
--- a/bundles/GlossaryBundle/src/Model/Glossary.php
+++ b/bundles/GlossaryBundle/src/Model/Glossary.php
@@ -167,7 +167,7 @@ class Glossary extends AbstractModel
         return $this->abbr;
     }
 
-    public function setLanguage(string $language): static
+    public function setLanguage(?string $language): static
     {
         $this->language = $language;
 
@@ -203,12 +203,12 @@ class Glossary extends AbstractModel
         return $this->exactmatch;
     }
 
-    public function setSite(Site|int $site): static
+    public function setSite(null|int|Site $site): static
     {
         if ($site instanceof Site) {
             $site = $site->getId();
         }
-        $this->site = (int) $site;
+        $this->site = $site;
 
         return $this;
     }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #14432 

## Additional info  
setLanguage and setSite are now nullable
