### PR TITLE
fix: check is stream not local in createXlsxExportFile

### DIFF
--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -864,8 +864,6 @@ class GridHelperService
             $tempMetaData = stream_get_meta_data($csvStream);
             $spreadsheet = $csvReader->load($tempMetaData['uri']);
         } else {
-            //TODO: use this method and storage->read() to avoid the extra temp file, is not available in the current version. See: https://github.com/PHPOffice/PhpSpreadsheet/pull/2792
-            //$spreadsheet = $csvReader->loadSpreadsheetFromString($storage->read($csvFile));
             $tmpFilePath = File::getLocalTempFilePath('xlsx', false);
             $dest = fopen($tmpFilePath, 'wb', false, File::getContext());
             if (!$dest) {

--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -859,10 +859,13 @@ class GridHelperService
         $csvReader->setSheetIndex(0);
 
         $csvStream= $storage->readStream($csvFile);
-        $tempMetaData = stream_get_meta_data($csvStream);
-        //TODO: use this method and storage->read() to avoid the extra temp file, is not available in the current version. See: https://github.com/PHPOffice/PhpSpreadsheet/pull/2792
-        //$spreadsheet = $csvReader->loadSpreadsheetFromString($storage->read($csvFile));
-        $spreadsheet = $csvReader->load($tempMetaData['uri']);
+        if (stream_is_local($csvStream)) {
+            $tempMetaData = stream_get_meta_data($csvStream);
+            $spreadsheet = $csvReader->load($tempMetaData['uri']);
+        } else {
+            $spreadsheet = $csvReader->loadSpreadsheetFromString($storage->read($csvFile));
+        }
+
         $writer = new Xlsx($spreadsheet);
         $xlsxFilename = PIMCORE_SYSTEM_TEMP_DIRECTORY. '/' .$fileHandle. '.xlsx';
         $writer->save($xlsxFilename);


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15225

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 97b28ad</samp>

Fix XLSX export bug for remote CSV files and remove outdated comment. Use different methods of loading the spreadsheet from the CSV stream depending on whether it is local or not in `GridHelperService.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 97b28ad</samp>

> _CSV stream check_
> _`loadFromContent` if remote_
> _Winter bug is fixed_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 97b28ad</samp>

*  Add a check for local or remote CSV stream and load the spreadsheet accordingly ([link](https://github.com/pimcore/pimcore/pull/15227/files?diff=unified&w=0#diff-784ceb6fcd03ce729cee15284714f611451fdbca75047cdae68a9d6a127ed37dL862-R868))
