### PR TITLE
Update Hardlink.php

### DIFF
--- a/models/Document/Hardlink.php
+++ b/models/Document/Hardlink.php
@@ -34,23 +34,23 @@ class Hardlink extends Document
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
-    protected int $sourceId;
+    protected ?int $sourceId = null;
 
     /**
      * @internal
      *
      * @var bool
      */
-    protected bool $propertiesFromSource;
+    protected bool $propertiesFromSource = false;
 
     /**
      * @internal
      *
      * @var bool
      */
-    protected bool $childrenFromSource;
+    protected bool $childrenFromSource = false;
 
     public function getSourceDocument(): ?Document
     {
@@ -106,14 +106,14 @@ class Hardlink extends Document
         return $this->childrenFromSource;
     }
 
-    public function setSourceId(int $sourceId): static
+    public function setSourceId(?int $sourceId): static
     {
         $this->sourceId = $sourceId;
 
         return $this;
     }
 
-    public function getSourceId(): int
+    public function getSourceId(): ?int
     {
         return $this->sourceId;
     }


### PR DESCRIPTION
set initialization values / add null as possible type

at the moment it is not possible to create a hardlink:

// Timestamp: Fri Jun 16 2023 11:14:17 GMT+0200 (Mitteleuropäische Sommerzeit) Status: 500 | URL: /admin/document/add Method: POST Message: Typed property Pimcore\Model\Document\Hardlink::$propertiesFromSource must not be accessed before initialization 