### PR TITLE
[Task]: Deprecated `Import from URL`

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/tree.js
@@ -596,7 +596,7 @@ pimcore.asset.tree = Class.create({
 
                         if (perspectiveCfg.inTreeContextMenu("asset.add.importFromServer") && pimcore.currentuser.admin) {
                             menuItems.push({
-                                text: t("import_from_server"),
+                                text: t("import_from_server") + '<sup class="deprecation" title="' + t("deprecated") + '">*</sup>',
                                 handler: this.importFromServer.bind(this, tree, record),
                                 iconCls: "pimcore_icon_import_server"
                             });
@@ -1250,7 +1250,7 @@ pimcore.asset.tree = Class.create({
                                 });
 
                                 this.downloadProgressWin = new Ext.Window({
-                                    title: t("import_from_server") + '<sup class="deprecation" title="' + t("deprecated") + '">*</sup>',
+                                    title: t("import_from_server"),
                                     layout:'fit',
                                     width:200,
                                     bodyStyle: "padding: 10px;",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/tree.js
@@ -604,7 +604,7 @@ pimcore.asset.tree = Class.create({
 
                         if (perspectiveCfg.inTreeContextMenu("asset.add.uploadFromUrl")) {
                             menuItems.push({
-                                text: t("import_from_url"),
+                                text: t("import_from_url") + '<sup class="deprecation" title="' + t("deprecated") + '">*</sup>',
                                 handler: this.importFromUrl.bind(this, tree, record),
                                 iconCls: "pimcore_icon_world pimcore_icon_overlay_add"
                             });
@@ -1250,7 +1250,7 @@ pimcore.asset.tree = Class.create({
                                 });
 
                                 this.downloadProgressWin = new Ext.Window({
-                                    title: t("import_from_server"),
+                                    title: t("import_from_server") + '<sup class="deprecation" title="' + t("deprecated") + '">*</sup>',
                                     layout:'fit',
                                     width:200,
                                     bodyStyle: "padding: 10px;",

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -162,7 +162,7 @@
     "activate": "Activate",
     "image_is_too_small": "Image is too small, please choose a bigger one.",
     "name_is_not_allowed": "Name is not allowed",
-    "import_from_server": "Import from Server (deprecated)",
+    "import_from_server": "Import from Server",
     "upload_files": "Upload Files",
     "upload_zip": "Upload ZIP Archive",
     "document_root": "Document Root",

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,7 +1,7 @@
 # Upgrade Notes
 
 ## 10.6.0
-- [Assets] Deprecated `Import from Server`. It will be removed in Pimcore 11.
+- [Assets] Deprecated `Import from Server` and `Import from URL`. They will be removed in Pimcore 11.
 - [Naming] Deprecated master, blacklist and whitelist. Instead, use main, blocklist, allowlist
 - [Storage config] Deprecated setting write targets and storage directory in the .env file. Instead, use the [symfony config](../07_Updating_Pimcore/11_Preparing_for_V11.md)
 - [Session] The `getHandler`, `setHandler`, `useSession`, `getSessionId`, `getSessionName`, `invalidate`, `regenerateId`, `requestHasSessionId`, `getSessionIdFromRequest`, `get`, `getReadOnly` and `writeClose` methods of `Pimcore\Tool\Session` and class `PreAuthenticatedAdminSessionFactory` are deprecated and get removed with Pimcore 11. Session Management will be handled by Symfony in Pimcore 11.

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,7 +1,7 @@
 # Upgrade Notes
 
 ## 10.6.0
-- [Assets] Deprecated `Import from Server` and `Import from URL`. They will be removed in Pimcore 11.
+- [Assets] Deprecated `Import from Server` and `Import from URL` Admin UI options for adding assets. They will be removed in Pimcore 11.
 - [Naming] Deprecated master, blacklist and whitelist. Instead, use main, blocklist, allowlist
 - [Storage config] Deprecated setting write targets and storage directory in the .env file. Instead, use the [symfony config](../07_Updating_Pimcore/11_Preparing_for_V11.md)
 - [Session] The `getHandler`, `setHandler`, `useSession`, `getSessionId`, `getSessionName`, `invalidate`, `regenerateId`, `requestHasSessionId`, `getSessionIdFromRequest`, `get`, `getReadOnly` and `writeClose` methods of `Pimcore\Tool\Session` and class `PreAuthenticatedAdminSessionFactory` are deprecated and get removed with Pimcore 11. Session Management will be handled by Symfony in Pimcore 11.


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Related https://github.com/pimcore/admin-ui-classic-bundle/pull/15
Followup https://github.com/pimcore/pimcore/pull/15013

## Additional info
Changed a little how the deprecated item would displayed in the sub menu.
From an non-dev/non-admin user pov or a in a project that would be not upgraded to 11, it may not be relevant to know that this functionality is deprecated.
 
It would be an superscript asterix and displaying "deprecated" on hover.
![image](https://user-images.githubusercontent.com/6014195/235700348-90c6c754-1093-4392-ad82-8e74d304139f.png)
Added a css class `deprecation` to eventually allow hiding it with a custom rule.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 51e4298</samp>

Deprecated the import from server and URL features for assets and updated the menu items, the translation key, and the upgrade notes accordingly. These changes aim to simplify asset management and improve security in Pimcore.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 51e4298</samp>

> _Sing, O Muse, of the mighty deeds of Pimcore_
> _The versatile platform of digital experience_
> _That in its tenth version deprecated two features_
> _Of importing assets from server and URL._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 51e4298</samp>

*  Append deprecation notices and tooltips to the menu items for importing assets from server and URL, and update the translation key for the former feature ([link](https://github.com/pimcore/pimcore/pull/15079/files?diff=unified&w=0#diff-df13edaa9565f27b58afea2dc8114c79948677ff4f384fb4df907cb349b1318dL599-R599), [link](https://github.com/pimcore/pimcore/pull/15079/files?diff=unified&w=0#diff-df13edaa9565f27b58afea2dc8114c79948677ff4f384fb4df907cb349b1318dL607-R607), [link](https://github.com/pimcore/pimcore/pull/15079/files?diff=unified&w=0#diff-f4bfa3653bce4deb4bdec8f829355654c20f2e6d8e49981ed84e8a9ad8ba9b9bL165-R165))
*  Add upgrade notes for version 10.6.0 to inform users and developers of the deprecation of the import from server and URL features and the reasons behind them (`doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md`, [link](https://github.com/pimcore/pimcore/pull/15079/files?diff=unified&w=0#diff-8e789ff505cab9d3406d3f98e6856e6a0d42dfeeb5c4ee14d7f691c00df1d3c0L4-R4))
