### PR TITLE
Fix maintenance task for ObjectBricks and FieldCollections on DB with lower_case_table_names

### DIFF
--- a/lib/Maintenance/Tasks/CleanupBrickTablesTask.php
+++ b/lib/Maintenance/Tasks/CleanupBrickTablesTask.php
@@ -27,6 +27,8 @@ use Psr\Log\LoggerInterface;
  */
 class CleanupBrickTablesTask implements TaskInterface
 {
+    const PIMCORE_OBJECTBRICK_CLASS_DIRECTORY = PIMCORE_CLASS_DIRECTORY . '/DataObject/Objectbrick/Data';
+
     private LoggerInterface $logger;
     private $mapLowerToCamelCase = [];
 
@@ -34,8 +36,7 @@ class CleanupBrickTablesTask implements TaskInterface
     {
         $this->logger = $logger;
         
-        $obPath = PIMCORE_CLASS_DIRECTORY . '/DataObject/Objectbrick/Data';
-        $files = array_diff(scandir($obPath), array('..', '.'));
+        $files = array_diff(scandir(self::PIMCORE_OBJECTBRICK_CLASS_DIRECTORY), array('..', '.'));
         foreach ($files as $file) {
             $classname = str_replace('.php','',$file);
             $class = '\\Pimcore\\Model\\DataObject\\Objectbrick\\Data\\' . $classname;

--- a/lib/Maintenance/Tasks/CleanupBrickTablesTask.php
+++ b/lib/Maintenance/Tasks/CleanupBrickTablesTask.php
@@ -28,10 +28,20 @@ use Psr\Log\LoggerInterface;
 class CleanupBrickTablesTask implements TaskInterface
 {
     private LoggerInterface $logger;
+    private $mapLowerToCamelCase = [];
 
     public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
+        
+        $obPath = PIMCORE_CLASS_DIRECTORY . '/DataObject/Objectbrick/Data';
+        $files = array_diff(scandir($obPath), array('..', '.'));
+        foreach ($files as $file) {
+            $classname = str_replace('.php','',$file);
+            $class = '\\Pimcore\\Model\\DataObject\\Objectbrick\\Data\\' . $classname;
+            $object = new $class(new \Pimcore\Model\DataObject\Concrete());
+            $this->mapLowerToCamelCase[strtolower($classname)] = $object->getType();
+        }
     }
 
     /**
@@ -55,6 +65,7 @@ class CleanupBrickTablesTask implements TaskInterface
                 $fieldDescriptor = substr($tableName, strlen($prefix));
                 $idx = strpos($fieldDescriptor, '_');
                 $brickType = substr($fieldDescriptor, 0, $idx);
+                $brickType = $this->mapLowerToCamelCase[$brickType] ?? $brickType;
 
                 $brickDef = Definition::getByKey($brickType);
                 if (!$brickDef) {

--- a/lib/Maintenance/Tasks/CleanupBrickTablesTask.php
+++ b/lib/Maintenance/Tasks/CleanupBrickTablesTask.php
@@ -27,10 +27,10 @@ use Psr\Log\LoggerInterface;
  */
 class CleanupBrickTablesTask implements TaskInterface
 {
-    const PIMCORE_OBJECTBRICK_CLASS_DIRECTORY = PIMCORE_CLASS_DIRECTORY . '/DataObject/Objectbrick/Data';
+   private const PIMCORE_OBJECTBRICK_CLASS_DIRECTORY = PIMCORE_CLASS_DIRECTORY . '/DataObject/Objectbrick/Data';
 
     private LoggerInterface $logger;
-    private $mapLowerToCamelCase = [];
+    private array $mapLowerToCamelCase = [];
 
     public function __construct(LoggerInterface $logger)
     {
@@ -39,9 +39,7 @@ class CleanupBrickTablesTask implements TaskInterface
         $files = array_diff(scandir(self::PIMCORE_OBJECTBRICK_CLASS_DIRECTORY), array('..', '.'));
         foreach ($files as $file) {
             $classname = str_replace('.php','',$file);
-            $class = '\\Pimcore\\Model\\DataObject\\Objectbrick\\Data\\' . $classname;
-            $object = new $class(new \Pimcore\Model\DataObject\Concrete());
-            $this->mapLowerToCamelCase[strtolower($classname)] = $object->getType();
+            $this->mapLowerToCamelCase[strtolower($classname)] = $classname ;
         }
     }
 

--- a/lib/Maintenance/Tasks/CleanupFieldcollectionTablesTask.php
+++ b/lib/Maintenance/Tasks/CleanupFieldcollectionTablesTask.php
@@ -26,10 +26,10 @@ use Psr\Log\LoggerInterface;
  */
 class CleanupFieldcollectionTablesTask implements TaskInterface
 {
-    const PIMCORE_FIELDCOLLECTION_CLASS_DIRECTORY = PIMCORE_CLASS_DIRECTORY . '/DataObject/Fieldcollection/Data';
+    private const PIMCORE_FIELDCOLLECTION_CLASS_DIRECTORY = PIMCORE_CLASS_DIRECTORY . '/DataObject/Fieldcollection/Data';
 
     private LoggerInterface $logger;
-    private $mapLowerToCamelCase = [];
+    private array $mapLowerToCamelCase = [];
 
     public function __construct(LoggerInterface $logger)
     {
@@ -38,9 +38,7 @@ class CleanupFieldcollectionTablesTask implements TaskInterface
         $files = array_diff(scandir(self::PIMCORE_FIELDCOLLECTION_CLASS_DIRECTORY), array('..', '.'));
         foreach ($files as $file) {
             $classname = str_replace('.php','',$file);
-            $class = '\\Pimcore\\Model\\DataObject\\Fieldcollection\\Data\\' . $classname;
-            $object = new $class();
-            $this->mapLowerToCamelCase[strtolower($classname)] = $object->getType();
+            $this->mapLowerToCamelCase[strtolower($classname)] = $classname;
         }
     }
 

--- a/lib/Maintenance/Tasks/CleanupFieldcollectionTablesTask.php
+++ b/lib/Maintenance/Tasks/CleanupFieldcollectionTablesTask.php
@@ -26,6 +26,8 @@ use Psr\Log\LoggerInterface;
  */
 class CleanupFieldcollectionTablesTask implements TaskInterface
 {
+    const PIMCORE_FIELDCOLLECTION_CLASS_DIRECTORY = PIMCORE_CLASS_DIRECTORY . '/DataObject/Fieldcollection/Data';
+
     private LoggerInterface $logger;
     private $mapLowerToCamelCase = [];
 
@@ -33,8 +35,7 @@ class CleanupFieldcollectionTablesTask implements TaskInterface
     {
         $this->logger = $logger;
         
-        $fcPath = PIMCORE_CLASS_DIRECTORY . '/DataObject/Fieldcollection/Data';
-        $files = array_diff(scandir($fcPath), array('..', '.'));
+        $files = array_diff(scandir(self::PIMCORE_FIELDCOLLECTION_CLASS_DIRECTORY), array('..', '.'));
         foreach ($files as $file) {
             $classname = str_replace('.php','',$file);
             $class = '\\Pimcore\\Model\\DataObject\\Fieldcollection\\Data\\' . $classname;


### PR DESCRIPTION
This PR referes to bug #10427 which is caused by getting type names of ObjectBricks and FieldCollections from database table names and using these names for checking if the ObjectBricks and FieldCollections exist. When databases are created with `lower_case_table_names` the name to be checked will be with lowercase letters only although the definition of ObjectBricks and FieldCollections might have uppercase characters too.

We need somehow a possibility to get from the lowercase stringto the one used to create the ObjectBricks and FieldCollections. The best way I could find is to create a mapping table to find the correct name with uppercase letters for names with only lowercase based on the class files which ensures that all relevant classes are considered, not only the ones currently loaded.

The error can be reproduced by
- using databse with `lower_case_table_names` set
- creating an ObjectBrick and a FieldCollection with uppercase letter in the name
- run maintenance job

As a result you will see error messages in the log file complaining missing types:
- `app.ERROR: Brick 'brickname' not found. Please check table object_brick_query_brickname_objectname`
- `app.ERROR: Fieldcollection 'collectionname' not found. Please check table object_collection_collectionname_objectname`

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #10427
