### PR TITLE
Fix migration error without report settings in db

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20230202152342.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230202152342.php
@@ -36,6 +36,9 @@ final class Version20230202152342 extends AbstractMigration
 
         //update default site data in marketing settings
         $settings = SettingsStore::get(ReportConfigWriter::REPORT_SETTING_ID, ReportConfigWriter::REPORT_SETTING_SCOPE);
+        if (!$settings) {
+            return;
+        }
         $data = json_decode($settings->getData(), true);
 
         $marketingScopes = ['analytics', 'google_search_console', 'tagmanager'];


### PR DESCRIPTION
I've encountered this error after upgrading a project from Pimcore 10 to 11. The migration fails with a `Call to a member function getData() on null` error when no report settings were ever stored in the SettingsStore.