### PR TITLE
[Security] Fix xss in link editable

### DIFF
--- a/doc/Development_Documentation/03_Documents/01_Editables/18_Link.md
+++ b/doc/Development_Documentation/03_Documents/01_Editables/18_Link.md
@@ -6,7 +6,7 @@ The link editable is used for dynamic link creation in documents.
 
 ## Configuration
 
-You can pass every valid attribute an `<a>`-tag can have ([w3.org - Link](https://www.w3.org/TR/html52/textlevel-semantics.html#the-a-element)), 
+You can pass nearly every valid attribute an `<a>`-tag can have ([w3.org - Link](https://www.w3.org/TR/html52/textlevel-semantics.html#the-a-element)), 
 such as: `class`, `target`, `id`, `style`, `accesskey`, `name`, `title`, `data-*`, `aria-*` and additionally the following: 
 
 | Name     | Type     | Description                                                             |
@@ -16,6 +16,8 @@ such as: `class`, `target`, `id`, `style`, `accesskey`, `name`, `title`, `data-*
 | `textSuffix` | string  | Add an icon or something else after Text    |
 | `noText` | boolean  | If you need only the `<a>` tag without text (or only with an textSuffix/TextPrefix)    |
 | `required` | boolean/string  | (default: false) set to true to make link and text required for publish, set to "linkonly" to make only the link required for publish    |
+
+> For security reasons we created an [allow list](https://github.com/pimcore/pimcore/blob/9bf18aca55e5303661c68835c950412a428cf616/models/Document/Editable/Link.php#L115-L141) to filter harmfull html attributes. For example all `on*` attributes will be filtered out!
 
 ## Methods
 

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -2,6 +2,7 @@
 
 ## 10.5.21
 - [Assets] The Asset `Import from Server` feature is now only available for admins. It will be removed in Pimcore 11
+- [Editable] Removed all `on*` attributes from the `$allowedAttributes` list due to security reasons. These attributes are not allowed anymore in the "attributes" field.
 
 ## 10.5.13
 - [Web2Print] Print document twig expressions are now executed in a sandbox with restrictive security policies (just like Sending mails and Dataobject Text Layouts introduced in 10.5.9).

--- a/lib/Security/SecurityHelper.php
+++ b/lib/Security/SecurityHelper.php
@@ -25,4 +25,13 @@ class SecurityHelper
 
         return null;
     }
+
+    public static function sanitizeHtmlAttributes(?string $text): ?string
+    {
+        if(is_string($text)) {
+            return preg_replace('/[\/"\'\\\]/', '', $text);
+        }
+
+        return null;
+    }
 }

--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -19,6 +19,7 @@ use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Document;
+use Pimcore\Security\SecurityHelper;
 
 /**
  * @method \Pimcore\Model\Document\Editable\Dao getDao()
@@ -166,9 +167,9 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
                         strpos($key, 'aria-') === 0 ||
                         in_array($key, $allowedAttributes))) {
                     if (!empty($this->data[$key]) && !empty($this->config[$key])) {
-                        $attribs[] = $key.'="'. $this->data[$key] .' '. $this->config[$key] .'"';
+                        $attribs[] = $key.'="'. SecurityHelper::sanitizeHtmlAttributes($this->data[$key]) .' '. SecurityHelper::sanitizeHtmlAttributes($this->config[$key]) .'"';
                     } elseif (!empty($value)) {
-                        $attribs[] = $key.'="'.$value.'"';
+                        $attribs[] = $key.'="'.SecurityHelper::sanitizeHtmlAttributes($value).'"';
                     }
                 }
             }
@@ -242,8 +243,7 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
         }
 
         if (strlen($this->data['anchor'] ?? '') > 0) {
-            $anchor = $this->getAnchor();
-            $anchor = str_replace('"', urlencode('"'), $anchor);
+            $anchor = str_replace('"', urlencode('"'), $this->getAnchor());
             $url .= '#' . str_replace('#', '', $anchor);
         }
 
@@ -340,7 +340,7 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
      */
     public function getParameters()
     {
-        return $this->data['parameters'] ?? '';
+        return SecurityHelper::sanitizeHtmlAttributes($this->data['parameters']) ?? '';
     }
 
     /**
@@ -348,7 +348,7 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
      */
     public function getAnchor()
     {
-        return $this->data['anchor'] ?? '';
+        return SecurityHelper::sanitizeHtmlAttributes($this->data['anchor']) ?? '';
     }
 
     /**
@@ -372,7 +372,7 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
      */
     public function getTabindex()
     {
-        return $this->data['tabindex'] ?? '';
+        return SecurityHelper::sanitizeHtmlAttributes($this->data['tabindex']) ?? '';
     }
 
     /**
@@ -380,7 +380,7 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
      */
     public function getAccesskey()
     {
-        return $this->data['accesskey'] ?? '';
+        return SecurityHelper::sanitizeHtmlAttributes($this->data['accesskey']) ?? '';
     }
 
     /**
@@ -388,7 +388,7 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
      */
     public function getClass()
     {
-        return $this->data['class'] ?? '';
+        return SecurityHelper::sanitizeHtmlAttributes($this->data['class']) ?? '';
     }
 
     /**

--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -364,7 +364,7 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
      */
     public function getRel()
     {
-        return $this->data['rel'] ?? '';
+        return SecurityHelper::sanitizeHtmlAttributes($this->data['rel']) ?? '';
     }
 
     /**

--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -137,19 +137,7 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
                 'ping',
                 'type',
                 'referrerpolicy',
-                'xml:lang',
-                'onblur',
-                'onclick',
-                'ondblclick',
-                'onfocus',
-                'onmousedown',
-                'onmousemove',
-                'onmouseout',
-                'onmouseover',
-                'onmouseup',
-                'onkeydown',
-                'onkeypress',
-                'onkeyup',
+                'xml:lang'
             ];
             $defaultAttributes = [];
 
@@ -299,6 +287,10 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
             }
         }
 
+        if($editmode) {
+            unset($this->data['attributes']);
+        }
+
         // sanitize attributes
         if (isset($this->data['attributes'])) {
             $this->data['attributes'] = htmlspecialchars($this->data['attributes'], HTML_ENTITIES);
@@ -407,6 +399,14 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
         $this->data = \Pimcore\Tool\Serialize::unserialize($data);
         if (!is_array($this->data)) {
             $this->data = [];
+        }
+
+        //sanitize fields
+        $fieldsToExclude = ['path'];
+        foreach($this->data as $key => $value) {
+            if(!in_array($key, $fieldsToExclude)) {
+                $this->data[$key] = SecurityHelper::sanitizeHtmlAttributes($value);
+            }
         }
 
         return $this;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ff112d</samp>

The pull request adds a new method `SecurityHelper::sanitizeHtmlAttributes` to escape HTML attributes and uses it in the `Link` class to prevent XSS attacks through link elements.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6ff112d</samp>

> _Sing, O Muse, of the cunning SecurityHelper_
> _Who devised a skillful method to cleanse the strings_
> _Of slashes, quotes, and backslashes, those vile foes_
> _That lurk in HTML attributes to harm the links._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ff112d</samp>

*  Add a new method `sanitizeHtmlAttributes` to the `SecurityHelper` class that escapes potentially malicious HTML attributes in user input ([link](https://github.com/pimcore/pimcore/pull/14986/files?diff=unified&w=0#diff-24b062121eb9f8efd251b1e96a3acdefd634512adc0aa977a07752f423d3c39fR28-R36))
* Import the `SecurityHelper` class in the `Link` class to use the `sanitizeHtmlAttributes` method ([link](https://github.com/pimcore/pimcore/pull/14986/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043R22))
* Sanitize the data and config values of the link attributes using the `sanitizeHtmlAttributes` method in the `frontend` method of the `Link` class, which generates the HTML output of the link element ([link](https://github.com/pimcore/pimcore/pull/14986/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043L169-R172))
* Remove the redundant call to `str_replace` on the anchor value in the `getHref` method of the `Link` class, which returns the URL of the link element, as the anchor value is already sanitized by the `getAnchor` method ([link](https://github.com/pimcore/pimcore/pull/14986/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043L245-R246))
* Sanitize the data value of the parameters property using the `sanitizeHtmlAttributes` method in the `getParameters` method of the `Link` class, which returns the query string parameters of the link element ([link](https://github.com/pimcore/pimcore/pull/14986/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043L343-R343))
* Sanitize the data value of the anchor property using the `sanitizeHtmlAttributes` method in the `getAnchor` method of the `Link` class, which returns the anchor part of the link element ([link](https://github.com/pimcore/pimcore/pull/14986/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043L351-R351))
* Sanitize the data value of the tabindex property using the `sanitizeHtmlAttributes` method in the `getTabindex` method of the `Link` class, which returns the tabindex attribute of the link element ([link](https://github.com/pimcore/pimcore/pull/14986/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043L375-R375))
* Sanitize the data value of the accesskey property using the `sanitizeHtmlAttributes` method in the `getAccesskey` method of the `Link` class, which returns the accesskey attribute of the link element ([link](https://github.com/pimcore/pimcore/pull/14986/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043L383-R383))
* Sanitize the data value of the class property using the `sanitizeHtmlAttributes` method in the `getClass` method of the `Link` class, which returns the class attribute of the link element ([link](https://github.com/pimcore/pimcore/pull/14986/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043L391-R391))
