### PR TITLE
removeUnusedColumns should execute only one sql query

### DIFF
--- a/models/DataObject/ClassDefinition/Helper/Dao.php
+++ b/models/DataObject/ClassDefinition/Helper/Dao.php
@@ -135,8 +135,10 @@ trait Dao
                     $dropColumns[] = 'DROP COLUMN `' . $value . '`';
                 }
             }
-            $this->db->executeQuery('ALTER TABLE `' . $table . '` ' . implode(', ', $dropColumns) . ';');
-            $this->resetValidTableColumnsCache($table);
+            if ($dropColumns) {
+                $this->db->executeQuery('ALTER TABLE `' . $table . '` ' . implode(', ', $dropColumns) . ';');
+                $this->resetValidTableColumnsCache($table);
+            }
         }
     }
 

--- a/models/DataObject/ClassDefinition/Helper/Dao.php
+++ b/models/DataObject/ClassDefinition/Helper/Dao.php
@@ -128,12 +128,14 @@ trait Dao
     protected function removeUnusedColumns($table, $columnsToRemove, $protectedColumns)
     {
         if (is_array($columnsToRemove) && count($columnsToRemove) > 0) {
+            $dropColumns = [];
             foreach ($columnsToRemove as $value) {
                 //if (!in_array($value, $protectedColumns)) {
                 if (!in_array(strtolower($value), array_map('strtolower', $protectedColumns))) {
-                    $this->db->executeQuery('ALTER TABLE `' . $table . '` DROP COLUMN `' . $value . '`;');
+                    $dropColumns[] = 'DROP COLUMN `' . $value . '`';
                 }
             }
+            $this->db->executeQuery('ALTER TABLE `' . $table . '` ' . implode(', ', $dropColumns) . ';');
             $this->resetValidTableColumnsCache($table);
         }
     }


### PR DESCRIPTION
I get errors with a class with many color fields:
```
Syntax error or access violation: 1118 Row size too large. The maximum row size for the used table type, not counting BLOBs, is 8126. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs
```

So I want to split it in object bricks. But when Pimcore try to remove the field column with the `ALTER TABLE ... DROP COLUMN ..`, I get the error also.

When Pimcore drop the columns with one query it works.