### PR TITLE
Fix the type error in saving a document link

### DIFF
--- a/models/Document/Link.php
+++ b/models/Document/Link.php
@@ -230,7 +230,7 @@ class Link extends Model\Document
         return $this->linktype;
     }
 
-    public function setInternal(int $internal): static
+    public function setInternal(?int $internal): static
     {
         if (!empty($internal)) {
             $this->internal = $internal;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
Create a document link and try to save it 
<img width="819" alt="Screenshot 2023-07-06 135752" src="https://github.com/pimcore/pimcore/assets/97134765/fb6afdfe-a171-424c-abef-c80b6d5ee6f1">

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bfa3bd6</samp>

Fix internal link ID bug in `Link` class. Allow `setInternal` method to accept null values and handle them correctly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bfa3bd6</samp>

> _`setInternal` changed_
> _nullable integer now_
> _autumn bug is fixed_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bfa3bd6</samp>

* Fix a bug where the internal link ID was not properly saved or loaded in the admin interface ([link](https://github.com/pimcore/pimcore/pull/15486/files?diff=unified&w=0#diff-846d942949cbc1aa247a67f632de47fdd9d3e0affe63dec1755f3a5a16097fabL233-R233))
