### PR TITLE
[Bug]: Date::getDataForQueryResource(): Return value must be of type ?int, string returned

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Date.php
+++ b/models/DataObject/ClassDefinition/Data/Date.php
@@ -99,15 +99,9 @@ class Date extends Data implements ResourcePersistenceAwareInterface, QueryResou
     }
 
     /**
-     * @param mixed $data
-     * @param null|DataObject\Concrete $object
-     * @param array $params
-     *
-     * @return int|null
-     *
      * @see QueryResourcePersistenceAwareInterface::getDataForQueryResource
      */
-    public function getDataForQueryResource(mixed $data, DataObject\Concrete $object = null, array $params = []): ?int
+    public function getDataForQueryResource(mixed $data, DataObject\Concrete $object = null, array $params = []): int|null|string
     {
         return $this->getDataForResource($data, $object, $params);
     }


### PR DESCRIPTION
Resolves #15292

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c520f5d</samp>

Changed the return type of `Date::getDataForQueryResource` to support different database platforms. This was part of a pull request to improve PostgreSQL and SQLite compatibility in Pimcore.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c520f5d</samp>

> _`getDataForQueryResource`_
> _Returns more types now - kire_
> _PostgreSQL, SQLite_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c520f5d</samp>

* Changed the return type of `getDataForQueryResource` from `?int` to `int|null|string` to support different database platforms ([link](https://github.com/pimcore/pimcore/pull/15299/files?diff=unified&w=0#diff-f9e8614c6fe54e4873af1506ee66172b2c8aad0ee906e85e93b07c8905382c53L102-R104))
