### PR TITLE
Variant Sort By Index Fix

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1291,7 +1291,8 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                     ]
                 ).'\') ORDER BY o_index LIMIT '. $updatedObject->getParent()->getChildAmount([
                             DataObject::OBJECT_TYPE_OBJECT,
-                            DataObject::OBJECT_TYPE_VARIANT
+                            DataObject::OBJECT_TYPE_VARIANT,
+                            DataObject::OBJECT_TYPE_FOLDER
                         ]) .')
                             SELECT @n := IF(@n = ? - 1,@n + 2,@n + 1) AS newIndex, o_id
                             FROM cte,

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -1289,7 +1289,10 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                         DataObject::OBJECT_TYPE_VARIANT,
                         DataObject::OBJECT_TYPE_FOLDER,
                     ]
-                ).'\') ORDER BY o_index LIMIT '. $updatedObject->getParent()->getChildAmount() .')
+                ).'\') ORDER BY o_index LIMIT '. $updatedObject->getParent()->getChildAmount([
+                            DataObject::OBJECT_TYPE_OBJECT,
+                            DataObject::OBJECT_TYPE_VARIANT
+                        ]) .')
                             SELECT @n := IF(@n = ? - 1,@n + 2,@n + 1) AS newIndex, o_id
                             FROM cte,
                             (SELECT @n := -1) variable


### PR DESCRIPTION
## Changes in this pull request  
Resolves #14919

## Additional info
Fix indexing on variants in the object tree when sorting by index.
