### PR TITLE
[Security]: Admin Translation `Edit as HTML` and wyiswyg inline issue

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/translationEditor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/translationEditor.js
@@ -29,7 +29,7 @@ pimcore.settings.translation.editor = Class.create({
         if (editorType === 'wysiwyg') {
             this.editableDivId = "translationeditor_" + uniqid();
 
-            var html = '<div class="pimcore_editable_wysiwyg" id="' + this.editableDivId + '" contenteditable="true">' + value + '</div>';
+            var html = '<div class="pimcore_editable_wysiwyg" id="' + this.editableDivId + '" contenteditable="true"></div>';
             var pConf = {
                 html: html,
                 border: true,
@@ -186,6 +186,7 @@ pimcore.settings.translation.editor = Class.create({
 
         try {
             this.ckeditor = CKEDITOR.inline(this.editableDivId, eConfig);
+            this.ckeditor.setData(this.field.getValue());
 
             // disable URL field in image dialog
             this.ckeditor.on("dialogShow", function (e) {


### PR DESCRIPTION
Should be something mild, as it's something restricted to logged-in admins

### To reproduce

- Go to `Settings > Admin Translations` 
- Get any empty translation cell, 
- Press `Edit as plain text` ![image](https://user-images.githubusercontent.com/6014195/226889978-e91e7ac5-84eb-4359-9a06-aa037d3f4e4e.png)
- Paste `"><img src=x onerror=alert(document.domain);><b>some text</b>​​​​​​​`
-  It would recognize as HTML and show you only `Edit as HTML` icon, press on it and there would be an alert
