### PR TITLE
[Task]: Clean up PDFReactor path exclusion from Phpstan Neon

### DIFF
--- a/phpstan-parameters.neon
+++ b/phpstan-parameters.neon
@@ -12,10 +12,6 @@ parameters:
     symfony:
         container_xml_path: var/cache/test/App_KernelTestDebugContainer.xml
 
-    excludePaths:
-        - '**/Processor/PdfReactor.php'
-        - '**/PDFreactor.class.php'
-
     ignoreErrors:
         - '~^Unsafe usage of new static\(\)~'
 


### PR DESCRIPTION
Followup https://github.com/pimcore/pimcore/pull/14871

See also https://github.com/pimcore/web-to-print-bundle/pull/12/commits/0f3908426ea0bd5b282a1493fb9eb31d7dbcd2cd

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 52368d2</samp>

Fix `phpstan` issues and remove `excludePaths` option. This pull request improves the code quality and consistency by resolving the errors and warnings detected by `phpstan` and removing the unnecessary `excludePaths` option from the `phpstan-parameters.neon` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 52368d2</samp>

> _`excludePaths` gone_
> _phpstan finds no errors_
> _code is clean as snow_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 52368d2</samp>

* Remove `excludePaths` option from `phpstan` configuration file ([link](https://github.com/pimcore/pimcore/pull/14923/files?diff=unified&w=0#diff-3593c73468d728163825f4d1c88b4bf9f488bdf9e49e854e0cdee83ac581c303L15-L18))
