### PR TITLE
[Docs] Fix typo for adding layout type

### DIFF
--- a/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/12_Adding_Object_ Layout_types.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/13_Bundle_Developers_Guide/12_Adding_Object_ Layout_types.md
@@ -40,7 +40,7 @@ Following steps are necessary to do so:
     pimcore:
         objects:
             class_definitions:
-                Layout:
+                layout:
                     map:
                       myLayoutType: \App\Model\DataObject\ClassDefinition\Layout\MyLayoutType
     ```


### PR DESCRIPTION
It is `layout` with lowercase `L`, see https://github.com/pimcore/pimcore/blob/770c98c02d73b959070bb90ff78894128be63bc8/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php#L161