### PR TITLE
fix CSV Export breakes file at more than 20 rows

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1429,7 +1429,7 @@ class DataObjectHelperController extends AdminController
             } else {
                 fwrite($temp, implode($delimiter, array_map([$this, 'encodeFunc'], $line)));
             }
-            if ($i < $lineCount - 1) {
+            if ($i <= $lineCount - 1) {
                 fwrite($temp, "\r\n");
             }
         }


### PR DESCRIPTION
When the Pimcore export is started and there are more than 20 entries in the list, the last two entries are exported in one line, breaking the CSV file. Also affects the AdvancedObjectSearch. 

## Please make sure your PR complies with all of the following points: 
- [X ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [X ] Features need to be proper documented in `doc/` 
- [X ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [X ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5fee55f</samp>

Fix missing line break in CSV export of data objects. Adjust the condition for writing the line break in `DataObjectHelperController.php` to include the last line.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5fee55f</samp>

> _CSV export_
> _last line was missing_
> _now it has a `break`_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5fee55f</samp>

* Fix bug with missing line break in last line of CSV export ([link](https://github.com/pimcore/pimcore/pull/14946/files?diff=unified&w=0#diff-d504764dc26470263c53162e55e93645b847e0f8f6d6b69f133403149af19c4cL1432-R1432))
