### PR TITLE
[Bug]: Color branding for login page not working

### DIFF
--- a/.github/ci/files/config/config.yaml
+++ b/.github/ci/files/config/config.yaml
@@ -4,6 +4,13 @@ imports:
     - { resource: 'local/' }
 
 pimcore:
+    email:
+        sender:
+            name: pimcore
+            email: pimcore@example.com
+        return:
+            name: pimcore
+            email: pimcore@example.com
     config_location:
         image_thumbnails:
             write_target:

--- a/bundles/CoreBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Configuration.php
@@ -210,7 +210,7 @@ final class Configuration implements ConfigurationInterface
                     ->ifString()
                         ->then(fn ($v) => explode(',', $v))
                     ->end()
-                    ->defaultValue(['en'])
+                    ->defaultValue(['en', 'de', 'fr'])
                     ->prototype('scalar')->end()
                 ->end()
                 ->arrayNode('fallback_languages')

--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -567,8 +567,6 @@ class Installer
         if (!$this->skipDatabaseConfig) {
             $writer->writeDbConfig($config);
         }
-
-        $writer->writeSystemConfig();
     }
 
     private function clearKernelCacheDir(KernelInterface $kernel): void

--- a/bundles/InstallBundle/src/SystemConfig/ConfigWriter.php
+++ b/bundles/InstallBundle/src/SystemConfig/ConfigWriter.php
@@ -25,24 +25,10 @@ use Symfony\Component\Yaml\Yaml;
  */
 final class ConfigWriter
 {
-    private const SUBDIRECTORY = 'system_settings';
-
-    private array $defaultConfig = [
-        'pimcore' => [
-            'general' => [
-                'language' => 'en',
-            ],
-        ],
-    ];
-
     protected Filesystem $filesystem;
 
-    public function __construct(array $defaultConfig = null)
+    public function __construct()
     {
-        if (null !== $defaultConfig) {
-            $this->defaultConfig = $defaultConfig;
-        }
-
         $this->filesystem = new Filesystem();
     }
 

--- a/bundles/InstallBundle/src/SystemConfig/ConfigWriter.php
+++ b/bundles/InstallBundle/src/SystemConfig/ConfigWriter.php
@@ -46,49 +46,6 @@ final class ConfigWriter
         $this->filesystem = new Filesystem();
     }
 
-    public function writeSystemConfig(): void
-    {
-        $settings = null;
-
-        // check for an initial configuration template
-        // used eg. by the demo installer
-        $configTemplatePaths = [
-            PIMCORE_CONFIGURATION_DIRECTORY . '/system.template.yaml',
-            PIMCORE_CONFIGURATION_DIRECTORY . '/' . self::SUBDIRECTORY . '/system_settings.yaml',
-        ];
-
-        foreach ($configTemplatePaths as $configTemplatePath) {
-            if (!file_exists($configTemplatePath)) {
-                continue;
-            }
-
-            try {
-                $configTemplateArray = Yaml::parseFile($configTemplatePath);
-
-                if (!is_array($configTemplateArray)) {
-                    continue;
-                }
-
-                if (isset($configTemplateArray['pimcore']['general'])) { // check if the template contains a valid configuration
-                    $settings = $configTemplateArray;
-
-                    break;
-                }
-            } catch (\Exception $e) {
-            }
-        }
-
-        // set default configuration if no template is present
-        if (!$settings) {
-            // write configuration file
-            $settings = $this->defaultConfig;
-        }
-
-        $configFile = \Pimcore\Config::locateConfigFile(self::SUBDIRECTORY . '/system_settings.yaml');
-        $settingsYml = Yaml::dump($settings, 5);
-        $this->filesystem->dumpFile($configFile, $settingsYml);
-    }
-
     public function writeDbConfig(array $config = []): void
     {
         if (count($config)) {

--- a/lib/Cache/Symfony/CacheClearer.php
+++ b/lib/Cache/Symfony/CacheClearer.php
@@ -29,7 +29,7 @@ class CacheClearer
 {
     private int $processTimeout;
 
-    private \Closure $runCallback;
+    private ?\Closure $runCallback = null;
 
     public function __construct(array $options = [])
     {

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -171,7 +171,7 @@ class Mail extends Email
     public function init(string $type = 'email', ?array $config = null): void
     {
         if(empty($config)) {
-            $config = \Pimcore\Bundle\AdminBundle\System\Config::get()['email'];
+            $config = Config::getSystemConfiguration($type);
         }
 
         if (!empty($config['sender']['email']) && empty($this->getFrom())) {

--- a/tests/Support/Helper/AbstractDefinitionHelper.php
+++ b/tests/Support/Helper/AbstractDefinitionHelper.php
@@ -37,59 +37,12 @@ abstract class AbstractDefinitionHelper extends Module
     {
         if ($this->config['initialize_definitions']) {
             if (TestHelper::supportsDbTests()) {
-                $systemSettings = '
-                    {
-                        "general": {
-                            "domain": "pimcore-test.dev",
-                        "redirect_to_maindomain": false,
-                        "language": "en",
-                        "valid_languages": [
-                                "en",
-                                "de",
-                                "fr"
-                            ],
-                        "fallback_languages": {
-                                "en": "",
-                            "de": ""
-                        },
-                        "default_language": "",
-                        "debug_admin_translations": false
-                    },
-                    "documents": {
-                            "versions": {
-                                "days": null,
-                            "steps": 10
-                        },
-                        "error_pages": {
-                                "default": "/error"
-                        }
-                    },
-                    "objects": {
-                            "versions": {
-                                "days": null,
-                            "steps": 10
-                        }
-                    },
-                    "assets": {
-                            "versions": {
-                                "days": null,
-                            "steps": 10
-                        },
-                        "hide_edit_image": false,
-                        "disable_tree_preview": false
-                    },
-                    "email": {
-                            "sender": {
-                                "name": "pimcore",
-                            "email": "pimcore@example.com"
-                        },
-                        "return": {
-                                "name": "pimcore",
-                            "email": "pimcore@example.com"
-                        }
-                    }
-                }';
-                SettingsStore::set('system_settings', $systemSettings, 'string', 'pimcore_system_settings');
+                $path = TestHelper::resolveFilePath('system_settings.json');
+                if (!file_exists($path)) {
+                    throw new \RuntimeException(sprintf('System settings file in %s was not found', $path));
+                }
+                $data = file_get_contents($path);
+                SettingsStore::set('system_settings', $data, 'string', 'pimcore_system_settings');
                 $this->initializeDefinitions();
             } else {
                 $this->debug(sprintf(

--- a/tests/Support/Resources/system_settings.json
+++ b/tests/Support/Resources/system_settings.json
@@ -1,0 +1,41 @@
+{
+  "general": {
+    "domain": "pimcore-test.dev",
+    "redirect_to_maindomain": false,
+    "language": "en",
+    "valid_languages": [
+      "en",
+      "de",
+      "fr"
+    ],
+    "fallback_languages": {
+      "en": "",
+      "de": ""
+    },
+    "default_language": "",
+    "debug_admin_translations": false
+  },
+  "documents": {
+    "versions": {
+      "days": null,
+      "steps": 10
+    },
+    "error_pages": {
+      "default": "/error"
+    }
+  },
+  "objects": {
+    "versions": {
+      "days": null,
+      "steps": 10
+    }
+  },
+  "assets": {
+    "versions": {
+      "days": null,
+      "steps": 10
+    },
+    "hide_edit_image": false,
+    "disable_tree_preview": false
+  }
+}

--- a/tests/Unit/Mail/MailTest.php
+++ b/tests/Unit/Mail/MailTest.php
@@ -17,10 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Tests\Unit\Cache;
 
-use Pimcore\Bundle\AdminBundle\System\Config;
-use Pimcore\Tests\Support\Helper\Pimcore;
 use Pimcore\Tests\Support\Test\TestCase;
-use Pimcore\Version;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Part\TextPart;
 
@@ -84,13 +81,7 @@ class MailTest extends TestCase
      */
     public function testMailInit(): void
     {
-        if (Version::getMajorVersion() >= 11) {
-            $pimcoreModule = $this->getModule('\\'.Pimcore::class);
-            $config = $pimcoreModule->grabService(Config::class);
-            $emailConfig = $config->get()['email'];
-        } else {
-            $emailConfig = \Pimcore\Config::getSystemConfiguration('email');
-        }
+        $emailConfig = \Pimcore\Config::getSystemConfiguration('email');
         $mail = new \Pimcore\Mail();
 
         $this->assertEquals($emailConfig['sender']['email'], $mail->getFrom()[0]->getAddress(), 'From recipient not initialized from system settings');


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Partially Resolves #14911

## Additional info
- Adapt settings store in tests
- Revert mail config and tests - as those are not defined in system settings
- Fix cache clear exception
- Remove writeSystemConfig method from ConfigWriter class

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f0a419c</samp>

This pull request contains two main types of changes: one that moves the system settings from the database to a YAML file for easier management and deployment, and one that updates the test code and the Mail class to use the new system configuration service. It also fixes a bug in the cache clearing process and removes some deprecated and unnecessary code. The affected files are `tests/Unit/Mail/MailTest.php`, `.github/ci/files/config/config.yaml`, `bundles/CoreBundle/src/DependencyInjection/Configuration.php`, `bundles/InstallBundle/src/Installer.php`, `bundles/InstallBundle/src/SystemConfig/ConfigWriter.php`, `lib/Cache/Symfony/CacheClearer.php`, `lib/Mail.php`, `tests/Support/Helper/AbstractDefinitionHelper.php`, and `tests/Support/Resources/system_settings.json`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f0a419c</samp>

> _Oh we're moving the settings from the DB to YAML_
> _It's easier to manage and deploy, so we say farewell_
> _To the old `writeSystemConfig` and the JSON string_
> _Heave away, me hearties, heave away and sing_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f0a419c</samp>

*  Move system settings from database to YAML file for easier management and deployment ([link](https://github.com/pimcore/pimcore/pull/14921/files?diff=unified&w=0#diff-159a57553c090df4264e28ad7cd3df02a4817e814970a81ed2a06c1016f8f008R7-R13), [link](https://github.com/pimcore/pimcore/pull/14921/files?diff=unified&w=0#diff-bab0da2e129502ead20a1f1ac979fd2260c5d4c8da202b6a8fbf1e9d906d4541L213-R213), [link](https://github.com/pimcore/pimcore/pull/14921/files?diff=unified&w=0#diff-4eee5188dd424c74c2215a7595b21d4bde4443e3732f5b86d71484393076c498L570-L571), [link](https://github.com/pimcore/pimcore/pull/14921/files?diff=unified&w=0#diff-34440a166e4d250d9c0ac92dec7f5b1f93d7d2b25a13df8fdfa30ff3eaf95ae6L49-L91), [link](https://github.com/pimcore/pimcore/pull/14921/files?diff=unified&w=0#diff-af129cde6d39fbee4d185929ab1cee286b805bcae215d9aa219ee3a50a28e7f5L174-R174), [link](https://github.com/pimcore/pimcore/pull/14921/files?diff=unified&w=0#diff-381a2870ad3a97e995e14ea3c0f14e81b91017a5b7d8375621f7b6122ef8a86bL87-R84))
* Fix bug where runCallback was not initialized and caused an error when clearing the cache ([link](https://github.com/pimcore/pimcore/pull/14921/files?diff=unified&w=0#diff-77f2fa91256df9a7819884b04d82331cf2c9fd990ebe87b64811a06056580c45L32-R32))
* Improve readability and maintainability of test code by using a separate file for the system settings ([link](https://github.com/pimcore/pimcore/pull/14921/files?diff=unified&w=0#diff-9f37728cdde0c845df4cf1ef12bcfd3d6f84ee99080de4d2b830f9fef3e84ea5L40-R45), [link](https://github.com/pimcore/pimcore/pull/14921/files?diff=unified&w=0#diff-a5744c3c27a7df0293089798d6d9b2b7f2b6362dd9f3338c17c40b0fa4f66b0bL1-R40))
* Remove unused use statements from `MailTest.php` ([link](https://github.com/pimcore/pimcore/pull/14921/files?diff=unified&w=0#diff-381a2870ad3a97e995e14ea3c0f14e81b91017a5b7d8375621f7b6122ef8a86bL20-R20))
