### PR TITLE
Fix: Image editable should only return Image Assets or null

### DIFF
--- a/models/Document/Editable/Image.php
+++ b/models/Document/Editable/Image.php
@@ -455,8 +455,8 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
      */
     public function getImage()
     {
-        if (!$this->image instanceof Asset\Image && $this->getId()) {
-            $this->image = Asset\Image::getById($this->getId());
+        if (!$this->image instanceof Asset\Image) {
+            $this->image = $this->getId() ? Asset\Image::getById($this->getId()) : null;
         }
 
         return $this->image;

--- a/models/Document/Editable/Image.php
+++ b/models/Document/Editable/Image.php
@@ -463,18 +463,16 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
     }
 
     /**
-     * @param Asset\Image|null $image
+     * @param Asset\Image|ElementDescriptor|null $image
      *
      * @return $this
      */
     public function setImage($image)
     {
+        $this->image = $image;
+
         if ($image instanceof Asset\Image) {
-            $this->image = $image;
             $this->setId($image->getId());
-        } else {
-            $this->image = null;
-            $this->setId(null);
         }
 
         return $this;

--- a/models/Document/Editable/Image.php
+++ b/models/Document/Editable/Image.php
@@ -50,7 +50,7 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
      *
      * @internal
      *
-     * @var Asset\Image|ElementDescriptor|ElementInterface|null
+     * @var Asset\Image|ElementDescriptor|null
      */
     protected $image;
 
@@ -451,11 +451,11 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
     }
 
     /**
-     * @return Asset\Image|ElementDescriptor|ElementInterface|null
+     * @return Asset\Image|null
      */
     public function getImage()
     {
-        if (!$this->image) {
+        if (!$this->image instanceof Asset\Image) {
             $this->image = Asset\Image::getById($this->getId());
         }
 
@@ -463,7 +463,7 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
     }
 
     /**
-     * @param Asset\Image|ElementDescriptor|ElementInterface|null $image
+     * @param Asset\Image|null $image
      *
      * @return $this
      */
@@ -471,7 +471,7 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
     {
         $this->image = $image;
 
-        if ($image instanceof Asset) {
+        if ($image instanceof Asset\Image) {
             $this->setId($image->getId());
         }
 

--- a/models/Document/Editable/Image.php
+++ b/models/Document/Editable/Image.php
@@ -455,7 +455,7 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
      */
     public function getImage()
     {
-        if (!$this->image instanceof Asset\Image) {
+        if (!$this->image instanceof Asset\Image && $this->getId()) {
             $this->image = Asset\Image::getById($this->getId());
         }
 

--- a/models/Document/Editable/Image.php
+++ b/models/Document/Editable/Image.php
@@ -469,33 +469,35 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
      */
     public function setImage($image)
     {
-        $this->image = $image;
-
         if ($image instanceof Asset\Image) {
+            $this->image = $image;
             $this->setId($image->getId());
+        } else {
+            $this->image = null;
+            $this->setId(null);
         }
 
         return $this;
     }
 
     /**
-     * @param int $id
+     * @param int|null $id
      *
      * @return $this
      */
     public function setId($id)
     {
-        $this->id = $id;
+        $this->id = $id ? (int)$id : null;
 
         return $this;
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getId()
     {
-        return (int) $this->id;
+        return $this->id;
     }
 
     /**


### PR DESCRIPTION
Regression from https://github.com/pimcore/pimcore/pull/13474 and https://github.com/pimcore/pimcore/pull/13755

After Update to Pimcore 10.6 our PhpStan is not Happy anymore because the getImage() method can now return ElementDescriptor|ElementInterface. This shouldn't be.