### PR TITLE
[Task] Added migration to resave `classes`, `fieldCollections`, `objectBricks` and `customLayouts`

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20230412105530.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230412105530.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\Exception\DefinitionWriteException;
+
+final class Version20230412105530 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Rebuild classes, object-bricks, field-collection and custom layouts';
+    }
+
+    /**
+     * @throws DefinitionWriteException
+     */
+    public function up(Schema $schema): void
+    {
+        try {
+            $list = new DataObject\ClassDefinition\Listing();
+            foreach ($list->getClasses() as $class) {
+                $this->write(sprintf('Saving class: %s', $class->getName()));
+                $class->save();
+            }
+
+            $list = new DataObject\Objectbrick\Definition\Listing();
+            foreach ($list->load() as $brickDefinition) {
+                $this->write(sprintf('Saving object brick: %s', $brickDefinition->getKey()));
+                $brickDefinition->save();
+            }
+
+            $list = new DataObject\Fieldcollection\Definition\Listing();
+            foreach ($list->load() as $fc) {
+                $this->write(sprintf('Saving field collection: %s', $fc->getKey()));
+                $fc->save();
+            }
+
+            $list = new DataObject\ClassDefinition\CustomLayout\Listing();
+            foreach ($list->getLayoutDefinitions() as $layout) {
+                $this->write(sprintf('Saving custom layout: %s', $layout->getName()));
+                $layout->save();
+            }
+        } catch (DataObject\Exception\DefinitionWriteException $e) {
+            $this->write(
+                'Could not write class definition file. Please set PIMCORE_CLASS_DEFINITION_WRITABLE env.' . "\n" .
+                sprintf(
+                    'If you already have migrate the definitions you can skip this migration via "php bin/console doctrine:migrations:version --add %s"',
+                    __CLASS__
+                )
+            );
+
+            throw $e;
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->write(sprintf('Please restore your class definition files in %s and run bin/console pimcore:deployment:classes-rebuild manually.', PIMCORE_CLASS_DEFINITION_DIRECTORY));
+    }
+}

--- a/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
+++ b/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
@@ -75,3 +75,9 @@ bin/console pimcore:assets:remove-custom-setting faceCoordinates
 bin/console pimcore:assets:remove-custom-setting disableFocalPointDetection
 bin/console pimcore:assets:remove-custom-setting disableImageFeatureAutoDetection
 ```
+
+### Rebuild classes, objectBricks, fieldCollections and customLayouts
+Make sure you ran the following commands to rebuild the classes, objectBricks, fieldCollections and customLayouts:
+```bash
+bin/console doctrine:migration:exec 'Pimcore\Bundle\CoreBundle\Migrations\Version20230412105530'
+```

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -322,7 +322,6 @@ pimcore:
 - Removed deprecated property `Pimcore\Model\Asset::$types`, use `getTypes()` instead
 - Removed AdminSessionHandler and AdminSessionListener. The session is now handled by Symfony.
 - Methods `Pimcore\Navigation::setDefaultPageType`, `Pimcore\Navigation::getDefaultPageType`, `Pimcore\Navigation\Container::_sort() and `Pimcore\Navigation\Page::_normalizePropertyName()` have been marked as internal.
-- Added a migration to regenerate `classes`, `fieldCollections`, `objectBricks` and `custom layouts`. Make sure to run `bin/console doctrine:migration:exec 'Pimcore\Bundle\CoreBundle\Migrations\Version20230412105530'` when upgrading to Pimcore 11.
 
 ## 10.6.0
 

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -322,6 +322,7 @@ pimcore:
 - Removed deprecated property `Pimcore\Model\Asset::$types`, use `getTypes()` instead
 - Removed AdminSessionHandler and AdminSessionListener. The session is now handled by Symfony.
 - Methods `Pimcore\Navigation::setDefaultPageType`, `Pimcore\Navigation::getDefaultPageType`, `Pimcore\Navigation\Container::_sort() and `Pimcore\Navigation\Page::_normalizePropertyName()` have been marked as internal.
+- Added a migration to regenerate `classes`, `fieldCollections`, `objectBricks` and `custom layouts`. Make sure to run `bin/console doctrine:migration:exec 'Pimcore\Bundle\CoreBundle\Migrations\Version20230412105530'` when upgrading to Pimcore 11.
 
 ## 10.6.0
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #12859

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 421d7c9</samp>

This pull request adds a new migration file `Version20230412105530.php` that rebuilds the data object class definitions in Pimcore. This ensures that the class definitions are consistent with the latest schema and avoid potential errors.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 421d7c9</samp>

> _`Pimcore` classes_
> _Rebuilt by migration file_
> _Autumn of data_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 421d7c9</samp>

* Rebuild data object class definitions to the latest schema ([link](https://github.com/pimcore/pimcore/pull/14903/files?diff=unified&w=0#diff-549e6b61baae1f1fb4c7a0ba546b32ef810a9f007ca37e399c5f516605a7b92bR1-R78))
