### PR TITLE
[Bug]: Fix regression when renaming folder or node with children

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -596,7 +596,7 @@ class Asset extends Element\AbstractElement
             // refresh the inherited properties and update dependencies of each children
             if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
                 foreach ($updatedChildren as $updatedAsset) {
-                    $updatedAsset = self::getById($updatedAsset['id'], true);
+                    $updatedAsset = Asset::getById($updatedAsset, true);
                     $updatedAsset->renewInheritedProperties();
                     self::updateDependendencies($updatedAsset);
                 }

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -597,8 +597,10 @@ class Asset extends Element\AbstractElement
             if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
                 foreach ($updatedChildren as $updatedAsset) {
                     $updatedAsset = Asset::getById($updatedAsset, ['force' => true]);
-                    $updatedAsset->renewInheritedProperties();
-                    self::updateDependendencies($updatedAsset);
+                    if ($updatedAsset instanceof Asset){
+                        $updatedAsset->renewInheritedProperties();
+                        self::updateDependendencies($updatedAsset);
+                    }
                 }
             }
 

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -596,7 +596,7 @@ class Asset extends Element\AbstractElement
             // refresh the inherited properties and update dependencies of each children
             if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
                 foreach ($updatedChildren as $updatedAsset) {
-                    $updatedAsset = Asset::getById($updatedAsset, true);
+                    $updatedAsset = Asset::getById($updatedAsset, ['force' => true]);
                     $updatedAsset->renewInheritedProperties();
                     self::updateDependendencies($updatedAsset);
                 }

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -833,7 +833,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             // refresh the inherited properties and update dependencies of each children
             if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
                 foreach ($updatedChildren as $updatedObject) {
-                    $updatedObject = self::getById($updatedObject['id'], true);
+                    $updatedObject = DataObject::getById($updatedObject, true);
                     $updatedObject->renewInheritedProperties();
                     self::updateDependendencies($updatedObject);
                 }

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -833,7 +833,7 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             // refresh the inherited properties and update dependencies of each children
             if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
                 foreach ($updatedChildren as $updatedObject) {
-                    $updatedObject = DataObject::getById($updatedObject, true);
+                    $updatedObject = DataObject::getById($updatedObject, ['force' => true]);
                     $updatedObject->renewInheritedProperties();
                     self::updateDependendencies($updatedObject);
                 }

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -834,8 +834,10 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
                 foreach ($updatedChildren as $updatedObject) {
                     $updatedObject = DataObject::getById($updatedObject, ['force' => true]);
-                    $updatedObject->renewInheritedProperties();
-                    self::updateDependendencies($updatedObject);
+                    if ($updatedObject instanceof DataObject){
+                        $updatedObject->renewInheritedProperties();
+                        self::updateDependendencies($updatedObject);
+                    }
                 }
             }
 

--- a/models/Document.php
+++ b/models/Document.php
@@ -464,7 +464,7 @@ class Document extends Element\AbstractElement
             // refresh the inherited properties and update dependencies of each children
             if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
                 foreach ($updatedChildren as $updatedDocument) {
-                    $updatedDocument = Document::getById($updatedDocument['id'], true);
+                    $updatedDocument = Document::getById($updatedDocument['id'], ['force' => true]);
                     $updatedDocument->renewInheritedProperties();
                     self::updateDependendencies($updatedDocument);
                 }

--- a/models/Document.php
+++ b/models/Document.php
@@ -465,8 +465,10 @@ class Document extends Element\AbstractElement
             if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
                 foreach ($updatedChildren as $updatedDocument) {
                     $updatedDocument = Document::getById($updatedDocument['id'], ['force' => true]);
-                    $updatedDocument->renewInheritedProperties();
-                    self::updateDependendencies($updatedDocument);
+                    if ($updatedDocument instanceof Document) {
+                        $updatedDocument->renewInheritedProperties();
+                        self::updateDependendencies($updatedDocument);
+                    }
                 }
             }
 

--- a/models/Document.php
+++ b/models/Document.php
@@ -464,7 +464,7 @@ class Document extends Element\AbstractElement
             // refresh the inherited properties and update dependencies of each children
             if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
                 foreach ($updatedChildren as $updatedDocument) {
-                    $updatedDocument = self::getById($updatedDocument['id'], true);
+                    $updatedDocument = Document::getById($updatedDocument['id'], true);
                     $updatedDocument->renewInheritedProperties();
                     self::updateDependendencies($updatedDocument);
                 }

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -872,13 +872,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
 
     protected static function updateDependendencies(object $element): void
     {
-        $type = match (true) {
-            $element instanceof Model\Asset => 'asset',
-            $element instanceof Model\Document => 'document',
-            $element instanceof Model\DataObject\AbstractObject => 'object',
-            default => throw new \InvalidArgumentException('Unexpected element, expected Asset, Document, or AbstractObject')
-        };
-
+        $type = Service::getElementType($element);
         $d = new Dependency();
         $d->setSourceType($type);
         $d->setSourceId($element->getId());

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -870,7 +870,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
         $this->setProperties(array_merge($inheritedProperties, $myProperties));
     }
 
-    protected static function updateDependendencies(ElementInterface $element): void
+    protected static function updateDependendencies(AbstractElement $element): void
     {
         $type = Service::getElementType($element);
         $d = new Dependency();

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -870,7 +870,7 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
         $this->setProperties(array_merge($inheritedProperties, $myProperties));
     }
 
-    protected static function updateDependendencies(object $element): void
+    protected static function updateDependendencies(ElementInterface $element): void
     {
         $type = Service::getElementType($element);
         $d = new Dependency();


### PR DESCRIPTION
## Changes in this pull request  
Related https://github.com/pimcore/pimcore/pull/15280

## Additional info
For documents, it has the `id` key, but not for the other element type
https://github.com/pimcore/pimcore/blob/731774643b48a39258de2c52d0e6f0910f4d21d4/models/Document.php#L448

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7317746</samp>

This pull request fixes a bug in the `save` methods of the `Asset`, `AbstractObject`, and `Document` classes, where the wrong object was used for updating inherited properties and dependencies. The fix uses the respective `getById` methods to get the correct object by ID.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7317746</samp>

> _`save` method fixed_
> _wrong variable assigned_
> _autumn bug hunting_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7317746</samp>

* Fix a bug in the `save` methods of `Asset`, `AbstractObject`, and `Document` classes, where the wrong object was used for updating inherited properties and dependencies ([link](https://github.com/pimcore/pimcore/pull/15420/files?diff=unified&w=0#diff-867a334e4cc9a097b215afcb2b1f4949910cb2f2103a2cd997d8699d4d414fc9L599-R599), [link](https://github.com/pimcore/pimcore/pull/15420/files?diff=unified&w=0#diff-fa70d4e562bbd6e9db822e92f1733cc1d740c01f0bc36b4e923132b700f5cab6L836-R836), [link](https://github.com/pimcore/pimcore/pull/15420/files?diff=unified&w=0#diff-48235de7b392a4ff9ed273062d750e2732a5b1f8355cd76109abf4c5538a6c45L467-R467))
