### PR TITLE
[Task]: Follow-up Gotenberg as LibreOffice Adapter

### DIFF
--- a/lib/Document/Adapter/Gotenberg.php
+++ b/lib/Document/Adapter/Gotenberg.php
@@ -60,7 +60,7 @@ class Gotenberg extends Ghostscript
      */
     public static function checkGotenberg(): bool
     {
-        if (!class_exists(GotenbergAPI::class, false)) {
+        if (!class_exists(GotenbergAPI::class, true)) {
             return false;
         }
         $request = GotenbergAPI::chromium(Config::getSystemConfiguration('gotenberg')['base_url'])

--- a/lib/Document/Adapter/Gotenberg.php
+++ b/lib/Document/Adapter/Gotenberg.php
@@ -29,7 +29,7 @@ use Pimcore\Tool\Storage;
  */
 class Gotenberg extends Ghostscript
 {
-    protected static $validPing = false;
+    protected static bool $validPing = false;
     
     public function isAvailable(): bool
     {
@@ -74,9 +74,8 @@ class Gotenberg extends Ghostscript
 
         try {
             GotenbergAPI::send($request);
-            if (!self::$validPing) {
-                self::$validPing = true;
-            }
+            self::$validPing = true;
+            
             return true;
         } catch (GotenbergApiErroed $e) {
             return false;

--- a/lib/Document/Adapter/Gotenberg.php
+++ b/lib/Document/Adapter/Gotenberg.php
@@ -29,6 +29,8 @@ use Pimcore\Tool\Storage;
  */
 class Gotenberg extends Ghostscript
 {
+    protected static $validPing = false;
+    
     public function isAvailable(): bool
     {
         try {
@@ -60,6 +62,10 @@ class Gotenberg extends Ghostscript
      */
     public static function checkGotenberg(): bool
     {
+        if (self::$validPing) {
+            return true;
+        }
+        
         if (!class_exists(GotenbergAPI::class, true)) {
             return false;
         }
@@ -68,7 +74,9 @@ class Gotenberg extends Ghostscript
 
         try {
             GotenbergAPI::send($request);
-
+            if (!self::$validPing) {
+                self::$validPing = true;
+            }
             return true;
         } catch (GotenbergApiErroed $e) {
             return false;


### PR DESCRIPTION
Class_exists: It seems that it would be always returning `false`, if autoload param is not set to `true`
validPing: to avoid checking with a dummy html everytime `::checkGotenberg()` is called. When is set to true, it means that it's enabled in that project. This is because it's used by `$adapter->isAvailable()` and just need to know if it's available as installed/setted up.

## Changes in this pull request  
Follow-up https://github.com/pimcore/pimcore/pull/14212

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 502e239</samp>

Fixed a bug in the `Gotenberg` adapter for document conversion by using the autoloader to load the `GotenbergAPI` class. This change affects the file `lib/Document/Adapter/Gotenberg.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 502e239</samp>

> _`Gotenberg` adapter_
> _Fixes class loading bug with_
> _Autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 502e239</samp>

* Fix bug where GotenbergAPI class is not found by using autoloader in class_exists ([link](https://github.com/pimcore/pimcore/pull/14960/files?diff=unified&w=0#diff-d552f8bac550679f5ec6e920ae880899c001b31a36072b4d83bde80ed2e9373eL63-R63))
