### PR TITLE
Return Pimcore JsonResponse from AdminController::adminjson

### DIFF
--- a/bundles/AdminBundle/Controller/AdminController.php
+++ b/bundles/AdminBundle/Controller/AdminController.php
@@ -15,13 +15,13 @@
 
 namespace Pimcore\Bundle\AdminBundle\Controller;
 
+use Pimcore\Bundle\AdminBundle\HttpFoundation\JsonResponse;
 use Pimcore\Bundle\AdminBundle\Security\User\TokenStorageUserResolver;
 use Pimcore\Bundle\AdminBundle\Security\User\User as UserProxy;
 use Pimcore\Controller\Traits\JsonHelperTrait;
 use Pimcore\Controller\UserAwareController;
 use Pimcore\Extension\Bundle\PimcoreBundleManager;
 use Pimcore\Model\User;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;


### PR DESCRIPTION
## Changes in this pull request  
Follow up to https://github.com/pimcore/pimcore/pull/14918

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e300584</samp>

Improved JSON response handling in `AdminController` by using Pimcore's own `JsonResponse` class. Avoided potential namespace conflicts with Symfony's `JsonResponse` class.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e300584</samp>

> _`JsonResponse` is the key to our fate_
> _We must avoid the namespace clash of hate_
> _We switch to Pimcore for better control_
> _`AdminController` will unleash our soul_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e300584</samp>

* Import the `JsonResponse` class from the `Pimcore\Bundle\AdminBundle\HttpFoundation` namespace to use its enhanced features ([link](https://github.com/pimcore/pimcore/pull/15219/files?diff=unified&w=0#diff-b593e2bcfbced77caf1f98463132ebbd5342479cc582699388f7fcf2ee105ba1R18))
* Remove the unused `JsonResponse` class from the `Symfony\Component\HttpFoundation` namespace to avoid conflicts ([link](https://github.com/pimcore/pimcore/pull/15219/files?diff=unified&w=0#diff-b593e2bcfbced77caf1f98463132ebbd5342479cc582699388f7fcf2ee105ba1L24))
