### PR TITLE
[Admin] Check whether the user image is valid or not

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -570,14 +570,16 @@ final class User extends User\UserRole
                 $targetFile = File::getLocalTempFilePath('png');
 
                 $image = \Pimcore\Image::getInstance();
-                $image->load($localFile);
-                $image->cover($width, $height);
-                $image->save($targetFile, 'png');
-
-                $storage->write($this->getThumbnailImageStoragePath(), file_get_contents($targetFile));
+                if($image->load($localFile)) {
+                    $image->cover($width, $height);
+                    $image->save($targetFile, 'png');
+                    $storage->write($this->getThumbnailImageStoragePath(), file_get_contents($targetFile));
+                }
             }
 
-            return $storage->readStream($this->getThumbnailImageStoragePath());
+            if ($storage->fileExists($this->getThumbnailImageStoragePath())) {
+                return $storage->readStream($this->getThumbnailImageStoragePath());
+            }
         }
 
         return fopen($this->getFallbackImage(), 'rb');


### PR DESCRIPTION
It could be the case that user images are not valid image formats, in this case it's impossible to open the user object again in the admin interface. 