### PR TITLE
do not mark JsonHelperTrait as internal

### DIFF
--- a/doc/Development_Documentation/20_Extending_Pimcore/24_Add_Your_Own_Permissions.md
+++ b/doc/Development_Documentation/20_Extending_Pimcore/24_Add_Your_Own_Permissions.md
@@ -11,26 +11,27 @@ You should now be able to select the permission in the users/roles tabs:
 ```php
 namespace App\Controller;
 
-
-use Pimcore\Bundle\AdminBundle\Controller\AdminController as PimcoreAdminController;
+use Pimcore\Controller\UserAwareController;
+use Pimcore\Controller\Traits\JsonHelperTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-class AdminController extends PimcoreAdminController
+class AdminController extends UserAwareController
 {
+    use JsonHelperTrait;
     /**
      * @Route("/admin/my-admin-action")
      * @param Request $request
      */
     public function myAdminAction(Request $request) {
 
-        /** @var \Pimcore\Security\User\User $user */
-        $user = $this->getUser();
-        $pimcoreUser = $user->getUser();
+        $pimcoreUser = $this->getPimcoreUser();
 
-        if($pimcoreUser->isAllowed('my_permission')) {
-            ...
+        if($pimcoreUser?->isAllowed('my_permission')) {
+            //...
         }
+        
+        return $this->jsonResponse(['success' => true]);
     }
 }
 ```
@@ -39,7 +40,7 @@ class AdminController extends PimcoreAdminController
 ```js
 document.addEventListener(pimcore.events.pimcoreReady, (e) => {
     if(pimcore.currentuser.permissions.indexOf("my_permission") >= 0) {
-        ...
+        //...
     }
 });
 ```

--- a/lib/Controller/Traits/JsonHelperTrait.php
+++ b/lib/Controller/Traits/JsonHelperTrait.php
@@ -20,8 +20,6 @@ use Pimcore\Serializer\Serializer as PimcoreSerializer;
 use Psr\Container\ContainerInterface;
 
 /**
- * @internal
- *
  * @property ContainerInterface $container
  */
 trait JsonHelperTrait


### PR DESCRIPTION
…solution for a non-internal class.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [X] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [X] Features need to be proper documented in `doc/` 
- [X] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [X] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #15466 

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at efaf391</samp>

The pull request improves the user management and JSON response logic in the `AdminController` class by using common traits. It also allows custom controllers to use the `JsonHelperTrait` trait and documents how to add custom permissions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at efaf391</samp>

> _Oh we're the coders of the sea, we write and refactor with glee_
> _We use the `JsonHelperTrait` to make our controllers neat_
> _We share the methods and the traits for user management and states_
> _And we comment our logic well, so it's easy to tell_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at efaf391</samp>

*  Refactor `AdminController` to extend `UserAwareController` and use `JsonHelperTrait` for JSON responses ([link](https://github.com/pimcore/pimcore/pull/15467/files?diff=unified&w=0#diff-144e69f7b838222d2f4af6d6fe3fbc5267b69155bd3e20f952f4a042afbc2483L14-R21), [link](https://github.com/pimcore/pimcore/pull/15467/files?diff=unified&w=0#diff-144e69f7b838222d2f4af6d6fe3fbc5267b69155bd3e20f952f4a042afbc2483L27-R34))
*  Remove `@internal` annotation from `JsonHelperTrait` to allow usage by custom controllers ([link](https://github.com/pimcore/pimcore/pull/15467/files?diff=unified&w=0#diff-dcfdc22c16d093c81bab953b9a33994b2e915415ea1497881730a1e0638916c5L23-L24))
*  Add comment to frontend JavaScript code to indicate where custom permission logic should go ([link](https://github.com/pimcore/pimcore/pull/15467/files?diff=unified&w=0#diff-144e69f7b838222d2f4af6d6fe3fbc5267b69155bd3e20f952f4a042afbc2483L42-R43))
