### PR TITLE
[Bug]: Fix Recycle Bin permissions workspace

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/RecyclebinController.php
+++ b/bundles/AdminBundle/Controller/Admin/RecyclebinController.php
@@ -140,36 +140,10 @@ class RecyclebinController extends AdminAbstractController implements KernelCont
             $data = [];
             if (is_array($items)) {
 
-                $knownParents = [];
-
                 /** @var Recyclebin\Item $item */
                 foreach ($items as $item) {
                     $dataRow = $item->getObjectVars();
-
-                    $path = $item->getPath();
-                    $explodedPath = explode('/', $path);
-                    $obj = Service::getElementByPath($item->getType(), $path);
-
-                    // TODO: this is always false for the moment, due cascade deletion of permissions
-                    if (!$obj) {
-                        // searching for any existing parent element from the given path and take those permissions as valid
-                        while (!$obj) {
-                            array_pop($explodedPath);
-                            $path = implode('/', $explodedPath);
-                            if (!array_key_exists($path, $knownParents)) {
-                                $obj = Service::getElementByPath($item->getType(), $path);
-                                if ($obj instanceof AbstractElement) {
-                                    $knownParents[$path] = $obj->getUserPermissions();
-                                }
-                            }
-                            if (isset($knownParents[$path])){
-                                $dataRow['permissions'] = $knownParents[$path];
-                                break;
-                            }
-                        }
-                    }
-
-
+                    $dataRow['permissions'] = $item->getClosestExistingParent()->getUserPermissions();
                     $data[] = $dataRow;
                 }
             }

--- a/bundles/AdminBundle/Controller/Admin/RecyclebinController.php
+++ b/bundles/AdminBundle/Controller/Admin/RecyclebinController.php
@@ -18,6 +18,7 @@ namespace Pimcore\Bundle\AdminBundle\Controller\Admin;
 use Pimcore\Bundle\AdminBundle\Controller\AdminAbstractController;
 use Pimcore\Controller\KernelControllerEventInterface;
 use Pimcore\Model\Element;
+use Pimcore\Model\Element\AbstractElement;
 use Pimcore\Model\Element\Recyclebin;
 use Pimcore\Model\Element\Service;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -157,7 +158,7 @@ class RecyclebinController extends AdminAbstractController implements KernelCont
                             $path = implode('/', $explodedPath);
                             if (!array_key_exists($path, $knownParents)) {
                                 $obj = Service::getElementByPath($item->getType(), $path);
-                                if ($obj) {
+                                if ($obj instanceof AbstractElement) {
                                     $knownParents[$path] = $obj->getUserPermissions();
                                 }
                             }

--- a/bundles/AdminBundle/Controller/Admin/RecyclebinController.php
+++ b/bundles/AdminBundle/Controller/Admin/RecyclebinController.php
@@ -143,7 +143,10 @@ class RecyclebinController extends AdminAbstractController implements KernelCont
                 /** @var Recyclebin\Item $item */
                 foreach ($items as $item) {
                     $dataRow = $item->getObjectVars();
-                    $dataRow['permissions'] = $item->getClosestExistingParent()->getUserPermissions();
+                    $closestParent = $item->getClosestExistingParent();
+                    if ($closestParent instanceof AbstractElement) {
+                        $dataRow['permissions'] = $closestParent->getUserPermissions();
+                    }
                     $data[] = $dataRow;
                 }
             }

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/recyclebin.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/recyclebin.js
@@ -123,7 +123,13 @@ pimcore.settings.recyclebin = Class.create({
                     handler: function (grid, rowIndex) {
                         grid.getStore().removeAt(rowIndex);
                     }.bind(this)
-                }]
+                }],
+                renderer: function (value, metaData, record, rowIndex, colIndex, store) {
+                    // when not allowed to delete, hide the delete icon
+                    if (record.data.permissions.delete == 0) {
+                        this.items = [];
+                    }
+                },
             }
         ];
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/recyclebin.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/recyclebin.js
@@ -187,34 +187,72 @@ pimcore.settings.recyclebin = Class.create({
     },
 
     updateButtonStates: function() {
-        var selectedRows = this.grid.getSelectionModel().getSelection();
+        let selectedRows = this.grid.getSelectionModel().getSelection();
+        let selectedCount = selectedRows.length;
+        let deleteButton = true;
+        let publishButton = true;
 
-        if (selectedRows.length >= 1) {
-            Ext.getCmp("pimcore_recyclebin_button_restore").enable();
+        Ext.getCmp("pimcore_recyclebin_button_restore").disable();
+        Ext.getCmp("pimcore_recyclebin_button_delete").disable();
+
+        for (let i = 0; i < selectedCount; i++) {
+            //it only takes one element not deletable to disable the delete button
+            if (selectedRows[i].data.permissions.delete == 0) {
+                //it only takes one not deleteable element among selected to disable the delete button
+                deleteButton = false;
+                break;
+            }
+        }
+        if (deleteButton && selectedCount > 0){
             Ext.getCmp("pimcore_recyclebin_button_delete").enable();
-        } else {
-            Ext.getCmp("pimcore_recyclebin_button_restore").disable();
-            Ext.getCmp("pimcore_recyclebin_button_delete").disable();
+        }
+
+        for (let i = 0; i < selectedCount; i++) {
+            //it only takes one not publishable element among selected to disable the publish button
+            if (selectedRows[i].data.permissions.publish == 0) {
+                publishButton = false;
+                break;
+            }
+        }
+        if (publishButton && selectedCount > 0){
+            Ext.getCmp("pimcore_recyclebin_button_restore").enable();
         }
     },
 
     onRowContextmenu: function (grid, record, tr, rowIndex, e, eOpts) {
 
-        var menu = new Ext.menu.Menu();
-        var selModel = grid.getSelectionModel();
-        var selectedRows = selModel.getSelection();
+        let menu = new Ext.menu.Menu();
+        let selModel = grid.getSelectionModel();
+
+        let canDelete = true;
+        let canPublish = true;
+
+        for (let i = 0; i < selModel.selected.items.length; i++) {
+            //it only takes one not deleteable element among selected to disable the delete button
+            if (selModel.selected.items[i].data.permissions.delete == 0) {
+                canDelete = false;
+                break;
+            }
+        }
+        for (let i = 0; i < selModel.selected.items.length; i++) {
+            //it only takes one not publishable element among selected to disable the publish button
+            if (selModel.selected.items[i].data.permissions.publish == 0) {
+                canPublish = false;
+                break;
+            }
+        }
 
         menu.add(new Ext.menu.Item({
             text: t('restore'),
             iconCls: "pimcore_icon_restore",
             handler: this.restoreSelected.bind(this),
-            disabled: !selectedRows.length
+            disabled: !canPublish
         }));
         menu.add(new Ext.menu.Item({
             text: t('delete'),
             iconCls: "pimcore_icon_delete",
             handler: this.deleteSelected.bind(this),
-            disabled: !selectedRows.length
+            disabled: !canDelete
         }));
 
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/recyclebin.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/recyclebin.js
@@ -122,14 +122,13 @@ pimcore.settings.recyclebin = Class.create({
                     icon: "/bundles/pimcoreadmin/img/flat-color-icons/delete.svg",
                     handler: function (grid, rowIndex) {
                         grid.getStore().removeAt(rowIndex);
-                    }.bind(this)
-                }],
-                renderer: function (value, metaData, record, rowIndex, colIndex, store) {
-                    // when not allowed to delete, hide the delete icon
-                    if (record.data.permissions.delete == 0) {
-                        this.items = [];
+                    }.bind(this),
+                    getClass: function(v, meta, rec) {
+                        if (rec.data.permissions.delete == 0) {
+                            return "pimcore_hidden";
+                        }
                     }
-                },
+                }],
             }
         ];
 

--- a/models/Element/Recyclebin.php
+++ b/models/Element/Recyclebin.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Model\Element;
 
+use League\Flysystem\UnableToDeleteDirectory;
 use Pimcore\Model;
 use Pimcore\Tool\Storage;
 
@@ -28,6 +29,19 @@ final class Recyclebin extends Model\AbstractModel
     public function flush()
     {
         $this->getDao()->flush();
-        Storage::get('recycle_bin')->deleteDirectory('/');
+        $bin = Storage::get('recycle_bin');
+        try {
+            $bin->deleteDirectory('/');
+        } catch (UnableToDeleteDirectory) {
+            // it seems there is a problem with AW3 adapter due the trim
+            // https://github.com/thephpleague/flysystem-aws-s3-v3/blob/d8de61ee10b6a607e7996cff388c5a3a663e8c8a/AwsS3V3Adapter.php#L236
+
+            $listing = $bin->listContents('/', true);
+
+            /** @var \League\Flysystem\StorageAttributes $item */
+            foreach ($listing as $item) {
+                $bin->delete($item->path());
+            }
+        }
     }
 }

--- a/models/Element/Recyclebin/Item.php
+++ b/models/Element/Recyclebin/Item.php
@@ -123,7 +123,7 @@ class Item extends Model\AbstractModel
     {
         $path = $this->getPath();
         $explodedPath = explode('/', $path);
-        /** @var AbstractElement $obj */
+        /** @var AbstractElement|null $obj */
         $obj = Service::getElementByPath($this->getType(), $path);
 
         // TODO: this is always false for the moment, due cascade deletion of permissions

--- a/models/Element/Recyclebin/Item.php
+++ b/models/Element/Recyclebin/Item.php
@@ -119,11 +119,10 @@ class Item extends Model\AbstractModel
      * When restoring or checking for permissions on deleted files, cannot be guaranteed that the direct parent path
      * still exists, therefore, we need to find the closest existing parent and use that path for the permissions.
      */
-    public function getClosestExistingParent(): AbstractElement
+    public function getClosestExistingParent(): ElementInterface
     {
         $path = $this->getPath();
         $explodedPath = explode('/', $path);
-        /** @var AbstractElement|null $obj */
         $obj = Service::getElementByPath($this->getType(), $path);
 
         // TODO: this is always false for the moment, due cascade deletion of permissions

--- a/models/Element/Recyclebin/Item.php
+++ b/models/Element/Recyclebin/Item.php
@@ -31,6 +31,7 @@ use Pimcore\Model\Element;
 use Pimcore\Model\Element\AbstractElement;
 use Pimcore\Model\Element\DeepCopy\PimcoreClassDefinitionMatcher;
 use Pimcore\Model\Element\DeepCopy\PimcoreClassDefinitionReplaceFilter;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
 use Pimcore\Tool\Serialize;
 use Pimcore\Tool\Storage;
@@ -68,7 +69,7 @@ class Item extends Model\AbstractModel
     protected $amount = 0;
 
     /**
-     * @var Element\ElementInterface
+     * @var ElementInterface
      */
     protected $element;
 
@@ -85,10 +86,10 @@ class Item extends Model\AbstractModel
     /**
      * @static
      *
-     * @param Element\ElementInterface $element
+     * @param ElementInterface $element
      * @param Model\User|null $user
      */
-    public static function create(Element\ElementInterface $element, Model\User $user = null)
+    public static function create(ElementInterface $element, Model\User $user = null)
     {
         $item = new self();
         $item->setElement($element);
@@ -118,7 +119,7 @@ class Item extends Model\AbstractModel
      * When restoring or checking for permissions on deleted files, cannot be guaranteed that the direct parent path
      * still exists, therefore, we need to find the closest existing parent and use that path for the permissions.
      */
-    public function getClosestExistingParent(): AbstractElement
+    public function getClosestExistingParent(): ElementInterface
     {
         $path = $this->getPath();
         $explodedPath = explode('/', $path);
@@ -192,7 +193,7 @@ class Item extends Model\AbstractModel
 
         if (\Pimcore\Tool\Admin::getCurrentUser()) {
             $parent = $this->getClosestExistingParent();
-            if ($parent && !$parent->isAllowed('publish')) {
+            if (!$parent->isAllowed('publish')) {
                 throw new \Exception('Not sufficient permissions');
             }
         }
@@ -273,10 +274,8 @@ class Item extends Model\AbstractModel
 
         if (\Pimcore\Tool\Admin::getCurrentUser()) {
             $parent = $this->getClosestExistingParent();
-            if ($parent) {
-                if ((!$byRestore && !$parent->isAllowed('delete')) || ($byRestore && !$parent->isAllowed('publish'))){
-                    throw new \Exception('Not sufficient permissions');
-                }
+            if ((!$byRestore && !$parent->isAllowed('delete')) || ($byRestore && !$parent->isAllowed('publish'))){
+                throw new \Exception('Not sufficient permissions');
             }
         }
 
@@ -296,9 +295,9 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param Element\ElementInterface $element
+     * @param ElementInterface $element
      */
-    public function loadChildren(Element\ElementInterface $element)
+    public function loadChildren(ElementInterface $element)
     {
         $this->amount++;
 
@@ -333,14 +332,14 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param Element\ElementInterface $element
+     * @param ElementInterface $element
      *
      * @throws \Exception
      */
-    protected function doRecursiveRestore(Element\ElementInterface $element)
+    protected function doRecursiveRestore(ElementInterface $element)
     {
         $storage = Storage::get('recycle_bin');
-        $restoreBinaryData = function (Element\ElementInterface $element, self $scope) use ($storage) {
+        $restoreBinaryData = function (ElementInterface $element, self $scope) use ($storage) {
             // assets are kinda special because they can contain massive amount of binary data which isn't serialized, we create separate files for them
             if ($element instanceof Asset) {
                 $binFile = $scope->getStorageFileBinary($element);
@@ -377,7 +376,7 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param Element\ElementInterface $data
+     * @param ElementInterface $data
      *
      * @return mixed
      */
@@ -408,7 +407,7 @@ class Item extends Model\AbstractModel
                 public function matches($element)
                 {
                     //compress only elements with full_dump_state = false
-                    return $element instanceof Element\ElementInterface && $element instanceof Element\ElementDumpStateInterface && !($element->isInDumpState());
+                    return $element instanceof ElementInterface && $element instanceof Element\ElementDumpStateInterface && !($element->isInDumpState());
                 }
             }
         );
@@ -433,9 +432,9 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param Element\ElementInterface $data
+     * @param ElementInterface $data
      *
-     * @return Element\ElementInterface
+     * @return ElementInterface
      */
     public function unmarshalData($data)
     {
@@ -472,7 +471,7 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param Element\ElementInterface $element
+     * @param ElementInterface $element
      *
      * @return string
      */
@@ -602,7 +601,7 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @return Element\ElementInterface
+     * @return ElementInterface
      */
     public function getElement()
     {
@@ -610,7 +609,7 @@ class Item extends Model\AbstractModel
     }
 
     /**
-     * @param Element\ElementInterface $element
+     * @param ElementInterface $element
      *
      * @return $this
      */

--- a/models/Element/Recyclebin/Item.php
+++ b/models/Element/Recyclebin/Item.php
@@ -119,10 +119,11 @@ class Item extends Model\AbstractModel
      * When restoring or checking for permissions on deleted files, cannot be guaranteed that the direct parent path
      * still exists, therefore, we need to find the closest existing parent and use that path for the permissions.
      */
-    public function getClosestExistingParent(): ElementInterface
+    public function getClosestExistingParent(): AbstractElement
     {
         $path = $this->getPath();
         $explodedPath = explode('/', $path);
+        /** @var AbstractElement $obj */
         $obj = Service::getElementByPath($this->getType(), $path);
 
         // TODO: this is always false for the moment, due cascade deletion of permissions


### PR DESCRIPTION
## Changes in this pull request  
Partially Resolves https://github.com/pimcore/pimcore/issues/14649

Before PR, the recycle bin is more like an admin power tool with few limitations, after PR, it could be used to list only and the permission of list/restore/delete is more clear and consider the rules of the workspaces. 

Copied `getPermittedPaths` which was already used in the Search grids and adapted column names in the query.
The `array_pop($explodedPath);` part is crucial for the moment, since the workspace rules are deleted as soon as the deletion is successful, we don't have any permissions rule specific to the element itself, so we look for the closest existing parent and consider its permissions rules.
On frontend/js side, the buttons got refactored, now they are disabled when selected elements do not have delete/publish permissions (from parent), all these loops and switch on/off to works on group selection.
The flush seems having a problem with the `/` when using AWS adapter of flysystem. Added a fallback that goes through each file


For 11.1, eventually would be able to avoid deleting the permission on specific element by removing the foreign key cascade deletion via a migration.

## Additional info
TODO:  still need to decide wheter `Flush Recycle Bin` should be possible for non-admin and in case refactor to follow the individual `delete` permissions, beside fixing the sonarcloud code smell and code duplication warnings

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8dcaac</samp>

This pull request enhances the recycle bin feature by adding more fine-grained permission checks for the items in the bin. It filters the items based on the user's permissions to publish or delete them, and disables the restore and delete actions accordingly. It also refactors some code in the `RecyclebinController` and the `recyclebin.js` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e8dcaac</samp>

> _Recycle bin fix_
> _`let` replaces `var` now_
> _Winter code cleanup_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e8dcaac</samp>

*  Add permission checks to recycle bin items to prevent non-admin users from seeing or restoring items that they do not have access to ([link](https://github.com/pimcore/pimcore/pull/15470/files?diff=unified&w=0#diff-7e7188e826846ef57b038c8911b723bd73a5adabd565f7d55dee6935cf04daa8R22), [link](https://github.com/pimcore/pimcore/pull/15470/files?diff=unified&w=0#diff-7e7188e826846ef57b038c8911b723bd73a5adabd565f7d55dee6935cf04daa8R128-R131), [link](https://github.com/pimcore/pimcore/pull/15470/files?diff=unified&w=0#diff-7e7188e826846ef57b038c8911b723bd73a5adabd565f7d55dee6935cf04daa8L132-R172), [link](https://github.com/pimcore/pimcore/pull/15470/files?diff=unified&w=0#diff-7e7188e826846ef57b038c8911b723bd73a5adabd565f7d55dee6935cf04daa8L144-R236), [link](https://github.com/pimcore/pimcore/pull/15470/files?diff=unified&w=0#diff-c95f9fb24e59d7c9b0db451020317a0e08c2b6b64b4a0ff2455d1bedbe3cda2eL190-R249), [link](https://github.com/pimcore/pimcore/pull/15470/files?diff=unified&w=0#diff-c95f9fb24e59d7c9b0db451020317a0e08c2b6b64b4a0ff2455d1bedbe3cda2eL217-R255))
  * Use `Service` class from `Element` namespace to get forbidden and allowed paths for each element type in `RecyclebinController.php` ([link](https://github.com/pimcore/pimcore/pull/15470/files?diff=unified&w=0#diff-7e7188e826846ef57b038c8911b723bd73a5adabd565f7d55dee6935cf04daa8R22), [link](https://github.com/pimcore/pimcore/pull/15470/files?diff=unified&w=0#diff-7e7188e826846ef57b038c8911b723bd73a5adabd565f7d55dee6935cf04daa8L144-R236))
  * Filter the query for recycle bin items based on the user's permissions in `listAction` method in `RecyclebinController.php` ([link](https://github.com/pimcore/pimcore/pull/15470/files?diff=unified&w=0#diff-7e7188e826846ef57b038c8911b723bd73a5adabd565f7d55dee6935cf04daa8R128-R131))
  * Handle the case when the original element is not found and use the closest existing parent element's permissions as a fallback in `listAction` method in `RecyclebinController.php` ([link](https://github.com/pimcore/pimcore/pull/15470/files?diff=unified&w=0#diff-7e7188e826846ef57b038c8911b723bd73a5adabd565f7d55dee6935cf04daa8L132-R172))
  * Update the state of the restore and delete buttons and menu items based on the permissions of the selected items in `recyclebin.js` ([link](https://github.com/pimcore/pimcore/pull/15470/files?diff=unified&w=0#diff-c95f9fb24e59d7c9b0db451020317a0e08c2b6b64b4a0ff2455d1bedbe3cda2eL190-R249), [link](https://github.com/pimcore/pimcore/pull/15470/files?diff=unified&w=0#diff-c95f9fb24e59d7c9b0db451020317a0e08c2b6b64b4a0ff2455d1bedbe3cda2eL217-R255))
* Simplify the code that gets the element by its type and id in `addAction` method in `RecyclebinController.php` by removing the redundant `Element\` prefix ([link](https://github.com/pimcore/pimcore/pull/15470/files?diff=unified&w=0#diff-7e7188e826846ef57b038c8911b723bd73a5adabd565f7d55dee6935cf04daa8L186-R278))
