### PR TITLE
Fix ordering pimcore specific attributes in TinyMCE config

### DIFF
--- a/bundles/TinymceBundle/public/js/editor.js
+++ b/bundles/TinymceBundle/public/js/editor.js
@@ -88,7 +88,7 @@ pimcore.bundle.tinymce.editor = Class.create({
             base_url: '/bundles/pimcoretinymce/build/tinymce',
             suffix: '.min',
             convert_urls: false,
-            extended_valid_elements: 'a[name|href|target|title|pimcore_type|pimcore_id],img[style|longdesc|usemap|src|border|alt=|title|hspace|vspace|width|height|align|pimcore_type|pimcore_id]',
+            extended_valid_elements: 'a[name|href|target|title|pimcore_type|pimcore_id],img[style|longdesc|usemap|src|border|alt=|title|hspace|vspace|width|height|align|pimcore_id|pimcore_type]',
             init_instance_callback: function (editor) {
                 editor.on('input', function (eChange) {
                     const charCount = tinymce.activeEditor.plugins.wordcount.body.getCharacterCount();


### PR DESCRIPTION
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [x] Meet all coding standards (see PhpStan actions) 
  

## Changes in this pull request  
Resolves partially #15410

## Additional info
Regex in [ `Pimcore\Tool\Text::getElementsTagsInWysiwyg`](https://github.com/pimcore/pimcore/blob/bdc9a2dcd6d75403a3a1750c4c117fc8e1ea541e/lib/Tool/Text.php#L194) expects `id`˙ first, than `type`.

`pimcore.wysiwyg_sanitizer` should be checked as well to allow `pimcore_type` and `pimcore_id` attributes on supported elements. But this can be done outside of the CoreBundle by overriding the symfony config fot that sanitizer.

## How to reproduce
Login to current 11.0.2 demo admin - try to link any document/object/asset in any Wysiwyg editor, save the changes, and see that the linked object/document/asset is not in the HTML.
* **Issue 1:** TinyMCE reorders attributes on the HTML to filter out the dete.
* **Issue 2:** The current sanitizer config strips out every pimcore specific attribute

This PR solves **Issue 1** only, because Issue 2 can be solved by extending symfony configuration e.g.
```yaml
# framework.yaml
framework:
    html_sanitizer:
        sanitizers:
                pimcore.wysiwyg_sanitizer:
                    allow_attributes:
                        pimcore_type: '*'
                        pimcore_id: '*'
```
