### PR TITLE
Remove px in width of video editable progress image

### DIFF
--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -1047,7 +1047,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
                 }
             </style>
             <div class="pimcore_editable_video_progress" id="' . $uid . '">
-                <img src="' . $thumbnail . '" style="width: ' . $this->getWidth() . 'px; height: ' . $this->getHeight() . 'px;">
+                <img src="' . $thumbnail . '" style="width: ' . $this->getWidth() . '; height: ' . $this->getHeight() . 'px;">
                 <div class="pimcore_editable_video_progress_status"></div>
             </div>
         </div>';

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -1047,7 +1047,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
                 }
             </style>
             <div class="pimcore_editable_video_progress" id="' . $uid . '">
-                <img src="' . $thumbnail . '" style="width: ' . $this->getWidth() . '; height: ' . $this->getHeight() . 'px;">
+                <img src="' . $thumbnail . '" style="width: ' . $this->getWidth() . '; height: ' . $this->getHeight() . ';">
                 <div class="pimcore_editable_video_progress_status"></div>
             </div>
         </div>';


### PR DESCRIPTION
Because it'll result in 100%px otherwise as getWidth() function does return 100%:

![video-100-percent-px](https://user-images.githubusercontent.com/2771909/226948564-bb8dbb59-1924-4941-9871-a607588a836c.png)

  

## Changes in this pull request  
Does remove 100%px result in video progress html

## Additional info  

