### PR TITLE
[Image thumbnails] Return correct thumbnail dimensions when using high-res configuration

### DIFF
--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -246,8 +246,13 @@ trait ImageThumbnailTrait
             }
 
             if ($config->getHighResolution() && $config->getHighResolution() > 1) {
-                $dimensions['width'] = (int)floor($dimensions['width'] / $config->getHighResolution());
-                $dimensions['height'] = (int)floor($dimensions['height'] / $config->getHighResolution());
+                if(!empty($dimensions['width'])) {
+                    $dimensions['width'] = (int)floor($dimensions['width'] / $config->getHighResolution());
+                }
+
+                if (!empty($dimensions['height'])) {
+                    $dimensions['height'] = (int)floor($dimensions['height'] / $config->getHighResolution());
+                }
             }
 
             $this->width = $dimensions['width'] ?? null;

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -245,7 +245,7 @@ trait ImageThumbnailTrait
                 $dimensions = $this->readDimensionsFromFile();
             }
 
-            if ($config->getHighResolution() && $config->getHighResolution() > 1) {
+            if ($config && $config->getHighResolution() && $config->getHighResolution() > 1) {
                 if(!empty($dimensions['width'])) {
                     $dimensions['width'] = (int)floor($dimensions['width'] / $config->getHighResolution());
                 }

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -239,15 +239,15 @@ trait ImageThumbnailTrait
                 $dimensions = $config->getEstimatedDimensions($asset);
             }
 
-            if ($config->getHighResolution() && $config->getHighResolution() > 1) {
-                $dimensions['width'] = (int)floor($dimensions['width'] / $config->getHighResolution());
-                $dimensions['height'] = (int)floor($dimensions['height'] / $config->getHighResolution());
-            }
-
             if (empty($dimensions)) {
                 // unable to calculate dimensions -> use fallback
                 // generate the thumbnail and get dimensions from the thumbnail file
                 $dimensions = $this->readDimensionsFromFile();
+            }
+
+            if ($config->getHighResolution() && $config->getHighResolution() > 1) {
+                $dimensions['width'] = (int)floor($dimensions['width'] / $config->getHighResolution());
+                $dimensions['height'] = (int)floor($dimensions['height'] / $config->getHighResolution());
             }
 
             $this->width = $dimensions['width'] ?? null;

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -245,26 +245,16 @@ trait ImageThumbnailTrait
                 $dimensions = $this->readDimensionsFromFile();
             }
 
-            if ($config && $config->getHighResolution() && $config->getHighResolution() > 1) {
-                if(!empty($dimensions['width'])) {
-                    $dimensions['width'] = (int)floor($dimensions['width'] / $config->getHighResolution());
+            // realWidth / realHeight is only relevant if using high-res option (retina, ...)
+            $this->width = $this->realWidth = $dimensions['width'] ?? null;
+            $this->height = $this->realHeight = $dimensions['height'] ?? null;
+            if ($config && $config->getHighResolution() > 1) {
+                if ($this->width) {
+                    $this->width = (int)floor($this->realWidth / $config->getHighResolution());
                 }
-
-                if (!empty($dimensions['height'])) {
-                    $dimensions['height'] = (int)floor($dimensions['height'] / $config->getHighResolution());
+                if ($this->height) {
+                    $this->height = (int)floor($this->realHeight / $config->getHighResolution());
                 }
-            }
-
-            $this->width = $dimensions['width'] ?? null;
-            $this->height = $dimensions['height'] ?? null;
-
-            // the following is only relevant if using high-res option (retina, ...)
-            $this->realHeight = $this->height;
-            $this->realWidth = $this->width;
-
-            if ($config && $config->getHighResolution() && $config->getHighResolution() > 1) {
-                $this->realWidth = (int)floor($this->width * $config->getHighResolution());
-                $this->realHeight = (int)floor($this->height * $config->getHighResolution());
             }
         }
 

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -239,6 +239,11 @@ trait ImageThumbnailTrait
                 $dimensions = $config->getEstimatedDimensions($asset);
             }
 
+            if ($config->getHighResolution() && $config->getHighResolution() > 1) {
+                $dimensions['width'] = (int)floor($dimensions['width'] / $config->getHighResolution());
+                $dimensions['height'] = (int)floor($dimensions['height'] / $config->getHighResolution());
+            }
+
             if (empty($dimensions)) {
                 // unable to calculate dimensions -> use fallback
                 // generate the thumbnail and get dimensions from the thumbnail file


### PR DESCRIPTION
Steps to reproduce:

1. Create thumbnail definition `test` with output format "Auto (web-optimized)" and `High Resolution: 2`
2. Add `Scale by width` transformation with `Width: 100`
3. Upload image `60_proz-PR_de.png` whose width > 100
4. Create controller + template with `{{ pimcore_asset_by_path('/path/to/image.jpg').thumbnail('test').html()|raw }}`

Output will be 
```html
<picture>
  <source srcset="/path/to/image/9927/image-thumb__9927__test/60_proz-PR_de.webp 1x, /path/to/image/9927/image-thumb__9927__test/60_proz-PR_de@2x.webp 2x" width="200" height="200" type="image/webp">
  <source srcset="/path/to/image/9927/image-thumb__9927__test/60_proz-PR_de.png 1x, /path/to/image/9927/image-thumb__9927__test/60_proz-PR_de@2x.png 2x" width="200" height="200" type="image/png"> 
  <img src="/path/to/image/9927/image-thumb__9927__test/60_proz-PR_de@2x.png" alt="" srcset="/path/to/image/9927/image-thumb__9927__test/60_proz-PR_de.png 1x, /path/to/image/9927/image-thumb__9927__test/60_proz-PR_de@2x.png 2x" width="200" height="200">
</picture>
```

`width` and `height` are doubled. This is because in https://github.com/pimcore/pimcore/blob/1100a2046f6ccca580991dc6fbe2a14a1983e8f4/models/Asset/Thumbnail/ImageThumbnailTrait.php#L241-L244 the dimensions for the thumbnail get multiplied with the high-res factor.

But the underlying data from https://github.com/pimcore/pimcore/blob/1100a2046f6ccca580991dc6fbe2a14a1983e8f4/models/Asset/Thumbnail/ImageThumbnailTrait.php#L212 already contains the high-res dimensions from https://github.com/pimcore/pimcore/blob/1100a2046f6ccca580991dc6fbe2a14a1983e8f4/models/Asset/Image/Thumbnail/Processor.php#L420-L422 (`getimagesize()` is applied here to the final generated thumbnail and this already has the high-res-factored dimensions).

Same for the fetched dimensions from https://github.com/pimcore/pimcore/blob/1100a2046f6ccca580991dc6fbe2a14a1983e8f4/models/Asset/Thumbnail/ImageThumbnailTrait.php#L219-L221 
This also calculates the dimensions from the final thumbnail in https://github.com/pimcore/pimcore/blob/1100a2046f6ccca580991dc6fbe2a14a1983e8f4/models/Asset/Thumbnail/ImageThumbnailTrait.php#L180-L194

Multiplying the high-res factor again will give the wrong `width` and `height` attributes.