### PR TITLE
Fix lowercase table/filename problems

### DIFF
--- a/models/DataObject/Fieldcollection/Definition.php
+++ b/models/DataObject/Fieldcollection/Definition.php
@@ -256,7 +256,9 @@ class Definition extends Model\AbstractModel
      */
     public function getDefinitionFile($key = null)
     {
-        return $this->locateDefinitionFile($key ?? $this->getKey(), 'fieldcollections/%s.php');
+        $definitionFileKey = $key ?? $this->getKey();
+
+        return $this->locateDefinitionFile(strtolower($definitionFileKey), 'fieldcollections/%s.php');
     }
 
     /**

--- a/models/DataObject/Objectbrick/Definition.php
+++ b/models/DataObject/Objectbrick/Definition.php
@@ -597,7 +597,9 @@ class Definition extends Model\DataObject\Fieldcollection\Definition
      */
     public function getDefinitionFile($key = null)
     {
-        return $this->locateDefinitionFile($key ?? $this->getKey(), 'objectbricks/%s.php');
+        $definitionFileKey = $key ?? $this->getKey();
+
+        return $this->locateDefinitionFile(strtolower($definitionFileKey), 'objectbricks/%s.php');
     }
 
     /**


### PR DESCRIPTION
MySQL 8 stores all tables names in lower case by default. ObjectBricks and fieldcollections are created case-sensitiv on the filesystem. The cleanup task uses names from the database, which are lower cased, and tries to find filenames, which are casesensitive.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #10427

## Explanation
The cleanup cronjobs for objectbricks and fieldcollections are using the tablenames from the sql-server (mariadb in my case, but works with mysql) to find the matching definition_{files}  on the filesystem.
On most OS the filename is case-sensitive, and with the default settings for mysql8/mariadb the table names are **case-insensitive**.

## Severity
:warning: currently we are not sure if this maybe considered as breaking change

## How to test
### Requirements
- Use a linux based case-sensitive system
- Use mysql 8 or verify that the setting for `lower_case_table_names` is `1` -> This can be used to show the settings `select @@lower_case_file_system, @@lower_case_table_names;`  
- More information about `lower_case_table_names` in the [Documentation](https://dev.mysql.com/doc/refman/8.0/en/identifier-case-sensitivity.html)

### Steps
- Create a new objectbrick `TestObjectBrick` and add this to dataobject class
- Now a file in `var/classes/objectbricks`-Folder will be created in lowercase
- Run the maintenance cronjob `./bin/console pimcore:maintenance`