### PR TITLE
[Bug]: Fix Document paste inheritance infinite loop

### DIFF
--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -413,25 +413,25 @@ abstract class PageSnippet extends Model\Document
             return $editables[$name];
         }
 
+        $inheritedEditable = null;
         if (array_key_exists($name, $this->inheritedEditables)) {
-            return $this->inheritedEditables[$name];
+            $inheritedEditable = $this->inheritedEditables[$name];
         }
 
-        // check for content main document (inherit data)
-        if ($contentMainDocument = $this->getContentMainDocument()) {
+        if (!$inheritedEditable) {
+            // check for content main document (inherit data)
+            $contentMainDocument = $this->getContentMainDocument();
             if ($contentMainDocument instanceof self && $contentMainDocument->getId() != $this->getId()) {
                 $inheritedEditable = $contentMainDocument->getEditable($name);
                 if ($inheritedEditable) {
                     $inheritedEditable = clone $inheritedEditable;
                     $inheritedEditable->setInherited(true);
                     $this->inheritedEditables[$name] = $inheritedEditable;
-
-                    return $inheritedEditable;
                 }
             }
         }
 
-        return null;
+        return $inheritedEditable;
     }
 
     /**

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -419,7 +419,7 @@ abstract class PageSnippet extends Model\Document
 
         // check for content main document (inherit data)
         if ($contentMainDocument = $this->getContentMainDocument()) {
-            if ($contentMainDocument instanceof self) {
+            if ($contentMainDocument instanceof self && $contentMainDocument->getId() != $this->getId()) {
                 $inheritedEditable = $contentMainDocument->getEditable($name);
                 if ($inheritedEditable) {
                     $inheritedEditable = clone $inheritedEditable;

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -211,6 +211,7 @@ class Service extends Model\Element\Service
 
         if ($enableInheritance && ($new instanceof Document\PageSnippet) && $new->supportsContentMain()) {
             $new->setEditables([]);
+            $new->setMissingRequiredEditable([]);
             $new->setContentMainDocumentId($source->getId(), true);
         }
 

--- a/models/Document/Service.php
+++ b/models/Document/Service.php
@@ -211,7 +211,7 @@ class Service extends Model\Element\Service
 
         if ($enableInheritance && ($new instanceof Document\PageSnippet) && $new->supportsContentMain()) {
             $new->setEditables([]);
-            $new->setMissingRequiredEditable([]);
+            $new->setMissingRequiredEditable(false);
             $new->setContentMainDocumentId($source->getId(), true);
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Potentially resolves https://github.com/pimcore/pimcore/issues/15428

## Additional info

The crash is caused somewhere in `checkMissingRequiredEditable` in the `$editable = $documentCopy->getEditable($editableName);` recursion. Somehow it end up in a document that has own id as ContentMainDocument
https://github.com/pimcore/pimcore/blob/bdc9a2dcd6d75403a3a1750c4c117fc8e1ea541e/models/Document/PageSnippet.php#L590-L624

Since it's already setting to empty on the line above the change and it is for copy paste operation, i guess there's no need this check anyways. 


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d0e5144</samp>

Fix error when copying document with required editables. Set `missingRequiredEditable` to false for new document in `models/Document/Service.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d0e5144</samp>

> _Copy document_
> _`missingRequiredEditable` false_
> _No error in spring_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d0e5144</samp>

* Fix issue #10212 by setting `missingRequiredEditable` to false when copying a document with required editables ([link](https://github.com/pimcore/pimcore/pull/15504/files?diff=unified&w=0#diff-be2f2234588c6da18c7b5b84a009810bbe0efe6be173d1b2a219147eb0966794R214))
