### PR TITLE
[Documents] force inject metadata tags for static page renderer

### DIFF
--- a/lib/Document/StaticPageGenerator.php
+++ b/lib/Document/StaticPageGenerator.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Document;
 
+use Pimcore\Bundle\CoreBundle\EventListener\Frontend\DocumentMetaDataListener;
 use Pimcore\Document\Renderer\DocumentRenderer;
 use Pimcore\Http\Request\Resolver\StaticPageResolver;
 use Pimcore\Logger;
@@ -86,6 +87,7 @@ class StaticPageGenerator
                 $response = $this->documentRenderer->render($document, [
                     'pimcore_static_page_generator' => true,
                     StaticPageResolver::ATTRIBUTE_PIMCORE_STATIC_PAGE => true,
+                    DocumentMetaDataListener::FORCE_INJECTION => true
                 ]);
             }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #14922

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0cca782</samp>

Added an option to force meta data injection for static pages in `StaticPageGenerator`. This improves the accuracy and consistency of meta data for cached or static documents.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0cca782</samp>

> _`FORCE_INJECTION`_
> _Meta data for static pages_
> _Winter cache melts_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0cca782</samp>

*  Import `DocumentMetaDataListener` class to use its `FORCE_INJECTION` constant ([link](https://github.com/pimcore/pimcore/pull/15191/files?diff=unified&w=0#diff-d457906ebd50f5e7051931d821a79d12970959978069590f47ee8f203de98d67R20))
*  Add `FORCE_INJECTION` option to `setOptions` method call in `generate` function to force meta data injection for static pages ([link](https://github.com/pimcore/pimcore/pull/15191/files?diff=unified&w=0#diff-d457906ebd50f5e7051931d821a79d12970959978069590f47ee8f203de98d67R90))
