### PR TITLE
[Bug]: Links in Blocks will not be cleaned up when Target Document is deleted

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Block.php
+++ b/models/DataObject/ClassDefinition/Data/Block.php
@@ -1125,6 +1125,9 @@ class Block extends Data implements CustomResourcePersistingInterface, ResourceP
                                 $fd->performMultipleAssignmentCheck($data);
                             }
 
+                            if ($fd instanceof Link) {
+                                $params['resetInvalidFields'] = true;
+                            }
                             $fd->checkValidity($data, false, $params);
                         } catch (Model\Element\ValidationException $ve) {
                             $ve->addContext($this->getName() . '-' . $idx);

--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -82,12 +82,8 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
                 }
             }
 
-            try {
-                $this->checkValidity($data, true, $params);
-            } catch (\Exception $e) {
-                $data->setInternalType(null);
-                $data->setInternal(null);
-            }
+            $params['resetInvalidFields'] = true;
+            $this->checkValidity($data, true, $params);
 
             return Serialize::serialize($data);
         }
@@ -115,12 +111,8 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
                 $link->_setOwnerLanguage($params['language'] ?? null);
             }
 
-            try {
-                $this->checkValidity($link, true, $params);
-            } catch (\Exception) {
-                $link->setInternalType(null);
-                $link->setInternal(null);
-            }
+            $params['resetInvalidFields'] = true;
+            $this->checkValidity($link, true, $params);
 
             return $link;
         }
@@ -231,17 +223,32 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
                 if ($data->getInternalType() == 'document') {
                     $doc = Document::getById($data->getInternal());
                     if (!$doc instanceof Document) {
-                        throw new Element\ValidationException('invalid internal link, referenced document with id [' . $data->getInternal() . '] does not exist');
+                        if (isset($params['resetInvalidFields']) && $params['resetInvalidFields']) {
+                            $data->setInternalType(null);
+                            $data->setInternal(null);
+                        } else {
+                            throw new Element\ValidationException('invalid internal link, referenced document with id [' . $data->getInternal() . '] does not exist');
+                        }
                     }
                 } elseif ($data->getInternalType() == 'asset') {
                     $asset = Asset::getById($data->getInternal());
                     if (!$asset instanceof Asset) {
-                        throw new Element\ValidationException('invalid internal link, referenced asset with id [' . $data->getInternal() . '] does not exist');
+                        if (isset($params['resetInvalidFields']) && $params['resetInvalidFields']) {
+                            $data->setInternalType(null);
+                            $data->setInternal(null);
+                        } else {
+                            throw new Element\ValidationException('invalid internal link, referenced document with id [' . $data->getInternal() . '] does not exist');
+                        }
                     }
                 }
             }
         } elseif ($data !== null) {
-            throw new Element\ValidationException('Expected DataObject\\Data\\Link or null');
+            if (isset($params['resetInvalidFields']) && $params['resetInvalidFields']) {
+                $data->setInternalType(null);
+                $data->setInternal(null);
+            } else {
+                throw new Element\ValidationException('Expected DataObject\\Data\\Link or null');
+            }
         }
     }
 

--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -243,12 +243,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
                 }
             }
         } elseif ($data !== null) {
-            if (isset($params['resetInvalidFields']) && $params['resetInvalidFields']) {
-                $data->setInternalType(null);
-                $data->setInternal(null);
-            } else {
-                throw new Element\ValidationException('Expected DataObject\\Data\\Link or null');
-            }
+            throw new Element\ValidationException('Expected DataObject\\Data\\Link or null');
         }
     }
 

--- a/models/DataObject/Concrete.php
+++ b/models/DataObject/Concrete.php
@@ -23,6 +23,7 @@ use Pimcore\Messenger\VersionDeleteMessage;
 use Pimcore\Model;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data\LazyLoadingSupportInterface;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Link;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Relations\AbstractRelations;
 use Pimcore\Model\DataObject\Exception\InheritanceParentNotFoundException;
 use Pimcore\Model\Element\DirtyIndicatorInterface;
@@ -139,6 +140,9 @@ class Concrete extends DataObject implements LazyLoadedFieldsInterface
 
                     //check throws Exception
                     try {
+                        if ($fd instanceof Link) {
+                            $params['resetInvalidFields'] = true;
+                        }
                         $fd->checkValidity($value, $omitMandatoryCheck, $params);
                     } catch (\Exception $e) {
                         if ($this->getClass()->getAllowInherit() && $fd->supportsInheritance() && $fd->isEmpty($value)) {

--- a/tests/Model/DataType/LinkTest.php
+++ b/tests/Model/DataType/LinkTest.php
@@ -41,17 +41,6 @@ class LinkTest extends ModelTestCase
     {
         parent::setUp();
         TestHelper::cleanUp();
-
-        $this->testAsset = TestHelper::createImageAsset();
-
-        $link = new Link();
-        $link->setInternal($this->testAsset->getId());
-        $link->setInternalType('asset');
-        $this->link = $link;
-
-        $linkObject = $this->createLinkObject();
-        $linkObject->setTestlink($link);
-        $this->linkDefinition = $linkObject->getClass()->getFieldDefinition('testlink');
     }
 
     public function tearDown(): void
@@ -63,6 +52,20 @@ class LinkTest extends ModelTestCase
     protected function setUpTestClasses()
     {
         $this->tester->setupPimcoreClass_Link();
+    }
+
+    protected function setupInternalLinkObjects()
+    {
+        $this->testAsset = TestHelper::createImageAsset();
+
+        $link = new Link();
+        $link->setInternal($this->testAsset->getId());
+        $link->setInternalType('asset');
+        $this->link = $link;
+
+        $linkObject = $this->createLinkObject();
+        $linkObject->setTestlink($link);
+        $this->linkDefinition = $linkObject->getClass()->getFieldDefinition('testlink');
     }
 
     /**
@@ -107,6 +110,7 @@ class LinkTest extends ModelTestCase
      */
     public function testInternalCheckValidity()
     {
+        $this->setupInternalLinkObjects();
         $this->testAsset->delete();
 
         //Should return validation exception as asset was deleted
@@ -116,6 +120,7 @@ class LinkTest extends ModelTestCase
 
     public function testAsset()
     {
+        $this->setupInternalLinkObjects();
         $this->testAsset->delete();
         //Should not return validation exception as parameter is set
         $this->linkDefinition->checkValidity($this->link, true, ['resetInvalidFields' => true]);

--- a/tests/Model/DataType/LinkTest.php
+++ b/tests/Model/DataType/LinkTest.php
@@ -109,7 +109,7 @@ class LinkTest extends ModelTestCase
     }
 
     /**
-     * Verifies that Internal Link data throws correct exception if invalid data is given
+     * Verifies that checkValidity method throws correct exception if invalid data is provided
      *
      */
     public function testInternalCheckValidity()
@@ -123,7 +123,7 @@ class LinkTest extends ModelTestCase
     }
 
     /**
-     * Verifies that Internal Link data sanitize the link data if invalid data is given
+     * Verifies that checkValidity method sanitize the link data if invalid data is provided
      *
      */
     public function testInternalCheckValidityParam()

--- a/tests/Model/DataType/LinkTest.php
+++ b/tests/Model/DataType/LinkTest.php
@@ -54,6 +54,11 @@ class LinkTest extends ModelTestCase
         $this->tester->setupPimcoreClass_Link();
     }
 
+    /**
+     * Prepares objects for internal link tests
+     *
+     * @throws \Exception
+     */
     protected function setupInternalLinkObjects()
     {
         $this->testAsset = TestHelper::createImageAsset();
@@ -104,9 +109,8 @@ class LinkTest extends ModelTestCase
     }
 
     /**
-     * Verifies that Internal Link data throws correct exceptions if invalid data is given
+     * Verifies that Internal Link data throws correct exception if invalid data is given
      *
-     * @throws \Exception
      */
     public function testInternalCheckValidity()
     {
@@ -118,7 +122,11 @@ class LinkTest extends ModelTestCase
         $this->linkDefinition->checkValidity($this->link);
     }
 
-    public function testAsset()
+    /**
+     * Verifies that Internal Link data sanitize the link data if invalid data is given
+     *
+     */
+    public function testInternalCheckValidityParam()
     {
         $this->setupInternalLinkObjects();
         $this->testAsset->delete();


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #15144

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bfab7b4</samp>

This pull request fixes a problem with invalid links in data objects, especially in blocks, by adding a new parameter to the `Link` class and using it in the `Concrete` and `Block` classes. This parameter allows link data to be reset to null instead of throwing an exception, which enables saving the object without losing other data. This resolves issue #10376.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bfab7b4</samp>

> _Sing, O Muse, of the cunning code that fixed the link issue_
> _That plagued the blocks of data objects with errors and confusion_
> _When the `checkValidity` method, devised by skillful programmers_
> _Reset the `resetInvalidFields` parameter, like Zeus hurling thunder_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bfab7b4</samp>

*  Fix issue #10376 where invalid links in blocks cause an exception and prevent saving the object by adding a `resetInvalidFields` parameter to the Link class and its methods ([link](https://github.com/pimcore/pimcore/pull/15241/files?diff=unified&w=0#diff-3ab1a102ce726d358d038f48c51a6786a2dbade3d3076fd98ce0f24246b1cc8aR1128-R1130), [link](https://github.com/pimcore/pimcore/pull/15241/files?diff=unified&w=0#diff-7a63344b18fb2194d0ce7958619cdf5c26b339df494ad957e8e192b07f89f6afL85-R86), [link](https://github.com/pimcore/pimcore/pull/15241/files?diff=unified&w=0#diff-7a63344b18fb2194d0ce7958619cdf5c26b339df494ad957e8e192b07f89f6afL118-R115), [link](https://github.com/pimcore/pimcore/pull/15241/files?diff=unified&w=0#diff-7a63344b18fb2194d0ce7958619cdf5c26b339df494ad957e8e192b07f89f6afL234-R251), [link](https://github.com/pimcore/pimcore/pull/15241/files?diff=unified&w=0#diff-8ff96247c8a26d5a3ecbf9b79e38c31b8fc8a638bd145a46b9cdb7ee27d4869bR143-R145))
*  Use the `resetInvalidFields` parameter to check and reset the link data to null if the referenced element does not exist or is invalid, instead of throwing an exception, in the `getDataForResource`, `getDataFromResource`, and `checkValidity` methods of the Link class ([link](https://github.com/pimcore/pimcore/pull/15241/files?diff=unified&w=0#diff-7a63344b18fb2194d0ce7958619cdf5c26b339df494ad957e8e192b07f89f6afL85-R86), [link](https://github.com/pimcore/pimcore/pull/15241/files?diff=unified&w=0#diff-7a63344b18fb2194d0ce7958619cdf5c26b339df494ad957e8e192b07f89f6afL118-R115), [link](https://github.com/pimcore/pimcore/pull/15241/files?diff=unified&w=0#diff-7a63344b18fb2194d0ce7958619cdf5c26b339df494ad957e8e192b07f89f6afL234-R251))
*  Set the `resetInvalidFields` parameter to true before calling the Link methods in the Block and Concrete classes, which are used to handle block fields and data objects respectively ([link](https://github.com/pimcore/pimcore/pull/15241/files?diff=unified&w=0#diff-3ab1a102ce726d358d038f48c51a6786a2dbade3d3076fd98ce0f24246b1cc8aR1128-R1130), [link](https://github.com/pimcore/pimcore/pull/15241/files?diff=unified&w=0#diff-8ff96247c8a26d5a3ecbf9b79e38c31b8fc8a638bd145a46b9cdb7ee27d4869bR143-R145))
*  Add the use statement for the Link class to the Concrete class to access its methods ([link](https://github.com/pimcore/pimcore/pull/15241/files?diff=unified&w=0#diff-8ff96247c8a26d5a3ecbf9b79e38c31b8fc8a638bd145a46b9cdb7ee27d4869bR26))
