### PR TITLE
[DataObjects] Fix adding multiple objectbricks on update

### DIFF
--- a/models/DataObject/Objectbrick.php
+++ b/models/DataObject/Objectbrick.php
@@ -44,9 +44,9 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
     /**
      * @internal
      *
-     * @var Model\DataObject\Concrete|null
+     * @var Concrete|Model\Element\ElementDescriptor|null
      */
-    protected ?Concrete $object = null;
+    protected Concrete|Model\Element\ElementDescriptor|null $object = null;
 
     /**
      * @internal
@@ -195,8 +195,12 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
         return $this->object;
     }
 
-    public function setObject(?Concrete $object): static
+    public function setObject(Concrete|Model\Element\ElementDescriptor|null $object): static
     {
+        if ($object instanceof Model\Element\ElementDescriptor) {
+            $object = Service::getElementById($object->getType(), $object->getId());
+        }
+
         $this->objectId = $object ? $object->getId() : null;
         $this->object = $object;
 

--- a/models/DataObject/Objectbrick.php
+++ b/models/DataObject/Objectbrick.php
@@ -195,13 +195,9 @@ class Objectbrick extends Model\AbstractModel implements DirtyIndicatorInterface
         return $this->object;
     }
 
-    public function setObject(Concrete|Model\Element\ElementDescriptor|null $object): static
+    public function setObject(?Concrete $object): static
     {
-        if ($object instanceof Model\Element\ElementDescriptor) {
-            $object = Service::getElementById($object->getType(), $object->getId());
-        }
-
-        $this->objectId = $object ? $object->getId() : null;
+        $this->objectId = $object?->getId();
         $this->object = $object;
 
         // update all items with the new $object

--- a/models/DataObject/Objectbrick/Data/Dao.php
+++ b/models/DataObject/Objectbrick/Data/Dao.php
@@ -93,13 +93,17 @@ class Dao extends Model\Dao\AbstractDao
             Logger::warning('Error during removing old relations: ' . $e);
         }
 
-        if ($this->model->getObject()->getClass()->getAllowInherit() && isset($params['isUpdate']) && $params['isUpdate'] === false) {
+        if (($params['isUpdate'] ?? false) === false && $this->model->getObject()->getClass()->getAllowInherit()) {
             // if this is a fresh object, then we don't need the check
             $isBrickUpdate = false; // used to indicate whether we want to consider the default value
         } else {
             // or brick has been added
-            $existsResult = $this->db->fetchOne('SELECT id FROM ' . $storetable . ' WHERE id = ? LIMIT 1', [$object->getId()]);
-            $isBrickUpdate = $existsResult ? true : false;  // used to indicate whether we want to consider the default value
+            $existsResult = $this->db->fetchOne(
+                'SELECT id FROM ' . $storetable . ' WHERE id = ? LIMIT 1',
+                [$object->getId()]
+            );
+
+            $isBrickUpdate = (bool)$existsResult; // used to indicate whether we want to consider the default value
         }
 
         foreach ($fieldDefinitions as $fieldName => $fd) {


### PR DESCRIPTION
 ## Changes in this pull request  
Resolves #15547

## Additional info
tests will be fixed by https://github.com/pimcore/pimcore/pull/15543

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad414fa</samp>

Added support for loading object bricks from serialized data in `Objectbrick` class and improved code readability and consistency in `Dao` class.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ad414fa</samp>

> _Oh we are the coders of the `Objectbrick` class_
> _We load and save our data with a bit of sass_
> _We use the `??` operator and cast to boolean_
> _And format our SQL queries to make them clean_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ad414fa</samp>

*  Change type of `object` property and `setObject` parameter to allow `ElementDescriptor` in `Objectbrick` class ([link](https://github.com/pimcore/pimcore/pull/15548/files?diff=unified&w=0#diff-0a5b70799b5caaa32011d78d907e4156d1b627d54d9411f5c58e0e6c3fb257c2L47-R49))
*  Convert `ElementDescriptor` to `Concrete` object in `setObject` method of `Objectbrick` class ([link](https://github.com/pimcore/pimcore/pull/15548/files?diff=unified&w=0#diff-0a5b70799b5caaa32011d78d907e4156d1b627d54d9411f5c58e0e6c3fb257c2L198-R203))
*  Refactor and format SQL query in `save` method of `Dao` class in `models/DataObject/Objectbrick/Data/Dao.php` ([link](https://github.com/pimcore/pimcore/pull/15548/files?diff=unified&w=0#diff-172fd2de1642339e0d8ad96ad20217a17e710da22ba9457e3a431f1ecfcc1b89L96-R106))
