### PR TITLE
bugfix for thumbnails TmpStore generation

### DIFF
--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -54,6 +54,9 @@ class PublicServicesController extends Controller
         $asset = Asset::getById($assetId);
 
         if ($asset) {
+            $thumbnailDir = rtrim($asset->getRealPath(), '/').'/'.$asset->getId().'/image-thumb__'.$asset->getId().'__'.$thumbnailName;
+            $thumbnailFileStoragePath = $thumbnailDir . '/' . $filename;
+
             $prefix = preg_replace('@^cache-buster\-[\d]+\/@', '', $request->get('prefix'));
             $prefix = preg_replace('@' . $asset->getId() . '/$@', '', $prefix);
             if ($asset->getPath() === ('/' . $prefix)) {
@@ -83,6 +86,9 @@ class PublicServicesController extends Controller
                         } elseif ($this->getParameter('pimcore.config')['assets'][$thumbnailType]['thumbnails']['status_cache']) {
                             // Delete Thumbnail Name from Cache so the next call can generate a new TmpStore entry
                             $asset->getDao()->deleteFromThumbnailCache($thumbnailName);
+
+                            // Also delete the thumbnail if it already exists in the storage so that a new TmpStore entry can be generated
+                            $storage->delete($thumbnailFileStoragePath);
                         }
                     }
 


### PR DESCRIPTION
ok so this explanation is going to be a hard one.

to reproduce this issue:

create a twig template with a {{ pimcore_image("image") }}-tag. Open the template in the backend and add an image to the editable. right-click on the image and select a specific area of the image. save the document.

if you open the document in the frontend, the image is display and behind the scenes some entries are created in the TmpStore (database table tmp_store) and one entry is created in the ThumbnailCache (database table assets_image_thumbnail_cache)

everything is alright so far. now right click on the image and open it in a new tab. Refresh the table assets_image_thumbnail_cache in the database and you'll see that the entry of your image is now gone.

If you reload the document in the frontend you would assume that the entry is created again - but it isn't because the thumbnail-file still exists in the storage and therefore no TmpStore-Entry is created. if you host your thumbnails on for example s3 than the frontend_prefix for your assets is never attached because of the missing entry in assets_image_thumbnail_cache.

now this "open in new tab" thing is just a way to reproduce this issue. in a real world example this happens when 2 users visit one document with image-thumbnails that are still being processed (deferred). the second visit of the site wipes all those entries in assets_image_thumbnail_cache and now your frontend-prefixes are missing for those thumbnails.

to fix this issue we have to not only remove the thumbnail from the cache but also from the storage. thats exactly what this PR does.