### PR TITLE
Allow configuring Argon2 password hashes only if the algorithm exists

### DIFF
--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -1265,8 +1265,8 @@ final class Configuration implements ConfigurationInterface
                                     ->values(array_filter([
                                         PASSWORD_DEFAULT,
                                         PASSWORD_BCRYPT,
-                                        defined('PASSWORD_ARGON2I') ? PASSWORD_ARGON2I : null,
-                                        defined('PASSWORD_ARGON2ID') ? PASSWORD_ARGON2ID : null,
+                                        defined('PASSWORD_ARGON2I') ? \PASSWORD_ARGON2I : null,
+                                        defined('PASSWORD_ARGON2ID') ? \PASSWORD_ARGON2ID : null,
                                     ]))
                                     ->defaultValue(PASSWORD_DEFAULT)
                                 ->end()

--- a/bundles/CoreBundle/DependencyInjection/Configuration.php
+++ b/bundles/CoreBundle/DependencyInjection/Configuration.php
@@ -1262,7 +1262,12 @@ final class Configuration implements ConfigurationInterface
                                 ->enumNode('algorithm')
                                     ->info('The hashing algorithm to use for backend users and objects containing a "password" field.')
                                     ->example('!php/const PASSWORD_BCRYPT')
-                                    ->values([PASSWORD_DEFAULT, PASSWORD_BCRYPT, PASSWORD_ARGON2I, PASSWORD_ARGON2ID])
+                                    ->values(array_filter([
+                                        PASSWORD_DEFAULT,
+                                        PASSWORD_BCRYPT,
+                                        defined('PASSWORD_ARGON2I') ? PASSWORD_ARGON2I : null,
+                                        defined('PASSWORD_ARGON2ID') ? PASSWORD_ARGON2ID : null,
+                                    ]))
                                     ->defaultValue(PASSWORD_DEFAULT)
                                 ->end()
                                 ->arrayNode('options')


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/pull/14297#issuecomment-1631978988

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f337068</samp>

Filter out unsupported hashing algorithms in security configuration. This change prevents errors when using pimcore with PHP versions lower than 7.2.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f337068</samp>

> _`hashing_algorithm`_
> _adapts to PHP versions_
> _autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f337068</samp>

*  Filter out unsupported hashing algorithms for PHP versions lower than 7.2 in the security configuration ([link](https://github.com/pimcore/pimcore/pull/15518/files?diff=unified&w=0#diff-8a52499b820e9a8b0948d28098c6b4e0791a4c1791116fccac874b31e149fe32L1265-R1270))
