### PR TITLE
Update priority for CoreBundle & AdminBundle to load after defaults

### DIFF
--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -448,7 +448,7 @@ abstract class Kernel extends SymfonyKernel
         $collection->addBundles([
             new PimcoreCoreBundle(),
             new PimcoreAdminBundle(),
-        ], 60);
+        ], -10);
 
         // load development bundles only in matching environments
         if (in_array($this->getEnvironment(), $this->getEnvironmentsForDevBundles(), true)) {


### PR DESCRIPTION
## Changes in this pull request  
resolves #14929

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b0022d0</samp>

Lowered the priority of core and admin bundles in `Kernel.php` to enable better customization of Pimcore. This change is part of a pull request that improves the flexibility and extensibility of Pimcore.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b0022d0</samp>

> _`CoreBundle` lowered_
> _Other bundles can extend_
> _Winter of freedom_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b0022d0</samp>

* Lower the priority of `PimcoreCoreBundle` and `PimcoreAdminBundle` to -10 ([link](https://github.com/pimcore/pimcore/pull/15270/files?diff=unified&w=0#diff-332ac2e54ccef891942249e9f2d654a5e8dc16de6f5243f11802991919d5396eL451-R451)). This allows other bundles to override or extend the core and admin services and routes more easily in `lib/Kernel.php`.
