### PR TITLE
added logic to handle dynamic widths

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/time.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/time.js
@@ -26,7 +26,7 @@ pimcore.object.tags.time = Class.create(pimcore.object.tags.abstract, {
     },
 
     getLayoutEdit: function () {
-        let options = { 
+        const options = { 
             fieldLabel: this.fieldConfig.title,
             format: "H:i",
             emptyText: "",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/time.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/time.js
@@ -26,7 +26,7 @@ pimcore.object.tags.time = Class.create(pimcore.object.tags.abstract, {
     },
 
     getLayoutEdit: function () {
-        var options ={ 
+        let options = { 
             fieldLabel: this.fieldConfig.title,
             format: "H:i",
             emptyText: "",

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/time.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/time.js
@@ -26,19 +26,29 @@ pimcore.object.tags.time = Class.create(pimcore.object.tags.abstract, {
     },
 
     getLayoutEdit: function () {
-        this.component = new Ext.form.TimeField({
+        var options ={ 
             fieldLabel: this.fieldConfig.title,
             format: "H:i",
             emptyText: "",
-            width: 200,
+            width: this.fieldConfig.width ? this.fieldConfig.width : 250,
             value: this.data,
             allowBlank: (!this.fieldConfig.mandatory),
             minValue: (this.fieldConfig.minValue) ? this.fieldConfig.minValue : null,
             maxValue: (this.fieldConfig.maxValue) ? this.fieldConfig.maxValue : null,
             componentCls: this.getWrapperClassNames(),
             increment: (this.fieldConfig.increment) ? this.fieldConfig.increment : 15
-        });
+        };
+    
+        if (this.fieldConfig.labelWidth) {
+            options.labelWidth = this.fieldConfig.labelWidth;
+        }
 
+        if (!this.fieldConfig.labelAlign || 'left' === this.fieldConfig.labelAlign) {
+            options.width = this.sumWidths(options.width, options.labelWidth);
+        }
+
+        this.component = new Ext.form.TimeField(options)
+        
         return this.component;
     },
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #12446

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 86a9b9c</samp>

Added width and label options for `TimeField` object tags. This allows users to customize the appearance and behavior of the time input field in the admin UI.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 86a9b9c</samp>

> _`TimeField` of doom, you can change its shape and name_
> _Object tags are your slaves, you control their fate and fame_
> _No more limits on your power, you can tweak the hours and minutes_
> _`TimeField` of doom, you are the master of the time input_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 86a9b9c</samp>

*  Make the width, label width, and label alignment of the time input field configurable by the fieldConfig object ([link](https://github.com/pimcore/pimcore/pull/15388/files?diff=unified&w=0#diff-da6566179e85beaee9b3ada2d72b24d35bafb2d596aeeedec26b8194d3acee2fL29-R33), [link](https://github.com/pimcore/pimcore/pull/15388/files?diff=unified&w=0#diff-da6566179e85beaee9b3ada2d72b24d35bafb2d596aeeedec26b8194d3acee2fL40-R51))


