### PR TITLE
Add check if bundle is installed

### DIFF
--- a/bundles/UuidBundle/src/EventListener/UUIDListener.php
+++ b/bundles/UuidBundle/src/EventListener/UUIDListener.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\UuidBundle\EventListener;
 
 use Pimcore\Bundle\UuidBundle\Model\Tool\UUID;
+use Pimcore\Bundle\UuidBundle\PimcoreUuidBundle;
 use Pimcore\Event\AssetEvents;
 use Pimcore\Event\DataObjectClassDefinitionEvents;
 use Pimcore\Event\DataObjectEvents;
@@ -76,6 +77,10 @@ class UUIDListener implements EventSubscriberInterface
 
     protected function isEnabled(): bool
     {
+        if (!PimcoreUuidBundle::isInstalled()) {
+            return false;
+        }
+
         $config = \Pimcore::getKernel()->getContainer()->getParameter('pimcore_uuid.instance_identifier');
         if (!empty($config)) {
             return true;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Follow up to https://github.com/pimcore/pimcore/issues/14165#issuecomment-1446929450

## Additional info  
As we kept the event listener for data objects an error occurs during the installation of pimcore as the uuid table does not exist during that time. By adding a check if the bundle is installed we can prevent the further execution of the event listener and prevent that error.
