### PR TITLE
Fix: No encoder has been configured for account "Pimcore\Security\User\User".

### DIFF
--- a/bundles/CoreBundle/Resources/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/Resources/config/pimcore/default.yaml
@@ -112,7 +112,7 @@ pimcore:
 
     security:
         encoder_factories:
-            Pimcore\Bundle\AdminBundle\Security\User\User: pimcore_admin.security.password_encoder_factory
+            Pimcore\Security\User\User: pimcore_admin.security.password_encoder_factory
 
     bundles:
         search_paths:


### PR DESCRIPTION
We used the pimcore_admin providers for some frontends. 

After update from 10.5 to 10.6 there is this error after login:
`No encoder has been configured for account "Pimcore\Security\User\User".`