### PR TITLE
[Security] Fixed xss on login page

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/LoginController.php
+++ b/bundles/AdminBundle/Controller/Admin/LoginController.php
@@ -29,6 +29,7 @@ use Pimcore\Event\AdminEvents;
 use Pimcore\Http\ResponseHelper;
 use Pimcore\Logger;
 use Pimcore\Model\User;
+use Pimcore\Security\SecurityHelper;
 use Pimcore\Tool;
 use Pimcore\Tool\Authentication;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -114,7 +115,7 @@ class LoginController extends AdminController implements BruteforceProtectedCont
         $params['csrfTokenRefreshInterval'] = ((int)$session_gc_maxlifetime - 60) * 1000;
 
         if ($request->get('too_many_attempts')) {
-            $params['error'] = $request->get('too_many_attempts');
+            $params['error'] = SecurityHelper::convertHtmlSpecialChars($request->get('too_many_attempts'));
         }
         if ($request->get('auth_failed')) {
             $params['error'] = 'error_auth_failed';


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b9e3ffb</samp>

This pull request improves the security of the login controller by sanitizing the error message for failed login attempts. It uses the `SecurityHelper` class from the `AdminBundle` to prevent XSS attacks.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b9e3ffb</samp>

> _`SecurityHelper`_
> _Sanitizes error message_
> _No XSS in spring_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b9e3ffb</samp>

*  Escape error message for login attempts limit to prevent XSS attacks ([link](https://github.com/pimcore/pimcore/pull/14975/files?diff=unified&w=0#diff-95e54498307da574303c55b71b02f22177e0f6f025d7daf7c35f440c5369621eR32), [link](https://github.com/pimcore/pimcore/pull/14975/files?diff=unified&w=0#diff-95e54498307da574303c55b71b02f22177e0f6f025d7daf7c35f440c5369621eL117-R118))
*  Add `SecurityHelper` class to `use` statement in `LoginController.php` ([link](https://github.com/pimcore/pimcore/pull/14975/files?diff=unified&w=0#diff-95e54498307da574303c55b71b02f22177e0f6f025d7daf7c35f440c5369621eR32))
