### PR TITLE
fix: make two separate error log items a single item

### DIFF
--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -142,8 +142,7 @@ final class Thumbnail
                     $deferred = $deferredAllowed && $this->deferred;
                     $this->pathReference = Thumbnail\Processor::process($this->asset, $this->config, null, $deferred, $generated);
                 } catch (\Exception $e) {
-                    Logger::error("Couldn't create thumbnail of image " . $this->asset->getRealFullPath());
-                    Logger::error($e->getMessage());
+                    Logger::error("Couldn't create thumbnail of image " . $this->asset->getRealFullPath() .': '.$e->getMessage());
                 }
             }
         }


### PR DESCRIPTION
## Changes in this pull request  

Make the two separate error log calls a single call to increase the quality of logs produces by Pimcore.

## Additional info  

Two separate error log items might show up totally separated in the target logging system (think Sentry with separate filters, etc)
