### PR TITLE
Fix preview links for DataObjects when using generators

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php
@@ -2060,8 +2060,8 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 throw new NotFoundHttpException('Cannot render preview due to empty URL');
             }
 
-            // replace all remaining % signs
-            $url = str_replace('%', '%25', $url);
+            // replace all remaining % signs which are not an url encoded characters
+            $url = preg_replace('/%(?![0-9A-F]{2})/i', '%25', $url);
 
             $urlParts = parse_url($url);
 


### PR DESCRIPTION
Using a LinkGenerator or PreviewGenerator service, the link shoudl be seen as "final" and no additional replacements should take place in the url string. Otherwise the link will most likely be invalid because auf double encoding the % sign.

Steps to reproduce:
1. add a link generator to any object
2. generate a link with escaped query parameters i.e. `/category/blaue%20schuhe~123456`
3. the preview will not work because the link was double quoted i.e. `/category/blaue%2520schuhe~123456`