### PR TITLE
explicitly set flysystem permissions as octal

### DIFF
--- a/bundles/CoreBundle/Resources/config/pimcore/flysystem.yaml
+++ b/bundles/CoreBundle/Resources/config/pimcore/flysystem.yaml
@@ -21,9 +21,9 @@ flysystem:
                 directory: '%kernel.project_dir%/public/var/assets'
                 permissions:
                     file:
-                        private: 0644
+                        private: 0o644
                     dir:
-                        private: 0755
+                        private: 0o755
         pimcore.asset_cache.storage:
             # Storage for cached asset files, e.g. PDF and image files generated out of Office files or videos
             # which are then used by the thumbnail engine as source files
@@ -39,9 +39,9 @@ flysystem:
                 directory: '%kernel.project_dir%/public/var/tmp/thumbnails'
                 permissions:
                     file:
-                        private: 0644
+                        private: 0o644
                     dir:
-                        private: 0755
+                        private: 0o755
         pimcore.version.storage:
             # Storage for serialized versioning data of documents/asset/data objects
             adapter: 'local'


### PR DESCRIPTION
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [x] Meet all coding standards (see PhpStan actions) 

## Changes in this pull request  
Resolves: -

## Additional info  
`symfony/yaml:5.x` complains that file flysystem permissions are implicit octal numbers, and `symfony/yaml:6` will parse them as strings which can result in errors. Therefore this PR sets permissions explicitly as octal
