### PR TITLE
[Documents] Fix: Image editable typehints

### DIFF
--- a/models/Document/Editable/Image.php
+++ b/models/Document/Editable/Image.php
@@ -48,7 +48,7 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
      *
      * @var Asset\Image|ElementDescriptor|null
      */
-    protected Asset\Image|ElementInterface|Element\ElementDescriptor|null $image = null;
+    protected Asset\Image|Element\ElementDescriptor|null $image = null;
 
     /**
      * @internal
@@ -436,13 +436,12 @@ class Image extends Model\Document\Editable implements IdRewriterInterface, Edit
     }
 
     /**
-     * @param int|null $id
      *
      * @return $this
      */
-    public function setId(int $id): static
+    public function setId(?int $id): static
     {
-        $this->id = $id ? (int)$id : null;
+        $this->id = $id;
 
         return $this;
     }


### PR DESCRIPTION
## Changes in this pull request  
follow up to #15356

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9d95bb2</samp>

Refactored the `Image` editable class to use consistent and simple type declarations for the `image` property and the `setId` method. This enhances the readability and reliability of the code in `models/Document/Editable/Image.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9d95bb2</samp>

> _There once was a class called `Image`_
> _Whose type declarations were a smidge_
> _Too complex and verbose_
> _So they got a refactor dose_
> _And now they are simpler and rigid_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9d95bb2</samp>

*  Simplify the type declaration of the `image` property by removing the redundant `ElementInterface` type ([link](https://github.com/pimcore/pimcore/pull/15403/files?diff=unified&w=0#diff-a4253070399493532b7da5f2e33e4a3ebc4be35de25ce3f6b6811dda3b9dd0edL51-R51))
*  Simplify the type declaration and assignment of the `id` parameter in the `setId` method by using the nullable type `?int` ([link](https://github.com/pimcore/pimcore/pull/15403/files?diff=unified&w=0#diff-a4253070399493532b7da5f2e33e4a3ebc4be35de25ce3f6b6811dda3b9dd0edL439-R444))
