### PR TITLE
Remove reference to `pimcore:deployment:custom-layouts-rebuild` in the docs

### DIFF
--- a/doc/21_Deployment/05_Deployment_Tools.md
+++ b/doc/21_Deployment/05_Deployment_Tools.md
@@ -83,7 +83,6 @@ To get a list of all available commands use `./bin/console list`.
 | pimcore:definition:import:fieldcollection            | Import FieldCollection definition from a JSON export                                                                              |
 | pimcore:definition:import:objectbrick                | Import ObjectBrick definition from a JSON export                                                                                  |
 | pimcore:deployment:classes-rebuild                   | Rebuilds classes and db structure based on updated `var/classes/definition_*.php` files                                           |
-| pimcore:deployment:custom-layouts-rebuild            | Rebuilds db structure for custom layouts based on updated `var/classes/customlayouts/definition_*.php` files                      |
 | pimcore:thumbnails:image                             | Generate image thumbnails, useful to pre-generate thumbnails in the background. Use `--processes` option for parallel processing. |
 | pimcore:thumbnails:optimize-images                   | Optimize file size of all images in `web/var/tmp`                                                                                 |
 | pimcore:thumbnails:video                             | Generate video thumbnails, useful to pre-generate thumbnails in the background. Use `--processes` option for parallel processing. |


### PR DESCRIPTION
## Changes in this pull request  
The command was removed in #12779

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b311ab9</samp>

Removed outdated command for custom layouts rebuild from deployment documentation. Updated the documentation to reflect the new way of storing and managing custom layouts as JSON files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b311ab9</samp>

> _`custom-layouts-rebuild`_
> _Gone with the autumn wind_
> _JSON files remain_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b311ab9</samp>

* Remove `pimcore:deployment:custom-layouts-rebuild` command from documentation ([link](https://github.com/pimcore/pimcore/pull/15402/files?diff=unified&w=0#diff-b0cf9bd66612826b7114395f825930bef3d9429bf92204da63df4ea8df3053a9L86))
