### PR TITLE
Fix edit tooltips

### DIFF
--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -50,8 +50,11 @@ class SearchController extends AdminController
      * @return JsonResponse
      *
      * @todo: $conditionTypeParts could be undefined
+     *
      * @todo: $conditionSubtypeParts could be undefined
+     *
      * @todo: $conditionClassnameParts could be undefined
+     *
      * @todo: $data could be undefined
      */
     public function findAction(Request $request, EventDispatcherInterface $eventDispatcher, GridHelperService $gridHelperService)

--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -50,11 +50,8 @@ class SearchController extends AdminController
      * @return JsonResponse
      *
      * @todo: $conditionTypeParts could be undefined
-
      * @todo: $conditionSubtypeParts could be undefined
-
      * @todo: $conditionClassnameParts could be undefined
-
      * @todo: $data could be undefined
      */
     public function findAction(Request $request, EventDispatcherInterface $eventDispatcher, GridHelperService $gridHelperService)

--- a/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
+++ b/bundles/AdminBundle/Controller/Searchadmin/SearchController.php
@@ -50,11 +50,11 @@ class SearchController extends AdminController
      * @return JsonResponse
      *
      * @todo: $conditionTypeParts could be undefined
-     *
+
      * @todo: $conditionSubtypeParts could be undefined
-     *
+
      * @todo: $conditionClassnameParts could be undefined
-     *
+
      * @todo: $data could be undefined
      */
     public function findAction(Request $request, EventDispatcherInterface $eventDispatcher, GridHelperService $gridHelperService)

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/edit.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/edit.js
@@ -403,7 +403,10 @@ pimcore.object.helpers.edit = {
                             try {
                                 var el = this.getEl();
                                 if(!el.hasCls("object_field")) {
-                                    el = el.parent(".object_field");
+                                    var parentEl = el.parent(".object_field");
+                                    if(parentEl !== null && parentEl !== undefined){
+                                        el = parentEl;
+                                    }
                                 }
                             } catch (e4) {
                                 console.log(e4);


### PR DESCRIPTION
## Changes in this pull request  
No tooltip is shown if a data component from the type "Permission Resource" from the PermissionToolkit is used.

For me it is unclear why the parent element is used in the edit.js class. With this fix at least the current element is used if the parent element not exists.


### HOW

Add a data component to any class with the type "permission resource" and add a tooltip
![grafik](https://user-images.githubusercontent.com/1992165/234845513-890b5078-9b77-49e1-bf4f-64e9c6b5f3d7.png)
Open a corresponding object and notice the console error and the missing tooltip
![grafik](https://user-images.githubusercontent.com/1992165/234845617-236f09ec-8c9b-4bfc-8a23-4861c4a7a20d.png)

