### PR TITLE
Definitions: Set correct types for Pimcore 11

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20230720161000.php
+++ b/bundles/CoreBundle/Migrations/Version20230720161000.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Pimcore\Model\DataObject;
+
+final class Version20230720161000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Updates class definition files';
+    }
+
+    public function up(Schema $schema): void
+    {
+        try {
+            $list = new DataObject\ClassDefinition\Listing();
+            foreach ($list->getClasses() as $class) {
+                $this->write(sprintf('Saving class: %s', $class->getName()));
+                $class->save();
+            }
+
+            $list = new DataObject\ClassDefinition\CustomLayout\Listing();
+            foreach ($list->getLayoutDefinitions() as $layout) {
+                $this->write(sprintf('Saving custom layout: %s', $layout->getName()));
+                $layout->save();
+            }
+        } catch (DataObject\Exception\DefinitionWriteException $e) {
+            $this->write(
+                'Could not write class definition file. Please set PIMCORE_CLASS_DEFINITION_WRITABLE env.' . "\n" .
+                sprintf(
+                    'If you already have migrate the definitions you can skip this migration via "php bin/console doctrine:migrations:version --add %s"',
+                    __CLASS__
+                )
+            );
+
+            throw $e;
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->write(sprintf('Please restore your class definition files in %s and run bin/console pimcore:deployment:classes-rebuild manually.', PIMCORE_CLASS_DEFINITION_DIRECTORY));
+    }
+}

--- a/models/DataObject/ClassDefinition.php
+++ b/models/DataObject/ClassDefinition.php
@@ -1045,7 +1045,7 @@ final class ClassDefinition extends Model\AbstractModel
      */
     public function setParentClass($parentClass)
     {
-        $this->parentClass = $parentClass;
+        $this->parentClass = (string) $parentClass;
 
         return $this;
     }
@@ -1253,7 +1253,7 @@ final class ClassDefinition extends Model\AbstractModel
      */
     public function setDescription($description)
     {
-        $this->description = $description;
+        $this->description = (string) $description;
 
         return $this;
     }

--- a/models/DataObject/ClassDefinition/CustomLayout.php
+++ b/models/DataObject/ClassDefinition/CustomLayout.php
@@ -555,7 +555,7 @@ class CustomLayout extends Model\AbstractModel
      */
     public function setDescription($description)
     {
-        $this->description = $description;
+        $this->description = (string) $description;
 
         return $this;
     }

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -460,7 +460,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
     }
 
     /**
-     * @param bool|int|null $invisible
+     * @param bool $invisible
      *
      * @return $this
      */
@@ -480,7 +480,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
     }
 
     /**
-     * @param bool|int|null $visibleGridView
+     * @param bool $visibleGridView
      *
      * @return $this
      */
@@ -500,7 +500,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
     }
 
     /**
-     * @param bool|int|null $visibleSearch
+     * @param bool $visibleSearch
      *
      * @return $this
      */

--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -50,7 +50,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
     public $noteditable;
 
     /**
-     * @var int|null
+     * @var bool
      */
     public $index;
 
@@ -360,7 +360,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
     }
 
     /**
-     * @return int|null
+     * @return bool
      */
     public function getIndex()
     {
@@ -368,13 +368,13 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
     }
 
     /**
-     * @param int|null $index
+     * @param bool $index
      *
      * @return $this
      */
     public function setIndex($index)
     {
-        $this->index = $index;
+        $this->index = (bool) $index;
 
         return $this;
     }

--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -51,7 +51,7 @@ class Areablock extends Model\Document\Editable implements BlockInterface
     /**
      * @internal
      *
-     * @var array
+     * @var array|null
      */
     protected $currentIndex;
 

--- a/models/Document/Editable/Areablock.php
+++ b/models/Document/Editable/Areablock.php
@@ -58,7 +58,7 @@ class Areablock extends Model\Document\Editable implements BlockInterface
     /**
      * @internal
      *
-     * @var bool
+     * @var bool|null
      */
     protected $blockStarted;
 

--- a/tests/_support/Helper/AbstractDefinitionHelper.php
+++ b/tests/_support/Helper/AbstractDefinitionHelper.php
@@ -68,13 +68,13 @@ abstract class AbstractDefinitionHelper extends Module
      * @param string $type
      * @param string|null $name
      * @param bool $mandatory
-     * @param int $index
+     * @param bool $index
      * @param bool $visibleInGridView
      * @param bool $visibleInSearchResult
      *
      * @return Data
      */
-    public function createDataChild($type, $name = null, $mandatory = false, $index = 0, $visibleInGridView = true, $visibleInSearchResult = true)
+    public function createDataChild($type, $name = null, $mandatory = false, $index = false, $visibleInGridView = true, $visibleInSearchResult = true)
     {
         if (!$name) {
             $name = $type;


### PR DESCRIPTION
After updating a Pimcore with [customer-data-framework](https://github.com/pimcore/customer-data-framework) extension you have to update some incorrect definition attribute types manually. It would be good if Pimcore 10.6 would cast this attributes like other attributes (useTraits, allowVariants) which also was incorrect. So the update proccess would be easier.

See https://github.com/pimcore/customer-data-framework/pull/487