### PR TITLE
[Bug] Fix  Classification Store inheritance 

### DIFF
--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -525,7 +525,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
         $object = $this->getObject();
         while (!is_null($object) && ($parent = Service::hasInheritableParentObject($object)) !== null) {
             $fieldsArray = $mergeFunction($parent->{"get" . $this->getFieldname()}(), $fieldsArray);
-            }
+            
             $object = $parent;
         }
         return $fieldsArray;

--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -75,7 +75,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     protected $groupCollectionMapping = [];
 
     /**
-     * @param array|null $items
+     * @param array $items
      */
     public function __construct($items = null)
     {
@@ -95,7 +95,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     }
 
     /**
-     * @param array $items
+     * @param  array $items
      *
      * @return $this
      */
@@ -124,7 +124,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return $this
      */
-    public function setObject($object)
+    public function setObject(Concrete $object)
     {
         if ($this->object) {
             if ($this->object->getId() != $object->getId()) {
@@ -149,7 +149,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return $this
      */
-    public function setClass( $class)
+    public function setClass(?ClassDefinition $class)
     {
         $this->class = $class;
 
@@ -173,7 +173,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return string
      */
-    public function getLanguage( $language = null)
+    public function getLanguage($language = null)
     {
         if ($language) {
             return (string) $language;
@@ -190,16 +190,16 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return $this
      *
-     * @throws Exception
+     * @throws \Exception
      */
     public function setLocalizedKeyValue($groupId, $keyId, $value, $language = null)
     {
         if (!$groupId) {
-            throw new Exception('groupId not valid');
+            throw new \Exception('groupId not valid');
         }
 
         if (!$keyId) {
-            throw new Exception('keyId not valid');
+            throw new \Exception('keyId not valid');
         }
 
         $language = $this->getLanguage($language);
@@ -346,7 +346,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return mixed
      */
-    private function getFallbackValue($groupId, $keyId, $language, $fielddefinition): mixed
+    private function getFallbackValue($groupId, $keyId, $language, $fielddefinition)
     {
         $fallbackLanguages = Tool::getFallbackLanguagesFor($language);
         $data = null;
@@ -380,7 +380,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return mixed
      *
-     * @throws Exception
+     * @throws \Exception
      */
     public function getLocalizedKeyValue($groupId, $keyId, $language = 'default', $ignoreFallbackLanguage = false, $ignoreDefaultLanguage = false)
     {
@@ -475,7 +475,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      * @param bool $withInheritance
      * @return array
      */
-    public function getGroupCollectionMappings($withInheritance = false)
+    public function getGroupCollectionMappings($withInheritance = false): array
     {
         if(!$withInheritance) {
             return $this->groupCollectionMapping;
@@ -515,7 +515,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /**
      * @return Model\DataObject\Classificationstore\Group[]
      */
-    public function getGroups($withInheritance = false)
+    public function getGroups($withInheritance = false): array
     {
         return Classificationstore::getActiveGroupsWithConfig($this,$withInheritance);
     }
@@ -537,7 +537,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
         return $fieldsArray;
     }
 
-    private static function getActiveGroupsWithConfig($classificationStore,$withInheritance)
+    private static function getActiveGroupsWithConfig(Classificationstore $classificationStore,$withInheritance): array
     {
         $groups = [];
         $activeGroups = $classificationStore->getActiveGroups($withInheritance);
@@ -545,6 +545,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
             $groupConfig = $classificationStore->getGroupConfigById($groupId);
             $groups[] = $classificationStore->createGroup($classificationStore, $groupConfig);
         }
+
         return $groups;
     }
 

--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -524,7 +524,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
         $fieldsArray = $mergeFunction($this, []);
         $object = $this->getObject();
         while (!is_null($object) && ($parent = Service::hasInheritableParentObject($object)) !== null) {
-            $fieldsArray = $mergeFunction($parent->{"get" . $this->getFieldname()}(), $fieldsArray);
+            $fieldsArray = $mergeFunction($parent->{"get" . ucfirst($this->getFieldname())}(), $fieldsArray);
             
             $object = $parent;
         }

--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -297,7 +297,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      */
     public function getActiveGroups()
     {
-        return $this->activeGroups;
+        return $this->getAllDataFromField(fn ($classificationStore, $fieldsArray) => $classificationStore->activeGroups + $fieldsArray);
     }
 
     private function sanitizeActiveGroups($activeGroups)
@@ -504,7 +504,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      */
     public function getGroups(): array
     {
-        return $this->getAllDataFromField(fn ($classificationStore, $fieldsArray) => array_merge(Classificationstore::getActiveGroupsWithConfig($classificationStore), $fieldsArray));
+        return Classificationstore::getActiveGroupsWithConfig($this);
     }
 
     private function getAllDataFromField(callable $mergeFunction): array
@@ -512,16 +512,15 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
         $fieldsArray = $mergeFunction($this, []);
         $object = $this->getObject();
         while (($parent = Service::hasInheritableParentObject($object)) !== null) {
-            $fieldDefintions = $parent->getClass()->getFieldDefinitions();
-            foreach ($fieldDefintions as $key => $fd) {
-                if ($fd instanceof Model\DataObject\ClassDefinition\Data\Classificationstore) {
+            $fieldDefinitions = $parent->getClass()->getFieldDefinitions();
+            foreach ($fieldDefinitions as $key => $fd) {
+                if ($fd instanceof Model\DataObject\ClassDefinition\Data\Classificationstore && $key == $this->getFieldname()) {
                     $getter = 'get' . ucfirst($key);
                     $fieldsArray = $mergeFunction($parent->$getter(), $fieldsArray);
                 }
             }
             $object = $parent;
         }
-
         return $fieldsArray;
     }
 

--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -37,7 +37,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @var array
      */
-    protected array $items = [];
+    protected $items = [];
 
     /**
      * @internal
@@ -58,26 +58,26 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @var string
      */
-    protected string $fieldname;
+    protected $fieldname;
 
     /**
      * @internal
      *
      * @var array
      */
-    protected array $activeGroups = [];
+    protected $activeGroups = [];
 
     /**
      * @internal
      *
      * @var array
      */
-    protected array $groupCollectionMapping = [];
+    protected $groupCollectionMapping = [];
 
     /**
      * @param array|null $items
      */
-    public function __construct(array $items = null)
+    public function __construct($items = null)
     {
         if ($items) {
             $this->setItems($items);
@@ -88,7 +88,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /**
      * @param array $item
      */
-    public function addItem(array $item)
+    public function addItem($item)
     {
         $this->items[] = $item;
         $this->markFieldDirty('_self');
@@ -99,7 +99,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return $this
      */
-    public function setItems(array $items): static
+    public function setItems($items)
     {
         $this->items = $items;
         $this->markFieldDirty('_self');
@@ -111,7 +111,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      * @param bool $withInheritance
      * @return array
      */
-    public function getItems(bool $withInheritance = false): array
+    public function getItems($withInheritance = false)
     {
         if(!$withInheritance) {
             return $this->items;
@@ -124,7 +124,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return $this
      */
-    public function setObject(Concrete $object): static
+    public function setObject($object)
     {
         if ($this->object) {
             if ($this->object->getId() != $object->getId()) {
@@ -149,7 +149,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return $this
      */
-    public function setClass(?ClassDefinition $class): static
+    public function setClass( $class)
     {
         $this->class = $class;
 
@@ -173,10 +173,10 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return string
      */
-    public function getLanguage(?string $language = null): string
+    public function getLanguage( $language = null)
     {
         if ($language) {
-            return $language;
+            return (string) $language;
         }
 
         return 'default';
@@ -192,7 +192,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @throws Exception
      */
-    public function setLocalizedKeyValue(int $groupId, int $keyId, mixed $value, ?string $language = null): static
+    public function setLocalizedKeyValue($groupId, $keyId, $value, $language = null)
     {
         if (!$groupId) {
             throw new Exception('groupId not valid');
@@ -268,7 +268,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @param int $groupId
      */
-    public function removeGroupData(int $groupId)
+    public function removeGroupData($groupId)
     {
         unset($this->items[$groupId]);
     }
@@ -276,7 +276,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /** Returns an array of
      * @return array
      */
-    public function getGroupIdsWithData(): array
+    public function getGroupIdsWithData()
     {
         return array_keys($this->items);
     }
@@ -284,7 +284,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /**
      * @return string
      */
-    public function getFieldname(): string
+    public function getFieldname()
     {
         return $this->fieldname;
     }
@@ -292,7 +292,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /**
      * @param string $fieldname
      */
-    public function setFieldname(string $fieldname)
+    public function setFieldname($fieldname)
     {
         $this->fieldname = $fieldname;
     }
@@ -301,7 +301,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      * @param bool $withInheritance
      * @return array
      */
-    public function getActiveGroups(bool $withInheritance = false): array
+    public function getActiveGroups($withInheritance = false)
     {
         if(!$withInheritance) {
             return $this->activeGroups;
@@ -309,7 +309,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
         return $this->getAllDataFromField(fn ($classificationStore, $fieldsArray) => $classificationStore->activeGroups + $fieldsArray);
     }
 
-    private function sanitizeActiveGroups($activeGroups): array
+    private function sanitizeActiveGroups($activeGroups)
     {
         $newList = [];
 
@@ -327,7 +327,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /**
      * @param array $activeGroups
      */
-    public function setActiveGroups(array $activeGroups)
+    public function setActiveGroups($activeGroups)
     {
         $activeGroups = $this->sanitizeActiveGroups($activeGroups);
         $diff1 = array_diff(array_keys($activeGroups), array_keys($this->activeGroups));
@@ -346,7 +346,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return mixed
      */
-    private function getFallbackValue(int $groupId, int $keyId, string $language, ClassDefinition\Data $fielddefinition): mixed
+    private function getFallbackValue($groupId, $keyId, $language, $fielddefinition): mixed
     {
         $fallbackLanguages = Tool::getFallbackLanguagesFor($language);
         $data = null;
@@ -466,7 +466,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /**
      * @return bool
      */
-    public static function doGetFallbackValues(): bool
+    public static function doGetFallbackValues()
     {
         return true;
     }
@@ -475,7 +475,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      * @param bool $withInheritance
      * @return array
      */
-    public function getGroupCollectionMappings(bool $withInheritance = false): array
+    public function getGroupCollectionMappings($withInheritance = false)
     {
         if(!$withInheritance) {
             return $this->groupCollectionMapping;
@@ -495,7 +495,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      * @param int|null $groupId
      * @param int|null $collectionId
      */
-    public function setGroupCollectionMapping(?int $groupId = null, ?int $collectionId = null): void
+    public function setGroupCollectionMapping($groupId = null, $collectionId = null): void
     {
         if ($groupId && $collectionId) {
             $this->groupCollectionMapping[$groupId] = $collectionId;
@@ -507,7 +507,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return int|null
      */
-    public function getGroupCollectionMapping(int $groupId): ?int
+    public function getGroupCollectionMapping($groupId)
     {
         return $this->getGroupCollectionMappings()[$groupId] ?? null;
     }
@@ -515,7 +515,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /**
      * @return Model\DataObject\Classificationstore\Group[]
      */
-    public function getGroups(bool $withInheritance = false): array
+    public function getGroups($withInheritance = false)
     {
         return Classificationstore::getActiveGroupsWithConfig($this,$withInheritance);
     }
@@ -537,7 +537,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
         return $fieldsArray;
     }
 
-    private static function getActiveGroupsWithConfig(Classificationstore $classificationStore,bool $withInheritance): array
+    private static function getActiveGroupsWithConfig($classificationStore,$withInheritance)
     {
         $groups = [];
         $activeGroups = $classificationStore->getActiveGroups($withInheritance);
@@ -545,7 +545,6 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
             $groupConfig = $classificationStore->getGroupConfigById($groupId);
             $groups[] = $classificationStore->createGroup($classificationStore, $groupConfig);
         }
-
         return $groups;
     }
 

--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Model\DataObject;
 
+use Exception;
 use Pimcore\Model;
 use Pimcore\Model\DataObject\ClassDefinition\Data\PreGetDataInterface;
 use Pimcore\Model\Element\DirtyIndicatorInterface;
@@ -36,7 +37,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @var array
      */
-    protected $items = [];
+    protected array $items = [];
 
     /**
      * @internal
@@ -57,26 +58,26 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @var string
      */
-    protected $fieldname;
+    protected string $fieldname;
 
     /**
      * @internal
      *
      * @var array
      */
-    protected $activeGroups = [];
+    protected array $activeGroups = [];
 
     /**
      * @internal
      *
      * @var array
      */
-    protected $groupCollectionMapping = [];
+    protected array $groupCollectionMapping = [];
 
     /**
-     * @param array $items
+     * @param array|null $items
      */
-    public function __construct($items = null)
+    public function __construct(array $items = null)
     {
         if ($items) {
             $this->setItems($items);
@@ -87,18 +88,18 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /**
      * @param array $item
      */
-    public function addItem($item)
+    public function addItem(array $item)
     {
         $this->items[] = $item;
         $this->markFieldDirty('_self');
     }
 
     /**
-     * @param  array $items
+     * @param array $items
      *
      * @return $this
      */
-    public function setItems($items)
+    public function setItems(array $items): static
     {
         $this->items = $items;
         $this->markFieldDirty('_self');
@@ -107,10 +108,14 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     }
 
     /**
+     * @param bool $withInheritance
      * @return array
      */
-    public function getItems()
+    public function getItems(bool $withInheritance = false): array
     {
+        if(!$withInheritance) {
+            return $this->items;
+        }
         return $this->getAllDataFromField(fn ($classificationStore, $fieldsArray) => $fieldsArray + $classificationStore->items);
     }
 
@@ -119,7 +124,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return $this
      */
-    public function setObject(Concrete $object)
+    public function setObject(Concrete $object): static
     {
         if ($this->object) {
             if ($this->object->getId() != $object->getId()) {
@@ -144,7 +149,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return $this
      */
-    public function setClass(?ClassDefinition $class)
+    public function setClass(?ClassDefinition $class): static
     {
         $this->class = $class;
 
@@ -168,10 +173,10 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return string
      */
-    public function getLanguage($language = null)
+    public function getLanguage(?string $language = null): string
     {
         if ($language) {
-            return (string) $language;
+            return $language;
         }
 
         return 'default';
@@ -185,16 +190,16 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return $this
      *
-     * @throws \Exception
+     * @throws Exception
      */
-    public function setLocalizedKeyValue($groupId, $keyId, $value, $language = null)
+    public function setLocalizedKeyValue(int $groupId, int $keyId, mixed $value, ?string $language = null): static
     {
         if (!$groupId) {
-            throw new \Exception('groupId not valid');
+            throw new Exception('groupId not valid');
         }
 
         if (!$keyId) {
-            throw new \Exception('keyId not valid');
+            throw new Exception('keyId not valid');
         }
 
         $language = $this->getLanguage($language);
@@ -263,7 +268,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @param int $groupId
      */
-    public function removeGroupData($groupId)
+    public function removeGroupData(int $groupId)
     {
         unset($this->items[$groupId]);
     }
@@ -271,7 +276,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /** Returns an array of
      * @return array
      */
-    public function getGroupIdsWithData()
+    public function getGroupIdsWithData(): array
     {
         return array_keys($this->items);
     }
@@ -279,7 +284,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /**
      * @return string
      */
-    public function getFieldname()
+    public function getFieldname(): string
     {
         return $this->fieldname;
     }
@@ -287,20 +292,24 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /**
      * @param string $fieldname
      */
-    public function setFieldname($fieldname)
+    public function setFieldname(string $fieldname)
     {
         $this->fieldname = $fieldname;
     }
 
     /**
+     * @param bool $withInheritance
      * @return array
      */
-    public function getActiveGroups()
+    public function getActiveGroups(bool $withInheritance = false): array
     {
+        if(!$withInheritance) {
+            return $this->activeGroups;
+        }
         return $this->getAllDataFromField(fn ($classificationStore, $fieldsArray) => $classificationStore->activeGroups + $fieldsArray);
     }
 
-    private function sanitizeActiveGroups($activeGroups)
+    private function sanitizeActiveGroups($activeGroups): array
     {
         $newList = [];
 
@@ -318,7 +327,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /**
      * @param array $activeGroups
      */
-    public function setActiveGroups($activeGroups)
+    public function setActiveGroups(array $activeGroups)
     {
         $activeGroups = $this->sanitizeActiveGroups($activeGroups);
         $diff1 = array_diff(array_keys($activeGroups), array_keys($this->activeGroups));
@@ -337,7 +346,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return mixed
      */
-    private function getFallbackValue($groupId, $keyId, $language, $fielddefinition)
+    private function getFallbackValue(int $groupId, int $keyId, string $language, ClassDefinition\Data $fielddefinition): mixed
     {
         $fallbackLanguages = Tool::getFallbackLanguagesFor($language);
         $data = null;
@@ -371,7 +380,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return mixed
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function getLocalizedKeyValue($groupId, $keyId, $language = 'default', $ignoreFallbackLanguage = false, $ignoreDefaultLanguage = false)
     {
@@ -457,16 +466,20 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /**
      * @return bool
      */
-    public static function doGetFallbackValues()
+    public static function doGetFallbackValues(): bool
     {
         return true;
     }
 
     /**
+     * @param bool $withInheritance
      * @return array
      */
-    public function getGroupCollectionMappings(): array
+    public function getGroupCollectionMappings(bool $withInheritance = false): array
     {
+        if(!$withInheritance) {
+            return $this->groupCollectionMapping;
+        }
         return $this->getAllDataFromField(fn ($classificationStore, $fieldsArray) => $fieldsArray + $classificationStore->groupCollectionMapping);
     }
 
@@ -482,7 +495,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      * @param int|null $groupId
      * @param int|null $collectionId
      */
-    public function setGroupCollectionMapping($groupId = null, $collectionId = null): void
+    public function setGroupCollectionMapping(?int $groupId = null, ?int $collectionId = null): void
     {
         if ($groupId && $collectionId) {
             $this->groupCollectionMapping[$groupId] = $collectionId;
@@ -494,7 +507,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      *
      * @return int|null
      */
-    public function getGroupCollectionMapping($groupId)
+    public function getGroupCollectionMapping(int $groupId): ?int
     {
         return $this->getGroupCollectionMappings()[$groupId] ?? null;
     }
@@ -502,9 +515,9 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /**
      * @return Model\DataObject\Classificationstore\Group[]
      */
-    public function getGroups(): array
+    public function getGroups(bool $withInheritance = false): array
     {
-        return Classificationstore::getActiveGroupsWithConfig($this);
+        return Classificationstore::getActiveGroupsWithConfig($this,$withInheritance);
     }
 
     private function getAllDataFromField(callable $mergeFunction): array
@@ -524,10 +537,10 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
         return $fieldsArray;
     }
 
-    private static function getActiveGroupsWithConfig(Classificationstore $classificationStore): array
+    private static function getActiveGroupsWithConfig(Classificationstore $classificationStore,bool $withInheritance): array
     {
         $groups = [];
-        $activeGroups = $classificationStore->getActiveGroups();
+        $activeGroups = $classificationStore->getActiveGroups($withInheritance);
         foreach (array_keys($activeGroups) as $groupId) {
             $groupConfig = $classificationStore->getGroupConfigById($groupId);
             $groups[] = $classificationStore->createGroup($classificationStore, $groupConfig);

--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -523,7 +523,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     {
         $fieldsArray = $mergeFunction($this, []);
         $object = $this->getObject();
-        while (($parent = Service::hasInheritableParentObject($object)) !== null) {
+        while (!is_null($object) && ($parent = Service::hasInheritableParentObject($object)) !== null) {
             $fieldDefinitions = $parent->getClass()->getFieldDefinitions();
             foreach ($fieldDefinitions as $key => $fd) {
                 if ($fd instanceof Model\DataObject\ClassDefinition\Data\Classificationstore && $key == $this->getFieldname()) {

--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -15,7 +15,6 @@
 
 namespace Pimcore\Model\DataObject;
 
-use Exception;
 use Pimcore\Model;
 use Pimcore\Model\DataObject\ClassDefinition\Data\PreGetDataInterface;
 use Pimcore\Model\Element\DirtyIndicatorInterface;
@@ -108,12 +107,12 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     }
 
     /**
-     * @param bool $withInheritance
      * @return array
      */
-    public function getItems($withInheritance = false)
+    public function getItems()
     {
-        if(!$withInheritance) {
+        $doGetInheritedValues = Model\DataObject::doGetInheritedValues();
+        if(!$doGetInheritedValues) {
             return $this->items;
         }
         return $this->getAllDataFromField(fn ($classificationStore, $fieldsArray) => $fieldsArray + $classificationStore->items);
@@ -298,12 +297,12 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     }
 
     /**
-     * @param bool $withInheritance
      * @return array
      */
-    public function getActiveGroups($withInheritance = false)
+    public function getActiveGroups()
     {
-        if(!$withInheritance) {
+        $doGetInheritedValues = Model\DataObject::doGetInheritedValues();
+        if(!$doGetInheritedValues) {
             return $this->activeGroups;
         }
         return $this->getAllDataFromField(fn ($classificationStore, $fieldsArray) => $classificationStore->activeGroups + $fieldsArray);
@@ -472,12 +471,12 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     }
 
     /**
-     * @param bool $withInheritance
      * @return array
      */
-    public function getGroupCollectionMappings($withInheritance = false): array
+    public function getGroupCollectionMappings(): array
     {
-        if(!$withInheritance) {
+        $doGetInheritedValues = Model\DataObject::doGetInheritedValues();
+        if(!$doGetInheritedValues) {
             return $this->groupCollectionMapping;
         }
         return $this->getAllDataFromField(fn ($classificationStore, $fieldsArray) => $fieldsArray + $classificationStore->groupCollectionMapping);
@@ -515,9 +514,9 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
     /**
      * @return Model\DataObject\Classificationstore\Group[]
      */
-    public function getGroups($withInheritance = false): array
+    public function getGroups(): array
     {
-        return Classificationstore::getActiveGroupsWithConfig($this,$withInheritance);
+        return Classificationstore::getActiveGroupsWithConfig($this);
     }
 
     private function getAllDataFromField(callable $mergeFunction): array
@@ -537,10 +536,10 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
         return $fieldsArray;
     }
 
-    private static function getActiveGroupsWithConfig(Classificationstore $classificationStore,$withInheritance): array
+    private static function getActiveGroupsWithConfig(Classificationstore $classificationStore): array
     {
         $groups = [];
-        $activeGroups = $classificationStore->getActiveGroups($withInheritance);
+        $activeGroups = $classificationStore->getActiveGroups();
         foreach (array_keys($activeGroups) as $groupId) {
             $groupConfig = $classificationStore->getGroupConfigById($groupId);
             $groups[] = $classificationStore->createGroup($classificationStore, $groupConfig);

--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -524,12 +524,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
         $fieldsArray = $mergeFunction($this, []);
         $object = $this->getObject();
         while (!is_null($object) && ($parent = Service::hasInheritableParentObject($object)) !== null) {
-            $fieldDefinitions = $parent->getClass()->getFieldDefinitions();
-            foreach ($fieldDefinitions as $key => $fd) {
-                if ($fd instanceof Model\DataObject\ClassDefinition\Data\Classificationstore && $key == $this->getFieldname()) {
-                    $getter = 'get' . ucfirst($key);
-                    $fieldsArray = $mergeFunction($parent->$getter(), $fieldsArray);
-                }
+            $fieldsArray = $mergeFunction($parent->{"get" . $this->getFieldname()}(), $fieldsArray);
             }
             $object = $parent;
         }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #14874 

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46dcb94</samp>

This pull request enhances the `Classificationstore` class with type declarations, return types, and inheritance options, and fixes a typo and a logic issue. These changes improve the code quality and functionality of the class, which handles data storage and retrieval for data objects.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 46dcb94</samp>

> _Oh we're the coders of the `Classificationstore`_
> _We type and test and refactor with care_
> _We add declarations, return types, and inheritance_
> _And fix the bugs that lurk in there_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 46dcb94</samp>

*  Add `use Exception` statement and replace `\Exception` with `Exception` to simplify the code ([link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eR18), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL188-R202), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL374-R383))
*  Add type declarations to properties, parameters, and return values to make the code more consistent and explicit about the expected data types ([link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL39-R40), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL60-R61), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL67-R68), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL74-R80), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL90-R91), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL97-R102), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL110-R118), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL122-R127), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL147-R152), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL171-R179), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL266-R271), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL274-R279), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL282-R287), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL290-R295), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL296-R312), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL321-R330), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL340-R349), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL460-R469), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL466-R482), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL485-R498), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL497-R510), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL505-R520))
*  Add `bool` parameters `$withInheritance` to methods that fetch data from the classification store, to allow the option to include the inherited data from the parent objects in the result ([link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL110-R118), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL296-R312), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL466-R482), [link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL505-R520))
*  Simplify the logic of the `getGroups` method by calling the `getActiveGroupsWithConfig` method directly with the current object and the inheritance option, instead of using the `getAllDataFromField` method with a closure ([link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL505-R520))
*  Fix a typo in the variable name `$fieldDefintions` to `$fieldDefinitions` in the `getAllDataFromField` method, and add a condition to check if the current field name matches the field name of the classification store data object in the loop, to avoid unnecessary calls to the getter methods of other fields ([link](https://github.com/pimcore/pimcore/pull/14948/files?diff=unified&w=0#diff-08971fa2cb1531e8fd9723c4ac947cdc8cfee491e2fee2294b57f92f4eb8dc8eL515-R530))
