### PR TITLE
[DataObject] Link: Attributes can be null

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,7 +1,7 @@
 # Upgrade Notes
 
 ## Pimcore 11.0.6
-- Properties of `Pimcore\Model\DataObject\Data\Link` and their getter/setter typehints are nullable now. 
+- Properties of `Pimcore\Model\DataObject\Data\Link` are nullable now. 
 
 ## Pimcore 11.0.0
 ### API

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,6 +1,10 @@
-# Upgrade Notes - Pimcore 11.0.0
+# Upgrade Notes
 
-## API
+## Pimcore 11.0.6
+- Properties of `Pimcore\Model\DataObject\Data\Link` and their getter/setter typehints are nullable now. 
+
+## Pimcore 11.0.0
+### API
 #### [General] :
 
 -  **Attention:** Added native php types for argument types, property types, return types and strict type declaration where possible. Double check your classes which are extending from Pimcore classes and adapt if necessary. 
@@ -66,7 +70,7 @@
 -  Bumped `league/flysystem-bundle` minimum requirement to ^3.0 (which introduces `directoryExists()`,`has()` methods and fixes support for `directory_visibility` configuration option). Please bump the Flysystem Adapters requirement accordingly to `^3.0` in your project `composer.json`.
 
 -----------------
-## Admin UI
+### Admin UI
 #### [General] :
 
 -  Removed `adminer` as built-in database management tool.
@@ -99,7 +103,7 @@
 
 
 -----------------
-## Bundles
+### Bundles
 #### [Bundles General] :
 
 - Removed support for loading bundles through `extensions.php`.
@@ -182,7 +186,7 @@
         - Service ids changed from `pimcore.newsletter` to `pimcore_newsletter` e.g. `pimcore_newsletter.document.newsletter.factory.default`
 
 
-## Core
+### Core
 
 #### [Commands] :
 
@@ -263,7 +267,7 @@ pimcore:
 - `EcommerceFrameworkBundle\Tracking\TrackingManager` requires session from request stack.
 
 -----------------
-## Ecommerce
+### Ecommerce
 #### [Ecommerce General] :
 
 - Ecommerce bundle has been moved into a package `pimcore/ecommerce-bundle`. If you wish to continue using the ecommerce framework, then please require the package in your composer.json and install it after enabling in `config/bundles.php`.
@@ -288,7 +292,7 @@ pimcore:
 -  Changed return type-hints of `CheckoutableInterface` methods `getOSPrice`, `getOSPriceInfo`, `getOSAvailabilityInfo`, `getPriceSystemName`, `getAvailabilitySystemName`, `getPriceSystemImplementation`, `getAvailabilitySystemImplementation` to be non-nullable.
 
 -----------------
-## Elements
+### Elements
 
 #### [All] :
 
@@ -477,7 +481,7 @@ pimcore_seo:
 -  Removed [deprecated and legacy `<iframe>` attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe): `frameborder`, `webkitAllowFullScreen`, `mozallowfullscreen`, and `allowfullscreen` for YouTube, Vimeo, and DailyMotion embeds.
 
 -----------------
-## Infrastructure
+### Infrastructure
 #### [PHP Options] :
 
 -  Removed setting following options: `memory_limit`, `max_execution_time`, `max_input_time` and `display_errors`
@@ -492,7 +496,7 @@ pimcore_seo:
 -  Replace deprecated `Symfony\Component\HttpFoundation\RequestMatcher` with `Symfony\Component\HttpFoundation\ChainRequestMatcher`
 
 -----------------
-## Tools
+### Tools
 #### [Application Logger] :
 
 -  Removed deprecated `PIMCORE_LOG_FILEOBJECT_DIRECTORY` constant, since flysystem is used to save/get fileobjects. Please make sure to adapt your code and migrate your fileobjects manually.

--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -306,7 +306,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
     {
         $data = $this->getDataFromObjectParam($object, $params);
         if ($data instanceof DataObject\Data\Link) {
-            return $data->getText() ?? '';
+            return $data->getText();
         }
 
         return '';

--- a/models/DataObject/ClassDefinition/Data/Link.php
+++ b/models/DataObject/ClassDefinition/Data/Link.php
@@ -306,7 +306,7 @@ class Link extends Data implements ResourcePersistenceAwareInterface, QueryResou
     {
         $data = $this->getDataFromObjectParam($object, $params);
         if ($data instanceof DataObject\Data\Link) {
-            return $data->getText();
+            return $data->getText() ?? '';
         }
 
         return '';

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -357,7 +357,7 @@ class Link implements OwnerAwareFieldInterface
                 }
             }
         } else {
-            $path = $this->getDirect();
+            $path = $this->getDirect() ?? '';
         }
 
         if (strlen($this->getParameters() ?? '') > 0) {

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -41,29 +41,32 @@ class Link implements OwnerAwareFieldInterface
 
     protected ?string $linktype = null;
 
-    protected string $target;
+    protected ?string $target = null;
 
-    protected string $parameters;
+    protected ?string $parameters = null;
 
-    protected string $anchor;
+    protected ?string $anchor = null;
 
-    protected string $title;
+    protected ?string $title = null;
 
-    protected string $accesskey;
+    protected ?string $accesskey = null;
 
-    protected string $rel;
+    protected ?string $rel = null;
 
-    protected string $tabindex;
+    protected ?string $tabindex = null;
 
-    protected string $class;
+    protected ?string $class = null;
 
-    protected string $attributes;
+    protected ?string $attributes = null;
 
     public function getText(): string
     {
         return $this->text;
     }
 
+    /**
+     * @return $this
+     */
     public function setText(string $text): static
     {
         $this->text = $text;
@@ -77,6 +80,9 @@ class Link implements OwnerAwareFieldInterface
         return $this->internalType;
     }
 
+    /**
+     * @return $this
+     */
     public function setInternalType(?string $internalType): static
     {
         $this->internalType = $internalType;
@@ -90,6 +96,9 @@ class Link implements OwnerAwareFieldInterface
         return $this->internal;
     }
 
+    /**
+     * @return $this
+     */
     public function setInternal(?int $internal): static
     {
         $this->internal = $internal;
@@ -103,6 +112,9 @@ class Link implements OwnerAwareFieldInterface
         return $this->direct;
     }
 
+    /**
+     * @return $this
+     */
     public function setDirect(?string $direct): static
     {
         $this->direct = $direct;
@@ -116,6 +128,9 @@ class Link implements OwnerAwareFieldInterface
         return $this->linktype;
     }
 
+    /**
+     * @return $this
+     */
     public function setLinktype(?string $linktype): static
     {
         $this->linktype = $linktype;
@@ -124,12 +139,15 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getTarget(): string
+    public function getTarget(): ?string
     {
         return $this->target;
     }
 
-    public function setTarget(string $target): static
+    /**
+     * @return $this
+     */
+    public function setTarget(?string $target): static
     {
         $this->target = $target;
         $this->markMeDirty();
@@ -137,12 +155,15 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getParameters(): string
+    public function getParameters(): ?string
     {
         return $this->parameters;
     }
 
-    public function setParameters(string $parameters): static
+    /**
+     * @return $this
+     */
+    public function setParameters(?string $parameters): static
     {
         $this->parameters = $parameters;
         $this->markMeDirty();
@@ -150,12 +171,15 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getAnchor(): string
+    public function getAnchor(): ?string
     {
         return $this->anchor;
     }
 
-    public function setAnchor(string $anchor): static
+    /**
+     * @return $this
+     */
+    public function setAnchor(?string $anchor): static
     {
         $this->anchor = $anchor;
         $this->markMeDirty();
@@ -163,12 +187,15 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getTitle(): string
+    public function getTitle(): ?string
     {
         return $this->title;
     }
 
-    public function setTitle(string $title): static
+    /**
+     * @return $this
+     */
+    public function setTitle(?string $title): static
     {
         $this->title = $title;
         $this->markMeDirty();
@@ -176,12 +203,18 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getAccesskey(): string
+    /**
+     * @return $this
+     */
+    public function getAccesskey(): ?string
     {
         return $this->accesskey;
     }
 
-    public function setAccesskey(string $accesskey): static
+    /**
+     * @return $this
+     */
+    public function setAccesskey(?string $accesskey): static
     {
         $this->accesskey = $accesskey;
         $this->markMeDirty();
@@ -189,12 +222,15 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getRel(): string
+    public function getRel(): ?string
     {
         return $this->rel;
     }
 
-    public function setRel(string $rel): static
+    /**
+     * @return $this
+     */
+    public function setRel(?string $rel): static
     {
         $this->rel = $rel;
         $this->markMeDirty();
@@ -202,12 +238,15 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getTabindex(): string
+    public function getTabindex(): ?string
     {
         return $this->tabindex;
     }
 
-    public function setTabindex(string $tabindex): static
+    /**
+     * @return $this
+     */
+    public function setTabindex(?string $tabindex): static
     {
         $this->tabindex = $tabindex;
         $this->markMeDirty();
@@ -215,28 +254,41 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function setAttributes(string $attributes): void
+    /**
+     * @return $this
+     */
+    public function setAttributes(?string $attributes): static
     {
         $this->attributes = $attributes;
         $this->markMeDirty();
+
+        return $this;
     }
 
-    public function getAttributes(): string
+    public function getAttributes(): ?string
     {
         return $this->attributes;
     }
 
-    public function setClass(string $class): void
+    /**
+     * @return $this
+     */
+    public function setClass(?string $class): static
     {
         $this->class = $class;
         $this->markMeDirty();
+
+        return $this;
     }
 
-    public function getClass(): string
+    public function getClass(): ?string
     {
         return $this->class;
     }
 
+    /**
+     * @return $this
+     */
     public function setPath(string $path): static
     {
         if (!empty($path)) {
@@ -311,10 +363,10 @@ class Link implements OwnerAwareFieldInterface
             $path = $this->getDirect();
         }
 
-        if (strlen($this->getParameters()) > 0) {
+        if (strlen($this->getParameters() ?? '') > 0) {
             $path .= '?' . str_replace('?', '', $this->getParameters());
         }
-        if (strlen($this->getAnchor()) > 0) {
+        if (strlen($this->getAnchor() ?? '') > 0) {
             $path .= '#' . str_replace('#', '', $this->getAnchor());
         }
 
@@ -336,13 +388,13 @@ class Link implements OwnerAwareFieldInterface
         return $element;
     }
 
+    /**
+     * @return $this
+     */
     public function setElement(ElementInterface $object): static
     {
-        if ($object instanceof ElementInterface) {
-            $this->internal = $object->getId();
-            $this->internalType = Service::getElementType($object);
-        }
-
+        $this->internal = $object->getId();
+        $this->internalType = Service::getElementType($object);
         $this->markMeDirty();
 
         return $this;
@@ -372,7 +424,7 @@ class Link implements OwnerAwareFieldInterface
     public function isEmpty(): bool
     {
         $vars = get_object_vars($this);
-        foreach ($vars as $key => $value) {
+        foreach ($vars as $value) {
             if (!empty($value)) {
                 return false;
             }
@@ -381,6 +433,9 @@ class Link implements OwnerAwareFieldInterface
         return true;
     }
 
+    /**
+     * @return $this
+     */
     public function setValues(array $data = []): static
     {
         if (is_array($data) && count($data) > 0) {

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -31,7 +31,7 @@ class Link implements OwnerAwareFieldInterface
     use OwnerAwareFieldTrait;
     use ObjectVarTrait;
 
-    protected ?string $text = null;
+    protected ?string $text = '';
 
     protected ?string $internalType = null;
 
@@ -41,33 +41,33 @@ class Link implements OwnerAwareFieldInterface
 
     protected ?string $linktype = null;
 
-    protected ?string $target = null;
+    protected ?string $target = '';
 
-    protected ?string $parameters = null;
+    protected ?string $parameters = '';
 
-    protected ?string $anchor = null;
+    protected ?string $anchor = '';
 
-    protected ?string $title = null;
+    protected ?string $title = '';
 
-    protected ?string $accesskey = null;
+    protected ?string $accesskey = '';
 
-    protected ?string $rel = null;
+    protected ?string $rel = '';
 
-    protected ?string $tabindex = null;
+    protected ?string $tabindex = '';
 
-    protected ?string $class = null;
+    protected ?string $class = '';
 
-    protected ?string $attributes = null;
+    protected ?string $attributes = '';
 
-    public function getText(): ?string
+    public function getText(): string
     {
-        return $this->text;
+        return $this->text ?? '';
     }
 
     /**
      * @return $this
      */
-    public function setText(?string $text): static
+    public function setText(string $text): static
     {
         $this->text = $text;
         $this->markMeDirty();
@@ -139,15 +139,15 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getTarget(): ?string
+    public function getTarget(): string
     {
-        return $this->target;
+        return $this->target ?? '';
     }
 
     /**
      * @return $this
      */
-    public function setTarget(?string $target): static
+    public function setTarget(string $target): static
     {
         $this->target = $target;
         $this->markMeDirty();
@@ -155,15 +155,15 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getParameters(): ?string
+    public function getParameters(): string
     {
-        return $this->parameters;
+        return $this->parameters ?? '';
     }
 
     /**
      * @return $this
      */
-    public function setParameters(?string $parameters): static
+    public function setParameters(string $parameters): static
     {
         $this->parameters = $parameters;
         $this->markMeDirty();
@@ -171,15 +171,15 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getAnchor(): ?string
+    public function getAnchor(): string
     {
-        return $this->anchor;
+        return $this->anchor ?? '';
     }
 
     /**
      * @return $this
      */
-    public function setAnchor(?string $anchor): static
+    public function setAnchor(string $anchor): static
     {
         $this->anchor = $anchor;
         $this->markMeDirty();
@@ -187,15 +187,15 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getTitle(): ?string
+    public function getTitle(): string
     {
-        return $this->title;
+        return $this->title ?? '';
     }
 
     /**
      * @return $this
      */
-    public function setTitle(?string $title): static
+    public function setTitle(string $title): static
     {
         $this->title = $title;
         $this->markMeDirty();
@@ -203,15 +203,15 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getAccesskey(): ?string
+    public function getAccesskey(): string
     {
-        return $this->accesskey;
+        return $this->accesskey ?? '';
     }
 
     /**
      * @return $this
      */
-    public function setAccesskey(?string $accesskey): static
+    public function setAccesskey(string $accesskey): static
     {
         $this->accesskey = $accesskey;
         $this->markMeDirty();
@@ -219,15 +219,15 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getRel(): ?string
+    public function getRel(): string
     {
-        return $this->rel;
+        return $this->rel ?? '';
     }
 
     /**
      * @return $this
      */
-    public function setRel(?string $rel): static
+    public function setRel(string $rel): static
     {
         $this->rel = $rel;
         $this->markMeDirty();
@@ -235,15 +235,15 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getTabindex(): ?string
+    public function getTabindex(): string
     {
-        return $this->tabindex;
+        return $this->tabindex ?? '';
     }
 
     /**
      * @return $this
      */
-    public function setTabindex(?string $tabindex): static
+    public function setTabindex(string $tabindex): static
     {
         $this->tabindex = $tabindex;
         $this->markMeDirty();
@@ -254,7 +254,7 @@ class Link implements OwnerAwareFieldInterface
     /**
      * @return $this
      */
-    public function setAttributes(?string $attributes): static
+    public function setAttributes(string $attributes): static
     {
         $this->attributes = $attributes;
         $this->markMeDirty();
@@ -262,15 +262,15 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getAttributes(): ?string
+    public function getAttributes(): string
     {
-        return $this->attributes;
+        return $this->attributes ?? '';
     }
 
     /**
      * @return $this
      */
-    public function setClass(?string $class): static
+    public function setClass(string $class): static
     {
         $this->class = $class;
         $this->markMeDirty();
@@ -278,9 +278,9 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getClass(): ?string
+    public function getClass(): string
     {
-        return $this->class;
+        return $this->class ?? '';
     }
 
     /**
@@ -360,10 +360,10 @@ class Link implements OwnerAwareFieldInterface
             $path = $this->getDirect() ?? '';
         }
 
-        if (strlen($this->getParameters() ?? '') > 0) {
+        if (strlen($this->getParameters()) > 0) {
             $path .= '?' . str_replace('?', '', $this->getParameters());
         }
-        if (strlen($this->getAnchor() ?? '') > 0) {
+        if (strlen($this->getAnchor()) > 0) {
             $path .= '#' . str_replace('#', '', $this->getAnchor());
         }
 

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -31,7 +31,7 @@ class Link implements OwnerAwareFieldInterface
     use OwnerAwareFieldTrait;
     use ObjectVarTrait;
 
-    protected string $text;
+    protected ?string $text = null;
 
     protected ?string $internalType = null;
 
@@ -59,7 +59,7 @@ class Link implements OwnerAwareFieldInterface
 
     protected ?string $attributes = null;
 
-    public function getText(): string
+    public function getText(): ?string
     {
         return $this->text;
     }
@@ -67,7 +67,7 @@ class Link implements OwnerAwareFieldInterface
     /**
      * @return $this
      */
-    public function setText(string $text): static
+    public function setText(?string $text): static
     {
         $this->text = $text;
         $this->markMeDirty();
@@ -414,11 +414,13 @@ class Link implements OwnerAwareFieldInterface
             $attribs[] = $this->getAttributes();
         }
 
-        if (empty($this->text)) {
+        $text = $this->getText();
+
+        if (empty($text)) {
             return '';
         }
 
-        return '<a href="' . $this->getHref() . '" ' . implode(' ', $attribs) . '>' . htmlspecialchars($this->getText()) . '</a>';
+        return '<a href="' . $this->getHref() . '" ' . implode(' ', $attribs) . '>' . htmlspecialchars($text) . '</a>';
     }
 
     public function isEmpty(): bool

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -41,7 +41,7 @@ class Link implements OwnerAwareFieldInterface
 
     protected ?string $linktype = null;
 
-    protected ?string $target = '';
+    protected ?string $target = null;
 
     protected ?string $parameters = '';
 
@@ -139,15 +139,15 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    public function getTarget(): string
+    public function getTarget(): ?string
     {
-        return $this->target ?? '';
+        return $this->target;
     }
 
     /**
      * @return $this
      */
-    public function setTarget(string $target): static
+    public function setTarget(?string $target): static
     {
         $this->target = $target;
         $this->markMeDirty();

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -332,7 +332,7 @@ class Link implements OwnerAwareFieldInterface
                 $path = $this->getElement()->getFullPath();
             }
         } else {
-            $path = $this->getDirect();
+            $path = $this->getDirect() ?? '';
         }
 
         return $path;

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -437,12 +437,10 @@ class Link implements OwnerAwareFieldInterface
      */
     public function setValues(array $data = []): static
     {
-        if (is_array($data) && count($data) > 0) {
-            foreach ($data as $key => $value) {
-                $method = 'set' . $key;
-                if (method_exists($this, $method)) {
-                    $this->$method($value);
-                }
+        foreach ($data as $key => $value) {
+            $method = 'set' . ucfirst($key);
+            if (method_exists($this, $method)) {
+                $this->$method($value);
             }
         }
         $this->markMeDirty();

--- a/models/DataObject/Data/Link.php
+++ b/models/DataObject/Data/Link.php
@@ -203,9 +203,6 @@ class Link implements OwnerAwareFieldInterface
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function getAccesskey(): ?string
     {
         return $this->accesskey;


### PR DESCRIPTION
I have errors after update to Pimcore 11 with Link field types. The attributes can be null.

```
Cannot assign null to property Pimcore\Model\DataObject\Data\Link::$target of type string
```
```
Cannot assign null to property Pimcore\Model\DataObject\Data\Link::$text of type string
```