### PR TITLE
[Multiselect] getDiffVersionPreview -> prevent error when $options is null

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Multiselect.php
+++ b/models/DataObject/ClassDefinition/Data/Multiselect.php
@@ -397,7 +397,7 @@ class Multiselect extends Data implements
 
             $html = '<ul>';
 
-            foreach ($this->options as $option) {
+            foreach ((array)$this->options as $option) {
                 if ($map[$option['value']] ?? false) {
                     $value = $option['key'];
                     $html .= '<li>' . $value . '</li>';


### PR DESCRIPTION
`$this->options` in
https://github.com/pimcore/pimcore/blob/dd654dde67eed57f4c27436b1dca2bd3042da1b6/models/DataObject/ClassDefinition/Data/Multiselect.php#L52
can be null.
For this reason looping it in https://github.com/pimcore/pimcore/blob/dd654dde67eed57f4c27436b1dca2bd3042da1b6/models/DataObject/ClassDefinition/Data/Multiselect.php#L400 may result in an error. 