### PR TITLE
[Admin][Events] Trigger Login Redirect event on login page not on authentication

### DIFF
--- a/bundles/AdminBundle/Security/Authenticator/AdminLoginAuthenticator.php
+++ b/bundles/AdminBundle/Security/Authenticator/AdminLoginAuthenticator.php
@@ -57,12 +57,7 @@ class AdminLoginAuthenticator extends AdminAbstractAuthenticator implements Auth
             return $response;
         }
 
-        $event = new LoginRedirectEvent(self::PIMCORE_ADMIN_LOGIN, ['perspective' => strip_tags($request->get('perspective', ''))]);
-        $this->dispatcher->dispatch($event, AdminEvents::LOGIN_REDIRECT);
-
-        $url = $this->router->generate($event->getRouteName(), $event->getRouteParams());
-
-        return new RedirectResponse($url);
+        return new RedirectResponse($this->router->generate(self::PIMCORE_ADMIN_LOGIN, ['perspective' => strip_tags($request->get('perspective', ''))]));
     }
 
     /**

--- a/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
+++ b/bundles/AdminBundle/Security/Guard/AdminAuthenticator.php
@@ -136,12 +136,7 @@ class AdminAuthenticator extends AbstractGuardAuthenticator implements LoggerAwa
             return $response;
         }
 
-        $event = new LoginRedirectEvent('pimcore_admin_login', ['perspective' => strip_tags($request->get('perspective', ''))]);
-        $this->dispatcher->dispatch($event, AdminEvents::LOGIN_REDIRECT);
-
-        $url = $this->router->generate($event->getRouteName(), $event->getRouteParams());
-
-        return new RedirectResponse($url);
+        return new RedirectResponse($this->router->generate('pimcore_admin_login', ['perspective' => strip_tags($request->get('perspective', ''))]));
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
At the moment, `pimcore.admin.login.redirect` is dispatched from the authentication instead it should be triggered on login page as per docs here https://github.com/pimcore/pimcore/blob/befebc4f90a8276dda78beac18a7c5ab4658367c/bundles/AdminBundle/Event/AdminEvents.php#L21

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0fadd86</samp>

The pull request refactors the admin login and authentication logic to use dependency injection and a common method for the login redirect event. It also updates the upgrade notes to document the change in the event behavior. The changes improve the code quality and flexibility of the admin bundle.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0fadd86</samp>

> _`AdminAuthenticator`_
> _Simpler redirect logic_
> _Autumn leaves fall fast_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0fadd86</samp>

*  Add a new property `$eventDispatcher` to the `LoginController` class and inject it via the constructor ([link](https://github.com/pimcore/pimcore/pull/15137/files?diff=unified&w=0#diff-95e54498307da574303c55b71b02f22177e0f6f025d7daf7c35f440c5369621eR60))
*  Refactor the `loginAction` and `deeplinkAction` methods of the `LoginController` class to use a new private method `dispatchLoginRedirect` for triggering the `AdminEvents::LOGIN_REDIRECT` event and generating the redirect URL ([link](https://github.com/pimcore/pimcore/pull/15137/files?diff=unified&w=0#diff-95e54498307da574303c55b71b02f22177e0f6f025d7daf7c35f440c5369621eL101-R110), [link](https://github.com/pimcore/pimcore/pull/15137/files?diff=unified&w=0#diff-95e54498307da574303c55b71b02f22177e0f6f025d7daf7c35f440c5369621eL268-R275), [link](https://github.com/pimcore/pimcore/pull/15137/files?diff=unified&w=0#diff-95e54498307da574303c55b71b02f22177e0f6f025d7daf7c35f440c5369621eR374-R382))
*  Remove unused parameters `$eventDispatcher` from the `lostpasswordAction` and `deeplinkAction` methods of the `LoginController` class and use the property `$this->eventDispatcher` instead ([link](https://github.com/pimcore/pimcore/pull/15137/files?diff=unified&w=0#diff-95e54498307da574303c55b71b02f22177e0f6f025d7daf7c35f440c5369621eL179-R186), [link](https://github.com/pimcore/pimcore/pull/15137/files?diff=unified&w=0#diff-95e54498307da574303c55b71b02f22177e0f6f025d7daf7c35f440c5369621eL227-R234), [link](https://github.com/pimcore/pimcore/pull/15137/files?diff=unified&w=0#diff-95e54498307da574303c55b71b02f22177e0f6f025d7daf7c35f440c5369621eL278-R300))
*  Simplify the redirect logic in the `start` methods of the `AdminLoginAuthenticator` and `AdminAuthenticator` classes by removing the creation and dispatching of the `LoginRedirectEvent`, which is now handled by the `LoginController` class ([link](https://github.com/pimcore/pimcore/pull/15137/files?diff=unified&w=0#diff-867568d178c97e83c7a389964158543684c43ab23bacd88b4451feb8caa51ed8L60-R60), [link](https://github.com/pimcore/pimcore/pull/15137/files?diff=unified&w=0#diff-35018ee99529e333a3135b62fe16e1a080ad47bf3d2a12a8e0083fe63d6e55b0L139-R139))
*  Update the upgrade notes document to inform the developers about the change in the behavior of the `AdminEvents::LOGIN_REDIRECT` event, which is now triggered on the login page instead of on the authentication ([link](https://github.com/pimcore/pimcore/pull/15137/files?diff=unified&w=0#diff-8e789ff505cab9d3406d3f98e6856e6a0d42dfeeb5c4ee14d7f691c00df1d3c0R76))
