### PR TITLE
Remove unused DocumentController::getSeoNodeConfig() method

### DIFF
--- a/bundles/AdminBundle/src/Controller/Admin/Document/DocumentController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/Document/DocumentController.php
@@ -1498,27 +1498,6 @@ class DocumentController extends ElementControllerBase implements KernelControll
         ]);
     }
 
-    private function getSeoNodeConfig(Document $document): array
-    {
-        $nodeConfig = $this->getTreeNodeConfig($document);
-
-        if ($document instanceof Document\Page) {
-            // analyze content
-            $nodeConfig['prettyUrl'] = $document->getPrettyUrl();
-
-            $title = $document->getTitle();
-            $description = $document->getDescription();
-
-            $nodeConfig['title'] = $title;
-            $nodeConfig['description'] = $description;
-
-            $nodeConfig['title_length'] = mb_strlen($title);
-            $nodeConfig['description_length'] = mb_strlen($description);
-        }
-
-        return $nodeConfig;
-    }
-
     public function onKernelControllerEvent(ControllerEvent $event): void
     {
         if (!$event->isMainRequest()) {


### PR DESCRIPTION
The method was moved to `Pimcore\Bundle\SeoBundle\Controller\Document\getSeoNodeConfig()` in https://github.com/pimcore/pimcore/pull/13851