### PR TITLE
[Bug]: Permission problems with objectbricks in the enterprise demo for superuser

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20230517115427.php
+++ b/bundles/CoreBundle/src/Migrations/Version20230517115427.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230517115427 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add "object bricks" permission and remove category, when updating from new v11 installation to v11.0.1.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("INSERT INTO `users_permission_definitions` (`key`) VALUES ('objectbricks') ON DUPLICATE KEY UPDATE category = ''");
+        $this->addSql("INSERT INTO `users_permission_definitions` (`key`) VALUES ('fieldcollections') ON DUPLICATE KEY UPDATE category = ''");
+        $this->addSql("INSERT INTO `users_permission_definitions` (`key`) VALUES ('quantityValueUnits') ON DUPLICATE KEY UPDATE category = ''");
+        $this->addSql("INSERT INTO `users_permission_definitions` (`key`) VALUES ('classificationstore') ON DUPLICATE KEY UPDATE category = ''");
+    }
+
+    public function down(Schema $schema): void
+    {
+
+    }
+}

--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -845,6 +845,10 @@ class Installer
             'notifications_send',
             'sites',
             'objects_sort_method',
+            'objectbricks',
+            'fieldcollections',
+            'quantityValueUnits',
+            'classificationstore'
         ];
 
         foreach ($userPermissions as $permission) {


### PR DESCRIPTION
Resolves #15220

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c6cde8e</samp>

This pull request fixes a bug that prevented users from accessing the object bricks feature in data objects after upgrading to v11.0.1. It adds a new migration script and updates the installer to grant the necessary permission to the users.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c6cde8e</samp>

> _`object bricks` fix_
> _migration script and install_
> _autumn bug hunting_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c6cde8e</samp>

* Fix a bug that prevented users from accessing object bricks and other data object features after upgrading to v11.0.1 ([link](https://github.com/pimcore/pimcore/pull/15226/files?diff=unified&w=0#diff-a1d4ea78fe44748b1d831aa6e3669c8db0891804d460d4f8530df3436cb4d543R1-R42))
* Ensure that the admin user can access the object bricks feature after installing or updating to v11.0.1 ([link](https://github.com/pimcore/pimcore/pull/15226/files?diff=unified&w=0#diff-4eee5188dd424c74c2215a7595b21d4bde4443e3732f5b86d71484393076c498R848-R851))
