### PR TITLE
[Ecommerce] Remove deprecated methods check() and exists() from class Reservation

### DIFF
--- a/bundles/EcommerceFrameworkBundle/src/VoucherService/Reservation.php
+++ b/bundles/EcommerceFrameworkBundle/src/VoucherService/Reservation.php
@@ -34,12 +34,6 @@ class Reservation extends AbstractModel
 
     public ?string $cart_id = null;
 
-    /**
-     * @param string $code
-     * @param CartInterface|null $cart
-     *
-     * @return self|null
-     */
     public static function get(string $code, CartInterface $cart = null): ?self
     {
         try {
@@ -51,42 +45,6 @@ class Reservation extends AbstractModel
             //            Logger::debug($ex->getMessage());
             return null;
         }
-    }
-
-    /**
-     * @deprecated
-     *
-     * @return bool
-     */
-    public function exists(): bool
-    {
-        trigger_deprecation(
-            'pimcore/pimcore',
-            '10.2.5',
-            sprintf('%s is deprecated. It will be removed in Pimcore 11.', __METHOD__)
-        );
-
-        return isset($this->id);
-    }
-
-    /**
-     * Check whether the reservation object contains a reservations.
-     *
-     * @param int $cart_id
-     *
-     * @return bool
-     *
-     * @deprecated
-     */
-    public function check(int $cart_id): bool
-    {
-        trigger_deprecation(
-            'pimcore/pimcore',
-            '10.2.5',
-            sprintf('%s is deprecated. It will be removed in Pimcore 11.', __METHOD__)
-        );
-
-        return $cart_id == $this->getCartId();
     }
 
     public static function create(string $code, CartInterface $cart): ?self
@@ -102,12 +60,6 @@ class Reservation extends AbstractModel
         }
     }
 
-    /**
-     * @param string $code
-     * @param CartInterface|null $cart
-     *
-     * @return bool
-     */
     public static function releaseToken(string $code, CartInterface $cart = null): bool
     {
         $db = \Pimcore\Db::get();

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -159,6 +159,7 @@ Please make sure to set your preferred storage location ***before*** migration. 
 - [Ecommerce][IndexService] Please make sure to rebuild your product index to make sure changes apply accordingly (this is relevant for mysql and elasticsearch indices). As an alternative you could manually rename and remove `o_` from all index columns/fields.
 - [Ecommerce] Elasticsearch 7 support was removed
 - [Ecommerce] Config option `es_client_params` in `index_service` was removed 
+- [Ecommerce] Remove deprecated methods `check()` and `exists()` from class `Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\Reservation`
 - [ClassSavedInterface] Removed `method_exists` bc layer. Please add the corresponding `ClassSavedInterface` interface to your custom field definitions. For more details check the 10.6.0 patch notes.
 - [UrlSlug] Allow processing unpublished fallback document is now default behaviour, removed the related configuration options and usages (`allow_processing_unpublished_fallback_document`, `ElementListener::FORCE_ALLOW_PROCESSING_UNPUBLISHED_ELEMENTS`). For details, please see [#10005](https://github.com/pimcore/pimcore/issues/10005#issuecomment-907007745)
 - [DataObjects\Documents] **BC Break**: Calling `getChildren/getSiblings` on `AbstractObject`, `Document` and `Asset` now returns unloaded listing. If the list is not traveresed immediately, then it is required to call `load()` explicitily.


### PR DESCRIPTION
Followup to https://github.com/pimcore/pimcore/pull/10881