### PR TITLE
[Task]: Improve non-admin update user

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -287,12 +287,13 @@ class UserController extends AdminController implements KernelControllerEventInt
     public function updateAction(Request $request)
     {
         $user = User\UserRole::getById((int)$request->get('id'));
+        $currentUserIsAdmin = $this->getAdminUser()->isAdmin();
 
         if (!$user) {
             throw $this->createNotFoundException();
         }
 
-        if ($user instanceof User && $user->isAdmin() && !$this->getAdminUser()->isAdmin()) {
+        if ($user instanceof User && $user->isAdmin() && !$currentUserIsAdmin) {
             throw $this->createAccessDeniedHttpException('Only admin users are allowed to modify admin users');
         }
 
@@ -325,7 +326,7 @@ class UserController extends AdminController implements KernelControllerEventInt
 
             // only admins are allowed to create admin users
             // if the logged in user isn't an admin, set admin always to false
-            if ($user instanceof User && !$this->getAdminUser()->isAdmin()) {
+            if ($user instanceof User && !$currentUserIsAdmin) {
                 $user->setAdmin(false);
             }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c518c6e</samp>

Refactor admin status check in `UserController`. Use a variable instead of calling `isAllowed` multiple times.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c518c6e</samp>

> _The `UserController` had some code_
> _That was not following the best mode_
> _It checked for admin_
> _Again and again_
> _So a variable was used to lighten the load_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c518c6e</samp>

*  Introduce a variable `$currentUserIsAdmin` to store the result of checking if the logged in user is an admin ([link](https://github.com/pimcore/pimcore/pull/15205/files?diff=unified&w=0#diff-bb120ec2add0f38f3f2a96541c0ab9713041dfe02593c3e6bbd835dd456c082cR290))
* Use `$currentUserIsAdmin` instead of calling `$this->getAdminUser()->isAdmin()` multiple times in the `updateAction` method of `UserController.php` ([link](https://github.com/pimcore/pimcore/pull/15205/files?diff=unified&w=0#diff-bb120ec2add0f38f3f2a96541c0ab9713041dfe02593c3e6bbd835dd456c082cL295-R296), [link](https://github.com/pimcore/pimcore/pull/15205/files?diff=unified&w=0#diff-bb120ec2add0f38f3f2a96541c0ab9713041dfe02593c3e6bbd835dd456c082cL328-R329))
