### PR TITLE
[Security] Fix Admin Translation Export SQL Injection

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Bundle\AdminBundle\Controller\Admin;
 
+use Doctrine\DBAL\Exception\SyntaxErrorException;
 use Doctrine\DBAL\Query\QueryBuilder as DoctrineQueryBuilder;
 use Pimcore\Bundle\AdminBundle\Controller\AdminController;
 use Pimcore\File;
@@ -196,7 +197,12 @@ class TranslationController extends AdminController
         }
 
         $this->extendTranslationQuery($joins, $list, $tableName, $filters);
-        $list->load();
+
+        try {
+            $list->load();
+        } catch (SyntaxErrorException $syntaxErrorException) {
+            throw new \InvalidArgumentException('Check your arguments.');
+        }
 
         $translations = [];
         $translationObjects = $list->getTranslations();
@@ -474,7 +480,11 @@ class TranslationController extends AdminController
 
             $this->extendTranslationQuery($joins, $list, $tableName, $filters);
 
-            $list->load();
+            try {
+                $list->load();
+            } catch (SyntaxErrorException $syntaxErrorException) {
+                throw new \InvalidArgumentException('Check your arguments.');
+            }
 
             $translations = [];
             $searchString = $request->get('searchString');
@@ -606,6 +616,7 @@ class TranslationController extends AdminController
                 if (in_array(ltrim($fieldname, '_'), $validLanguages)) {
                     $fieldname = ltrim($fieldname, '_');
                 }
+                $fieldname = str_replace('--', '', $fieldname);
 
                 if (!$languageMode && in_array($fieldname, $validLanguages)
                     || $languageMode && !in_array($fieldname, $validLanguages)) {

--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -50,6 +50,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class TranslationController extends AdminController
 {
+    protected const PLACEHOLDER_NAME = 'placeHolder';
+
     /**
      * @Route("/import", name="pimcore_admin_translation_import", methods={"POST"})
      *
@@ -606,7 +608,6 @@ class TranslationController extends AdminController
             $filters = $this->decodeJson($filterJson);
 
             foreach ($filters as $filter) {
-                $placeHolderName = 'placeHolder';
                 $operator = '=';
                 $field = null;
                 $value = null;
@@ -656,7 +657,7 @@ class TranslationController extends AdminController
                             'language' => $fieldname,
                         ];
                     } else {
-                        $placeHolderName = $placeHolderName . $placeHolderCount;
+                        $placeHolderName = self::PLACEHOLDER_NAME . $placeHolderCount;
                         $placeHolderCount++;
                         $conditionFilters[] = [
                             'condition' => $field . ' ' . $operator . ' :' . $placeHolderName,
@@ -674,16 +675,13 @@ class TranslationController extends AdminController
                 'field' => 'filterTerm',
                 'value' => '%' . mb_strtolower($request->get('searchString')) . '%'
             ];
-
         }
 
         if ($languageMode) {
-            $result = [
+            return [
                 'joins' => $joins,
                 'conditions' => $conditions,
             ];
-
-            return $result;
         }
 
         if(!empty($conditionFilters)) {

--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -50,7 +50,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class TranslationController extends AdminController
 {
-
     /**
      * @Route("/import", name="pimcore_admin_translation_import", methods={"POST"})
      *


### PR DESCRIPTION
## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 87dcc28</samp>

This pull request enhances the translation controller by using safer and more flexible SQL queries, and by handling errors gracefully. It also allows more advanced filtering options for the translation grid.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 87dcc28</samp>

> _To make the translation controller secure_
> _We use placeholders and catch errors for sure_
> _We also change `getGridFilterCondition`_
> _To return an array with more precision_
> _And support filters that are complex and obscure_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 87dcc28</samp>

*  Import `SyntaxErrorException` class to handle syntax errors in SQL queries ([link](https://github.com/pimcore/pimcore/pull/14968/files?diff=unified&w=0#diff-92f44ad5cf4f7c7b3590da6460d10eaf0cade512cd3eabfa219ccd59ace1d79eR18))
*  Modify `exportAction` and `translationsAction` methods to use array format of `getGridFilterCondition` method and catch `SyntaxErrorException` ([link](https://github.com/pimcore/pimcore/pull/14968/files?diff=unified&w=0#diff-92f44ad5cf4f7c7b3590da6460d10eaf0cade512cd3eabfa219ccd59ace1d79eL186-R190), [link](https://github.com/pimcore/pimcore/pull/14968/files?diff=unified&w=0#diff-92f44ad5cf4f7c7b3590da6460d10eaf0cade512cd3eabfa219ccd59ace1d79eL198-R206), [link](https://github.com/pimcore/pimcore/pull/14968/files?diff=unified&w=0#diff-92f44ad5cf4f7c7b3590da6460d10eaf0cade512cd3eabfa219ccd59ace1d79eL463-R470), [link](https://github.com/pimcore/pimcore/pull/14968/files?diff=unified&w=0#diff-92f44ad5cf4f7c7b3590da6460d10eaf0cade512cd3eabfa219ccd59ace1d79eL469-R487))
*  Refactor `getGridFilterCondition` method to return array with condition and parameters, use placeholders, and support admin filter ([link](https://github.com/pimcore/pimcore/pull/14968/files?diff=unified&w=0#diff-92f44ad5cf4f7c7b3590da6460d10eaf0cade512cd3eabfa219ccd59ace1d79eL577-R594), [link](https://github.com/pimcore/pimcore/pull/14968/files?diff=unified&w=0#diff-92f44ad5cf4f7c7b3590da6460d10eaf0cade512cd3eabfa219ccd59ace1d79eL595-R610), [link](https://github.com/pimcore/pimcore/pull/14968/files?diff=unified&w=0#diff-92f44ad5cf4f7c7b3590da6460d10eaf0cade512cd3eabfa219ccd59ace1d79eR619), [link](https://github.com/pimcore/pimcore/pull/14968/files?diff=unified&w=0#diff-92f44ad5cf4f7c7b3590da6460d10eaf0cade512cd3eabfa219ccd59ace1d79eL644-R666), [link](https://github.com/pimcore/pimcore/pull/14968/files?diff=unified&w=0#diff-92f44ad5cf4f7c7b3590da6460d10eaf0cade512cd3eabfa219ccd59ace1d79eL651-R678), [link](https://github.com/pimcore/pimcore/pull/14968/files?diff=unified&w=0#diff-92f44ad5cf4f7c7b3590da6460d10eaf0cade512cd3eabfa219ccd59ace1d79eL662-R703))