### PR TITLE
[Task]: Fix docs about removal of import from server and url

### DIFF
--- a/doc/05_Objects/01_Object_Classes/05_Class_Settings/20_Custom_Views.md
+++ b/doc/05_Objects/01_Object_Classes/05_Class_Settings/20_Custom_Views.md
@@ -112,8 +112,6 @@ pimcore:
                                     upload: true
                                     uploadCompatibility: true
                                     uploadZip: true
-                                    importFromServer: true
-                                    uploadFromUrl: true
                             addFolder: true
                             rename: true
                             copy: true
@@ -221,8 +219,6 @@ pimcore:
                                     upload: true
                                     uploadCompatibility: true
                                     uploadZip: true
-                                    importFromServer: false     #deny importFromServer
-                                    uploadFromUrl: true
                             addFolder: false
                             rename: true
                             copy: false                         #deny copy

--- a/doc/18_Tools_and_Features/13_Perspectives.md
+++ b/doc/18_Tools_and_Features/13_Perspectives.md
@@ -140,8 +140,6 @@ demo:
                                 upload: true
                                 uploadCompatibility: true
                                 uploadZip: true
-                                importFromServer: true
-                                uploadFromUrl: true
                         addFolder: true
                         rename: true
                         copy: true

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -221,6 +221,7 @@
     ```
 
 - [Asset] Removed the deprecated `marshal()/unmarshal()` methods for metadata, use `normalize()/denormalize()` methods instead.
+- [Asset] Removed the deprecated `Import from Server` and `Import from URL` options.
 - [Asset] Asset/Asset Thumbnail Update messages are now routed to different queue
     instead of `pimcore_core`. please add option `pimcore_asset_update` to command `bin/console messenger:consume pimcore_core... pimcore_asset_update` to post process assets on update.
     Also run command `bin/console messenger:consume pimcore_core` before the upgrade, so that `AssetUpdateTasksMessage` on the queue gets consumed.


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Related https://github.com/pimcore/pimcore/pull/15079, https://github.com/pimcore/pimcore/pull/15013

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d998770</samp>

This pull request updates the documentation to reflect the removal of `importFromServer` and `uploadFromUrl` options from the asset tree context menu in Pimcore 11.0.0. It also provides an example of how to configure custom views without these options.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d998770</samp>

> _Oh, we're the crew of the Pimcore ship_
> _And we sail the web so free_
> _But we've got some changes to make on board_
> _So listen up to me_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d998770</samp>

* Remove `importFromServer` and `uploadFromUrl` options from custom view configuration examples in `doc/05_Objects/01_Object_Classes/05_Class_Settings/20_Custom_Views.md` ([link](https://github.com/pimcore/pimcore/pull/15080/files?diff=unified&w=0#diff-034f66059f12fb375fa9102f43acdd81dd0fb3827c0ff10a7f76641100ff8d54L115-L116), [link](https://github.com/pimcore/pimcore/pull/15080/files?diff=unified&w=0#diff-034f66059f12fb375fa9102f43acdd81dd0fb3827c0ff10a7f76641100ff8d54L224-L225))
* Add upgrade note for Pimcore 11.0.0 about the removal of `Import from Server` and `Import from URL` options from the asset tree context menu in `doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md` ([link](https://github.com/pimcore/pimcore/pull/15080/files?diff=unified&w=0#diff-375aded12dfb868b84d5b8c27d1aed2358680a27b683e8a985f1b85193dd79aaR224))
