### PR TITLE
[Folder] Update modification date when saving folder

### DIFF
--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -222,9 +222,10 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
      */
     public function setModificationDate($modificationDate)
     {
-        $this->markFieldDirty('modificationDate');
-
-        $this->modificationDate = (int) $modificationDate;
+        if($this->modificationDate != (int)$modificationDate) {
+            $this->markFieldDirty('modificationDate');
+            $this->modificationDate = (int)$modificationDate;
+        }
 
         return $this;
     }


### PR DESCRIPTION
Steps to reproduce bug:
1. Create data object folder
2. Look at modification date
3. Save folder
4. Reload folder
5. Look at modification date -> is still the same (even if you add properties or really change anything)

The reason is that the modification date are sent from backend UI to https://github.com/pimcore/pimcore/blob/7821f65a897349e64223cc02b9c3e04d740ad9f7/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php#L1562-L1563.
This calls `setModificationDate` and this marks the field as dirty, even if nothing changed:
https://github.com/pimcore/pimcore/blob/7821f65a897349e64223cc02b9c3e04d740ad9f7/models/Element/AbstractElement.php#L223-L230

And as `modificationDate` is dirty then, the following code does not get executed:
https://github.com/pimcore/pimcore/blob/7821f65a897349e64223cc02b9c3e04d740ad9f7/models/Element/AbstractElement.php#L392-L396