### PR TITLE
Fix missing dependencies to DataObjects in document link editables

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -276,7 +276,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
                         ];
                     }
                 } elseif ($data->getInternalType() == 'object') {
-                    if ($object = DataObject\Concrete::getById($data->getInternalType())) {
+                    if ($object = DataObject\Concrete::getById($data->getInternal())) {
                         $key = 'object_' . $object->getId();
 
                         $dependencies[$key] = [

--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -275,6 +275,15 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
                             'type' => 'asset',
                         ];
                     }
+                } elseif ($data->getInternalType() == 'object') {
+                    if ($object = DataObject\Concrete::getById($data->getInternalType())) {
+                        $key = 'object_' . $object->getId();
+
+                        $dependencies[$key] = [
+                            'id' => $object->getId(),
+                            'type' => 'object',
+                        ];
+                    }
                 }
             }
         }

--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -19,6 +19,7 @@ use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Document;
+use Pimcore\Model\Document\DataObject;
 
 /**
  * @method \Pimcore\Model\Document\Editable\Dao getDao()
@@ -481,11 +482,20 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
                     }
                 } elseif ($this->data['internalType'] == 'asset') {
                     if ($asset = Asset::getById($this->data['internalId'])) {
-                        $key = 'asset_'.$asset->getId();
+                        $key = 'asset_' . $asset->getId();
 
                         $dependencies[$key] = [
                             'id' => $asset->getId(),
                             'type' => 'asset',
+                        ];
+                    }
+                } elseif ($this->data['internalType'] == 'object') {
+                    if ($object = DataObject\Concrete::getById($this->data['internalId'])) {
+                        $key = 'object_' . $object->getId();
+
+                        $dependencies[$key] = [
+                            'id' => $object->getId(),
+                            'type' => 'object',
                         ];
                     }
                 }

--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -19,7 +19,7 @@ use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Document;
-use Pimcore\Model\Document\DataObject;
+use Pimcore\Model\DataObject;
 
 /**
  * @method \Pimcore\Model\Document\Editable\Dao getDao()


### PR DESCRIPTION
Dependencies to data objects, which are referenced in link editables of documents, currently are not saved and thus not displayed within Pimcore backend dependencies tab of documents or objects. 

This PR fixes the issue.