### PR TITLE
fix: fixed checking variable if is array and array key exists

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -1268,7 +1268,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
                 $data['key_as_string'] = $bucket['key_as_string'];
             } elseif (is_array($reverseAggregationBucket) && array_key_exists('doc_count', $reverseAggregationBucket)) { // reverse aggregation
                 $data['reverse_count'] = $reverseAggregationBucket['doc_count'];
-            } elseif (is_array($subAggregationBuckets) && array_key_exists('buckets', $subAggregationBuckets)) {         // sub aggregations
+            } elseif (is_array($subAggregationBuckets) && isset($subAggregationBuckets['buckets'])) {         // sub aggregations
                 foreach ($subAggregationBuckets['buckets'] as $bucket) {
                     $data[$subAggregationField][] = $this->convertBucketValues($bucket);
                 }

--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -1268,7 +1268,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
                 $data['key_as_string'] = $bucket['key_as_string'];
             } elseif (is_array($reverseAggregationBucket) && array_key_exists('doc_count', $reverseAggregationBucket)) { // reverse aggregation
                 $data['reverse_count'] = $reverseAggregationBucket['doc_count'];
-            } elseif (is_array($subAggregationBuckets['buckets'])) {        // sub aggregations
+            } elseif (is_array($subAggregationBuckets) && array_key_exists('buckets', $subAggregationBuckets)) {         // sub aggregations
                 foreach ($subAggregationBuckets['buckets'] as $bucket) {
                     $data[$subAggregationField][] = $this->convertBucketValues($bucket);
                 }


### PR DESCRIPTION
Resolves #

The convertBucketValues checks for subAggregationBuckets but it is not checking if we have at least an array and if the array key exists. This could lead to errors if the bucket data is only a single value