### PR TITLE
[Bug] Remove unclickable area of WYSIWYG

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/admin.css
+++ b/bundles/AdminBundle/Resources/public/css/admin.css
@@ -1184,7 +1184,8 @@ span.warning {
 .pimcore_editable_wysiwyg {
     position:relative;
     padding: 10px;
-    height: max(100%, 100px);
+    min-height: 80px;
+    height: 100%;
     font: normal 12px tahoma, arial, helvetica, sans-serif;
     background-color: #fff;
 }

--- a/bundles/AdminBundle/Resources/public/css/admin.css
+++ b/bundles/AdminBundle/Resources/public/css/admin.css
@@ -1184,7 +1184,7 @@ span.warning {
 .pimcore_editable_wysiwyg {
     position:relative;
     padding: 10px;
-    min-height: 80px;
+    min-height: 100%;
     font: normal 12px tahoma, arial, helvetica, sans-serif;
     background-color: #fff;
 }

--- a/bundles/AdminBundle/Resources/public/css/admin.css
+++ b/bundles/AdminBundle/Resources/public/css/admin.css
@@ -1184,7 +1184,7 @@ span.warning {
 .pimcore_editable_wysiwyg {
     position:relative;
     padding: 10px;
-    min-height: 100%;
+    height: max(100%, 100px);
     font: normal 12px tahoma, arial, helvetica, sans-serif;
     background-color: #fff;
 }


### PR DESCRIPTION
## Changes in this pull request  
Resolves an issue where part of the WYSIWYG would be unclickable, causing no `focus` to happen and leaving users asking if there is some forcefield or empty element preventing them from clicking to start typing into the field.

Before and after illustration of actual clickable areas.
![Screenshot 2023-03-13 at 16 22 07](https://user-images.githubusercontent.com/279826/224748304-1dd1a571-b108-42d2-8eb3-c84da96578cc.png)
![Screenshot 2023-03-13 at 16 21 49](https://user-images.githubusercontent.com/279826/224748322-c80df1cd-9435-4563-9945-0577bbd502e6.png)


