### PR TITLE
Feat: using object brick multiple time over one object across different fields

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
@@ -1105,7 +1105,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
                             continue;
                         }
 
-                        $key = $brickDefinition->getKey();
+                        $key = sprintf("%s@%s", $brickDefinition->getKey(), $fieldName);
 
                         $brickLayoutDefinitions = $brickDefinition->getLayoutDefinitions();
                         $context = [
@@ -1116,11 +1116,10 @@ class ClassController extends AdminAbstractController implements KernelControlle
                         DataObject\Service::enrichLayoutDefinition($brickLayoutDefinitions, null, $context);
 
                         $result[$key]['nodeLabel'] = $key;
+                        $result[$key]['brickType'] = $brickDefinition->getKey();
                         $result[$key]['brickField'] = $fieldName;
                         $result[$key]['nodeType'] = 'objectbricks';
                         $result[$key]['children'] = $brickLayoutDefinitions->getChildren();
-
-                        break;
                     }
                 }
             }

--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -446,6 +446,13 @@ class DataObjectHelperController extends AdminAbstractController
                             }
 
                             $fieldname = $keyParts[1];
+                            $brickName = null;
+                            if (strpos($fieldname, '.')) {
+                                $p = explode('.', $fieldname);
+                                $fieldname = $p[1];
+                                $brickName = $p[0];
+                                $keyPrefix .= $brickName . '.';
+                            }
 
                             $brickClass = DataObject\Objectbrick\Definition::getByKey($brick);
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/classTree.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/classTree.js
@@ -142,7 +142,7 @@ pimcore.object.helpers.classTree = Class.create({
                     if (data[keys[i]].nodeType == "objectbricks") {
                         brickDescriptor = {
                             insideBrick: true,
-                            brickType: data[keys[i]].nodeLabel,
+                            brickType: data[keys[i]].brickType,
                             brickField: data[keys[i]].brickField
                         };
 
@@ -250,9 +250,9 @@ pimcore.object.helpers.classTree = Class.create({
                         fieldname: brickDescriptor.brickField,
                         brickfield: key
                     }
-                    key = "?" + Ext.encode(parts) + "~" + key;
+                    key = "?" + Ext.encode(parts) + "~" + brickDescriptor.brickField + '.' + key;
                 } else {
-                    key = brickDescriptor.brickType + "~" + key;
+                    key = brickDescriptor.brickType + "~" + brickDescriptor.brickField + '.' + key;
                 }
             }
 

--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbricks/field.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/objectbricks/field.js
@@ -237,6 +237,7 @@ pimcore.object.objectbricks.field = Class.create(pimcore.object.classes.klass, {
             store: fieldComboStore,
             displayField: 'key',
             valueField: 'key',
+            multiSelect: true,
             name: 'fieldname',
             disableKeyFilter: "true",
             valueNotFoundText: "",

--- a/models/DataObject/ClassDefinition/Data/Objectbricks.php
+++ b/models/DataObject/ClassDefinition/Data/Objectbricks.php
@@ -238,7 +238,7 @@ class Objectbricks extends Data implements CustomResourcePersistingInterface, Ty
             $refKey = $key;
             $refId = null;
 
-            $relations = $item->getRelationData($refKey, true, $refId);
+            $relations = $item->getRelationData($refKey, true, $refId, $params["fieldname"]);
             if (empty($relations) && !empty($parent)) {
                 $parentItem = $parent->{'get' . ucfirst($this->getName())}();
                 if (!empty($parentItem)) {

--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -101,7 +101,8 @@ class Dao extends Model\Dao\AbstractDao
             $isBrickUpdate = false; // used to indicate whether we want to consider the default value
         } else {
             // or brick has been added
-            $existsResult = $this->db->fetchOne('SELECT o_id FROM ' . $storetable . ' WHERE o_id = ? LIMIT 1', [$object->getId()]);
+            $sql = 'SELECT o_id FROM ' . $storetable . ' WHERE o_id = ? AND fieldname = ? LIMIT 1';
+            $existsResult = $this->db->fetchOne($sql, [$object->getId(), $params["fieldname"]]);
             $isBrickUpdate = $existsResult ? true : false;  // used to indicate whether we want to consider the default value
         }
 
@@ -158,7 +159,7 @@ class Dao extends Model\Dao\AbstractDao
         }
 
         if ($isBrickUpdate) {
-            $this->db->update($storetable, $data, ['o_id'=> $object->getId()]);
+            $this->db->update($storetable, $data, ['o_id'=> $object->getId(), 'fieldname' => $params["fieldname"]]);
         } else {
             $this->db->insert($storetable, $data);
         }

--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -373,7 +373,7 @@ class Dao extends Model\Dao\AbstractDao
      *
      * @return array
      */
-    public function getRelationData($field, $forOwner, $remoteClassId)
+    public function getRelationData($field, $forOwner, $remoteClassId, $brickField)
     {
         $id = $this->model->getObject()->getId();
         if ($remoteClassId) {
@@ -382,7 +382,7 @@ class Dao extends Model\Dao\AbstractDao
             $classId = $this->model->getObject()->getClassId();
         }
 
-        $params = [$field, $id, $field, $id, $field, $id];
+        $params = [$brickField, $field, $id, $brickField, $field, $id, $brickField, $field, $id];
 
         $dest = 'dest_id';
         $src = 'src_id';
@@ -393,7 +393,8 @@ class Dao extends Model\Dao\AbstractDao
 
         $relations = $this->db->fetchAllAssociative('SELECT r.' . $dest . ' as dest_id, r.' . $dest . ' as id, r.type, o.o_className as subtype, concat(o.o_path ,o.o_key) as path , r.index, o.o_published as published
             FROM objects o, object_relations_' . $classId . " r
-            WHERE r.fieldname= ?
+            WHERE r.ownername= ?
+            AND r.fieldname= ?
             AND r.ownertype = 'objectbrick'
             AND r." . $src . ' = ?
             AND o.o_id = r.' . $dest . "
@@ -402,7 +403,8 @@ class Dao extends Model\Dao\AbstractDao
 
             UNION SELECT r." . $dest . ' as dest_id, r.' . $dest . ' as id, r.type,  a.type as subtype,  concat(a.path,a.filename) as path, r.index, "null" as published
             FROM assets a, object_relations_' . $classId . " r
-            WHERE r.fieldname= ?
+            WHERE r.ownername= ?
+            AND r.fieldname= ?
             AND r.ownertype = 'objectbrick'
             AND r." . $src . ' = ?
             AND a.id = r.' . $dest . "
@@ -411,7 +413,8 @@ class Dao extends Model\Dao\AbstractDao
 
             UNION SELECT r." . $dest . ' as dest_id, r.' . $dest . ' as id, r.type, d.type as subtype, concat(d.path,d.key) as path, r.index, d.published as published
             FROM documents d, object_relations_' . $classId . " r
-            WHERE r.fieldname= ?
+            WHERE r.ownername= ?
+            AND r.fieldname= ?
             AND r.ownertype = 'objectbrick'
             AND r." . $src . ' = ?
             AND d.id = r.' . $dest . "

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -377,6 +377,12 @@ class Service extends Model\Element\Service
 
                     $key = self::getFieldForBrickType($object->getclass(), $brickType);
 
+                    if (strpos($brickKey, '.')) {
+                        $p = explode('.', $brickKey);
+                        $brickKey = $p[1];
+                        $key = $p[0];
+                    }
+
                     $brickClass = Objectbrick\Definition::getByKey($brickType);
                     $context['outerFieldname'] = $key;
 


### PR DESCRIPTION
This was new feature/Idea which should allow developer to assign same object bricks on multiple fields of same DataObject

Grid: user see object brick for each mentioning in that class (_for each field where objectbrick is attached_)

**Issues**
- ~Current issue is manyToOne relation, it share value between bricks~ (_solved in d5a2c4908596cd27f1bd28b8a6cfc76b8dd0b82e_)

