### PR TITLE
[StaticRoutes] Fix Config storage env vars

### DIFF
--- a/models/Staticroute/Dao.php
+++ b/models/Staticroute/Dao.php
@@ -36,8 +36,8 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
         $storageConfig = LocationAwareConfigRepository::getStorageConfigurationCompatibilityLayer(
             $config,
             self::CONFIG_KEY,
-            'PIMCORE_CONFIG_STORAGE_DIR_TARGET_STATICROUTES',
-            'PIMCORE_WRITE_TARGET_TARGET_STATICROUTES'
+            'PIMCORE_CONFIG_STORAGE_DIR_STATICROUTES',
+            'PIMCORE_WRITE_TARGET_STATICROUTES'
         );
 
         parent::configure([


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15100

Regression of https://github.com/pimcore/pimcore/pull/14486

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c2a583</samp>

Fix typo in static routes configuration paths. The change corrects the constants used in `models/Staticroute/Dao.php` to set and access the storage and write target paths for the static routes configuration.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9c2a583</samp>

> _`configure` fixes_
> _typo in static routes paths_
> _autumn leaves no trace_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9c2a583</samp>

* Fix typo in static routes configuration paths ([link](https://github.com/pimcore/pimcore/pull/15158/files?diff=unified&w=0#diff-21f4608728a4d672672228b62363e3438f5382dc8243e9696d56831f5b23084fL39-R40))
