### PR TITLE
Revert "[Bug]: Fix Dependencies not resolved correctly (#15280)"

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -587,21 +587,6 @@ class Asset extends Element\AbstractElement
             }
             $this->clearDependentCache($additionalTags);
 
-            // if the path changed, refresh the inherited properties before updating dependencies
-            if ($differentOldPath) {
-                $this->renewInheritedProperties();
-            }
-            self::updateDependendencies($this);
-
-            // refresh the inherited properties and update dependencies of each children
-            if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
-                foreach ($updatedChildren as $updatedAsset) {
-                    $updatedAsset = self::getById($updatedAsset['id'], true);
-                    $updatedAsset->renewInheritedProperties();
-                    self::updateDependendencies($updatedAsset);
-                }
-            }
-
             if ($this->getDataChanged()) {
                 if (in_array($this->getType(), ['image', 'video', 'document'])) {
                     $this->addToUpdateTaskQueue();
@@ -791,6 +776,21 @@ class Asset extends Element\AbstractElement
                 }
             }
         }
+
+        // save dependencies
+        $d = new Dependency();
+        $d->setSourceType('asset');
+        $d->setSourceId($this->getId());
+
+        foreach ($this->resolveDependencies() as $requirement) {
+            if ($requirement['id'] == $this->getId() && $requirement['type'] == 'asset') {
+                // dont't add a reference to yourself
+                continue;
+            } else {
+                $d->addRequirement($requirement['id'], $requirement['type']);
+            }
+        }
+        $d->save();
 
         $this->getDao()->update();
 

--- a/models/DataObject/AbstractObject.php
+++ b/models/DataObject/AbstractObject.php
@@ -824,21 +824,6 @@ abstract class AbstractObject extends Model\Element\AbstractElement
             }
             $this->clearDependentCache($additionalTags);
 
-            // if the path changed, refresh the inherited properties before updating dependencies
-            if ($differentOldPath) {
-                $this->renewInheritedProperties();
-            }
-            self::updateDependendencies($this);
-
-            // refresh the inherited properties and update dependencies of each children
-            if ($differentOldPath && isset($updatedChildren) && is_array($updatedChildren)) {
-                foreach ($updatedChildren as $updatedObject) {
-                    $updatedObject = self::getById($updatedObject['id'], true);
-                    $updatedObject->renewInheritedProperties();
-                    self::updateDependendencies($updatedObject);
-                }
-            }
-
             $postEvent = new DataObjectEvent($this, $params);
             if ($isUpdate) {
                 if ($differentOldPath) {
@@ -949,6 +934,22 @@ abstract class AbstractObject extends Model\Element\AbstractElement
                 }
             }
         }
+
+        // save dependencies
+        $d = new Model\Dependency();
+        $d->setSourceType('object');
+        $d->setSourceId($this->getId());
+
+        foreach ($this->resolveDependencies() as $requirement) {
+            if ($requirement['id'] == $this->getId() && $requirement['type'] === 'object') {
+                // dont't add a reference to yourself
+                continue;
+            }
+
+            $d->addRequirement($requirement['id'], $requirement['type']);
+        }
+
+        $d->save();
 
         //set object to registry
         RuntimeCache::set(self::getCacheKey($this->getId()), $this);

--- a/models/Element/AbstractElement.php
+++ b/models/Element/AbstractElement.php
@@ -21,7 +21,6 @@ use Pimcore\Event\AdminEvents;
 use Pimcore\Event\Model\ElementEvent;
 use Pimcore\Event\Traits\RecursionBlockingEventDispatchHelperTrait;
 use Pimcore\Model;
-use Pimcore\Model\Dependency;
 use Pimcore\Model\Element\Traits\DirtyIndicatorTrait;
 use Pimcore\Model\User;
 
@@ -868,29 +867,5 @@ abstract class AbstractElement extends Model\AbstractModel implements ElementInt
         $myProperties = $this->getProperties();
         $inheritedProperties = $this->getDao()->getProperties(true);
         $this->setProperties(array_merge($inheritedProperties, $myProperties));
-    }
-
-    protected static function updateDependendencies(object $element): void
-    {
-        $type = match (true) {
-            $element instanceof Model\Asset => 'asset',
-            $element instanceof Model\Document => 'document',
-            $element instanceof Model\DataObject\AbstractObject => 'object',
-            default => throw new \InvalidArgumentException('Unexpected element, expected Asset, Document, or AbstractObject')
-        };
-
-        $d = new Dependency();
-        $d->setSourceType($type);
-        $d->setSourceId($element->getId());
-
-        foreach ($element->resolveDependencies() as $requirement) {
-            if ($requirement['id'] == $element->getId() && $requirement['type'] == $type) {
-                // dont't add a reference to yourself
-                continue;
-            }
-
-            $d->addRequirement($requirement['id'], $requirement['type']);
-        }
-        $d->save();
     }
 }


### PR DESCRIPTION
This reverts https://github.com/pimcore/pimcore/pull/15280


## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e5c7be9</samp>

This pull request refactors the dependency management of assets, data objects, and documents by removing duplicated and unused code from the `AbstractElement` class and delegating the responsibility to the respective subclasses. This improves the performance and readability of the code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e5c7be9</samp>

> _`AbstractElement`_
> _Cutting redundant code - fall_
> _Leaves only subclasses_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e5c7be9</samp>

*  Remove redundant and inefficient code that updates dependencies of elements and their children when their paths change ([link](https://github.com/pimcore/pimcore/pull/15427/files?diff=unified&w=0#diff-867a334e4cc9a097b215afcb2b1f4949910cb2f2103a2cd997d8699d4d414fc9L590-L604), [link](https://github.com/pimcore/pimcore/pull/15427/files?diff=unified&w=0#diff-fa70d4e562bbd6e9db822e92f1733cc1d740c01f0bc36b4e923132b700f5cab6L827-L841), [link](https://github.com/pimcore/pimcore/pull/15427/files?diff=unified&w=0#diff-48235de7b392a4ff9ed273062d750e2732a5b1f8355cd76109abf4c5538a6c45L458-L472))
*  Move code that saves dependencies of elements using the `Dependency` model from `AbstractElement` to its subclasses `Asset`, `Document`, and `AbstractObject` ([link](https://github.com/pimcore/pimcore/pull/15427/files?diff=unified&w=0#diff-867a334e4cc9a097b215afcb2b1f4949910cb2f2103a2cd997d8699d4d414fc9R780-R794), [link](https://github.com/pimcore/pimcore/pull/15427/files?diff=unified&w=0#diff-fa70d4e562bbd6e9db822e92f1733cc1d740c01f0bc36b4e923132b700f5cab6R938-R953), [link](https://github.com/pimcore/pimcore/pull/15427/files?diff=unified&w=0#diff-48235de7b392a4ff9ed273062d750e2732a5b1f8355cd76109abf4c5538a6c45R572-R586), [link](https://github.com/pimcore/pimcore/pull/15427/files?diff=unified&w=0#diff-464ea7ee8142d9960b6349fb040c177d818aefdd437151c3417ff72b04fced26L872-L895))
*  Remove unused `use` statement for the `Dependency` model from `AbstractElement` ([link](https://github.com/pimcore/pimcore/pull/15427/files?diff=unified&w=0#diff-464ea7ee8142d9960b6349fb040c177d818aefdd437151c3417ff72b04fced26L24))
