### PR TITLE
[Bug]: Fix Base Units in QuantityValue Unit GridView not displaying all units

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/quantityvalue/unitsettings.js
@@ -76,6 +76,9 @@ pimcore.object.quantityValue.unitsettings = Class.create({
                 reader: {
                     type: 'json',
                     rootProperty: 'data'
+                },
+                extraParams: {
+                    limit: 0
                 }
             },
             // disable client pagination, default: 25


### PR DESCRIPTION
## Changes in this pull request  
Alternative to https://github.com/pimcore/admin-ui-classic-bundle/pull/153

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 607cf74</samp>

Fix unit grid pagination bug in quantity value settings. Set `limit` to 0 in `unitsettings.js` to load all units.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 607cf74</samp>

> _`store` config changed_
> _to load all units at once_
> _bug fixed in winter_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 607cf74</samp>

* Fix a bug where the unit grid would not display all the units if there were more than 25 by setting the limit to 0 for the store configuration ([link](https://github.com/pimcore/pimcore/pull/15576/files?diff=unified&w=0#diff-81b52d77d2f17c4b1dc83501ed4e03d419abc0faf948587282fb7b1be4d73385R79-R81))
