### PR TITLE
[Messenger] Support handling failed maintenance jobs

### DIFF
--- a/bundles/CoreBundle/Command/SearchBackendReindexCommand.php
+++ b/bundles/CoreBundle/Command/SearchBackendReindexCommand.php
@@ -21,6 +21,7 @@ use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Element\Service;
 use Pimcore\Model\Search;
+use Pimcore\Model\Version;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -77,8 +78,9 @@ class SearchBackendReindexCommand extends AbstractCommand
                 foreach ($elements as $element) {
                     try {
                         //process page count, if not exists
-                        if ($element instanceof Asset\Document && $element->getCustomSetting('document_page_count')) {
+                        if ($element instanceof Asset\Document && !$element->getCustomSetting('document_page_count')) {
                             $element->processPageCount();
+                            $this->saveAsset($element);
                         }
 
                         $searchEntry = Search\Backend\Data::getForElement($element);
@@ -100,5 +102,13 @@ class SearchBackendReindexCommand extends AbstractCommand
         $db->executeQuery('OPTIMIZE TABLE search_backend_data;');
 
         return 0;
+    }
+
+    private function saveAsset(Asset $asset)
+    {
+        Version::disable();
+        $asset->markFieldDirty('modificationDate'); // prevent modificationDate from being changed
+        $asset->save();
+        Version::enable();
     }
 }

--- a/bundles/CoreBundle/Resources/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yaml
@@ -32,18 +32,10 @@ framework:
             main: native://default
             pimcore_newsletter: native://default
     messenger:
-        failure_transport: pimcore_failed_jobs
         transports:
             pimcore_core: "doctrine://default?queue_name=pimcore_core"
             pimcore_maintenance: "doctrine://default?queue_name=pimcore_maintenance"
             pimcore_image_optimize: "doctrine://default?queue_name=pimcore_image_optimize"
-            pimcore_failed_jobs:
-                dsn: "doctrine://default?queue_name=pimcore_failed_jobs"
-                retry_strategy:
-                    max_retries: 5
-                    delay: 1000
-                    multiplier: 2
-
         routing:
             'Pimcore\Messenger\SendNewsletterMessage': pimcore_core
             'Pimcore\Messenger\VideoConvertMessage': pimcore_core

--- a/bundles/CoreBundle/Resources/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yaml
@@ -32,10 +32,18 @@ framework:
             main: native://default
             pimcore_newsletter: native://default
     messenger:
+        failure_transport: pimcore_failed_jobs
         transports:
             pimcore_core: "doctrine://default?queue_name=pimcore_core"
             pimcore_maintenance: "doctrine://default?queue_name=pimcore_maintenance"
             pimcore_image_optimize: "doctrine://default?queue_name=pimcore_image_optimize"
+            pimcore_failed_jobs:
+                dsn: "doctrine://default?queue_name=pimcore_failed_jobs"
+                retry_strategy:
+                    max_retries: 5
+                    delay: 1000
+                    multiplier: 2
+
         routing:
             'Pimcore\Messenger\SendNewsletterMessage': pimcore_core
             'Pimcore\Messenger\VideoConvertMessage': pimcore_core

--- a/doc/Development_Documentation/01_Getting_Started/00_Installation.md
+++ b/doc/Development_Documentation/01_Getting_Started/00_Installation.md
@@ -70,7 +70,7 @@ have a look at the logs as a starting point when debugging installation issues.
 ## 5. Maintenance Cron Job
 
 Maintenance tasks are handled with Symfony Messenger. The `pimcore:maintenance` command will add the maintenance
-messages to the bus and runs them afterwards immediately from the queue. However it's recommended to setup independent
+messages to the bus and runs them afterwards immediately from the queue. However, it is  recommended to set up independent
 workers that process the queues, by running `bin/console messenger:consume pimcore_core pimcore_maintenance pimcore_image_optimize` (using e.g.
 `Supervisor`) and adding `--async` option to the `pimcore:maintenance` command that stops the maintenance command to process
 the queue directly.
@@ -87,6 +87,11 @@ the queue directly.
 ```
 
 Keep in mind, that the cron job has to run as the same user as the web interface to avoid permission issues (eg. `www-data`).
+
+### Handle Failed jobs
+If there are maintenance jobs that are failed in the processing, after defined retries they are moved to `pimcore_failed_jobs`
+transports. You can process the failed jobs again by fixing the underlying issue with command `bin/console messenger:consume pimcore_failed_jobs`.
+Please follow the [Symfony docs](https://symfony.com/doc/current/messenger.html#saving-retrying-failed-messages) for options on failed jobs processing.
 
 ## 6. Additional Information & Help
 

--- a/doc/Development_Documentation/01_Getting_Started/00_Installation.md
+++ b/doc/Development_Documentation/01_Getting_Started/00_Installation.md
@@ -89,8 +89,21 @@ the queue directly.
 Keep in mind, that the cron job has to run as the same user as the web interface to avoid permission issues (eg. `www-data`).
 
 ### Handle Failed jobs
-If there are maintenance jobs that are failed in the processing, after defined retries they are moved to `pimcore_failed_jobs`
-transports. You can process the failed jobs again by fixing the underlying issue with command `bin/console messenger:consume pimcore_failed_jobs`.
+If there are maintenance jobs that are failed in the processing, after defined retries they are discarded from the respective transport. 
+However, you can move the failed jobs to a new transport e.g. `pimcore_failed_jobs` instead of discarding them completely, with following config:
+```yaml
+framework:
+    messenger:
+        transports:
+            pimcore_failed_jobs:
+                dsn: "doctrine://default?queue_name=pimcore_failed_jobs&table_name=messenger_messages_pimcore_failed"
+
+            pimcore_core:
+                dsn: "doctrine://default?queue_name=pimcore_core"
+                failure_transport: pimcore_failed_jobs
+```
+which can be re-processed later after fixing the underlying issue with command `bin/console messenger:consume pimcore_failed_jobs`.
+
 Please follow the [Symfony docs](https://symfony.com/doc/current/messenger.html#saving-retrying-failed-messages) for options on failed jobs processing.
 
 ## 6. Additional Information & Help

--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -61,7 +61,7 @@ class AssetUpdateTasksHandler
         $pageCount = $asset->getCustomSetting('document_page_count');
         if (!$pageCount || $pageCount === 'failed') {
             $asset->processPageCount();
-            if ($asset->getCustomSetting('document_page_count') == 'failed') {
+            if ($asset->getCustomSetting('document_page_count') === 'failed') {
                 throw new \RuntimeException(sprintf('Failed processing page count for document asset %s.', $asset->getId()));
             }
             $this->saveAsset($asset);

--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -61,10 +61,10 @@ class AssetUpdateTasksHandler
         $pageCount = $asset->getCustomSetting('document_page_count');
         if (!$pageCount || $pageCount === 'failed') {
             $asset->processPageCount();
+            $this->saveAsset($asset);
             if ($asset->getCustomSetting('document_page_count') === 'failed') {
                 throw new \RuntimeException(sprintf('Failed processing page count for document asset %s.', $asset->getId()));
             }
-            $this->saveAsset($asset);
         }
 
         $asset->getImageThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->generate(false);

--- a/lib/Messenger/Handler/AssetUpdateTasksHandler.php
+++ b/lib/Messenger/Handler/AssetUpdateTasksHandler.php
@@ -61,6 +61,9 @@ class AssetUpdateTasksHandler
         $pageCount = $asset->getCustomSetting('document_page_count');
         if (!$pageCount || $pageCount === 'failed') {
             $asset->processPageCount();
+            if ($asset->getCustomSetting('document_page_count') == 'failed') {
+                throw new \RuntimeException(sprintf('Failed processing page count for document asset %s.', $asset->getId()));
+            }
             $this->saveAsset($asset);
         }
 

--- a/models/Asset/Document.php
+++ b/models/Asset/Document.php
@@ -96,8 +96,8 @@ class Document extends Model\Asset
             return new Document\ImageThumbnail(null);
         }
 
-        $pageCount = $this->getCustomSetting('document_page_count');
-        if (!$pageCount || $pageCount === 'failed') {
+        if (!$this->getCustomSetting('document_page_count')) {
+            Logger::info('Image thumbnail not yet available, processing is done asynchronously.');
             $this->addToUpdateTaskQueue();
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #14686

## Additional info  
Run command `bin/console messenger:consume pimcore_failed_jobs` to reprocess failed jobs from the default queue.
