### PR TITLE
[ClassDefinition/CustomLayout] Disallow remove if definitions are not writeable

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/class.js
@@ -208,7 +208,8 @@ pimcore.object.klass = Class.create({
         menu.add(new Ext.menu.Item({
             text: t('delete'),
             iconCls: "pimcore_icon_class pimcore_icon_overlay_delete",
-            handler: this.deleteClass.bind(this, tree, record)
+            handler: this.deleteClass.bind(this, tree, record),
+            disabled: !pimcore.settings['class-definition-writeable']
         }));
 
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/customLayoutEditor.js
@@ -291,9 +291,9 @@ pimcore.object.helpers.customLayoutEditor = Class.create({
                     xtype: "button",
                     text: t("delete_layout"),
                     iconCls: "pimcore_icon_delete",
-                    disabled: false,
                     handler: this.deleteLayout.bind(this),
-                    hidden: typeof this.klass.id === 'undefined'
+                    hidden: typeof this.klass.id === 'undefined',
+                    disabled: !pimcore.settings['class-definition-writeable']
                 }
             ]
         };

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -571,6 +571,9 @@ final class ClassDefinition extends Model\AbstractModel
         return $cd;
     }
 
+    /**
+     * @throws Exception\DefinitionWriteException
+     */
     public function delete()
     {
         if (!$this->isWritable()) {

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -573,6 +573,9 @@ final class ClassDefinition extends Model\AbstractModel
 
     public function delete()
     {
+        if (!$this->isWritable()) {
+            throw new DataObject\Exception\DefinitionWriteException();
+        }
         $this->dispatchEvent(new ClassDefinitionEvent($this), DataObjectClassDefinitionEvents::PRE_DELETE);
 
         // delete all objects using this class

--- a/models/DataObject/ClassDefinition/CustomLayout.php
+++ b/models/DataObject/ClassDefinition/CustomLayout.php
@@ -359,6 +359,9 @@ class CustomLayout extends Model\AbstractModel
         }
     }
 
+    /**
+     * @throws DataObject\Exception\DefinitionWriteException
+     */
     public function delete()
     {
         if (!$this->isWritable()) {

--- a/models/DataObject/ClassDefinition/CustomLayout.php
+++ b/models/DataObject/ClassDefinition/CustomLayout.php
@@ -361,6 +361,10 @@ class CustomLayout extends Model\AbstractModel
 
     public function delete()
     {
+        if (!$this->isWritable()) {
+            throw new DataObject\Exception\DefinitionWriteException();
+        }
+
         // empty object cache
         try {
             Cache::clearTag('customlayout_' . $this->getId());


### PR DESCRIPTION
It shouldn't be possible to delete a class if the class is not writeable. Only add/save is protected.