### PR TITLE
[Feature] Add `AsAreabrick` attribute

### DIFF
--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/AreabrickPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/AreabrickPass.php
@@ -96,14 +96,12 @@ final class AreabrickPass implements CompilerPassInterface
      *
      *  - implement AreabrickInterface
      *  - be situated in a bundle in the sub-namespace Document\Areabrick (can be nested into a deeper namespace)
-     *  - the class is not already defined as areabrick through manual config (not included in the tagged results above)
+     *  - the class is not yet defined as areabrick through manual config (not included in the tagged results above)
      *
      * Valid examples:
      *
      *  - MyBundle\Document\Areabrick\Foo
      *  - MyBundle\Document\Areabrick\Foo\Bar\Baz
-     *
-     *
      */
     private function autoloadAreabricks(
         ContainerBuilder $container,
@@ -165,7 +163,6 @@ final class AreabrickPass implements CompilerPassInterface
 
     /**
      * Adds setContainer() call to bricks implementing ContainerAwareInterface
-     *
      */
     private function handleContainerAwareDefinition(ContainerBuilder $container, Definition $definition, \ReflectionClass $reflector = null): void
     {
@@ -180,8 +177,6 @@ final class AreabrickPass implements CompilerPassInterface
 
     /**
      * Look for classes implementing AreabrickInterface in each bundle's Document\Areabrick sub-namespace
-     *
-     *
      */
     private function findBundleBricks(ContainerBuilder $container, string $name, array $metadata, array $excludedClasses = []): array
     {
@@ -247,8 +242,6 @@ final class AreabrickPass implements CompilerPassInterface
 
     /**
      * GalleryTeaserRow -> gallery-teaser-row
-     *
-     *
      */
     private function generateBrickId(\ReflectionClass $reflector): string
     {
@@ -264,8 +257,6 @@ final class AreabrickPass implements CompilerPassInterface
      *
      *  - MyBundle\Document\Areabrick\Foo         -> my.area.brick.foo
      *  - MyBundle\Document\Areabrick\Foo\Bar\Baz -> my.area.brick.foo.bar.baz
-     *
-     *
      */
     private function generateServiceId(string $bundleName, string $subNamespace, string $className): string
     {

--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/AreabrickPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/AreabrickPass.php
@@ -20,6 +20,7 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Pimcore\Extension\Document\Areabrick\AreabrickInterface;
 use Pimcore\Extension\Document\Areabrick\AreabrickManager;
+use Pimcore\Extension\Document\Areabrick\Attribute\AsAreabrick;
 use Pimcore\Extension\Document\Areabrick\Exception\ConfigurationException;
 use Pimcore\Templating\Renderer\EditableRenderer;
 use Symfony\Component\Config\Resource\DirectoryResource;
@@ -30,6 +31,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\String\UnicodeString;
 
 /**
  * @internal
@@ -250,10 +252,11 @@ final class AreabrickPass implements CompilerPassInterface
      */
     protected function generateBrickId(\ReflectionClass $reflector): string
     {
-        $id = $this->inflector->tableize($reflector->getShortName());
-        $id = str_replace('_', '-', $id);
+        if ($attribute = $reflector->getAttributes(AsAreabrick::class)[0] ?? null) {
+            return $attribute->newInstance()->id;
+        }
 
-        return $id;
+        return str_replace('_', '-', $this->inflector->tableize($reflector->getShortName()));
     }
 
     /**

--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/AreabrickPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/AreabrickPass.php
@@ -105,7 +105,7 @@ final class AreabrickPass implements CompilerPassInterface
      *
      *
      */
-    protected function autoloadAreabricks(
+    private function autoloadAreabricks(
         ContainerBuilder $container,
         Definition $areaManagerDefinition,
         array $locatorMapping,
@@ -167,7 +167,7 @@ final class AreabrickPass implements CompilerPassInterface
      * Adds setContainer() call to bricks implementing ContainerAwareInterface
      *
      */
-    protected function handleContainerAwareDefinition(ContainerBuilder $container, Definition $definition, \ReflectionClass $reflector = null): void
+    private function handleContainerAwareDefinition(ContainerBuilder $container, Definition $definition, \ReflectionClass $reflector = null): void
     {
         if (null === $reflector) {
             $reflector = new \ReflectionClass($definition->getClass());
@@ -183,7 +183,7 @@ final class AreabrickPass implements CompilerPassInterface
      *
      *
      */
-    protected function findBundleBricks(ContainerBuilder $container, string $name, array $metadata, array $excludedClasses = []): array
+    private function findBundleBricks(ContainerBuilder $container, string $name, array $metadata, array $excludedClasses = []): array
     {
         $sourcePath = is_dir($metadata['path'].'/src') ? $metadata['path'].'/src' : $metadata['path'];
         $directory = $sourcePath.DIRECTORY_SEPARATOR.'Document'.DIRECTORY_SEPARATOR.'Areabrick';
@@ -250,7 +250,7 @@ final class AreabrickPass implements CompilerPassInterface
      *
      *
      */
-    protected function generateBrickId(\ReflectionClass $reflector): string
+    private function generateBrickId(\ReflectionClass $reflector): string
     {
         if ($attribute = $reflector->getAttributes(AsAreabrick::class)[0] ?? null) {
             return $attribute->newInstance()->id;
@@ -267,7 +267,7 @@ final class AreabrickPass implements CompilerPassInterface
      *
      *
      */
-    protected function generateServiceId(string $bundleName, string $subNamespace, string $className): string
+    private function generateServiceId(string $bundleName, string $subNamespace, string $className): string
     {
         $bundleName = str_replace('Bundle', '', $bundleName);
         $bundleName = $this->inflector->tableize($bundleName);

--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/AreabrickPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/AreabrickPass.php
@@ -79,7 +79,7 @@ final class AreabrickPass implements CompilerPassInterface
             }
 
             // handle bricks implementing ContainerAwareInterface
-            $this->handleContainerAwareDefinition($container, $definition);
+            $this->handleContainerAwareDefinition($definition);
             $this->handleEditableRendererCall($definition);
         }
 
@@ -142,7 +142,7 @@ final class AreabrickPass implements CompilerPassInterface
                 ]);
 
                 // handle bricks implementing ContainerAwareInterface
-                $this->handleContainerAwareDefinition($container, $definition, $reflector);
+                $this->handleContainerAwareDefinition($definition, $reflector);
                 $this->handleEditableRendererCall($definition);
             }
         }
@@ -164,11 +164,9 @@ final class AreabrickPass implements CompilerPassInterface
     /**
      * Adds setContainer() call to bricks implementing ContainerAwareInterface
      */
-    private function handleContainerAwareDefinition(ContainerBuilder $container, Definition $definition, \ReflectionClass $reflector = null): void
+    private function handleContainerAwareDefinition(Definition $definition, \ReflectionClass $reflector = null): void
     {
-        if (null === $reflector) {
-            $reflector = new \ReflectionClass($definition->getClass());
-        }
+        $reflector ??= new \ReflectionClass($definition->getClass());
 
         if ($reflector->implementsInterface(ContainerAwareInterface::class)) {
             $definition->addMethodCall('setContainer', [new Reference('service_container')]);

--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/AreabrickPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/AreabrickPass.php
@@ -62,28 +62,29 @@ final class AreabrickPass implements CompilerPassInterface
 
         foreach ($taggedServices as $id => $tags) {
             $definition = $container->getDefinition($id);
-            $taggedAreas[] = $definition->getClass();
+            $class = $definition->getClass();
+            $reflector = new \ReflectionClass($class);
+            $taggedAreas[] = $class;
 
-            // tags must define the id attribute which will be used to register the brick
-            // e.g. { name: pimcore.area.brick, id: blockquote }
             foreach ($tags as $tag) {
-                if (!array_key_exists('id', $tag)) {
-                    throw new ConfigurationException(sprintf('Missing "id" attribute on areabrick DI tag for service %s', $id));
-                }
+                // tags may define the id which will be used to register the brick
+                // e.g. { name: pimcore.area.brick, id: blockquote }
+                // if they don't, it will be auto-generated from the class name
+                $brickId = $tag['id'] ?? $this->generateBrickId($reflector);
 
                 // add the service to the locator
-                $locatorMapping[$tag['id']] = new Reference($id);
+                $locatorMapping[$brickId] = new Reference($id);
 
                 // register the brick with its ID on the areabrick manager
-                $areabrickManager->addMethodCall('registerService', [$tag['id'], $id]);
+                $areabrickManager->addMethodCall('registerService', [$brickId, $id]);
             }
 
             // handle bricks implementing ContainerAwareInterface
-            $this->handleContainerAwareDefinition($definition);
-            $this->handleEditableRendererCall($definition);
+            $this->handleContainerAwareDefinition($definition, $reflector);
+            $this->handleEditableRendererCall($definition, $reflector);
         }
 
-        // autoload areas from bundles if not yet defined via service config
+        // autoload areas if not yet defined via service config
         if ($config['documents']['areas']['autoload']) {
             $locatorMapping = $this->autoloadAreabricks($container, $areabrickManager, $locatorMapping, $taggedAreas);
         }
@@ -95,12 +96,12 @@ final class AreabrickPass implements CompilerPassInterface
      * To be autoloaded, an area must fulfill the following conditions:
      *
      *  - implement AreabrickInterface
-     *  - be situated in a bundle in the sub-namespace Document\Areabrick (can be nested into a deeper namespace)
-     *  - the class is not yet defined as areabrick through manual config (not included in the tagged results above)
+     *  - be in the sub-namespace Document\Areabrick (can be nested into a deeper namespace)
+     *  - the class is not yet defined as an areabrick through manual config (not included in the tagged results above)
      *
      * Valid examples:
      *
-     *  - MyBundle\Document\Areabrick\Foo
+     *  - App\Document\Areabrick\Foo
      *  - MyBundle\Document\Areabrick\Foo\Bar\Baz
      */
     private function autoloadAreabricks(
@@ -143,19 +144,15 @@ final class AreabrickPass implements CompilerPassInterface
 
                 // handle bricks implementing ContainerAwareInterface
                 $this->handleContainerAwareDefinition($definition, $reflector);
-                $this->handleEditableRendererCall($definition);
+                $this->handleEditableRendererCall($definition, $reflector);
             }
         }
 
         return $locatorMapping;
     }
 
-    /**
-     * @throws \ReflectionException
-     */
-    private function handleEditableRendererCall(Definition $definition): void
+    private function handleEditableRendererCall(Definition $definition, \ReflectionClass $reflector): void
     {
-        $reflector = new \ReflectionClass($definition->getClass());
         if ($reflector->hasMethod('setEditableRenderer')) {
             $definition->addMethodCall('setEditableRenderer', [new Reference(EditableRenderer::class)]);
         }
@@ -164,10 +161,8 @@ final class AreabrickPass implements CompilerPassInterface
     /**
      * Adds setContainer() call to bricks implementing ContainerAwareInterface
      */
-    private function handleContainerAwareDefinition(Definition $definition, \ReflectionClass $reflector = null): void
+    private function handleContainerAwareDefinition(Definition $definition, \ReflectionClass $reflector): void
     {
-        $reflector ??= new \ReflectionClass($definition->getClass());
-
         if ($reflector->implementsInterface(ContainerAwareInterface::class)) {
             $definition->addMethodCall('setContainer', [new Reference('service_container')]);
         }
@@ -239,15 +234,15 @@ final class AreabrickPass implements CompilerPassInterface
     }
 
     /**
+     * Tries to read the ID from the `AsAreabrick` attribute and falls back to auto-generation if not defined:
      * GalleryTeaserRow -> gallery-teaser-row
      */
     private function generateBrickId(\ReflectionClass $reflector): string
     {
-        if ($attribute = $reflector->getAttributes(AsAreabrick::class)[0] ?? null) {
-            return $attribute->newInstance()->id;
-        }
+        $attribute = $reflector->getAttributes(AsAreabrick::class)[0] ?? null;
 
-        return str_replace('_', '-', $this->inflector->tableize($reflector->getShortName()));
+        return $attribute?->newInstance()->id
+            ?? str_replace('_', '-', $this->inflector->tableize($reflector->getShortName()));
     }
 
     /**

--- a/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
+++ b/bundles/CoreBundle/src/DependencyInjection/PimcoreCoreExtension.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\CoreBundle\DependencyInjection;
 
 use Pimcore\Bundle\CoreBundle\EventListener\TranslationDebugListener;
+use Pimcore\Extension\Document\Areabrick\Attribute\AsAreabrick;
 use Pimcore\Http\Context\PimcoreContextGuesser;
 use Pimcore\Loader\ImplementationLoader\ClassMapLoader;
 use Pimcore\Loader\ImplementationLoader\PrefixLoader;
@@ -24,6 +25,7 @@ use Pimcore\Model\Document\Editable\Loader\EditableLoader;
 use Pimcore\Model\Document\Editable\Loader\PrefixLoader as DocumentEditablePrefixLoader;
 use Pimcore\Model\Factory;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -125,6 +127,13 @@ final class PimcoreCoreExtension extends ConfigurableExtension implements Prepen
         $container->setParameter('pimcore.workflow', $config['workflows']);
 
         $this->addContextRoutes($container, $config['context']);
+
+        $container->registerAttributeForAutoconfiguration(
+            AsAreabrick::class,
+            static function (ChildDefinition $definition, AsAreabrick $attribute): void {
+                $definition->addTag('pimcore.area.brick', ['id' => $attribute->id]);
+            },
+        );
     }
 
     private function configureModelFactory(ContainerBuilder $container, array $config): void

--- a/doc/03_Documents/01_Editables/02_Areablock/02_Bricks.md
+++ b/doc/03_Documents/01_Editables/02_Areablock/02_Bricks.md
@@ -18,10 +18,10 @@ system. If a brick ID is registered twice (e.g. by multiple bundles), an error w
 register a brick is to just save it to a special namespace `Document\Areabrick` inside your bundle. Every bundle will
 be scanned for classes implementing `AreabrickInterface` and all found bricks will be automatically registered to 
 the system. The brick ID will be built from the class name of the implementing class by converting the class name to 
-dashed case. For example a brick named `MyCustomAreaBrick` will be automatically registered as `my-custom-area-brick`.
+dashed case. For example, a brick named `MyCustomAreaBrick` will be automatically registered as `my-custom-area-brick`.
 
 A basic brick implementation could look like the following. As it is defined in the special namespace, Pimcore will
-implicitely auto-create a service `app.area.brick.iframe` and register it on the areabrick manager with the ID `iframe`.
+implicitly auto-create a service `app.area.brick.iframe` and register it on the areabrick manager with the ID `iframe`.
 
 ```php
 <?php
@@ -36,9 +36,7 @@ class Iframe implements AreabrickInterface
 }
 ```
 
-> Please note that you need to clear the cache after you added a brick to the special namespace.
-
-If you need more control over the brick instance (e.g. because your brick has dependencies on other services or you
+If you need more control over the brick instance (e.g. because your brick has dependencies on other services, or you
 want to specify the brick ID manually), you can add the service definition yourself and tag the service with the DI
 tag `pimcore.area.brick`. Bricks defined manually will be excluded from the auto-registration, even if they're
 defined in the special namespace. Let's define our brick as above, but assume it needs access to a logger instance:
@@ -54,6 +52,25 @@ services:
 
 This will register the brick as above, but you have control over the brick ID and are able to make use of the
 container for dependencies.
+
+There's also the `AsAreabrick` attribute, as a way to control its ID when using the auto-loading,
+or to automatically tag it when defining the service yourself.
+
+```php
+<?php
+
+namespace App\Document\Areabrick;
+
+use Pimcore\Extension\Document\Areabrick\AreabrickInterface;
+use Pimcore\Extension\Document\Areabrick\Attribute\AsAreabrick;
+use Psr\Log\LoggerInterface;
+
+#[AsAreabrick(id: 'iframe')]
+class Iframe implements AreabrickInterface
+{
+    // implementing class methods
+}
+```
 
 > Although it might be tempting to overwrite the `getId()` method in your bricks, please make sure the brick always
 refers to the ID which is set via `setId($id)` when the brick is registered. Overriding `getId()` won't affect the
@@ -72,10 +89,10 @@ The template location defines the base path which will be used to find your temp
 locations. `<bundlePath>` is the filesystem path of the bundle the brick resides in, `<brickId>` the ID of the brick 
 as registered on the areabrick manager (see below).
 
-| Location | Path                                                                                                                                                                                      |
-|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| global   | `templates/areas/<brickId>/`                                                                                                                                                              |
-| bundle   | `<bundlePath>/Resources/views/areas/<brickId>/` for legacy (Symfony <= 4) bundle strucure<br/>or<br/>`<bundlePath>/templates/areas/<brickId>/` for modern (Symfony >= 5) bundle structure |
+| Location | Path                                                                                                                                                                                       |
+|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| global   | `templates/areas/<brickId>/`                                                                                                                                                               |
+| bundle   | `<bundlePath>/Resources/views/areas/<brickId>/` for legacy (Symfony <= 4) bundle structure<br/>or<br/>`<bundlePath>/templates/areas/<brickId>/` for modern (Symfony >= 5) bundle structure |
 
 Depending on the template location, the following files will be used. You can always completely control locations by 
 implementing the methods for templates and icon yourself (see `AreabrickInterface`):
@@ -112,7 +129,7 @@ The icon path and URL are the same as above, but the view scripts are expected i
 
 ## How to Create a Brick
  
-Let's suppose, that our iframe brick defined above is responsible for generating an `<iframe>` containing contents 
+Let's suppose that our iframe brick defined above is responsible for generating an `<iframe>` containing contents 
 from a specified URL in the editmode. First of all, let's update the class to add metadata for the extension manager, to
 make use of template auto-discovery and to load the view template from `templates` instead of the bundle
 directory:
@@ -147,8 +164,8 @@ class Iframe extends AbstractTemplateAreabrick
 }
 ```
 
-Let's create a view as next step. Views behave exactly as native controller views and you have access to the current 
-document, to editmode and to editables and templating helpers as everywhere else. In addition there's a `instance` 
+Let's create a view as next step. Views behave exactly as native controller views, and you have access to the current 
+document, to editmode and to editables and templating helpers as everywhere else. In addition, there's a `instance` 
 variable on the view which gives you access to the brick instance. A `info` variable (see below) gives you access to 
 brick metadata.
 
@@ -284,7 +301,7 @@ class WysiwygWithImages extends AbstractAreabrick implements EditableDialogBoxIn
 }
 ``` 
 
-### Advaned Example Config using Layouts
+### Advanced Example Config using Layouts
 It is also possible to use tab panels in your configuration. 
 ```php
 <?php
@@ -432,8 +449,8 @@ class WysiwygWithImages extends AbstractAreabrick implements EditableDialogBoxIn
 ```
 
 ### Accessing Data of the Editable Dialog
-The editables in the dialog are just normal editables, there's not difference to editables which are defined 
-via the template. So can either use them as well in the template or access them in your custom code. 
+The editables in the dialog are just normal editables, there's no difference to editables which are defined 
+via the template. So you can either use them as well in the template or access them in your custom code. 
 
 
 ## Methods on the brick class

--- a/lib/Extension/Document/Areabrick/Attribute/AsAreabrick.php
+++ b/lib/Extension/Document/Areabrick/Attribute/AsAreabrick.php
@@ -7,7 +7,7 @@ namespace Pimcore\Extension\Document\Areabrick\Attribute;
 final class AsAreabrick
 {
     public function __construct(
-        public readonly string $id,
+        public readonly ?string $id = null,
     ) {
     }
 }

--- a/lib/Extension/Document/Areabrick/Attribute/AsAreabrick.php
+++ b/lib/Extension/Document/Areabrick/Attribute/AsAreabrick.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Pimcore\Extension\Document\Areabrick\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsAreabrick
+{
+    public function __construct(
+        public readonly string $id,
+    ) {
+    }
+}


### PR DESCRIPTION
## Changes in this pull request  
This allows easier custom Areabrick registration, as you don't have to tag them manually anymore. So when you want them to live in e.g. `App\Custom\Location\Areabricks` instead of `App\Document\Areabrick`, you would have to register and tag them one by one at the moment. With this, you can just register the namespace as a resource, like:

```yaml
# config/services.yaml
services: 
    App\Custom\Location\Areabricks\:
        resource: '../src/App/Custom/Location/Areabricks/*'
```

and then tag the class with the `AsAreabrick` attribute, like:

```php
<?php

namespace App\Custom\Location\Areabricks;

use Pimcore\Extension\Document\Areabrick\AreabrickInterface;
use Pimcore\Extension\Document\Areabrick\Attribute\AsAreabrick;
use Psr\Log\LoggerInterface;

#[AsAreabrick(id: 'iframe')]
class Iframe implements AreabrickInterface
{
    // ...
}
```

---

The attribute can also be used to manually define the brick's ID when using the auto-registration. In this case, it won't be auto-generated from the class name anymore.

## Additional info

### WHAT
copilot:summary

copilot:poem

### HOW
copilot:walkthrough
