### PR TITLE
prevent pimcore logout when logging out from another firewall

### DIFF
--- a/bundles/AdminBundle/Security/Event/LogoutListener.php
+++ b/bundles/AdminBundle/Security/Event/LogoutListener.php
@@ -71,9 +71,11 @@ class LogoutListener implements EventSubscriberInterface, LoggerAwareInterface
      */
     public function onLogout(LogoutEvent $event): RedirectResponse|Response
     {
-        $request = $event->getRequest();
-
-        return $this->onLogoutSuccess($request);
+        if ($event->getToken()->getFirewallName() == 'pimcore_admin') {
+            return $this->onLogoutSuccess($event->getRequest());
+        } else {
+            return $event->getResponse();
+        }
     }
 
     /**


### PR DESCRIPTION
if you logout from another firewall (for example your frontend) you get also logged out from pimcore ("pimcore_admin" firewall). i assume this is unwanted behaviour. this PR fixes this.

