### PR TITLE
[Task] Improved validation of url slug

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
@@ -153,8 +153,14 @@ pimcore.object.tags.urlSlug = Class.create(pimcore.object.tags.abstract, {
                         }
                     }
 
-                    const matches = [...value.match(/([#?*:\\<>|"%&@=;])/)];
-                    if (matches.length > 0) {
+                    const regex = new RegExp(/[^a-z0-9-._~:/?#[\]@!$&'()*+,;=]/, 'g')
+                    let matches = value.match(regex);
+                    if(matches !== null) {
+                        matches = [...matches];
+                        //TODO: lets discuss if we should override the value here -> this would make the error message obsolete
+                        //const sanitizedSlug = this.getValue().replace(regex, '-');
+                        //this.setValue(sanitizedSlug);
+
                         return t('url-slug-invalid-chars') + ' [' + matches.join(', ') + ']';
                     }
                 }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
@@ -134,7 +134,7 @@ pimcore.object.tags.urlSlug = Class.create(pimcore.object.tags.abstract, {
             fieldLabel: title + domain,
             name: "slug",
             labelWidth: 100,
-            value: decodeURI(siteData['slug']),
+            value: siteData['slug'],
             componentCls: this.getWrapperClassNames(),
             validator: function(value) {
                 if (value) {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
@@ -145,17 +145,17 @@ pimcore.object.tags.urlSlug = Class.create(pimcore.object.tags.abstract, {
                     value = value.substring(1);
                     value = value.replace(/\/$/, "");
 
-                    var parts = value.split('/');
+                    const parts = value.split('/');
                     for (let i = 0; i < parts.length; i++) {
                         let part = parts[i];
                         if  (part.length == 0) {
                             return false;
                         }
+                    }
 
-                        sanitizedPart = part.replace(/[#\?\*\:\\\\<\>\|"%&@=;]/g, '-');
-                        if (sanitizedPart != part) {
-                            return t('url-slug-invalid-chars');
-                        }
+                    const matches = [...value.match(/([#?*:\\<>|"%&@=;])/)];
+                    if (matches.length > 0) {
+                        return t('url-slug-invalid-chars') + ' [' + matches.join(', ') + ']';
                     }
                 }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
@@ -153,7 +153,7 @@ pimcore.object.tags.urlSlug = Class.create(pimcore.object.tags.abstract, {
                         }
                     }
 
-                    const regex = new RegExp(/[^a-z0-9-._~:/?#[\]@!$&'()*+,;=]/, 'g')
+                    const regex = new RegExp(/[^a-z0-9-._~:/?#[\]@!$&'()*+,;=]/, 'gi')
                     let matches = value.match(regex);
                     if(matches !== null) {
                         matches = [...matches];

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
@@ -157,10 +157,6 @@ pimcore.object.tags.urlSlug = Class.create(pimcore.object.tags.abstract, {
                     let matches = value.match(regex);
                     if(matches !== null) {
                         matches = [...matches];
-                        //TODO: lets discuss if we should override the value here -> this would make the error message obsolete
-                        //const sanitizedSlug = this.getValue().replace(regex, '-');
-                        //this.setValue(sanitizedSlug);
-
                         return t('url-slug-invalid-chars') + ' [' + matches.join(', ') + ']';
                     }
                 }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/urlSlug.js
@@ -134,7 +134,7 @@ pimcore.object.tags.urlSlug = Class.create(pimcore.object.tags.abstract, {
             fieldLabel: title + domain,
             name: "slug",
             labelWidth: 100,
-            value: siteData['slug'],
+            value: decodeURI(siteData['slug']),
             componentCls: this.getWrapperClassNames(),
             validator: function(value) {
                 if (value) {
@@ -152,17 +152,9 @@ pimcore.object.tags.urlSlug = Class.create(pimcore.object.tags.abstract, {
                             return false;
                         }
                     }
-
-                    const regex = new RegExp(/[^a-z0-9-._~:/?#[\]@!$&'()*+,;=]/, 'gi')
-                    let matches = value.match(regex);
-                    if(matches !== null) {
-                        matches = [...matches];
-                        return t('url-slug-invalid-chars') + ' [' + matches.join(', ') + ']';
-                    }
                 }
 
                 return true;
-
             }
         };
         if (this.fieldConfig.width) {

--- a/bundles/CoreBundle/Resources/translations/en.json
+++ b/bundles/CoreBundle/Resources/translations/en.json
@@ -1002,5 +1002,4 @@
     "address_not_found": "The entered address was not found",
     "possible_causes": "Possible causes",
     "postal_code_format_error": "Postal code format, e.g. use \"5020 Salzburg, Söllheimer Straße 16\" instead of \"A-5020 Salzburg, Söllheimer Straße 16\"",
-    "url-slug-invalid-chars": "Provided invalid character in URL slug"
 }

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/65_Others.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/65_Others.md
@@ -130,7 +130,10 @@ For example, if the URL is `https://demo.pimcore.fun/slug`, then the slug simply
 This data-type can be used to manage custom URL slugs for data objects, you can add as many fields of this type to a class as you want. 
 Pimcore then cares automatically about the routing and calls the configured controller/action if a slug matches.
 
-You could use the [Symfony String component's slugger](https://symfony.com/doc/current/components/string.html#slugger) to generate the slugs. 
+You could use the [Symfony String component's slugger](https://symfony.com/doc/current/components/string.html#slugger) to generate the slugs.
+
+> Note that slugs can't contain the following chars: `! * ' ( ) ; : @ & = + $ , ? % # [ ]` since they are reserved characters.
+> For more information check the [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-2.2).
 
 ### Example
 

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/65_Others.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/65_Others.md
@@ -132,7 +132,7 @@ Pimcore then cares automatically about the routing and calls the configured cont
 
 You could use the [Symfony String component's slugger](https://symfony.com/doc/current/components/string.html#slugger) to generate the slugs.
 
-> Note that slugs can't contain the following chars: `! * ' ( ) ; : @ & = + $ , ? % # [ ]` since they are reserved characters.
+> Note that slugs can't contain the following chars: `! #` since they are reserved characters.
 > For more information check the [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-2.2).
 
 ### Example

--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/65_Others.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/65_Others.md
@@ -130,7 +130,7 @@ For example, if the URL is `https://demo.pimcore.fun/slug`, then the slug simply
 This data-type can be used to manage custom URL slugs for data objects, you can add as many fields of this type to a class as you want. 
 Pimcore then cares automatically about the routing and calls the configured controller/action if a slug matches.
 
-Slugs are validated against [`FILTER_VALIDATE_URL`](https://www.php.net/manual/en/filter.filters.validate.php) and you could use the [Symfony String component's slugger](https://symfony.com/doc/current/components/string.html#slugger) to generate them 
+You could use the [Symfony String component's slugger](https://symfony.com/doc/current/components/string.html#slugger) to generate the slugs. 
 
 ### Example
 

--- a/lib/Routing/DynamicRouteProvider.php
+++ b/lib/Routing/DynamicRouteProvider.php
@@ -73,7 +73,7 @@ final class DynamicRouteProvider implements RouteProviderInterface
             return $collection;
         }
 
-        $path = $originalPath = urldecode($request->getPathInfo());
+        $path = $originalPath = rawurldecode($request->getPathInfo());
 
         // site path handled by FrontendRoutingListener which runs before routing is started
         if (null !== $sitePath = $this->siteResolver->getSitePath($request)) {

--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -181,9 +181,8 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
                 $foundSlug = true;
 
                 if (strlen($slug) > 0) {
-                    $slugToCompare = preg_replace('/[#\?\*\:\\\\<\>\|"%&@=;]/', '-', $item->getSlug());
-                    if ($item->getSlug() !== $slugToCompare) {
-                        throw new Model\Element\ValidationException('Slug contains forbidden characters!');
+                    if (preg_match_all('/[#?*:\\<>|"%&@=;]/', $item->getSlug(), $matches)) {
+                        throw new Model\Element\ValidationException('Slug contains forbidden characters: [ ' .  implode(' ', $matches[0]) . ' ] ');
                     }
 
                     $document = Model\Document::getByPath($slug);

--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -181,10 +181,6 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
                 $foundSlug = true;
 
                 if (strlen($slug) > 0) {
-                    if (preg_match_all('/[^a-z0-9-._~:\/?#[\]@!$&\'()*+,;=]/i', $item->getSlug(), $matches)) {
-                        throw new Model\Element\ValidationException('Slug contains forbidden characters: [ ' .  implode(' ', $matches[0]) . ' ] ');
-                    }
-
                     $document = Model\Document::getByPath($slug);
                     if ($document) {
                         throw new Model\Element\ValidationException('Slug must be unique. Found conflict with document path "' . $slug . '"');
@@ -359,7 +355,7 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
                         'objectId' => $object->getId(),
                         'classId' => $object->getClassId(),
                         'fieldname' => $this->getName(),
-                        'slug' => $slugItem->getSlug(),
+                        'slug' => urlencode_ignore_slash($slugItem->getSlug()),
                         'siteId' => $slugItem->getSiteId() ?? 0,
                     ];
                 } else {

--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -177,6 +177,7 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
         if (is_array($data)) {
             /** @var Model\DataObject\Data\UrlSlug $item */
             foreach ($data as $item) {
+                $matches = [];
                 $slug = htmlspecialchars($item->getSlug());
                 $foundSlug = true;
 
@@ -188,6 +189,10 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
 
                     if (strlen($slug) < 2 || $slug[0] !== '/') {
                         throw new Model\Element\ValidationException('Slug must be at least 2 characters long and start with slash');
+                    }
+
+                    if(preg_match_all('([!*\'\(\);:@&=+$,?%#\[\]])', $item->getSlug(), $matches)) {
+                        throw new Model\Element\ValidationException('Slug contains reserved characters! [' . implode(' ', array_unique($matches[0])) . ']');
                     }
                 }
             }

--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -191,7 +191,7 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
                         throw new Model\Element\ValidationException('Slug must be at least 2 characters long and start with slash');
                     }
 
-                    if(preg_match_all('([!*\'\(\);:@&=+$,?%#\[\]])', $item->getSlug(), $matches)) {
+                    if(preg_match_all('([?#])', $item->getSlug(), $matches)) {
                         throw new Model\Element\ValidationException('Slug contains reserved characters! [' . implode(' ', array_unique($matches[0])) . ']');
                     }
                 }

--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -355,7 +355,7 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
                         'objectId' => $object->getId(),
                         'classId' => $object->getClassId(),
                         'fieldname' => $this->getName(),
-                        'slug' => urlencode_ignore_slash($slugItem->getSlug()),
+                        'slug' => $slugItem->getSlug(),
                         'siteId' => $slugItem->getSiteId() ?? 0,
                     ];
                 } else {

--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -181,7 +181,7 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
                 $foundSlug = true;
 
                 if (strlen($slug) > 0) {
-                    if (preg_match_all('/[#?*:\\<>|"%&@=;]/', $item->getSlug(), $matches)) {
+                    if (preg_match_all('/[^a-z0-9-._~:\/?#[\]@!$&\'()*+,;=]/', $item->getSlug(), $matches)) {
                         throw new Model\Element\ValidationException('Slug contains forbidden characters: [ ' .  implode(' ', $matches[0]) . ' ] ');
                     }
 

--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -181,7 +181,7 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
                 $foundSlug = true;
 
                 if (strlen($slug) > 0) {
-                    if (preg_match_all('/[^a-z0-9-._~:\/?#[\]@!$&\'()*+,;=]/', $item->getSlug(), $matches)) {
+                    if (preg_match_all('/[^a-z0-9-._~:\/?#[\]@!$&\'()*+,;=]/i', $item->getSlug(), $matches)) {
                         throw new Model\Element\ValidationException('Slug contains forbidden characters: [ ' .  implode(' ', $matches[0]) . ' ] ');
                     }
 

--- a/models/DataObject/ClassDefinition/Data/UrlSlug.php
+++ b/models/DataObject/ClassDefinition/Data/UrlSlug.php
@@ -189,10 +189,6 @@ class UrlSlug extends Data implements CustomResourcePersistingInterface, LazyLoa
                     if (strlen($slug) < 2 || $slug[0] !== '/') {
                         throw new Model\Element\ValidationException('Slug must be at least 2 characters long and start with slash');
                     }
-
-                    if (strpos($slug, '//') !== false || !filter_var('https://example.com' . $slug, FILTER_VALIDATE_URL)) {
-                        throw new Model\Element\ValidationException('Slug "' . $slug . '" is not valid');
-                    }
                 }
             }
         }

--- a/models/DataObject/Data/UrlSlug.php
+++ b/models/DataObject/Data/UrlSlug.php
@@ -123,7 +123,7 @@ class UrlSlug implements OwnerAwareFieldInterface
      */
     public function getSlug(): ?string
     {
-        return $this->slug;
+        return urldecode($this->slug);
     }
 
     /**
@@ -133,7 +133,7 @@ class UrlSlug implements OwnerAwareFieldInterface
      */
     public function setSlug(?string $slug)
     {
-        $this->slug = $slug;
+        $this->slug = urlencode_ignore_slash($slug);
 
         return $this;
     }
@@ -145,7 +145,7 @@ class UrlSlug implements OwnerAwareFieldInterface
      */
     public function getPreviousSlug(): ?string
     {
-        return $this->previousSlug;
+        return urldecode($this->previousSlug);
     }
 
     /**
@@ -155,7 +155,7 @@ class UrlSlug implements OwnerAwareFieldInterface
      */
     public function setPreviousSlug(?string $previousSlug): void
     {
-        $this->previousSlug = $previousSlug;
+        $this->previousSlug = urlencode_ignore_slash($previousSlug);
     }
 
     /**
@@ -349,7 +349,7 @@ class UrlSlug implements OwnerAwareFieldInterface
             $query = sprintf(
                 'SELECT * FROM %s WHERE slug = %s AND %s ORDER BY siteId DESC LIMIT 1',
                 self::TABLE_NAME,
-                $db->quote($path),
+                $db->quote(urlencode_ignore_slash($path)),
                 $filterSiteId
             );
 

--- a/models/DataObject/Data/UrlSlug.php
+++ b/models/DataObject/Data/UrlSlug.php
@@ -123,7 +123,7 @@ class UrlSlug implements OwnerAwareFieldInterface
      */
     public function getSlug(): ?string
     {
-        return urldecode($this->slug);
+        return $this->slug;
     }
 
     /**
@@ -133,7 +133,7 @@ class UrlSlug implements OwnerAwareFieldInterface
      */
     public function setSlug(?string $slug)
     {
-        $this->slug = urlencode_ignore_slash($slug);
+        $this->slug = $slug;
 
         return $this;
     }
@@ -145,7 +145,7 @@ class UrlSlug implements OwnerAwareFieldInterface
      */
     public function getPreviousSlug(): ?string
     {
-        return urldecode($this->previousSlug);
+        return $this->previousSlug;
     }
 
     /**
@@ -155,7 +155,7 @@ class UrlSlug implements OwnerAwareFieldInterface
      */
     public function setPreviousSlug(?string $previousSlug): void
     {
-        $this->previousSlug = urlencode_ignore_slash($previousSlug);
+        $this->previousSlug = $previousSlug;
     }
 
     /**

--- a/models/DataObject/Data/UrlSlug.php
+++ b/models/DataObject/Data/UrlSlug.php
@@ -349,7 +349,7 @@ class UrlSlug implements OwnerAwareFieldInterface
             $query = sprintf(
                 'SELECT * FROM %s WHERE slug = %s AND %s ORDER BY siteId DESC LIMIT 1',
                 self::TABLE_NAME,
-                $db->quote(urlencode_ignore_slash($path)),
+                $db->quote($path),
                 $filterSiteId
             );
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #14813

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0297bff</samp>

Improved the validation and error handling of the `urlSlug` data type for objects, both on the client and server side. Fixed the inconsistency between the JavaScript and PHP logic for checking the slug format.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0297bff</samp>

> _`urlSlug` tag changed_
> _Validation logic synced_
> _Autumn leaves fall fast_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0297bff</samp>

*  Update the validation logic for URL slug parts on both the client and server side to use a regular expression match instead of a replace, and to show the invalid characters found in the slug ([link](https://github.com/pimcore/pimcore/pull/15145/files?diff=unified&w=0#diff-eb671fd7a3437c0090b544ce988f835fa8b907295ed3f103d4c72cc36a782d76L148-R148), [link](https://github.com/pimcore/pimcore/pull/15145/files?diff=unified&w=0#diff-eb671fd7a3437c0090b544ce988f835fa8b907295ed3f103d4c72cc36a782d76L154-R158), [link](https://github.com/pimcore/pimcore/pull/15145/files?diff=unified&w=0#diff-a520e5406f0131e41cd1471566927447636662db5e1b8f1fff131d81f52e7a83L184-R185))
*  Use `const` instead of `var` to declare the `parts` variable in `urlSlug.js`, following the ES6 syntax and best practices for immutable variables ([link](https://github.com/pimcore/pimcore/pull/15145/files?diff=unified&w=0#diff-eb671fd7a3437c0090b544ce988f835fa8b907295ed3f103d4c72cc36a782d76L148-R148))
