### PR TITLE
Make phpdoc consistent with higher version

### DIFF
--- a/models/Document/Hardlink.php
+++ b/models/Document/Hardlink.php
@@ -34,7 +34,7 @@ class Hardlink extends Document
     /**
      * @internal
      *
-     * @var int
+     * @var int|null
      */
     protected $sourceId;
 
@@ -121,19 +121,19 @@ class Hardlink extends Document
     }
 
     /**
-     * @param int $sourceId
+     * @param int|null $sourceId
      *
      * @return $this
      */
     public function setSourceId($sourceId)
     {
-        $this->sourceId = (int) $sourceId;
+        $this->sourceId = $sourceId ? (int)$sourceId : null;
 
         return $this;
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getSourceId()
     {

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -165,12 +165,13 @@ class Service extends Model\Element\Service
      * @param Document $source
      * @param bool $enableInheritance
      * @param bool $resetIndex
+     * @param string $language
      *
      * @return Document
      *
      * @throws \Exception
      */
-    public function copyAsChild($target, $source, $enableInheritance = false, $resetIndex = false, $language = false)
+    public function copyAsChild($target, $source, $enableInheritance = false, $resetIndex = false, $language = null)
     {
         if ($source instanceof Document\PageSnippet) {
             $source->getEditables();

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -165,7 +165,7 @@ class Service extends Model\Element\Service
      * @param Document $source
      * @param bool $enableInheritance
      * @param bool $resetIndex
-     * @param string $language
+     * @param string|null $language
      *
      * @return Document
      *


### PR DESCRIPTION
## Changes in this pull request  
Related to #15386 & #15440

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c717932</samp>

Fixed a bug with hardlink sources and improved language handling for document copying. Changed the `sourceId` property in `Hardlink.php` and the `$language` parameter in `Service.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c717932</samp>

> _We are the hardlinks, we have no source_
> _We break the chains of the null cast curse_
> _We copy the documents, we keep the tongue_
> _We are the service, we are the ones_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c717932</samp>

*  Allow null values for hardlink sourceId property and related methods ([link](https://github.com/pimcore/pimcore/pull/15442/files?diff=unified&w=0#diff-6c00cadc364882cd734dfe66e70dcf70aefcfc8f7b3c4a5068c02906de0dca6aL37-R37), [link](https://github.com/pimcore/pimcore/pull/15442/files?diff=unified&w=0#diff-6c00cadc364882cd734dfe66e70dcf70aefcfc8f7b3c4a5068c02906de0dca6aL124-R124), [link](https://github.com/pimcore/pimcore/pull/15442/files?diff=unified&w=0#diff-6c00cadc364882cd734dfe66e70dcf70aefcfc8f7b3c4a5068c02906de0dca6aL130-R130), [link](https://github.com/pimcore/pimcore/pull/15442/files?diff=unified&w=0#diff-6c00cadc364882cd734dfe66e70dcf70aefcfc8f7b3c4a5068c02906de0dca6aL136-R136))
* Add and change `$language` parameter for document copy methods ([link](https://github.com/pimcore/pimcore/pull/15442/files?diff=unified&w=0#diff-be2f2234588c6da18c7b5b84a009810bbe0efe6be173d1b2a219147eb0966794R168), [link](https://github.com/pimcore/pimcore/pull/15442/files?diff=unified&w=0#diff-be2f2234588c6da18c7b5b84a009810bbe0efe6be173d1b2a219147eb0966794L173-R174))
