### PR TITLE
[Bug]: WYSIWYG editor crashing due `component.up` error

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/wysiwyg.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/wysiwyg.js
@@ -107,23 +107,6 @@ pimcore.document.editables.wysiwyg = Class.create(pimcore.document.editable, {
 
             this.ckeditor = CKEDITOR.inline(this.textarea, eConfig);
 
-            let panelComponent = this.component?.up('panel');
-            let timeoutId;
-            do{
-                if(panelComponent?.scrollable){
-                    panelComponent.body.dom.onscroll = function () {
-                        if (typeof timeoutId === "number") {
-                            clearTimeout(timeoutId);
-                        }
-
-                        timeoutId = setTimeout(function(){
-                            CKEDITOR.document.getWindow().fire('scroll');
-                        }, 100);
-                    }
-                }
-                panelComponent = panelComponent?.up('panel');
-            } while(panelComponent)
-
             this.ckeditor.on('change', this.checkValue.bind(this, true));
 
                 // disable URL field in image dialog

--- a/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/wysiwyg.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/document/editables/wysiwyg.js
@@ -107,7 +107,7 @@ pimcore.document.editables.wysiwyg = Class.create(pimcore.document.editable, {
 
             this.ckeditor = CKEDITOR.inline(this.textarea, eConfig);
 
-            let panelComponent = this.component.up('panel');
+            let panelComponent = this.component?.up('panel');
             let timeoutId;
             do{
                 if(panelComponent?.scrollable){
@@ -121,7 +121,7 @@ pimcore.document.editables.wysiwyg = Class.create(pimcore.document.editable, {
                         }, 100);
                     }
                 }
-                panelComponent = panelComponent.up('panel');
+                panelComponent = panelComponent?.up('panel');
             } while(panelComponent)
 
             this.ckeditor.on('change', this.checkValue.bind(this, true));


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15604
Reverts https://github.com/pimcore/pimcore/pull/15024/files?w=1#diff-68d72da21a48e1070cd7b356e5d1d8c3f3f2d47f705637baa8627db97a2b2af9R110-R126

Actually is not needed for Documents, the problem of the menu floating is not noticeable on there


## Additional info
![image](https://github.com/pimcore/pimcore/assets/6014195/b27f0f75-4980-4dc5-8bf1-5ff779cec448)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b91610</samp>

Fixed a bug in wysiwyg editables that caused them to fail when not rendered or nested in hidden panels. Used optional chaining operators to safely access `this.component` and `panelComponent` in `wysiwyg.js`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1b91610</samp>

> _Sing, O Muse, of the cunning coder who devised_
> _A subtle fix for the wysiwyg editables, those splendid tools_
> _That adorn the web with rich and varied texts, like the gifts of Hephaestus_
> _But often faltered when their components were hidden or absent, like the eyes of Polyphemus_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1b91610</samp>

*  Prevent errors when editable components are null or undefined by using optional chaining operator ([link](https://github.com/pimcore/pimcore/pull/15613/files?diff=unified&w=0#diff-68d72da21a48e1070cd7b356e5d1d8c3f3f2d47f705637baa8627db97a2b2af9L110-R110), [link](https://github.com/pimcore/pimcore/pull/15613/files?diff=unified&w=0#diff-68d72da21a48e1070cd7b356e5d1d8c3f3f2d47f705637baa8627db97a2b2af9L124-R124)) in `wysiwyg.js`
