### PR TITLE
Ensure leading slashes

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -70,10 +70,16 @@ trait Relation
             if ($classes = $this->getClasses()) {
                 foreach ($classes as $item) {
                     try {
-                        $types[] = $factory->getClassNameFor(sprintf('\Pimcore\Model\DataObject\%s', ucfirst($item['classes'])));
+                        $className = $factory->getClassNameFor(sprintf('\Pimcore\Model\DataObject\%s', ucfirst($item['classes'])));
                     } catch (UnsupportedException) {
                         continue;
                     }
+
+                    if (str_starts_with($className, '\\') === false) {
+                        $className = '\\' . $className;
+                    }
+
+                    $types[] = $className;
                 }
             } else {
                 $types[] = '\\' . AbstractObject::class;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Adding a check if there are leading slashes to ensure correct classes in doc block i.e. for return types

## Additional info  
If you override classes the leading slashes are missing in the doc block of a class. Therefore the return type is not correct as i.e. a class `\Pimcore\Model\DataObject\App\Model\DataObject\Class` does not exist. This happends because the doc block is the following:

```
/**
* Get class - Class
* @return App\Model\DataObject\Class|null
*/
```

but should be

```
/**
* Get class - Class
* @return \App\Model\DataObject\Class|null
*/
```
