### PR TITLE
Fix `extended_valid_elements` order in TinyMCE config

### DIFF
--- a/bundles/TinymceBundle/public/js/editor.js
+++ b/bundles/TinymceBundle/public/js/editor.js
@@ -88,7 +88,7 @@ pimcore.bundle.tinymce.editor = Class.create({
             base_url: '/bundles/pimcoretinymce/build/tinymce',
             suffix: '.min',
             convert_urls: false,
-            extended_valid_elements: 'a[name|href|target|title|pimcore_type|pimcore_id],img[style|longdesc|usemap|src|border|alt=|title|hspace|vspace|width|height|align|pimcore_type|pimcore_id]',
+            extended_valid_elements: 'a[name|href|target|title|pimcore_id|pimcore_type],img[style|longdesc|usemap|src|border|alt=|title|hspace|vspace|width|height|align|pimcore_id|pimcore_type]',
             init_instance_callback: function (editor) {
                 editor.on('input', function (eChange) {
                     const charCount = tinymce.activeEditor.plugins.wordcount.body.getCharacterCount();


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  
[Pimcore\Tool\Text::getElementsTagsInWysiwyg](https://github.com/pimcore/pimcore/blob/7130dca888104c752c680615a3ed789073f8b235/lib/Tool/Text.php#L182) searches for pimcore_id and picmore_text attributes in order with regex.

## Changes in this pull request  
Resolves #15583 

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 56ef951</samp>

Fixed a bug in the TinyMCE editor that caused incorrect element type detection for links and images. Swapped the order of `pimcore_type` and `pimcore_id` attributes in `editor.js`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 56ef951</samp>

> _`pimcore_type` swapped_
> _TinyMCE bug is fixed_
> _Autumn leaves fall fast_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 56ef951</samp>

*  Swap the order of `pimcore_type` and `pimcore_id` attributes in the TinyMCE editor configuration to fix element type detection bug ([link](https://github.com/pimcore/pimcore/pull/15584/files?diff=unified&w=0#diff-8a2dc43663bb99540091e249b44189b63f7f4ba73bf2a3b7d470a998eeabd19cL91-R91))
