### PR TITLE
[Flysystem] change default visibility for public storages

### DIFF
--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/FlysystemVisibilityPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/FlysystemVisibilityPass.php
@@ -39,7 +39,7 @@ final class FlysystemVisibilityPass implements CompilerPassInterface
                     $adapter = $container->findDefinition((string)$definition->getArgument(0));
                     /** @var Definition $visibilityDef */
                     $visibilityDef = $adapter->getArgument(1);
-                    $visibilityDef->addArgument(Visibility::PUBLIC);
+                    $visibilityDef->setArgument(1, Visibility::PUBLIC);
                 }
             }
         }

--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/FlysystemVisibilityPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/FlysystemVisibilityPass.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use League\Flysystem\Visibility;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @internal
+ */
+final class FlysystemVisibilityPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $serviceIds = $container->findTaggedServiceIds('flysystem.storage');
+        foreach($serviceIds as $serviceId => $tags) {
+            if(str_starts_with($serviceId, 'pimcore.')) {
+                $definition = $container->findDefinition($serviceId);
+                $config = $definition->getArgument(1);
+                if (($config['directory_visibility'] ?? null) === Visibility::PUBLIC) {
+                    $adapter = $container->findDefinition((string)$definition->getArgument(0));
+                    /** @var Definition $visibilityDef */
+                    $visibilityDef = $adapter->getArgument(1);
+                    $visibilityDef->addArgument(Visibility::PUBLIC);
+                }
+            }
+        }
+    }
+}

--- a/bundles/CoreBundle/src/PimcoreCoreBundle.php
+++ b/bundles/CoreBundle/src/PimcoreCoreBundle.php
@@ -18,6 +18,7 @@ namespace Pimcore\Bundle\CoreBundle;
 
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\AreabrickPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\CacheFallbackPass;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\FlysystemVisibilityPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\HtmlSanitizerPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\LongRunningHelperPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\MessageBusPublicPass;
@@ -85,6 +86,7 @@ class PimcoreCoreBundle extends Bundle
         $container->addCompilerPass(new HtmlSanitizerPass());
         $container->addCompilerPass(new TranslationSanitizerPass());
         $container->addCompilerPass(new SerializerPass());
+        $container->addCompilerPass(new FlysystemVisibilityPass());
     }
 
     public function getPath(): string


### PR DESCRIPTION
If the configured directory of a configured Flysystem storage doesn't exists, it tries to create it automatically, e.g.: 

```yaml
flysystem:
    storages:
        pimcore.thumbnail.storage:
            adapter: 'local'
            visibility: public
            directory_visibility: public
            options:
                directory: '%kernel.project_dir%/public/var/tmp/thumbnails'
```

if `%kernel.project_dir%/public/var/tmp/thumbnails` doesn't exists, it get's created, BUT not using `directory_visibility` for permissions, but it uses the default permissions for directories, which is `private`. 
This happens in the factory `\League\Flysystem\UnixVisibility\PortableVisibilityConverter::fromArray`. 

Not sure whether this is intended behavior of Flysystem or if it's a bug, but this at least is a workaround fixing the issue. 
