### PR TITLE
Remove `pimcore.templating.helper_broker` from the docs

### DIFF
--- a/doc/Development_Documentation/20_Extending_Pimcore/13_Dependency_Injection_Tags.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/13_Dependency_Injection_Tags.md
@@ -9,6 +9,4 @@ Following an overview of all additional service tags provided by Pimcore:
  
 | Name                               | Usage                                                                           |
 |------------------------------------|---------------------------------------------------------------------------------|
-| `pimcore.templating.helper_broker` | Add a helper broker service to the templating engine. Using `templating.helper` is more common, and recommended |
 | `pimcore.area.brick`               | Used to register your [custom area bricks](../03_Documents/01_Editables/02_Areablock/02_Bricks.md), which are not loaded by the discovering service |
-


### PR DESCRIPTION
## Changes in this pull request  
I don't know when this `pimcore.templating.helper_broker` was a part of Pimcore, but apparently it was removed a while ago, as I couldn't find any mention of it anymore.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b8e1b0f</samp>

Removed deprecated `pimcore.templating.helper_broker` tag from the documentation. Updated the dependency injection tags section to reflect the current templating engine.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b8e1b0f</samp>

> _`helper_broker` gone_
> _No more confusion for users_
> _Spring cleaning the docs_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b8e1b0f</samp>

* Remove the deprecated `pimcore.templating.helper_broker` tag from the documentation ([link](https://github.com/pimcore/pimcore/pull/15405/files?diff=unified&w=0#diff-a470ccaa686a8ea629daf0f70ef4d8a8858d37fb7ef4b2827063472ef1621ca4L12-R12))
