### PR TITLE
fix Xss in the attributes tab of the link editable

### DIFF
--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -174,9 +174,18 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
                 $attribs[] = $this->data['attributes'];
             }
 
-            return '<a href="'.$url.'" '.implode(' ', $attribs).'>' . $prefix . ($noText ? '' : htmlspecialchars($this->data['text'])) . $suffix . '</a>';
+            $html =  '<a href="'.$url.'" '.implode(' ', $attribs).'>' . $prefix . ($noText ? '' : htmlspecialchars($this->data['text'])) . $suffix . '</a>';
+            $dom = new \DOMDocument();
+            $dom->loadHTML($html);
+            // get DOM Node list of the <a> tag
+            $nodeList = $dom->getElementsByTagName('a')->item(0);
+            foreach ($nodeList->attributes as $name => $attrNode) {
+                if(!in_array($name, $allowedAttributes) && $name != 'href'){
+                    $nodeList->removeAttribute($name);
+                }
+            }
+            return $dom->saveHTML($nodeList);
         }
-
         return '';
     }
 

--- a/models/Document/Editable/Link.php
+++ b/models/Document/Editable/Link.php
@@ -174,7 +174,8 @@ class Link extends Model\Document\Editable implements IdRewriterInterface, Editm
                 $attribs[] = $this->data['attributes'];
             }
 
-            $html =  '<a href="'.$url.'" '.implode(' ', $attribs).'>' . $prefix . ($noText ? '' : htmlspecialchars($this->data['text'])) . $suffix . '</a>';
+            $html =  '<a href="'.$url.'" '.implode(' ', $attribs).'>' . $prefix . ($noText ? '' :
+                    htmlspecialchars($this->data['text'])) . $suffix . '</a>';
             $dom = new \DOMDocument();
             $dom->loadHTML($html);
             // get DOM Node list of the <a> tag


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9847a8e</samp>

Sanitize link attributes in `Link` editable to prevent XSS attacks. Use `DOMDocument` to filter out unwanted attributes from the `<a>` tag in `models/Document/Editable/Link.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9847a8e</samp>

> _`Link` class updated_
> _Sanitizes attributes_
> _No more XSS bugs_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9847a8e</samp>

* Sanitize link attributes to prevent XSS attacks ([link](https://github.com/pimcore/pimcore/pull/15610/files?diff=unified&w=0#diff-c35541d0aea564c845ae03c018bb61018c369cb36ca7b405c9d1183be3a5e043L177-R188))
