### PR TITLE
Pimcore\Bundle\AdminBundle\Security\User\User: Fix trigger_deprecation error

### DIFF
--- a/bundles/AdminBundle/Security/User/User.php
+++ b/bundles/AdminBundle/Security/User/User.php
@@ -20,8 +20,7 @@ use Pimcore\Security\User\User as PimcoreUser;
 trigger_deprecation(
     'pimcore/pimcore',
     '10.6',
-    'The "%s" class is deprecated and will be removed in Pimcore 11. Use %s instead.',
-    [User::class, PimcoreUser::class]
+    sprintf('The "%s" class is deprecated and will be removed in Pimcore 11. Use %s instead.', User::class, PimcoreUser::class)
 );
 
 /**


### PR DESCRIPTION
In https://github.com/pimcore/pimcore/blob/81be9535e5b461fe045c0cce6cf3d94be92901bf/bundles/AdminBundle/Security/User/User.php#L20-L25 the parameters for the string placeholders are provided as array but https://github.com/symfony/symfony/blob/6f13a09de8d9933ebdcf9ec1bc9f0c36e9ca73e0/src/Symfony/Contracts/Deprecation/function.php#L23 uses the splat operator (assuming that the placeholder values get provided directly without array).

Currently the code causes the PHP critical error:
`The arguments array must contain 2 items, 1 given`

This PR fixes this error in a similar way as for example in https://github.com/pimcore/pimcore/blob/81be9535e5b461fe045c0cce6cf3d94be92901bf/lib/Extension/Bundle/PimcoreBundleManager.php#L677-L686
with sprintf and without parameters provided for `trigger_deprecation()`.