### PR TITLE
Fix typo in the docs

### DIFF
--- a/doc/01_Getting_Started/02_Advanced_Installation_Topics.md
+++ b/doc/01_Getting_Started/02_Advanced_Installation_Topics.md
@@ -126,7 +126,7 @@ services:
 You can preconfigure the values used by the installer by adding a config file which sets values for the database
 credentials. This is especially useful when installing Pimcore on platforms where credentials are available via env vars
 instead of having direct access to them. To preconfigure the installer, add a config file in `config/installer.yaml` 
-(note: the file can be of any format supported by Symfony's config, so you could also use xml or php as the format), then configure the `pimcore_installer` tree:
+(note: the file can be of any format supported by Symfony's config, so you could also use xml or php as the format), then configure the `pimcore_install` tree:
 
 ```yaml
 # config/installer.yaml


### PR DESCRIPTION
## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c482827</samp>

Renamed `pimcore_installer` config key to `pimcore_install` in installation documentation. This improves consistency and clarity for users who follow the advanced installation topics.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c482827</samp>

> _`pimcore_install`_
> _Clearer name for the command_
> _Spring cleaning the docs_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c482827</samp>

*  Rename `pimcore_installer` config key to `pimcore_install` in installation documentation and code examples ([link](https://github.com/pimcore/pimcore/pull/15461/files?diff=unified&w=0#diff-af9a0ec0242a3ba90ff43200e6381f96a4a69c2795a676ab53dedd6f268460abL129-R129),                           
