### PR TITLE
[Staticroute] Fix: str_replace(): Argument #3 ($subject) must be of type array|string, int given

### DIFF
--- a/bundles/StaticRoutesBundle/src/Model/Staticroute.php
+++ b/bundles/StaticRoutesBundle/src/Model/Staticroute.php
@@ -404,7 +404,7 @@ final class Staticroute extends AbstractModel
         $tmpReversePattern = $this->getReverse();
         foreach ($urlParams as $key => $param) {
             if (strpos($tmpReversePattern, '%' . $key) !== false) {
-                $parametersInReversePattern[$key] = $param;
+                $parametersInReversePattern[$key] = (string) $param;
 
                 // we need to replace the found variable to that it cannot match again a placeholder
                 // eg. %abcd prior %ab if %abcd matches already %ab shouldn't match again on the same placeholder


### PR DESCRIPTION
Fix Staticroutes with integer parameters (like object id):

```
TypeError:
str_replace(): Argument #3 ($subject) must be of type array|string, int given

  at vendor/pimcore/pimcore/bundles/StaticRoutesBundle/src/Model/Staticroute.php:430 at str_replace(array('#', ':', '?'), '', 70)
     (vendor/pimcore/pimcore/bundles/StaticRoutesBundle/src/Model/Staticroute.php:430)
```