### PR TITLE
[Bug]: Fix `The "processes" option does not exist.` when running ` pimcore:thumbnails:image` without the optional WebMozart

### DIFF
--- a/lib/Console/Traits/Parallelization.php
+++ b/lib/Console/Traits/Parallelization.php
@@ -55,7 +55,7 @@ trait Parallelization
 
     protected function runAfterBatch(InputInterface $input, OutputInterface $output, array $items): void
     {
-        if ((int)$this->input->getOption('processes') <= 1) {
+        if ($this->input->hasOption('processes') && (int)$this->input->getOption('processes') <= 1) {
             if ($output->isVeryVerbose()) {
                 $output->writeln('Collect garbage.');
             }


### PR DESCRIPTION

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15234

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1698f6</samp>

Fixed a potential error with garbage collection in parallelized console commands. Modified the condition for running `gc_collect_cycles()` in `lib/Console/Traits/Parallelization.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e1698f6</samp>

> _`processes` checked_
> _before casting to integer_
> _autumn leaves swept up_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e1698f6</samp>

* Fix parallelization issues in console commands ([link](https://github.com/pimcore/pimcore/pull/15235/files?diff=unified&w=0#diff-bf93403fbed0b03916787eede1a32242e7e6e18657b8d6919d9fd2a7cd50c8cbL58-R58),                              F0
