### PR TITLE
[Bug]: Fix Dependencies not resolved correctly

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -585,12 +585,21 @@ class Asset extends Element\AbstractElement
                 }
             }
             $this->clearDependentCache($additionalTags);
-            
+
             // if the path changed, refresh the inherited properties before updating dependencies
             if ($differentOldPath){
                 $this->renewInheritedProperties();
             }
             self::updateDependendencies($this);
+
+            // refresh the inherited properties and update dependencies of each children
+            if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
+                foreach ($updatedChildren as $updatedDocument) {
+                    $updatedDocument = self::getById($updatedDocument['id'], true);
+                    $updatedDocument->renewInheritedProperties();
+                    self::updateDependendencies($updatedDocument);
+                }
+            }
 
             if ($this->getDataChanged()) {
                 if (in_array($this->getType(), ['image', 'video', 'document'])) {

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -594,10 +594,10 @@ class Asset extends Element\AbstractElement
 
             // refresh the inherited properties and update dependencies of each children
             if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
-                foreach ($updatedChildren as $updatedDocument) {
-                    $updatedDocument = self::getById($updatedDocument['id'], true);
-                    $updatedDocument->renewInheritedProperties();
-                    self::updateDependendencies($updatedDocument);
+                foreach ($updatedChildren as $updatedAsset) {
+                    $updatedAsset = self::getById($updatedAsset['id'], true);
+                    $updatedAsset->renewInheritedProperties();
+                    self::updateDependendencies($updatedAsset);
                 }
             }
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -584,8 +584,10 @@ class Asset extends Element\AbstractElement
                     RuntimeCache::set($tag, null);
                 }
             }
-            self::updateDependendencies(self::getById($this->getId(), true));
             $this->clearDependentCache($additionalTags);
+            if ($isUpdate) {
+                self::updateDependendencies(self::getById($this->getId(), true));
+            }
 
             if ($this->getDataChanged()) {
                 if (in_array($this->getType(), ['image', 'video', 'document'])) {

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -584,8 +584,8 @@ class Asset extends Element\AbstractElement
                     RuntimeCache::set($tag, null);
                 }
             }
+            self::updateDependendencies(self::getById($this->getId(), true));
             $this->clearDependentCache($additionalTags);
-            self::updateDependendencies(Asset::getById($this->getId(), true));
 
             if ($this->getDataChanged()) {
                 if (in_array($this->getType(), ['image', 'video', 'document'])) {

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -585,6 +585,7 @@ class Asset extends Element\AbstractElement
                 }
             }
             $this->clearDependentCache($additionalTags);
+            self::updateDependendencies(Asset::getById($this->getId(), true));
 
             if ($this->getDataChanged()) {
                 if (in_array($this->getType(), ['image', 'video', 'document'])) {
@@ -775,21 +776,6 @@ class Asset extends Element\AbstractElement
                 }
             }
         }
-
-        // save dependencies
-        $d = new Dependency();
-        $d->setSourceType('asset');
-        $d->setSourceId($this->getId());
-
-        foreach ($this->resolveDependencies() as $requirement) {
-            if ($requirement['id'] == $this->getId() && $requirement['type'] == 'asset') {
-                // dont't add a reference to yourself
-                continue;
-            } else {
-                $d->addRequirement($requirement['id'], $requirement['type']);
-            }
-        }
-        $d->save();
 
         $this->getDao()->update();
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -585,9 +585,12 @@ class Asset extends Element\AbstractElement
                 }
             }
             $this->clearDependentCache($additionalTags);
-            if ($isUpdate) {
-                self::updateDependendencies(self::getById($this->getId(), true));
+            
+            // if the path changed, refresh the inherited properties before updating dependencies
+            if ($differentOldPath){
+                $this->renewInheritedProperties();
             }
+            self::updateDependendencies($this);
 
             if ($this->getDataChanged()) {
                 if (in_array($this->getType(), ['image', 'video', 'document'])) {

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -823,9 +823,12 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                 }
             }
             $this->clearDependentCache($additionalTags);
-            if ($isUpdate) {
-                self::updateDependendencies(self::getById($this->getId(), true));
+
+            // if the path changed, refresh the inherited properties before updating dependencies
+            if ($differentOldPath){
+                $this->renewInheritedProperties();
             }
+            self::updateDependendencies($this);
 
             $postEvent = new DataObjectEvent($this, $params);
             if ($isUpdate) {

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -830,6 +830,15 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             }
             self::updateDependendencies($this);
 
+            // refresh the inherited properties and update dependencies of each children
+            if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
+                foreach ($updatedChildren as $updatedDocument) {
+                    $updatedDocument = self::getById($updatedDocument['id'], true);
+                    $updatedDocument->renewInheritedProperties();
+                    self::updateDependendencies($updatedDocument);
+                }
+            }
+
             $postEvent = new DataObjectEvent($this, $params);
             if ($isUpdate) {
                 if ($differentOldPath) {

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -823,6 +823,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                 }
             }
             $this->clearDependentCache($additionalTags);
+            self::updateDependendencies(AbstractObject::getById($this->getId(), true));
 
             $postEvent = new DataObjectEvent($this, $params);
             if ($isUpdate) {
@@ -934,22 +935,6 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                 }
             }
         }
-
-        // save dependencies
-        $d = new Model\Dependency();
-        $d->setSourceType('object');
-        $d->setSourceId($this->getId());
-
-        foreach ($this->resolveDependencies() as $requirement) {
-            if ($requirement['id'] == $this->getId() && $requirement['type'] === 'object') {
-                // dont't add a reference to yourself
-                continue;
-            }
-
-            $d->addRequirement($requirement['id'], $requirement['type']);
-        }
-
-        $d->save();
 
         //set object to registry
         RuntimeCache::set(self::getCacheKey($this->getId()), $this);

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -832,10 +832,10 @@ abstract class AbstractObject extends Model\Element\AbstractElement
 
             // refresh the inherited properties and update dependencies of each children
             if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
-                foreach ($updatedChildren as $updatedDocument) {
-                    $updatedDocument = self::getById($updatedDocument['id'], true);
-                    $updatedDocument->renewInheritedProperties();
-                    self::updateDependendencies($updatedDocument);
+                foreach ($updatedChildren as $updatedObject) {
+                    $updatedObject = self::getById($updatedObject['id'], true);
+                    $updatedObject->renewInheritedProperties();
+                    self::updateDependendencies($updatedObject);
                 }
             }
 

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -822,8 +822,8 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                     RuntimeCache::set($tag, null);
                 }
             }
+            self::updateDependendencies(self::getById($this->getId(), true));
             $this->clearDependentCache($additionalTags);
-            self::updateDependendencies(AbstractObject::getById($this->getId(), true));
 
             $postEvent = new DataObjectEvent($this, $params);
             if ($isUpdate) {

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -822,8 +822,10 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                     RuntimeCache::set($tag, null);
                 }
             }
-            self::updateDependendencies(self::getById($this->getId(), true));
             $this->clearDependentCache($additionalTags);
+            if ($isUpdate) {
+                self::updateDependendencies(self::getById($this->getId(), true));
+            }
 
             $postEvent = new DataObjectEvent($this, $params);
             if ($isUpdate) {

--- a/models/Document.php
+++ b/models/Document.php
@@ -453,8 +453,10 @@ class Document extends Element\AbstractElement
                     RuntimeCache::set(self::getPathCacheKey($updatedDocument['oldPath']), null);
                 }
             }
-            self::updateDependendencies(self::getById($this->getId(), true));
             $this->clearDependentCache($additionalTags);
+            if ($isUpdate) {
+                self::updateDependendencies(self::getById($this->getId(), true));
+            }
 
 
             $postEvent = new DocumentEvent($this, $params);

--- a/models/Document.php
+++ b/models/Document.php
@@ -416,6 +416,13 @@ class Document extends Element\AbstractElement
                             $this->getDao()->updateChildPaths($oldPath),
                         );
                     }
+                    
+                    // if the path changed, refresh the inherited proprerties
+                    if ($differentOldPath){
+                        $this->renewInheritedProperties();
+                    }
+                    self::updateDependendencies($this->getId());
+                    
 
                     $this->commit();
 
@@ -454,10 +461,6 @@ class Document extends Element\AbstractElement
                 }
             }
             $this->clearDependentCache($additionalTags);
-            if ($isUpdate) {
-                self::updateDependendencies(self::getById($this->getId(), true));
-            }
-
 
             $postEvent = new DocumentEvent($this, $params);
             if ($isUpdate) {

--- a/models/Document.php
+++ b/models/Document.php
@@ -421,7 +421,7 @@ class Document extends Element\AbstractElement
                     if ($differentOldPath){
                         $this->renewInheritedProperties();
                     }
-                    self::updateDependendencies($this->getId());
+                    self::updateDependendencies($this);
                     
 
                     $this->commit();

--- a/models/Document.php
+++ b/models/Document.php
@@ -455,6 +455,8 @@ class Document extends Element\AbstractElement
             }
             $this->clearDependentCache($additionalTags);
 
+            self::updateDependendencies(Document::getById($this->getId(), true));
+
             $postEvent = new DocumentEvent($this, $params);
             if ($isUpdate) {
                 if ($differentOldPath) {
@@ -568,21 +570,6 @@ class Document extends Element\AbstractElement
                 }
             }
         }
-
-        // save dependencies
-        $d = new Dependency();
-        $d->setSourceType('document');
-        $d->setSourceId($this->getId());
-
-        foreach ($this->resolveDependencies() as $requirement) {
-            if ($requirement['id'] == $this->getId() && $requirement['type'] == 'document') {
-                // dont't add a reference to yourself
-                continue;
-            } else {
-                $d->addRequirement($requirement['id'], $requirement['type']);
-            }
-        }
-        $d->save();
 
         $this->getDao()->update();
 

--- a/models/Document.php
+++ b/models/Document.php
@@ -416,13 +416,6 @@ class Document extends Element\AbstractElement
                             $this->getDao()->updateChildPaths($oldPath),
                         );
                     }
-                    
-                    // if the path changed, refresh the inherited proprerties
-                    if ($differentOldPath){
-                        $this->renewInheritedProperties();
-                    }
-                    self::updateDependendencies($this);
-                    
 
                     $this->commit();
 
@@ -461,6 +454,13 @@ class Document extends Element\AbstractElement
                 }
             }
             $this->clearDependentCache($additionalTags);
+
+            // if the path changed, refresh the inherited properties before updating dependencies
+            if ($differentOldPath){
+                $this->renewInheritedProperties();
+            }
+            self::updateDependendencies($this);
+
 
             $postEvent = new DocumentEvent($this, $params);
             if ($isUpdate) {

--- a/models/Document.php
+++ b/models/Document.php
@@ -453,9 +453,9 @@ class Document extends Element\AbstractElement
                     RuntimeCache::set(self::getPathCacheKey($updatedDocument['oldPath']), null);
                 }
             }
+            self::updateDependendencies(self::getById($this->getId(), true));
             $this->clearDependentCache($additionalTags);
 
-            self::updateDependendencies(Document::getById($this->getId(), true));
 
             $postEvent = new DocumentEvent($this, $params);
             if ($isUpdate) {

--- a/models/Document.php
+++ b/models/Document.php
@@ -461,6 +461,14 @@ class Document extends Element\AbstractElement
             }
             self::updateDependendencies($this);
 
+            // refresh the inherited properties and update dependencies of each children
+            if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
+                foreach ($updatedChildren as $updatedDocument) {
+                    $updatedDocument = self::getById($updatedDocument['id'], true);
+                    $updatedDocument->renewInheritedProperties();
+                    self::updateDependendencies($updatedDocument);
+                }
+            }
 
             $postEvent = new DocumentEvent($this, $params);
             if ($isUpdate) {

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -876,7 +876,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
             $element instanceof \Pimcore\Model\Asset => "asset",
             $element instanceof \Pimcore\Model\Document => "document",
             $element instanceof \Pimcore\Model\DataObject\AbstractObject => "object",
-            default => throw new \InvalidArgumentException('Unexpected element');
+            default => throw new \InvalidArgumentException('Unexpected element')
         };
 
         $d = new Dependency();

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -873,10 +873,10 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
     protected static function updateDependendencies(object $element): void
     {
         $type = match (true) {
-            $element instanceof \Pimcore\Model\Asset => "asset",
-            $element instanceof \Pimcore\Model\Document => "document",
-            $element instanceof \Pimcore\Model\DataObject\AbstractObject => "object",
-            default => throw new \InvalidArgumentException('Unexpected element')
+            $element instanceof Model\Asset => "asset",
+            $element instanceof Model\Document => "document",
+            $element instanceof Model\DataObject\AbstractObject => "object",
+            default => throw new \InvalidArgumentException('Unexpected element, expected Asset, Document, or AbstractObject')
         };
 
         $d = new Dependency();

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -870,13 +870,13 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
         $this->setProperties(array_merge($inheritedProperties, $myProperties));
     }
 
-    protected static function updateDependendencies($element)
+    protected static function updateDependendencies(object $element): void
     {
         $type = match (true) {
             $element instanceof \Pimcore\Model\Asset => "asset",
             $element instanceof \Pimcore\Model\Document => "document",
             $element instanceof \Pimcore\Model\DataObject\AbstractObject => "object",
-            default => "object"
+            default => throw new \InvalidArgumentException('Unexpected element');
         };
 
         $d = new Dependency();
@@ -887,9 +887,9 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
             if ($requirement['id'] == $element->getId() && $requirement['type'] == $type) {
                 // dont't add a reference to yourself
                 continue;
-            } else {
-                $d->addRequirement($requirement['id'], $requirement['type']);
             }
+
+            $d->addRequirement($requirement['id'], $requirement['type']);
         }
         $d->save();
     }

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -21,6 +21,7 @@ use Pimcore\Event\AdminEvents;
 use Pimcore\Event\Model\ElementEvent;
 use Pimcore\Event\Traits\RecursionBlockingEventDispatchHelperTrait;
 use Pimcore\Model;
+use Pimcore\Model\Dependency;
 use Pimcore\Model\Element\Traits\DirtyIndicatorTrait;
 use Pimcore\Model\User;
 
@@ -867,5 +868,29 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
         $myProperties = $this->getProperties();
         $inheritedProperties = $this->getDao()->getProperties(true);
         $this->setProperties(array_merge($inheritedProperties, $myProperties));
+    }
+
+    protected static function updateDependendencies($element)
+    {
+        $type = match (true) {
+            $element instanceof \Pimcore\Model\Asset => "asset",
+            $element instanceof \Pimcore\Model\Document => "document",
+            $element instanceof \Pimcore\Model\DataObject\AbstractObject => "object",
+            default => "object"
+        };
+
+        $d = new Dependency();
+        $d->setSourceType($type);
+        $d->setSourceId($element->getId());
+
+        foreach ($element->resolveDependencies() as $requirement) {
+            if ($requirement['id'] == $element->getId() && $requirement['type'] == $type) {
+                // dont't add a reference to yourself
+                continue;
+            } else {
+                $d->addRequirement($requirement['id'], $requirement['type']);
+            }
+        }
+        $d->save();
     }
 }


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/14699



## Additional info
The problem was due the fact that properties are inheritable and are dynamically loaded (not stored in db, getted from parent element) while the dependencies are carbon copied the inherited properties values on element save and not synced again outside the save. 
After PR, the children gets all the dependencies on latest inherited properties.


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eea5c27</samp>

This pull request refactors the dependency saving logic for assets, documents, and objects. It extracts the common logic to a new static method `updateDependencies` in the `AbstractElement` class and calls it from the respective `save` methods. This change improves code reusability, consistency, and readability.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at eea5c27</samp>

> _`updateDependencies`_
> _saves element relations_
> _autumn leaves fall_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eea5c27</samp>

*  Refactor the dependency saving logic for assets, documents, and objects into a single static method in the `AbstractElement` class ([link](https://github.com/pimcore/pimcore/pull/15280/files?diff=unified&w=0#diff-464ea7ee8142d9960b6349fb040c177d818aefdd437151c3417ff72b04fced26R24), [link](https://github.com/pimcore/pimcore/pull/15280/files?diff=unified&w=0#diff-464ea7ee8142d9960b6349fb040c177d818aefdd437151c3417ff72b04fced26R872-R895))
*  Replace the duplicated code for saving dependencies in the `save` methods of the `Asset`, `Document`, and `AbstractObject` classes with calls to the new static method ([link](https://github.com/pimcore/pimcore/pull/15280/files?diff=unified&w=0#diff-867a334e4cc9a097b215afcb2b1f4949910cb2f2103a2cd997d8699d4d414fc9R588), [link](https://github.com/pimcore/pimcore/pull/15280/files?diff=unified&w=0#diff-867a334e4cc9a097b215afcb2b1f4949910cb2f2103a2cd997d8699d4d414fc9L779-L793), [link](https://github.com/pimcore/pimcore/pull/15280/files?diff=unified&w=0#diff-fa70d4e562bbd6e9db822e92f1733cc1d740c01f0bc36b4e923132b700f5cab6R826), [link](https://github.com/pimcore/pimcore/pull/15280/files?diff=unified&w=0#diff-fa70d4e562bbd6e9db822e92f1733cc1d740c01f0bc36b4e923132b700f5cab6L938-L953), [link](https://github.com/pimcore/pimcore/pull/15280/files?diff=unified&w=0#diff-48235de7b392a4ff9ed273062d750e2732a5b1f8355cd76109abf4c5538a6c45R458-R459), [link](https://github.com/pimcore/pimcore/pull/15280/files?diff=unified&w=0#diff-48235de7b392a4ff9ed273062d750e2732a5b1f8355cd76109abf4c5538a6c45L572-L586))
