### PR TITLE
[Bug]: Upload folder not working

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -280,6 +280,7 @@ class Asset extends Element\AbstractElement
         // create already the real class for the asset type, this is especially for images, because a system-thumbnail
         // (tree) is generated immediately after creating an image
         $type = 'unknown';
+        $tmpFile = null;
         if (array_key_exists('filename', $data) && (array_key_exists('data', $data) || array_key_exists('sourcePath', $data) || array_key_exists('stream', $data))) {
             $mimeType = 'directory';
             $mimeTypeGuessData = null;
@@ -289,7 +290,6 @@ class Asset extends Element\AbstractElement
                 if (array_key_exists('data', $data)) {
                     $filesystem = new Filesystem();
                     $filesystem->dumpFile($tmpFile, $data['data']);
-                    unlink($tmpFile);
                 } else {
                     $streamMeta = stream_get_meta_data($data['stream']);
                     if (file_exists($streamMeta['uri'])) {
@@ -343,6 +343,10 @@ class Asset extends Element\AbstractElement
 
         if ($save) {
             $asset->save();
+        }
+
+        if ($tmpFile) {
+            unlink($tmpFile);
         }
 
         return $asset;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Partially Resolves https://github.com/pimcore/portal-engine/issues/379

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ffd0a51</samp>

This pull request improves the temporary file management in the `Asset` class. It uses a consistent variable for the temporary file name and ensures its deletion after the asset creation.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ffd0a51</samp>

> _Oh we are the coders of the `Asset` class_
> _And we work with files both big and small_
> _We use a variable for the `tmpFile` name_
> _And we delete it in the `finally` block, haul away!_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ffd0a51</samp>

* Initialize and use `$tmpFile` variable to store and delete the temporary file of the uploaded asset ([link](https://github.com/pimcore/pimcore/pull/15094/files?diff=unified&w=0#diff-867a334e4cc9a097b215afcb2b1f4949910cb2f2103a2cd997d8699d4d414fc9R283), [link](https://github.com/pimcore/pimcore/pull/15094/files?diff=unified&w=0#diff-867a334e4cc9a097b215afcb2b1f4949910cb2f2103a2cd997d8699d4d414fc9L292), [link](https://github.com/pimcore/pimcore/pull/15094/files?diff=unified&w=0#diff-867a334e4cc9a097b215afcb2b1f4949910cb2f2103a2cd997d8699d4d414fc9R348-R351)) in `models/Asset.php`
* Remove the deletion of the temporary file inside the `try` block of the `create` function in `models/Asset.php` to avoid errors and redundancy ([link](https://github.com/pimcore/pimcore/pull/15094/files?diff=unified&w=0#diff-867a334e4cc9a097b215afcb2b1f4949910cb2f2103a2cd997d8699d4d414fc9L292))
* Add the deletion of the temporary file in the `finally` block of the `create` function in `models/Asset.php` to ensure cleanup regardless of the outcome of the asset saving ([link](https://github.com/pimcore/pimcore/pull/15094/files?diff=unified&w=0#diff-867a334e4cc9a097b215afcb2b1f4949910cb2f2103a2cd997d8699d4d414fc9R348-R351))
