### PR TITLE
[Security] Fix xss in predefined properties panel

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
@@ -165,11 +165,15 @@ pimcore.settings.properties.predefined = Class.create({
                     tooltip: t('delete'),
                     handler: function (grid, rowIndex) {
                         let data = grid.getStore().getAt(rowIndex);
-                        pimcore.helpers.deleteConfirm(t('predefined_properties'),
-                            Ext.util.Format.htmlEncode(data.data.name),
+                        const decodedName = Ext.util.Format.htmlDecode(data.data.name);
+                        
+                        pimcore.helpers.deleteConfirm(
+                            t('predefined_properties'),
+                            Ext.util.Format.htmlEncode(decodedName),
                             function () {
-                            grid.getStore().removeAt(rowIndex);
-                        }.bind(this));
+                                grid.getStore().removeAt(rowIndex);
+                            }.bind(this)
+                        );
                     }.bind(this)
                 }]
             },{

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
@@ -57,8 +57,8 @@ pimcore.settings.properties.predefined = Class.create({
 
         this.store = pimcore.helpers.grid.buildDefaultStore(
             url,
-            ['id',
-
+            [
+                'id',
                 {name: 'name', allowBlank: false},'description',
                 {name: 'key', allowBlank: false},
                 {name: 'type', allowBlank: false}, 'data', 'config',
@@ -108,8 +108,8 @@ pimcore.settings.properties.predefined = Class.create({
 
 
         var propertiesColumns = [
-            {text: t("name"), flex: 100, sortable: true, dataIndex: 'name', editor: new Ext.form.TextField({})},
-            {text: t("description"), sortable: true, dataIndex: 'description', editor: new Ext.form.TextArea({}),
+            {text: t("name"), flex: 100, sortable: true, dataIndex: 'name', editor: new Ext.form.TextField({listeners: {'change': this.htmlEncodeTextField}})},
+            {text: t("description"), sortable: true, dataIndex: 'description', editor: new Ext.form.TextArea({listeners: {'change': this.htmlEncodeTextField}}),
                 renderer: function (value, metaData, record, rowIndex, colIndex, store) {
                     if(empty(value)) {
                         return "";
@@ -117,7 +117,7 @@ pimcore.settings.properties.predefined = Class.create({
                     return nl2br(Ext.util.Format.htmlEncode(value));
                }
             },
-            {text: t("key"), flex: 50, sortable: true, dataIndex: 'key', editor: new Ext.form.TextField({})},
+            {text: t("key"), flex: 50, sortable: true, dataIndex: 'key', editor: new Ext.form.TextField({listeners: {'change': this.htmlEncodeTextField}})},
             {text: t("type"), flex: 50, sortable: true, dataIndex: 'type',
                 editor: new Ext.form.ComboBox({
                     triggerAction: 'all',
@@ -125,8 +125,8 @@ pimcore.settings.properties.predefined = Class.create({
                     store: ["text","document","asset","object","bool","select"]
 
             })},
-            {text: t("value"), flex: 50, sortable: true, dataIndex: 'data', editor: new Ext.form.TextField({})},
-            {text: t("configuration"), flex: 50, sortable: false, dataIndex: 'config', editor: new Ext.form.TextField({})},
+            {text: t("value"), flex: 50, sortable: true, dataIndex: 'data', editor: new Ext.form.TextField({listeners: {'change': this.htmlEncodeTextField}})},
+            {text: t("configuration"), flex: 50, sortable: false, dataIndex: 'config', editor: new Ext.form.TextField({listeners: {'change': this.htmlEncodeTextField}})},
             {text: t("content_type"), flex: 50, sortable: true, dataIndex: 'ctype',
                 editor: new Ext.ux.form.MultiSelect({
                     store: new Ext.data.ArrayStore({
@@ -279,5 +279,13 @@ pimcore.settings.properties.predefined = Class.create({
             ctype: "document",
             type: "text"
         });
+    },
+
+    htmlEncodeTextField: function (textField) {
+        if(textField.getValue()) {
+            textField.setValue(
+                Ext.util.Format.htmlEncode(textField.getValue())
+            );
+        }
     }
 });

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
@@ -108,8 +108,8 @@ pimcore.settings.properties.predefined = Class.create({
 
 
         var propertiesColumns = [
-            {text: t("name"), flex: 100, sortable: true, dataIndex: 'name', editor: new Ext.form.TextField({listeners: {'change': this.htmlEncodeTextField}})},
-            {text: t("description"), sortable: true, dataIndex: 'description', editor: new Ext.form.TextArea({listeners: {'change': this.htmlEncodeTextField}}),
+            {text: t("name"), flex: 100, sortable: true, dataIndex: 'name', editor: new Ext.form.TextField({listeners: {'change': pimcore.helpers.htmlEncodeTextField}})},
+            {text: t("description"), sortable: true, dataIndex: 'description', editor: new Ext.form.TextArea({listeners: {'change': pimcore.helpers.htmlEncodeTextField}}),
                 renderer: function (value, metaData, record, rowIndex, colIndex, store) {
                     if(empty(value)) {
                         return "";
@@ -117,7 +117,7 @@ pimcore.settings.properties.predefined = Class.create({
                     return nl2br(Ext.util.Format.htmlEncode(value));
                }
             },
-            {text: t("key"), flex: 50, sortable: true, dataIndex: 'key', editor: new Ext.form.TextField({listeners: {'change': this.htmlEncodeTextField}})},
+            {text: t("key"), flex: 50, sortable: true, dataIndex: 'key', editor: new Ext.form.TextField({listeners: {'change': pimcore.helpers.htmlEncodeTextField}})},
             {text: t("type"), flex: 50, sortable: true, dataIndex: 'type',
                 editor: new Ext.form.ComboBox({
                     triggerAction: 'all',
@@ -125,8 +125,8 @@ pimcore.settings.properties.predefined = Class.create({
                     store: ["text","document","asset","object","bool","select"]
 
             })},
-            {text: t("value"), flex: 50, sortable: true, dataIndex: 'data', editor: new Ext.form.TextField({listeners: {'change': this.htmlEncodeTextField}})},
-            {text: t("configuration"), flex: 50, sortable: false, dataIndex: 'config', editor: new Ext.form.TextField({listeners: {'change': this.htmlEncodeTextField}})},
+            {text: t("value"), flex: 50, sortable: true, dataIndex: 'data', editor: new Ext.form.TextField({listeners: {'change': pimcore.helpers.htmlEncodeTextField}})},
+            {text: t("configuration"), flex: 50, sortable: false, dataIndex: 'config', editor: new Ext.form.TextField({listeners: {'change': pimcore.helpers.htmlEncodeTextField}})},
             {text: t("content_type"), flex: 50, sortable: true, dataIndex: 'ctype',
                 editor: new Ext.ux.form.MultiSelect({
                     store: new Ext.data.ArrayStore({
@@ -279,13 +279,5 @@ pimcore.settings.properties.predefined = Class.create({
             ctype: "document",
             type: "text"
         });
-    },
-
-    htmlEncodeTextField: function (textField) {
-        if(textField.getValue()) {
-            textField.setValue(
-                Ext.util.Format.htmlEncode(textField.getValue())
-            );
-        }
     }
 });

--- a/models/Property/Predefined.php
+++ b/models/Property/Predefined.php
@@ -177,7 +177,7 @@ final class Predefined extends Model\AbstractModel
      */
     public function setKey($key)
     {
-        $this->key = $key;
+        $this->key = htmlspecialchars($key);
 
         return $this;
     }
@@ -189,7 +189,7 @@ final class Predefined extends Model\AbstractModel
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = htmlspecialchars($name);
 
         return $this;
     }
@@ -213,7 +213,7 @@ final class Predefined extends Model\AbstractModel
      */
     public function setData($data)
     {
-        $this->data = $data;
+        $this->data = htmlspecialchars($data);
 
         return $this;
     }
@@ -253,7 +253,7 @@ final class Predefined extends Model\AbstractModel
      */
     public function setConfig($config)
     {
-        $this->config = $config;
+        $this->config = htmlspecialchars($config);
 
         return $this;
     }
@@ -305,7 +305,7 @@ final class Predefined extends Model\AbstractModel
      */
     public function setDescription($description)
     {
-        $this->description = $description;
+        $this->description = htmlspecialchars($description);
 
         return $this;
     }

--- a/models/Property/Predefined.php
+++ b/models/Property/Predefined.php
@@ -16,6 +16,7 @@
 namespace Pimcore\Model\Property;
 
 use Pimcore\Model;
+use Pimcore\Security\SecurityHelper;
 
 /**
  * @internal
@@ -177,7 +178,7 @@ final class Predefined extends Model\AbstractModel
      */
     public function setKey($key)
     {
-        $this->key = htmlspecialchars($key);
+        $this->key = SecurityHelper::convertHtmlSpecialChars($key);
 
         return $this;
     }
@@ -189,7 +190,7 @@ final class Predefined extends Model\AbstractModel
      */
     public function setName($name)
     {
-        $this->name = htmlspecialchars($name);
+        $this->name = SecurityHelper::convertHtmlSpecialChars($name);
 
         return $this;
     }
@@ -213,7 +214,7 @@ final class Predefined extends Model\AbstractModel
      */
     public function setData($data)
     {
-        $this->data = htmlspecialchars($data);
+        $this->data = SecurityHelper::convertHtmlSpecialChars($data);
 
         return $this;
     }
@@ -253,7 +254,7 @@ final class Predefined extends Model\AbstractModel
      */
     public function setConfig($config)
     {
-        $this->config = htmlspecialchars($config);
+        $this->config = SecurityHelper::convertHtmlSpecialChars($config);
 
         return $this;
     }
@@ -305,7 +306,7 @@ final class Predefined extends Model\AbstractModel
      */
     public function setDescription($description)
     {
-        $this->description = htmlspecialchars($description);
+        $this->description = SecurityHelper::convertHtmlSpecialChars($description);
 
         return $this;
     }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7567efe</samp>

This pull request enhances the security of predefined properties by encoding HTML characters in the input fields and the database. It modifies the `predefined.js` file to use a helper function and listeners for the grid editors, and the `Predefined.php` file to sanitize the setter methods.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7567efe</samp>

> _We are the defenders of the grid_
> _We fight the evil XSS_
> _We use `htmlEncodeTextField` to seal the breach_
> _We sanitize with `htmlspecialchars`_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7567efe</samp>

*  Encode HTML characters in predefined properties input fields to prevent XSS attacks ([link](https://github.com/pimcore/pimcore/pull/14943/files?diff=unified&w=0#diff-c83f84a95e801afe56da0c735ea0a92de3ee4c26dfa4d0bb78773146296c8f51L60-R61), [link](https://github.com/pimcore/pimcore/pull/14943/files?diff=unified&w=0#diff-c83f84a95e801afe56da0c735ea0a92de3ee4c26dfa4d0bb78773146296c8f51L111-R112), [link](https://github.com/pimcore/pimcore/pull/14943/files?diff=unified&w=0#diff-c83f84a95e801afe56da0c735ea0a92de3ee4c26dfa4d0bb78773146296c8f51L120-R120), [link](https://github.com/pimcore/pimcore/pull/14943/files?diff=unified&w=0#diff-c83f84a95e801afe56da0c735ea0a92de3ee4c26dfa4d0bb78773146296c8f51L128-R129), [link](https://github.com/pimcore/pimcore/pull/14943/files?diff=unified&w=0#diff-c83f84a95e801afe56da0c735ea0a92de3ee4c26dfa4d0bb78773146296c8f51R282-R289), [link](https://github.com/pimcore/pimcore/pull/14943/files?diff=unified&w=0#diff-deccc10d6fbb72879b844422d39f16dbbbff934266dab8fba57a2cd7ca00e913L180-R180), [link](https://github.com/pimcore/pimcore/pull/14943/files?diff=unified&w=0#diff-deccc10d6fbb72879b844422d39f16dbbbff934266dab8fba57a2cd7ca00e913L192-R192), [link](https://github.com/pimcore/pimcore/pull/14943/files?diff=unified&w=0#diff-deccc10d6fbb72879b844422d39f16dbbbff934266dab8fba57a2cd7ca00e913L216-R216), [link](https://github.com/pimcore/pimcore/pull/14943/files?diff=unified&w=0#diff-deccc10d6fbb72879b844422d39f16dbbbff934266dab8fba57a2cd7ca00e913L256-R256), [link](https://github.com/pimcore/pimcore/pull/14943/files?diff=unified&w=0#diff-deccc10d6fbb72879b844422d39f16dbbbff934266dab8fba57a2cd7ca00e913L308-R308))
