### PR TITLE
Use spaceship operator in PositionSortTrait

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Extension/PositionSortTrait.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/PositionSortTrait.php
@@ -21,10 +21,16 @@ namespace Pimcore\Model\DataObject\ClassDefinition\Data\Extension;
  */
 trait PositionSortTrait
 {
+    /**
+     * @param array|string|null $a If of type array must have key `position` with numeric value
+     * @param array|string|null $b If of type array must have key `position` with numeric value
+     *
+     * @return int Any of -1, 0, 1
+     */
     protected function sort(array|string|null $a, array|string|null $b): int
     {
         if (is_array($a) && is_array($b)) {
-            return $a['position'] - $b['position'];
+            return $a['position'] <=> $b['position'];
         }
         if (is_string($a) && is_string($b)) {
             return strcmp($a, $b);

--- a/models/DataObject/ClassDefinition/Data/Extension/PositionSortTrait.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/PositionSortTrait.php
@@ -22,10 +22,10 @@ namespace Pimcore\Model\DataObject\ClassDefinition\Data\Extension;
 trait PositionSortTrait
 {
     /**
-     * @param array|string|null $a If of type array must have key `position` with numeric value
-     * @param array|string|null $b If of type array must have key `position` with numeric value
+     * @param array{position: int|string}|string|null $a If of type array must have key `position` with numeric value
+     * @param array{position: int|string}|string|null $b If of type array must have key `position` with numeric value
      *
-     * @return int Any of -1, 0, 1
+     * @return -1|0|1
      */
     protected function sort(array|string|null $a, array|string|null $b): int
     {


### PR DESCRIPTION
## Changes in this pull request  
Proper use of spaceship operator for sorting callback.

## Additional info  
Should not have any meaningful effect on which order items end up since this is just to guarantee that it is `-1`, `0`, or `1` which sorting functions generally expects.
```php
print_r(1 <=> 5); // Returns -1
print_r(1 - 5); // Returns -4
```