### PR TITLE
Add missing `cache.end()` call in the performance docs

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/09_Performance_Guide.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/03_System_Setup_and_Hosting/09_Performance_Guide.md
@@ -381,7 +381,7 @@ You can cache part of a template like:
         {% set navStartNode = pimcore_document(1) %}
     {% endif %}
 
-    {% set mainNavigation =  app_navigation_data_links(document, navStartNode) %}
+    {% set mainNavigation = app_navigation_data_links(document, navStartNode) %}
     <div class="container">
         ...
         {{
@@ -396,6 +396,7 @@ You can cache part of a template like:
         }}
         ...
     </div>
+    {% do cache.end() %}
 {% endif %}
 ```
 


### PR DESCRIPTION
According to the [twig cache docs](https://pimcore.com/docs/pimcore/current/Development_Documentation/MVC/Template/Template_Extensions/index.html#page_section_4) you need to call `{% do cache.end() %}` at the end of the `if`-block, which is missing in the performance guide.