### PR TITLE
[Bug] Fixed log detail window

### DIFF
--- a/bundles/ApplicationLoggerBundle/public/js/log/admin.js
+++ b/bundles/ApplicationLoggerBundle/public/js/log/admin.js
@@ -249,7 +249,7 @@ pimcore.bundle.applicationlogger.log.admin = Class.create({
 
                 listeners: {
                     rowdblclick : function(grid, record, tr, rowIndex, e, eOpts ) {
-                        new pimcore.log.detailwindow(this.store.getAt(rowIndex).data);
+                        new pimcore.bundle.applicationlogger.log.detailwindow(this.store.getAt(rowIndex).data);
                     }.bind(this)
                 },
 


### PR DESCRIPTION
Detail window for application logger logs wasn´t working after extracting the app logger into a separate bundle.