### PR TITLE
[System requirements] Add check for UTF-8 locale

### DIFF
--- a/bundles/AdminBundle/Resources/views/Admin/Install/check.html.twig
+++ b/bundles/AdminBundle/Resources/views/Admin/Install/check.html.twig
@@ -25,7 +25,7 @@
             {% endif %}
         </td>
 
-        <td><img src="/bundles/pimcoreadmin/img/flat-color-icons/{{ icon }}.svg" /></td>
+        <td><img src="/bundles/pimcoreadmin/img/flat-color-icons/{{ icon }}.svg" title="{% if check.message is defined %}{{ check.message }}{%  endif %}" /></td>
     </tr>
 {% endmacro %}
 

--- a/lib/Tool/Requirements.php
+++ b/lib/Tool/Requirements.php
@@ -609,6 +609,13 @@ final class Requirements
             ]);
         }
 
+        $checks[] = new Check([
+            'name' => 'locales-utf8',
+            'link' => 'https://packages.debian.org/en/stable/locales-all',
+            'state' => setlocale(LC_ALL, ['en.utf8', 'en_US.utf8', 'en_GB.utf8']) === false ? Check::STATE_ERROR : Check::STATE_OK,
+            'message' => "UTF-8 locale is not available, thus all CLI calls which use escapeshellarg() will strip multibyte characters",
+        ]);
+
         // Imagick
         $checks[] = new Check([
             'name' => 'Imagick',

--- a/lib/Tool/Requirements.php
+++ b/lib/Tool/Requirements.php
@@ -613,7 +613,7 @@ final class Requirements
             'name' => 'locales-utf8',
             'link' => 'https://packages.debian.org/en/stable/locales-all',
             'state' => setlocale(LC_ALL, ['en.utf8', 'en_US.utf8', 'en_GB.utf8']) === false ? Check::STATE_ERROR : Check::STATE_OK,
-            'message' => "UTF-8 locale is not available, thus all CLI calls which use escapeshellarg() will strip multibyte characters",
+            'message' => "It is recommended to install UTF-8 locale, otherwise all CLI calls which use escapeshellarg() will strip multibyte characters",
         ]);
 
         // Imagick


### PR DESCRIPTION
In https://github.com/pimcore/pimcore/blob/6e5f1ab571e342839b06528965c653f710f718b3/lib/Console/Application.php#L59 it is tried to set PHP's locale to UTF-8. This only works if one of the listed locales is available in the operating system.
In our case we only had locale `C` installed. This causes problems in CLI processing of assets which have umlauts (or other special characters in their filenames).
For example for an asset with full path `/Produktdatenblätter/123.pdf` in https://github.com/pimcore/pimcore/blob/6e5f1ab571e342839b06528965c653f710f718b3/lib/Document/Adapter/Ghostscript.php#L152 `$localFile` will be `/var/www/html/public/var/assets/Produktdatenbltter/123.pdf` (see the missing "ä" in "Produktdatenblätter").

This PR adds a requirement check for UTF-8 locale.

Additionally it shows the `message`s from the checks in the system requirements page as tooltip when the user hovers the check icon:
<img width="841" alt="Bildschirmfoto 2023-04-28 um 08 02 43" src="https://user-images.githubusercontent.com/8749138/235067036-8a3307f3-1511-433d-ac1b-0eb377dd69e0.png">
