### PR TITLE
RuntimeCache::clear() does not keep items

### DIFF
--- a/lib/Cache/RuntimeCache.php
+++ b/lib/Cache/RuntimeCache.php
@@ -182,7 +182,6 @@ class RuntimeCache extends \ArrayObject
      */
     public static function clear($keepItems = [])
     {
-        self::$instance = null;
         $newInstance = new self();
         $oldInstance = self::getInstance();
 

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -222,9 +222,10 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
      */
     public function setModificationDate($modificationDate)
     {
-        $this->markFieldDirty('modificationDate');
-
-        $this->modificationDate = (int) $modificationDate;
+        if($this->modificationDate != (int)$modificationDate) {
+            $this->markFieldDirty('modificationDate');
+            $this->modificationDate = (int)$modificationDate;
+        }
 
         return $this;
     }


### PR DESCRIPTION
In https://github.com/pimcore/pimcore/blob/7821f65a897349e64223cc02b9c3e04d740ad9f7/lib/Cache/RuntimeCache.php#L183-L193 `self::$instance` gets set to `null`. This means that `self::getInstance()` will create a new instance and thus `$newInstance` and `$oldInstance` are both new instances - making it impossible to keep items.