### PR TITLE
[Bug]: regex for image thumbnails media queries high resolution

### DIFF
--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -597,7 +597,7 @@ class Service extends Model\Element\Service
 
                 //check if high res image is called
 
-                preg_match("@([^\@]+)(\@[0-9.]+x)?\.([a-zA-Z]{2,5})@", $config['filename'], $matches);
+                preg_match("@([^\@]+)(\@[0-9.]+x)?\.(.*)\.([a-zA-Z]{2,5})@", $config['filename'], $matches);
 
                 if (empty($matches) || !isset($matches[1])) {
                     return null;

--- a/models/Asset/Service.php
+++ b/models/Asset/Service.php
@@ -597,7 +597,7 @@ class Service extends Model\Element\Service
 
                 //check if high res image is called
 
-                preg_match("@([^\@]+)(\@[0-9.]+x)?\.(.*)\.([a-zA-Z]{2,5})@", $config['filename'], $matches);
+                preg_match("@([^\@]+)(\@[0-9.]+x)?\.([^\.]+)\.([a-zA-Z]{2,5})@", $config['filename'], $matches);
 
                 if (empty($matches) || !isset($matches[1])) {
                     return null;


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
The change of the generation of thumbnail file name in [this commit](https://github.com/pimcore/pimcore/commit/41d8033ce5c87a214af76f41bfbaf6399f0ff576#diff-16840b1fd40929e8fda46a67eae733c84fc71dc91da6a38097ba58b5da0c321cR167) causes, that the filename is now generated with a hash before the file extension.

Pimcore 11: `~-~media--cac93fe4--query@2x.457729d8.jpg`, 
Pimcore 10: `~-~media--92aa2fb2--query@2x.webp`

But the regex, for the check of a high resolution image call was not adapted, so the hash was considered as part `([a-zA-Z]{2,5})` of the regex, if it started with two characters, and ignored if it started with two digits.
Therefore the condition `if (array_key_exists(2, $matches) && $matches[2])` was false and no thumbnail for this resolution was generated.


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 35f4520</samp>

Improved thumbnail filename regex to support custom suffixes. This enables better caching control for image thumbnails as requested in issue #10312.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 35f4520</samp>

> _`regex` changes_
> _thumbnail suffix optional_
> _snowflakes in cache_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 35f4520</samp>

* Allow optional suffix for image thumbnail filename ([link](https://github.com/pimcore/pimcore/pull/15594/files?diff=unified&w=0#diff-fd51b37126eb63374242a3788ce8cb52ae243560ab4e55e9a296ac0582a59e65L600-R600))
