### PR TITLE
[Bug]: Remove user from runtime cache on user deletion

### DIFF
--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -239,10 +239,10 @@ class AbstractUser extends Model\AbstractModel
      */
     public function delete()
     {
-        $parentUserId = $this->getParentId();
         if ($this->getId() < 1) {
             throw new \Exception('Deleting the system user is not allowed!');
         }
+        $parentUserId = $this->getParentId();
 
         $this->dispatchEvent(new UserRoleEvent($this), UserRoleEvents::PRE_DELETE);
 

--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -239,6 +239,7 @@ class AbstractUser extends Model\AbstractModel
      */
     public function delete()
     {
+        $parentUserId = $this->getParentId();
         if ($this->getId() < 1) {
             throw new \Exception('Deleting the system user is not allowed!');
         }
@@ -261,10 +262,17 @@ class AbstractUser extends Model\AbstractModel
 
         // now delete the current user
         $this->getDao()->delete();
-        
+
         $cacheKey = 'user_' . $this->getId();
         if (RuntimeCache::isRegistered($cacheKey)) {
             RuntimeCache::set($cacheKey, null);
+        }
+
+        if ($parentUserId && $parentUserId > 1) {
+            $parentCacheKey = 'user_' . $parentUserId;
+            if (RuntimeCache::isRegistered($parentCacheKey)) {
+                RuntimeCache::set($parentCacheKey, null);
+            }
         }
 
         $this->dispatchEvent(new UserRoleEvent($this), UserRoleEvents::POST_DELETE);

--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Model\User;
 
+use Pimcore\Cache\RuntimeCache;
 use Pimcore\Event\Model\UserRoleEvent;
 use Pimcore\Event\Traits\RecursionBlockingEventDispatchHelperTrait;
 use Pimcore\Event\UserRoleEvents;
@@ -64,8 +65,8 @@ class AbstractUser extends Model\AbstractModel
         $cacheKey = 'user_' . $id;
 
         try {
-            if (\Pimcore\Cache\RuntimeCache::isRegistered($cacheKey)) {
-                $user = \Pimcore\Cache\RuntimeCache::get($cacheKey);
+            if (RuntimeCache::isRegistered($cacheKey)) {
+                $user = RuntimeCache::get($cacheKey);
             } else {
                 $user = new static();
                 $user->getDao()->getById($id);
@@ -76,7 +77,7 @@ class AbstractUser extends Model\AbstractModel
                     $user = $className::getById($user->getId());
                 }
 
-                \Pimcore\Cache\RuntimeCache::set($cacheKey, $user);
+                RuntimeCache::set($cacheKey, $user);
             }
         } catch (Model\Exception\NotFoundException $e) {
             return null;
@@ -262,8 +263,8 @@ class AbstractUser extends Model\AbstractModel
         $this->getDao()->delete();
         
         $cacheKey = 'user_' . $this->getId();
-        if (\Pimcore\Cache\RuntimeCache::isRegistered($cacheKey)) {
-            Cache\RuntimeCache::set($cacheKey, null);
+        if (::isRegistered($cacheKey)) {
+            RuntimeCache::set($cacheKey, null);
         }
 
         $this->dispatchEvent(new UserRoleEvent($this), UserRoleEvents::POST_DELETE);

--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -260,7 +260,11 @@ class AbstractUser extends Model\AbstractModel
 
         // now delete the current user
         $this->getDao()->delete();
-        \Pimcore\Cache::clearAll();
+        
+        $cacheKey = 'user_' . $this->getId();
+        if (\Pimcore\Cache\RuntimeCache::isRegistered($cacheKey)) {
+            Cache\RuntimeCache::set($cacheKey, null);
+        }
 
         $this->dispatchEvent(new UserRoleEvent($this), UserRoleEvents::POST_DELETE);
     }

--- a/models/User/AbstractUser.php
+++ b/models/User/AbstractUser.php
@@ -263,7 +263,7 @@ class AbstractUser extends Model\AbstractModel
         $this->getDao()->delete();
         
         $cacheKey = 'user_' . $this->getId();
-        if (::isRegistered($cacheKey)) {
+        if (RuntimeCache::isRegistered($cacheKey)) {
             RuntimeCache::set($cacheKey, null);
         }
 


### PR DESCRIPTION
## Changes in this pull request  
(Indirectly) Resolves https://github.com/pimcore/pimcore/issues/13616

## Additional info
Tried to check if the Cache Clear All removal has any purpose but didn't find any.
Found instead that RuntimeCache should be cleared.
eg:
```
        $current = User::getById($id);
        $cached  = RuntimeCache::get('user_'.$id);
        $user->delete();
        $cached2  = RuntimeCache::get('user_'.$id);
```
without this PR, the $cached2 would contain the former info.


Due 
https://github.com/pimcore/pimcore/blob/5c929b093b07f9533589d99f55c02528a3d41fc9/models/User/AbstractUser.php#L58-L68
and "lack" of `force` optional parameter in `getById`

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c929b0</samp>

Fix cache invalidation bug when deleting a user. Clear the runtime cache for the deleted user in `models/User/AbstractUser.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5c929b0</samp>

> _`runtime` cache cleared_
> _user deletion bug is fixed_
> _autumn leaves fall fast_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5c929b0</samp>

* Clear the runtime cache for the deleted user to prevent stale data and errors ([link](https://github.com/pimcore/pimcore/pull/15609/files?diff=unified&w=0#diff-33922f1600adee6c57d7b56216b6fc1188e2ffef899a5ee79eaed8414edb352fL263-R267) in `models/User/AbstractUser.php`)
