### PR TITLE
[Task] Deprecated `attributes` field of link editable

### DIFF
--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -61,6 +61,7 @@
             hide_edit_image: false
             disable_tree_preview: true
     ```
+- [Link Editable] The "attributes" field in the "advanced" tab is deprecated. The field will be removed in Pimcore 11 due to security reasons.
 
 ## 10.5.13
 - [Web2Print] Print document twig expressions are now executed in a sandbox with restrictive security policies (just like Sending mails and Dataobject Text Layouts introduced in 10.5.9).

--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -176,6 +176,12 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
             $attribs = array_unique($attribs);
 
             if (array_key_exists('attributes', $this->data) && !empty($this->data['attributes'])) {
+                trigger_deprecation(
+                    'pimcore/pimcore',
+                    '10.6',
+                    'Using the "attributes" field in the link editable is deprecated. The field will be removed in Pimcore 11.0.'
+                );
+
                 $attribs[] = $this->data['attributes'];
             }
 
@@ -301,6 +307,12 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
 
         // sanitize attributes
         if (isset($this->data['attributes'])) {
+            trigger_deprecation(
+                'pimcore/pimcore',
+                '10.6',
+                'Using the "attributes" field in the link editable is deprecated. The field will be removed in Pimcore 11.0.'
+            );
+
             $this->data['attributes'] = htmlspecialchars($this->data['attributes'], HTML_ENTITIES);
         }
 
@@ -393,6 +405,8 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
 
     /**
      * @return mixed
+     *
+     * @deprecated This method is deprecated and will be removed in Pimcore 11.
      */
     public function getAttributes()
     {


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Belongs-To #14986

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a6b35c</samp>

Deprecate and document the removal of the "attributes" field and the `getClass` method in the link editable class. This improves security and consistency in the Pimcore codebase.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9a6b35c</samp>

> _Sing, O Muse, of the wise and skillful coders_
> _Who strive to improve the Pimcore platform_
> _And guard it from the wiles of evil hackers_
> _Who lurk in the dark web with ill intent._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a6b35c</samp>

*  Deprecate the "attributes" field in the link editable for security reasons ([link](https://github.com/pimcore/pimcore/pull/14994/files?diff=unified&w=0#diff-8e789ff505cab9d3406d3f98e6856e6a0d42dfeeb5c4ee14d7f691c00df1d3c0R64), [link](https://github.com/pimcore/pimcore/pull/14994/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043R179-R184), [link](https://github.com/pimcore/pimcore/pull/14994/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043R310-R315))
  * Add a note to the upgrade documentation in `README.md` to inform users of the deprecation and the migration options ([link](https://github.com/pimcore/pimcore/pull/14994/files?diff=unified&w=0#diff-8e789ff505cab9d3406d3f98e6856e6a0d42dfeeb5c4ee14d7f691c00df1d3c0R64))
  * Add deprecation warnings to the `frontend` and `updatePathFromInternal` methods of the `Link` class to advise users to stop using the field and switch to other options ([link](https://github.com/pimcore/pimcore/pull/14994/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043R179-R184), [link](https://github.com/pimcore/pimcore/pull/14994/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043R310-R315))
* Deprecate the `getClass` method of the link editable as it is no longer needed ([link](https://github.com/pimcore/pimcore/pull/14994/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043R408-R409))
  * Add a deprecation annotation to the method in the `Link` class to indicate that it will be removed in Pimcore 11 ([link](https://github.com/pimcore/pimcore/pull/14994/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043R408-R409))
