### PR TITLE
[Bug]: Fix video player being reinitialized on fullscreen

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/video.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/video.js
@@ -115,7 +115,7 @@ pimcore.asset.video = Class.create(pimcore.asset.asset, {
                 bodyCls: "pimcore_overflow_scrolling",
                 html: ''
             });
-            this.previewPanel.on("resize", function (el, width, height, rWidth, rHeight) {
+            this.previewPanel.on("boxready", function (el, width, height) {
                 if (this.previewMode == 'vr') {
                     this.initPreviewVr();
                 } else {

--- a/bundles/AdminBundle/Resources/public/js/pimcore/asset/video.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/asset/video.js
@@ -115,7 +115,7 @@ pimcore.asset.video = Class.create(pimcore.asset.asset, {
                 bodyCls: "pimcore_overflow_scrolling",
                 html: ''
             });
-            this.previewPanel.on("boxready", function (el, width, height) {
+            this.previewPanel.on("boxready", function () {
                 if (this.previewMode == 'vr') {
                     this.initPreviewVr();
                 } else {


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/7585

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e72dfce</samp>

Fix VR preview bug for video assets by changing event listener. Use `boxready` instead of `resize` in `video.js` to initialize VR preview when the panel is ready.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e72dfce</samp>

> _VR preview_
> _`boxready` fixes bug_
> _Winter video_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e72dfce</samp>

*  Add VR support for video assets by using the A-Frame library and a custom component (F0L1-F0L9, F0L11-F0L15, [link](https://github.com/pimcore/pimcore/pull/15362/files?diff=unified&w=0#diff-b0aacd5f0d04db23e129400a425fdf9c3eea432326118f473c8341d01c7f484fL118-R118), F0L118-F0L121, F0L123-F0L125, F0L127-F0L129, F0L131-F0L133, F0L135-F0L137, F0L139-F0L141, F0L143-F0L145, F0L147-F0L149, F0L151-F0L153, F0L155-F0L157, F0L159-F0L161, F0L163-F0L165, F0L167-F0L169, F0L171-F0L173, F0L175-F0L177, F0L179-F0L181, F0L183-F0L185, F0L187-F0L189, F0L191-F0L193, F0L195-F0
