### PR TITLE
[Mail]: Add a new event to modify data before persisting

### DIFF
--- a/lib/Event/MailEvents.php
+++ b/lib/Event/MailEvents.php
@@ -27,4 +27,5 @@ final class MailEvents
      * @var string
      */
     const PRE_SEND = 'pimcore.mail.preSend';
+    const PRE_LOG = 'pimcore.mail.preLog';
 }

--- a/lib/Mail.php
+++ b/lib/Mail.php
@@ -553,6 +553,8 @@ class Mail extends Email
                 $recipients = $this->getDebugMailRecipients($recipients);
             }
 
+            \Pimcore::getEventDispatcher()->dispatch($event, MailEvents::PRE_LOG);
+
             try {
                 $this->lastLogEntry = MailHelper::logEmail($this, $recipients, $sendingFailedException === null ? null : $sendingFailedException->getMessage());
             } catch (\Exception $e) {


### PR DESCRIPTION
For privacy policy it is useful to have a possibility to modify the mail data before it will persist in the database.
