### PR TITLE
Fix ordering pimcore specific attributes in TinyMCE config

### DIFF
--- a/bundles/TinymceBundle/public/js/editor.js
+++ b/bundles/TinymceBundle/public/js/editor.js
@@ -88,7 +88,7 @@ pimcore.bundle.tinymce.editor = Class.create({
             base_url: '/bundles/pimcoretinymce/build/tinymce',
             suffix: '.min',
             convert_urls: false,
-            extended_valid_elements: 'a[name|href|target|title|pimcore_type|pimcore_id],img[style|longdesc|usemap|src|border|alt=|title|hspace|vspace|width|height|align|pimcore_type|pimcore_id]',
+            extended_valid_elements: 'a[name|href|target|title|pimcore_type|pimcore_id],img[style|longdesc|usemap|src|border|alt=|title|hspace|vspace|width|height|align|pimcore_id|pimcore_type]',
             init_instance_callback: function (editor) {
                 editor.on('input', function (eChange) {
                     const charCount = tinymce.activeEditor.plugins.wordcount.body.getCharacterCount();

--- a/lib/Tool/Text.php
+++ b/lib/Tool/Text.php
@@ -218,7 +218,7 @@ class Text
 
                 if ($id && $type) {
                     $elements[] = [
-                        'id' => $id,
+                        'id' => (int) $id,
                         'type' => $type,
                     ];
                 }


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves partially #15410

## Additional info
Regex in [ `Pimcore\Tool\Text::getElementsTagsInWysiwyg`](https://github.com/pimcore/pimcore/blob/fa490deece7f7ddaea42a88b5385a2aff6174805/lib/Tool/Text.php#L194) expects `id`˙ first, than `type`.

### Reproducer
## How to reproduce
Login to current 11.0.3 demo admin - try to link any document/object/asset in any Wysiwyg editor, save the changes, and see that the linked object/document/asset is not in the HTML.
* **Issue 1:** TinyMCE reorders attributes on the HTML to filter out the data.
* **Issue 2:** The current sanitizer config strips out every pimcore specific attribute

This PR solves **Issue 1** only, because Issue 2 can be solved by extending symfony configuration e.g.
```yaml
# framework.yaml
framework:
    html_sanitizer:
        sanitizers:
                pimcore.wysiwyg_sanitizer:
                    allow_attributes:
                        pimcore_type: '*'
                        pimcore_id: '*'
```

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a0cf675</samp>

Fixed a bug in the TinyMCE editor that caused incorrect element type detection for links and images. Swapped the `pimcore_type` and `pimcore_id` attributes in the `extended_valid_elements` option in `editor.js`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a0cf675</samp>

> _`pimcore_type` first_
> _Swapped with `pimcore_id`_
> _Editor bug fixed_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a0cf675</samp>

*  Swap the order of `pimcore_type` and `pimcore_id` attributes in the TinyMCE editor configuration to fix a bug in element type detection ([link](https://github.com/pimcore/pimcore/pull/15556/files?diff=unified&w=0#diff-8a2dc43663bb99540091e249b44189b63f7f4ba73bf2a3b7d470a998eeabd19cL91-R91))
