### PR TITLE
[Bug]: JS error after saving object with field collection item

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/fieldcollections.js
@@ -99,9 +99,8 @@ pimcore.object.tags.fieldcollections = Class.create(pimcore.object.tags.abstract
         return this.component;
     },
 
-
     postSaveObject: function(e) {
-        if (e.detail.object.id === this.object.id) {
+        if (this.component.items && (e.detail.object.id === this.object.id)) {
             for (var itemIndex = 0; itemIndex < this.component.items.items.length; itemIndex++) {
                 var item = this.component.items.items[itemIndex];
                 item["pimcore_oIndex"] = itemIndex;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #15003

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0c763f5</samp>

Fix a JavaScript error when saving objects with field collections. Add a safety check for `this.component.items` in `fieldcollections.js`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0c763f5</samp>

> _`this.component.items`_
> _check before accessing them_
> _autumn bug is fixed_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0c763f5</samp>

*  Prevent JavaScript error when saving object with field collections ([link](https://github.com/pimcore/pimcore/pull/15195/files?diff=unified&w=0#diff-ef56ff0d78e547b3dd4cbb5331452c95ad5c81efb2f11a29b3526dbec4b975ebL102-R103))
