### PR TITLE
[Bug]: Make `Alt` not nullable in `Document\Editable\Image`

### DIFF
--- a/models/Document/Editable/Image.php
+++ b/models/Document/Editable/Image.php
@@ -40,7 +40,7 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
      *
      * @internal
      */
-    protected ?string $alt = null;
+    protected string $alt = '';
 
     /**
      * Contains the imageobject itself


### PR DESCRIPTION
## Changes in this pull request  
It looks like it shouldn't be nullable anymore in 11, setter param type and getter return type, also this
https://github.com/pimcore/pimcore/blob/6da69939d3e400b9de3450460e0cd1f197ee25f3/models/Document/Editable/Image.php#L378

In the demo, exporting via XLIFF the document `/en/Popular-Brands/More-Stuff/Developers-Corner/Editable-Roundup`, would throw an error.

`request.CRITICAL: Uncaught PHP Exception TypeError: "Pimcore\Model\Document\Editable\Image::getText(): Return value must be of type string, null returned" at /var/www/html/dev/pimcore/pimcore/models/Document/Editable/Image.php line 391 {"exception":"[object] (TypeError(code: 0): Pimcore\\Model\\Document\\Editable\\Image::getText(): Return value must be of type string, null returned at /var/www/html/dev/pimcore/pimcore/models/Document/Editable/Image.php:391)"} []`

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6da6993</samp>

Updated the `Image` class to make the `alt` property non-nullable and initialized. This improved the image rendering and the PHP 8.0 compatibility.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6da6993</samp>

> _`Image` alt fixed_
> _No more nulls in PHP eight_
> _Winter of strict types_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6da6993</samp>

*  Make the `alt` property of the `Image` class non-nullable and initialize it to an empty string to prevent rendering errors and comply with PHP 8.0 strict typing ([link](https://github.com/pimcore/pimcore/pull/15117/files?diff=unified&w=0#diff-a4253070399493532b7da5f2e33e4a3ebc4be35de25ce3f6b6811dda3b9dd0edL43-R43))
