### PR TITLE
Fix running psalm - use ghcr docker image

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -21,7 +21,7 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Psalm
-              uses: docker://vimeo/psalm-github-actions
+              uses: docker://ghcr.io/psalm/psalm-github-actions
               with:
                 security_analysis: true
                 composer_ignore_platform_reqs: true


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/actions/runs/5275744659/jobs/9541576856

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0af6ce4</samp>

Updated Psalm action to use GitHub Container Registry. This fixes a deprecation warning and enhances the workflow's performance and security.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0af6ce4</samp>

> _`uses` value changed_
> _From docker to ghcr.io_
> _A winter upgrade_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0af6ce4</samp>

* Update the Psalm action to use the new GitHub Container Registry instead of the deprecated Docker Hub ([link](https://github.com/pimcore/pimcore/pull/15380/files?diff=unified&w=0#diff-d0547c297b4cf0631b625910fa903e937ff9bacee96c5ea6e2aec7cd236f0a75L24-R24))
