### PR TITLE
fix: high res PDF thumbnails always display page 1

### DIFF
--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -569,7 +569,7 @@ class Service extends Model\Element\Service
                 }
             } elseif ($asset instanceof Asset\Document) {
                 $page = 1;
-                if (preg_match("|~\-~page\-(\d+)\.|", $config['filename'], $matchesThumbs)) {
+                if (preg_match("|~\-~page\-(\d+)(@[0-9.]+x)?\.|", $config['filename'], $matchesThumbs)) {
                     $page = (int)$matchesThumbs[1];
                 }
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Follow up to https://github.com/pimcore/pimcore/pull/15480

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 449d7ed</samp>

Fix resolution suffix handling for document asset thumbnails. Update regex in `models/Asset/Service.php` to include the suffix and use it to generate high-resolution thumbnails.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 449d7ed</samp>

> _`regex` updated_
> _now matches resolution_
> _bug fixed for winter_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 449d7ed</samp>

* Fix a bug where the resolution suffix of document asset thumbnails was ignored and the default resolution was used instead ([link](https://github.com/pimcore/pimcore/pull/15581/files?diff=unified&w=0#diff-fd51b37126eb63374242a3788ce8cb52ae243560ab4e55e9a296ac0582a59e65L572-R572) in `models/Asset/Service.php`)
