### PR TITLE
Bug BundleEventSetup -  Initialize null arrays as empty

### DIFF
--- a/bundles/InstallBundle/src/Event/BundleSetupEvent.php
+++ b/bundles/InstallBundle/src/Event/BundleSetupEvent.php
@@ -23,9 +23,9 @@ class BundleSetupEvent extends Event
 
     private array $recommendations;
 
-    private array $required;
+    private array $required = [];
 
-    private array $excludeFromBundlesPhp;
+    private array $excludeFromBundlesPhp = [];
 
     public function __construct(array $bundles, array $recommendations)
     {
@@ -46,7 +46,7 @@ class BundleSetupEvent extends Event
     public function addInstallableBundle(string $key, string $class, bool $recommend = false): void
     {
         $this->bundles[$key] = $class;
-        if($recommend) {
+        if ($recommend) {
             $this->recommendations[] = $key;
         }
     }
@@ -62,7 +62,7 @@ class BundleSetupEvent extends Event
     public function addRequiredBundle(string $key, string $class, bool $excludeFromBundlesPhp = false): void
     {
         $this->required[$key] = $class;
-        if($excludeFromBundlesPhp) {
+        if ($excludeFromBundlesPhp) {
             $this->excludeFromBundlesPhp[$key] = $class;
         }
     }


### PR DESCRIPTION
## Changes in this pull request  

The new BundleEventSetup::getInstallableBundles() that gets triggered by the pimcore-install command generates
```
In BundleSetupEvent.php line 74 [Error] Typed property Pimcore\Bundle\InstallBundle\Event\BundleSetupEvent::$required must not be accessed before initialization
```
[Image]
This PR adds initial values for two class variables that will generate must not be accessed before initialization errors.

![image](https://github.com/pimcore/pimcore/assets/67965755/cf456832-11d2-4c14-b33f-301ecb17752b)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 569abbe</samp>

Added new properties to `BundleSetupEvent` to support bundle dependencies and exclusions. This allows bundle developers to specify which other bundles are needed or incompatible with their bundle.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 569abbe</samp>

> _`BundleSetupEvent`_
> _Adds required, excluded_
> _Autumn of bundles_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 569abbe</samp>

* Add two new properties to `BundleSetupEvent` class to store bundle dependencies and exclusions ([link](https://github.com/pimcore/pimcore/pull/15396/files?diff=unified&w=0#diff-426790dbb366c950e0c883528623194c392da1d66f0a7e963f234d1b42ebefecR34-R35))
