### PR TITLE
[Bug]: Fix picture source tag intrisic size 

### DIFF
--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -260,7 +260,9 @@ final class Thumbnail
 
         $html = '<picture ' . array_to_html_attribute_string($pictureTagAttributes) . '>' . "\n";
 
-        $html.= $this->getMediaConfigsHtml($thumbConfig, $image, $options, $isAutoFormat);
+        if ($thumbConfig instanceof Image\Thumbnail\Config) {
+            $html.= $this->getMediaConfigsHtml($thumbConfig, $image, $options, $isAutoFormat);
+        }
 
         if (!($options['disableImgTag'] ?? null)) {
             $html .= "\t" . $this->getImageTag($options) . "\n";

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -261,7 +261,8 @@ final class Thumbnail
         $html = '<picture ' . array_to_html_attribute_string($pictureTagAttributes) . '>' . "\n";
 
         if ($thumbConfig instanceof Image\Thumbnail\Config) {
-            $html.= $this->getMediaConfigsHtml($thumbConfig, $image, $options, $isAutoFormat);
+            $thumbConfigRes = clone $thumbConfig;
+            $html.= $this->getMediaConfigsHtml($thumbConfigRes, $image, $options, $isAutoFormat);
         }
 
         if (!($options['disableImgTag'] ?? null)) {
@@ -287,6 +288,7 @@ final class Thumbnail
         array_push($mediaConfigs, $thumbConfig->getItems()); //add the default config at the end - picturePolyfill v4
 
         foreach ($mediaConfigs as $mediaQuery => $config) {
+            $thumbConfig->setItems($config);
             $sourceHtml = $this->getSourceTagHtml($thumbConfig, $mediaQuery, $image, $options);
             if (!empty($sourceHtml)) {
                 if ($isAutoFormat) {

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -273,11 +273,12 @@ final class Thumbnail
             array_push($mediaConfigs, $thumbConfig->getItems()); //add the default config at the end - picturePolyfill v4
 
             foreach ($mediaConfigs as $mediaQuery => $config) {
-                $thumbConfig->setItems($config);
-                $sourceHtml = $this->getSourceTagHtml($thumbConfig, $mediaQuery, $image, $options);
+                $thumbConfigRes = clone $thumbConfig;
+                $thumbConfigRes->setItems($config);
+                $sourceHtml = $this->getSourceTagHtml($thumbConfigRes, $mediaQuery, $image, $options);
                 if (!empty($sourceHtml)) {
                     if ($isAutoFormat) {
-                        foreach ($thumbConfig->getAutoFormatThumbnailConfigs() as $autoFormatConfig) {
+                        foreach ($thumbConfigRes->getAutoFormatThumbnailConfigs() as $autoFormatConfig) {
                             $autoFormatThumbnailHtml = $this->getSourceTagHtml($autoFormatConfig, $mediaQuery, $image, $options);
                             if (!empty($autoFormatThumbnailHtml)) {
                                 $html .= "\t" . $autoFormatThumbnailHtml . "\n";

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -272,8 +272,8 @@ final class Thumbnail
             ksort($mediaConfigs, SORT_NUMERIC);
             array_push($mediaConfigs, $thumbConfig->getItems()); //add the default config at the end - picturePolyfill v4
 
+            $thumbConfigRes = clone $thumbConfig;
             foreach ($mediaConfigs as $mediaQuery => $config) {
-                $thumbConfigRes = clone $thumbConfig;
                 $thumbConfigRes->setItems($config);
                 $sourceHtml = $this->getSourceTagHtml($thumbConfigRes, $mediaQuery, $image, $options);
                 if (!empty($sourceHtml)) {

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -273,6 +273,7 @@ final class Thumbnail
             array_push($mediaConfigs, $thumbConfig->getItems()); //add the default config at the end - picturePolyfill v4
 
             foreach ($mediaConfigs as $mediaQuery => $config) {
+                $thumbConfig->setItems($config);
                 $sourceHtml = $this->getSourceTagHtml($thumbConfig, $mediaQuery, $image, $options);
                 if (!empty($sourceHtml)) {
                     if ($isAutoFormat) {

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -263,7 +263,7 @@ final class Thumbnail
 
         if ($thumbConfig instanceof Config) {
             $thumbConfigRes = clone $thumbConfig;
-            $html.= $this->getMediaConfigsHtml($thumbConfigRes, $image, $options, $isAutoFormat);
+            $html.= $this->getMediaConfigHtml($thumbConfigRes, $image, $options, $isAutoFormat);
         }
 
         if (!($options['disableImgTag'] ?? null)) {
@@ -279,7 +279,7 @@ final class Thumbnail
         return $html;
     }
 
-    protected function getMediaConfigsHtml(Config $thumbConfig, Image $image, array $options, bool $isAutoFormat): string
+    protected function getMediaConfigHtml(Config $thumbConfig, Image $image, array $options, bool $isAutoFormat): string
     {
         $html = '';
         $mediaConfigs = $thumbConfig->getMedias();

--- a/models/Asset/Image/Thumbnail.php
+++ b/models/Asset/Image/Thumbnail.php
@@ -20,6 +20,7 @@ use Pimcore\Event\FrontendEvents;
 use Pimcore\Logger;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Asset\Image;
+use Pimcore\Model\Asset\Image\Thumbnail\Config;
 use Pimcore\Model\Asset\Thumbnail\ImageThumbnailTrait;
 use Pimcore\Model\Exception\NotFoundException;
 use Pimcore\Tool;
@@ -189,7 +190,7 @@ final class Thumbnail
         return $path;
     }
 
-    private function getSourceTagHtml(Image\Thumbnail\Config $thumbConfig, string $mediaQuery, Image $image, array $options): string
+    private function getSourceTagHtml(Config $thumbConfig, string $mediaQuery, Image $image, array $options): string
     {
         $sourceTagAttributes = [];
         $sourceTagAttributes['srcset'] = $this->getSrcset($thumbConfig, $image, $options, $mediaQuery);
@@ -246,7 +247,7 @@ final class Thumbnail
             $options['previewDataUri'] =  $image->getLowQualityPreviewDataUri() ?: $emptyGif;
         }
 
-        $isAutoFormat = $thumbConfig instanceof Image\Thumbnail\Config ? strtolower($thumbConfig->getFormat()) === 'source' : false;
+        $isAutoFormat = $thumbConfig instanceof Config ? strtolower($thumbConfig->getFormat()) === 'source' : false;
 
         if ($isAutoFormat) {
             // ensure the default image is not WebP
@@ -260,7 +261,7 @@ final class Thumbnail
 
         $html = '<picture ' . array_to_html_attribute_string($pictureTagAttributes) . '>' . "\n";
 
-        if ($thumbConfig instanceof Image\Thumbnail\Config) {
+        if ($thumbConfig instanceof Config) {
             $thumbConfigRes = clone $thumbConfig;
             $html.= $this->getMediaConfigsHtml($thumbConfigRes, $image, $options, $isAutoFormat);
         }
@@ -278,7 +279,7 @@ final class Thumbnail
         return $html;
     }
 
-    protected function getMediaConfigsHtml(Image\Thumbnail\Config $thumbConfig, Image $image, array $options, bool $isAutoFormat): string
+    protected function getMediaConfigsHtml(Config $thumbConfig, Image $image, array $options, bool $isAutoFormat): string
     {
         $html = '';
         $mediaConfigs = $thumbConfig->getMedias();
@@ -450,14 +451,14 @@ final class Thumbnail
     /**
      * Get value that can be directly used ina srcset HTML attribute for images.
      *
-     * @param Image\Thumbnail\Config $thumbConfig
+     * @param Config $thumbConfig
      * @param Image $image
      * @param array $options
      * @param string|null $mediaQuery Can be empty string if no media queries are defined.
      *
      * @return string Relative paths to different thunbnail images with 1x and 2x resolution
      */
-    private function getSrcset(Image\Thumbnail\Config $thumbConfig, Image $image, array $options, ?string $mediaQuery = null): string
+    private function getSrcset(Config $thumbConfig, Image $image, array $options, ?string $mediaQuery = null): string
     {
         $srcSetValues = [];
         foreach ([1, 2] as $highRes) {


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15243

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f3adb0</samp>

Add support for custom thumbnail options in `Thumbnail.php`. This enables passing an array of config items to the thumbnail constructor and setter methods.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1f3adb0</samp>

> _`thumbnailConfig` set_
> _custom options for images_
> _autumn leaves crisp, clear_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f3adb0</samp>

* Add more flexibility to the thumbnail API by allowing custom options to be passed to the thumbnail generation ([link](https://github.com/pimcore/pimcore/pull/15253/files?diff=unified&w=0#diff-c1144c6a30525acb9f7006167ec8142edec7f4e974123db8824f11af57cfb4e6R276))
