### PR TITLE
Update Video.php

### DIFF
--- a/models/Asset/Video.php
+++ b/models/Asset/Video.php
@@ -64,13 +64,13 @@ class Video extends Model\Asset
     /**
      * @internal
      *
-     * @param string|Video\Thumbnail\Config $config
+     * @param null|string|Video\Thumbnail\Config $config
      *
      * @return Video\Thumbnail\Config|null
      *
      * @throws Model\Exception\NotFoundException
      */
-    public function getThumbnailConfig(string|Video\Thumbnail\Config $config): ?Video\Thumbnail\Config
+    public function getThumbnailConfig(null|string|Video\Thumbnail\Config $config): ?Video\Thumbnail\Config
     {
         $thumbnail = null;
 

--- a/models/Document/Editable/Video.php
+++ b/models/Document/Editable/Video.php
@@ -935,7 +935,7 @@ class Video extends Model\Document\Editable implements IdRewriterInterface
                 $attributesString .= ' ' . $key;
                 if (!empty($value)) {
                     $quoteChar = '"';
-                    if (strpos($value, '"')) {
+                    if (is_string($value) && strpos($value, '"')) {
                         $quoteChar = "'";
                     }
                     $attributesString .= '=' . $quoteChar . $value . $quoteChar;


### PR DESCRIPTION
Link a local video to pimcore_video element without config

Pimcore\Model\Asset\Video::getThumbnailConfig(): Argument #1 ($config) must be of type Pimcore\Model\Asset\Video\Thumbnail\Config|string, null given, called in /var/www/html/vendor/pimcore/pimcore/models/Document/Editable/Video.php on line 492 File: /var/www/html/vendor/pimcore/pimcore/models/Asset/Video.php Line: 73

