### PR TITLE
[Bug]: Return value must be of type int, null returned

### DIFF
--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -124,7 +124,7 @@ trait ImageThumbnailTrait
         $this->realWidth = null;
     }
 
-    public function getWidth(): int
+    public function getWidth(): ?int
     {
         if (!$this->width) {
             $this->getDimensions();
@@ -133,7 +133,7 @@ trait ImageThumbnailTrait
         return $this->width;
     }
 
-    public function getHeight(): int
+    public function getHeight(): ?int
     {
         if (!$this->height) {
             $this->getDimensions();
@@ -142,7 +142,7 @@ trait ImageThumbnailTrait
         return $this->height;
     }
 
-    public function getRealWidth(): int
+    public function getRealWidth(): ?int
     {
         if (!$this->realWidth) {
             $this->getDimensions();
@@ -151,7 +151,7 @@ trait ImageThumbnailTrait
         return $this->realWidth;
     }
 
-    public function getRealHeight(): int
+    public function getRealHeight(): ?int
     {
         if (!$this->realHeight) {
             $this->getDimensions();


### PR DESCRIPTION

## Changes in this pull request  
The problem in the current implementation is that the methods getWidth(), getHeight(), getRealWidth(), and getRealHeight() return int types even when the values are not set, leading to potential null exceptions.

To address this issue, the patch modifies the return types of these methods to ?int, allowing them to return null when the values are not set. This change ensures that the calling code can handle null values appropriately and avoids potential null exceptions.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2ff1695</samp>

Improved type safety and error handling for thumbnail dimensions in `ImageThumbnailTrait`. Made four methods return `?int` instead of `int` to allow for null values.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2ff1695</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The `ImageThumbnailTrait`, a gift to mortal kind,_
> _Who made the methods yield `?int` instead of `int` alone,_
> _To guard against the errors that the fates might have sown._

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2ff1695</samp>

*  Change the return types of four methods in `ImageThumbnailTrait.php` from `int` to `?int` to allow for `null` values ([link](https://github.com/pimcore/pimcore/pull/15526/files?diff=unified&w=0#diff-b48489e5be12fb4a4ec4f716c03e4690a799c39a87430cbb1a435d7badebf97cL127-R127), [link](https://github.com/pimcore/pimcore/pull/15526/files?diff=unified&w=0#diff-b48489e5be12fb4a4ec4f716c03e4690a799c39a87430cbb1a435d7badebf97cL136-R136), [link](https://github.com/pimcore/pimcore/pull/15526/files?diff=unified&w=0#diff-b48489e5be12fb4a4ec4f716c03e4690a799c39a87430cbb1a435d7badebf97cL145-R145), [link](https://github.com/pimcore/pimcore/pull/15526/files?diff=unified&w=0#diff-b48489e5be12fb4a4ec4f716c03e4690a799c39a87430cbb1a435d7badebf97cL154-R154))
