### PR TITLE
[Cache] Remove unused dynamic property ____pimcore_cache_item__

### DIFF
--- a/lib/Cache/Core/CoreCacheHandler.php
+++ b/lib/Cache/Core/CoreCacheHandler.php
@@ -270,10 +270,6 @@ class CoreCacheHandler implements LoggerAwareInterface
         if ($item->isHit()) {
             $data = $item->get();
 
-            if (is_object($data)) {
-                $data->____pimcore_cache_item__ = $key; // TODO where is this used?
-            }
-
             return $data;
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Setting dynamic property `____pimcore_cache_item__` in CoreCacheHandler for some objects throws exception on php 8.2 (in theory, it should only trigger deprecation as per https://php.watch/versions/8.2/dynamic-properties-deprecated

We are not even using this property anywhere so removal should be fine.

## Additional info  

