### PR TITLE
[Bug] Unable to download image in Custom download

### DIFF
--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -427,7 +427,7 @@ final class Config extends Model\AbstractModel
         return $this->format;
     }
 
-    public function setQuality(int $quality): static
+    public function setQuality(?int $quality): static
     {
         if ($quality) {
             $this->quality = $quality;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/frontend-tests/issues/99

## Additional info
Make the $quality optional since it has already a default value of 85.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 124cc2c</samp>

Allow thumbnail quality to be null in `Config::setQuality`. This improves the flexibility and usability of the thumbnail configuration system.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 124cc2c</samp>

> _`setQuality` changes_
> _nullable parameter_
> _autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 124cc2c</samp>

* Allow setting the quality of thumbnails to null, which means the default quality will be used ([link](https://github.com/pimcore/pimcore/pull/15172/files?diff=unified&w=0#diff-de2fb2d6c9873638e6632e713bcbbf15099a44862159b86493ded6662d693b84L430-R430))
