### PR TITLE
[Task] Merged `10.6` upgrade notes

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -334,6 +334,7 @@ pimcore:
 
 ## 10.6.0
 
+- [Naming] Deprecated master, blacklist and whitelist. Instead, use main, blocklist, allowlist
 - [Storage config] Deprecated setting write targets and storage directory in the .env file. Instead, use the [symfony config](../07_Updating_Pimcore/11_Preparing_for_V11.md)
 - [Session] The `getHandler`, `setHandler`, `useSession`, `getSessionId`, `getSessionName`, `invalidate`, `regenerateId`, `requestHasSessionId`, `getSessionIdFromRequest`, `get`, `getReadOnly` and `writeClose` methods of `Pimcore\Tool\Session` and class `PreAuthenticatedAdminSessionFactory` are deprecated and get removed with Pimcore 11. Session Management will be handled by Symfony in Pimcore 11.
 - [AreabrickManagerInterface] The `enable`, `disable`, `isEnabled` and `getState` methods of `Pimcore\Extension\Document\Areabrick\AreabrickManagerInterface` are deprecated as maintaining state of extensions is deprecated. This impacts `\Pimcore\Document\Editable\EditableHandler::isBrickEnabled()` method which is also deprecated.
@@ -386,6 +387,13 @@ pimcore:
   - `Pimcore\Event\Model\ObjectDeleteInfoEvent`
   - `Pimcore\Event\Model\ElementDeleteInfoEventInterface`
 - [Extension Manager] Trait `StateHelperTrait` is deprecated and will be removed in Pimcore 11.
+- [Configuration] Deprecated `hide_edit_image` & `disable_tree_preview` configs, they will be moved to `pimcore_admin` in Pimcore 11
+    ```yaml
+    pimcore_admin:
+        assets:
+            hide_edit_image: false
+            disable_tree_preview: true
+    ```
 
 ## 10.5.13
 


### PR DESCRIPTION
Added missing patch notes from 10.6 to 11.x

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 97a9436</samp>

This pull request updates the upgrade notes for Pimcore 10.6.0 to use more inclusive and consistent terminology and configuration options. It renames some terms and options and deprecates some legacy options in `doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 97a9436</samp>

> _The old words are fading, the new ones are rising_
> _`Main`, `blocklist` and `allowlist` are the law_
> _Don't cling to the past, embrace the future_
> _Or you'll face the wrath of Pimcore 10.6_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 97a9436</samp>

* Replace deprecated terms master, blacklist and whitelist with main, blocklist and allowlist in the codebase and documentation ([link](https://github.com/pimcore/pimcore/pull/14996/files?diff=unified&w=0#diff-375aded12dfb868b84d5b8c27d1aed2358680a27b683e8a985f1b85193dd79aaR337), [link](https://github.com/pimcore/pimcore/pull/14996/files?diff=unified&w=0#diff-375aded12dfb868b84d5b8c27d1aed2358680a27b683e8a985f1b85193dd79aaR390-R396),                                         F0L
