### PR TITLE
[Improvement]: Remove default quality for AVIF format

### DIFF
--- a/bundles/CoreBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Configuration.php
@@ -447,7 +447,7 @@ final class Configuration implements ConfigurationInterface
                                         ->defaultValue([
                                             'avif' => [
                                                 'enabled' => true,
-                                                'quality' => null,
+                                                'quality' => 50,
                                             ],
                                             'webp' => [
                                                 'enabled' => true,

--- a/bundles/CoreBundle/src/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Configuration.php
@@ -447,7 +447,7 @@ final class Configuration implements ConfigurationInterface
                                         ->defaultValue([
                                             'avif' => [
                                                 'enabled' => true,
-                                                'quality' => 15,
+                                                'quality' => null,
                                             ],
                                             'webp' => [
                                                 'enabled' => true,


### PR DESCRIPTION
Default quality for format "Auto (Web-optimized - recommended)" with quality 15 for avif is horrible.
