### PR TITLE
[Improvement]: Add getDirtyFields method to DirtyIndicatorTrait

### DIFF
--- a/models/Element/Traits/DirtyIndicatorTrait.php
+++ b/models/Element/Traits/DirtyIndicatorTrait.php
@@ -51,8 +51,11 @@ trait DirtyIndicatorTrait
         $this->dirtyFields = [];
     }
 
+    /**
+     * @return string[]
+     */
     public function getDirtyFields(): array
     {
-        return $this->dirtyFields;
+        return array_keys($this->dirtyFields);
     }
 }

--- a/models/Element/Traits/DirtyIndicatorTrait.php
+++ b/models/Element/Traits/DirtyIndicatorTrait.php
@@ -50,4 +50,9 @@ trait DirtyIndicatorTrait
     {
         $this->dirtyFields = [];
     }
+
+    public function getDirtyFields(): array
+    {
+        return $this->dirtyFields;
+    }
 }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Adds a method to return all fields mark as dirty from a DataObject using DirtyIndicatorTrait

## Additional info  

