### PR TITLE
Check $data is not null

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Textarea.php
+++ b/models/DataObject/ClassDefinition/Data/Textarea.php
@@ -190,7 +190,7 @@ class Textarea extends Data implements ResourcePersistenceAwareInterface, QueryR
     public function checkValidity(mixed $data, bool $omitMandatoryCheck = false, array $params = []): void
     {
         if (!$omitMandatoryCheck && $this->getMaxLength() !== null) {
-            if (mb_strlen($data) > $this->getMaxLength()) {
+            if ($data !== null && mb_strlen($data) > $this->getMaxLength()) {
                 throw new Model\Element\ValidationException('Value in field [ ' . $this->getName() . " ] longer than max length of '" . $this->getMaxLength() . "'");
             }
         }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Check if `$data` is not null, because otherwise you get the following error message in the logs:

`Deprecated: mb_strlen(): Passing null to parameter #1 ($string) of type string is deprecated`

### WHAT
copilot:summary

copilot:poem

### HOW
copilot:walkthrough
