### PR TITLE
fix CSV Export breakes file at more than 20 rows

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1429,7 +1429,7 @@ class DataObjectHelperController extends AdminController
             } else {
                 fwrite($temp, implode($delimiter, array_map([$this, 'encodeFunc'], $line)));
             }
-            if ($i < $lineCount - 1) {
+            if ($i <= $lineCount - 1) {
                 fwrite($temp, "\r\n");
             }
         }


### PR DESCRIPTION
When the Pimcore export is started and there are more than 20 entries in the list, the last two entries are exported in one line, breaking the CSV file. Also affects the AdvancedObjectSearch.

 
## Changes in this pull request  
Resolves a problem, that CSV Export breaks if more then 20 rows exported in GridView.