### PR TITLE
RgbaColor: column type shouldn't be UTF-8

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20230516161000.php
+++ b/bundles/CoreBundle/Migrations/Version20230516161000.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Model\DataObject;
+
+final class Version20230516161000 extends AbstractMigration
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getDescription(): string
+    {
+        return 'Updates class definition files';
+    }
+
+    public function up(Schema $schema): void
+    {
+        try {
+            $list = new DataObject\ClassDefinition\Listing();
+            foreach ($list->getClasses() as $class) {
+                $this->write(sprintf('Saving class: %s', $class->getName()));
+                $class->save();
+            }
+
+            $list = new DataObject\Objectbrick\Definition\Listing();
+            foreach ($list->load() as $brickDefinition) {
+                $this->write(sprintf('Saving object brick: %s', $brickDefinition->getKey()));
+                $brickDefinition->save();
+            }
+
+            $list = new DataObject\Fieldcollection\Definition\Listing();
+            foreach ($list->load() as $fc) {
+                $this->write(sprintf('Saving field collection: %s', $fc->getKey()));
+                $fc->save();
+            }
+
+            $list = new DataObject\ClassDefinition\CustomLayout\Listing();
+            foreach ($list->getLayoutDefinitions() as $layout) {
+                $this->write(sprintf('Saving custom layout: %s', $layout->getName()));
+                $layout->save();
+            }
+        } catch (DataObject\Exception\DefinitionWriteException $e) {
+            $this->write(
+                'Could not write class definition file. Please set PIMCORE_CLASS_DEFINITION_WRITABLE env.' . "\n" .
+                sprintf(
+                    'If you already have migrate the definitions you can skip this migration via "php bin/console doctrine:migrations:version --add %s"',
+                    __CLASS__
+                )
+            );
+
+            throw $e;
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->write(sprintf('Please restore your class definition files in %s and run bin/console pimcore:deployment:classes-rebuild manually.', PIMCORE_CLASS_DEFINITION_DIRECTORY));
+    }
+}

--- a/models/DataObject/ClassDefinition/Data/RgbaColor.php
+++ b/models/DataObject/ClassDefinition/Data/RgbaColor.php
@@ -57,8 +57,8 @@ class RgbaColor extends Data implements
      * @var array
      */
     public $queryColumnType = [
-        'rgb' => 'VARCHAR(6) NULL DEFAULT NULL',
-        'a' => 'VARCHAR(2) NULL DEFAULT NULL',
+        'rgb' => 'VARCHAR(6) CHARACTER SET latin1 COLLATE latin1_general_ci NULL DEFAULT NULL',
+        'a' => 'VARCHAR(2) CHARACTER SET latin1 COLLATE latin1_general_ci NULL DEFAULT NULL',
     ];
 
     /**
@@ -68,8 +68,9 @@ class RgbaColor extends Data implements
      *
      * @var array
      */
-    public $columnType = ['rgb' => 'VARCHAR(6) NULL DEFAULT NULL',
-        'a' => 'VARCHAR(2) NULL DEFAULT NULL',
+    public $columnType = [
+        'rgb' => 'VARCHAR(6) CHARACTER SET latin1 COLLATE latin1_general_ci NULL DEFAULT NULL',
+        'a' => 'VARCHAR(2) CHARACTER SET latin1 COLLATE latin1_general_ci NULL DEFAULT NULL',
     ];
 
     /**


### PR DESCRIPTION
I have problems with several RgbaColor fields in one class again.
The MariaDB reports the following error:
```
SQLSTATE[42000]: Syntax error or access violation: 1118 Row size too large. The maximum row size for the used table type, not counting BLOBs, is 8126. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs
```

I think it is not nessecary to save the data in utf8.
In the future it would be best to store the data in binary. Then `binary(3)` and `binary(1)` would be enough. But I don't know how we could migrate that.