### PR TITLE
[Improvement]: Improve error message for duplicate names in Predefined Asset Metadata

### DIFF
--- a/bundles/AdminBundle/src/Controller/Admin/SettingsController.php
+++ b/bundles/AdminBundle/src/Controller/Admin/SettingsController.php
@@ -179,7 +179,7 @@ class SettingsController extends AdminController
 
                 $existingItem = Metadata\Predefined\Listing::getByKeyAndLanguage($metadata->getName(), $metadata->getLanguage(), $metadata->getTargetSubtype());
                 if ($existingItem && $existingItem->getId() != $metadata->getId()) {
-                    return $this->adminJson(['message' => 'rule_violation', 'success' => false]);
+                    return $this->adminJson(['message' => 'predefined_metadata_definitions_error_name_exists_msg', 'success' => false]);
                 }
 
                 $metadata->minimize();

--- a/bundles/AdminBundle/translations/admin_ext.en.yaml
+++ b/bundles/AdminBundle/translations/admin_ext.en.yaml
@@ -399,6 +399,7 @@ select_all: Select All
 deselect_all: Deselect All
 definitions_saved: Definitions saved
 predefined_metadata_definitions: Predefined Metadata Definitions
+predefined_metadata_definitions_error_name_exists_msg: Definition with this name already exists
 default_layout: Use as default layout
 hide_edit_image_tab: Hide Edit Image Tab
 are_you_sure_recursive: There child nodes which will be deleted as well! Are you sure?


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #14344

## Additional info  
An improved error message has been added.
