### PR TITLE
[Bug] Value property of the operator is sometimes undefined

### DIFF
--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -540,9 +540,8 @@ class Service extends Model\Element\Service
         }
 
         return self::useInheritedValues(true, static function () use ($object, $config) {
-            if (!$config->getLabeledValue($object)) return null;
-
-            if (!isset($config->getLabeledValue($object)->value) || !$result = $config->getLabeledValue($object)->value) {
+            $labeledValue = $config->getLabeledValue($object);
+            if (!$labeledValue || !isset($labeledValue->value) || !$result = $labeledValue->value) {
                 return null;
             }
 

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -540,7 +540,7 @@ class Service extends Model\Element\Service
         }
 
         return self::useInheritedValues(true, static function () use ($object, $config) {
-            if (!$result = $config->getLabeledValue($object)?->value) {
+            if (!isset($config->getLabeledValue($object)->value) || (!$result = $config->getLabeledValue($object)?->value)) {
                 return null;
             }
 

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -540,7 +540,9 @@ class Service extends Model\Element\Service
         }
 
         return self::useInheritedValues(true, static function () use ($object, $config) {
-            if (!isset($config->getLabeledValue($object)->value) || (!$result = $config->getLabeledValue($object)?->value)) {
+            if (!$config->getLabeledValue($object)) return null;
+
+            if (!isset($config->getLabeledValue($object)->value) || !$result = $config->getLabeledValue($object)->value) {
                 return null;
             }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -131,7 +131,7 @@ parameters:
 
 		-
 			message: "#^Call to method getLabeledValue\\(\\) on an unknown class Pimcore\\\\Bundle\\\\AdminBundle\\\\DataObject\\\\GridColumnConfig\\\\ConfigElementInterface\\.$#"
-			count: 3
+			count: 1
 			path: models/DataObject/Service.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -131,7 +131,7 @@ parameters:
 
 		-
 			message: "#^Call to method getLabeledValue\\(\\) on an unknown class Pimcore\\\\Bundle\\\\AdminBundle\\\\DataObject\\\\GridColumnConfig\\\\ConfigElementInterface\\.$#"
-			count: 1
+			count: 2
 			path: models/DataObject/Service.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -131,7 +131,7 @@ parameters:
 
 		-
 			message: "#^Call to method getLabeledValue\\(\\) on an unknown class Pimcore\\\\Bundle\\\\AdminBundle\\\\DataObject\\\\GridColumnConfig\\\\ConfigElementInterface\\.$#"
-			count: 2
+			count: 3
 			path: models/DataObject/Service.php
 
 		-


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Add check if value property is defined again. Without this, adding some of the operators in data hub will result in exception as they do not have a value when initialized.

## Additional info
Check was removed here:
https://github.com/pimcore/pimcore/commit/da67cd0478c6f0ef95ac61956a71108ca23b2427#diff-c47f0147cc6e364ce6b905a4b8c97bb43ff1bec60048d90d2a062abd165ae4e8L547

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19c8a5a</samp>

Fix a PHP notice in `calculateCellValue` method of data object service. Add a null check for `getLabeledValue` return value in `models/DataObject/Service.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 19c8a5a</samp>

> _`getLabeledValue`_
> _Returns null, a bug to fix_
> _Check before compute_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19c8a5a</samp>

* Fix a bug that caused a PHP notice when the `getLabeledValue` method returned null ([link](https://github.com/pimcore/pimcore/pull/15152/files?diff=unified&w=0#diff-c47f0147cc6e364ce6b905a4b8c97bb43ff1bec60048d90d2a062abd165ae4e8L543-R543))
