### PR TITLE
Update `05_Deployment_Tools.md`

### DIFF
--- a/doc/Development_Documentation/21_Deployment/05_Deployment_Tools.md
+++ b/doc/Development_Documentation/21_Deployment/05_Deployment_Tools.md
@@ -29,6 +29,9 @@ Regarding the class modification, there is also an optional env variable `PIMCOR
 - `1` To allow the modification, including the classes in `config/pimcore/classes` that normally are read-only.
 - when `not set` classes in `config/pimcore/classes` are read-only, but new classes are allowed and will be created in `var/classes`. 
 
+With the env variable `PIMCORE_CLASS_DEFINITION_DIRECTORY` you can specify the directory to search for your class definitions
+if you do not want pimcore to search in `var/classes` or `config/pimcore/classes`.
+
 > **Note**: Changes on Pimcore class definitions not only have influence to configuration files but also on the database.
 > If deploying changes between different deployment stages also database changes need to be deployed. This can be done
 > with the `pimcore:deployment:classes-rebuild` command.
@@ -40,10 +43,10 @@ After every code update you should use the `pimcore:deployment:classes-rebuild` 
 ./bin/console pimcore:deployment:classes-rebuild
 ```
 
-To create new classes from your configuration files in the database you can use the create-classes option. With the env variable `PIMCORE_CLASS_DEFINITION_DIRECTORY` you can specify the directory to search for your class definitions if you do not want pimcore to search in `var/classes` or `config/pimcore/classes`.
+To create new classes from your configuration files in the database you can use the create-classes option. 
 
 ```bash
-./bin/console pimcore:deployment:classes-rebuild  --create-classes
+./bin/console pimcore:deployment:classes-rebuild --create-classes
 ```
 
 As an alternative also class export to json-files and the class import commands can be used.
@@ -67,22 +70,22 @@ To get a list of all available commands use `./bin/console list`.
 
 #### Potentially useful commands:
 
-| Command                                              | Description                                                                                     |
-|------------------------------------------------------|-------------------------------------------------------------------------------------------------|
-| pimcore:mysql-tools                                  | Optimize and warm up mysql database                                                              |
-| pimcore:search-backend-reindex                       | Re-indexes the backend search of Pimcore                                                        |
-| pimcore:cache:clear                                  | Clear Pimcore core caches                                                                                    |
-| cache:clear                                          | Clear Symfony caches                                                                                    |
-| pimcore:cache:warming                                | Warm up caches                                                                                  |
-| pimcore:classificationstore:delete-store                     | Delete Classification Store                                                                     |
-| pimcore:definition:import:class                      | Import Class definition from a JSON export                                                      |
-| pimcore:definition:import:customlayout               | Import Customlayout definition from a JSON export                                               |
-| pimcore:definition:import:fieldcollection            | Import FieldCollection definition from a JSON export                                            |
-| pimcore:definition:import:objectbrick                | Import ObjectBrick definition from a JSON export                                                |
-| pimcore:deployment:classes-rebuild                   | Rebuilds classes and db structure based on updated `var/classes/definition_*.php` files |
-| pimcore:thumbnails:image                             | Generate image thumbnails, useful to pre-generate thumbnails in the background. Use `--processes` option for parallel processing.                   |
-| pimcore:thumbnails:optimize-images                   | Optimize file size of all images in `web/var/tmp`                       |
-| pimcore:thumbnails:video                             | Generate video thumbnails, useful to pre-generate thumbnails in the background. Use `--processes` option for parallel processing.                   |
+| Command                                   | Description                                                                                                                       |
+|-------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| pimcore:mysql-tools                       | Optimize and warm up mysql database                                                                                               |
+| pimcore:search-backend-reindex            | Re-indexes the backend search of Pimcore                                                                                          |
+| pimcore:cache:clear                       | Clear Pimcore core caches                                                                                                         |
+| cache:clear                               | Clear Symfony caches                                                                                                              |
+| pimcore:cache:warming                     | Warm up caches                                                                                                                    |
+| pimcore:classificationstore:delete-store  | Delete Classification Store                                                                                                       |
+| pimcore:definition:import:class           | Import Class definition from a JSON export                                                                                        |
+| pimcore:definition:import:customlayout    | Import Customlayout definition from a JSON export                                                                                 |
+| pimcore:definition:import:fieldcollection | Import FieldCollection definition from a JSON export                                                                              |
+| pimcore:definition:import:objectbrick     | Import ObjectBrick definition from a JSON export                                                                                  |
+| pimcore:deployment:classes-rebuild        | Rebuilds classes and db structure based on updated `var/classes/definition_*.php` files                                           |
+| pimcore:thumbnails:image                  | Generate image thumbnails, useful to pre-generate thumbnails in the background. Use `--processes` option for parallel processing. |
+| pimcore:thumbnails:optimize-images        | Optimize file size of all images in `web/var/tmp`                                                                                 |
+| pimcore:thumbnails:video                  | Generate video thumbnails, useful to pre-generate thumbnails in the background. Use `--processes` option for parallel processing. |
 
 Find more about the Pimcore Console on the [dedicated page](../19_Development_Tools_and_Details/11_Console_CLI.md).
 

--- a/doc/Development_Documentation/21_Deployment/05_Deployment_Tools.md
+++ b/doc/Development_Documentation/21_Deployment/05_Deployment_Tools.md
@@ -43,7 +43,7 @@ After every code update you should use the `pimcore:deployment:classes-rebuild` 
 ./bin/console pimcore:deployment:classes-rebuild
 ```
 
-To create new classes from your configuration files in the database you can use the create-classes option. 
+To create new classes from your configuration files in the database you can use the `create-classes` option. 
 
 ```bash
 ./bin/console pimcore:deployment:classes-rebuild --create-classes


### PR DESCRIPTION
## Changes in this pull request  
Moves a paragraph to the top, where it makes more sense (and reformats the table).

> **Note**
It's easier to view this [without whitespace](https://github.com/pimcore/pimcore/pull/15266/files?w=1).

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2157c2f</samp>

This pull request introduces a new feature to customize the class definition directory with the `PIMCORE_CLASS_DEFINITION_DIRECTORY` env variable. It also improves the documentation of the deployment tools.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2157c2f</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A way to change the class definition directory_
> _By setting `PIMCORE_CLASS_DEFINITION_DIRECTORY`_
> _In the env file, as the gods had advised._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2157c2f</samp>

*  Add a new feature to allow specifying a custom directory for class definitions using an env variable ([link](https://github.com/pimcore/pimcore/pull/15266/files?diff=unified&w=0#diff-6e6ff415e126721dab39ab8d1984d22e4ad054736d63589c62fd61220db9e1d3R32-R34), [link](https://github.com/pimcore/pimcore/pull/15266/files?diff=unified&w=0#diff-6e6ff415e126721dab39ab8d1984d22e4ad054736d63589c62fd61220db9e1d3L43-R49), [link](https://github.com/pimcore/pimcore/pull/15266/files?diff=unified&w=0#diff-6e6ff415e126721dab39ab8d1984d22e4ad054736d63589c62fd61220db9e1d3L70-R88),  )
   - Update the documentation in `doc/Development_Documentation/21_Deployment/05_Deployment_Tools.md` to explain how to use the `PIMCORE_CLASS_DEFINITION_DIRECTORY` env variable and fix the table formatting ([link](https://github.com/pimcore/pimcore/pull/15266/files?diff=unified&w=0#diff-6e6ff415e126721dab39ab8d1984d22e4ad054736d63589c62fd61220db9e1d3R32-R34), [link](https://github.com/pimcore/pimcore/pull/15266/files?diff=unified&w=0#diff-6e6ff415e126721dab39ab8d1984d22e4ad054736d63589c62fd61220db9e1d3L43-R49), [link](https://github.com/pimcore/pimcore/pull/15266/files?diff=unified&w=0#diff-6e6ff415e126721dab39ab8d1984d22e4ad054736d63589c62fd61220db9e1d3L70-R88))
