### PR TITLE
Just return extension instance in `PimcoreCoreBundle::getContainerExtension()`

### DIFF
--- a/bundles/CoreBundle/src/PimcoreCoreBundle.php
+++ b/bundles/CoreBundle/src/PimcoreCoreBundle.php
@@ -33,6 +33,7 @@ use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\SerializerPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\ServiceControllersPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\TranslationSanitizerPass;
 use Pimcore\Bundle\CoreBundle\DependencyInjection\Compiler\WorkflowPass;
+use Pimcore\Bundle\CoreBundle\DependencyInjection\PimcoreCoreExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -42,27 +43,9 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class PimcoreCoreBundle extends Bundle
 {
-    public function getContainerExtension(): ?ExtensionInterface
+    public function getContainerExtension(): ExtensionInterface
     {
-        if (null === $this->extension) {
-            $extension = $this->createContainerExtension();
-
-            if (null !== $extension) {
-                if (!$extension instanceof ExtensionInterface) {
-                    throw new \LogicException(sprintf('Extension %s must implement Symfony\Component\DependencyInjection\Extension\ExtensionInterface.', get_class($extension)));
-                }
-
-                $this->extension = $extension;
-            } else {
-                $this->extension = false;
-            }
-        }
-
-        if ($this->extension) {
-            return $this->extension;
-        }
-
-        return null;
+        return new PimcoreCoreExtension();
     }
 
     public function build(ContainerBuilder $container): void


### PR DESCRIPTION
## Changes in this pull request  
There's no need to [copy Symfonys magic](https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/HttpKernel/Bundle/Bundle.php#L55-L80) to find the extension class, when we can just return an instance.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 13a4494</samp>

Removed redundant code from `PimcoreCoreBundle.php`. This improves the code quality and performance of the Pimcore core bundle.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 13a4494</samp>

> _`PimcoreCoreBundle`_
> _Simpler, faster, cleaner now_
> _Redundant code gone_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 13a4494</samp>

* Remove redundant and unnecessary code from `PimcoreCoreBundle` class ([link](https://github.com/pimcore/pimcore/pull/15238/files?diff=unified&w=0#diff-424769cb804791d147ebea261df019c537183bea9b1a3b43cc1f0431a3d393caL45-L67))
