### PR TITLE
[Elements] Do not clear property cache of all objects when saving element

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1088,7 +1088,7 @@ class Asset extends Element\AbstractElement
     public function clearDependentCache($additionalTags = [])
     {
         try {
-            $tags = [$this->getCacheTag(), 'asset_properties', 'output'];
+            $tags = [$this->getCacheTag(), 'asset_properties_'.$this->getId(), 'output'];
             $tags = array_merge($tags, $additionalTags);
 
             Cache::clearTags($tags);

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -976,7 +976,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
         }
 
         try {
-            $tags = ['object_' . $objectId, 'object_properties' . $objectId, 'output'];
+            $tags = ['object_' . $objectId, 'object_properties_' . $objectId, 'output'];
             $tags = array_merge($tags, $additionalTags);
 
             Cache::clearTags($tags);

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -976,7 +976,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
         }
 
         try {
-            $tags = ['object_' . $objectId, 'object_properties', 'output'];
+            $tags = ['object_' . $objectId, 'object_properties' . $objectId, 'output'];
             $tags = array_merge($tags, $additionalTags);
 
             Cache::clearTags($tags);

--- a/models/Document.php
+++ b/models/Document.php
@@ -607,7 +607,7 @@ class Document extends Element\AbstractElement
     public function clearDependentCache($additionalTags = [])
     {
         try {
-            $tags = [$this->getCacheTag(), 'document_properties', 'output'];
+            $tags = [$this->getCacheTag(), 'document_properties_'.$this->getId(), 'output'];
             $tags = array_merge($tags, $additionalTags);
 
             \Pimcore\Cache::clearTags($tags);


### PR DESCRIPTION
In https://github.com/pimcore/pimcore/blob/06d8323afeb46b04f9100999334099ed9426b99d/models/Element/AbstractElement.php#L239-L246 an element's properties get cached.

But in https://github.com/pimcore/pimcore/blob/06d8323afeb46b04f9100999334099ed9426b99d/models/DataObject/AbstractObject.php#L778-L781 the cache tag `object_properties` gets deleted. This will remove ALL `object_properties_<id>` entries from cache. 

Same for the documents and assets.

This PR changes this behaviour to only delete the cache items of the just saved element.

Beside this I wonder if caching the properties separately actually makes sense. Aren't they stored in the `<element type>_<element id>` cache entry anyway?