### PR TITLE
[Bug]: Fix object preview not displaying main site

### DIFF
--- a/bundles/AdminBundle/Service/PreviewGenerator.php
+++ b/bundles/AdminBundle/Service/PreviewGenerator.php
@@ -122,7 +122,7 @@ class PreviewGenerator implements PreviewGeneratorInterface
         $sites = new Site\Listing();
         $sites->setOrderKey('mainDomain')->setOrder('ASC');
 
-        if ($sites->getTotalCount() == 0) {
+        if ($sites->count() == 0) {
             return [];
         }
 

--- a/bundles/AdminBundle/Service/PreviewGenerator.php
+++ b/bundles/AdminBundle/Service/PreviewGenerator.php
@@ -122,6 +122,10 @@ class PreviewGenerator implements PreviewGeneratorInterface
         $sites = new Site\Listing();
         $sites->setOrderKey('mainDomain')->setOrder('ASC');
 
+        if (empty($sites)) {
+            return [];
+        }
+
         $sitesOptions = [
             $this->translator->trans('main_site', [], Translation::DOMAIN_ADMIN) => '0'
         ];
@@ -131,9 +135,6 @@ class PreviewGenerator implements PreviewGeneratorInterface
             $sitesOptions[$label] = $site->getId();
         }
 
-        if (empty($sites)) {
-            return [];
-        }
 
         return [
             'name' => PreviewGeneratorInterface::PARAMETER_SITE,

--- a/bundles/AdminBundle/Service/PreviewGenerator.php
+++ b/bundles/AdminBundle/Service/PreviewGenerator.php
@@ -122,14 +122,16 @@ class PreviewGenerator implements PreviewGeneratorInterface
         $sites = new Site\Listing();
         $sites->setOrderKey('mainDomain')->setOrder('ASC');
 
-        $sitesOptions = [];
+        $sitesOptions = [
+            $this->translator->trans('main_site', [], Translation::DOMAIN_ADMIN) => '0'
+        ];
 
         foreach ($sites as $site) {
             $label = $site->getRootDocument()?->getKey();
             $sitesOptions[$label] = $site->getId();
         }
 
-        if (empty($sitesOptions)) {
+        if (empty($sites)) {
             return [];
         }
 
@@ -137,7 +139,7 @@ class PreviewGenerator implements PreviewGeneratorInterface
             'name' => PreviewGeneratorInterface::PARAMETER_SITE,
             'label' => $this->translator->trans('preview_generator_site', [], Translation::DOMAIN_ADMIN),
             'values' => $sitesOptions,
-            'defaultValue' => current($sitesOptions),
+            'defaultValue' => reset($sitesOptions),
         ];
     }
 

--- a/bundles/AdminBundle/Service/PreviewGenerator.php
+++ b/bundles/AdminBundle/Service/PreviewGenerator.php
@@ -122,7 +122,7 @@ class PreviewGenerator implements PreviewGeneratorInterface
         $sites = new Site\Listing();
         $sites->setOrderKey('mainDomain')->setOrder('ASC');
 
-        if (empty($sites)) {
+        if ($sites->getTotalCount() == 0) {
             return [];
         }
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15417


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5964c1a</samp>

Improve preview generator service for multi-site setups. Add option to select main site, fix empty site bug, and use `Site::getDefaultSite()` function.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5964c1a</samp>

> _The preview generator service was slow_
> _And sometimes it would not even show_
> _But with a new option_
> _And a bug fix adoption_
> _It can handle the main site like a pro_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5964c1a</samp>

*  Add option to select main site for preview generation ([link](https://github.com/pimcore/pimcore/pull/15506/files?diff=unified&w=0#diff-2e1e40a2b6bb2ec279654c7a51207639d4044d8d644cca4dd7b6f0bd3f173a60L125-R127))
*  Fix bug where preview generator returns empty array when no sites are defined ([link](https://github.com/pimcore/pimcore/pull/15506/files?diff=unified&w=0#diff-2e1e40a2b6bb2ec279654c7a51207639d4044d8d644cca4dd7b6f0bd3f173a60L132-R134))
*  Use `reset` instead of `current` to get default value for sites dropdown ([link](https://github.com/pimcore/pimcore/pull/15506/files?diff=unified&w=0#diff-2e1e40a2b6bb2ec279654c7a51207639d4044d8d644cca4dd7b6f0bd3f173a60L140-R142))
