### PR TITLE
Support StatusCodes other than redirects in RedirectHandler 

### DIFF
--- a/lib/Routing/RedirectHandler.php
+++ b/lib/Routing/RedirectHandler.php
@@ -171,7 +171,7 @@ final class RedirectHandler implements LoggerAwareInterface
      * @param Request $request
      * @param array $matches
      *
-     * @return RedirectResponse|null
+     * @return Response|RedirectResponse|null
      *
      * @throws \Exception
      */

--- a/lib/Routing/RedirectHandler.php
+++ b/lib/Routing/RedirectHandler.php
@@ -89,7 +89,7 @@ final class RedirectHandler implements LoggerAwareInterface
      * @param bool $override
      * @param Site|null $sourceSite
      *
-     * @return RedirectResponse|null
+     * @return Response|RedirectResponse|null
      *
      * @throws \Exception
      */
@@ -127,7 +127,7 @@ final class RedirectHandler implements LoggerAwareInterface
      * @param RedirectUrlPartResolver $partResolver
      * @param Site|null $sourceSite
      *
-     * @return RedirectResponse|null
+     * @return Response|RedirectResponse|null
      *
      * @throws \Exception
      */

--- a/lib/Routing/RedirectHandler.php
+++ b/lib/Routing/RedirectHandler.php
@@ -171,7 +171,7 @@ final class RedirectHandler implements LoggerAwareInterface
      * @param Request $request
      * @param array $matches
      *
-     * @return Response|RedirectResponse|null
+     * @return Response|null
      *
      * @throws \Exception
      */

--- a/lib/Routing/RedirectHandler.php
+++ b/lib/Routing/RedirectHandler.php
@@ -89,7 +89,7 @@ final class RedirectHandler implements LoggerAwareInterface
      * @param bool $override
      * @param Site|null $sourceSite
      *
-     * @return Response|RedirectResponse|null
+     * @return Response|null
      *
      * @throws \Exception
      */

--- a/lib/Routing/RedirectHandler.php
+++ b/lib/Routing/RedirectHandler.php
@@ -244,7 +244,12 @@ final class RedirectHandler implements LoggerAwareInterface
         }
 
         $statusCode = $redirect->getStatusCode() ?: Response::HTTP_MOVED_PERMANENTLY;
-        $response = new RedirectResponse($url, $statusCode);
+        $response = new Response(null, $statusCode);
+        
+        if ($response->isRedirect()) {
+            $response = new RedirectResponse($url, $statusCode);
+        }
+        
         $response->headers->set(self::RESPONSE_HEADER_NAME_ID, (string) $redirect->getId());
 
         // log all redirects to the redirect log

--- a/lib/Routing/RedirectHandler.php
+++ b/lib/Routing/RedirectHandler.php
@@ -127,7 +127,7 @@ final class RedirectHandler implements LoggerAwareInterface
      * @param RedirectUrlPartResolver $partResolver
      * @param Site|null $sourceSite
      *
-     * @return Response|RedirectResponse|null
+     * @return Response|null
      *
      * @throws \Exception
      */


### PR DESCRIPTION
Follow up / Bugfix to https://github.com/pimcore/pimcore/pull/12088

Currently setting 410 status code in the dispatched event results in error 

> Uncaught Exception: The HTTP status code is not a redirect (\"410\" given).","context":{"exception":{"class":"InvalidArgumentException","message":"The HTTP status code is not a redirect (\"410\" given).","code":0,"file":"/var/www/html/vendor/symfony/http-foundation/RedirectResponse.php:42"}

See https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/HttpFoundation/RedirectResponse.php#L42

With this PR also status codes other than redirects can be handled.