### PR TITLE
[Bug] Removed serverside html sanitizer

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -25,9 +25,7 @@ pimcore.element.helpers.gridColumnConfig = {
             length: 50,
             allowBlank: false,
             value: this.settings.gridConfigName ? this.settings.gridConfigName : defaultName,
-            listeners: {
-                change: pimcore.helpers.htmlEncodeTextField
-            }
+            renderer: Ext.util.Format.htmlEncode
         });
 
         var descriptionField = new Ext.form.TextArea({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers.js
@@ -22,17 +22,6 @@ pimcore.helpers.sanitizeUrlSlug = function (slug) {
     return slug.replace(/[^a-z0-9-_+/]/gi, '');
 };
 
-pimcore.helpers.htmlEncodeTextField = function (textField) {
-    if(textField.getValue()) {
-        textField.suspendEvent('change');
-        const decodedValue = Ext.util.Format.htmlDecode(textField.getValue());
-        textField.setValue(
-            Ext.util.Format.htmlEncode(decodedValue)
-        );
-        textField.resumeEvent('change');
-    }
-};
-
 pimcore.helpers.registerKeyBindings = function (bindEl, ExtJS) {
 
     if (!ExtJS) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Alias.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Alias.js
@@ -87,7 +87,8 @@ pimcore.object.gridcolumn.operator.alias = Class.create(pimcore.object.gridcolum
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Anonymizer.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Anonymizer.js
@@ -72,7 +72,6 @@ pimcore.object.gridcolumn.operator.anonymizer = Class.create(pimcore.object.grid
                 label: source.data.text,
                 type: this.type,
                 class: this.class
-
             }
         });
 
@@ -87,7 +86,8 @@ pimcore.object.gridcolumn.operator.anonymizer = Class.create(pimcore.object.grid
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         var mode = this.node.data.configAttributes.mode;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/AnyGetter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/AnyGetter.js
@@ -84,7 +84,7 @@ pimcore.object.gridcolumn.operator.anygetter = Class.create(pimcore.object.gridc
                 length: 255,
                 width: 200,
                 value: this.node.data.configAttributes.label,
-                listeners: {'change': pimcore.helpers.htmlEncodeTextField }
+                renderer: Ext.util.Format.htmlEncode
             });
 
             this.attributeField = new Ext.form.TextField({
@@ -92,7 +92,7 @@ pimcore.object.gridcolumn.operator.anygetter = Class.create(pimcore.object.gridc
                 length: 255,
                 width: 200,
                 value: this.node.data.configAttributes.attribute,
-                listeners: {'change': pimcore.helpers.htmlEncodeTextField }
+                renderer: Ext.util.Format.htmlEncode
             });
 
             this.param1Field = new Ext.form.TextField({
@@ -100,7 +100,7 @@ pimcore.object.gridcolumn.operator.anygetter = Class.create(pimcore.object.gridc
                 length: 255,
                 width: 200,
                 value: this.node.data.configAttributes.param1,
-                listeners: {'change': pimcore.helpers.htmlEncodeTextField }
+                renderer: Ext.util.Format.htmlEncode
         });
 
             this.returnLastResultField = new Ext.form.Checkbox({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Arithmetic.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Arithmetic.js
@@ -86,7 +86,8 @@ pimcore.object.gridcolumn.operator.arithmetic = Class.create(pimcore.object.grid
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         var operator = this.node.data.configAttributes.operator;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/AssetMetadataGetter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/AssetMetadataGetter.js
@@ -83,7 +83,8 @@ pimcore.object.gridcolumn.operator.assetmetadatagetter = Class.create(pimcore.ob
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         var data = [];
@@ -102,7 +103,8 @@ pimcore.object.gridcolumn.operator.assetmetadatagetter = Class.create(pimcore.ob
             fieldLabel: t('metadata_field'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.metaField
+            value: this.node.data.configAttributes.metaField,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         var options = {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Base64.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Base64.js
@@ -88,7 +88,8 @@ pimcore.object.gridcolumn.operator.base64 = Class.create(pimcore.object.gridcolu
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         var mode = this.node.data.configAttributes.mode;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Boolean.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Boolean.js
@@ -86,7 +86,8 @@ pimcore.object.gridcolumn.operator.boolean = Class.create(pimcore.object.gridcol
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         var operator = this.node.data.configAttributes.operator;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/BooleanFormatter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/BooleanFormatter.js
@@ -85,21 +85,24 @@ pimcore.object.gridcolumn.operator.booleanformatter = Class.create(pimcore.objec
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.yesValueField = new Ext.form.TextField({
             fieldLabel: t('yes_value'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.yesValue
+            value: this.node.data.configAttributes.yesValue,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.noValueField = new Ext.form.TextField({
             fieldLabel: t('no_value'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.noValue
+            value: this.node.data.configAttributes.noValue,
+            renderer: Ext.util.Format.htmlEncode
         });
 
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/CaseConverter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/CaseConverter.js
@@ -87,7 +87,8 @@ pimcore.object.gridcolumn.operator.caseconverter = Class.create(pimcore.object.g
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         var capitalization = this.node.data.configAttributes.capitalization;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/CharCounter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/CharCounter.js
@@ -83,7 +83,8 @@ pimcore.object.gridcolumn.operator.charcounter = Class.create(pimcore.object.gri
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Concatenator.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Concatenator.js
@@ -82,21 +82,24 @@ pimcore.object.gridcolumn.operator.concatenator = Class.create(pimcore.object.gr
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.glue = new Ext.form.TextField({
             fieldLabel: t('glue'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.glue
+            value: this.node.data.configAttributes.glue,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.forceValue = new Ext.form.Checkbox({
             fieldLabel: t('force_value'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.forceValue
+            value: this.node.data.configAttributes.forceValue,
+            renderer: Ext.util.Format.htmlEncode
         });
 
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/DateFormatter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/DateFormatter.js
@@ -88,7 +88,8 @@ pimcore.object.gridcolumn.operator.dateformatter = Class.create(pimcore.object.g
             fieldLabel: t('date_format'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.format
+            value: this.node.data.configAttributes.format,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         var helpButton = new Ext.Button({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/ElementCounter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/ElementCounter.js
@@ -82,7 +82,8 @@ pimcore.object.gridcolumn.operator.elementcounter = Class.create(pimcore.object.
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.countEmptyField = new Ext.form.Checkbox({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/FieldCollectionGetter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/FieldCollectionGetter.js
@@ -90,7 +90,8 @@ pimcore.object.gridcolumn.operator.fieldcollectiongetter = Class.create(pimcore.
             length: 255,
             width: 200,
             value: this.node.data.configAttributes.label,
-            allowBlank: true
+            allowBlank: true,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.attributeField = new Ext.form.TextField({
@@ -98,7 +99,8 @@ pimcore.object.gridcolumn.operator.fieldcollectiongetter = Class.create(pimcore.
             length: 255,
             width: 200,
             value: this.node.data.configAttributes.attr,
-            allowBlank: false
+            allowBlank: false,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.indexField = new Ext.form.NumberField({
@@ -114,7 +116,8 @@ pimcore.object.gridcolumn.operator.fieldcollectiongetter = Class.create(pimcore.
             length: 255,
             width: 200,
             value: this.node.data.configAttributes.colAttr,
-            allowBlank: false
+            allowBlank: false,
+            renderer: Ext.util.Format.htmlEncode
         });
 
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/GeopointRenderer.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/GeopointRenderer.js
@@ -88,7 +88,8 @@ pimcore.object.gridcolumn.operator.geopointrenderer = Class.create(pimcore.objec
         this.textField = new Ext.form.TextField({
             fieldLabel: t('label'),
             labelWidth: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.configPanel = new Ext.Panel({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/HotspotimageRenderer.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/HotspotimageRenderer.js
@@ -88,7 +88,8 @@ pimcore.object.gridcolumn.operator.hotspotimagerenderer = Class.create(pimcore.o
         this.textField = new Ext.form.TextField({
             fieldLabel: t('label'),
             labelWidth: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.configPanel = new Ext.Panel({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/ImageRenderer.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/ImageRenderer.js
@@ -88,7 +88,8 @@ pimcore.object.gridcolumn.operator.imagerenderer = Class.create(pimcore.object.g
         this.textField = new Ext.form.TextField({
             fieldLabel: t('label'),
             labelWidth: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.configPanel = new Ext.Panel({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/IsEqual.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/IsEqual.js
@@ -86,7 +86,8 @@ pimcore.object.gridcolumn.operator.isequal = Class.create(pimcore.object.gridcol
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.skipNullField = new Ext.form.Checkbox({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Iterator.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Iterator.js
@@ -87,7 +87,8 @@ pimcore.object.gridcolumn.operator.iterator = Class.create(pimcore.object.gridco
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/JSON.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/JSON.js
@@ -88,7 +88,8 @@ pimcore.object.gridcolumn.operator.json = Class.create(pimcore.object.gridcolumn
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         var mode = this.node.data.configAttributes.mode;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/LFExpander.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/LFExpander.js
@@ -86,7 +86,8 @@ pimcore.object.gridcolumn.operator.lfexpander = Class.create(pimcore.object.grid
             fieldLabel: t('label'),
             length: 255,
             width: 220,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         var data = [];

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/LocaleSwitcher.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/LocaleSwitcher.js
@@ -85,7 +85,8 @@ pimcore.object.gridcolumn.operator.localeswitcher = Class.create(pimcore.object.
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         var data = [];

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Merge.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Merge.js
@@ -80,7 +80,8 @@ pimcore.object.gridcolumn.operator.merge = Class.create(pimcore.object.gridcolum
         this.textField = new Ext.form.TextField({
             fieldLabel: t('label'),
             labelWidth: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.flattenField = new Ext.form.Checkbox({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/ObjectFieldGetter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/ObjectFieldGetter.js
@@ -85,21 +85,24 @@ pimcore.object.gridcolumn.operator.objectfieldgetter = Class.create(pimcore.obje
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.attributeField = new Ext.form.TextField({
             fieldLabel: t('attribute'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.attribute
+            value: this.node.data.configAttributes.attribute,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.forwardAttributeField = new Ext.form.TextField({
             fieldLabel: t('forward_attribute'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.forwardAttribute
+            value: this.node.data.configAttributes.forwardAttribute,
+            renderer: Ext.util.Format.htmlEncode
         });
 
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/PHP.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/PHP.js
@@ -88,7 +88,8 @@ pimcore.object.gridcolumn.operator.php = Class.create(pimcore.object.gridcolumn.
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         var mode = this.node.data.configAttributes.mode;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/PHPCode.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/PHPCode.js
@@ -84,13 +84,15 @@ pimcore.object.gridcolumn.operator.phpcode = Class.create(pimcore.object.gridcol
             fieldLabel: t('label'),
             length: 255,
             width: 400,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.phpClassField = new Ext.form.TextField({
             fieldLabel: t('php_class'),
             width: 400,
-            value: this.node.data.configAttributes.phpClass
+            value: this.node.data.configAttributes.phpClass,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.additionalDataField = new Ext.form.TextArea({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/PropertyGetter.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/PropertyGetter.js
@@ -86,14 +86,16 @@ pimcore.object.gridcolumn.operator.propertygetter = Class.create(pimcore.object.
                 fieldLabel: t('label'),
                 length: 255,
                 width: 200,
-                value: this.node.data.configAttributes.label
+                value: this.node.data.configAttributes.label,
+                renderer: Ext.util.Format.htmlEncode
             });
 
             this.propertyNameField = new Ext.form.TextField({
                 fieldLabel: t('property_name'),
                 length: 255,
                 width: 200,
-                value: this.node.data.configAttributes.propertyName
+                value: this.node.data.configAttributes.propertyName,
+                renderer: Ext.util.Format.htmlEncode
             });
 
             this.configPanel = new Ext.Panel({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/RequiredBy.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/RequiredBy.js
@@ -86,7 +86,8 @@ pimcore.object.gridcolumn.operator.requiredby = Class.create(pimcore.object.grid
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         var data = [];

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/StringContains.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/StringContains.js
@@ -86,14 +86,16 @@ pimcore.object.gridcolumn.operator.stringcontains = Class.create(pimcore.object.
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.searchField = new Ext.form.TextField({
             fieldLabel: t('search'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.search
+            value: this.node.data.configAttributes.search,
+            renderer: Ext.util.Format.htmlEncode
         });
 
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/StringReplace.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/StringReplace.js
@@ -86,21 +86,24 @@ pimcore.object.gridcolumn.operator.stringreplace = Class.create(pimcore.object.g
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.searchField = new Ext.form.TextField({
             fieldLabel: t('search'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.search
+            value: this.node.data.configAttributes.search,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.replaceField = new Ext.form.TextField({
             fieldLabel: t('replace'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.replace
+            value: this.node.data.configAttributes.replace,
+            renderer: Ext.util.Format.htmlEncode
         });
 
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Substring.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Substring.js
@@ -85,7 +85,8 @@ pimcore.object.gridcolumn.operator.substring = Class.create(pimcore.object.gridc
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.startField = new Ext.form.NumberField({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Text.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Text.js
@@ -79,7 +79,8 @@ pimcore.object.gridcolumn.operator.text = Class.create(pimcore.object.gridcolumn
             fieldLabel: t('text'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.textValue
+            value: this.node.data.configAttributes.textValue,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.configPanel = new Ext.Panel({

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/TranslateValue.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/TranslateValue.js
@@ -85,14 +85,16 @@ pimcore.object.gridcolumn.operator.translatevalue = Class.create(pimcore.object.
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         this.prefix = new Ext.form.TextField({
             fieldLabel: t('prefix'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.prefix
+            value: this.node.data.configAttributes.prefix,
+            renderer: Ext.util.Format.htmlEncode
         });
 
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Trimmer.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/Trimmer.js
@@ -87,7 +87,8 @@ pimcore.object.gridcolumn.operator.trimmer = Class.create(pimcore.object.gridcol
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
         var trim = this.node.data.configAttributes.trim;

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/WorkflowState.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/gridcolumn/operator/WorkflowState.js
@@ -83,7 +83,8 @@ pimcore.object.gridcolumn.operator.workflowstate = Class.create(pimcore.object.g
             fieldLabel: t('label'),
             length: 255,
             width: 200,
-            value: this.node.data.configAttributes.label
+            value: this.node.data.configAttributes.label,
+            renderer: Ext.util.Format.htmlEncode
         });
 
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
@@ -105,9 +105,9 @@ pimcore.object.quantityValue.unitsettings = Class.create({
 
         var typesColumns = [
             {flex: 1, dataIndex: 'id', text: t("id"), filter: 'string'},
-            {flex: 1, dataIndex: 'abbreviation', text: t("abbreviation"), editor: new Ext.form.TextField({listeners: {change: pimcore.helpers.htmlEncodeTextField}}), filter: 'string'},
-            {flex: 2, dataIndex: 'longname', text: t("longname"), editor: new Ext.form.TextField({listeners: {change: pimcore.helpers.htmlEncodeTextField}}), filter: 'string'},
-            {flex: 1, dataIndex: 'group', text: t("group"), editor: new Ext.form.TextField({listeners: {change: pimcore.helpers.htmlEncodeTextField}}), filter: 'string', hidden: true},
+            {flex: 1, dataIndex: 'abbreviation', text: t("abbreviation"), editor: new Ext.form.TextField(), filter: 'string'},
+            {flex: 2, dataIndex: 'longname', text: t("longname"), editor: new Ext.form.TextField(), filter: 'string'},
+            {flex: 1, dataIndex: 'group', text: t("group"), editor: new Ext.form.TextField(), filter: 'string', hidden: true},
             {flex: 1, dataIndex: 'baseunit', text: t("baseunit"), editor: baseUnitEditor, renderer: function(value){
                 if(!value) {
                     return '('+t('empty')+')';
@@ -121,8 +121,8 @@ pimcore.object.quantityValue.unitsettings = Class.create({
             }},
             {flex: 1, dataIndex: 'factor', text: t("conversionFactor"), editor: new Ext.form.NumberField({decimalPrecision: 10}), filter: 'numeric'},
             {flex: 1, dataIndex: 'conversionOffset', text: t("conversionOffset"), editor: new Ext.form.NumberField({decimalPrecision: 10}), filter: 'numeric'},
-            {flex: 1, dataIndex: 'reference', text: t("reference"), editor: new Ext.form.TextField({listeners: {change: pimcore.helpers.htmlEncodeTextField}}), hidden: true, filter: 'string'},
-            {flex: 1, dataIndex: 'converter', text: t("converter_service"), editor: new Ext.form.TextField({listeners: {change: pimcore.helpers.htmlEncodeTextField}}), filter: 'string'}
+            {flex: 1, dataIndex: 'reference', text: t("reference"), editor: new Ext.form.TextField(), hidden: true, filter: 'string'},
+            {flex: 1, dataIndex: 'converter', text: t("converter_service"), editor: new Ext.form.TextField(), filter: 'string'}
         ];
 
         typesColumns.push({
@@ -196,7 +196,12 @@ pimcore.object.quantityValue.unitsettings = Class.create({
             plugins: ['pimcore.gridfilters', this.rowEditing],
             columnLines: true,
             stripeRows: true,
-            columns : typesColumns,
+            columns: {
+                items: typesColumns,
+                defaults: {
+                    renderer: Ext.util.Format.htmlEncode
+                },
+            },
             bbar: this.pagingtoolbar,
             selModel: Ext.create('Ext.selection.RowModel', {}),
             tbar: {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/metadata/predefined.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/metadata/predefined.js
@@ -138,13 +138,13 @@ pimcore.settings.metadata.predefined = Class.create({
                 sortable: true
             },
             {text: t("name"), width: 200, sortable: true, dataIndex: 'name',
-                getEditor: function() { return new Ext.form.TextField({ listeners: {'change': pimcore.helpers.htmlEncodeTextField } }); }
+                getEditor: function() { return new Ext.form.TextField(); }
             },
             {text: t("group"), width: 200, sortable: true, dataIndex: 'group',
-                getEditor: function() { return new Ext.form.TextField({}); }
+                getEditor: function() { return new Ext.form.TextField(); }
             },
             {text: t("description"), sortable: true, dataIndex: 'description',
-                getEditor: function() { return new Ext.form.TextArea({}); },
+                getEditor: function() { return new Ext.form.TextArea(); },
                 renderer: function (value, metaData, record, rowIndex, colIndex, store) {
                     if (empty(value)) {
                         return "";

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
@@ -170,11 +170,7 @@ pimcore.settings.properties.predefined = Class.create({
                 flex: 50,
                 sortable: false,
                 dataIndex: 'config',
-                editor: new Ext.form.TextField({
-                    listeners: {
-                        'change': pimcore.helpers.htmlEncodeTextField
-                    }
-                })
+                editor: new Ext.form.TextField()
             },
             {
                 text: t("content_type"),

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
@@ -108,26 +108,79 @@ pimcore.settings.properties.predefined = Class.create({
 
 
         var propertiesColumns = [
-            {text: t("name"), flex: 100, sortable: true, dataIndex: 'name', editor: new Ext.form.TextField({listeners: {'change': pimcore.helpers.htmlEncodeTextField}})},
-            {text: t("description"), sortable: true, dataIndex: 'description', editor: new Ext.form.TextArea({listeners: {'change': pimcore.helpers.htmlEncodeTextField}}),
+            {
+                text: t("name"),
+                flex: 100,
+                sortable: true,
+                dataIndex: 'name',
+                editor: new Ext.form.TextField({
+                    listeners: {
+                        'change': pimcore.helpers.htmlEncodeTextField
+                    }
+                })
+            },
+            {
+                text: t("description"),
+                sortable: true,
+                dataIndex: 'description',
+                editor: new Ext.form.TextArea({
+                    listeners: {
+                        'change': pimcore.helpers.htmlEncodeTextField
+                    }
+                }),
                 renderer: function (value, metaData, record, rowIndex, colIndex, store) {
                     if(empty(value)) {
                         return "";
                     }
                     return nl2br(Ext.util.Format.htmlEncode(value));
-               }
+                }
             },
-            {text: t("key"), flex: 50, sortable: true, dataIndex: 'key', editor: new Ext.form.TextField({listeners: {'change': pimcore.helpers.htmlEncodeTextField}})},
-            {text: t("type"), flex: 50, sortable: true, dataIndex: 'type',
+            {
+                text: t("key"),
+                flex: 50,
+                sortable: true,
+                dataIndex: 'key',
+                editor: new Ext.form.TextField({
+                    listeners: {
+                        'change': pimcore.helpers.htmlEncodeTextField
+                    }
+                })
+            },
+            {
+                text: t("type"),
+                flex: 50,
+                sortable: true,
+                dataIndex: 'type',
                 editor: new Ext.form.ComboBox({
                     triggerAction: 'all',
                     editable: false,
                     store: ["text","document","asset","object","bool","select"]
 
-            })},
-            {text: t("value"), flex: 50, sortable: true, dataIndex: 'data', editor: new Ext.form.TextField({listeners: {'change': pimcore.helpers.htmlEncodeTextField}})},
-            {text: t("configuration"), flex: 50, sortable: false, dataIndex: 'config', editor: new Ext.form.TextField({listeners: {'change': pimcore.helpers.htmlEncodeTextField}})},
-            {text: t("content_type"), flex: 50, sortable: true, dataIndex: 'ctype',
+                })
+            },
+            {
+                text: t("value"),
+                flex: 50,
+                sortable: true,
+                dataIndex: 'data',
+                editor: new Ext.form.TextField()
+            },
+            {
+                text: t("configuration"),
+                flex: 50,
+                sortable: false,
+                dataIndex: 'config',
+                editor: new Ext.form.TextField({
+                    listeners: {
+                        'change': pimcore.helpers.htmlEncodeTextField
+                    }
+                })
+            },
+            {
+                text: t("content_type"),
+                flex: 50,
+                sortable: true,
+                dataIndex: 'ctype',
                 editor: new Ext.ux.form.MultiSelect({
                     store: new Ext.data.ArrayStore({
                         fields: ['key', {
@@ -176,7 +229,8 @@ pimcore.settings.properties.predefined = Class.create({
                         );
                     }.bind(this)
                 }]
-            },{
+            },
+            {
                 xtype: 'actioncolumn',
                 menuText: t('translate'),
                 width: 30,
@@ -194,7 +248,11 @@ pimcore.settings.properties.predefined = Class.create({
                     }.bind(this)
                 }]
             },
-            {text: t("creationDate"), sortable: true, dataIndex: 'creationDate', editable: false,
+            {
+                text: t("creationDate"),
+                sortable: true,
+                dataIndex: 'creationDate',
+                editable: false,
                 hidden: true,
                 renderer: function(d) {
                     if (d !== undefined) {
@@ -205,7 +263,11 @@ pimcore.settings.properties.predefined = Class.create({
                     }
                 }
             },
-            {text: t("modificationDate"), sortable: true, dataIndex: 'modificationDate', editable: false,
+            {
+                text: t("modificationDate"),
+                sortable: true,
+                dataIndex: 'modificationDate',
+                editable: false,
                 hidden: true,
                 renderer: function(d) {
                     if (d !== undefined) {
@@ -216,7 +278,6 @@ pimcore.settings.properties.predefined = Class.create({
                     }
                 }
             }
-
         ];
 
         this.rowEditing = Ext.create('Ext.grid.plugin.RowEditing', {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/properties/predefined.js
@@ -113,21 +113,13 @@ pimcore.settings.properties.predefined = Class.create({
                 flex: 100,
                 sortable: true,
                 dataIndex: 'name',
-                editor: new Ext.form.TextField({
-                    listeners: {
-                        'change': pimcore.helpers.htmlEncodeTextField
-                    }
-                })
+                editor: new Ext.form.TextField()
             },
             {
                 text: t("description"),
                 sortable: true,
                 dataIndex: 'description',
-                editor: new Ext.form.TextArea({
-                    listeners: {
-                        'change': pimcore.helpers.htmlEncodeTextField
-                    }
-                }),
+                editor: new Ext.form.TextArea(),
                 renderer: function (value, metaData, record, rowIndex, colIndex, store) {
                     if(empty(value)) {
                         return "";
@@ -140,11 +132,7 @@ pimcore.settings.properties.predefined = Class.create({
                 flex: 50,
                 sortable: true,
                 dataIndex: 'key',
-                editor: new Ext.form.TextField({
-                    listeners: {
-                        'change': pimcore.helpers.htmlEncodeTextField
-                    }
-                })
+                editor: new Ext.form.TextField()
             },
             {
                 text: t("type"),

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/staticroutes.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/staticroutes.js
@@ -96,11 +96,11 @@ pimcore.settings.staticroutes = Class.create({
 
         var typesColumns = [
             {text:t("name"), flex:50, sortable:true, dataIndex:'name',
-                editor:new Ext.form.TextField({listeners: {'change': pimcore.helpers.htmlEncodeTextField}})},
+                editor:new Ext.form.TextField()},
             {text:t("pattern"), flex:100, sortable:true, dataIndex:'pattern',
-                editor:new Ext.form.TextField({listeners: {'change': pimcore.helpers.htmlEncodeTextField}})},
+                editor:new Ext.form.TextField()},
             {text:t("reverse"), flex:100, sortable:true, dataIndex:'reverse',
-                editor:new Ext.form.TextField({listeners: {'change': pimcore.helpers.htmlEncodeTextField}})},
+                editor:new Ext.form.TextField()},
             {text:t("controller"), flex:200, sortable:false, dataIndex:'controller',
                 editor:new Ext.form.ComboBox({
                     store:new Ext.data.JsonStore({
@@ -127,17 +127,14 @@ pimcore.settings.staticroutes = Class.create({
                     valueField:'name',
                     listConfig: {
                         maxWidth: 400
-                    },
-                    listeners: {
-                        'change': pimcore.helpers.htmlEncodeTextField
                     }
                 })},
             {text:t("variables"), flex:50, sortable:false, dataIndex:'variables',
-                editor:new Ext.form.TextField({listeners: {'change': pimcore.helpers.htmlEncodeTextField}})},
+                editor:new Ext.form.TextField()},
             {text:t("defaults"), flex:50, sortable:false, dataIndex:'defaults',
-                editor:new Ext.form.TextField({listeners: {'change': pimcore.helpers.htmlEncodeTextField}})},
+                editor:new Ext.form.TextField()},
             {text:t("site_ids"), flex:100, sortable:true, dataIndex:"siteId",
-                editor:new Ext.form.TextField({listeners: {'change': pimcore.helpers.htmlEncodeTextField}}),
+                editor:new Ext.form.TextField(),
                 tooltip: t("site_ids_tooltip")
             },
             {text:t("priority"), flex:50, sortable:true, dataIndex:'priority', editor:new Ext.form.ComboBox({
@@ -146,7 +143,7 @@ pimcore.settings.staticroutes = Class.create({
                 triggerAction:"all"
             })},
             {text:t("methods"), flex:50, sortable:false, dataIndex:'methods',
-                editor:new Ext.form.TextField({listeners: {'change': pimcore.helpers.htmlEncodeTextField}}),
+                editor:new Ext.form.TextField(),
             },
             {text: t("creationDate"), sortable: true, dataIndex: 'creationDate', editable: false,
                 hidden: true,

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/website.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/website.js
@@ -112,11 +112,7 @@ pimcore.settings.website = Class.create({
                 flex: 100,
                 editable: true,
                 sortable: true,
-                editor: new Ext.form.TextField({
-                    listeners: {
-                        'change': pimcore.helpers.htmlEncodeTextField
-                    }
-                })
+                editor: new Ext.form.TextField()
             },
             {
                 text: t('language'),

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/website.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/website.js
@@ -135,11 +135,7 @@ pimcore.settings.website = Class.create({
                 dataIndex: 'data',
                 flex: 300,
                 editable: true,
-                editor: new Ext.form.TextField({
-                    listeners: {
-                        'change': pimcore.helpers.htmlEncodeTextField
-                    }
-                }),
+                editor: new Ext.form.TextField(),
                 renderer: this.getCellRenderer.bind(this),
             },
             {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/website.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/website.js
@@ -116,8 +116,7 @@ pimcore.settings.website = Class.create({
                     listeners: {
                         'change': pimcore.helpers.htmlEncodeTextField
                     }
-                }),
-                renderer: Ext.util.Format.htmlEncode
+                })
             },
             {
                 text: t('language'),
@@ -209,7 +208,7 @@ pimcore.settings.website = Class.create({
                 icon:"/bundles/pimcoreadmin/img/flat-color-icons/delete.svg",
                 handler:function (grid, rowIndex) {
                     let data = grid.getStore().getAt(rowIndex);
-                    pimcore.helpers.deleteConfirm(t('website_settings'), data.data.name, function () {
+                    pimcore.helpers.deleteConfirm(t('website_settings'), Ext.util.Format.htmlEncode(data.data.name), function () {
                         grid.getStore().removeAt(rowIndex);
                     }.bind(this));
                 }.bind(this)

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/website.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/website.js
@@ -116,7 +116,8 @@ pimcore.settings.website = Class.create({
                     listeners: {
                         'change': pimcore.helpers.htmlEncodeTextField
                     }
-                })
+                }),
+                renderer: Ext.util.Format.htmlEncode
             },
             {
                 text: t('language'),
@@ -142,7 +143,11 @@ pimcore.settings.website = Class.create({
                 }),
                 renderer: this.getCellRenderer.bind(this),
             },
-            {text: t("site"), flex: 100, sortable:true, dataIndex: "siteId",
+            {
+                text: t("site"),
+                flex: 100,
+                sortable:true,
+                dataIndex: "siteId",
                 editor: new Ext.form.ComboBox({
                     store: pimcore.globalmanager.get("sites"),
                     valueField: "id",

--- a/bundles/EcommerceFrameworkBundle/PricingManager/Rule.php
+++ b/bundles/EcommerceFrameworkBundle/PricingManager/Rule.php
@@ -205,7 +205,7 @@ class Rule extends AbstractModel implements RuleInterface
      */
     public function setName($name, $locale = null)
     {
-        $this->name = SecurityHelper::convertHtmlSpecialChars($name);
+        $this->name = $name;
 
         return $this;
     }

--- a/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/item.js
+++ b/bundles/EcommerceFrameworkBundle/Resources/public/js/pricing/config/item.js
@@ -133,14 +133,16 @@ pimcore.bundle.EcommerceFramework.pricing.config.item = Class.create({
                     name: "label." + lang,
                     fieldLabel: t("label"),
                     width: 350,
-                    value: data.label[ lang ]
+                    value: data.label[ lang ],
+                    renderer: Ext.util.Format.htmlEncode
                 }, {
                     xtype: "textarea",
                     name: "description." + lang,
                     fieldLabel: t("description"),
                     width: 500,
                     height: 100,
-                    value: data.description[ lang ]
+                    value: data.description[ lang ],
+                    renderer: Ext.util.Format.htmlEncode
                 }]
             };
 

--- a/lib/DataObject/GridColumnConfig/Operator/AbstractOperator.php
+++ b/lib/DataObject/GridColumnConfig/Operator/AbstractOperator.php
@@ -42,7 +42,7 @@ abstract class AbstractOperator implements OperatorInterface
      */
     public function __construct(\stdClass $config, array $context = [])
     {
-        $this->label = SecurityHelper::convertHtmlSpecialChars($config->label);
+        $this->label = $config->label;
         $this->childs = $config->childs;
         $this->context = $context;
     }
@@ -92,7 +92,7 @@ abstract class AbstractOperator implements OperatorInterface
      */
     public function setLabel($label)
     {
-        $this->label = SecurityHelper::convertHtmlSpecialChars($label);
+        $this->label = $label;
     }
 
     /**

--- a/lib/DataObject/GridColumnConfig/Operator/AnyGetter.php
+++ b/lib/DataObject/GridColumnConfig/Operator/AnyGetter.php
@@ -65,8 +65,8 @@ final class AnyGetter extends AbstractOperator
 
         parent::__construct($config, $context);
 
-        $this->attribute = SecurityHelper::convertHtmlSpecialChars($config->attribute ?? '');
-        $this->param1 = SecurityHelper::convertHtmlSpecialChars($config->param1 ?? '');
+        $this->attribute = $config->attribute ?? '';
+        $this->param1 = $config->param1 ?? '';
         $this->isArrayType = $config->isArrayType ?? false;
 
         $this->forwardAttribute = $config->forwardAttribute ?? '';
@@ -183,7 +183,7 @@ final class AnyGetter extends AbstractOperator
      */
     public function setAttribute($attribute)
     {
-        $this->attribute = SecurityHelper::convertHtmlSpecialChars($attribute);
+        $this->attribute = $attribute;
     }
 
     /**
@@ -199,7 +199,7 @@ final class AnyGetter extends AbstractOperator
      */
     public function setParam1($param1)
     {
-        $this->param1 = SecurityHelper::convertHtmlSpecialChars($param1);
+        $this->param1 = $param1;
     }
 
     /**

--- a/models/DataObject/QuantityValue/Unit.php
+++ b/models/DataObject/QuantityValue/Unit.php
@@ -20,7 +20,6 @@ use Pimcore\Event\DataObjectQuantityValueEvents;
 use Pimcore\Event\Model\DataObject\QuantityValueUnitEvent;
 use Pimcore\Event\Traits\RecursionBlockingEventDispatchHelperTrait;
 use Pimcore\Model;
-use Pimcore\Security\SecurityHelper;
 
 /**
  * @method \Pimcore\Model\DataObject\QuantityValue\Unit\Dao getDao()
@@ -210,7 +209,7 @@ class Unit extends Model\AbstractModel
      */
     public function setAbbreviation($abbreviation)
     {
-        $this->abbreviation = SecurityHelper::convertHtmlSpecialChars($abbreviation);
+        $this->abbreviation = $abbreviation;
 
         return $this;
     }
@@ -277,7 +276,7 @@ class Unit extends Model\AbstractModel
      */
     public function setGroup($group)
     {
-        $this->group = SecurityHelper::convertHtmlSpecialChars($group);
+        $this->group = $group;
 
         return $this;
     }
@@ -317,7 +316,7 @@ class Unit extends Model\AbstractModel
      */
     public function setLongname($longname)
     {
-        $this->longname = SecurityHelper::convertHtmlSpecialChars($longname);
+        $this->longname = $longname;
 
         return $this;
     }
@@ -345,7 +344,7 @@ class Unit extends Model\AbstractModel
      */
     public function setReference($reference)
     {
-        $this->reference = SecurityHelper::convertHtmlSpecialChars($reference);
+        $this->reference = $reference;
 
         return $this;
     }
@@ -385,7 +384,7 @@ class Unit extends Model\AbstractModel
      */
     public function setConverter($converter)
     {
-        $this->converter = SecurityHelper::convertHtmlSpecialChars((string)$converter);
+        $this->converter = (string)$converter;
 
         return $this;
     }

--- a/models/Property/Predefined.php
+++ b/models/Property/Predefined.php
@@ -16,7 +16,6 @@
 namespace Pimcore\Model\Property;
 
 use Pimcore\Model;
-use Pimcore\Security\SecurityHelper;
 
 /**
  * @internal
@@ -178,7 +177,7 @@ final class Predefined extends Model\AbstractModel
      */
     public function setKey($key)
     {
-        $this->key = SecurityHelper::convertHtmlSpecialChars($key);
+        $this->key = $key;
 
         return $this;
     }
@@ -190,7 +189,7 @@ final class Predefined extends Model\AbstractModel
      */
     public function setName($name)
     {
-        $this->name = SecurityHelper::convertHtmlSpecialChars($name);
+        $this->name = $name;
 
         return $this;
     }
@@ -306,7 +305,7 @@ final class Predefined extends Model\AbstractModel
      */
     public function setDescription($description)
     {
-        $this->description = SecurityHelper::convertHtmlSpecialChars($description);
+        $this->description = $description;
 
         return $this;
     }

--- a/models/Property/Predefined.php
+++ b/models/Property/Predefined.php
@@ -254,7 +254,7 @@ final class Predefined extends Model\AbstractModel
      */
     public function setConfig($config)
     {
-        $this->config = SecurityHelper::convertHtmlSpecialChars($config);
+        $this->config = $config;
 
         return $this;
     }

--- a/models/Property/Predefined.php
+++ b/models/Property/Predefined.php
@@ -214,7 +214,7 @@ final class Predefined extends Model\AbstractModel
      */
     public function setData($data)
     {
-        $this->data = SecurityHelper::convertHtmlSpecialChars($data);
+        $this->data = $data;
 
         return $this;
     }

--- a/models/Staticroute.php
+++ b/models/Staticroute.php
@@ -293,7 +293,7 @@ final class Staticroute extends AbstractModel
      */
     public function setPattern($pattern)
     {
-        $this->pattern = SecurityHelper::convertHtmlSpecialChars($pattern);
+        $this->pattern = $pattern;
 
         return $this;
     }
@@ -305,7 +305,7 @@ final class Staticroute extends AbstractModel
      */
     public function setController($controller)
     {
-        $this->controller = SecurityHelper::convertHtmlSpecialChars($controller);
+        $this->controller = $controller;
 
         return $this;
     }
@@ -317,7 +317,7 @@ final class Staticroute extends AbstractModel
      */
     public function setVariables($variables)
     {
-        $this->variables = SecurityHelper::convertHtmlSpecialChars($variables);
+        $this->variables = $variables;
 
         return $this;
     }
@@ -329,7 +329,7 @@ final class Staticroute extends AbstractModel
      */
     public function setDefaults($defaults)
     {
-        $this->defaults = SecurityHelper::convertHtmlSpecialChars($defaults);
+        $this->defaults = $defaults;
 
         return $this;
     }
@@ -361,7 +361,7 @@ final class Staticroute extends AbstractModel
      */
     public function setName($name)
     {
-        $this->name = SecurityHelper::convertHtmlSpecialChars($name);
+        $this->name = $name;
 
         return $this;
     }
@@ -381,7 +381,7 @@ final class Staticroute extends AbstractModel
      */
     public function setReverse($reverse)
     {
-        $this->reverse = SecurityHelper::convertHtmlSpecialChars($reverse);
+        $this->reverse = $reverse;
 
         return $this;
     }
@@ -613,7 +613,7 @@ final class Staticroute extends AbstractModel
         if (is_string($methods)) {
             $methods = strlen($methods) ? explode(',', $methods) : [];
             foreach($methods as $key => $method) {
-                $methods[$key] = SecurityHelper::convertHtmlSpecialChars(trim($method));
+                $methods[$key] = trim($method);
             }
         }
 

--- a/models/WebsiteSetting.php
+++ b/models/WebsiteSetting.php
@@ -18,7 +18,6 @@ namespace Pimcore\Model;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
 use Pimcore\Model\Exception\NotFoundException;
-use Pimcore\Security\SecurityHelper;
 
 /**
  * @method \Pimcore\Model\WebsiteSetting\Dao getDao()
@@ -184,7 +183,7 @@ final class WebsiteSetting extends AbstractModel
      */
     public function setName($name)
     {
-        $this->name = SecurityHelper::convertHtmlSpecialChars($name);
+        $this->name = $name;
 
         return $this;
     }

--- a/models/WebsiteSetting.php
+++ b/models/WebsiteSetting.php
@@ -184,7 +184,7 @@ final class WebsiteSetting extends AbstractModel
      */
     public function setName($name)
     {
-        $this->name = SecurityHelper::convertHtmlSpecialChars($name);
+        $this->name = $name;
 
         return $this;
     }
@@ -229,7 +229,7 @@ final class WebsiteSetting extends AbstractModel
             $data = $data->getId();
         }
 
-        $this->data = SecurityHelper::convertHtmlSpecialChars($data);
+        $this->data = $data;
 
         return $this;
     }

--- a/models/WebsiteSetting.php
+++ b/models/WebsiteSetting.php
@@ -184,7 +184,7 @@ final class WebsiteSetting extends AbstractModel
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = SecurityHelper::convertHtmlSpecialChars($name);
 
         return $this;
     }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #15101

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at edfa449</samp>

This pull request fixes a XSS vulnerability and improves code quality in the website settings feature. It applies HTML encoding to the `name` column in the `website.js` grid, and removes it from the `setName` and `setData` methods in the `WebsiteSetting.php` model.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at edfa449</samp>

> _To make the website settings grid secure_
> _They encoded the `name` column for sure_
> _But they also removed_
> _The encoding they loved_
> _From the `setName` and `setData` methods pure_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at edfa449</samp>

*  Prevent XSS attacks and improve consistency by encoding website setting name and data in the JavaScript layer ([link](https://github.com/pimcore/pimcore/pull/15111/files?diff=unified&w=0#diff-1e95577ba95a2ffabb4b289d97e4f0a7b06d872a87adb84ddce4da3297cf3cc4L119-R120), [link](https://github.com/pimcore/pimcore/pull/15111/files?diff=unified&w=0#diff-1e95577ba95a2ffabb4b289d97e4f0a7b06d872a87adb84ddce4da3297cf3cc4L145-R150))
*  Remove HTML encoding from the setter methods for name and data in the `WebsiteSetting` PHP model class to avoid double encoding ([link](https://github.com/pimcore/pimcore/pull/15111/files?diff=unified&w=0#diff-9dff0d944b4fab5155a5a49e0e5125cccb25a836e4f5f98f3ab069ca4f24c9a6L187-R187), [link](https://github.com/pimcore/pimcore/pull/15111/files?diff=unified&w=0#diff-9dff0d944b4fab5155a5a49e0e5125cccb25a836e4f5f98f3ab069ca4f24c9a6L232-R232))
