### PR TITLE
Update Service.php to remove Windows EOL in generated classes

### DIFF
--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -516,7 +516,7 @@ class Service
         if ($useParts) {
             $result = '';
             foreach ($useParts as $part) {
-                $result .= 'use ' . $part . ";\r\n";
+                $result .= 'use ' . $part . ";\n";
             }
             $result .= "\n";
 


### PR DESCRIPTION
Hello,

Generated PHP classes can have mixed EOL. This PR fix this for Pimcore 11 (will do a Pimcore 10 fix too) so all EOL are Linux (\n).

Thanks.