### PR TITLE
[Docs] Update symfony messenger queue config

### DIFF
--- a/doc/01_Getting_Started/00_Installation/00_Docker_Based_Installation.md
+++ b/doc/01_Getting_Started/00_Installation/00_Docker_Based_Installation.md
@@ -37,7 +37,7 @@ docker run -u `id -u`:`id -g` --rm -v `pwd`:/var/www/html pimcore/pimcore:php8.2
 
 :::info
 
-If you also install backend search (which is installed by default), you also need to adapt the [supervisor configuration](https://github.com/pimcore/skeleton/blob/11.x/.docker/supervisord.conf#LL5C39-L5C90) and add the `pimcore_search_backend_message` receiver to build up the search index. 
+If you choose to install backend search (which is installed by default), you also need to adapt the [supervisor configuration](https://github.com/pimcore/skeleton/blob/11.x/.docker/supervisord.conf#LL5C39-L5C90) and add the `pimcore_search_backend_message` receiver to build up the search index. 
 
 :::
 

--- a/doc/01_Getting_Started/00_Installation/00_Docker_Based_Installation.md
+++ b/doc/01_Getting_Started/00_Installation/00_Docker_Based_Installation.md
@@ -37,7 +37,8 @@ docker run -u `id -u`:`id -g` --rm -v `pwd`:/var/www/html pimcore/pimcore:php8.2
 
 :::info
 
-If you choose to install backend search (which is installed by default), you also need to adapt the [supervisor configuration](https://github.com/pimcore/skeleton/blob/11.x/.docker/supervisord.conf#LL5C39-L5C90) and add the `pimcore_search_backend_message` receiver to build up the search index. 
+If you choose to install backend search (which is installed by default), you must also adapt the [supervisor configuration](https://github.com/pimcore/skeleton/blob/11.x/.docker/supervisord.conf#LL5C39-L5C90) and add the `pimcore_search_backend_message` receiver to build up the search index. 
+
 
 :::
 

--- a/doc/01_Getting_Started/00_Installation/00_Docker_Based_Installation.md
+++ b/doc/01_Getting_Started/00_Installation/00_Docker_Based_Installation.md
@@ -35,6 +35,12 @@ docker run -u `id -u`:`id -g` --rm -v `pwd`:/var/www/html pimcore/pimcore:php8.2
 4. Install pimcore and initialize the DB
     `docker compose exec php vendor/bin/pimcore-install` (for demo package the installation can take a while)
 
+:::info
+
+If you also install backend search (which is installed by default), you also need to adapt the [supervisor configuration](https://github.com/pimcore/skeleton/blob/11.x/.docker/supervisord.conf#LL5C39-L5C90) and add the `pimcore_search_backend_message` receiver to build up the search index. 
+
+:::
+
 5. :heavy_check_mark: DONE - You can now visit your pimcore instance:
     * The frontend: <http://localhost>
     * The admin interface, using the credentials you have chosen above:

--- a/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
+++ b/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
@@ -128,3 +128,11 @@ Make sure you ran the following commands to rebuild the classes, objectBricks, f
 ```bash
 bin/console doctrine:migration:exec 'Pimcore\Bundle\CoreBundle\Migrations\Version20230412105530'
 ```
+
+
+### Update Symfony Messenger Worker Configuration
+With Pimcore 11, certain symfony messenger tasks were moved to a separate receiver. Make sure, you adapt your symfony messenger worker configuration (e.g. your supervisor configuration [here](https://github.com/pimcore/skeleton/blob/11.x/.docker/supervisord.conf#LL5C39-L5C90) so that all receivers are consumed. Newly added consumers are: 
+- `pimcore_scheduled_tasks`
+- `pimcore_image_optimize`
+- `pimcore_asset_update`
+- `pimcore_search_backend_message`

--- a/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
+++ b/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
@@ -131,7 +131,7 @@ bin/console doctrine:migration:exec 'Pimcore\Bundle\CoreBundle\Migrations\Versio
 
 
 ### Update Symfony Messenger Worker Configuration
-With Pimcore 11, certain symfony messenger tasks were moved to a separate receiver. Make sure, you adapt your symfony messenger worker configuration (e.g. your supervisor configuration [here](https://github.com/pimcore/skeleton/blob/11.x/.docker/supervisord.conf#LL5C39-L5C90) so that all receivers are consumed. Newly added consumers are: 
+With Pimcore 11, certain Symfony Messenger tasks were moved to a separate receiver. Make sure you adapt your Symfony Messenger worker configuration (e.g. your supervisor configuration [here](https://github.com/pimcore/skeleton/blob/11.x/.docker/supervisord.conf#LL5C39-L5C90) so that all receivers are consumed. Newly added consumers are: 
 - `pimcore_scheduled_tasks`
 - `pimcore_image_optimize`
 - `pimcore_asset_update`


### PR DESCRIPTION


## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7041829</samp>

Updated documentation for upgrading from Pimcore 10 to 11. Added instructions for updating symfony messenger worker configuration and explained the new receivers for different tasks.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7041829</samp>

> _`symfony` tasks change_
> _upgrade your worker config_
> _autumn of Pimcore_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7041829</samp>

* Add a new subsection to the documentation for updating symfony messenger worker configuration ([link](https://github.com/pimcore/pimcore/pull/15168/files?diff=unified&w=0#diff-8a0efdf0f7447004dad83da8352b444c4af86c46bf531df1fa0a11a805ed9b7aR131-R138))
