### PR TITLE
[Bug] Make setAction accept null values

### DIFF
--- a/models/Schedule/Task.php
+++ b/models/Schedule/Task.php
@@ -151,7 +151,7 @@ class Task extends Model\AbstractModel
     /**
      * @return $this
      */
-    public function setAction(string $action): static
+    public function setAction(?string $action): static
     {
         $this->action = $action;
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
 
## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b9c64e</samp>

Allow null action for schedule tasks. Modify `setAction` method of `Task` class in `models/Schedule/Task.php` to accept null as a valid action value. This enables better handling of system maintenance tasks.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0b9c64e</samp>

> _`Task` can be null_
> _`setAction` adapts to it_
> _Autumn maintenance_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b9c64e</samp>

* Allow nullable action for schedule tasks ([link](https://github.com/pimcore/pimcore/pull/15136/files?diff=unified&w=0#diff-d18e2ef7cc9614b0c3c099bf25e3b9520007dd4de0b3533b1e64ea0dd2415603L154-R154))
