### PR TITLE
[Bug] Don't cast to int before rounding data

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Numeric.php
+++ b/models/DataObject/ClassDefinition/Data/Numeric.php
@@ -486,7 +486,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     public function preSetData(mixed $container, mixed $data, array $params = []): mixed
     {
         if (!is_null($data) && $this->getDecimalPrecision()) {
-            $data = round($data, $this->getDecimalPrecision());
+            $data = round((float) $data, $this->getDecimalPrecision());
         }
 
         return $data;

--- a/models/DataObject/ClassDefinition/Data/Numeric.php
+++ b/models/DataObject/ClassDefinition/Data/Numeric.php
@@ -486,7 +486,7 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
     public function preSetData(mixed $container, mixed $data, array $params = []): mixed
     {
         if (!is_null($data) && $this->getDecimalPrecision()) {
-            $data = round((int)$data, $this->getDecimalPrecision());
+            $data = round($data, $this->getDecimalPrecision());
         }
 
         return $data;


### PR DESCRIPTION
## Changes in this pull request
Rounding an int doesn't make sense. This is a regression of #13474

Resolves #15324

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9503852</samp>

Fix decimal precision loss for numeric data objects. Remove redundant integer casting in `Numeric.php` before rounding.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9503852</samp>

> _No need to cast `data`_
> _Rounding preserves decimals_
> _Winter bug is fixed_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9503852</samp>

* Fix rounding bug for numeric data objects by removing unnecessary integer casting ([link](https://github.com/pimcore/pimcore/pull/15325/files?diff=unified&w=0#diff-4697436a17e4bad9daa8ba079fa63f28620d2b530a0ed67cf9bf7ad901c9269cL489-R489))
