### PR TITLE
Fix XSS in name parameter of Pricing Rules

### DIFF
--- a/bundles/EcommerceFrameworkBundle/PricingManager/Rule.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Rule.php
@@ -24,7 +24,7 @@ use Pimcore\Cache\RuntimeCache;
 use Pimcore\Logger;
 use Pimcore\Model\AbstractModel;
 use Pimcore\Model\Exception\NotFoundException;
-
+use Pimcore\Security\SecurityHelper;
 /**
  * @method Dao getDao()
  */
@@ -204,8 +204,7 @@ class Rule extends AbstractModel implements RuleInterface
      */
     public function setName($name, $locale = null)
     {
-        $this->name = $name;
-
+        $this->name = SecurityHelper::convertHtmlSpecialChars($name);
         return $this;
     }
 

--- a/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/panel.js
+++ b/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/panel.js
@@ -299,7 +299,6 @@ pimcore.bundle.EcommerceFramework.pricing.config.panel = Class.create({
         pimcore.helpers.deleteConfirm(
             t('bundle_ecommerce_pricing_rule'),
             Ext.util.Format.htmlEncode(decodedName),
-            record.data.text,
             function () {
                 Ext.Ajax.request({
                     url: Routing.generate('pimcore_ecommerceframework_pricing_delete'),

--- a/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/panel.js
+++ b/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/panel.js
@@ -295,17 +295,22 @@ pimcore.bundle.EcommerceFramework.pricing.config.panel = Class.create({
      * delete existing rule
      */
     deleteRule: function (tree, record) {
-        pimcore.helpers.deleteConfirm(t('bundle_ecommerce_pricing_rule'), record.data.text, function () {
-            Ext.Ajax.request({
-                url: Routing.generate('pimcore_ecommerceframework_pricing_delete'),
-                method: 'DELETE',
-                params: {
-                    id: record.id
-                },
-                success: function () {
-                    this.refresh(this.tree.getRootNode());
-                }.bind(this)
-            });
+        const decodedName = Ext.util.Format.htmlDecode(record.data.text);
+        pimcore.helpers.deleteConfirm(
+            t('bundle_ecommerce_pricing_rule'),
+            Ext.util.Format.htmlEncode(decodedName),
+            record.data.text,
+            function () {
+                Ext.Ajax.request({
+                    url: Routing.generate('pimcore_ecommerceframework_pricing_delete'),
+                    method: 'DELETE',
+                    params: {
+                        id: record.id
+                    },
+                    success: function () {
+                        this.refresh(this.tree.getRootNode());
+                    }.bind(this)
+                });
         }.bind(this));
 
     },


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 41d90b5</samp>

Improved XSS protection and UI consistency for pricing rules in the Ecommerce Framework Bundle. Escaped and encoded rule names in `Rule.php` and `panel.js` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 41d90b5</samp>

> _We are the rule breakers, we defy the system_
> _We decode the secrets, we expose the lies_
> _But they try to stop us, they escape our vision_
> _They encode the names, they hide behind HTML entities_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 41d90b5</samp>

*  Escape HTML special characters in rule name to prevent XSS attacks ([link](https://github.com/pimcore/pimcore/pull/14969/files?diff=unified&w=0#diff-a9124cc8320862d4a5828510d58b42d8a46c33fb566f48ccb77d3953eb284b42L27-R27), [link](https://github.com/pimcore/pimcore/pull/14969/files?diff=unified&w=0#diff-a9124cc8320862d4a5828510d58b42d8a46c33fb566f48ccb77d3953eb284b42L207-R207))
* Decode and encode rule name from HTML entities for confirmation dialog ([link](https://github.com/pimcore/pimcore/pull/14969/files?diff=unified&w=0#diff-1c36dedb988162f2ec880aac99e835fcb4d460096265b4e11190ac7ca86f9f9cL298-R313))
