### PR TITLE
[Bug] Typed static property Pimcore\Image\Adapter\Imagick::$CMYKColorProfile must not be accessed before initialization

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -25,9 +25,9 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class Imagick extends Adapter
 {
-    protected static string $RGBColorProfile;
+    protected static ?string $RGBColorProfile = null;
 
-    protected static string $CMYKColorProfile;
+    protected static ?string $CMYKColorProfile = null;
 
     /**
      * @var \Imagick|null


### PR DESCRIPTION
Pimcore 11.0

Some TIFF-Assets are not displayed in a Image-Attribute. Downloading them in web format throws error "Typed static property Pimcore\Image\Adapter\Imagick::$CMYKColorProfile must not be accessed before initialization (500 Internal Server Error)"

#### Additional Info
This is the PR for Issue [https://github.com/pimcore/pimcore/issues/15450](https://github.com/pimcore/pimcore/issues/15450)

### Current Behavaviour

- Asset is not visible in Image-Attribute
- Download throws error

### Expected Behaviour

- Asset is visible in Image-Attribute
- Download possible without error

### Steps to reproduce

1. Upload Asset and add Asset to Image-Attribute
[Icon-metrisch.tif.zip](https://github.com/pimcore/pimcore/files/12040717/Icon-metrisch.tif.zip)
2. Open Asset and try to download as "Web Format"