### PR TITLE
[Bug] Shared Translations wrong route prefix.

### DIFF
--- a/bundles/XliffBundle/src/Controller/XliffTranslationController.php
+++ b/bundles/XliffBundle/src/Controller/XliffTranslationController.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\XliffBundle\Controller;
 
-use Pimcore\Bundle\AdminBundle\Controller\Admin\TranslationController;
+use Pimcore\Bundle\AdminBundle\Controller\AdminController;
 use Pimcore\Bundle\XliffBundle\ExportService\Exporter\ExporterInterface;
 use Pimcore\Bundle\XliffBundle\ExportService\ExportServiceInterface;
 use Pimcore\Bundle\XliffBundle\ImportDataExtractor\ImportDataExtractorInterface;
@@ -34,7 +34,7 @@ use Symfony\Component\Routing\Annotation\Route;
  * @Route("/translation")
  *
  */
-class XliffTranslationController extends TranslationController
+class XliffTranslationController extends AdminController
 {
     /**
      * @Route("/xliff-export", name="pimcore_bundle_xliff_translation_xliffexport", methods={"POST"})


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #14545

## Additional info  
It makes no sense for the `XliffTranslationController` to extend the `TranslationController` since no functionality is shared. 
This inheritance results in the route being overwritten. And the `TranslationController` actions use the Xliff prefix. 
