### PR TITLE
Update Service.php to remove Windows EOL in generated classes (Pimcore 10)

### DIFF
--- a/models/DataObject/ClassDefinition/Service.php
+++ b/models/DataObject/ClassDefinition/Service.php
@@ -561,7 +561,7 @@ class Service
         if ($useParts) {
             $result = '';
             foreach ($useParts as $part) {
-                $result .= 'use ' . $part . ";\r\n";
+                $result .= 'use ' . $part . ";\n";
             }
             $result .= "\n";
 


### PR DESCRIPTION
Hello,

Generated PHP classes can have mixed EOL. This PR fix this for Pimcore 10 (a Pimcore 11 fix PR has been proposed too) so all EOL are Linux (\n).

Thanks.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4bb60a2</samp>

This pull request fixes the code style of the use statements in the service classes generated by the data object class definition. It removes the carriage return `\r` from the `buildUseCode` function in `models/DataObject/ClassDefinition/Service.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4bb60a2</samp>

> _`buildUseCode` cleans_
> _carriage returns from use statements_
> _autumn leaves no trace_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4bb60a2</samp>

*  Remove carriage returns from use statements in service classes ([link](https://github.com/pimcore/pimcore/pull/15272/files?diff=unified&w=0#diff-c4ef938620b53e2cfdef566e578b31b0db33ad6caf0b9d9b18f6d8ecd2f6b0f0L564-R564))
