### PR TITLE
Cache translations

### DIFF
--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -229,4 +229,20 @@ class TranslatorTest extends TestCase
         $translationValues = $translations[0]->getTranslations();
         $this->assertArrayNotHasKey('fr', $translationValues);
     }
+
+    public function testCacheGetsInvalidatedOnSave() {
+        $translationsListing = new Translation\Listing();
+        $translationsListing->setDomain('messages');
+        $beforeAdd = $translationsListing->load();
+
+        $translation = new Translation();
+        $translation->setDomain('messages');
+        $translation->setTranslations(['en' => 'test']);
+        $translation->save();
+
+        $afterAdd = $translationsListing->load();
+
+        $this->assertCount(count($beforeAdd) + 1, $afterAdd);
+    }
 }
+

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -230,7 +230,8 @@ class TranslatorTest extends TestCase
         $this->assertArrayNotHasKey('fr', $translationValues);
     }
 
-    public function testCacheGetsInvalidatedOnSave() {
+    public function testCacheGetsInvalidatedOnSave()
+    {
         $translationsListing = new Translation\Listing();
         $translationsListing->setDomain('messages');
         $beforeAdd = $translationsListing->load();

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -237,6 +237,7 @@ class TranslatorTest extends TestCase
 
         $translation = new Translation();
         $translation->setDomain('messages');
+        $translation->setKey('test');
         $translation->setTranslations(['en' => 'test']);
         $translation->save();
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de3a709</samp>

Added caching logic to `load` function in `models/Translation/Listing/Dao.php` to improve performance of loading translations. Skipped caching if query has condition parameters.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at de3a709</samp>

> _`load` function cached_
> _to speed up translations_
> _but not always `Cache`_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at de3a709</samp>

*  Add caching logic to `load` function of `Dao` class to improve performance of loading translations ([link](https://github.com/pimcore/pimcore/pull/15126/files?diff=unified&w=0#diff-f28aba119c2334883e102db25bad594b03bb7900a84da7e69f470a4a3a40913aL128-R146))
