### PR TITLE
[Bug] Classification Store - Call to undefined function

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -1366,12 +1366,7 @@ class ClassificationstoreController extends AdminController implements KernelCon
         return $this->adminJson(['success' => false]);
     }
 
-    /**
-     * @param Classificationstore\KeyConfig|Classificationstore\CollectionConfig|Classificationstore\GroupConfig $config
-     *
-     * @return array
-     */
-    protected function getConfigItem($config): array
+    protected function getConfigItem(Classificationstore\KeyConfig|Classificationstore\CollectionConfig|Classificationstore\GroupConfig $config): array
     {
         $name = $config->getName();
 
@@ -1393,12 +1388,7 @@ class ClassificationstoreController extends AdminController implements KernelCon
         return $item;
     }
 
-    /**
-     * @param Classificationstore\KeyConfig $config
-     *
-     * @return array
-     */
-    protected function getKeyConfigItem($config): array
+    protected function getKeyConfigItem(Classificationstore\KeyConfig $config): array
     {
         $item = $this->getConfigItem($config);
         $item['type'] = $config->getType() ? $config->getType() : 'input';

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -1367,7 +1367,7 @@ class ClassificationstoreController extends AdminController implements KernelCon
     }
 
     /**
-     * @param Classificationstore\KeyConfig $config
+     * @param Classificationstore\KeyConfig|Classificationstore\CollectionConfig|Classificationstore\GroupConfig $config
      *
      * @return array
      */

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -366,7 +366,15 @@ class ClassificationstoreController extends AdminController implements KernelCon
 
             $config->save();
 
-            return $this->adminJson(['success' => true, 'data' => $config]);
+            return $this->adminJson(['success' => true, 'data' => [
+                'storeId' => $config->getStoreId(),
+                'id' => $config->getId(),
+                'name' => $config->getName(),
+                'description' => $config->getDescription(),
+                'modificationDate' => $config->getModificationDate(),
+                'creationDate' => $config->getCreationDate()
+                ]
+            ]);
         }
 
         return $this->adminJson(['success' => false]);

--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -366,15 +366,7 @@ class ClassificationstoreController extends AdminController implements KernelCon
 
             $config->save();
 
-            return $this->adminJson(['success' => true, 'data' => [
-                'storeId' => $config->getStoreId(),
-                'id' => $config->getId(),
-                'name' => $config->getName(),
-                'description' => $config->getDescription(),
-                'modificationDate' => $config->getModificationDate(),
-                'creationDate' => $config->getCreationDate()
-                ]
-            ]);
+            return $this->adminJson(['success' => true, 'data' => $this->getConfigItem($config)]);
         }
 
         return $this->adminJson(['success' => false]);
@@ -536,7 +528,7 @@ class ClassificationstoreController extends AdminController implements KernelCon
 
             $config->save();
 
-            return $this->adminJson(['success' => true, 'data' => $config]);
+            return $this->adminJson(['success' => true, 'data' => $this->getConfigItem($config)]);
         }
 
         return $this->adminJson(['success' => false]);
@@ -1330,7 +1322,7 @@ class ClassificationstoreController extends AdminController implements KernelCon
 
         $data = [];
         foreach ($configList as $config) {
-            $item = $this->getConfigItem($config);
+            $item = $this->getKeyConfigItem($config);
             $data[] = $item;
         }
         $rootElement['data'] = $data;
@@ -1366,7 +1358,7 @@ class ClassificationstoreController extends AdminController implements KernelCon
             }
 
             $config->save();
-            $item = $this->getConfigItem($config);
+            $item = $this->getKeyConfigItem($config);
 
             return $this->adminJson(['success' => true, 'data' => $item]);
         }
@@ -1383,22 +1375,12 @@ class ClassificationstoreController extends AdminController implements KernelCon
     {
         $name = $config->getName();
 
-        $groupDescription = null;
         $item = [
             'storeId' => $config->getStoreId(),
             'id' => $config->getId(),
             'name' => $name,
             'description' => $config->getDescription(),
-            'type' => $config->getType() ? $config->getType() : 'input',
-            'definition' => $config->getDefinition(),
         ];
-
-        if ($config->getDefinition()) {
-            $definition = json_decode($config->getDefinition(), true);
-            if ($definition) {
-                $item['title'] = $definition['title'];
-            }
-        }
 
         if ($config->getCreationDate()) {
             $item['creationDate'] = $config->getCreationDate();
@@ -1406,6 +1388,28 @@ class ClassificationstoreController extends AdminController implements KernelCon
 
         if ($config->getModificationDate()) {
             $item['modificationDate'] = $config->getModificationDate();
+        }
+
+        return $item;
+    }
+
+    /**
+     * @param Classificationstore\KeyConfig $config
+     *
+     * @return array
+     */
+    protected function getKeyConfigItem($config): array
+    {
+        $item = $this->getConfigItem($config);
+        $item['type'] = $config->getType() ? $config->getType() : 'input';
+        $definition = $config->getDefinition();
+        $item['definition'] = $definition;
+
+        if ($definition) {
+            $definition = json_decode($definition, true);
+            if ($definition) {
+                $item['title'] = $definition['title'];
+            }
         }
 
         return $item;


### PR DESCRIPTION
Resolves #14983

`getById` can and will return a classification store config from the cache. Since we returned the whole object to the front end the cache key was included. To fix this, we just return the necessary values instead of the whole configuration object.

