### PR TITLE
[Improvement]: removing block element with default set should clear editable values

### DIFF
--- a/bundles/AdminBundle/public/js/pimcore/document/editables/block.js
+++ b/bundles/AdminBundle/public/js/pimcore/document/editables/block.js
@@ -220,7 +220,7 @@ pimcore.document.editables.block = Class.create(pimcore.document.editable, {
         Ext.get(this.id).addCls("pimcore_block_limitnotreached pimcore_block_buttons");
     },
 
-    addBlock : function (element, amountbox) {
+    addBlock : function (element, amountbox, reload = true) {
 
         var index = this.getElementIndex(element) + 1;
         var amount = 1;
@@ -259,7 +259,9 @@ pimcore.document.editables.block = Class.create(pimcore.document.editable, {
             this.elements.splice.apply(this.elements, args);
 
             editWindow.lastScrollposition = '#' + this.id + ' .pimcore_block_entry[data-name="' + this.name + '"][key="' + firstNewKey + '"]';
-            this.reloadDocument();
+            if(reload) {
+                this.reloadDocument();
+            }
         } else {
             let template = this.config['template']['html'];
             let elements;
@@ -311,6 +313,10 @@ pimcore.document.editables.block = Class.create(pimcore.document.editable, {
 
         var index = this.getElementIndex(element);
 
+        // Add a new default block before removing last block.
+        if(is_numeric(this.config['default']) && this.elements.length === this.config['default']) {
+            this.addBlock(element, null, false); // do not reload document, will happen later here.
+        }
         this.elements.splice(index, 1);
         Ext.get(element).remove();
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #12774

## Additional info  
Twig snippet to test this.
```html
<div class="teasers">
    {% for i in pimcore_block('contentblock', {"default": 1, 'reload': true}).iterator %}
        <h2>{{ pimcore_input('subline') }}</h2>
    {% endfor %}
</div>
```
