### PR TITLE
[Task]: Improve Admin translation and application logger sorting

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/LogController.php
+++ b/bundles/AdminBundle/Controller/Admin/LogController.php
@@ -67,7 +67,7 @@ class LogController extends AdminController implements KernelControllerEventInte
         ));
 
         if ($sortingSettings['orderKey']) {
-            $qb->orderBy($sortingSettings['orderKey'], $sortingSettings['order']);
+            $qb->orderBy($db->quoteIdentifier($sortingSettings['orderKey']), $sortingSettings['order']);
         } else {
             $qb->orderBy('id', 'DESC');
         }

--- a/bundles/AdminBundle/Controller/Admin/TranslationController.php
+++ b/bundles/AdminBundle/Controller/Admin/TranslationController.php
@@ -443,6 +443,7 @@ class TranslationController extends AdminController
 
             $list->setOrder('asc');
             $list->setOrderKey($tableName . '.key', false);
+            $list->setLanguages($validLanguages);
 
             $sortingSettings = \Pimcore\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings(
                 array_merge($request->request->all(), $request->query->all())

--- a/bundles/AdminBundle/Helper/QueryParams.php
+++ b/bundles/AdminBundle/Helper/QueryParams.php
@@ -37,12 +37,12 @@ class QueryParams
             $sortParam = json_decode($sortParam, true);
             $sortParam = $sortParam[0];
 
+            $order = strtoupper($sortParam['direction']) === 'DESC' ? 'DESC' : 'ASC';
+
             if (substr($sortParam['property'], 0, 1) != '~') {
                 $orderKey = $sortParam['property'];
-                $order = $sortParam['direction'];
             } else {
                 $orderKey = $sortParam['property'];
-                $order = $sortParam['direction'];
 
                 $parts = explode('~', $orderKey);
 

--- a/models/Search/Backend/Data/Listing.php
+++ b/models/Search/Backend/Data/Listing.php
@@ -52,4 +52,30 @@ class Listing extends \Pimcore\Model\Listing\AbstractListing
     {
         $this->initDao(__CLASS__);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function isValidOrderKey($key)
+    {
+        return in_array(
+            $key,
+            [
+                'type',
+                'id',
+                'key',
+                'index',
+                'fullpath',
+                'maintype',
+                'subtype',
+                'published',
+                'creationDate',
+                'modificationDate',
+                'userOwner',
+                'userModification',
+                'data',
+                'properties'
+            ]
+        );
+    }
 }

--- a/models/Translation/Listing.php
+++ b/models/Translation/Listing.php
@@ -52,6 +52,14 @@ class Listing extends Model\Listing\AbstractListing
     protected ?array $languages = null;
 
     /**
+     * @inheritdoc
+     */
+    public function isValidOrderKey($key)
+    {
+        return in_array($key, ['key', 'type']) || in_array($key, $this->getLanguages());
+    }
+
+    /**
      * @return string
      */
     public function getDomain(): string


### PR DESCRIPTION
## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 70275fe</samp>

This pull request fixes a bug in log sorting, adds a language filter for translations, improves the validation of sorting direction, and extends the sorting options for translation listings. The changes affect the files `LogController.php`, `TranslationController.php`, `QueryParams.php`, and `Listing.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 70275fe</samp>

> _Sorting and filtering_
> _`translation` listing grows_
> _Autumn of bug fixes_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 70275fe</samp>

* Fix a bug where sorting log entries by a custom column would fail if the column name contained special characters ([link](https://github.com/pimcore/pimcore/pull/15303/files?diff=unified&w=0#diff-75bf3e1641b85a2eda2598a1bdd614a9b559ca12354e8128eed1cb9c88f33012L70-R70)). Use the `quoteIdentifier` method of the database adapter to escape the column name in `LogController.php`.
