### PR TITLE
[Task]: Deprecate Button control for DataObjects

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/button.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/classes/layout/button.js
@@ -25,7 +25,7 @@ pimcore.object.classes.layout.button = Class.create(pimcore.object.classes.layou
     },
 
     getTypeName: function () {
-        return t("button");
+        return t("button") + '<sup class="deprecation" title="' + t("deprecated") + '">*</sup>';
     },
 
     getIconClass: function () {

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -73,7 +73,7 @@
     - `Pimcore\Bundle\AdminBundle\Security\User\UserLoader` => `Pimcore\Security\User\UserLoader`
     - `Pimcore\Bundle\AdminBundle\Security\User\TokenStorageUserResolver` => `Pimcore\Security\User\TokenStorageUserResolver`
   - `pimcore_admin.serializer` service has been deprecated and will be removed in Pimcore 11. Please use `pimcore.serializer` instead.
-- [DataObjects] - Deprecated Button control for DataObjects layout definition. It will be removed in Pimcore 11.
+- [DataObjects] - Deprecated Button control for DataObjects layout definition. It will be removed in Pimcore 11. You can define your custom layout component to replace this element like described [here](../../20_Extending_Pimcore/13_Bundle_Developers_Guide/12_Adding_Object_%20Layout_types.md)
 
 ## 10.5.21
 - [Assets] The Asset `Import from Server` feature is now only available for admins. It will be removed in Pimcore 11

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -73,6 +73,7 @@
     - `Pimcore\Bundle\AdminBundle\Security\User\UserLoader` => `Pimcore\Security\User\UserLoader`
     - `Pimcore\Bundle\AdminBundle\Security\User\TokenStorageUserResolver` => `Pimcore\Security\User\TokenStorageUserResolver`
   - `pimcore_admin.serializer` service has been deprecated and will be removed in Pimcore 11. Please use `pimcore.serializer` instead.
+- [DataObjects] - Deprecated Button control for DataObjects layout definition. It will be removed in Pimcore 11.
 
 ## 10.5.21
 - [Assets] The Asset `Import from Server` feature is now only available for admins. It will be removed in Pimcore 11

--- a/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -73,7 +73,7 @@
     - `Pimcore\Bundle\AdminBundle\Security\User\UserLoader` => `Pimcore\Security\User\UserLoader`
     - `Pimcore\Bundle\AdminBundle\Security\User\TokenStorageUserResolver` => `Pimcore\Security\User\TokenStorageUserResolver`
   - `pimcore_admin.serializer` service has been deprecated and will be removed in Pimcore 11. Please use `pimcore.serializer` instead.
-- [DataObjects] - Deprecated Button control for DataObjects layout definition. It will be removed in Pimcore 11. You can define your custom layout component to replace this element like described [here](../../20_Extending_Pimcore/13_Bundle_Developers_Guide/12_Adding_Object_%20Layout_types.md)
+- [DataObjects] - Deprecated Button control for DataObjects layout definition. It will be removed in Pimcore 11. You can define your own custom layout component to replace this element like described [here](../../20_Extending_Pimcore/13_Bundle_Developers_Guide/12_Adding_Object_%20Layout_types.md)
 
 ## 10.5.21
 - [Assets] The Asset `Import from Server` feature is now only available for admins. It will be removed in Pimcore 11

--- a/models/DataObject/ClassDefinition/Layout/Button.php
+++ b/models/DataObject/ClassDefinition/Layout/Button.php
@@ -17,6 +17,9 @@ namespace Pimcore\Model\DataObject\ClassDefinition\Layout;
 
 use Pimcore\Model;
 
+/**
+ * @deprecated will be removed in Pimcore 11
+ */
 class Button extends Model\DataObject\ClassDefinition\Layout
 {
     /**


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #15123

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a45c027</samp>

The button layout element for data objects was deprecated and marked as such in the UI, the upgrade notes, and the code. This is to prepare for its removal in a future version of Pimcore.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a45c027</samp>

> _`button` fades away_
> _deprecated in data objects_
> _autumn of its life_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a45c027</samp>

*  Deprecate the button layout element for data objects ([link](https://github.com/pimcore/pimcore/pull/15132/files?diff=unified&w=0#diff-73035953b02b0c33189d0ac13dc713114b6c2754cf7f07048ad8edc2d1a30f34L28-R28), [link](https://github.com/pimcore/pimcore/pull/15132/files?diff=unified&w=0#diff-8e789ff505cab9d3406d3f98e6856e6a0d42dfeeb5c4ee14d7f691c00df1d3c0R76), [link](https://github.com/pimcore/pimcore/pull/15132/files?diff=unified&w=0#diff-a870cd07508c6a811aa49777626b8d000209255b437d141c9a0b9a981ad1a2adR20-R22))
