### PR TITLE
Fix Xss in the link Editable

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/link.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/link.js
@@ -97,10 +97,10 @@ pimcore.document.editables.link = Class.create(pimcore.document.editable, {
         } else if (this.data.path) {
             text = this.data.path;
         }
+        let displayHtml = Ext.util.Format.htmlEncode(text);
         if (this.data.path || this.data.anchor || this.data.parameters) {
             let fullpath = this.data.path + (this.data.parameters ? '?' + Ext.util.Format.htmlEncode(this.data.parameters) : '') + (this.data.anchor ? '#' + Ext.util.Format.htmlEncode(this.data.anchor) : '');
-            let displayHtml = Ext.util.Format.htmlEncode(text);
-            
+
             if (this.config.textPrefix !== undefined) {
                 displayHtml = this.config.textPrefix + displayHtml;
             }
@@ -110,7 +110,7 @@ pimcore.document.editables.link = Class.create(pimcore.document.editable, {
 
             return '<a href="' + fullpath + '" class="' + this.config["class"] + ' ' + Ext.util.Format.htmlEncode(this.data["class"]) + '">' + displayHtml + '</a>';
         }
-        return text;
+        return displayHtml;
     },
 
     save: function () {


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d8dec47</samp>

Fix link editable text display and refactor code. Use a single `displayHtml` variable for both link and text modes in `link.js`, and handle encoding and prefixing of text.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d8dec47</samp>

> _`link editable`_
> _bug fixed, code refactored_
> _autumn cleaning done_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d8dec47</samp>

* Fix the bug where the link editable would not show the text correctly when the path is empty by:
  - Moving the declaration of `displayHtml` variable outside of the if block ([link](https://github.com/pimcore/pimcore/pull/15541/files?diff=unified&w=0#diff-e3bd94a28bb39900a94469c1e85ed489061ee18aacb6642471d015eca7514e1cL100-R103))
  - Replacing the return value of `text` with `displayHtml` in the else case ([link](https://github.com/pimcore/pimcore/pull/15541/files?diff=unified&w=0#diff-e3bd94a28bb39900a94469c1e85ed489061ee18aacb6642471d015eca7514e1cL113-R113))
