### PR TITLE
[Bug]: Fix locales-utf8 check on macOS under requirements check

### DIFF
--- a/lib/Console/Application.php
+++ b/lib/Console/Application.php
@@ -55,7 +55,7 @@ final class Application extends \Symfony\Bundle\FrameworkBundle\Console\Applicat
         $this->setVersion(Version::getVersion());
 
         // we set locale to EN.UTF8 to not getting into UTF-8 issues, eg. when dealing with umlauts & escapeshellarg()
-        setlocale(LC_ALL, ['en.utf8', 'en_US.utf8', 'en_GB.utf8']);
+        setlocale(LC_ALL, ['en.utf8', 'en_US.utf8', 'en_GB.utf8']) ?: setlocale(LC_ALL, ['en.UTF-8', 'en_US.UTF-8', 'en_GB.UTF-8']);
 
         // allow to register commands here (e.g. through plugins)
         $dispatcher = \Pimcore::getEventDispatcher();

--- a/lib/Console/Application.php
+++ b/lib/Console/Application.php
@@ -55,7 +55,8 @@ final class Application extends \Symfony\Bundle\FrameworkBundle\Console\Applicat
         $this->setVersion(Version::getVersion());
 
         // we set locale to EN.UTF8 to not getting into UTF-8 issues, eg. when dealing with umlauts & escapeshellarg()
-        setlocale(LC_ALL, ['en.utf8', 'en_US.utf8', 'en_GB.utf8']) ?: setlocale(LC_ALL, ['en.UTF-8', 'en_US.UTF-8', 'en_GB.UTF-8']);
+        setlocale(LC_ALL, ['en.utf8', 'en_US.utf8', 'en_GB.utf8'])
+        ?: setlocale(LC_ALL, ['en.UTF-8', 'en_US.UTF-8', 'en_GB.UTF-8']); //fallback for macOS formats
 
         // allow to register commands here (e.g. through plugins)
         $dispatcher = \Pimcore::getEventDispatcher();

--- a/lib/Console/Application.php
+++ b/lib/Console/Application.php
@@ -55,8 +55,7 @@ final class Application extends \Symfony\Bundle\FrameworkBundle\Console\Applicat
         $this->setVersion(Version::getVersion());
 
         // we set locale to EN.UTF8 to not getting into UTF-8 issues, eg. when dealing with umlauts & escapeshellarg()
-        setlocale(LC_ALL, ['en.utf8', 'en_US.utf8', 'en_GB.utf8'])
-        ?: setlocale(LC_ALL, ['en.UTF-8', 'en_US.UTF-8', 'en_GB.UTF-8']); //fallback for macOS formats
+        setlocale(LC_ALL, ['en.utf8', 'en.UTF-8', 'en_US.utf8', 'en_US.UTF-8', 'en_GB.utf8', 'en_GB.UTF-8']);
 
         // allow to register commands here (e.g. through plugins)
         $dispatcher = \Pimcore::getEventDispatcher();

--- a/lib/Tool/Requirements.php
+++ b/lib/Tool/Requirements.php
@@ -608,19 +608,13 @@ final class Requirements
                 'message' => "It's recommended to have the GNU C Library locale data installed (eg. apt-get install locales-all).",
             ]);
         }
-
-        $utfLocaleState = Check::STATE_ERROR;
-        if (
-            setlocale(LC_ALL, ['en.utf8', 'en_US.utf8', 'en_GB.utf8'])
-            || setlocale(LC_ALL, ['en.UTF-8', 'en_US.UTF-8', 'en_GB.UTF-8']) // MacOS format
-        ) {
-            $utfLocaleState = Check::STATE_OK;
-        }
         
         $checks[] = new Check([
             'name' => 'locales-utf8',
             'link' => 'https://packages.debian.org/en/stable/locales-all',
-            'state' => $utfLocaleState,
+            'state' => setlocale(LC_ALL, ['en.utf8', 'en.UTF-8', 'en_US.utf8', 'en_US.UTF-8', 'en_GB.utf8', 'en_GB.UTF-8']) === false 
+                      ? Check::STATE_ERROR 
+                      : Check::STATE_OK,
             'message' => 'It is recommended to install UTF-8 locale, otherwise all CLI calls which use escapeshellarg() will strip multibyte characters',
         ]);
 

--- a/lib/Tool/Requirements.php
+++ b/lib/Tool/Requirements.php
@@ -609,10 +609,18 @@ final class Requirements
             ]);
         }
 
+        $utfLocaleState = Check::STATE_ERROR;
+        if (
+            setlocale(LC_ALL, ['en.utf8', 'en_US.utf8', 'en_GB.utf8'])
+            || setlocale(LC_ALL, ['en.UTF-8', 'en_US.UTF-8', 'en_GB.UTF-8']) // MacOS format
+        ) {
+            $utfLocaleState = Check::STATE_OK;
+        }
+        
         $checks[] = new Check([
             'name' => 'locales-utf8',
             'link' => 'https://packages.debian.org/en/stable/locales-all',
-            'state' => setlocale(LC_ALL, ['en.utf8', 'en_US.utf8', 'en_GB.utf8']) === false ? Check::STATE_ERROR : Check::STATE_OK,
+            'state' => $utfLocaleState,
             'message' => 'It is recommended to install UTF-8 locale, otherwise all CLI calls which use escapeshellarg() will strip multibyte characters',
         ]);
 

--- a/lib/Tool/Requirements.php
+++ b/lib/Tool/Requirements.php
@@ -612,9 +612,11 @@ final class Requirements
         $checks[] = new Check([
             'name' => 'locales-utf8',
             'link' => 'https://packages.debian.org/en/stable/locales-all',
-            'state' => setlocale(LC_ALL, ['en.utf8', 'en.UTF-8', 'en_US.utf8', 'en_US.UTF-8', 'en_GB.utf8', 'en_GB.UTF-8']) === false 
-                      ? Check::STATE_ERROR 
-                      : Check::STATE_OK,
+            'state' => setlocale(LC_ALL, [
+                           'en.utf8', 'en.UTF-8', 'en_US.utf8', 'en_US.UTF-8', 'en_GB.utf8', 'en_GB.UTF-8'
+                       ]) === false
+                       ? Check::STATE_ERROR
+                       : Check::STATE_OK,
             'message' => 'It is recommended to install UTF-8 locale, otherwise all CLI calls which use escapeshellarg() will strip multibyte characters',
         ]);
 


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15505

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 096e791</samp>

Improved locale check in `lib/Tool/Requirements.php` to support both Linux and MacOS formats of UTF-8 locale. This change is part of a pull request that fixes locale issues in pimcore.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 096e791</samp>

> _`pimcore` adapts_
> _to Linux and MacOS_
> _locale check in fall_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 096e791</samp>

* Fix locale check for MacOS and Linux formats ([link](https://github.com/pimcore/pimcore/pull/15612/files?diff=unified&w=0#diff-dfe29fe3b26573298372f467825b88de689af21021e590e9ab6868485cdde1c2L612-R623))
