### PR TITLE
Add scheme for gotenberg url

### DIFF
--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -303,4 +303,4 @@ pimcore:
                 functions: ['path', 'asset']
 
     gotenberg:
-        base_url: 'gotenberg:3000'
+        base_url: 'http://gotenberg:3000'

--- a/bundles/CoreBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Configuration.php
@@ -1879,7 +1879,7 @@ final class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('base_url')
-                            ->defaultValue('gotenberg:3000')
+                            ->defaultValue('http://gotenberg:3000')
                         ->end()
                     ->end()
                 ->end()


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Added scheme for gotenberg url. In #15277 the documentation is changed to contian the scheme but the default values are not changed. This will do that.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d51770</samp>

This pull request fixes the default configuration value for the `base_url` parameter of the Gotenberg service, which is used for HTML to PDF conversion. It adds the `http://` prefix to the value in both the `default.yaml` and the `Configuration.php` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4d51770</samp>

> _`Gotenberg` needs URL_
> _Adding `http://` prefix_
> _Winter of bug fix_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4d51770</samp>

*  Add `http://` prefix to default value of `base_url` parameter for Gotenberg service ([link](https://github.com/pimcore/pimcore/pull/15285/files?diff=unified&w=0#diff-34d259c58a9001df91ca2ccc5f41ab960a307d1566cffceb88262d679cfc6c70L306-L305), [link](https://github.com/pimcore/pimcore/pull/15285/files?diff=unified&w=0#diff-bab0da2e129502ead20a1f1ac979fd2260c5d4c8da202b6a8fbf1e9d906d4541L1882-R1882))
