### PR TITLE
[Translations] Consider only registered in available domains

### DIFF
--- a/doc/20_Extending_Pimcore/13_Bundle_Developers_Guide/README.md
+++ b/doc/20_Extending_Pimcore/13_Bundle_Developers_Guide/README.md
@@ -56,6 +56,17 @@ For bundles, translations should be stored in the `Resources/translations/` dire
 
 Example: admin.en.yml or messages.en.yml
 
+#### Translations Domain
+A translation domain is only considered valid when it is registered as follows:
+```yaml
+pimcore:
+    translations:
+        domains:
+            - site_1
+            - site_2
+````
+
+Then only translations stored in a dedicated domain table e.g. `translations_DOMAIN` are used by the Pimcore translation service.
 
 ### Security / Authentication
 

--- a/models/Translation/Dao.php
+++ b/models/Translation/Dao.php
@@ -143,7 +143,7 @@ class Dao extends Model\Dao\AbstractDao
     }
 
     /**
-     * Returns a array containing all available domains
+     * Returns a array containing all available (registered) domains
      *
      * @return array
      */
@@ -153,7 +153,10 @@ class Dao extends Model\Dao\AbstractDao
         $domains = [];
 
         foreach ($domainTables as $domainTable) {
-            $domains[] = str_replace('translations_', '', $domainTable[array_key_first($domainTable)]);
+            $domain =  str_replace('translations_', '', $domainTable[array_key_first($domainTable)]);
+            if ($this->isAValidDomain($domain)) {
+                $domains[] = $domain;
+            }
         }
 
         return $domains;

--- a/models/Translation/Listing.php
+++ b/models/Translation/Listing.php
@@ -68,7 +68,13 @@ class Listing extends Model\Listing\AbstractListing
     public function setDomain(string $domain): void
     {
         if (!Model\Translation::isAValidDomain($domain)) {
-            throw new NotFoundException(sprintf('Translation domain table "translations_%s" does not exist', $domain));
+            throw new NotFoundException(
+                sprintf(
+                    'Either translation domain %s is not registered in config `pimcore.translations.domains` or table "%s" does not exist',
+                    'translations_' . $domain,
+                    $domain
+                )
+            );
         }
 
         $this->domain = $domain;


### PR DESCRIPTION
## Changes in this pull request  
Follow up to https://github.com/pimcore/pimcore/pull/14091
Resolves #15623

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 409a4fe</samp>

Improved the domain handling and error messages for translations. Fixed a bug in `models/Translation/Dao.php` and clarified the exception message in `models/Translation/Listing.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 409a4fe</samp>

> _`Dao` class refined_
> _Translation domains checked_
> _Error message clear_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 409a4fe</samp>

*  Filter out invalid domains from the available languages and domains ([link](https://github.com/pimcore/pimcore/pull/15624/files?diff=unified&w=0#diff-d12fd3a68bfb8f0df7e549fa424f0d074eacc51fece6e6cb0c48ebaa952aee1eL146-R146), [link](https://github.com/pimcore/pimcore/pull/15624/files?diff=unified&w=0#diff-d12fd3a68bfb8f0df7e549fa424f0d074eacc51fece6e6cb0c48ebaa952aee1eL156-R159), [link](https://github.com/pimcore/pimcore/pull/15624/files?diff=unified&w=0#diff-4560d424f9a2a6f297ea7377e1aa3cd4d1e6a0f09649d8db77a8de7ca4bb7573L71-R77))
