### PR TITLE
[Task] Adding missing translation key

### DIFF
--- a/bundles/ApplicationLoggerBundle/src/Installer.php
+++ b/bundles/ApplicationLoggerBundle/src/Installer.php
@@ -20,7 +20,7 @@ use Pimcore\Extension\Bundle\Installer\SettingsStoreAwareInstaller;
 
 class Installer extends SettingsStoreAwareInstaller
 {
-    protected const USER_PERMISSIONS_CATEGORY = 'Application Logger Bundle';
+    protected const USER_PERMISSIONS_CATEGORY = 'Pimcore Application Logger Bundle';
 
     protected const USER_PERMISSIONS = [
         'application_logging',

--- a/bundles/XliffBundle/translations/admin.en.yaml
+++ b/bundles/XliffBundle/translations/admin.en.yaml
@@ -18,3 +18,5 @@ xliff_import_notice: >-
     then translated by a localization service provider (LSP) or by a CAT
     application. Please aware that the import will overwrite the elements which
     were selected by the import (read also export).
+xliff_import_export: Xliff Import/Export
+

--- a/bundles/XliffBundle/translations/admin.en.yaml
+++ b/bundles/XliffBundle/translations/admin.en.yaml
@@ -19,4 +19,3 @@ xliff_import_notice: >-
     application. Please aware that the import will overwrite the elements which
     were selected by the import (read also export).
 xliff_import_export: Xliff Import/Export
-


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 725ceca</samp>

This pull request improves the user interface and functionality of two Pimcore bundles: the Application Logger Bundle and the Xliff Bundle. It renames the user permissions category for the Application Logger Bundle to `Pimcore Application Logger` and adds a new translation key for the Xliff Import/Export feature in `admin.en.yaml`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 725ceca</samp>

> _`Pimcore` logging_
> _Xliff translations added_
> _Autumn of updates_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 725ceca</samp>

* Rename the user permissions category for the Application Logger Bundle to `Pimcore Application Logger` ([link](https://github.com/pimcore/pimcore/pull/15050/files?diff=unified&w=0#diff-efcb44377f805db9f17d93f3e9e3dc12a992b850981c26276b420f9e8a950116L23-R23) in `bundles/ApplicationLoggerBundle/src/Installer.php`)
