### PR TITLE
[Versions] Set default values for number of versions to be kept

### DIFF
--- a/bundles/InstallBundle/SystemConfig/ConfigWriter.php
+++ b/bundles/InstallBundle/SystemConfig/ConfigWriter.php
@@ -35,7 +35,7 @@ final class ConfigWriter
             ],
             'objects' => [
                 'versions' => [
-                    'days' => 10
+                    'steps' => 10
                 ]
             ],
             'assets' => [

--- a/bundles/InstallBundle/SystemConfig/ConfigWriter.php
+++ b/bundles/InstallBundle/SystemConfig/ConfigWriter.php
@@ -33,6 +33,21 @@ final class ConfigWriter
             'general' => [
                 'language' => 'en',
             ],
+            'objects' => [
+                'versions' => [
+                    'days' => 10
+                ]
+            ],
+            'assets' => [
+                'versions' => [
+                    'days' => 10
+                ]
+            ],
+            'documents' => [
+                'versions' => [
+                    'days' => 10
+                ]
+            ]
         ],
     ];
 

--- a/bundles/InstallBundle/SystemConfig/ConfigWriter.php
+++ b/bundles/InstallBundle/SystemConfig/ConfigWriter.php
@@ -40,7 +40,7 @@ final class ConfigWriter
             ],
             'assets' => [
                 'versions' => [
-                    'days' => 10
+                    'steps' => 10
                 ]
             ],
             'documents' => [

--- a/bundles/InstallBundle/SystemConfig/ConfigWriter.php
+++ b/bundles/InstallBundle/SystemConfig/ConfigWriter.php
@@ -45,7 +45,7 @@ final class ConfigWriter
             ],
             'documents' => [
                 'versions' => [
-                    'days' => 10
+                    'steps' => 10
                 ]
             ]
         ],


### PR DESCRIPTION
In the past the number of data object / asset / document versions was set to 10 by default. Somewhere this got lost so that nowadays there is no default value set during installation. This leads to the problem that no versions get cleaned up at all. With the time loading objects in backend gets slower and slower. 
This PR sets the number of versions to be kept to 10 again.