### PR TITLE
[CustomLayout] Use object-custom-layout-writeable setting for delete button

### DIFF
--- a/bundles/AdminBundle/public/js/pimcore/object/helpers/customLayoutEditor.js
+++ b/bundles/AdminBundle/public/js/pimcore/object/helpers/customLayoutEditor.js
@@ -296,7 +296,7 @@ pimcore.object.helpers.customLayoutEditor = Class.create({
                     iconCls: "pimcore_icon_delete",
                     handler: this.deleteLayout.bind(this),
                     hidden: typeof this.klass.id === 'undefined',
-                    disabled: !pimcore.settings['class-definition-writeable']
+                    disabled: !pimcore.settings['object-custom-layout-writeable']
                 }
             ]
         };

--- a/bundles/SimpleBackendSearchBundle/src/Command/SearchBackendReindexCommand.php
+++ b/bundles/SimpleBackendSearchBundle/src/Command/SearchBackendReindexCommand.php
@@ -105,7 +105,7 @@ class SearchBackendReindexCommand extends AbstractCommand
         return 0;
     }
 
-    private function saveAsset(Asset $asset)
+    private function saveAsset(Asset $asset): void
     {
         Version::disable();
         $asset->markFieldDirty('modificationDate'); // prevent modificationDate from being changed

--- a/models/DataObject/ClassDefinition/CustomLayout.php
+++ b/models/DataObject/ClassDefinition/CustomLayout.php
@@ -246,7 +246,7 @@ class CustomLayout extends Model\AbstractModel
      */
     public function delete(): void
     {
-        if (!$this->isWritable()) {
+        if (!$this->isWriteable()) {
             throw new DataObject\Exception\DefinitionWriteException();
         }
 


### PR DESCRIPTION
Followup to https://github.com/pimcore/pimcore/pull/14782 for branch 11.x

The setting was changed here https://github.com/pimcore/pimcore/pull/12779

The method isWritable was also changed to isWriteable