### PR TITLE
[Docs]: Add a hint in web to print about the maintenance cronjob 

### DIFF
--- a/doc/Development_Documentation/03_Documents/02_Document_Types/15_Print_Documents.md
+++ b/doc/Development_Documentation/03_Documents/02_Document_Types/15_Print_Documents.md
@@ -18,7 +18,7 @@ But of course you can setup your custom views to have separate trees for web doc
 Just use our completely redesigned [custom views](../../05_Objects/01_Object_Classes/05_Class_Settings/20_Custom_Views.md) 
 and all [new perspectives features](../../18_Tools_and_Features/13_Perspectives.md).
 
-Please note that [maintenance cron job](../../01_Getting_Started/00_Installation.md#5-maintenance-cron-job) is required to be set in place to properly process all the pdf conversion.
+Please note that [maintenance cron job](../../01_Getting_Started/00_Installation.md#5-maintenance-cron-job) is required to properly process all the PDF conversions.
 
 For more detail-information on the settings see later.
 

--- a/doc/Development_Documentation/03_Documents/02_Document_Types/15_Print_Documents.md
+++ b/doc/Development_Documentation/03_Documents/02_Document_Types/15_Print_Documents.md
@@ -18,6 +18,8 @@ But of course you can setup your custom views to have separate trees for web doc
 Just use our completely redesigned [custom views](../../05_Objects/01_Object_Classes/05_Class_Settings/20_Custom_Views.md) 
 and all [new perspectives features](../../18_Tools_and_Features/13_Perspectives.md).
 
+Please note that [maintenance cron job](../../01_Getting_Started/00_Installation.md#5-maintenance-cron-job) is required to be set in place to properly process all the pdf conversion.
+
 For more detail-information on the settings see later.
 
 ## Web-To-Print Document Types


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15031

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4f0d86</samp>

Fix pdf conversion bug for print documents and update documentation. Add a note to `Print Documents` section in `doc/Development_Documentation/03_Documents/02_Document_Types/15_Print_Documents.md` to remind users to set up a maintenance cron job.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e4f0d86</samp>

> _`Print Documents` note_
> _pdf conversion needs cron_
> _autumn maintenance_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e4f0d86</samp>

* Fix a bug related to the pdf conversion of print documents ([link](https://github.com/pimcore/pimcore/pull/15269/files?diff=unified&w=0#diff-53ba303d57088d3989feffd230e2b0ac0a7fe867ff3b7bc45bc27379fc4065e0R21-R22),                             F0L3R
