### PR TITLE
fix: high res PDF thumbnails always display page 1

### DIFF
--- a/bundles/CoreBundle/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/Controller/PublicServicesController.php
@@ -117,7 +117,7 @@ class PublicServicesController extends Controller
                         }
                     } elseif ($asset instanceof Asset\Document) {
                         $page = 1;
-                        if (preg_match("|~\-~page\-(\d+)\.|", $filename, $matchesThumbs)) {
+                        if (preg_match("|~\-~page\-(\d+)(@[0-9.]+x)?\.|", $filename, $matchesThumbs)) {
                             $page = (int)$matchesThumbs[1];
                         }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15479

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c7a585d</samp>

Fix thumbnail resolution for document assets. Update the regex in `PublicServicesController.php` to include the resolution suffix in the thumbnail filename.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c7a585d</samp>

> _`regex` updated_
> _to match resolution suffix_
> _thumbnails respect size_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c7a585d</samp>

* Fix bug in thumbnail generation for document assets by updating the regular expression to include the resolution suffix ([link](https://github.com/pimcore/pimcore/pull/15480/files?diff=unified&w=0#diff-80c761bc7a7fb7998e853a73bfc7ddb1a083639cc26b42c314ffa845633d94acL120-R120))
