### PR TITLE
[Grid] Support batch update for localized object brick fields

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1641,6 +1641,12 @@ class DataObjectHelperController extends AdminController
                     } elseif (count($parts) > 1) {
                         // check for bricks
                         $brickType = $parts[0];
+
+                        if (strpos($brickType, '?') !== false) {
+                            $brickDescriptor = substr($brickType, 1);
+                            $brickDescriptor = json_decode($brickDescriptor, true);
+                            $brickType = $brickDescriptor['containerKey'];
+                        }
                         $brickKey = $parts[1];
                         $brickField = DataObject\Service::getFieldForBrickType($object->getClass(), $brickType);
 


### PR DESCRIPTION
Steps to reproduce bug:

1. Create data object class with object brick container `bricks`
2. Create object brick `Test` with localized input field `input`, allow this object brick for above container field
3. Create object of this class and show it in grid
4. Open grid configuration, add `Test`.`input`
5. Select the created object in the grid, click `Batch edit selected` via column header, enter any value and apply

Expected result: 
Value gets set to selected items.

Actual result:
PHP error `Too few arguments to function Pimcore\Model\DataObject\AbstractObject::get(), 0 passed in /var/www/html/vendor/pimcore/pimcore/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php`

This PR applies the logic from https://github.com/pimcore/pimcore/blob/a5b86f3f9a63ac76282acee00879fb52b416a4ce/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectActionsTrait.php#L238-L247 also to batch-editing. This way batch-editing also works for localized object brick fields.