### PR TITLE
Fix default error page response

### DIFF
--- a/bundles/CoreBundle/src/EventListener/ResponseExceptionListener.php
+++ b/bundles/CoreBundle/src/EventListener/ResponseExceptionListener.php
@@ -18,13 +18,13 @@ namespace Pimcore\Bundle\CoreBundle\EventListener;
 
 use Doctrine\DBAL\Connection;
 use Pimcore\Bundle\CoreBundle\EventListener\Traits\PimcoreContextAwareTrait;
-use Pimcore\Config;
 use Pimcore\Document\Renderer\DocumentRenderer;
 use Pimcore\Http\Exception\ResponseException;
 use Pimcore\Http\Request\Resolver\PimcoreContextResolver;
 use Pimcore\Http\Request\Resolver\SiteResolver;
 use Pimcore\Model\Document;
 use Pimcore\Model\Site;
+use Pimcore\SystemSettingsConfig;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -44,7 +44,7 @@ class ResponseExceptionListener implements EventSubscriberInterface
     public function __construct(
         protected DocumentRenderer $documentRenderer,
         protected Connection $db,
-        protected Config $config,
+        protected SystemSettingsConfig $config,
         protected Document\Service $documentService,
         protected SiteResolver $siteResolver
     ) {
@@ -155,8 +155,9 @@ class ResponseExceptionListener implements EventSubscriberInterface
             }
         }
 
-        $localizedErrorDocumentsPaths = $this->config['documents']['error_pages']['localized'] ?? null;
-        $defaultErrorDocumentPath = $this->config['documents']['error_pages']['default'] ?? null;
+        $config = $this->config->getSystemSettingsConfig();
+        $localizedErrorDocumentsPaths = $config['documents']['error_pages']['localized'] ?? null;
+        $defaultErrorDocumentPath = $config['documents']['error_pages']['default'] ?? null;
 
         if (Site::isSiteRequest()) {
             $site = Site::getCurrentSite();


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15451

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f44158</samp>

Refactored a core event listener class to use a new configuration class. Updated imports and type hints in `ResponseExceptionListener.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3f44158</samp>

> _Oh, we're the coders of the sea, and we refactor as we please_
> _We use the `SystemSettingsConfig` class to set our keys_
> _We don't need the old `Config` class, we toss it in the bin_
> _And we clean up our imports and types, and then we check it in_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f44158</samp>

*  Refactor the `ResponseExceptionListener` class to use the `SystemSettingsConfig` class instead of the `Config` class ([link](https://github.com/pimcore/pimcore/pull/15565/files?diff=unified&w=0#diff-083637c221d9fe6b3a2616d0115697a08baf188419036a6406f5509aa1998f0eL21), [link](https://github.com/pimcore/pimcore/pull/15565/files?diff=unified&w=0#diff-083637c221d9fe6b3a2616d0115697a08baf188419036a6406f5509aa1998f0eR27), [link](https://github.com/pimcore/pimcore/pull/15565/files?diff=unified&w=0#diff-083637c221d9fe6b3a2616d0115697a08baf188419036a6406f5509aa1998f0eL47-R47), [link](https://github.com/pimcore/pimcore/pull/15565/files?diff=unified&w=0#diff-083637c221d9fe6b3a2616d0115697a08baf188419036a6406f5509aa1998f0eL158-R160))
  * Remove the unused `use Pimcore\Config` statement from `ResponseExceptionListener.php` ([link](https://github.com/pimcore/pimcore/pull/15565/files?diff=unified&w=0#diff-083637c221d9fe6b3a2616d0115697a08baf188419036a6406f5509aa1998f0eL21))
  * Import the `Pimcore\SystemSettingsConfig` class in `ResponseExceptionListener.php` ([link](https://github.com/pimcore/pimcore/pull/15565/files?diff=unified&w=0#diff-083637c221d9fe6b3a2616d0115697a08baf188419036a6406f5509aa1998f0eR27))
  * Change the type hint of the `$config` parameter in the constructor of the `ResponseExceptionListener` class to `SystemSettingsConfig` ([link](https://github.com/pimcore/pimcore/pull/15565/files?diff=unified&w=0#diff-083637c221d9fe6b3a2616d0115697a08baf188419036a6406f5509aa1998f0eL47-R47))
  * Assign the local variable `$config` the value of `$this->config->getSystemSettingsConfig()` to access the system settings configuration in the `onKernelException` method ([link](https://github.com/pimcore/pimcore/pull/15565/files?diff=unified&w=0#diff-083637c221d9fe6b3a2616d0115697a08baf188419036a6406f5509aa1998f0eL158-R160))
