### PR TITLE
Unmark BundleManagerEvents as Final

### DIFF
--- a/lib/Event/BundleManagerEvents.php
+++ b/lib/Event/BundleManagerEvents.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Event;
 
-final class BundleManagerEvents
+class BundleManagerEvents
 {
     /**
      * The CSS_PATHS event is triggered for paths to CSS files which are about to be loaded for the admin interface.


### PR DESCRIPTION
## Changes in this pull request  
Required for https://github.com/pimcore/admin-ui-classic-bundle/issues/174
## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e8fc59</samp>

Changed `BundleManagerEvents` class to be non-final and allow extension. This improves the bundle system and aligns it with Symfony's conventions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8e8fc59</samp>

> _`BundleManagerEvents`_
> _Now open for extension_
> _Spring of new bundles_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8e8fc59</samp>

*  Removed the final modifier from the `BundleManagerEvents` class to allow extension and customization of bundle events ([link](https://github.com/pimcore/pimcore/pull/15574/files?diff=unified&w=0#diff-29364e2d0b002e03d5bb2e7e6b0b6c255943ddf7926d965527d01b8c48509c5eL19-R19))
