### PR TITLE
[BUG] Fixed substr(): Argument #3 ($length) must be of type ?int, bool given

### DIFF
--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -405,7 +405,7 @@ EOT;
              * @see http://foone.org/apng/
              */
             $posIDAT = strpos($fileContent, 'IDAT');
-            $isAnimated = $posIDAT !== false ? strpos(substr($fileContent, 0, $posIDAT), 'acTL') !== false : false;
+            $isAnimated = $posIDAT !== false ? str_contains(substr($fileContent, 0, $posIDAT), 'acTL') : false;
         }
 
         return $isAnimated;

--- a/models/Asset/Image.php
+++ b/models/Asset/Image.php
@@ -404,7 +404,8 @@ EOT;
              *
              * @see http://foone.org/apng/
              */
-            $isAnimated = str_contains(substr($fileContent, 0, strpos($fileContent, 'IDAT')), 'acTL');
+            $posIDAT = strpos($fileContent, 'IDAT');
+            $isAnimated = $posIDAT !== false ? strpos(substr($fileContent, 0, $posIDAT), 'acTL') !== false : false;
         }
 
         return $isAnimated;


### PR DESCRIPTION

## Changes in this pull request  
Resolves #
If there is no content or image removed directly from server, it shows an error when trying to open from the object.
To fix the error, check whether the inner strpos() returns a valid integer position before using it as the length argument for substr() 


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fed00cd</samp>

Fixed a bug in `isAnimatedPng` function that caused warnings and incorrect results for some PNG files. Improved the handling of missing `IDAT` chunk in `models/Asset/Image.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fed00cd</samp>

> _`isAnimatedPng`_
> _No more warnings in fall_
> _Checks `IDAT` first_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fed00cd</samp>

*  Prevent warnings and improve accuracy of `isAnimatedPng` function by checking for `IDAT` chunk existence ([link](https://github.com/pimcore/pimcore/pull/15599/files?diff=unified&w=0#diff-5cc2bbd78fc2da7dfcf976d8120a6bbec2deab1b113c1f0c7a8b17840a191720L407-R408))
