### PR TITLE
Fix set title and description for video when values are null

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Video.php
+++ b/models/DataObject/ClassDefinition/Data/Video.php
@@ -169,8 +169,8 @@ class Video extends Data implements
                 $video->setData($raw['data']);
                 $video->setType($raw['type']);
                 $video->setPoster($raw['poster']);
-                $video->setTitle($raw['title']);
-                $video->setDescription($raw['description']);
+                $video->setTitle($raw['title'] ?? null);
+                $video->setDescription($raw['description'] ?? null);
 
                 return $video;
             }
@@ -254,8 +254,8 @@ class Video extends Data implements
             $video->setData($data['data']);
             $video->setType($data['type']);
             $video->setPoster($data['poster']);
-            $video->setTitle($data['title']);
-            $video->setDescription($data['description']);
+            $video->setTitle($data['title'] ?? null);
+            $video->setDescription($data['description'] ?? null);
         }
 
         return $video;

--- a/models/DataObject/Data/Video.php
+++ b/models/DataObject/Data/Video.php
@@ -33,9 +33,9 @@ class Video implements OwnerAwareFieldInterface
 
     protected string|int|Asset|\Pimcore\Model\Element\ElementDescriptor|null $poster = null;
 
-    protected string $title;
+    protected ?string $title = null;
 
-    protected string $description;
+    protected ?string $description = null;
 
     public function setData(Asset|int|string $data): void
     {
@@ -59,13 +59,13 @@ class Video implements OwnerAwareFieldInterface
         return $this->type;
     }
 
-    public function setDescription(string $description): void
+    public function setDescription(?string $description): void
     {
         $this->description = $description;
         $this->markMeDirty();
     }
 
-    public function getDescription(): string
+    public function getDescription(): ?string
     {
         return $this->description;
     }
@@ -81,13 +81,13 @@ class Video implements OwnerAwareFieldInterface
         return $this->poster;
     }
 
-    public function setTitle(string $title): void
+    public function setTitle(?string $title): void
     {
         $this->title = $title;
         $this->markMeDirty();
     }
 
-    public function getTitle(): string
+    public function getTitle(): ?string
     {
         return $this->title;
     }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
```
Pimcore\Model\DataObject\Data\Video::setTitle(): Argument #1 ($title) must be of type string, null given, called in /var/www/html/vendor/pimcore/pimcore/models/DataObject/ClassDefinition/Data/Video.php on line 172
```

## Additional info
when doing:
```
Pimcore\Model\DataObject\AbstractObject::getById($myId);
```
If title or description is NULL in the database it will throw above error
