### PR TITLE
[Bug] Unescape already escaped csv character

### DIFF
--- a/lib/Helper/CsvFormulaFormatter.php
+++ b/lib/Helper/CsvFormulaFormatter.php
@@ -20,11 +20,6 @@ namespace Pimcore\Helper;
 
 class CsvFormulaFormatter extends \League\Csv\EscapeFormula
 {
-    /**
-     * @param string $field
-     *
-     * @return string
-     */
     public function unEscapeField(string $field) : string
     {
         if(isset($field[0], $field[1])){

--- a/lib/Helper/CsvFormulaFormatter.php
+++ b/lib/Helper/CsvFormulaFormatter.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+
+namespace Pimcore\Helper;
+
+class CsvFormulaFormatter extends \League\Csv\EscapeFormula
+{
+    /**
+     * @var string
+     */
+    public function unEscapeField(string $field) : string
+    {
+        if(isset($field[0], $field[1])){
+            if($field[0] == $this->getEscape() && in_array($field[1], $this->getSpecialCharacters())) {
+                return ltrim($field, $field[0]);
+            }
+        }
+
+        return $field;
+    }
+
+}

--- a/lib/Helper/CsvFormulaFormatter.php
+++ b/lib/Helper/CsvFormulaFormatter.php
@@ -21,7 +21,9 @@ namespace Pimcore\Helper;
 class CsvFormulaFormatter extends \League\Csv\EscapeFormula
 {
     /**
-     * @var string
+     * @param string $field
+     *
+     * @return string
      */
     public function unEscapeField(string $field) : string
     {

--- a/lib/Helper/CsvFormulaFormatter.php
+++ b/lib/Helper/CsvFormulaFormatter.php
@@ -22,10 +22,11 @@ class CsvFormulaFormatter extends \League\Csv\EscapeFormula
 {
     public function unEscapeField(string $field) : string
     {
-        if(isset($field[0], $field[1])){
-            if($field[0] == $this->getEscape() && in_array($field[1], $this->getSpecialCharacters())) {
+        if (isset($field[0], $field[1])
+            && $field[0] === $this->getEscape()
+            && in_array($field[1], $this->getSpecialCharacters())
+        ) {
                 return ltrim($field, $field[0]);
-            }
         }
 
         return $field;

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -22,7 +22,7 @@ use DeepCopy\Matcher\PropertyNameMatcher;
 use DeepCopy\Matcher\PropertyTypeMatcher;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Query\QueryBuilder as DoctrineQueryBuilder;
-use League\Csv\EscapeFormula;
+use Pimcore\Helper\CsvFormulaFormatter;
 use Pimcore;
 use Pimcore\Db;
 use Pimcore\Event\SystemEvents;
@@ -54,9 +54,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class Service extends Model\AbstractModel
 {
     /**
-     * @var EscapeFormula|null
+     * @var CsvFormulaFormatter|null
      */
-    private static ?EscapeFormula $formatter = null;
+    private static ?CsvFormulaFormatter $formatter = null;
 
     /**
      * @internal
@@ -1650,11 +1650,28 @@ class Service extends Model\AbstractModel
     public static function escapeCsvRecord(array $rowData): array
     {
         if (self::$formatter === null) {
-            self::$formatter = new EscapeFormula("'", ['=', '-', '+', '@']);
+            self::$formatter = new CsvFormulaFormatter("'", ['=', '-', '+', '@']);
         }
         $rowData = self::$formatter->escapeRecord($rowData);
 
         return $rowData;
+    }
+
+    /**
+     * @internal
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    public static function unEscapeCsvField(string $value): string
+    {
+        if (self::$formatter === null) {
+            self::$formatter = new CsvFormulaFormatter("'", ['=', '-', '+', '@']);
+        }
+        $value = self::$formatter->unEscapeField($value);
+
+        return $value;
     }
 
     /**

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -53,9 +53,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class Service extends Model\AbstractModel
 {
-    /**
-     * @var CsvFormulaFormatter|null
-     */
     private static ?CsvFormulaFormatter $formatter = null;
 
     /**
@@ -1659,10 +1656,6 @@ class Service extends Model\AbstractModel
 
     /**
      * @internal
-     *
-     * @param string $value
-     *
-     * @return string
      */
     public static function unEscapeCsvField(string $value): string
     {

--- a/models/Translation.php
+++ b/models/Translation.php
@@ -21,6 +21,7 @@ use Pimcore\Cache\RuntimeCache;
 use Pimcore\Event\Model\TranslationEvent;
 use Pimcore\Event\Traits\RecursionBlockingEventDispatchHelperTrait;
 use Pimcore\Event\TranslationEvents;
+use Pimcore\Model\Element\Service;
 use Pimcore\File;
 use Pimcore\Localization\LocaleServiceInterface;
 use Pimcore\Tool;
@@ -522,6 +523,7 @@ final class Translation extends AbstractModel
                         $t = static::getByKey($textKey, $domain, true);
                         $dirty = false;
                         foreach ($keyValueArray as $key => $value) {
+                            $value = Service::unEscapeCsvField($value);
                             if (in_array($key, $languages)) {
                                 $currentTranslation = $t->hasTranslation($key) ? $t->getTranslation($key) : null;
                                 if ($replaceExistingTranslations) {

--- a/tests/Unit/Helper/CsvFormulaTest.php
+++ b/tests/Unit/Helper/CsvFormulaTest.php
@@ -25,12 +25,26 @@ class CsvFormulaTest extends TestCase
     {
         $formatter = new CsvFormulaFormatter("'", ['=', '-', '+', '@']);
 
-        $this->assertEquals("=1+1", $formatter->unEscapeField("'=1+1"));
-        $this->assertEquals("-1+1", $formatter->unEscapeField("'-1+1"));
-        $this->assertEquals("+1+1", $formatter->unEscapeField("'+1+1"));
-        $this->assertEquals("@1+1", $formatter->unEscapeField("'@1+1"));
+        $escapedRow = $formatter->escapeRecord(["=1+1"]);
+        $this->assertEquals("'=1+1", $escapedRow[0]);
+        $this->assertEquals("=1+1", $formatter->unEscapeField($escapedRow[0]));
+
+
+        $escapedRow = $formatter->escapeRecord(["-1+1"]);
+        $this->assertEquals("'-1+1", $escapedRow[0]);
+        $this->assertEquals("-1+1", $formatter->unEscapeField($escapedRow[0]));
+
+        $escapedRow = $formatter->escapeRecord(["+1+1"]);
+        $this->assertEquals("'+1+1", $escapedRow[0]);
+        $this->assertEquals("+1+1", $formatter->unEscapeField($escapedRow[0]));
+
+        $escapedRow = $formatter->escapeRecord(["@1+1"]);
+        $this->assertEquals("'@1+1", $escapedRow[0]);
+        $this->assertEquals("@1+1", $formatter->unEscapeField($escapedRow[0]));
 
         // There should be no escape. So the string should be returned as is.
-        $this->assertEquals("test", $formatter->unEscapeField("test"));
+        $escapedRow = $formatter->escapeRecord(["test"]);
+        $this->assertEquals("test", $escapedRow[0]);
+        $this->assertEquals("test", $formatter->unEscapeField($escapedRow[0]));
     }
 }

--- a/tests/Unit/Helper/CsvFormulaTest.php
+++ b/tests/Unit/Helper/CsvFormulaTest.php
@@ -46,5 +46,15 @@ class CsvFormulaTest extends TestCase
         $escapedRow = $formatter->escapeRecord(["test"]);
         $this->assertEquals("test", $escapedRow[0]);
         $this->assertEquals("test", $formatter->unEscapeField($escapedRow[0]));
+
+        $testString = "test=test";
+        $escapedRow = $formatter->escapeRecord([$testString]);
+        $this->assertEquals($testString, $escapedRow[0]);
+        $this->assertEquals($testString, $formatter->unEscapeField($escapedRow[0]));
+
+        $testString = "test+test";
+        $escapedRow = $formatter->escapeRecord([$testString]);
+        $this->assertEquals($testString, $escapedRow[0]);
+        $this->assertEquals($testString, $formatter->unEscapeField($escapedRow[0]));
     }
 }

--- a/tests/Unit/Helper/CsvFormulaTest.php
+++ b/tests/Unit/Helper/CsvFormulaTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+
+use Pimcore\Helper\CsvFormulaFormatter;
+use Pimcore\Tests\Test\TestCase;
+
+class CsvFormulaTest extends TestCase
+{
+    public function testUnEscapeFormula()
+    {
+        $formatter = new CsvFormulaFormatter("'", ['=', '-', '+', '@']);
+
+        $this->assertEquals("=1+1", $formatter->unEscapeField("'=1+1"));
+        $this->assertEquals("-1+1", $formatter->unEscapeField("'-1+1"));
+        $this->assertEquals("+1+1", $formatter->unEscapeField("'+1+1"));
+        $this->assertEquals("@1+1", $formatter->unEscapeField("'@1+1"));
+
+        // There should be no escape. So the string should be returned as is.
+        $this->assertEquals("test", $formatter->unEscapeField("test"));
+    }
+}

--- a/tests/Unit/Helper/CsvFormulaTest.php
+++ b/tests/Unit/Helper/CsvFormulaTest.php
@@ -21,7 +21,7 @@ use Pimcore\Tests\Test\TestCase;
 
 class CsvFormulaTest extends TestCase
 {
-    public function testUnEscapeFormula()
+    public function testUnEscapeFormula(): void
     {
         $formatter = new CsvFormulaFormatter("'", ['=', '-', '+', '@']);
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #15249

## Additional info

Check that the first two characters are an escape character and a special character. If this is the case, we remove the escape character.


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aab021a</samp>

This pull request adds a new helper class `CsvFormulaFormatter` that can unescape CSV fields that may contain formulas or commands. It also updates the `Service` and `Translation` classes to use this class for importing translations from CSV files. Additionally, it adds a unit test file `CsvFormulaTest` to test the new class and method.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aab021a</samp>

> _Unleash the power of the CSV_
> _Escape the formulas of doom_
> _Unescape the fields of fire_
> _Import the translations of truth_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aab021a</samp>

*  Add a new class `CsvFormulaFormatter` that extends `League\Csv\EscapeFormula` and provides a method `unEscapeField` to remove the escape character from CSV fields that may contain formulas or commands ([link](https://github.com/pimcore/pimcore/pull/15310/files?diff=unified&w=0#diff-cbd1d9c0567d80b312e5c5685b32f87fea4a3566d4df159f6ecda2b558e5f438R1-R37))
* Replace the use of `League\Csv\EscapeFormula` with `Pimcore\Helper\CsvFormulaFormatter` in the `Service` class of the `models/Element/Service.php` file ([link](https://github.com/pimcore/pimcore/pull/15310/files?diff=unified&w=0#diff-f1c5d50aa07c3685f76a2947c0c3859e2582f8b683ebadf175679eb4aae78785L25-R25))
* Update the type and instantiation of the `self::$formatter` property in the `Service` class to use the new class ([link](https://github.com/pimcore/pimcore/pull/15310/files?diff=unified&w=0#diff-f1c5d50aa07c3685f76a2947c0c3859e2582f8b683ebadf175679eb4aae78785L57-R59), [link](https://github.com/pimcore/pimcore/pull/15310/files?diff=unified&w=0#diff-f1c5d50aa07c3685f76a2947c0c3859e2582f8b683ebadf175679eb4aae78785L1653-R1653))
* Add a new method `unEscapeCsvField` to the `Service` class that calls the `unEscapeField` method of the `self::$formatter` property and returns the unescaped string ([link](https://github.com/pimcore/pimcore/pull/15310/files?diff=unified&w=0#diff-f1c5d50aa07c3685f76a2947c0c3859e2582f8b683ebadf175679eb4aae78785R1663-R1679))
* Use the `Service` class and the `unEscapeCsvField` method in the `Translation` class of the `models/Translation.php` file to unescape the CSV fields before importing them as translations ([link](https://github.com/pimcore/pimcore/pull/15310/files?diff=unified&w=0#diff-d0dc6d8e60e668f42bd2013951b548bf2c28f63b0a6a2cf0dd1a0d9ecb0a8425R24), [link](https://github.com/pimcore/pimcore/pull/15310/files?diff=unified&w=0#diff-d0dc6d8e60e668f42bd2013951b548bf2c28f63b0a6a2cf0dd1a0d9ecb0a8425R526))
* Add a new test file `tests/Unit/Helper/CsvFormulaTest.php` that contains a test class `CsvFormulaTest` and a test method `testUnEscapeFormula` that asserts the expected and actual results of unescaping different CSV fields ([link](https://github.com/pimcore/pimcore/pull/15310/files?diff=unified&w=0#diff-3f4b453f98d8208d6cb0088f81c007c49e14252a636b44bfa35089432c78b514R1-R36))
