### PR TITLE
[Task]: Improve relation tests

### DIFF
--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyObjectRelation.php
@@ -473,17 +473,19 @@ class AdvancedManyToManyObjectRelation extends ManyToManyObjectRelation implemen
      */
     public function save($object, $params = [])
     {
-        if (!DataObject::isDirtyDetectionDisabled() && $object instanceof Element\DirtyIndicatorInterface) {
-            if ($object instanceof DataObject\Localizedfield) {
-                if ($object->getObject() instanceof Element\DirtyIndicatorInterface) {
-                    if (!$object->hasDirtyFields()) {
-                        return;
+        if (!isset($params['forceSave']) || $params['forceSave'] !== true) {
+            if (!DataObject::isDirtyDetectionDisabled() && $object instanceof Element\DirtyIndicatorInterface) {
+                if ($object instanceof DataObject\Localizedfield) {
+                    if ($object->getObject() instanceof Element\DirtyIndicatorInterface) {
+                        if (!$object->hasDirtyFields()) {
+                            return;
+                        }
                     }
-                }
-            } else {
-                if ($this->supportsDirtyDetection()) {
-                    if (!$object->isFieldDirty($this->getName())) {
-                        return;
+                } else {
+                    if ($this->supportsDirtyDetection()) {
+                        if (!$object->isFieldDirty($this->getName())) {
+                            return;
+                        }
                     }
                 }
             }

--- a/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/AdvancedManyToManyRelation.php
@@ -549,21 +549,24 @@ class AdvancedManyToManyRelation extends ManyToManyRelation implements IdRewrite
      */
     public function save($object, $params = [])
     {
-        if (!DataObject::isDirtyDetectionDisabled() && $object instanceof Element\DirtyIndicatorInterface) {
-            if ($object instanceof DataObject\Localizedfield) {
-                if ($object->getObject() instanceof Element\DirtyIndicatorInterface) {
-                    if (!$object->hasDirtyFields()) {
-                        return;
+        if (!isset($params['forceSave']) || $params['forceSave'] !== true) {
+            if (!DataObject::isDirtyDetectionDisabled() && $object instanceof Element\DirtyIndicatorInterface) {
+                if ($object instanceof DataObject\Localizedfield) {
+                    if ($object->getObject() instanceof Element\DirtyIndicatorInterface) {
+                        if (!$object->hasDirtyFields()) {
+                            return;
+                        }
                     }
-                }
-            } else {
-                if ($this->supportsDirtyDetection()) {
-                    if (!$object->isFieldDirty($this->getName())) {
-                        return;
+                } else {
+                    if ($this->supportsDirtyDetection()) {
+                        if (!$object->isFieldDirty($this->getName())) {
+                            return;
+                        }
                     }
                 }
             }
         }
+
 
         $multihrefMetadata = $this->getDataFromObjectParam($object, $params);
 

--- a/tests/Model/Relations/MultipleAssigmentTest.php
+++ b/tests/Model/Relations/MultipleAssigmentTest.php
@@ -149,6 +149,23 @@ class MultipleAssigmentTest extends ModelTestCase
         }
     }
 
+    protected function checkMultipleAssignmentsOnMultipleManyToManyAfterDelete(array $metaDataList, $positionMessage = '')
+    {
+        $this->assertEquals(8, count($metaDataList), "Relation count $positionMessage.");
+        $number = 0;
+        foreach ($metaDataList as $i => $metadata) {
+            if ($number == 2){
+                continue;
+            }
+            if ($i % 2) {
+                $this->assertEquals("multiple-some-more-metadata $number", $metadata->getMeta(), "Metadata $positionMessage.");
+                $number++;
+            } else {
+                $this->assertEquals("multiple-some-metadata $number", $metadata->getMeta(), "Metadata $positionMessage.");
+            }
+        }
+    }
+
     public function testMultipleAssignmentsMultipleManyToMany()
     {
         $listing = new RelationTest\Listing();
@@ -194,6 +211,17 @@ class MultipleAssigmentTest extends ModelTestCase
         $deserializedObject = unserialize($serializedData);
         $metaDataList = $deserializedObject->getMultipleManyToMany();
         $this->checkMultipleAssignmentsOnMultipleManyToMany($metaDataList, 'after serialize/unserialize');
+
+
+        //delete relationTest element 2
+        $listing[2]->delete();
+
+        //reload data object from database without element 2
+        $object = MultipleAssignments::getById($id, ['force' => true]);
+
+        $metaDataList = $object->getMultipleManyToMany();
+        $this->checkMultipleAssignmentsOnMultipleManyToManyAfterDelete($metaDataList, 'after loading without metadata 2');
+
     }
 
     public function testMultipleAssignmentsMultipleManyToManyObject()

--- a/tests/Model/Relations/MultipleAssigmentTest.php
+++ b/tests/Model/Relations/MultipleAssigmentTest.php
@@ -214,7 +214,7 @@ class MultipleAssigmentTest extends ModelTestCase
 
 
         //delete relationTest element 2
-        $listing[2]->delete();
+        $listing->getItems(2, 1)->delete();
 
         //reload data object from database without element 2
         $object = MultipleAssignments::getById($id, ['force' => true]);


### PR DESCRIPTION
Just opening a PR for tests

## Changes in this pull request  
See https://github.com/pimcore/pimcore/pull/15483

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43fc52e</samp>

This pull request fixes a bug and adds a feature related to object relations in Pimcore. It ensures that the `forceSave` parameter is respected when saving `AdvancedManyToManyRelation` and `AdvancedManyToManyObjectRelation` data. It also adds new tests to verify the multiple assignments functionality of object relations.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 43fc52e</samp>

> _`forceSave` option_
> _bypasses dirty detection_
> _relations updated_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 43fc52e</samp>

*  Add `forceSave` parameter to bypass dirty detection for object relations ([link](https://github.com/pimcore/pimcore/pull/15494/files?diff=unified&w=0#diff-8e4a057e810ba8704021bf022c42ea1800fa97d72cbe86f9c38661f4e95ee5b8L476-R488), [link](https://github.com/pimcore/pimcore/pull/15494/files?diff=unified&w=0#diff-1d0bb2ae86274681b1012717ccb5958660cfdaf177d0c2a3e5f6b1cf039dbf98L552-R564))
*  Remove unnecessary whitespace from `save` method of `AdvancedManyToManyRelation` class ([link](https://github.com/pimcore/pimcore/pull/15494/files?diff=unified&w=0#diff-1d0bb2ae86274681b1012717ccb5958660cfdaf177d0c2a3e5f6b1cf039dbf98R570))
*  Enhance test case for multiple assignments feature of object relations ([link](https://github.com/pimcore/pimcore/pull/15494/files?diff=unified&w=0#diff-124d398dc141806493cdef50ecde9c29f2463dc49bbb147c9aad278e55723d77R152-R168), [link](https://github.com/pimcore/pimcore/pull/15494/files?diff=unified&w=0#diff-124d398dc141806493cdef50ecde9c29f2463dc49bbb147c9aad278e55723d77R214-R224))
