### PR TITLE
fix AreabrickPass to work on Windows

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Compiler/AreabrickPass.php
+++ b/bundles/CoreBundle/DependencyInjection/Compiler/AreabrickPass.php
@@ -204,7 +204,7 @@ final class AreabrickPass implements CompilerPassInterface
     protected function findBundleBricks(ContainerBuilder $container, string $name, array $metadata, array $excludedClasses = []): array
     {
         $sourcePath = is_dir($metadata['path'].'/src') ? $metadata['path'].'/src' : $metadata['path'];
-        $directory = $sourcePath.'/Document/Areabrick';
+        $directory = $sourcePath.DIRECTORY_SEPARATOR.'Document'.DIRECTORY_SEPARATOR.'Areabrick';
 
         // update cache when directory is added/removed
         $container->addResource(new FileExistenceResource($directory));


### PR DESCRIPTION


<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #12938 

## Additional info

Areabricks were not automatically registered on Windows because hardcoded forward-slash was used here but bellow in `str_replace` calls `DIRECTORY_SEPARATOR` was used which caused mismatch on Windows.

Was already reported previously as #12938 (was closed without fix).

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5d1565</samp>

This change improves the portability of the `AreabrickPass` class by using the `DIRECTORY_SEPARATOR` constant instead of hard-coded slashes. This is part of a pull request to enhance the Windows compatibility of Pimcore.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c5d1565</samp>

> _`DIRECTORY_SEPARATOR`_
> _No more hard-coded slashes_
> _Code adapts to winter_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c5d1565</samp>

* Use `DIRECTORY_SEPARATOR` constant instead of hard-coded slashes for path manipulation ([link](https://github.com/pimcore/pimcore/pull/15021/files?diff=unified&w=0#diff-2b2fdd9d344066a0eee77195d487f20860edb5471ff0db54aae8bffbdd555e05L207-R207))
