### PR TITLE
[Bug] Fixed loading class during classes rebuild command

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -68,12 +68,14 @@ trait Relation
         // add objects
         if ($this->getObjectsAllowed()) {
             if ($classes = $this->getClasses()) {
+                $classMap = $factory->getClassMap();
                 foreach ($classes as $item) {
-                    try {
-                        $className = $factory->getClassNameFor(sprintf('\Pimcore\Model\DataObject\%s', ucfirst($item['classes'])));
-                    } catch (UnsupportedException) {
-                        continue;
-                    }
+                    /**
+                     * Don´t use the factory method getClassNameFor here, because it will actually load the requested class and this could
+                     * lead to problems during classes-rebuild command.
+                     */
+                    $className = sprintf('Pimcore\Model\DataObject\%s', ucfirst($item['classes']));
+                    $className = $classMap[$className] ?? $className;
 
                     if (str_starts_with($className, '\\') === false) {
                         $className = '\\' . $className;


### PR DESCRIPTION
Follow up to https://github.com/pimcore/pimcore/pull/14407

`getClassNameFor` loads the php class. This can lead to problems during the classes-rebuild command, when a class gets loaded which actually needs to be rebuild due to certain changes in the class.