### PR TITLE
[Bug] update 65_Others.md

### DIFF
--- a/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/65_Others.md
+++ b/doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/65_Others.md
@@ -132,7 +132,7 @@ Pimcore then cares automatically about the routing and calls the configured cont
 
 You could use the [Symfony String component's slugger](https://symfony.com/doc/current/components/string.html#slugger) to generate the slugs.
 
-> Note that slugs can't contain the following chars: `! #` since they are reserved characters.
+> Note that slugs can't contain the following chars: `? #` since they are reserved characters.
 > For more information check the [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-2.2).
 
 ### Example


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Followup for https://github.com/pimcore/pimcore/commit/2adfe3bf341d3ebad4c7d202627eb549635f4593#r115211818

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b35c8af</samp>

Fixed the list of reserved characters for slugs in the documentation. Updated the file `doc/Development_Documentation/05_Objects/01_Object_Classes/01_Data_Types/65_Others.md` to reflect the correct characters according to RFC 3986.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b35c8af</samp>

> _`!` in slugs is fine_
> _`?` is reserved, can't use_
> _Docs reflect the truth_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b35c8af</samp>

* Remove `!` and add `?` to the list of reserved characters for slugs in the documentation ([link](https://github.com/pimcore/pimcore/pull/15290/files?diff=unified&w=0#diff-3524d48ffb240fd69dfc06511da6a3667f80f113659ac2f1b638feccd814f82bL135-R135))
