### PR TITLE
[Task] Reworked xss prevention

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
@@ -105,9 +105,9 @@ pimcore.object.quantityValue.unitsettings = Class.create({
 
         var typesColumns = [
             {flex: 1, dataIndex: 'id', text: t("id"), filter: 'string'},
-            {flex: 1, dataIndex: 'abbreviation', text: t("abbreviation"), editor: new Ext.form.TextField({listeners: {change: this.sanitizeTextColumn}}), filter: 'string'},
-            {flex: 2, dataIndex: 'longname', text: t("longname"), editor: new Ext.form.TextField({listeners: {change: this.sanitizeTextColumn}}), filter: 'string'},
-            {flex: 1, dataIndex: 'group', text: t("group"), editor: new Ext.form.TextField({listeners: {change: this.sanitizeTextColumn}}), filter: 'string', hidden: true},
+            {flex: 1, dataIndex: 'abbreviation', text: t("abbreviation"), editor: new Ext.form.TextField({listeners: {change: pimcore.helpers.htmlEncodeTextField}}), filter: 'string'},
+            {flex: 2, dataIndex: 'longname', text: t("longname"), editor: new Ext.form.TextField({listeners: {change: pimcore.helpers.htmlEncodeTextField}}), filter: 'string'},
+            {flex: 1, dataIndex: 'group', text: t("group"), editor: new Ext.form.TextField({listeners: {change: pimcore.helpers.htmlEncodeTextField}}), filter: 'string', hidden: true},
             {flex: 1, dataIndex: 'baseunit', text: t("baseunit"), editor: baseUnitEditor, renderer: function(value){
                 if(!value) {
                     return '('+t('empty')+')';
@@ -121,8 +121,8 @@ pimcore.object.quantityValue.unitsettings = Class.create({
             }},
             {flex: 1, dataIndex: 'factor', text: t("conversionFactor"), editor: new Ext.form.NumberField({decimalPrecision: 10}), filter: 'numeric'},
             {flex: 1, dataIndex: 'conversionOffset', text: t("conversionOffset"), editor: new Ext.form.NumberField({decimalPrecision: 10}), filter: 'numeric'},
-            {flex: 1, dataIndex: 'reference', text: t("reference"), editor: new Ext.form.TextField({listeners: {change: this.sanitizeTextColumn}}), hidden: true, filter: 'string'},
-            {flex: 1, dataIndex: 'converter', text: t("converter_service"), editor: new Ext.form.TextField({listeners: {change: this.sanitizeTextColumn}}), filter: 'string'}
+            {flex: 1, dataIndex: 'reference', text: t("reference"), editor: new Ext.form.TextField({listeners: {change: pimcore.helpers.htmlEncodeTextField}}), hidden: true, filter: 'string'},
+            {flex: 1, dataIndex: 'converter', text: t("converter_service"), editor: new Ext.form.TextField({listeners: {change: pimcore.helpers.htmlEncodeTextField}}), filter: 'string'}
         ];
 
         typesColumns.push({
@@ -279,12 +279,5 @@ pimcore.object.quantityValue.unitsettings = Class.create({
         }
         var rec = selections.getAt(0);
         this.grid.store.remove(rec);
-    },
-
-    sanitizeTextColumn: function (textField) {
-        if(textField.getValue()){
-            const sanitizedValue = textField.getValue().replace(/[<>"'!?/\\&%$();]/gi, '');
-            textField.setValue(sanitizedValue);
-        }
     }
 });

--- a/models/DataObject/QuantityValue/Unit.php
+++ b/models/DataObject/QuantityValue/Unit.php
@@ -20,6 +20,7 @@ use Pimcore\Event\DataObjectQuantityValueEvents;
 use Pimcore\Event\Model\DataObject\QuantityValueUnitEvent;
 use Pimcore\Event\Traits\RecursionBlockingEventDispatchHelperTrait;
 use Pimcore\Model;
+use Pimcore\Security\SecurityHelper;
 
 /**
  * @method \Pimcore\Model\DataObject\QuantityValue\Unit\Dao getDao()
@@ -209,7 +210,7 @@ class Unit extends Model\AbstractModel
      */
     public function setAbbreviation($abbreviation)
     {
-        $this->abbreviation = htmlspecialchars($abbreviation);
+        $this->abbreviation = SecurityHelper::convertHtmlSpecialChars($abbreviation);
 
         return $this;
     }
@@ -276,7 +277,7 @@ class Unit extends Model\AbstractModel
      */
     public function setGroup($group)
     {
-        $this->group = htmlspecialchars($group);
+        $this->group = SecurityHelper::convertHtmlSpecialChars($group);
 
         return $this;
     }
@@ -316,7 +317,7 @@ class Unit extends Model\AbstractModel
      */
     public function setLongname($longname)
     {
-        $this->longname = htmlspecialchars($longname);
+        $this->longname = SecurityHelper::convertHtmlSpecialChars($longname);
 
         return $this;
     }
@@ -344,7 +345,7 @@ class Unit extends Model\AbstractModel
      */
     public function setReference($reference)
     {
-        $this->reference = htmlspecialchars($reference);
+        $this->reference = SecurityHelper::convertHtmlSpecialChars($reference);
 
         return $this;
     }
@@ -384,7 +385,7 @@ class Unit extends Model\AbstractModel
      */
     public function setConverter($converter)
     {
-        $this->converter = htmlspecialchars((string)$converter);
+        $this->converter = SecurityHelper::convertHtmlSpecialChars((string)$converter);
 
         return $this;
     }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
## Changes in this pull request  
Updates #14937

This should change the original implementation to the more general one.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at abb9b44</samp>

This pull request improves the security of the quantity value unit feature by preventing XSS attacks. It applies HTML encoding to the user input and the unit data using a common helper function. It affects the files `unitsettings.js` and `Unit.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at abb9b44</samp>

> _No more XSS in the grid of doom_
> _We use the helper to seal their tomb_
> _`SecurityHelper` is our shield_
> _We encode the chars in every field_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at abb9b44</samp>

*  Replace `this.sanitizeTextColumn` with `pimcore.helpers.htmlEncodeTextField` in editor listeners for unit settings grid columns to prevent XSS attacks ([link](https://github.com/pimcore/pimcore/pull/14965/files?diff=unified&w=0#diff-81b52d77d2f17c4b1dc83501ed4e03d419abc0faf948587282fb7b1be4d73385L108-R110), [link](https://github.com/pimcore/pimcore/pull/14965/files?diff=unified&w=0#diff-81b52d77d2f17c4b1dc83501ed4e03d419abc0faf948587282fb7b1be4d73385L124-R125))
* Remove unused `sanitizeTextColumn` function from `unitsettings.js` ([link](https://github.com/pimcore/pimcore/pull/14965/files?diff=unified&w=0#diff-81b52d77d2f17c4b1dc83501ed4e03d419abc0faf948587282fb7b1be4d73385L282-L288))
* Use `SecurityHelper::convertHtmlSpecialChars` instead of `htmlspecialchars` in setter methods for unit properties in `Unit.php` to ensure consistency with frontend validation and prevent XSS attacks ([link](https://github.com/pimcore/pimcore/pull/14965/files?diff=unified&w=0#diff-946a09395ce6d866f794fd211f1b09f22d4ff7ba4ff88e162e1bbf7567ff415fL212-R213), [link](https://github.com/pimcore/pimcore/pull/14965/files?diff=unified&w=0#diff-946a09395ce6d866f794fd211f1b09f22d4ff7ba4ff88e162e1bbf7567ff415fL279-R280), [link](https://github.com/pimcore/pimcore/pull/14965/files?diff=unified&w=0#diff-946a09395ce6d866f794fd211f1b09f22d4ff7ba4ff88e162e1bbf7567ff415fL319-R320), [link](https://github.com/pimcore/pimcore/pull/14965/files?diff=unified&w=0#diff-946a09395ce6d866f794fd211f1b09f22d4ff7ba4ff88e162e1bbf7567ff415fL347-R348), [link](https://github.com/pimcore/pimcore/pull/14965/files?diff=unified&w=0#diff-946a09395ce6d866f794fd211f1b09f22d4ff7ba4ff88e162e1bbf7567ff415fL387-R388))
