### PR TITLE
Remove (outdated) recipe implementation of `Kernel::configureContainer()` and `::configureRoutes()` methods

### DIFF
--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -40,11 +40,9 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
-use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Twig\Extra\TwigExtraBundle\TwigExtraBundle;
 
 abstract class Kernel extends SymfonyKernel
@@ -87,35 +85,6 @@ abstract class Kernel extends SymfonyKernel
     public function getLogDir(): string
     {
         return PIMCORE_LOG_DIRECTORY;
-    }
-
-    protected function configureContainer(ContainerConfigurator $container): void
-    {
-        $projectDir = realpath($this->getProjectDir());
-
-        $container->import($projectDir . '/config/{packages}/*.yaml');
-        $container->import($projectDir . '/config/{packages}/'.$this->environment.'/*.yaml');
-
-        if (is_file($projectDir . '/config/services.yaml')) {
-            $container->import($projectDir . '/config/services.yaml');
-            $container->import($projectDir . '/config/{services}_'.$this->environment.'.yaml');
-        } elseif (is_file($path = $projectDir . '/config/services.php')) {
-            (require $path)($container->withPath($path), $this);
-        }
-    }
-
-    protected function configureRoutes(RoutingConfigurator $routes): void
-    {
-        $projectDir = realpath($this->getProjectDir());
-
-        $routes->import($projectDir . '/config/{routes}/'.$this->environment.'/*.yaml');
-        $routes->import($projectDir . '/config/{routes}/*.yaml');
-
-        if (is_file($projectDir . '/config/routes.yaml')) {
-            $routes->import($projectDir . '/config/routes.yaml');
-        } elseif (is_file($path = $projectDir . '/config/routes.php')) {
-            (require $path)($routes->withPath($path), $this);
-        }
     }
 
     /**

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -49,8 +49,9 @@ abstract class Kernel extends SymfonyKernel
 {
     use MicroKernelTrait {
         registerContainerConfiguration as microKernelRegisterContainerConfiguration;
-
         registerBundles as microKernelRegisterBundles;
+        configureContainer as protected;
+        configureRoutes as protected;
     }
 
     private const CONFIG_LOCATION = 'config_location';

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -76,11 +76,7 @@ abstract class Kernel extends SymfonyKernel
      */
     public function getCacheDir(): string
     {
-        if (isset($_SERVER['APP_CACHE_DIR'])) {
-            return $_SERVER['APP_CACHE_DIR'].'/'.$this->environment;
-        }
-
-        return PIMCORE_SYMFONY_CACHE_DIRECTORY . '/' . $this->environment;
+        return ($_SERVER['APP_CACHE_DIR'] ?? PIMCORE_SYMFONY_CACHE_DIRECTORY) . '/' . $this->environment;
     }
 
     /**


### PR DESCRIPTION
Pimcore still uses the [Symfony 5.2 `Kernel` recipe](https://github.com/symfony/recipes/blob/main/symfony/framework-bundle/5.2/src/Kernel.php), which changed a bit in [Symfony 5.3](https://github.com/symfony/recipes/blob/main/symfony/framework-bundle/5.3/src/Kernel.php) and was integrated into the `MicroKernelTrait` in Symfony 5.4 via symfony/symfony#42991.

Since Pimcore 11 only supports Symonfy 6 as a minimum, we can rely on the default implementation (which also has the advantage that it [allows PHP config by default](https://github.com/symfony/symfony/pull/44503), which is the new preferred way of Symfony).

---

Please note that this is a breaking change as [`MicroKernelTrait::configureContainer()` has three parameters](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php#L49) instead of one.