### PR TITLE
Fix XSS in Conditions tab of Pricing Rules

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PricingManager/Condition/DateRange.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Condition/DateRange.php
@@ -92,8 +92,8 @@ class DateRange implements DateRangeInterface
     {
         return json_encode([
             'type' => 'DateRange',
-            'starting' => $this->getStarting()->format('d.m.Y'),
-            'ending' => $this->getEnding()->format('d.m.Y'),
+            'starting' => $this->getStarting()?->format('d.m.Y'),
+            'ending' => $this->getEnding()?->format('d.m.Y'),
         ]);
     }
 
@@ -107,13 +107,17 @@ class DateRange implements DateRangeInterface
         $json = json_decode($string);
 
         $starting = \DateTime::createFromFormat('d.m.Y', $json->starting, new DateTimeZone('UTC'));
-        $starting->setTime(0, 0, 0);
-
+        if($starting instanceof \DateTime) {
+            $starting->setTime(0, 0, 0);
+            $this->setStarting($starting);
+        }
         $ending = \DateTime::createFromFormat('d.m.Y', $json->ending, new DateTimeZone('UTC'));
-        $ending->setTime(23, 59, 59);
 
-        $this->setStarting($starting);
-        $this->setEnding($ending);
+        if($ending instanceof \DateTime) {
+            $ending->setTime(23, 59, 59);
+            $this->setEnding($ending);
+        }
+
 
         return $this;
     }

--- a/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/item.js
+++ b/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/item.js
@@ -707,13 +707,11 @@ pimcore.bundle.EcommerceFramework.pricing.conditions = {
                 altFormats: 'U',
                 value: data.starting,
                 width: 400,
-                listeners: {
-                    change: function () {
-                        if (typeof this.getValue() != 'object') {
-                            this.setValue(null);
-                        }
+                onChange: function (value) {
+                    if (Ext.String.hasHtmlCharacters(value)) {
+                        this.setValue(null);
                     }
-                }
+                },
             },{
                 xtype:'datefield',
                 fieldLabel: t("to"),
@@ -722,13 +720,11 @@ pimcore.bundle.EcommerceFramework.pricing.conditions = {
                 altFormats: 'U',
                 value: data.ending,
                 width: 400,
-                listeners: {
-                    change: function () {
-                        if (typeof this.getValue() != 'object') {
-                            this.setValue(null);
-                        }
+                onChange: function (value) {
+                    if (Ext.String.hasHtmlCharacters(value)) {
+                        this.setValue(null);
                     }
-                }
+                },
             }],
             listeners: {
 

--- a/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/item.js
+++ b/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/item.js
@@ -706,7 +706,14 @@ pimcore.bundle.EcommerceFramework.pricing.conditions = {
                 format: 'd.m.Y',
                 altFormats: 'U',
                 value: data.starting,
-                width: 400
+                width: 400,
+                listeners: {
+                    change: function () {
+                        if (typeof this.getValue() != 'object') {
+                            this.setValue(null);
+                        }
+                    }
+                }
             },{
                 xtype:'datefield',
                 fieldLabel: t("to"),
@@ -714,7 +721,14 @@ pimcore.bundle.EcommerceFramework.pricing.conditions = {
                 format: 'd.m.Y',
                 altFormats: 'U',
                 value: data.ending,
-                width: 400
+                width: 400,
+                listeners: {
+                    change: function () {
+                        if (typeof this.getValue() != 'object') {
+                            this.setValue(null);
+                        }
+                    }
+                }
             }],
             listeners: {
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f1db5f9</samp>

Fixed a bug in the `DateRange` condition of the pricing manager that could cause errors with invalid or null dates. Improved the UI validation for date inputs in pricing rule configuration.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f1db5f9</samp>

> _Oh we're the brave and clever crew of the pricing manager_
> _We fix the bugs and make the rules for every customer_
> _We use the null-safe operators and check the `DateRange`_
> _And on the count of three we heave and save the changes_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f1db5f9</samp>

*  Fix a bug where pricing rules with date range conditions could not be saved or loaded properly if the dates were not set or invalid ([link](https://github.com/pimcore/pimcore/pull/14963/files?diff=unified&w=0#diff-e29a8b8dd7ae26daf7b6420ef31d642ff48d1a350a706c3ad50ce8caec08c922L95-R96), [link](https://github.com/pimcore/pimcore/pull/14963/files?diff=unified&w=0#diff-e29a8b8dd7ae26daf7b6420ef31d642ff48d1a350a706c3ad50ce8caec08c922L110-R121), [link](https://github.com/pimcore/pimcore/pull/14963/files?diff=unified&w=0#diff-2364fe1a623c7980424e48f7c9e167deb67fc7efe51e449d651d184c083b224aL709-R716), [link](https://github.com/pimcore/pimcore/pull/14963/files?diff=unified&w=0#diff-2364fe1a623c7980424e48f7c9e167deb67fc7efe51e449d651d184c083b224aL717-R731))
  * Add null-safe operators to the `format` method calls on the `starting` and `ending` properties of the `DateRange` condition in `bundles/EcommerceFrameworkBundle/PricingManager/Condition/DateRange.php` ([link](https://github.com/pimcore/pimcore/pull/14963/files?diff=unified&w=0#diff-e29a8b8dd7ae26daf7b6420ef31d642ff48d1a350a706c3ad50ce8caec08c922L95-R96))
  * Add type checks for the `\DateTime` instances created from the JSON input in the `fromJSON` method of the `DateRange` condition in the same file ([link](https://github.com/pimcore/pimcore/pull/14963/files?diff=unified&w=0#diff-e29a8b8dd7ae26daf7b6420ef31d642ff48d1a350a706c3ad50ce8caec08c922L110-R121))
  * Add `change` listeners to the `datefield` components for the `starting` and `ending` dates in the pricing rule configuration UI in `bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/item.js` ([link](https://github.com/pimcore/pimcore/pull/14963/files?diff=unified&w=0#diff-2364fe1a623c7980424e48f7c9e167deb67fc7efe51e449d651d184c083b224aL709-R716), [link](https://github.com/pimcore/pimcore/pull/14963/files?diff=unified&w=0#diff-2364fe1a623c7980424e48f7c9e167deb67fc7efe51e449d651d184c083b224aL717-R731))
  * Set the values of the `datefield` components to null if they are not valid dates in the UI ([link](https://github.com/pimcore/pimcore/pull/14963/files?diff=unified&w=0#diff-2364fe1a623c7980424e48f7c9e167deb67fc7efe51e449d651d184c083b224aL709-R716), [link](https://github.com/pimcore/pimcore/pull/14963/files?diff=unified&w=0#diff-2364fe1a623c7980424e48f7c9e167deb67fc7efe51e449d651d184c083b224aL717-R731))
