### PR TITLE
[Thumbnails] Fix accessing the deferred thumbnail URL doesn't add it to cache

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -38,6 +38,7 @@ use Pimcore\Messenger\AssetUpdateTasksMessage;
 use Pimcore\Messenger\VersionDeleteMessage;
 use Pimcore\Model\Asset\Dao;
 use Pimcore\Model\Asset\Folder;
+use Pimcore\Model\Asset\Image\Thumbnail\Config as ThumbnailConfig;
 use Pimcore\Model\Asset\Listing;
 use Pimcore\Model\Asset\MetaData\ClassDefinition\Data\Data;
 use Pimcore\Model\Asset\MetaData\ClassDefinition\Data\DataDefinitionInterface;
@@ -1858,5 +1859,40 @@ class Asset extends Element\AbstractElement
         }
 
         return $path;
+    }
+
+    /**
+     * @internal
+     *
+     * @throws Exception
+     */
+    public function addThumbnailFileToCache(string $localFile, string $filename, ThumbnailConfig $config): void
+    {
+        //try to get the dimensions with getimagesize because it is much faster than e.g. the Imagick-Adapter
+        if ($imageSize = @getimagesize($localFile)) {
+            $dimensions = [
+                'width' => $imageSize[0],
+                'height' => $imageSize[1],
+            ];
+        } else {
+            //fallback to Default Adapter
+            $image = \Pimcore\Image::getInstance();
+            if ($image->load($localFile)) {
+                $dimensions = [
+                    'width' => $image->getWidth(),
+                    'height' => $image->getHeight(),
+                ];
+            }
+        }
+
+        if (!empty($dimensions)) {
+            $this->getDao()->addToThumbnailCache(
+                $config->getName(),
+                $filename,
+                filesize($localFile),
+                $dimensions['width'],
+                $dimensions['height']
+            );
+        }
     }
 }

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -205,6 +205,11 @@ class Processor
                     // the local tmp-file to the real storage a bit further down doesn't work, as it has a
                     // check for race-conditions & locking, so it needs to check for the existence of the thumbnail
                     $storage->delete($storagePath);
+
+                    // refresh the thumbnail cache, if the asset modification date is modified
+                    // this is necessary because the thumbnail cache is not cleared automatically
+                    // when the original asset is modified
+                    self::addOrUpdateThumbnailCache($asset, $config, $filename);
                 }
             } catch (FilesystemException $e) {
                 // nothing to do
@@ -430,11 +435,7 @@ class Processor
                     fclose($stream);
                 }
 
-                if ($statusCacheEnabled) {
-                    if ($imageInfo = @getimagesize($tmpFsPath)) {
-                        $asset->getDao()->addToThumbnailCache($config->getName(), $filename, filesize($tmpFsPath), $imageInfo[0], $imageInfo[1]);
-                    }
-                }
+                self::addOrUpdateThumbnailCache($asset, $config, $filename);
 
                 $generated = true;
 
@@ -470,6 +471,27 @@ class Processor
             'type' => 'thumbnail',
             'storagePath' => $storagePath,
         ];
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private static function addOrUpdateThumbnailCache(
+        Asset $asset,
+        Config $config,
+        string $filename
+    ): void
+    {
+        $tmpFsPath = $asset->getLocalFile();
+        if ($imageInfo = @getimagesize($tmpFsPath)) {
+            $asset->getDao()->addToThumbnailCache(
+                $config->getName(),
+                $filename,
+                filesize($tmpFsPath),
+                $imageInfo[0],
+                $imageInfo[1]
+            );
+        }
     }
 
     /**

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -209,7 +209,7 @@ class Processor
                     // refresh the thumbnail cache, if the asset modification date is modified
                     // this is necessary because the thumbnail cache is not cleared automatically
                     // when the original asset is modified
-                    self::addOrUpdateThumbnailCache($asset, $config, $filename);
+                    $asset->getDao()->deleteFromThumbnailCache($config->getName());
                 }
             } catch (FilesystemException $e) {
                 // nothing to do

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -435,8 +435,8 @@ class Processor
                     fclose($stream);
                 }
 
-                if ($statusCacheEnabled) {
-                    self::addOrUpdateThumbnailCache($asset, $config, $filename);
+                if ($statusCacheEnabled && $asset instanceof Asset\Image) {
+                    $asset->getThumbnail($config->getName())->readDimensionsFromFile(); //update thumbnail dimensions to cache
                 }
 
                 $generated = true;
@@ -473,27 +473,6 @@ class Processor
             'type' => 'thumbnail',
             'storagePath' => $storagePath,
         ];
-    }
-
-    /**
-     * @throws \Exception
-     */
-    private static function addOrUpdateThumbnailCache(
-        Asset $asset,
-        Config $config,
-        string $filename
-    ): void
-    {
-        $tmpFsPath = $asset->getLocalFile();
-        if ($imageInfo = @getimagesize($tmpFsPath)) {
-            $asset->getDao()->addToThumbnailCache(
-                $config->getName(),
-                $filename,
-                filesize($tmpFsPath),
-                $imageInfo[0],
-                $imageInfo[1]
-            );
-        }
     }
 
     /**

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -435,7 +435,9 @@ class Processor
                     fclose($stream);
                 }
 
-                self::addOrUpdateThumbnailCache($asset, $config, $filename);
+                if ($statusCacheEnabled) {
+                    self::addOrUpdateThumbnailCache($asset, $config, $filename);
+                }
 
                 $generated = true;
 

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -436,7 +436,8 @@ class Processor
                 }
 
                 if ($statusCacheEnabled && $asset instanceof Asset\Image) {
-                    $asset->getThumbnail($config->getName())->readDimensionsFromFile(); //update thumbnail dimensions to cache
+                    //update thumbnail dimensions to cache
+                    $asset->addThumbnailFileToCache($tmpFsPath, $filename, $config);
                 }
 
                 $generated = true;

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -183,7 +183,7 @@ trait ImageThumbnailTrait
     /**
      * @internal
      *
-     * @return array
+     * @return array{width?: int, height?: int}
      */
     public function readDimensionsFromFile(): array
     {

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -192,35 +192,12 @@ trait ImageThumbnailTrait
         if (in_array($pathReference['type'], ['thumbnail', 'asset'])) {
             try {
                 $localFile = $this->getLocalFile();
-                if (null !== $localFile) {
-                    //try to get the dimensions with getimagesize because it is much faster than e.g. the Imagick-Adapter
-                    if ($imageSize = @getimagesize($localFile)) {
-                        $dimensions = [
-                            'width' => $imageSize[0],
-                            'height' => $imageSize[1],
-                        ];
-                    } else {
-                        //fallback to Default Adapter
-                        $image = \Pimcore\Image::getInstance();
-                        if ($image->load($localFile)) {
-                            $dimensions = [
-                                'width' => $image->getWidth(),
-                                'height' => $image->getHeight(),
-                            ];
-                        }
-                    }
-
-                    if (!empty($dimensions)) {
-                        if ($config = $this->getConfig()) {
-                            $this->getAsset()->getDao()->addToThumbnailCache(
-                                $config->getName(),
-                                basename($pathReference['storagePath']),
-                                filesize($localFile),
-                                $dimensions['width'],
-                                $dimensions['height']
-                            );
-                        }
-                    }
+                if (null !== $localFile && isset($pathReference['storagePath']) && $config = $this->getConfig()) {
+                    $this->getAsset()->addThumbnailFileToCache(
+                        $localFile,
+                        basename($pathReference['storagePath']),
+                        $config
+                    );
                 }
             } catch (\Exception $e) {
                 // noting to do

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -180,7 +180,12 @@ trait ImageThumbnailTrait
         return $this->realHeight;
     }
 
-    private function readDimensionsFromFile(): array
+    /**
+     * @internal
+     *
+     * @return array
+     */
+    public function readDimensionsFromFile(): array
     {
         $dimensions = [];
         $pathReference = $this->getPathReference();


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15233

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f13178</samp>

This pull request fixes a bug with thumbnail caching and refactors the `Processor` class. It adds a new method `addOrUpdateThumbnailCache` to `models/Asset/Image/Thumbnail/Processor.php` that updates the cache for a given asset and config.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0f13178</samp>

> _Oh, we are the coders of the sea, me hearties_
> _We fix the bugs and refactor the code_
> _We heave and ho and `addOrUpdateThumbnailCache`_
> _To make the assets look as good as gold_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0f13178</samp>

*  Add a new method `addOrUpdateThumbnailCache` to refresh the thumbnail cache for an asset and a config ([link](https://github.com/pimcore/pimcore/pull/15351/files?diff=unified&w=0#diff-16840b1fd40929e8fda46a67eae733c84fc71dc91da6a38097ba58b5da0c321cR477-R497))
*  Call `addOrUpdateThumbnailCache` when generating a thumbnail from a stream or a file to ensure the cache is updated when the original asset is modified ([link](https://github.com/pimcore/pimcore/pull/15351/files?diff=unified&w=0#diff-16840b1fd40929e8fda46a67eae733c84fc71dc91da6a38097ba58b5da0c321cR208-R212), [link](https://github.com/pimcore/pimcore/pull/15351/files?diff=unified&w=0#diff-16840b1fd40929e8fda46a67eae733c84fc71dc91da6a38097ba58b5da0c321cL433-R438))
*  Refactor the code in `models/Asset/Image/Thumbnail/Processor.php` to avoid duplication and simplify the logic for adding thumbnails to the cache ([link](https://github.com/pimcore/pimcore/pull/15351/files?diff=unified&w=0#diff-16840b1fd40929e8fda46a67eae733c84fc71dc91da6a38097ba58b5da0c321cL433-R438), [link](https://github.com/pimcore/pimcore/pull/15351/files?diff=unified&w=0#diff-16840b1fd40929e8fda46a67eae733c84fc71dc91da6a38097ba58b5da0c321cR477-R497))
