### PR TITLE
Show display blocks in WYSIWYG

### DIFF
--- a/bundles/TinymceBundle/public/js/editor.js
+++ b/bundles/TinymceBundle/public/js/editor.js
@@ -46,7 +46,7 @@ pimcore.bundle.tinymce.editor = Class.create({
             language = {};
         }
 
-        const toolbar1 = 'undo redo | formatselect | ' +
+        const toolbar1 = 'undo redo | blocks | ' +
             'bold italic | alignleft aligncenter ' +
             'alignright alignjustify | link';
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15444

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 40c06d8</samp>

Added `blocks` button to `toolbar1` in `editor.js` to enable content blocks feature in TinymceBundle. Content blocks allow users to insert predefined snippets of HTML into the editor.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 40c06d8</samp>

> _`toolbar1` changes_
> _Adding `blocks` button for_
> _Content in autumn_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 40c06d8</samp>

* Add `blocks` button to the editor toolbar to enable content block insertion ([link](https://github.com/pimcore/pimcore/pull/15445/files?diff=unified&w=0#diff-8a2dc43663bb99540091e249b44189b63f7f4ba73bf2a3b7d470a998eeabd19cL49-R49))
