### PR TITLE
Fix Xss in name field of custom reports

### DIFF
--- a/bundles/AdminBundle/Controller/Reports/CustomReportController.php
+++ b/bundles/AdminBundle/Controller/Reports/CustomReportController.php
@@ -76,6 +76,8 @@ class CustomReportController extends ReportsControllerBase
 
         $success = false;
 
+        $this->isValidConfigName($request->get('name'));
+
         $report = CustomReport\Config::getByName($request->get('name'));
 
         if (!$report) {
@@ -129,6 +131,7 @@ class CustomReportController extends ReportsControllerBase
         $this->checkPermission('reports_config');
 
         $newName = $request->get('newName');
+        $this->isValidConfigName($newName);
         $report = CustomReport\Config::getByName($newName);
         if ($report) {
             throw new \Exception('report already exists');
@@ -187,7 +190,7 @@ class CustomReportController extends ReportsControllerBase
     public function updateAction(Request $request)
     {
         $this->checkPermission('reports_config');
-
+        $this->isValidConfigName($request->get('name'));
         $report = CustomReport\Config::getByName($request->get('name'));
         if (!$report) {
             throw $this->createNotFoundException();
@@ -518,5 +521,14 @@ class CustomReportController extends ReportsControllerBase
         }
 
         throw new FileNotFoundException("File \"$exportFile\" not found!");
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function isValidConfigName(string $configName) {
+        if(!preg_match('/^[a-zA-Z0-9_\-]+$/', $configName)) {
+            throw new \Exception('The customer report name is invalid');
+        }
     }
 }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/panel.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/report/custom/panel.js
@@ -206,7 +206,8 @@ pimcore.report.custom.panel = Class.create({
     },
 
     deleteField: function (tree, record) {
-        Ext.Msg.confirm(t('delete'), sprintf(t('delete_message_advanced'), t('portlet_customreport'), record.data.text), function (btn) {
+        const decodedName = Ext.util.Format.htmlDecode(record.data.text);
+        Ext.Msg.confirm(t('delete'), sprintf(t('delete_message_advanced'), t('portlet_customreport'), Ext.util.Format.htmlEncode(decodedName)), function (btn) {
             if (btn == 'yes') {
                 Ext.Ajax.request({
                     url: Routing.generate('pimcore_admin_reports_customreport_delete'),


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d6a57ca</samp>

This pull request fixes a XSS vulnerability in the custom report feature of the AdminBundle. It adds validation for the custom report name in the `CustomReportController` class and encodes/decodes the name in the `panel.js` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d6a57ca</samp>

> _`CustomReportController` is the gatekeeper of the name_
> _No XSS can pass through its validation flame_
> _`deleteField` must encode and decode with care_
> _Or the `panel.js` will unleash the XSS nightmare_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d6a57ca</samp>

*  Add validation checks for custom report name to prevent XSS vulnerability ([link](https://github.com/pimcore/pimcore/pull/15007/files?diff=unified&w=0#diff-c05d7e81a9209ca0da1680fe24b90cf04fa304dac83ae677cb1c22dde5180b05R79-R80), [link](https://github.com/pimcore/pimcore/pull/15007/files?diff=unified&w=0#diff-c05d7e81a9209ca0da1680fe24b90cf04fa304dac83ae677cb1c22dde5180b05R134), [link](https://github.com/pimcore/pimcore/pull/15007/files?diff=unified&w=0#diff-c05d7e81a9209ca0da1680fe24b90cf04fa304dac83ae677cb1c22dde5180b05L190-R193))
*  Extract validation logic to a helper method `isValidConfigName` in `CustomReportController.php` to avoid code duplication and improve readability ([link](https://github.com/pimcore/pimcore/pull/15007/files?diff=unified&w=0#diff-c05d7e81a9209ca0da1680fe24b90cf04fa304dac83ae677cb1c22dde5180b05R525-R533))
*  Encode and decode custom report name when deleting a field in `panel.js` to prevent XSS vulnerability ([link](https://github.com/pimcore/pimcore/pull/15007/files?diff=unified&w=0#diff-4e26e3e0dc75b47344bb75222e074cc329a643062a7af9c79848862ef10d7620L209-R210))
