### PR TITLE
[Sitemap generation] Add option handleCurrentSite

### DIFF
--- a/bundles/SeoBundle/src/Sitemap/Document/DocumentTreeGenerator.php
+++ b/bundles/SeoBundle/src/Sitemap/Document/DocumentTreeGenerator.php
@@ -79,7 +79,7 @@ class DocumentTreeGenerator extends AbstractElementGenerator
             }
         }
 
-        if ($this->options['handleCurrentDomain'] && (null === $section || $section === 'default')) {
+        if ($this->options['handleCurrentSite']) {
             try {
                 $currentSite = Site::getCurrentSite();
                 $rootDocument = $currentSite->getRootDocument();

--- a/bundles/SeoBundle/src/Sitemap/Document/DocumentTreeGenerator.php
+++ b/bundles/SeoBundle/src/Sitemap/Document/DocumentTreeGenerator.php
@@ -63,7 +63,7 @@ class DocumentTreeGenerator extends AbstractElementGenerator
 
         $options->setAllowedTypes('rootId', 'int');
         $options->setAllowedTypes('handleMainDomain', 'bool');
-        $options->setAllowedTypes('handleCurrentDomain', 'bool');
+        $options->setAllowedTypes('handleCurrentSite', 'bool');
         $options->setAllowedTypes('handleSites', 'bool');
         $options->setAllowedTypes('urlGeneratorOptions', 'array');
         $options->setAllowedTypes('garbageCollectThreshold', 'int');

--- a/bundles/SeoBundle/src/Sitemap/Document/DocumentTreeGenerator.php
+++ b/bundles/SeoBundle/src/Sitemap/Document/DocumentTreeGenerator.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\SeoBundle\Sitemap\Document;
 
 use Pimcore\Bundle\SeoBundle\Sitemap\Element\AbstractElementGenerator;
+use Pimcore\Logger;
 use Pimcore\Model\Document;
 use Pimcore\Model\Site;
 use Presta\SitemapBundle\Service\UrlContainerInterface;
@@ -54,6 +55,7 @@ class DocumentTreeGenerator extends AbstractElementGenerator
         $options->setDefaults([
             'rootId' => 1,
             'handleMainDomain' => true,
+            'handleCurrentSite' => true,
             'handleSites' => true,
             'urlGeneratorOptions' => [],
             'garbageCollectThreshold' => 50,
@@ -61,6 +63,7 @@ class DocumentTreeGenerator extends AbstractElementGenerator
 
         $options->setAllowedTypes('rootId', 'int');
         $options->setAllowedTypes('handleMainDomain', 'bool');
+        $options->setAllowedTypes('handleCurrentDomain', 'bool');
         $options->setAllowedTypes('handleSites', 'bool');
         $options->setAllowedTypes('urlGeneratorOptions', 'array');
         $options->setAllowedTypes('garbageCollectThreshold', 'int');
@@ -68,10 +71,25 @@ class DocumentTreeGenerator extends AbstractElementGenerator
 
     public function populate(UrlContainerInterface $urlContainer, string $section = null): void
     {
-        if ($this->options['handleMainDomain'] && null === $section || $section === 'default') {
+        if ($this->options['handleMainDomain'] && (null === $section || $section === 'default')) {
             $rootDocument = Document::getById($this->options['rootId']);
 
-            $this->populateCollection($urlContainer, $rootDocument, 'default');
+            if($rootDocument instanceof Document) {
+                $this->populateCollection($urlContainer, $rootDocument, 'default');
+            }
+        }
+
+        if ($this->options['handleCurrentDomain'] && (null === $section || $section === 'default')) {
+            try {
+                $currentSite = Site::getCurrentSite();
+                $rootDocument = $currentSite->getRootDocument();
+                if ($rootDocument instanceof Document) {
+                    $siteSection = sprintf('site_%s', $currentSite->getId());
+                    $this->populateCollection($urlContainer, $rootDocument, $siteSection, $currentSite);
+                }
+            } catch (\Exception $e) {
+                Logger::error('Cannot determine current domain for sitemap generation');
+            }
         }
 
         if ($this->options['handleSites']) {

--- a/bundles/SeoBundle/src/Sitemap/Document/DocumentTreeGenerator.php
+++ b/bundles/SeoBundle/src/Sitemap/Document/DocumentTreeGenerator.php
@@ -55,7 +55,7 @@ class DocumentTreeGenerator extends AbstractElementGenerator
         $options->setDefaults([
             'rootId' => 1,
             'handleMainDomain' => true,
-            'handleCurrentSite' => true,
+            'handleCurrentSite' => false,
             'handleSites' => true,
             'urlGeneratorOptions' => [],
             'garbageCollectThreshold' => 50,

--- a/doc/18_Tools_and_Features/39_Sitemaps.md
+++ b/doc/18_Tools_and_Features/39_Sitemaps.md
@@ -121,6 +121,10 @@ services:
             $processors:
                 - '@Pimcore\Sitemap\Element\Processor\ModificationDateProcessor'
                 - '@Pimcore\Sitemap\Element\Processor\PropertiesProcessor'
+            $options:
+                handleMainDomain: true
+                handleCurrentSite: true
+                handleSites: true
 ```
 
 If you need to influence the behaviour of the document tree sitemap either overwrite the core service definition or define

--- a/doc/18_Tools_and_Features/39_Sitemaps.md
+++ b/doc/18_Tools_and_Features/39_Sitemaps.md
@@ -123,7 +123,7 @@ services:
                 - '@Pimcore\Sitemap\Element\Processor\PropertiesProcessor'
             $options:
                 handleMainDomain: true
-                handleCurrentSite: true
+                handleCurrentSite: false
                 handleSites: true
 ```
 


### PR DESCRIPTION
Assume you have a multi-site project with domains site1.com and site2.com and use `DocumentTreeGenerator` to generate the sitemap based on the documents. When you call the sitemap index URL https://site1.com/sitemap.xml, by default you will get the sitemap files for all the sites: 
```xml
<sitemapindex xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd">
  <sitemap>
    <loc>
      https://site1.com/sitemap.site_1.xml
    </loc>
    <loc>
      https://site1.com/sitemap.site_2.xml
    </loc>
    <lastmod>2023-05-31T11:51:16+02:00</lastmod>
  </sitemap>
</sitemapindex>
```
https://site2.com/sitemap.xml will contain https://site2.com/sitemap.site_1.xml and https://site2.com/sitemap.site_2.xml - for Google https://site1.com/sitemap.site_1.xml and https://site2.com/sitemap.site_1.xml are different sitemaps.
From SEO perspective it is also a problem that https://site1.com/sitemap.site_2.xml only contains URLs for site2.com (although it is called with domain site1.com).
Currently there is no setting to only retrieve sitemap URLs for the current site.

With this PR it is possible to set `handleCurrentSite` option in the service defintion:
```yaml
Pimcore\Sitemap\Document\DocumentTreeGenerator:
        arguments:
            $filters:
                - '@Pimcore\Sitemap\Element\Filter\PublishedFilter'
                - '@Pimcore\Sitemap\Element\Filter\PropertiesFilter'
                - '@Pimcore\Sitemap\Document\Filter\DocumentTypeFilter'
                - '@Pimcore\Sitemap\Document\Filter\SiteRootFilter'
            $processors:
                - '@Pimcore\Sitemap\Element\Processor\ModificationDateProcessor'
                - '@Pimcore\Sitemap\Element\Processor\PropertiesProcessor'
            $options:
                handleCurrentSite: true
                handleMainDomain: false
                handleSites: false
```

This way https://site1.com/sitemap.xml will link to https://site1.com/sitemap.site_1.xml and https://site2.com/sitemap.xml will only link to https://site2.com/sitemap.site_2.xml.