### PR TITLE
[Admin][Documents] Fix (un)publishing documents from tree

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/tree.js
@@ -1522,37 +1522,46 @@ pimcore.document.tree = Class.create({
         var parameters = {};
         parameters.id = id;
 
-        Ext.Ajax.request({
-            url: '/admin/' + type + '/save?task=' + task,
-            method: "PUT",
-            params: parameters,
-            success: function (task, response) {
-                try {
-                    var rdata = Ext.decode(response.responseText);
-                    if (rdata && rdata.success) {
-                        var options = {
-                            elementType: "document",
-                            id: record.data.id,
-                            published: task != "unpublish"
-                        };
-                        pimcore.elementservice.setElementPublishedState(options);
-                        pimcore.elementservice.setElementToolbarButtons(options);
-                        pimcore.elementservice.reloadVersions(options);
+        var doc = pimcore.globalmanager.get("document_" + id);
 
-                        pimcore.helpers.showNotification(t("success"), t("successful_" + task + "_document"),
-                            "success");
+        if (doc) {
+            if (task == "publish") {
+                doc.publish(false);
+            } else {
+                doc.unpublish(false);
+            }
+        } else {
+            Ext.Ajax.request({
+                url: '/admin/' + type + '/save?task=' + task,
+                method: "PUT",
+                params: parameters,
+                success: function (task, response) {
+                    try {
+                        var rdata = Ext.decode(response.responseText);
+                        if (rdata && rdata.success) {
+                            var options = {
+                                elementType: "document",
+                                id: record.data.id,
+                                published: task != "unpublish"
+                            };
+                            pimcore.elementservice.setElementPublishedState(options);
+                            pimcore.elementservice.setElementToolbarButtons(options);
+                            pimcore.elementservice.reloadVersions(options);
+
+                            pimcore.helpers.showNotification(t("success"), t("successful_" + task + "_document"),
+                                "success");
+                        }
+                        else {
+                            pimcore.helpers.showNotification(t("error"), t("error_" + task + "_document"),
+                                "error", t(rdata.message));
+                        }
+                    } catch (e) {
+                        pimcore.helpers.showNotification(t("error"), t("error_" + task + "_document"), "error");
                     }
-                    else {
-                        pimcore.helpers.showNotification(t("error"), t("error_" + task + "_document"),
-                            "error", t(rdata.message));
-                    }
-                } catch (e) {
-                    pimcore.helpers.showNotification(t("error"), t("error_" + task + "_document"), "error");
-                }
 
-            }.bind(this, task)
-        });
-
+                }.bind(this, task)
+            });
+        }
     },
 
     addDocumentCreate : function (tree, record, params) {


### PR DESCRIPTION
Resolves #15019


## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00e3d33</samp>

Fix publishing and unpublishing documents from tree view. Use document object methods instead of Ajax requests if document is open in editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 00e3d33</samp>

> _`publish` or `unpublish`_
> _no more Ajax if open_
> _save a winter breath_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00e3d33</samp>

* Fix bug where publishing or unpublishing a document from the tree view would not update the editor ([link](https://github.com/pimcore/pimcore/pull/15194/files?diff=unified&w=0#diff-7f71093467e7725af83acc510120728dcae86d71092bec7d40b50a9d06721328L1525-R1564))
