### PR TITLE
[Security] Fixed xss in `quantity values` panel

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
@@ -77,7 +77,6 @@ pimcore.object.quantityValue.unitsettings = Class.create({
                     type: 'json',
                     rootProperty: 'data'
                 }
-
             },
             // disable client pagination, default: 25
             pageSize: 0,
@@ -106,9 +105,9 @@ pimcore.object.quantityValue.unitsettings = Class.create({
 
         var typesColumns = [
             {flex: 1, dataIndex: 'id', text: t("id"), filter: 'string'},
-            {flex: 1, dataIndex: 'abbreviation', text: t("abbreviation"), editor: new Ext.form.TextField({}), filter: 'string'},
-            {flex: 2, dataIndex: 'longname', text: t("longname"), editor: new Ext.form.TextField({}), filter: 'string'},
-            {flex: 1, dataIndex: 'group', text: t("group"), editor: new Ext.form.TextField({}), filter: 'string', hidden: true},
+            {flex: 1, dataIndex: 'abbreviation', text: t("abbreviation"), editor: new Ext.form.TextField({listeners: {change: this.sanitizeTextColumn}}), filter: 'string'},
+            {flex: 2, dataIndex: 'longname', text: t("longname"), editor: new Ext.form.TextField({listeners: {change: this.sanitizeTextColumn}}), filter: 'string'},
+            {flex: 1, dataIndex: 'group', text: t("group"), editor: new Ext.form.TextField({listeners: {change: this.sanitizeTextColumn}}), filter: 'string', hidden: true},
             {flex: 1, dataIndex: 'baseunit', text: t("baseunit"), editor: baseUnitEditor, renderer: function(value){
                 if(!value) {
                     return '('+t('empty')+')';
@@ -122,8 +121,8 @@ pimcore.object.quantityValue.unitsettings = Class.create({
             }},
             {flex: 1, dataIndex: 'factor', text: t("conversionFactor"), editor: new Ext.form.NumberField({decimalPrecision: 10}), filter: 'numeric'},
             {flex: 1, dataIndex: 'conversionOffset', text: t("conversionOffset"), editor: new Ext.form.NumberField({decimalPrecision: 10}), filter: 'numeric'},
-            {flex: 1, dataIndex: 'reference', text: t("reference"), editor: new Ext.form.TextField({}), hidden: true, filter: 'string'},
-            {flex: 1, dataIndex: 'converter', text: t("converter_service"), editor: new Ext.form.TextField({}), filter: 'string'}
+            {flex: 1, dataIndex: 'reference', text: t("reference"), editor: new Ext.form.TextField({listeners: {change: this.sanitizeTextColumn}}), hidden: true, filter: 'string'},
+            {flex: 1, dataIndex: 'converter', text: t("converter_service"), editor: new Ext.form.TextField({listeners: {change: this.sanitizeTextColumn}}), filter: 'string'}
         ];
 
         typesColumns.push({
@@ -280,5 +279,12 @@ pimcore.object.quantityValue.unitsettings = Class.create({
         }
         var rec = selections.getAt(0);
         this.grid.store.remove(rec);
+    },
+
+    sanitizeTextColumn: function (textField) {
+        if(textField.getValue()){
+            const sanitizedValue = textField.getValue().replace(/[<>"'!?/\\&%$();]/gi, '');
+            textField.setValue(sanitizedValue);
+        }
     }
 });

--- a/models/DataObject/QuantityValue/Unit.php
+++ b/models/DataObject/QuantityValue/Unit.php
@@ -209,7 +209,7 @@ class Unit extends Model\AbstractModel
      */
     public function setAbbreviation($abbreviation)
     {
-        $this->abbreviation = $abbreviation;
+        $this->abbreviation = htmlspecialchars($abbreviation);
 
         return $this;
     }
@@ -276,7 +276,7 @@ class Unit extends Model\AbstractModel
      */
     public function setGroup($group)
     {
-        $this->group = $group;
+        $this->group = htmlspecialchars($group);
 
         return $this;
     }
@@ -316,7 +316,7 @@ class Unit extends Model\AbstractModel
      */
     public function setLongname($longname)
     {
-        $this->longname = $longname;
+        $this->longname = htmlspecialchars($longname);
 
         return $this;
     }
@@ -344,7 +344,7 @@ class Unit extends Model\AbstractModel
      */
     public function setReference($reference)
     {
-        $this->reference = $reference;
+        $this->reference = htmlspecialchars($reference);
 
         return $this;
     }
@@ -384,7 +384,7 @@ class Unit extends Model\AbstractModel
      */
     public function setConverter($converter)
     {
-        $this->converter = (string)$converter;
+        $this->converter = htmlspecialchars((string)$converter);
 
         return $this;
     }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4df9226</samp>

This pull request improves the security of the object quantity value feature by adding input sanitization and HTML encoding to the unit settings. It affects the `unitsettings.js` file in the AdminBundle and the `Unit.php` file in the DataObject model.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4df9226</samp>

> _No more tainted data in the grid of doom_
> _We encode and sanitize every unit of the room_
> _`Unit` class is fortified with HTML power_
> _We resist the XSS attacks that make us cower_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4df9226</samp>

*  Sanitize and encode special characters in text fields for unit settings in PHP and JS ([link](https://github.com/pimcore/pimcore/pull/14937/files?diff=unified&w=0#diff-81b52d77d2f17c4b1dc83501ed4e03d419abc0faf948587282fb7b1be4d73385L80), [link](https://github.com/pimcore/pimcore/pull/14937/files?diff=unified&w=0#diff-81b52d77d2f17c4b1dc83501ed4e03d419abc0faf948587282fb7b1be4d73385L109-R110), [link](https://github.com/pimcore/pimcore/pull/14937/files?diff=unified&w=0#diff-81b52d77d2f17c4b1dc83501ed4e03d419abc0faf948587282fb7b1be4d73385L125-R125), [link](https://github.com/pimcore/pimcore/pull/14937/files?diff=unified&w=0#diff-81b52d77d2f17c4b1dc83501ed4e03d419abc0faf948587282fb7b1be4d73385R282-R288), [link](https://github.com/pimcore/pimcore/pull/14937/files?diff=unified&w=0#diff-946a09395ce6d866f794fd211f1b09f22d4ff7ba4ff88e162e1bbf7567ff415fL212-R212), [link](https://github.com/pimcore/pimcore/pull/14937/files?diff=unified&w=0#diff-946a09395ce6d866f794fd211f1b09f22d4ff7ba4ff88e162e1bbf7567ff415fL279-R279), [link](https://github.com/pimcore/pimcore/pull/14937/files?diff=unified&w=0#diff-946a09395ce6d866f794fd211f1b09f22d4ff7ba4ff88e162e1bbf7567ff415fL319-R319), [link](https://github.com/pimcore/pimcore/pull/14937/files?diff=unified&w=0#diff-946a09395ce6d866f794fd211f1b09f22d4ff7ba4ff88e162e1bbf7567ff415fL347-R347), [link](https://github.com/pimcore/pimcore/pull/14937/files?diff=unified&w=0#diff-946a09395ce6d866f794fd211f1b09f22d4ff7ba4ff88e162e1bbf7567ff415fL387-R387))
