### PR TITLE
[BUG] getValidKey() - key should not end with space after cut

### DIFF
--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -1148,9 +1148,8 @@ class Service extends Model\AbstractModel
             $key = ltrim($key, '. ');
         }
 
-        $key = mb_substr($key, 0, 255);
-
-        return $key;
+        // key should not end with space after cut
+        return trim(mb_substr($key, 0, 255));
     }
 
     /**

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -1148,7 +1148,7 @@ class Service extends Model\AbstractModel
             $key = ltrim($key, '. ');
         }
 
-        // key should not end with space after cut
+        // key should not end (or start) with space after cut
         return trim(mb_substr($key, 0, 255));
     }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.0` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

Error: invalid key for object with id [ ] key is: [***** ] with a last space after using Service::getValidKey($title, 'object')

## Additional info  

Generate a valid key programmatically by the service function:

$key = Service::getValidKey('1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 123456 7', 'object');

On object save you'll get an error:

invalid key for object with id [ ] key is: [1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 123456 ]

Because of a last space after cut.

In Admin UI frontend trims a key properly.
