### PR TITLE
fix: try to fetch metadata without checking if file exists

### DIFF
--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -185,8 +185,10 @@ class Processor
         if ($statusCacheEnabled && $deferred) {
             $modificationDate = $asset->getDao()->getCachedThumbnailModificationDate($config->getName(), $filename);
         } else {
-            if ($storage->fileExists($storagePath)) {
+            try {
                 $modificationDate = $storage->lastModified($storagePath);
+            } catch (FilesystemException $e) {
+                // nothing to do
             }
         }
 


### PR DESCRIPTION
This fixes two things:
1. race condition between exists() and metadata()
2. doesn't do a exists(), speeding up pimcore:thumb:image significantly

