### PR TITLE
[Bug] Fixed `LibreOffice::getText` method

### DIFF
--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -223,7 +223,7 @@ class Ghostscript extends Adapter
                 }
 
                 if(empty($path)) {
-                    throw new \Exception('Variable $path can\'t be null at this point.');
+                    throw new \Exception('Could not get local file for asset with id ' . $asset->getId());
                 }
             }
 

--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -223,7 +223,7 @@ class Ghostscript extends Adapter
                 }
 
                 if(empty($path)) {
-                    throw new \Exception('Variable $path can\'t be null.');
+                    throw new \Exception('Variable $path can\'t be null at this point.');
                 }
             }
 

--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -221,6 +221,10 @@ class Ghostscript extends Adapter
                 if(self::isFileTypeSupported($asset->getFilename())) {
                     $path = $asset->getLocalFile();
                 }
+
+                if(empty($path)) {
+                    throw new \Exception('Variable $path can\'t be null.');
+                }
             }
 
             try {

--- a/lib/Document/Adapter/Ghostscript.php
+++ b/lib/Document/Adapter/Ghostscript.php
@@ -210,14 +210,18 @@ class Ghostscript extends Adapter
     /**
      * {@inheritdoc}
      */
-    public function getText(?int $page = null, ?Asset\Document $asset = null)
+    public function getText(?int $page = null, ?Asset\Document $asset = null, ?string $path = null)
     {
         try {
             if (!$asset && $this->asset) {
                 $asset = $this->asset;
             }
 
-            $path = $asset->getLocalFile();
+            if(!$path || !file_exists($path)) {
+                if(self::isFileTypeSupported($asset->getFilename())) {
+                    $path = $asset->getLocalFile();
+                }
+            }
 
             try {
                 $pdftotextBin = self::getPdftotextCli();

--- a/lib/Document/Adapter/LibreOffice.php
+++ b/lib/Document/Adapter/LibreOffice.php
@@ -176,20 +176,20 @@ class LibreOffice extends Ghostscript
     /**
      * {@inheritdoc}
      */
-    public function getText(?int $page = null, ?Asset\Document $asset = null)
+    public function getText(?int $page = null, ?Asset\Document $asset = null, ?string $path = null)
     {
         if (!$asset && $this->asset) {
             $asset = $this->asset;
         }
 
-        if ($page) {
-            // for per page extraction we have to convert the document to PDF and extract the text via ghostscript
+        // if asset is pdf extract via ghostscript
+        if (parent::isFileTypeSupported($asset->getFilename())) {
             return parent::getText($page, $asset);
         }
 
-        // if asset is pdf extract via ghostscript
-        if (parent::isFileTypeSupported($asset->getFilename())) {
-            return parent::getText(null, $asset);
+        if ($page) {
+            // for per page extraction we have to convert the document to PDF and extract the text via ghostscript
+            return parent::getText($page, $asset, self::getTemporaryFileFromStream($this->getPdf()));
         }
 
         if ($this->isFileTypeSupported($asset->getFilename())) {
@@ -216,7 +216,7 @@ class LibreOffice extends Ghostscript
             $message = "Couldn't convert document to Text: " . $asset->getRealFullPath() . " with the command: '" . $process->getCommandLine() . "' - now trying to get the text out of the PDF with ghostscript...";
             Logger::notice($message);
 
-            return parent::getText(null, $asset);
+            return parent::getText($page, $asset, self::getTemporaryFileFromStream($this->getPdf()));
         }
 
         return ''; // default empty string

--- a/lib/Document/Adapter/LibreOffice.php
+++ b/lib/Document/Adapter/LibreOffice.php
@@ -185,7 +185,7 @@ class LibreOffice extends Ghostscript
         try {
             if (!parent::isFileTypeSupported($asset->getFilename())) {
                 $file = $this->getPdf($asset);
-                if(!$file) {
+                if(!is_resource($file)) {
                     throw new \Exception(sprintf('Could not convert asset with id %s to pdf', $asset->getId()));
                 }
 

--- a/lib/Document/Adapter/LibreOffice.php
+++ b/lib/Document/Adapter/LibreOffice.php
@@ -184,7 +184,15 @@ class LibreOffice extends Ghostscript
 
         try {
             if (!parent::isFileTypeSupported($asset->getFilename())) {
-                $path = $this->getPdf($asset);
+                $file = $this->getPdf($asset);
+                if(!$file) {
+                    throw new \Exception(sprintf('Could not convert asset with id %s to pdf', $asset->getId()));
+                }
+
+                $fileMetaData = stream_get_meta_data($file);
+                if (array_key_exists('uri', $fileMetaData) && !empty($fileMetaData['uri'])) {
+                    $path = $fileMetaData['uri'];
+                }
             }
 
             return parent::getText($page, $asset, $path);

--- a/lib/Document/Adapter/LibreOffice.php
+++ b/lib/Document/Adapter/LibreOffice.php
@@ -189,7 +189,7 @@ class LibreOffice extends Ghostscript
 
         if ($page) {
             // for per page extraction we have to convert the document to PDF and extract the text via ghostscript
-            return parent::getText($page, $asset, self::getTemporaryFileFromStream($this->getPdf()));
+            return parent::getText($page, $asset, self::getTemporaryFileFromStream($this->getPdf($asset)));
         }
 
         if ($this->isFileTypeSupported($asset->getFilename())) {
@@ -216,7 +216,7 @@ class LibreOffice extends Ghostscript
             $message = "Couldn't convert document to Text: " . $asset->getRealFullPath() . " with the command: '" . $process->getCommandLine() . "' - now trying to get the text out of the PDF with ghostscript...";
             Logger::notice($message);
 
-            return parent::getText($page, $asset, self::getTemporaryFileFromStream($this->getPdf()));
+            return parent::getText($page, $asset, self::getTemporaryFileFromStream($this->getPdf($asset)));
         }
 
         return ''; // default empty string


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  
## Error Description

It seems that the convert to txt (txt:Text) doesn't work properly ...
That effects certain command (e.g. `pimcore:search-backend-reindex`)

## Additional info  
fixed some logical issues in `LibreOffice::getText`.

