### PR TITLE
fix: check if asset id exists before creating a hotspot image

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Hotspotimage.php
+++ b/models/DataObject/ClassDefinition/Data/Hotspotimage.php
@@ -298,7 +298,7 @@ class Hotspotimage extends Data implements ResourcePersistenceAwareInterface, Qu
      * @param null|DataObject\Concrete $object
      * @param mixed $params
      *
-     * @return DataObject\Data\Hotspotimage
+     * @return DataObject\Data\Hotspotimage|null
      */
     public function getDataFromEditmode($data, $object = null, $params = [])
     {

--- a/models/DataObject/ClassDefinition/Data/Hotspotimage.php
+++ b/models/DataObject/ClassDefinition/Data/Hotspotimage.php
@@ -330,7 +330,10 @@ class Hotspotimage extends Data implements ResourcePersistenceAwareInterface, Qu
             $data['hotspots'] = $rewritePath($data['hotspots']);
         }
 
-        return new DataObject\Data\Hotspotimage($data['id'] ?? null, $data['hotspots'] ?? [], $data['marker'] ?? [], $data['crop'] ?? []);
+        if ($data && isset($data['id']) && (int)$data['id'] > 0) {
+            return new DataObject\Data\Hotspotimage($data['id'], $data['hotspots'] ?? [], $data['marker'] ?? [], $data['crop'] ?? []);
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
## Changes in this pull request  
check asset id before creating a hotspot image object when getting data from edit mode

## Additional info
If a hotpsot image is saved without an asset the function `getDataFromEditMode` returns a new object even no id from asset is set. This could bypass a validation check as a new object is created.

I added the same check as in the corresponding Image class: https://github.com/pimcore/pimcore/blob/10.6/models/DataObject/ClassDefinition/Data/Image.php#L153

### HOW
- create a fieldcollection with an advanced image type and set the image as mandatory
- add the fieldcollection to any object
- create a new object
- add a fieldcollection entry but without adding an asset reference
- save and publish the object
- the mandatory check is bypassed as the current code returns a new object even an asset isn't assigned
