### PR TITLE
[Bug]: Quote sorting key

### DIFF
--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -571,8 +571,7 @@ class GridHelperService
                     if (strpos($orderKey, '?') !== false) {
                         $brickDescriptor = substr($orderKeyParts[0], 1);
                         $brickDescriptor = json_decode($brickDescriptor, true);
-                        $db = Db::get();
-                        $orderKey = $db->quoteIdentifier($brickDescriptor['containerKey'] . '_localized') . '.' . $db->quoteIdentifier($brickDescriptor['brickfield']);
+                        $orderKey = $list->quoteIdentifier($brickDescriptor['containerKey'] . '_localized') . '.' . $list->quoteIdentifier($brickDescriptor['brickfield']);
                         $doNotQuote = true;
                     } elseif (count($orderKeyParts) === 2) {
                         $orderKey = $list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1]);

--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -575,7 +575,7 @@ class GridHelperService
                         $orderKey = $db->quoteIdentifier($brickDescriptor['containerKey'] . '_localized') . '.' . $db->quoteIdentifier($brickDescriptor['brickfield']);
                         $doNotQuote = true;
                     } elseif (count($orderKeyParts) === 2) {
-                        $orderKey = $orderKeyParts[0].'.'.$orderKeyParts[1];
+                        $orderKey = $list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1]);
                         $doNotQuote = true;
                     }
                 } else {

--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -571,11 +571,11 @@ class GridHelperService
                     if (strpos($orderKey, '?') !== false) {
                         $brickDescriptor = substr($orderKeyParts[0], 1);
                         $brickDescriptor = json_decode($brickDescriptor, true);
-                        $orderKey = $list->quoteIdentifier($brickDescriptor['containerKey'] . '_localized') 
+                        $orderKey = $list->quoteIdentifier($brickDescriptor['containerKey'] . '_localized')
                             . '.' . $list->quoteIdentifier($brickDescriptor['brickfield']);
                         $doNotQuote = true;
                     } elseif (count($orderKeyParts) === 2) {
-                        $orderKey = $list->quoteIdentifier($orderKeyParts[0]) 
+                        $orderKey = $list->quoteIdentifier($orderKeyParts[0])
                             . '.' . $list->quoteIdentifier($orderKeyParts[1]);
                         $doNotQuote = true;
                     }

--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -579,7 +579,7 @@ class GridHelperService
                         $doNotQuote = true;
                     }
                 } else {
-                    $orderKey = $list->getDao()->getTableName().'.'.$orderKey;
+                    $orderKey = $list->getDao()->getTableName().'.'.$list->quoteIdentifier($orderKey);
                     $doNotQuote = true;
                 }
             }

--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -580,7 +580,7 @@ class GridHelperService
                         $doNotQuote = true;
                     }
                 } else {
-                    $orderKey = $list->getDao()->getTableName().'.'.$list->quoteIdentifier($orderKey);
+                    $orderKey = $list->getDao()->getTableName() . '.' . $list->quoteIdentifier($orderKey);
                     $doNotQuote = true;
                 }
             }

--- a/bundles/AdminBundle/Helper/GridHelperService.php
+++ b/bundles/AdminBundle/Helper/GridHelperService.php
@@ -571,10 +571,12 @@ class GridHelperService
                     if (strpos($orderKey, '?') !== false) {
                         $brickDescriptor = substr($orderKeyParts[0], 1);
                         $brickDescriptor = json_decode($brickDescriptor, true);
-                        $orderKey = $list->quoteIdentifier($brickDescriptor['containerKey'] . '_localized') . '.' . $list->quoteIdentifier($brickDescriptor['brickfield']);
+                        $orderKey = $list->quoteIdentifier($brickDescriptor['containerKey'] . '_localized') 
+                            . '.' . $list->quoteIdentifier($brickDescriptor['brickfield']);
                         $doNotQuote = true;
                     } elseif (count($orderKeyParts) === 2) {
-                        $orderKey = $list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1]);
+                        $orderKey = $list->quoteIdentifier($orderKeyParts[0]) 
+                            . '.' . $list->quoteIdentifier($orderKeyParts[1]);
                         $doNotQuote = true;
                     }
                 } else {


### PR DESCRIPTION
## Additional info
The table doesn't need to be quoted but the `column` name should be.
`$doNotQuote` still need to be `true`, otherwise it would end up `` `table.column` ``

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9f08c9</samp>

Fix SQL errors in grid listing due to unquoted order key. Use `quoteIdentifier` method to escape order key in `GridHelperService.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c9f08c9</samp>

> _`quoteIdentifier`_
> _Fixes SQL bug in grid_
> _Autumn leaves no trace_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c9f08c9</samp>

* Fix a bug where the order key for the grid listing was not quoted properly ([link](https://github.com/pimcore/pimcore/pull/15523/files?diff=unified&w=0#diff-784ceb6fcd03ce729cee15284714f611451fdbca75047cdae68a9d6a127ed37dL582-R582))
