### PR TITLE
[Bug]: Admin throws SessionBagInterface "pimcore_admin" is not registered

### DIFF
--- a/lib/Event/SystemEvents.php
+++ b/lib/Event/SystemEvents.php
@@ -130,4 +130,13 @@ final class SystemEvents
      * @var string
      */
     const SAVE_ACTION_SYSTEM_SETTINGS = 'pimcore.system.settings.saveAction';
+
+    /**
+     * The GET_SYSTEM_CONFIGURATION event is triggered when the system configuration is requested.
+     *
+     * @Event("Symfony\Component\EventDispatcher\GenericEvent")
+     *
+     * @var string
+     */
+    const GET_SYSTEM_CONFIGURATION = 'pimcore.system.configuration.get';
 }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #15006

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8ba21df</samp>

Added a new event `SystemEvents::GET_SYSTEM_CONFIGURATION` to allow modifying the system configuration dynamically. This event is dispatched in the `Config` class when loading the configuration from the cache or the file system.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8ba21df</samp>

> _`SystemEvents` class_
> _defines new configuration_
> _event for listeners_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8ba21df</samp>

*  Add event dispatching logic for system configuration ([link](https://github.com/pimcore/pimcore/pull/15014/files?diff=unified&w=0#diff-a9facf8547f41c9326235cee2e92dcfeed102a5eb138475b054fe1f13028e80aL24-R28), [link](https://github.com/pimcore/pimcore/pull/15014/files?diff=unified&w=0#diff-a9facf8547f41c9326235cee2e92dcfeed102a5eb138475b054fe1f13028e80aL155-R166), [link](https://github.com/pimcore/pimcore/pull/15014/files?diff=unified&w=0#diff-96327146e5bd457550ba8427c9039a3d9e57f7b7ef3e013413877ac9805512cfR133-R141))
  - Import `SystemEvents` and `GenericEvent` classes in `lib/Config.php` ([link](https://github.com/pimcore/pimcore/pull/15014/files?diff=unified&w=0#diff-a9facf8547f41c9326235cee2e92dcfeed102a5eb138475b054fe1f13028e80aL24-R28))
  - Define and document a new event constant `SystemEvents::GET_SYSTEM_CONFIGURATION` in `lib/Event/SystemEvents.php` ([link](https://github.com/pimcore/pimcore/pull/15014/files?diff=unified&w=0#diff-96327146e5bd457550ba8427c9039a3d9e57f7b7ef3e013413877ac9805512cfR133-R141))
  - Dispatch the event with the configuration as an argument before caching and returning it in `lib/Config.php` ([link](https://github.com/pimcore/pimcore/pull/15014/files?diff=unified&w=0#diff-a9facf8547f41c9326235cee2e92dcfeed102a5eb138475b054fe1f13028e80aL155-R166))
  - Update the configuration with the possibly modified argument after the event ([link](https://github.com/pimcore/pimcore/pull/15014/files?diff=unified&w=0#diff-a9facf8547f41c9326235cee2e92dcfeed102a5eb138475b054fe1f13028e80aL155-R166))
