### PR TITLE
allow Back Office order to display actual currency

### DIFF
--- a/bundles/EcommerceFrameworkBundle/OrderManager/Order/Listing.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/Order/Listing.php
@@ -72,6 +72,7 @@ class Listing extends AbstractOrderList implements OrderListInterface
             $queryBuilder = Db::getConnection()->createQueryBuilder();
             $queryBuilder->select(['SQL_CALC_FOUND_ROWS 1', 'order.oo_id AS OrderId']);
             $queryBuilder->from('object_query_' . OnlineShopOrder::classId(), '`order`');
+            $queryBuilder->addSelect(['order.currency AS Currency']);
 
             // join ordered products
             $this->joinItemsAndSubItems($queryBuilder);

--- a/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderAgent.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderAgent.php
@@ -259,9 +259,10 @@ class OrderAgent implements OrderAgentInterface
      */
     public function getCurrency()
     {
-        if($this->getOrder()->getCurrency() !== null) {
+        if ($this->getOrder()->getCurrency() !== null) {
             return new Currency($this->getOrder()->getCurrency());
-        } 
+        }
+
         return $this->environment->getDefaultCurrency();
     }
 

--- a/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderAgent.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderAgent.php
@@ -259,7 +259,10 @@ class OrderAgent implements OrderAgentInterface
      */
     public function getCurrency()
     {
-        return $this->getOrder()->getCurrency() !== null ? new Currency($this->order->getCurrency()) : $this->environment->getDefaultCurrency();
+        if($this->getOrder()->getCurrency() !== null) {
+            return new Currency($this->getOrder()->getCurrency());
+        } 
+        return $this->environment->getDefaultCurrency();
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderAgent.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderAgent.php
@@ -257,9 +257,9 @@ class OrderAgent implements OrderAgentInterface
     /**
      * @return Currency
      */
-    public function getCurrency()
+    public function getCurrency(): Currency
     {
-        return $this->environment->getDefaultCurrency();
+        return $this->getOrder()?->getCurrency() !== null ? new Currency($this->order->getCurrency()) : $this->environment->getDefaultCurrency();
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderAgent.php
+++ b/bundles/EcommerceFrameworkBundle/OrderManager/V7/OrderAgent.php
@@ -257,9 +257,9 @@ class OrderAgent implements OrderAgentInterface
     /**
      * @return Currency
      */
-    public function getCurrency(): Currency
+    public function getCurrency()
     {
-        return $this->getOrder()?->getCurrency() !== null ? new Currency($this->order->getCurrency()) : $this->environment->getDefaultCurrency();
+        return $this->getOrder()->getCurrency() !== null ? new Currency($this->order->getCurrency()) : $this->environment->getDefaultCurrency();
     }
 
     /**

--- a/bundles/EcommerceFrameworkBundle/Resources/views/admin_order/list.html.twig
+++ b/bundles/EcommerceFrameworkBundle/Resources/views/admin_order/list.html.twig
@@ -85,6 +85,7 @@
 
         {% for item in paginator.items %}
             {% set totalSum = totalSum + item['TotalPrice'] %}
+            {% set totalSums = totalSums|merge({(item['Currency']): ((totalSums[item['Currency']] is defined ? totalSums[item['Currency']] : 0) + item['TotalPrice'])}) %}
 
         <tr>
             <td>
@@ -103,17 +104,19 @@
             </td>
             <td>{{ item['Items'] }}</td>
             </td>
-            <td class="text-right">{{ formatter.formatCurrency(item['TotalPrice'], defaultCurrency.getShortName()) }}</td>
+            <td class="text-right">{{ formatter.formatCurrency(item['TotalPrice'], currency) }}</td>
         </tr>
         {% endfor %}
         </tbody>
         <tfoot>
-        <tr>
-            <td colspan="3"></td>
-            <td class="text-right">
-                <strong>{{ defaultCurrency.toCurrency(totalSum) }}</strong>
-            </td>
-        </tr>
+        {% for currency, totalSum in totalSums %}
+            <tr>
+                <td colspan="3"></td>
+                <td class="text-right">
+                    <strong>{{ formatter.formatCurrency(totalSum, currency) }}</strong>
+                </td>
+            </tr>
+        {% endfor %}
         </tfoot>
     </table>
 

--- a/bundles/EcommerceFrameworkBundle/Resources/views/admin_order/list.html.twig
+++ b/bundles/EcommerceFrameworkBundle/Resources/views/admin_order/list.html.twig
@@ -81,7 +81,7 @@
         </tr>
         </thead>
         <tbody>
-
+        {% set totalSums = {(defaultCurrency.getShortName()): 0} %}
         {% for item in paginator.items %}
             {% set totalSums = totalSums|merge({(item['Currency']): ((totalSums[item['Currency']] is defined ? totalSums[item['Currency']] : 0) + item['TotalPrice'])}) %}
 

--- a/bundles/EcommerceFrameworkBundle/Resources/views/admin_order/list.html.twig
+++ b/bundles/EcommerceFrameworkBundle/Resources/views/admin_order/list.html.twig
@@ -81,7 +81,7 @@
         </tr>
         </thead>
         <tbody>
-        {% set totalSums = {(defaultCurrency.getShortName()): 0} %}
+        {% set totalSums = {} %}
         {% for item in paginator.items %}
             {% set totalSums = totalSums|merge({(item['Currency']): ((totalSums[item['Currency']] is defined ? totalSums[item['Currency']] : 0) + item['TotalPrice'])}) %}
 
@@ -101,20 +101,29 @@
                 {{ formatter.formatDateTime(date, constant('\\Pimcore\\Localization\\IntlFormatter::DATETIME_MEDIUM')) }}
             </td>
             <td>{{ item['Items'] }}</td>
-            </td>
             <td class="text-right">{{ formatter.formatCurrency(item['TotalPrice'], item['Currency']) }}</td>
         </tr>
         {% endfor %}
         </tbody>
         <tfoot>
-        {% for currency, totalSum in totalSums %}
-            <tr>
-                <td colspan="3"></td>
-                <td class="text-right">
+        {% if totalSums|length == 0  %}
+            {% set totalSums = {(defaultCurrency.getShortName()): 0} %}
+        {% endif %}
+        <tr>
+            <td colspan="1">
+                {% if totalSums|length > 1  %}
+                    <strong>
+                        {{ 'bundle_ecommerce.back-office.order.price.total'|trans([],'admin') }}
+                    </strong>
+                {% endif %}
+            </td>
+            <td colspan="3" class="text-right">
+                {% for currency, totalSum in totalSums %}
                     <strong>{{ formatter.formatCurrency(totalSum, currency) }}</strong>
-                </td>
-            </tr>
-        {% endfor %}
+                    {% if not loop.last %} | {% endif %}
+                {% endfor %}
+            </td>
+        </tr>
         </tfoot>
     </table>
 

--- a/bundles/EcommerceFrameworkBundle/Resources/views/admin_order/list.html.twig
+++ b/bundles/EcommerceFrameworkBundle/Resources/views/admin_order/list.html.twig
@@ -81,10 +81,8 @@
         </tr>
         </thead>
         <tbody>
-        {% set totalSum = 0 %}
 
         {% for item in paginator.items %}
-            {% set totalSum = totalSum + item['TotalPrice'] %}
             {% set totalSums = totalSums|merge({(item['Currency']): ((totalSums[item['Currency']] is defined ? totalSums[item['Currency']] : 0) + item['TotalPrice'])}) %}
 
         <tr>

--- a/bundles/EcommerceFrameworkBundle/Resources/views/admin_order/list.html.twig
+++ b/bundles/EcommerceFrameworkBundle/Resources/views/admin_order/list.html.twig
@@ -102,7 +102,7 @@
             </td>
             <td>{{ item['Items'] }}</td>
             </td>
-            <td class="text-right">{{ formatter.formatCurrency(item['TotalPrice'], currency) }}</td>
+            <td class="text-right">{{ formatter.formatCurrency(item['TotalPrice'], item['Currency']) }}</td>
         </tr>
         {% endfor %}
         </tbody>

--- a/bundles/EcommerceFrameworkBundle/Resources/views/admin_order/list.html.twig
+++ b/bundles/EcommerceFrameworkBundle/Resources/views/admin_order/list.html.twig
@@ -81,10 +81,7 @@
         </tr>
         </thead>
         <tbody>
-        {% set totalSums = {} %}
         {% for item in paginator.items %}
-            {% set totalSums = totalSums|merge({(item['Currency']): ((totalSums[item['Currency']] is defined ? totalSums[item['Currency']] : 0) + item['TotalPrice'])}) %}
-
         <tr>
             <td>
                 {% set urlDetail = path('pimcore_ecommerce_backend_admin-order_detail', {'id' : item['OrderId']}|merge(urlParams)) %}
@@ -105,26 +102,6 @@
         </tr>
         {% endfor %}
         </tbody>
-        <tfoot>
-        {% if totalSums|length == 0  %}
-            {% set totalSums = {(defaultCurrency.getShortName()): 0} %}
-        {% endif %}
-        <tr>
-            <td colspan="1">
-                {% if totalSums|length > 1  %}
-                    <strong>
-                        {{ 'bundle_ecommerce.back-office.order.price.total'|trans([],'admin') }}
-                    </strong>
-                {% endif %}
-            </td>
-            <td colspan="3" class="text-right">
-                {% for currency, totalSum in totalSums %}
-                    <strong>{{ formatter.formatCurrency(totalSum, currency) }}</strong>
-                    {% if not loop.last %} | {% endif %}
-                {% endfor %}
-            </td>
-        </tr>
-        </tfoot>
     </table>
 
     {% if paginator.getPaginationData().pageCount > 1 %}


### PR DESCRIPTION
allow Back Office order to display actual currency instead of default currency.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [X] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ~] Features need to be proper documented in `doc/` 
- [~] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [X] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #6984

## Additional info  
Prioritises the orders currency over the default currency.
