### PR TITLE
[Docoument] Fix null-safe statement in ContentTemplatelistener

### DIFF
--- a/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
@@ -68,7 +68,7 @@ class ContentTemplateListener implements EventSubscriberInterface
             return;
         }
 
-        $attribute = $event->controllerArgumentsEvent?->getAttributes()[Template::class][0] ?? null;
+        $attribute = $event->controllerArgumentsEvent?->getAttributes()[Template::class][0];
 
         if (!$attribute instanceof Template) {
             return;


### PR DESCRIPTION
## Changes in this pull request  
Follow up to #14062

Fixes error` Cannot modify readonly property Symfony\Component\HttpKernel\Event\ViewEvent::$controllerArgumentsEvent`

## Additional info  
how to reproduce?

- Move a document with children to another document level
