### PR TITLE
allow special characters in group name of custom reports

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/item.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/item.js
@@ -902,7 +902,7 @@ pimcore.report.custom.item = Class.create({
         let m = this.getValues();
         let error = false;
 
-        ['group', 'groupIconClass', 'iconClass', 'reportClass'].forEach(function (name) {
+        ['groupIconClass', 'iconClass', 'reportClass'].forEach(function (name) {
             if(m[name].length && !m[name].match(/^[_a-zA-Z]+[_a-zA-Z0-9-.\s]*$/)) {
                 error = name;
             }


### PR DESCRIPTION
With this pull request the filter for the name of group of custom reports will be removed. So it is possible to use nice names as group names.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0309829</samp>

Removed `group` property validation from custom report creation. This fixes issue #10376 and enables more flexible group naming.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0309829</samp>

> _`group` is now free_
> _to break the naming pattern_
> _custom reports bloom_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0309829</samp>

*  Removed `group` property from validation loop to allow more flexible group names for custom reports ([link](https://github.com/pimcore/pimcore/pull/14936/files?diff=unified&w=0#diff-2cdb556a3da7921a316ba6291f39a08d26fe951a9546fb52127543cb0864c396L905-R905))
