### PR TITLE
Remove deprecated param 'type' in ElasticSearch  requests

### DIFF
--- a/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -570,7 +570,6 @@ abstract class AbstractElasticSearch implements ProductListInterface
 
         $params = [];
         $params['index'] = $this->getIndexName();
-        $params['type'] = $this->getTenantConfig()->getElasticSearchClientParams()['indexType'];
         $params['track_total_hits'] = true;
         $params['rest_total_hits_as_int'] = true;
 

--- a/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
+++ b/bundles/EcommerceFrameworkBundle/IndexService/Worker/ElasticSearch/AbstractElasticSearch.php
@@ -639,7 +639,6 @@ abstract class AbstractElasticSearch extends Worker\ProductCentricBatchProcessin
                 }
                 $esClient->delete([
                     'index' => $this->getIndexNameVersion(),
-                    'type' => $tenantConfig->getElasticSearchClientParams()['indexType'],
                     'id' => $objectId,
                     $this->routingParamName => $storeEntry['o_virtualProductId'],
                 ]);


### PR DESCRIPTION
Passing a `type` param to the ElasticSearch client search request will result in errors in newer elastic search / open search versions (i.e. 2.5).

This PR removes the param from the calls.

Error is:
> {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"request [/assortment_de/_doc/_search] contains unrecognized parameters: [rest_total_hits_as_int], [track_total_hits]"}],"type":"illegal_argument_exception","reason":"request [/assortment_de/_doc/_search] contains unrecognized parameters: [rest_total_hits_as_int], [track_total_hits]"},"status":400} File: /var/www/html/vendor/elasticsearch/elasticsearch/src/Elasticsearch/Connections/Connection.php Line: 693

ElasticSearch client vendor code:
![image](https://user-images.githubusercontent.com/9052094/236221865-e2c90f5c-8aec-4f5e-bcd0-f037577ec97c.png)
