### PR TITLE
Fix link in upgrade guide

### DIFF
--- a/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
+++ b/doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md
@@ -79,7 +79,7 @@ Update Pimcore to Pimcore 11 via composer statement `composer require -W pimcore
 
 Depending on your setup, it might be necessary to include additional dependencies in the update statement and/or to clean up the `composer.lock` file and the `vendor` folder.
 
-After composer, some tasks like `bin/console assets:install` might fail due to necessary additional adaptions before the Symfony container can be built again. For more info, see the following [Tasks](#Tasks to Do After the Update) section.
+After composer, some tasks like `bin/console assets:install` might fail due to necessary additional adaptions before the Symfony container can be built again. For more info, see the following [Tasks](#tasks-to-do-after-the-update) section.
 
 ## Tasks to Do After the Update
 


### PR DESCRIPTION
## Changes in this pull request  
It's currently broken: 
![image](https://github.com/pimcore/pimcore/assets/424602/346883ad-397c-4c57-a3e7-c957b0992667)


## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed428ec</samp>

Fixed a broken anchor link in the documentation file `doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md`. The link now matches the case of the section title it refers to.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ed428ec</samp>

> _`anchor link` fixed_
> _lowercase letters match now_
> _autumn leaves no trace_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ed428ec</samp>

* Fix the anchor link to the `Tasks to Do After the Update` section in `doc/23_Installation_and_Upgrade/07_Updating_Pimcore/12_V10_to_V11.md` to use lowercase letters ([link](https://github.com/pimcore/pimcore/pull/15223/files?diff=unified&w=0#diff-8a0efdf0f7447004dad83da8352b444c4af86c46bf531df1fa0a11a805ed9b7aL82-R82))
