### PR TITLE
[Bug] Fix Objectbrick container class dumping

### DIFF
--- a/lib/DataObject/ClassBuilder/PHPObjectBrickContainerClassDumper.php
+++ b/lib/DataObject/ClassBuilder/PHPObjectBrickContainerClassDumper.php
@@ -26,6 +26,7 @@ class PHPObjectBrickContainerClassDumper implements PHPObjectBrickContainerClass
 
     public function dumpContainerClasses(Definition $definition): void
     {
+        $objectClassesFolders = array_unique([PIMCORE_CLASS_DEFINITION_DIRECTORY, PIMCORE_CUSTOM_CONFIGURATION_CLASS_DEFINITION_DIRECTORY]);
         $containerDefinition = [];
 
         foreach ($definition->getClassDefinitions() as $cl) {
@@ -46,27 +47,29 @@ class PHPObjectBrickContainerClassDumper implements PHPObjectBrickContainerClass
         }
 
         foreach ($containerDefinition as $classId => $cd) {
-            $file = PIMCORE_CLASS_DEFINITION_DIRECTORY . '/definition_' . $classId . '.php';
-            if (!file_exists($file)) {
-                continue;
-            }
-
-            $class = include $file;
-
-            if (!$class) {
-                continue;
-            }
-
-            foreach ($cd as $fieldname => $brickKeys) {
-                $cd = $this->classBuilder->buildContainerClass($definition, $class, $fieldname, $brickKeys);
-                $folder = $definition->getContainerClassFolder($class->getName());
-
-                if (!is_dir($folder)) {
-                    File::mkdir($folder);
+            foreach ($objectClassesFolders as $objectClassesFolder) {
+                $file = $objectClassesFolder . '/definition_' . $classId . '.php';
+                if (!file_exists($file)) {
+                    continue;
                 }
 
-                $file = $folder . '/' . ucfirst($fieldname) . '.php';
-                File::put($file, $cd);
+                $class = include $file;
+
+                if (!$class) {
+                    continue;
+                }
+
+                foreach ($cd as $fieldname => $brickKeys) {
+                    $cd = $this->classBuilder->buildContainerClass($definition, $class, $fieldname, $brickKeys);
+                    $folder = $definition->getContainerClassFolder($class->getName());
+
+                    if (!is_dir($folder)) {
+                        File::mkdir($folder);
+                    }
+
+                    $file = $folder . '/' . ucfirst($fieldname) . '.php';
+                    File::put($file, $cd);
+                }
             }
         }
     }


### PR DESCRIPTION
## Changes in this pull request  
Objectbrick container classes were not generated when class definitions are stored in `config/pimcore/classes` instead of `var/classes`.

> **Note**
This PR is best viewed [without whitespace changes](https://github.com/pimcore/pimcore/pull/15317/files?w=1).

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3163357</samp>

This pull request enhances object brick containers to allow custom class definitions. It modifies the `dumpContainerClasses` method in `PHPObjectBrickContainerClassDumper.php` to search for both default and custom class definition files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3163357</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A way to add custom classes to object bricks sublime,_
> _And changed the `dumpContainerClasses` method wise_
> _To search both default and custom paths in due time._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3163357</samp>

*  Support custom class definitions for object brick containers by:
   * Introducing a new variable `$objectClassesFolders` that holds an array of possible directories for class definition files ([link](https://github.com/pimcore/pimcore/pull/15317/files?diff=unified&w=0#diff-2c760ac7de5e8172031c729a36847bdc1d0c64e15b32e54d54fbd504c786b8aaR29))
   * Modifying the loop that iterates over the container definition array to check for both default and custom class definition files ([link](https://github.com/pimcore/pimcore/pull/15317/files?diff=unified&w=0#diff-2c760ac7de5e8172031c729a36847bdc1d0c64e15b32e54d54fbd504c786b8aaL49-R72))
