### PR TITLE
fix: DataObjectParamResolver::resolver on nullable argument 

### DIFF
--- a/bundles/CoreBundle/src/Request/ParamResolver/DataObjectParamResolver.php
+++ b/bundles/CoreBundle/src/Request/ParamResolver/DataObjectParamResolver.php
@@ -54,7 +54,7 @@ class DataObjectParamResolver implements ValueResolverInterface
         if (!$value && $argument->isNullable()) {
             $request->attributes->set($param, null);
 
-            return [];
+            return [null];
         }
 
         /** @var Concrete|null $object */


### PR DESCRIPTION
To avoid other value resolvers to be called, it should return [null] instead of an empty array

Background info: it currently works, because at a later stadium the Symfony `RequestAttributeValueResolver` will process the attribute, but it's better to immediately return this `null` value so the other resolvers are skipped.

Relates to #15256