### PR TITLE
[Bug]: Delete user error caused by instatiating AbstractUser class

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -249,7 +249,7 @@ class UserController extends AdminController implements KernelControllerEventInt
      */
     public function deleteAction(Request $request)
     {
-        $user = User\AbstractUser::getById((int)$request->get('id'));
+        $user = User::getById((int)$request->get('id'));
 
         // only admins are allowed to delete admins and folders
         // because a folder might contain an admin user, so it is simply not allowed for users with the "users" permission


### PR DESCRIPTION
Closing for the moment, need to take a deeper look



## Changes in this pull request  
Related https://github.com/pimcore/pimcore/pull/14650 but for 10.5

## Additional info  

![image](https://user-images.githubusercontent.com/6014195/225075583-66c8c248-6ef9-47e7-b5bf-f2b0efb64021.png)

On demo seems working fine, I don't know how to reproduce it but encountered locally when reviewing an openid connect PR, probably my runtime cache is broken or so, but this PR should fix the problem with `new static()`
https://github.com/pimcore/pimcore/blob/671a08bcc2df9afe2a2843ad196fe716c852dbe9/models/User/AbstractUser.php#L61-L64