### PR TITLE
Fix deprecation in WebsiteSetting

### DIFF
--- a/models/WebsiteSetting.php
+++ b/models/WebsiteSetting.php
@@ -192,7 +192,7 @@ final class WebsiteSetting extends AbstractModel
     {
         // lazy-load data of type asset, document, object
         if (in_array($this->getType(), ['document', 'asset', 'object']) && !$this->data instanceof ElementInterface && is_numeric($this->data)) {
-            return Element\Service::getElementById($this->getType(), $this->data);
+            return Element\Service::getElementById($this->getType(), (int) $this->data);
         }
 
         return $this->data;


### PR DESCRIPTION
The data is a numeric string.
```
PHP Deprecated: Since pimcore/pimcore 11.0: Passing id as string to method Pimcore\Model\Element\Service::getElementById is deprecated
```