### PR TITLE
GridHelperService::prepareListingForGrid should make sure ClassDefinition::getById gets a string

### DIFF
--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -510,7 +510,7 @@ class GridHelperService
     public function prepareListingForGrid(array $requestParams, string $requestedLanguage, $adminUser): DataObject\Listing\Concrete
     {
         $folder = Model\DataObject::getById((int) $requestParams['folderId']);
-        $class = ClassDefinition::getById($requestParams['classId']);
+        $class = ClassDefinition::getById((string) $requestParams['classId']);
         $className = $class->getName();
 
         $listClass = '\\Pimcore\\Model\\DataObject\\' . ucfirst($className) . '\\Listing';


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [x] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [x] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves issue where classid were numeric and would therefore throw an error:

> `Message: Pimcore\Model\DataObject\ClassDefinition::getById(): Argument #1 ($id) must be of type string, int given, called in /var/www/pimcore/vendor/pimcore/pimcore/bundles/AdminBundle/Helper/GridHelperService.php on line 512`

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bfb710d</samp>

Cast class ID to string in `GridHelperService.php` to prevent type error. This is one of several fixes for PHP 8 compatibility.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bfb710d</samp>

> _`getById` expects_
> _a string for class ID_
> _cast it in winter_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bfb710d</samp>

*  Cast the class ID to a string to avoid a type error in `ClassDefinition::getById` ([link](https://github.com/pimcore/pimcore/pull/15352/files?diff=unified&w=0#diff-784ceb6fcd03ce729cee15284714f611451fdbca75047cdae68a9d6a127ed37dL513-R513))
