### PR TITLE
SecurityHelper: there could be numeric values as well, which shouldn't be casted to string

### DIFF
--- a/lib/Security/SecurityHelper.php
+++ b/lib/Security/SecurityHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Pimcore
  *

--- a/lib/Security/SecurityHelper.php
+++ b/lib/Security/SecurityHelper.php
@@ -38,12 +38,12 @@ class SecurityHelper
         }
     }
 
-    public static function sanitizeHtmlAttributes(?string $text): ?string
+    public static function sanitizeHtmlAttributes(mixed $text): mixed
     {
         if(is_string($text)) {
             return preg_replace('/[\/"\'\\\]/', '', $text);
+        } else {
+            return $text;
         }
-
-        return null;
     }
 }


### PR DESCRIPTION
Follow up to #14986