### PR TITLE
[Task] Improved application logger panel

### DIFF
--- a/bundles/ApplicationLoggerBundle/public/js/log/admin.js
+++ b/bundles/ApplicationLoggerBundle/public/js/log/admin.js
@@ -223,11 +223,11 @@ pimcore.bundle.applicationlogger.log.admin = Class.create({
                     sortable: false,
                     renderer: function (value, p, record) {
                         if (value) {
-                            return Ext.String.format('<a href="#" onclick="pimcore.helpers.openElement({0}, \'{1}\')">{2}</a>', value, record.get('relatedobjecttype'), record.get('relatedobjecttype')+' '+value);
+                            return Ext.String.format('<a href="#">{0}</a>', record.get('relatedobjecttype')+' '+value);
                         }
 
                         return '';
-                    },
+                    }
                 },{
                     text: t("log_component"),
                     dataIndex: 'component',
@@ -253,6 +253,12 @@ pimcore.bundle.applicationlogger.log.admin = Class.create({
                 listeners: {
                     rowdblclick : function(grid, record, tr, rowIndex, e, eOpts ) {
                         new pimcore.bundle.applicationlogger.log.detailwindow(this.store.getAt(rowIndex).data);
+                    }.bind(this),
+                    cellclick: function(grid,  td, cellIndex, record, tr, rowIndex, e, eOpts) {
+                        const row = this.store.getAt(rowIndex);
+                        if (cellIndex === 5 && row.data.relatedobject && row.data.relatedobjecttype) { //5 = relatedobject
+                            pimcore.helpers.openElement(row.data.relatedobject, row.data.relatedobjecttype);
+                        }
                     }.bind(this)
                 },
 

--- a/bundles/ApplicationLoggerBundle/public/js/log/detailwindow.js
+++ b/bundles/ApplicationLoggerBundle/public/js/log/detailwindow.js
@@ -115,7 +115,7 @@ pimcore.bundle.applicationlogger.log.detailwindow = Class.create({
             if (fileObjectText.length > 60) {
                 fileObjectText = fileObjectText.substr(0, 60) + "...";
             }
-            var url = Routing.generate('pimcore_admin_bundle_log_showfileobject', {filePath: this.data.fileobject});
+            var url = Routing.generate('pimcore_admin_bundle_applicationlogger_log_showfileobject', {filePath: this.data.fileobject});
 
             var html = Ext.String.format('<a href="{0}" target="_blank">{1}</a>', url, fileObjectText);
             items.push({


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #15029

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 22d705c</samp>

This pull request improves the log grid and the log detail window in the Application Logger Bundle. It fixes a bug with opening related objects, adds a feature to open them in a new tab, and updates a route name to match a controller rename.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 22d705c</samp>

> _`LogController` is no more, we renamed it in the code_
> _But we forgot to change the route, and now we face the load_
> _Of fixing broken links and bugs, that haunt us in the night_
> _We open tabs with cellclicks, we fight for our `showfileobject` right_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 22d705c</samp>

*  Fix a bug that causes the related object to open twice when clicking on the link in the log grid ([link](https://github.com/pimcore/pimcore/pull/15095/files?diff=unified&w=0#diff-e082f2902effc641c87d75e904e3f6a778d698d367f29082a9a01d894873a69fL226-R230))
*  Add a feature that allows the user to open the related object in a new tab by clicking on the cell in the log grid ([link](https://github.com/pimcore/pimcore/pull/15095/files?diff=unified&w=0#diff-e082f2902effc641c87d75e904e3f6a778d698d367f29082a9a01d894873a69fR256-R261))
*  Fix a broken link that prevents the user from accessing the file object in the log detail window by updating the route name to match the renamed controller ([link](https://github.com/pimcore/pimcore/pull/15095/files?diff=unified&w=0#diff-40e0b7c0239ace99b51f069d7bbfe227533796876384faeb98b7f0a8b9f09ddfL118-R118))
