### PR TITLE
Fix error on - Trying to access array offset

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Geobounds.php
+++ b/models/DataObject/ClassDefinition/Data/Geobounds.php
@@ -203,7 +203,7 @@ class Geobounds extends AbstractGeo implements
      */
     public function getDataFromEditmode($data, $object = null, $params = [])
     {
-        if ($data && $data['NElongitude'] !== null && $data['NElatitude'] !== null && $data['SWlongitude'] !== null && $data['SWlatitude'] !== null) {
+        if (is_array($data) && $data['NElongitude'] !== null && $data['NElatitude'] !== null && $data['SWlongitude'] !== null && $data['SWlatitude'] !== null) {
             $ne = new DataObject\Data\GeoCoordinates($data['NElatitude'], $data['NElongitude']);
             $sw = new DataObject\Data\GeoCoordinates($data['SWlatitude'], $data['SWlongitude']);
 

--- a/models/DataObject/ClassDefinition/Data/Geobounds.php
+++ b/models/DataObject/ClassDefinition/Data/Geobounds.php
@@ -203,7 +203,7 @@ class Geobounds extends AbstractGeo implements
      */
     public function getDataFromEditmode($data, $object = null, $params = [])
     {
-        if ($data['NElongitude'] !== null && $data['NElatitude'] !== null && $data['SWlongitude'] !== null && $data['SWlatitude'] !== null) {
+        if ($data && $data['NElongitude'] !== null && $data['NElatitude'] !== null && $data['SWlongitude'] !== null && $data['SWlatitude'] !== null) {
             $ne = new DataObject\Data\GeoCoordinates($data['NElatitude'], $data['NElongitude']);
             $sw = new DataObject\Data\GeoCoordinates($data['SWlatitude'], $data['SWlongitude']);
 


### PR DESCRIPTION
Fix error on "Trying to access array offset on value of type null" when clearing the Geobounds Field in in the backend using the "Empty" button.