### PR TITLE
[Task]: Temporary revert `cbschuld/browser.php` requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     "ext-zip": "*",
     "ext-zlib": "*",
     "ext-curl": "*",
+    "cbschuld/browser.php": "^1.9.6",
     "composer/ca-bundle": "^1.2",
     "composer-runtime-api": "^2.0",
     "defuse/php-encryption": "^2.2.0",


### PR DESCRIPTION
Related https://github.com/pimcore/pimcore/pull/14876
Needs to be removed once the AdminBundle is extracted and removed from repo https://github.com/pimcore/pimcore/issues/12531

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c56153f</samp>

Added the cbschuld/browser.php package as a dependency in `composer.json` to enable browser detection in pimcore. This change is part of a pull request that aims to resolve issue #10312.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c56153f</samp>

> _`composer.json`_
> _Updated for browser.php_
> _A winter feature_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c56153f</samp>

* Add browser detection functionality to pimcore using the cbschuld/browser.php package ([link](https://github.com/pimcore/pimcore/pull/14883/files?diff=unified&w=0#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R46))
