### PR TITLE
Fix: migrations fail when updating to 10.6.4 from 10.6.3

### DIFF
--- a/bundles/CoreBundle/Migrations/Version20230616085142.php
+++ b/bundles/CoreBundle/Migrations/Version20230616085142.php
@@ -56,7 +56,7 @@ final class Version20230616085142 extends AbstractMigration
                 ]);
 
                 $fkName = AbstractDao::getForeignKeyName($tableName, self::ID_COLUMN);
-                $metaDataTable->removeForeignKey($fkName);
+                $this->addSql('ALTER TABLE `' . $tableName . '` DROP FOREIGN KEY IF EXISTS `' . $fkName . '`');
                 $metaDataTable->dropPrimaryKey();
                 $metaDataTable->setPrimaryKey([self::AUTO_ID]);
                 $metaDataTable->addUniqueIndex(self::PK_COLUMNS, self::UNIQUE_INDEX_NAME);


### PR DESCRIPTION
The foreign key will not removed with `$metaDataTable->removeForeignKey($fkName);`
Maybe a bug of dbal?

Fix: https://github.com/pimcore/pimcore/issues/15586