### PR TITLE
[Bug] Check if marketing menu is available

### DIFF
--- a/bundles/CustomReportsBundle/public/js/startup.js
+++ b/bundles/CustomReportsBundle/public/js/startup.js
@@ -23,24 +23,26 @@ pimcore.bundle.customreports.startup = Class.create({
         const user = pimcore.globalmanager.get('user');
         const perspectiveCfg = pimcore.globalmanager.get("perspective");
 
-        if (user.isAllowed("reports") && perspectiveCfg.inToolbar("marketing.reports")) {
-            menu.marketing.items.push({
-                text: t("reports"),
-                priority: 5,
-                iconCls: "pimcore_nav_icon_reports",
-                itemId: 'pimcore_menu_marketing_reports',
-                handler: this.showReports.bind(this, null)
-            });
-        }
+        if(menu.marketing) {
+            if (user.isAllowed("reports") && perspectiveCfg.inToolbar("marketing.reports")) {
+                menu.marketing.items.push({
+                    text: t("reports"),
+                    priority: 5,
+                    iconCls: "pimcore_nav_icon_reports",
+                    itemId: 'pimcore_menu_marketing_reports',
+                    handler: this.showReports.bind(this, null)
+                });
+            }
 
-        if (user.isAllowed("reports_config") && perspectiveCfg.inToolbar("settings.customReports")) {
-            menu.marketing.items.push({
-                text: t("custom_reports"),
-                priority: 6,
-                iconCls: "pimcore_nav_icon_reports",
-                itemId: 'pimcore_menu_marketing_custom_reports',
-                handler: this.showCustomReports
-            });
+            if (user.isAllowed("reports_config") && perspectiveCfg.inToolbar("settings.customReports")) {
+                menu.marketing.items.push({
+                    text: t("custom_reports"),
+                    priority: 6,
+                    iconCls: "pimcore_nav_icon_reports",
+                    itemId: 'pimcore_menu_marketing_custom_reports',
+                    handler: this.showCustomReports
+                });
+            }
         }
     },
 


### PR DESCRIPTION
`menu.marketing` can be null. 
E.g. if the menu is hidden via perspectives.
Added a check for marketing menu.