### PR TITLE
Operator alias throws warning if it is null

### DIFF
--- a/lib/DataObject/GridColumnConfig/Operator/Alias.php
+++ b/lib/DataObject/GridColumnConfig/Operator/Alias.php
@@ -39,7 +39,7 @@ final class Alias extends AbstractOperator
 
             $childResult = $c->getLabeledValue($element);
             $isArrayType = $childResult->isArrayType ?? null;
-            $childValues = $childResult->value;
+            $childValues = $childResult->value ?? null;
             if ($childValues && !$isArrayType) {
                 $childValues = [$childValues];
             }


### PR DESCRIPTION
Occurs in grid view with table options