### PR TITLE
[Classification Store] When deleting data object class, also delete classification store data tables

### DIFF
--- a/models/DataObject/ClassDefinition/Dao.php
+++ b/models/DataObject/ClassDefinition/Dao.php
@@ -295,6 +295,9 @@ class Dao extends Model\Dao\AbstractDao
             $this->db->executeQuery('DROP TABLE `'.$brickTable.'`');
         }
 
+        $this->db->executeQuery('DROP TABLE IF EXISTS object_classificationstore_data_'.$this->model->getId());
+        $this->db->executeQuery('DROP TABLE IF EXISTS object_classificationstore_groups_'.$this->model->getId());
+
         // clean slug table
         DataObject\Data\UrlSlug::handleClassDeleted($this->model->getId());
     }


### PR DESCRIPTION
Steps to reproduce bug:

1. Create classification store `store`
2. Create data object class `Test`, add a classification store field with store `store`
3. Delete class `Test`

Now in the database the tables `object_classificationstore_data_<class id>` and `object_classificationstore_groups_<class id>` still exist. We only stumbled upon the problem because https://github.com/pimcore/pimcore/blob/5427e5ffd03ca73b6496f8eef9db0db3b7fe64c9/lib/Maintenance/Tasks/CleanupClassificationstoreTablesTask.php#L42-L70 complains about those tables.

With this PR the classification store data tables get deleted when the corresponding class gets deleted.