### PR TITLE
Use SYMFONY_ASSETS_INSTALL env variable when calling assets:install

### DIFF
--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -216,7 +216,7 @@ class Composer
             $arguments = $phpFinder->findArguments();
         }
 
-        if ($env = getenv('COMPOSER_ORIGINAL_INIS')) {
+        if ($env = $_SERVER['COMPOSER_ORIGINAL_INIS']) {
             $paths = explode(PATH_SEPARATOR, $env);
             $ini = array_shift($paths);
         } else {
@@ -234,8 +234,8 @@ class Composer
     {
         $options = array_merge(static::$options, $event->getComposer()->getPackage()->getExtra());
 
-        $options['symfony-assets-install'] = getenv('SYMFONY_ASSETS_INSTALL') ?: $options['symfony-assets-install'];
-        $options['symfony-cache-warmup'] = getenv('SYMFONY_CACHE_WARMUP') ?: $options['symfony-cache-warmup'];
+        $options['symfony-assets-install'] = $_SERVER['SYMFONY_ASSETS_INSTALL'] ?: $options['symfony-assets-install'];
+        $options['symfony-cache-warmup'] = $_SERVER['SYMFONY_CACHE_WARMUP'] ?: $options['symfony-cache-warmup'];
 
         $options['process-timeout'] = $event->getComposer()->getConfig()->get('process-timeout');
         $options['vendor-dir'] = $event->getComposer()->getConfig()->get('vendor-dir');

--- a/lib/Composer.php
+++ b/lib/Composer.php
@@ -216,8 +216,8 @@ class Composer
             $arguments = $phpFinder->findArguments();
         }
 
-        if ($env = $_SERVER['COMPOSER_ORIGINAL_INIS']) {
-            $paths = explode(PATH_SEPARATOR, $env);
+        if (!empty($_SERVER['COMPOSER_ORIGINAL_INIS'])) {
+            $paths = explode(PATH_SEPARATOR, $_SERVER['COMPOSER_ORIGINAL_INIS']);
             $ini = array_shift($paths);
         } else {
             $ini = php_ini_loaded_file();
@@ -234,8 +234,13 @@ class Composer
     {
         $options = array_merge(static::$options, $event->getComposer()->getPackage()->getExtra());
 
-        $options['symfony-assets-install'] = $_SERVER['SYMFONY_ASSETS_INSTALL'] ?: $options['symfony-assets-install'];
-        $options['symfony-cache-warmup'] = $_SERVER['SYMFONY_CACHE_WARMUP'] ?: $options['symfony-cache-warmup'];
+        if(!empty($_SERVER['SYMFONY_ASSETS_INSTALL'])) {
+            $options['symfony-assets-install'] = $_SERVER['SYMFONY_ASSETS_INSTALL'];
+        }
+
+        if (!empty($_SERVER['SYMFONY_CACHE_WARMUP'])) {
+            $options['symfony-cache-warmup'] = $_SERVER['SYMFONY_CACHE_WARMUP'];
+        }
 
         $options['process-timeout'] = $event->getComposer()->getConfig()->get('process-timeout');
         $options['vendor-dir'] = $event->getComposer()->getConfig()->get('vendor-dir');

--- a/lib/Tool/AssetsInstaller.php
+++ b/lib/Tool/AssetsInstaller.php
@@ -119,8 +119,8 @@ class AssetsInstaller
     private function configureOptions(OptionsResolver $resolver)
     {
         $defaults = [
-            'symlink' => true,
-            'relative' => true,
+            'symlink' => false,
+            'relative' => false,
             'env' => false,
             'ansi' => false,
             'no-ansi' => false,
@@ -129,16 +129,30 @@ class AssetsInstaller
         $composerJsonSetting = $this->readComposerJsonSetting();
         if (null !== $composerJsonSetting) {
             if ('symlink' === $composerJsonSetting) {
-                $defaults = array_merge([
-                    'symlink' => true,
-                    'relative' => false,
-                ], $defaults);
+                $defaults = array_merge(
+                    $defaults,
+                    [
+                        'symlink' => true,
+                        'relative' => false,
+                    ]
+                );
             } elseif ('relative' === $composerJsonSetting) {
-                $defaults = array_merge([
-                    'symlink' => true,
-                    'relative' => true,
-                ], $defaults);
+                $defaults = array_merge(
+                    $defaults,
+                    [
+                        'symlink' => true,
+                        'relative' => true,
+                    ]
+                );
             }
+        }
+
+        if(in_array(getenv('SYMFONY_ASSETS_INSTALL'), ['symlink', 'relative'])) {
+            $defaults['symlink'] = true;
+        }
+
+        if(getenv('SYMFONY_ASSETS_INSTALL') === 'relative') {
+            $defaults['relative'] = true;
         }
 
         $resolver->setDefaults($defaults);

--- a/lib/Tool/AssetsInstaller.php
+++ b/lib/Tool/AssetsInstaller.php
@@ -147,11 +147,11 @@ class AssetsInstaller
             }
         }
 
-        if(!empty($_SERVER['SYMFONY_ASSETS_INSTALL']) && in_array($_SERVER['SYMFONY_ASSETS_INSTALL'], ['symlink', 'relative'])) {
+        if(in_array($_SERVER['SYMFONY_ASSETS_INSTALL'] ?? null, ['symlink', 'relative'])) {
             $defaults['symlink'] = true;
         }
 
-        if(!empty($_SERVER['SYMFONY_ASSETS_INSTALL']) && $_SERVER['SYMFONY_ASSETS_INSTALL'] === 'relative') {
+        if(($_SERVER['SYMFONY_ASSETS_INSTALL'] ?? null) === 'relative') {
             $defaults['relative'] = true;
         }
 

--- a/lib/Tool/AssetsInstaller.php
+++ b/lib/Tool/AssetsInstaller.php
@@ -147,11 +147,11 @@ class AssetsInstaller
             }
         }
 
-        if(in_array($_SERVER['SYMFONY_ASSETS_INSTALL'], ['symlink', 'relative'])) {
+        if(!empty($_SERVER['SYMFONY_ASSETS_INSTALL']) && in_array($_SERVER['SYMFONY_ASSETS_INSTALL'], ['symlink', 'relative'])) {
             $defaults['symlink'] = true;
         }
 
-        if($_SERVER['SYMFONY_ASSETS_INSTALL'] === 'relative') {
+        if(!empty($_SERVER['SYMFONY_ASSETS_INSTALL']) && $_SERVER['SYMFONY_ASSETS_INSTALL'] === 'relative') {
             $defaults['relative'] = true;
         }
 

--- a/lib/Tool/AssetsInstaller.php
+++ b/lib/Tool/AssetsInstaller.php
@@ -147,11 +147,11 @@ class AssetsInstaller
             }
         }
 
-        if(in_array(getenv('SYMFONY_ASSETS_INSTALL'), ['symlink', 'relative'])) {
+        if(in_array($_SERVER['SYMFONY_ASSETS_INSTALL'], ['symlink', 'relative'])) {
             $defaults['symlink'] = true;
         }
 
-        if(getenv('SYMFONY_ASSETS_INSTALL') === 'relative') {
+        if($_SERVER['SYMFONY_ASSETS_INSTALL'] === 'relative') {
             $defaults['relative'] = true;
         }
 


### PR DESCRIPTION
In https://github.com/pimcore/pimcore/blob/abdca558837f67183845260bc1250ee37936ac52/lib/Composer.php#L251-L258 `assets:install` gets executed without parameters by default (= copy asset files). This can be changed via composer.json's `extra.symfony-assets-install` or env variable `SYMFONY_ASSETS_INSTALL` in https://github.com/pimcore/pimcore/blob/abdca558837f67183845260bc1250ee37936ac52/lib/Composer.php#L190-L193

Imho this is implemented correctly.

In contrast, in https://github.com/pimcore/pimcore/blob/abdca558837f67183845260bc1250ee37936ac52/lib/Tool/AssetsInstaller.php#L64-L83 by default `assets:install` gets executed with `--symlink --relative` because of https://github.com/pimcore/pimcore/blob/abdca558837f67183845260bc1250ee37936ac52/lib/Tool/AssetsInstaller.php#L113-L143

Moreover:
https://github.com/pimcore/pimcore/blob/abdca558837f67183845260bc1250ee37936ac52/lib/Tool/AssetsInstaller.php#L125-L135 does not make sense anyway because 
`$defaults = array_merge([ 'symlink' => true, 'relative' => false ], $defaults)` will overwrite colliding array keys with the second item (see https://www.php.net/manual/de/function.array-merge.php#refsect1-function.array-merge-examples). Thus `$defaults` stays the same anyway.

This PR adjusts `AssetsInstaller` in the same manor as the `Composer` class does it:
1. Environment variable `SYMFONY_ASSETS_INSTALL` has highest priority
2. If 1. is not set, use `extra.symfony-assets-install` from composer.json
3. If 2. is not set, *copy* files instead of *linking*