### PR TITLE
Fix generation of thumbnails with inline thumbnail config

### DIFF
--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -207,7 +207,8 @@ class Processor
         if ($deferred) {
             // only add the config to the TmpStore if necessary (e.g. if the config is auto-generated)
             if (!Config::exists($config->getName())) {
-                $configId = 'thumb_' . $asset->getId() . '__' . md5($storagePath);
+                $pathInfo = trim($asset->getRealPath(), '/').'/'.$asset->getId() . '/';
+                $configId = 'thumb_' . $asset->getId() . '__' . md5($pathInfo);
                 TmpStore::add($configId, $config, 'thumbnail_deferred');
             }
 


### PR DESCRIPTION
steps to reproduce: open accessories pages of our demo, e.g. https://11.x-dev.pimcore.fun/en/shop/Spare-Parts/Hood-Ornaments~c409

--> there all the thumbnails are not created based on a named thumbnail config, but inline (because the images are cropped in data object) and they cannot be generated. 

this fixes it. 

Reason was different path information encoded into tmpstore entry id: 
https://github.com/pimcore/pimcore/blob/85d6471de3a187cc32db282dc4be2179a4da50a1/models/Asset/Image/Thumbnail/Processor.php#L210 vs. https://github.com/pimcore/pimcore/blob/85d6471de3a187cc32db282dc4be2179a4da50a1/models/Asset/Service.php#L533


regression of https://github.com/pimcore/pimcore/pull/14155