### PR TITLE
Fix sizing of custom admin tab icons

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -1081,7 +1081,7 @@ pimcore.helpers.getClassForIcon = function (icon) {
 
     var content = styleContainer.dom.innerHTML;
     var classname = "pimcore_dynamic_class_for_icon_" + uniqid();
-    content += ("." + classname + " { background: url(" + icon + ") left center no-repeat !important; background-size: 100% 100% !important; }\n");
+    content += ("." + classname + " { background: url(" + icon + ") left center no-repeat !important; background-size: contain !important; }\n");
     styleContainer.dom.innerHTML = content;
 
     return classname;


### PR DESCRIPTION
## Changes in this pull request  
Resolves an issue where icons would have unwanted sizing in admin tabs, especially flags:

![Screenshot 2023-02-28 at 15 43 58](https://user-images.githubusercontent.com/279826/221887564-bba710ab-254a-4034-9eb4-40e1740b6e44.png)

Example with fix:
![Screenshot 2023-02-28 at 15 42 50](https://user-images.githubusercontent.com/279826/221887246-24ebe469-8c0b-4842-8ad9-0c1d10b14042.png)

