### PR TITLE
[JsonHelperTrait] Use default serializer from the container for encode/decode json

### DIFF
--- a/lib/Controller/Traits/JsonHelperTrait.php
+++ b/lib/Controller/Traits/JsonHelperTrait.php
@@ -18,7 +18,6 @@ namespace Pimcore\Controller\Traits;
 use Pimcore\Bundle\AdminBundle\HttpFoundation\JsonResponse;
 use Pimcore\Serializer\Serializer as PimcoreSerializer;
 use Psr\Container\ContainerInterface;
-use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * @internal
@@ -27,8 +26,6 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 trait JsonHelperTrait
 {
-    protected SerializerInterface $serializer;
-
     protected PimcoreSerializer $pimcoreSerializer;
 
     /**
@@ -39,16 +36,6 @@ trait JsonHelperTrait
     public function setPimcoreSerializer(PimcoreSerializer $pimcoreSerializer): void
     {
         $this->pimcoreSerializer = $pimcoreSerializer;
-    }
-
-    /**
-     * @required
-     *
-     * @param SerializerInterface $serializer
-     */
-    public function setSerializer(SerializerInterface $serializer): void
-    {
-        $this->serializer = $serializer;
     }
 
     /**
@@ -85,7 +72,7 @@ trait JsonHelperTrait
         if ($usePimcoreSerializer) {
             $serializer = $this->pimcoreSerializer;
         } else {
-            $serializer = $this->serializer;
+            $serializer = $this->container->get('serializer');
         }
 
         return $serializer->serialize($data, 'json', array_merge([
@@ -108,7 +95,7 @@ trait JsonHelperTrait
         if ($usePimcoreSerializer) {
             $serializer = $this->pimcoreSerializer;
         } else {
-            $serializer = $this->serializer;
+            $serializer = $this->container->get('serializer');
         }
 
         if ($associative) {


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/14929#issuecomment-1551671910

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ade562</samp>

Simplified the `JsonHelperTrait` by using the `container` service instead of the `serializer` service. This avoids dependency injection issues with other controllers.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5ade562</samp>

> _Oh we're the coders of the sea, and we work with agility_
> _We don't need no `serializer`, we use the `container` here_
> _So heave away, me hearties, heave away with glee_
> _We'll simplify the `JsonHelperTrait`, and make it conflict-free_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5ade562</samp>

*  Remove unused `use` statement and `$serializer` property from `JsonHelperTrait` ([link](https://github.com/pimcore/pimcore/pull/15252/files?diff=unified&w=0#diff-dcfdc22c16d093c81bab953b9a33994b2e915415ea1497881730a1e0638916c5L21), [link](https://github.com/pimcore/pimcore/pull/15252/files?diff=unified&w=0#diff-dcfdc22c16d093c81bab953b9a33994b2e915415ea1497881730a1e0638916c5L30-L31))
*  Delete `setSerializer` method from `JsonHelperTrait`, as it is no longer needed for dependency injection ([link](https://github.com/pimcore/pimcore/pull/15252/files?diff=unified&w=0#diff-dcfdc22c16d093c81bab953b9a33994b2e915415ea1497881730a1e0638916c5L45-L54))
*  Replace `$serializer` property with `container` service in `encodeJson` and `decodeJson` methods of `JsonHelperTrait`, to access the `serializer` service directly ([link](https://github.com/pimcore/pimcore/pull/15252/files?diff=unified&w=0#diff-dcfdc22c16d093c81bab953b9a33994b2e915415ea1497881730a1e0638916c5L88-R75), [link](https://github.com/pimcore/pimcore/pull/15252/files?diff=unified&w=0#diff-dcfdc22c16d093c81bab953b9a33994b2e915415ea1497881730a1e0638916c5L111-R98))
