### PR TITLE
Fix loading empty data object class - 

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -569,10 +569,12 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
             DataObject\Service::removeElementFromSession('object', $object->getId());
 
-            $layoutArray = json_decode($this->encodeJson($data['layout']), true);
-            $this->classFieldDefinitions = json_decode($this->encodeJson($object->getClass()->getFieldDefinitions()), true);
-            $this->injectValuesForCustomLayout($layoutArray);
-            $data['layout'] = $layoutArray;
+            if ($data['layout'] ?? false) {
+                $layoutArray = json_decode($this->encodeJson($data['layout']), true);
+                $this->classFieldDefinitions = json_decode($this->encodeJson($object->getClass()->getFieldDefinitions()), true);
+                $this->injectValuesForCustomLayout($layoutArray);
+                $data['layout'] = $layoutArray;
+            }
 
             return $this->adminJson($data);
         }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15027

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7172ff5</samp>

Fix layout undefined error for data objects. Check if `$data['layout']` exists in `DataObjectController.php` before using it.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7172ff5</samp>

> _`$data['layout']`_
> _Check if key exists or not_
> _Autumn bug fixing_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7172ff5</samp>

* Fix a bug that caused errors when the layout was not defined for a data object ([link](https://github.com/pimcore/pimcore/pull/15201/files?diff=unified&w=0#diff-804241927f027b7f757ad3a42d2bb51630d9e97d90669e785f6e863149fe256eL572-R577))
