### PR TITLE
Follow up to #15280

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -556,7 +556,7 @@ class Asset extends Element\AbstractElement
             // refresh the inherited properties and update dependencies of each children
             if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
                 foreach ($updatedChildren as $updatedAsset) {
-                    $updatedAsset = self::getById($updatedAsset['id'], true);
+                    $updatedAsset = self::getById($updatedAsset['id'], ['force' => true]);
                     $updatedAsset->renewInheritedProperties();
                     self::updateDependendencies($updatedAsset);
                 }

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -638,7 +638,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             // refresh the inherited properties and update dependencies of each children
             if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
                 foreach ($updatedChildren as $updatedObject) {
-                    $updatedObject = self::getById($updatedObject['id'], true);
+                    $updatedObject = self::getById($updatedObject['id'], ['force' => true]);
                     $updatedObject->renewInheritedProperties();
                     self::updateDependendencies($updatedObject);
                 }

--- a/models/Document.php
+++ b/models/Document.php
@@ -391,7 +391,7 @@ class Document extends Element\AbstractElement
             // refresh the inherited properties and update dependencies of each children
             if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
                 foreach ($updatedChildren as $updatedDocument) {
-                    $updatedDocument = self::getById($updatedDocument['id'], true);
+                    $updatedDocument = self::getById($updatedDocument['id'], ['force' => true]);
                     $updatedDocument->renewInheritedProperties();
                     self::updateDependendencies($updatedDocument);
                 }


### PR DESCRIPTION
## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 018dfcd</samp>

The pull request fixes a cache clearing bug for assets, documents, and data objects by passing an array with the `force` key set to `true` to the `getById` method calls in their respective `save` methods. This makes the method signatures consistent with the `AbstractResource` class.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 018dfcd</samp>

> _`save` methods change_
> _`force` parameter is now_
> _an array in spring_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 018dfcd</samp>

*  Make `getById` method calls consistent with `force` parameter as an array in `save` methods of `Asset`, `Document`, and `AbstractObject` classes to fix cache clearing bug when renaming or moving assets ([link](https://github.com/pimcore/pimcore/pull/15404/files?diff=unified&w=0#diff-867a334e4cc9a097b215afcb2b1f4949910cb2f2103a2cd997d8699d4d414fc9L559-R559), [link](https://github.com/pimcore/pimcore/pull/15404/files?diff=unified&w=0#diff-fa70d4e562bbd6e9db822e92f1733cc1d740c01f0bc36b4e923132b700f5cab6L641-R641), [link](https://github.com/pimcore/pimcore/pull/15404/files?diff=unified&w=0#diff-48235de7b392a4ff9ed273062d750e2732a5b1f8355cd76109abf4c5538a6c45L394-R394))
