### PR TITLE
[Bug]: Weekday translation key conflicting with short country code (Language)

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/translation.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/translation.js
@@ -156,7 +156,7 @@ pimcore.settings.translation.domain = Class.create({
 
                     let languageStore = [];
                     for (var i = 0; i < this.languages.length; i++) {
-                        languageStore.push([this.languages[i], t(this.languages[i])]);
+                        languageStore.push([this.languages[i], this.languages[i]]);
                     }
 
                     this.filterLocaleField.getStore().loadData(languageStore);


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Partially Resolves #14507

## Additional info  
We should not translate locale codes
