### PR TITLE
If low_quality_image_preview is not enabled, prevent further executio…

### DIFF
--- a/lib/Maintenance/Tasks/LowQualityImagePreviewTask.php
+++ b/lib/Maintenance/Tasks/LowQualityImagePreviewTask.php
@@ -50,6 +50,10 @@ class LowQualityImagePreviewTask implements TaskInterface
      */
     public function execute()
     {
+        $isLowQualityPreviewEnabled = \Pimcore::getContainer()->getParameter('pimcore.config')['assets']['image']['low_quality_image_preview']['enabled'];
+        if (!$isLowQualityPreviewEnabled) {
+            return;
+        }
         if (date('H') <= 4 && $this->lock->acquire()) {
             // execution should be only sometime between 0:00 and 4:59 -> less load expected
             $this->logger->debug('Execute low quality image preview generation');


### PR DESCRIPTION
even If the low_quality_image_preview option is disabled, the task loads all the image assets and loop through them in order to generate
```
foreach ($images as $image) {
    if (!$image->getLowQualityPreviewDataUri()) {
        try {
            $this->logger->debug(sprintf('Generate LQIP for asset %s', $image->getId()));
            $image->generateLowQualityPreview();
        } catch (\Exception $e) {
            $this->logger->error((string) $e);
        }
    }
}
```
and do the check only in `generateLowQualityPreview` method in `models/Asset/Image.php`               
```
public function generateLowQualityPreview($generator = null)
{
    if (!$this->isLowQualityPreviewEnabled()) {
        return false;
    }
    ....
}
```
we can optimise it, by checking this option from the very begining
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
If low_quality_image_preview is not enabled, prevent further execution of the task and avoid unnecessary calls to database

## Additional info  

