### PR TITLE
Service::copyAsChild() - $language param should be a string or null

### DIFF
--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -37,10 +37,10 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @method \Pimcore\Model\Document\Service\Dao getDao()
  * @method int[] getTranslations(Document $document, string $task = 'open')
- * @method addTranslation(Document $document, Document $translation, $language = null)
- * @method removeTranslation(Document $document)
+ * @method void addTranslation(Document $document, Document $translation, string $language = null)
+ * @method void removeTranslation(Document $document)
  * @method int getTranslationSourceId(Document $document)
- * @method removeTranslationLink(Document $document, Document $targetDocument)
+ * @method void removeTranslationLink(Document $document, Document $targetDocument)
  */
 class Service extends Model\Element\Service
 {
@@ -157,18 +157,9 @@ class Service extends Model\Element\Service
     }
 
     /**
-     *
-     * @param Document $target
-     * @param Document $source
-     * @param bool $enableInheritance
-     * @param bool $resetIndex
-     * @param bool $language
-     *
-     * @return Page|Document|PageSnippet
-     *
      * @throws ValidationException
      */
-    public function copyAsChild(Document $target, Document $source, bool $enableInheritance = false, bool $resetIndex = false, bool $language = false): Page|Document|PageSnippet
+    public function copyAsChild(Document $target, Document $source, bool $enableInheritance = false, bool $resetIndex = false, ?string $language = null): Page|Document|PageSnippet
     {
         if ($source instanceof Document\PageSnippet) {
             $source->getEditables();


### PR DESCRIPTION
See https://github.com/pimcore/pimcore/issues/15428 and https://github.com/pimcore/admin-ui-classic-bundle/pull/143