### PR TITLE
fix(xliff): process blocks in localized fields in field collections

### DIFF
--- a/lib/Translation/AttributeSet/Attribute.php
+++ b/lib/Translation/AttributeSet/Attribute.php
@@ -31,6 +31,8 @@ class Attribute
 
     const TYPE_BLOCK_IN_LOCALIZED_FIELD = 'blockinlocalizedfield';
 
+    const TYPE_BLOCK_IN_LOCALIZED_FIELD_COLLECTION = 'blockinlocalizedfieldcollection';
+
     const TYPE_FIELD_COLLECTION_LOCALIZED_FIELD = 'localizedfieldcollection';
 
     const TYPE_ELEMENT_KEY = 'key';

--- a/lib/Translation/ExportDataExtractorService/DataExtractor/DataObjectDataExtractor.php
+++ b/lib/Translation/ExportDataExtractorService/DataExtractor/DataObjectDataExtractor.php
@@ -147,7 +147,7 @@ class DataObjectDataExtractor extends AbstractElementDataExtractor
             foreach ($definitions as $definition) {
                 if (!$this->isFieldExportable($object->getClassName(), $definition, $exportAttributes)) {
                     if ($definition->getFieldtype() === Attribute::TYPE_BLOCK) {
-                        $this->addBlocksInLocalizedfields($fd, $definition, $object, $result, $exportAttributes);
+                        $this->addBlocksInLocalizedfields($definition, $object, $result);
                     }
 
                     continue;

--- a/lib/Translation/ImporterService/Importer/DataObjectImporter.php
+++ b/lib/Translation/ImporterService/Importer/DataObjectImporter.php
@@ -83,6 +83,40 @@ class DataObjectImporter extends AbstractElementImporter
             $element->{'set' . $blockName}($blockData, $targetLanguage);
         }
 
+        if ($attribute->getType() === Attribute::TYPE_BLOCK_IN_LOCALIZED_FIELD_COLLECTION) {
+            list($fieldCollectionField, $fieldCollectionItemIndex, $blockName, $blockIndex, $fieldname, $sourceLanguage) = explode(DataObjectDataExtractor::BLOCK_DELIMITER, $attribute->getName());
+
+            /** @var DataObject\Fieldcollection|null $fieldCollection */
+            $fieldCollection = $element->{'get' . $fieldCollectionField}();
+
+            if ($fieldCollection) {
+                $item = $fieldCollection->get((int) $fieldCollectionItemIndex);
+                /** @var DataObject\Localizedfield $localizedFields */
+                if ($item && method_exists($item, 'getLocalizedfields') && ($localizedFields = $item->getLocalizedfields())) {
+                    /** @var array $originalBlockData */
+                    $originalBlockData = $item->{'get' . $blockName}($sourceLanguage);
+                    $originalBlockItem = $originalBlockData[$blockIndex] ?? null;
+                    $originalBlockItemData = $originalBlockItem[$fieldname] ?? null;
+
+                    /** @var array $blockData */
+                    $blockData = $item->{'get' . $blockName}($targetLanguage);
+                    $blockItem = isset($blockData[$blockIndex]) ? $blockData[$blockIndex] : $originalBlockItem;
+
+                    /** @var DataObject\Data\BlockElement $blockItemData */
+                    $blockItemData = !empty($blockData) ? clone $blockItem[$fieldname] : clone $originalBlockItemData;
+
+                    $blockItemData->setLanguage($targetLanguage);
+
+                    $blockItemData->setData($attribute->getContent());
+
+                    $blockItem[$fieldname] = $blockItemData;
+                    $blockData[$blockIndex] = $blockItem;
+
+                    $item->{'set' . $blockName}($blockData, $targetLanguage);
+                }
+            }
+        }
+
         if ($attribute->getType() === Attribute::TYPE_BLOCK) {
             list($blockName, $blockIndex, $dummy, $fieldname) = explode(DataObjectDataExtractor::BLOCK_DELIMITER, $attribute->getName());
             /** @var array $blockData */


### PR DESCRIPTION
## Changes in this pull request  
This PR enhances #4529 in the way, that also localized blocks in field collections are processed in XLIFF export & import.

## Additional info
First I tried to enhance the function addBlocksInLocalizedfields(), but in my opinion it's better for read- & maintainability to add the new function addBlocksInLocalizedFieldCollections(). 

Tested it several times, but I would suggest some additional deeper tests. Just add a block to localizedfields in a field collection and attach e.g. input fields. 
