### PR TITLE
[Bug] Handle possibly non-existing `Template` attribute

### DIFF
--- a/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
@@ -67,7 +67,7 @@ class ContentTemplateListener implements EventSubscriberInterface
             return;
         }
 
-        $attribute = $event->controllerArgumentsEvent?->getAttributes()[Template::class][0];
+        $attribute = $event->controllerArgumentsEvent?->getAttributes()[Template::class][0] ?? null;
 
         if (!$attribute instanceof Template) {
             return;

--- a/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
@@ -69,17 +69,15 @@ class ContentTemplateListener implements EventSubscriberInterface
 
         $attribute = $event->controllerArgumentsEvent?->getAttributes()[Template::class][0] ?? null;
 
+        if (!$attribute instanceof Template) {
+            return;
+        }
+        
         $resolvedTemplate = $this->templateResolver->getTemplate($request);
         if (null === $resolvedTemplate) {
             // no contentTemplate on the request -> nothing to do
             return;
         }
-
-        if (!$attribute instanceof Template) {
-            $event->setResponse(new Response($this->twig->display($resolvedTemplate, $event->controllerArgumentsEvent->getNamedArguments())));
-            return;
-        }
-        
 
         $parameters = $this->resolveParameters($event->controllerArgumentsEvent, $attribute->vars);
         $status = 200;

--- a/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
@@ -69,15 +69,17 @@ class ContentTemplateListener implements EventSubscriberInterface
 
         $attribute = $event->controllerArgumentsEvent?->getAttributes()[Template::class][0] ?? null;
 
-        if (!$attribute instanceof Template) {
-            return;
-        }
-
         $resolvedTemplate = $this->templateResolver->getTemplate($request);
         if (null === $resolvedTemplate) {
             // no contentTemplate on the request -> nothing to do
             return;
         }
+
+        if (!$attribute instanceof Template) {
+            $event->setResponse(new Response($this->twig->display($resolvedTemplate, $event->controllerArgumentsEvent->getNamedArguments())));
+            return;
+        }
+        
 
         $parameters = $this->resolveParameters($event->controllerArgumentsEvent, $attribute->vars);
         $status = 200;


### PR DESCRIPTION
## Changes in this pull request  
Pimcore should not fail when there's no attribute of type `Template::class` in the controller arguments event.

Currently, it does:
> ErrorException: "Warning: Undefined array key "Symfony\Bridge\Twig\Attribute\Template""
at /var/www/html/vendor/pimcore/pimcore/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
line 70

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b4de0e0</samp>

Fix a bug with the `Template` annotation on controller actions. Use the null coalescing operator to avoid errors when the `Template` attribute is not set or is null in `ContentTemplateListener.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b4de0e0</samp>

> _`Template` may be null_
> _Use coalescing operator_
> _Fix bug in winter_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b4de0e0</samp>

*  Prevent errors when using `Template` annotation on controller action by adding null coalescing operator to check for `Template` attribute ([link](https://github.com/pimcore/pimcore/pull/15453/files?diff=unified&w=0#diff-2f932cea0ff8fb705f8b326c34e77f71766bf96d6b9a40ac2d31371580d5f1deL70-R70))
