### PR TITLE
Fix Document link marshalling

### DIFF
--- a/models/Document/Link.php
+++ b/models/Document/Link.php
@@ -268,7 +268,7 @@ class Link extends Model\Document
         return $this;
     }
 
-    public function getElement(): ?Model\Element\ElementInterface
+    public function getElement(): Model\Element\ElementInterface|Model\Element\ElementDescriptor|null
     {
         if ($this->object instanceof Model\Element\ElementInterface) {
             return $this->object;
@@ -287,7 +287,7 @@ class Link extends Model\Document
         return $this;
     }
 
-    private function setObjectFromId(): ?Model\Element\ElementInterface
+    private function setObjectFromId(): Model\Element\ElementInterface|Model\Element\ElementDescriptor|null
     {
         try {
             if ($this->internal) {

--- a/models/Document/Link.php
+++ b/models/Document/Link.php
@@ -272,7 +272,7 @@ class Link extends Model\Document
     public function getElement(): ?Model\Element\ElementInterface
     {
         if ($this->object instanceof Model\Element\ElementDescriptor) {
-            return Element\Service::getElementById($this->object->getType(), $this->object->getId());
+            $this->object = Element\Service::getElementById($this->object->getType(), $this->object->getId());
         }
         if ($this->object instanceof Model\Element\ElementInterface) {
             return $this->object;

--- a/models/Document/Link.php
+++ b/models/Document/Link.php
@@ -20,6 +20,7 @@ use Pimcore\Logger;
 use Pimcore\Model;
 use Pimcore\Model\Asset;
 use Pimcore\Model\Document;
+use Pimcore\Model\Element;
 
 /**
  * @method \Pimcore\Model\Document\Link\Dao getDao()
@@ -268,15 +269,17 @@ class Link extends Model\Document
         return $this;
     }
 
-    public function getElement(): Model\Element\ElementInterface|Model\Element\ElementDescriptor|null
+    public function getElement(): ?Model\Element\ElementInterface
     {
+        if ($this->object instanceof Model\Element\ElementDescriptor) {
+            return Element\Service::getElementById($this->object->getType(), $this->object->getId());
+        }
         if ($this->object instanceof Model\Element\ElementInterface) {
             return $this->object;
         }
         if ($this->setObjectFromId()) {
             return $this->object;
         }
-
         return null;
     }
 
@@ -287,7 +290,7 @@ class Link extends Model\Document
         return $this;
     }
 
-    private function setObjectFromId(): Model\Element\ElementInterface|Model\Element\ElementDescriptor|null
+    private function setObjectFromId(): ?Model\Element\ElementInterface
     {
         try {
             if ($this->internal) {

--- a/models/Document/Link.php
+++ b/models/Document/Link.php
@@ -51,9 +51,9 @@ class Link extends Model\Document
      *
      * @internal
      *
-     * @var Model\Element\ElementInterface|null
+     * @var Model\Element\ElementInterface|Model\Element\ElementDescriptor|null
      */
-    protected ?Model\Element\ElementInterface $object = null;
+    protected Model\Element\ElementInterface|Model\Element\ElementDescriptor|null $object = null;
 
     /**
      * Contains the direct link as plain text


### PR DESCRIPTION
## Changes in this pull request  
 Resolves #15348

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e83273</samp>

Updated type annotation of `Link::$object` to support lazy loading of linked elements. Part of a performance and memory optimization refactoring of the `Link` class and its related classes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8e83273</samp>

> _`Link` class refactored_
> _Lazy loading elements now_
> _A breeze in summer_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8e83273</samp>

*  Update the type annotation of the `object` property of the `Link` class to allow lazy loading of linked elements ([link](https://github.com/pimcore/pimcore/pull/15524/files?diff=unified&w=0#diff-846d942949cbc1aa247a67f632de47fdd9d3e0affe63dec1755f3a5a16097fabL54-R56))
