### PR TITLE
[SeoBundle] Fix deprecation in Seo Bundle

### DIFF
--- a/bundles/SeoBundle/src/Controller/Document/DocumentController.php
+++ b/bundles/SeoBundle/src/Controller/Document/DocumentController.php
@@ -98,7 +98,7 @@ class DocumentController extends UserAwareController
         // make sure document routes are also built for unpublished documents
         $documentRouteHandler->setForceHandleUnpublishedDocuments(true);
 
-        $document = Document::getById($allParams['node']);
+        $document = Document::getById((int) $allParams['node']);
 
         $documents = [];
         if ($document->hasChildren()) {


### PR DESCRIPTION
```
Passing id as string to method Pimcore\Model\Document::getById is deprecated
```
