### PR TITLE
[Thumbnails] Fix generating image-thumbnail dimensions with fallback to image adapter

### DIFF
--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -188,11 +188,24 @@ trait ImageThumbnailTrait
             try {
                 $localFile = $this->getLocalFile();
                 if (null !== $localFile) {
-                    if ($imageInfo = @getimagesize($localFile)) {
+                    //try to get the dimensions with getimagesize because it is much faster than e.g. the Imagick-Adapter
+                    if ($imageSize = @getimagesize($localFile)) {
                         $dimensions = [
-                            'width' => $imageInfo[0],
-                            'height' => $imageInfo[1],
+                            'width' => $imageSize[0],
+                            'height' => $imageSize[1],
                         ];
+                    } else {
+                        //fallback to Default Adapter
+                        $image = \Pimcore\Image::getInstance();
+                        if ($image->load($localFile)) {
+                            $dimensions = [
+                                'width' => $image->getWidth(),
+                                'height' => $image->getHeight(),
+                            ];
+                        }
+                    }
+
+                    if (!empty($dimensions)) {
                         if ($config = $this->getConfig()) {
                             $this->getAsset()->getDao()->addToThumbnailCache(
                                 $config->getName(),


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15231

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 763483a</samp>

This pull request enhances the image thumbnail generation by adding a fallback mechanism to get the dimensions of an image using the default image adapter. It also improves the readability of the code in `ImageThumbnailTrait.php` by renaming a variable and adding a comment.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 763483a</samp>

> _`getimagesize` fails_
> _use image adapter instead_
> _fall leaves no errors_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 763483a</samp>

* Add a fallback mechanism to get image thumbnail dimensions using the default image adapter ([link](https://github.com/pimcore/pimcore/pull/15323/files?diff=unified&w=0#diff-b48489e5be12fb4a4ec4f716c03e4690a799c39a87430cbb1a435d7badebf97cL191-R208),                             F0
