### PR TITLE
Allow images and relative media in HTMLSanitizer

### DIFF
--- a/bundles/CoreBundle/config/pimcore/default.yaml
+++ b/bundles/CoreBundle/config/pimcore/default.yaml
@@ -61,6 +61,7 @@ framework:
                     pimcore_type: '*'
                     pimcore_id: '*'
                 allow_relative_links: true
+                allow_relative_medias: true
                 allow_elements:
                     span : [ 'class', 'style', 'id' ]
                     div : [ 'class', 'style', 'id' ]
@@ -79,6 +80,7 @@ framework:
                     li: ['class', 'style', 'id']
                     ol: ['class', 'style', 'id']
                     br: ''
+                    img: ['alt', 'style', 'src']
             pimcore.translation_sanitizer:
                 allow_attributes:
                     pimcore_type: '*'


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #15582 

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 13a2a2a</samp>

This pull request enhances the `html` data type with new options for media handling and styling. It allows users to configure relative URLs for assets and set the `alt` and `style` attributes for images in `bundles/CoreBundle/config/pimcore/default.yaml`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 13a2a2a</samp>

> _`html` is the power, the source of creation_
> _We unleash its potential with configuration_
> _No more absolute paths, we use relative URLs_
> _We style and describe our images with `alt` and `style`_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 13a2a2a</samp>

*  Add a new configuration option `allow_relative_media` for the `html` data type to enable relative URLs for media assets ([link](https://github.com/pimcore/pimcore/pull/15585/files?diff=unified&w=0#diff-34d259c58a9001df91ca2ccc5f41ab960a307d1566cffceb88262d679cfc6c70R64))
*  Allow the `alt` and `style` attributes for the `img` tag in the `html` data type to enable alternative text and custom styles for images ([link](https://github.com/pimcore/pimcore/pull/15585/files?diff=unified&w=0#diff-34d259c58a9001df91ca2ccc5f41ab960a307d1566cffceb88262d679cfc6c70R83))
