### PR TITLE
Wrap Editable exception in <pre>

### DIFF
--- a/models/Document/Editable.php
+++ b/models/Document/Editable.php
@@ -491,7 +491,7 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
                 // the __toString method isn't allowed to throw exceptions
                 $result = '<b style="color:#f00">' . $e->getMessage().' File: ' . $e->getFile().' Line: '. $e->getLine().'</b><br/>'.$e->getTraceAsString();
 
-                return $result;
+                return '<pre class="pimcore_editable_error">' . $result . '</pre>';
             }
 
             Logger::error('toString() returned an exception: {exception}', [

--- a/models/Document/Editable.php
+++ b/models/Document/Editable.php
@@ -410,7 +410,7 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
                 // the __toString method isn't allowed to throw exceptions
                 $result = '<b style="color:#f00">' . $e->getMessage().' File: ' . $e->getFile().' Line: '. $e->getLine().'</b><br/>'.$e->getTraceAsString();
 
-                return $result;
+                return '<pre class="pimcore_editable_error">' . $result . '</pre>';
             }
 
             Logger::error('toString() returned an exception: {exception}', [


### PR DESCRIPTION
Wrap Editable exception in `<pre>` so that exception lines are shown orderly (line by line starting with line number).
Also add identifying class so that the exception may be scopable.