### PR TITLE
[Image Thumbnails] Fix auto format enabled check

### DIFF
--- a/models/Asset/Image/Thumbnail/Config.php
+++ b/models/Asset/Image/Thumbnail/Config.php
@@ -952,7 +952,7 @@ final class Config extends Model\AbstractModel
         $autoFormatThumbnails = [];
 
         foreach ($this->getAutoFormats() as $autoFormat => $autoFormatConfig) {
-            if (Model\Asset\Image\Thumbnail::supportsFormat($autoFormat) && $autoFormatConfig['enabled']) {
+            if ($autoFormatConfig['enabled'] && Model\Asset\Image\Thumbnail::supportsFormat($autoFormat)) {
                 $autoFormatThumbnail = clone $this;
                 $autoFormatThumbnail->setFormat($autoFormat);
                 if (!empty($autoFormatConfig['quality'])) {


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15340

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e57fb0</samp>

Optimized the condition order in `Config.php` to avoid unnecessary calls to `supportsFormat` for disabled auto formats. This change improves the performance of thumbnail generation.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0e57fb0</samp>

> _`enabled` first checked_
> _a performance boost in spring_
> _`supportsFormat` skipped_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e57fb0</samp>

* Optimize the performance of the auto format check in the thumbnail config by changing the order of the conditions in the if statement ([link](https://github.com/pimcore/pimcore/pull/15408/files?diff=unified&w=0#diff-de2fb2d6c9873638e6632e713bcbbf15099a44862159b86493ded6662d693b84L955-R955))
* Avoid unnecessary calls to the `supportsFormat` method for disabled auto formats by checking the `enabled` flag first ([link](https://github.com/pimcore/pimcore/pull/15408/files?diff=unified&w=0#diff-de2fb2d6c9873638e6632e713bcbbf15099a44862159b86493ded6662d693b84L955-R955))
