### PR TITLE
Fix TinyMCE config for pimcore specific attributes and drag and drop feature

### DIFF
--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -57,6 +57,10 @@ framework:
     html_sanitizer:
         sanitizers:
             pimcore.wysiwyg_sanitizer:
+                allow_attributes:
+                    pimcore_type: '*'
+                    pimcore_id: '*'
+                allow_relative_links: true
                 allow_elements:
                     span : [ 'class', 'style', 'id' ]
                     div : [ 'class', 'style', 'id' ]
@@ -76,6 +80,10 @@ framework:
                     ol: ['class', 'style', 'id']
                     br: ''
             pimcore.translation_sanitizer:
+                allow_attributes:
+                    pimcore_type: '*'
+                    pimcore_id: '*'
+                allow_relative_links: true
                 allow_elements:
                     span: [ 'class', 'style', 'id' ]
                     p: [ 'class', 'style', 'id' ]

--- a/lib/Tool/Text.php
+++ b/lib/Tool/Text.php
@@ -68,7 +68,7 @@ class Text
                         } elseif ($element instanceof Document) {
                             // get parameters
                             preg_match('/href="([^"]+)*"/', $oldTag, $oldHref);
-                            if ($oldHref[1] && (strpos($oldHref[1], '?') !== false || strpos($oldHref[1], '#') !== false)) {
+                            if (isset($oldHref[1]) && (strpos($oldHref[1], '?') !== false || strpos($oldHref[1], '#') !== false)) {
                                 $urlParts = parse_url($oldHref[1]);
                                 if (array_key_exists('query', $urlParts) && !empty($urlParts['query'])) {
                                     $path .= '?' . $urlParts['query'];

--- a/models/Document.php
+++ b/models/Document.php
@@ -504,7 +504,7 @@ class Document extends Element\AbstractElement
                 // dont't add a reference to yourself
                 continue;
             } else {
-                $d->addRequirement($requirement['id'], $requirement['type']);
+                $d->addRequirement((int)$requirement['id'], $requirement['type']);
             }
         }
         $d->save();


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves partially https://github.com/pimcore/pimcore/issues/15410
And resolves **Issue 2** from https://github.com/pimcore/pimcore/pull/15556

## Additional info / How to reproduce

- **Issue 1** ``default.yaml``: The current sanitizer config strips out every pimcore specific attribute, but as pimcore offers the possibility to drag & drop documents / assets / objects into the WYSIWYGS, this should be handled via default.yaml

- **Issue 2** ``default.yaml``: As the website internal links are relative, if you add an element via drag & drop, ``allow_relative_links`` has to be set to ``true`` via default.yaml

- **Issue3** ``Text.php``: However, if you don't set ``allow_relative_links`` to true, and have old hrefs within the database (because it's updated from an older pimcore version), ``Text.php`` throws an error, because ``$oldHref[1]`` is not set

- **Issue 4** ``Document.php``: if all of the other issues are fixed, then saving the document throws an error, because sometimes ``$requirement['id']`` is a string, but ``addRequirement`` requires an int

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a7826b0</samp>

This pull request improves link handling and rewriting for documents, and fixes some minor code issues. It enhances the `html` filter in `bundles/CoreBundle/config/pimcore/default.yaml`, fixes a notice error in `lib/Tool/Text.php`, and casts the `id` value to an integer in `models/Document.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a7826b0</samp>

> _We rewrite the links of doom_
> _We cast the ids to the flame_
> _We filter the html with our custom rules_
> _We fix the whitespace of shame_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a7826b0</samp>

*  Add `allow_attributes` and `allow_relative_links` options to `html` filter for `email`, `newsletter`, `printpage`, and `printcontainer` document types to enable custom and relative links ([link](https://github.com/pimcore/pimcore/pull/15569/files?diff=unified&w=0#diff-34d259c58a9001df91ca2ccc5f41ab960a307d1566cffceb88262d679cfc6c70R60-R63), [link](https://github.com/pimcore/pimcore/pull/15569/files?diff=unified&w=0#diff-34d259c58a9001df91ca2ccc5f41ab960a307d1566cffceb88262d679cfc6c70R83-R86))
*  Fix notice error when `href` attribute is empty or missing in link tag by using `isset` instead of `if` in `wysiwygText` function of `Text` class ([link](https://github.com/pimcore/pimcore/pull/15569/files?diff=unified&w=0#diff-35d04b1f729d96706fd5bae0da21a28e7f842301d3be236e50be44969363ee77L71-R71))
*  Cast `id` value to integer when calling `addRequirement` method on document object to ensure consistent data type ([link](https://github.com/pimcore/pimcore/pull/15569/files?diff=unified&w=0#diff-48235de7b392a4ff9ed273062d750e2732a5b1f8355cd76109abf4c5538a6c45L507-R507))
*  Remove trailing whitespace from `gotenberg.base_url` configuration value in `default.yaml` file for code style improvement ([link](https://github.com/pimcore/pimcore/pull/15569/files?diff=unified&w=0#diff-34d259c58a9001df91ca2ccc5f41ab960a307d1566cffceb88262d679cfc6c70L308-R316))
