### PR TITLE
[Bug]: Handle possibly non-existing Template attribute

### DIFF
--- a/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
@@ -74,16 +74,7 @@ class ContentTemplateListener implements EventSubscriberInterface
             return;
         }
 
-        if (!$attribute instanceof Template) {
-            $event->setResponse(
-                new Response(
-                    $this->twig->render($resolvedTemplate, $event->controllerArgumentsEvent->getNamedArguments())
-                )
-            );
-            return;
-        }
-
-        $parameters = $this->resolveParameters($event->controllerArgumentsEvent, $attribute->vars);
+        $parameters = $this->resolveParameters($event->controllerArgumentsEvent, $attribute?->vars);
         $status = 200;
 
         if (interface_exists('Symfony\\Component\\Form\\FormInterface')) {
@@ -98,7 +89,7 @@ class ContentTemplateListener implements EventSubscriberInterface
             }
         }
 
-        $event->setResponse($attribute->stream
+        $event->setResponse(($attribute instanceof Template && $attribute->stream)
             ? new StreamedResponse(fn () => $this->twig->display($resolvedTemplate, $parameters), $status)
             : new Response($this->twig->render($resolvedTemplate, $parameters), $status)
         );
@@ -106,10 +97,6 @@ class ContentTemplateListener implements EventSubscriberInterface
 
     private function resolveParameters(ControllerArgumentsEvent $event, ?array $vars): array
     {
-        if ([] === $vars) {
-            return [];
-        }
-
         $parameters = $event->getNamedArguments();
 
         if (null !== $vars) {

--- a/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
@@ -67,7 +67,7 @@ class ContentTemplateListener implements EventSubscriberInterface
             return;
         }
 
-        $attribute = $event->controllerArgumentsEvent?->getAttributes()[Template::class][0];
+        $attribute = $event->controllerArgumentsEvent?->getAttributes()[Template::class][0] ?? null;
 
         if (!$attribute instanceof Template) {
             return;

--- a/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
@@ -68,14 +68,18 @@ class ContentTemplateListener implements EventSubscriberInterface
         }
 
         $attribute = $event->controllerArgumentsEvent?->getAttributes()[Template::class][0] ?? null;
-
-        if (!$attribute instanceof Template) {
-            return;
-        }
-
         $resolvedTemplate = $this->templateResolver->getTemplate($request);
         if (null === $resolvedTemplate) {
             // no contentTemplate on the request -> nothing to do
+            return;
+        }
+
+        if (!$attribute instanceof Template) {
+            $event->setResponse(
+                new Response(
+                    $this->twig->render($resolvedTemplate, $event->controllerArgumentsEvent->getNamedArguments())
+                )
+            );
             return;
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Based on https://github.com/pimcore/pimcore/pull/15453
May Resolve
```
ErrorException: "Warning: Undefined array key "Symfony\Bridge\Twig\Attribute\Template""
at /var/www/html/vendor/pimcore/pimcore/bundles/CoreBundle/src/EventListener/Frontend/ContentTemplateListener.php
line 70
```
and
```
An exception has been thrown during the rendering of a template ("The controller must return a "Symfony\Component\HttpFoundation\Response" object but it returned an array ([]).").
```

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c944d0e</samp>

This pull request enhances the `ContentTemplateListener` class to simplify the logic for resolving template names from annotations and fallbacks. It also allows using the `@Template` annotation without specifying a template name explicitly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c944d0e</samp>

> _We're the ContentTemplate crew, we know what to do_
> _We use the `??` operator to simplify our view_
> _We support the `@Template` annotation with or without a name_
> _We make our code more concise and flexible, that's our aim_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c944d0e</samp>

*  Simplify the code by using the null coalescing operator to assign a default value to `$attribute` ([link](https://github.com/pimcore/pimcore/pull/15485/files?diff=unified&w=0#diff-2f932cea0ff8fb705f8b326c34e77f71766bf96d6b9a40ac2d31371580d5f1deL70-R70))
*  Add a new condition to handle the case when `$attribute` is not an instance of `Template` ([link](https://github.com/pimcore/pimcore/pull/15485/files?diff=unified&w=0#diff-2f932cea0ff8fb705f8b326c34e77f71766bf96d6b9a40ac2d31371580d5f1deR77-R85))
