### PR TITLE
Fix/custom reports not opening

### DIFF
--- a/bundles/AdminBundle/Controller/Reports/CustomReportController.php
+++ b/bundles/AdminBundle/Controller/Reports/CustomReportController.php
@@ -292,6 +292,7 @@ class CustomReportController extends ReportsControllerBase
         $items = $list->getDao()->loadForGivenUser($this->getAdminUser());
 
         foreach ($items as $report) {
+            if($report->getDataSourceConfig() !== null){
             $reports[] = [
                 'name' => htmlspecialchars($report->getName()),
                 'niceName' => htmlspecialchars($report->getNiceName()),
@@ -301,6 +302,7 @@ class CustomReportController extends ReportsControllerBase
                 'menuShortcut' => $report->getMenuShortcut(),
                 'reportClass' => htmlspecialchars($report->getReportClass()),
             ];
+        }
         }
 
         return $this->adminJson([

--- a/bundles/AdminBundle/Controller/Reports/CustomReportController.php
+++ b/bundles/AdminBundle/Controller/Reports/CustomReportController.php
@@ -293,16 +293,16 @@ class CustomReportController extends ReportsControllerBase
 
         foreach ($items as $report) {
             if($report->getDataSourceConfig() !== null){
-            $reports[] = [
-                'name' => htmlspecialchars($report->getName()),
-                'niceName' => htmlspecialchars($report->getNiceName()),
-                'iconClass' => htmlspecialchars($report->getIconClass()),
-                'group' => htmlspecialchars($report->getGroup()),
-                'groupIconClass' => htmlspecialchars($report->getGroupIconClass()),
-                'menuShortcut' => $report->getMenuShortcut(),
-                'reportClass' => htmlspecialchars($report->getReportClass()),
-            ];
-        }
+                $reports[] = [
+                    'name' => htmlspecialchars($report->getName()),
+                    'niceName' => htmlspecialchars($report->getNiceName()),
+                    'iconClass' => htmlspecialchars($report->getIconClass()),
+                    'group' => htmlspecialchars($report->getGroup()),
+                    'groupIconClass' => htmlspecialchars($report->getGroupIconClass()),
+                    'menuShortcut' => $report->getMenuShortcut(),
+                    'reportClass' => htmlspecialchars($report->getReportClass()),
+                ];
+            }
         }
 
         return $this->adminJson([


### PR DESCRIPTION
## Changes in this pull request  
Resolves #14745

## Additional info
Hide custom reports in the reports list, unless the report has a `DataSourceConfig` set.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b7a3eb</samp>

Fix bug with custom reports without data source configuration. Check for data source configuration in `CustomReportController.php` before adding report to the list.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8b7a3eb</samp>

> _`report` has no source_
> _skip it to avoid errors_
> _autumn bug fixing_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8b7a3eb</samp>

*  Prevent errors when rendering custom reports without data source configuration ([link](https://github.com/pimcore/pimcore/pull/15379/files?diff=unified&w=0#diff-c05d7e81a9209ca0da1680fe24b90cf04fa304dac83ae677cb1c22dde5180b05L295-R305))
*  Use the `getDataSourceConfig` method in the `CustomReportController` to check if the report has a valid data source configuration before adding it to the reports array ([link](https://github.com/pimcore/pimcore/pull/15379/files?diff=unified&w=0#diff-c05d7e81a9209ca0da1680fe24b90cf04fa304dac83ae677cb1c22dde5180b05L295-R305))
