### PR TITLE
Make `EncoreHelper` non-internal

### DIFF
--- a/lib/Helper/EncoreHelper.php
+++ b/lib/Helper/EncoreHelper.php
@@ -16,9 +16,6 @@ declare(strict_types=1);
 
 namespace Pimcore\Helper;
 
-/**
- * @internal
- */
 final class EncoreHelper
 {
     public static function getBuildPathsFromEntrypoints(string $entrypointsFile, string $type = 'js'): array


### PR DESCRIPTION
Its usage is propagated in the docs (see [here](https://github.com/pimcore/pimcore/blob/d4f5c77f8e47be17332f1695325a23dd0c0d2cc4/doc/20_Extending_Pimcore/13_Bundle_Developers_Guide/05_Pimcore_Bundles/README.md?plain=1#L112) and here #15116) so I think it shouldn't be `@internal`.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46a4c83</samp>

Removed `@internal` annotation from `EncoreHelper` class to reflect its public API status and avoid confusion.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 46a4c83</samp>

> _`EncoreHelper` class_
> _No longer internal now_
> _Spring cleaning the code_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 46a4c83</samp>

* Remove `@internal` annotation from `EncoreHelper` class to clarify its public usage and avoid breaking changes ([link](https://github.com/pimcore/pimcore/pull/15119/files?diff=unified&w=0#diff-ae46b2c34891ec99e8400db580aa227f8391fe9ac7cea54abacc35bb79b1fb21L19-L21))
