### PR TITLE
[Task][Web2PrintBundle]: Fix `Add PrintPage` position in right-click menu 

### DIFF
--- a/bundles/WebToPrintBundle/public/js/startup.js
+++ b/bundles/WebToPrintBundle/public/js/startup.js
@@ -76,7 +76,7 @@ pimcore.bundle.web2print.startup = Class.create({
             });
 
             if (document.data.type != "email" && document.data.type != "newsletter" && document.data.type != "link") {
-                menu.add(new Ext.menu.Item({
+                menu.insert(0, new Ext.menu.Item({
                     text: t('add_printpage'),
                     iconCls: "pimcore_icon_printpage pimcore_icon_overlay_add",
                     menu: documentMenu.printPage,


### PR DESCRIPTION
Currently looks like this in 11
![image](https://user-images.githubusercontent.com/6014195/223357469-f25b85ad-2785-4d6d-9420-56c5e33c3218.png)


Followup to https://github.com/pimcore/pimcore/pull/14175

Draft: this approach makes it always go on top, instead should implement some ways to define exactly where it should go by using a `priority` proterty or so.