### PR TITLE
[Localized fields] During serialization do not reset unsaved data

### DIFF
--- a/models/DataObject/Localizedfield.php
+++ b/models/DataObject/Localizedfield.php
@@ -716,10 +716,12 @@ final class Localizedfield extends Model\AbstractModel implements
             $lazyLoadedFields = $this->getLazyLoadedFieldNames();
             foreach ($lazyLoadedFields as $fieldName) {
                 foreach (Tool::getValidLanguages() as $language) {
-                    unset($this->items[$language][$fieldName]);
+                    if (!$this->isLanguageDirty($language)) {
+                        unset($this->items[$language][$fieldName]);
 
-                    $lazyKey = $this->buildLazyKey($fieldName, $language);
-                    $this->unmarkLazyKeyAsLoaded($lazyKey);
+                        $lazyKey = $this->buildLazyKey($fieldName, $language);
+                        $this->unmarkLazyKeyAsLoaded($lazyKey);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Steps to reproduce bug:
1. Create class `Product` with localized many-to-many object relation `relation`
2. Create `Product` object `/test` and assign itself to the relation
3. Create `Product` objects `/test2` and `/test3`
4. Run the following script:
```php
<?php
$product = \Pimcore\Model\DataObject\Product::getByPath('/test');
var_dump('current (should be 1): '.count($product->getRelation('en')));

$product->setRelation([
  \Pimcore\Model\DataObject\Product::getByPath('/test2'), 
  \Pimcore\Model\DataObject\Product::getByPath('/test3')
], 'en');
var_dump('current (should be 2): '.count($product->getRelation('en')));

$serialized = serialize($product);
var_dump('current (should be 2): '.count($product->getRelation('en')));
```
The last line returns `1` because the `serialize()` call triggers the `__sleep` method in https://github.com/pimcore/pimcore/blob/ffdf58049a5210c85e45b6bc18eb2b7574c5e7ed/models/DataObject/Localizedfield.php#L616-L635 
And this currently removes the loaded data for all lazy-loadable fields in the original object. For this reason the last call for `$product->getRelation('en')` will retrieve the field contents again and has forgotten the previously set (but not yet saved) data.

With this PR "dirty" data will not get reset during serialisation.
