### PR TITLE
fix: config might be undefined

### DIFF
--- a/bundles/CoreBundle/EventListener/ResponseExceptionListener.php
+++ b/bundles/CoreBundle/EventListener/ResponseExceptionListener.php
@@ -187,8 +187,8 @@ class ResponseExceptionListener implements EventSubscriberInterface
             }
         }
 
-        $localizedErrorDocumentsPaths = $this->config['documents']['error_pages']['localized'];
-        $defaultErrorDocumentPath = $this->config['documents']['error_pages']['default'];
+        $localizedErrorDocumentsPaths = $this->config['documents']['error_pages']['localized'] ?? null;
+        $defaultErrorDocumentPath = $this->config['documents']['error_pages']['default'] ?? null;
 
         if (Site::isSiteRequest()) {
             $site = Site::getCurrentSite();


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

If config is undefined, it will not raise a warning

```
      Warning: Undefined array key "error_pages" in vendor/pimcore/pimcore/bundles/CoreBundle/EventListener/ResponseExceptionListener.php line 190
```

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a2f2f4a</samp>

Fix undefined index errors in `ResponseExceptionListener.php` when error document config is missing. This improves PHP 8 compatibility for the pimcore core bundle.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a2f2f4a</samp>

> _`??` operators_
> _avoid undefined indexes_
> _winter of errors_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a2f2f4a</samp>

*  Prevent undefined index errors when accessing error document paths from config by using null coalescing operators ([link](https://github.com/pimcore/pimcore/pull/15329/files?diff=unified&w=0#diff-1be9370a0c5dbeeedecc49569c3d3c29a3b7f973a364de15667fd94532b0411dL190-R191))
