### PR TITLE
Add missing column to install.sql to correct missing column from migration

### DIFF
--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -904,7 +904,7 @@ CREATE TABLE `gridconfigs` (
 	`creationDate` INT(11) NULL,
 	`modificationDate` INT(11) NULL,
 	`shareGlobally` TINYINT(1) NULL,
-  `setAsFavourite` TINYINT(1) NULL,
+	`setAsFavourite` TINYINT(1) NULL,
 	PRIMARY KEY (`id`),
 	INDEX `ownerId` (`ownerId`),
 	INDEX `classId` (`classId`),

--- a/bundles/InstallBundle/Resources/install.sql
+++ b/bundles/InstallBundle/Resources/install.sql
@@ -904,6 +904,7 @@ CREATE TABLE `gridconfigs` (
 	`creationDate` INT(11) NULL,
 	`modificationDate` INT(11) NULL,
 	`shareGlobally` TINYINT(1) NULL,
+  `setAsFavourite` TINYINT(1) NULL,
 	PRIMARY KEY (`id`),
 	INDEX `ownerId` (`ownerId`),
 	INDEX `classId` (`classId`),


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15359

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 62fa29d</samp>

This pull request introduces a new feature that allows users to mark documents, assets and objects as favourites in the Pimcore UI. It adds a new `setAsFavourite` column to the `users` table in the `install.sql` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 62fa29d</samp>

> _`setAsFavourite`_
> _A new column for users_
> _Winter of choices_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 62fa29d</samp>

*  Add a new column `setAsFavourite` to the `users` table to store the user's favourite documents, assets and objects ([link](https://github.com/pimcore/pimcore/pull/15360/files?diff=unified&w=0#diff-c624477d3d2ae554e390ee2b45c5f4c48c160471609aee1e4df2478ab395c4a8R907))
