### PR TITLE
[Docs]: Improve explanation about recycle bin

### DIFF
--- a/doc/Development_Documentation/22_Administration_of_Pimcore/02_Cleanup_Data_Storage.md
+++ b/doc/Development_Documentation/22_Administration_of_Pimcore/02_Cleanup_Data_Storage.md
@@ -59,9 +59,7 @@ All temporary files can be deleted at any time.
 **WARNING: Deleting all files in `public/var/tmp/` can have a huge impact on performance until all needed thumbnails are generated again.**
 
 ## Recycle Bin
-Deleting items in Pimcore moves them to the recycle bin first. 
-
-The recycle bin works quite similar to the versioning, 
+Deleting items in Pimcore moves them to the recycle bin first. The recycle bin works quite similar to the versioning, 
 so the references are kept in the database but the contents itself are dumped into files in `var/recyclebin/`.   
 You can review items in the bin in the admin user-interface under *Tools* > *Recycle Bin*, there it's also possible to 
 flush the entire contents. 

--- a/doc/Development_Documentation/22_Administration_of_Pimcore/02_Cleanup_Data_Storage.md
+++ b/doc/Development_Documentation/22_Administration_of_Pimcore/02_Cleanup_Data_Storage.md
@@ -59,7 +59,9 @@ All temporary files can be deleted at any time.
 **WARNING: Deleting all files in `public/var/tmp/` can have a huge impact on performance until all needed thumbnails are generated again.**
 
 ## Recycle Bin
-Deleting items in Pimcore moves them to the recycle bin first. The recycle bin works quite similar to the versioning, 
+Deleting items in Pimcore moves them to the recycle bin first. 
+
+The recycle bin works quite similar to the versioning, 
 so the references are kept in the database but the contents itself are dumped into files in `var/recyclebin/`.   
 You can review items in the bin in the admin user-interface under *Tools* > *Recycle Bin*, there it's also possible to 
 flush the entire contents. 
@@ -71,3 +73,6 @@ amount of items in your recycle bin:
 mysql -e "TRUNCATE TABLE ###.recyclebin;"
 rm -r var/recyclebin
 ```
+
+**WARNING: The recycle bin is an administrative tool and displays all the deleted elements by any user. 
+Due to the nature and complexity of element deletion and restoration process, this should be reserved to administrator and advanced users**

--- a/doc/Development_Documentation/22_Administration_of_Pimcore/02_Cleanup_Data_Storage.md
+++ b/doc/Development_Documentation/22_Administration_of_Pimcore/02_Cleanup_Data_Storage.md
@@ -72,5 +72,5 @@ mysql -e "TRUNCATE TABLE ###.recyclebin;"
 rm -r var/recyclebin
 ```
 
-**WARNING: The recycle bin is an administrative tool and displays all the deleted elements by any user. 
-Due to the nature and complexity of element deletion and restoration process, this should be reserved to administrator and advanced users**
+**WARNING: The recycle bin is an administrative tool that displays any user's deleted elements. 
+Due to the nature and complexity of the elements deletion and restoration process, this tool should be reserved for administrator and advanced users**

--- a/doc/Development_Documentation/22_Administration_of_Pimcore/07_Users_and_Roles.md
+++ b/doc/Development_Documentation/22_Administration_of_Pimcore/07_Users_and_Roles.md
@@ -2,7 +2,7 @@
 
 ## General
 
-User permissions in Pimcore are based on a users and roles concept. Each user can have serveral roles and both - users
+User permissions in Pimcore are based on a users and roles concept. Each user can have several roles and both - users
  and roles - can have permissions. 
  
 Users and roles are configured in Pimcore backend UI at *Settings* > *Users & Roles* > *Users* and
@@ -42,7 +42,7 @@ The following list outlines what the different system permissions (available for
 * **Notes & Events**: Notes & Events are visible 
 * **Objects**: objects tree is visible 
 * **Predefined Properties**: User can create and modify predefined properties
-* **Recycle Bin**: User has access to recycle bin
+* **Recycle Bin**: User has access to recycle bin and see all deleted elements by anyone
 * **Redirects**: User can create and modify redirects
 * **Reports**: User has access to reports module
 * **Seemode**: Seemode available/not available for user

--- a/doc/Development_Documentation/22_Administration_of_Pimcore/07_Users_and_Roles.md
+++ b/doc/Development_Documentation/22_Administration_of_Pimcore/07_Users_and_Roles.md
@@ -42,7 +42,7 @@ The following list outlines what the different system permissions (available for
 * **Notes & Events**: Notes & Events are visible 
 * **Objects**: objects tree is visible 
 * **Predefined Properties**: User can create and modify predefined properties
-* **Recycle Bin**: User has access to recycle bin and see all deleted elements by anyone
+* **Recycle Bin**: User has access to the recycle bin and see all the deleted elements (even by other users).
 * **Redirects**: User can create and modify redirects
 * **Reports**: User has access to reports module
 * **Seemode**: Seemode available/not available for user


### PR DESCRIPTION
## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/14649

## Additional info
See https://github.com/pimcore/pimcore/pull/15470#issuecomment-1635469834 
This tool always been "more" as an administrative tool, with this PR is explained better to prevent that is being assigned and used to/by "basic" users and allowing seeing more than what they are defined to


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a349c9</samp>

This pull request updates the documentation of the `Users and Roles` and the `Cleanup Data Storage` sections to fix a typo, add a clarification, and warn users about the recycle bin feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2a349c9</samp>

> _Oh, we're the docs crew of the Pimcore ship_
> _And we write and review with care and wit_
> _We warn of the `Recycle Bin` and its tricks_
> _Heave away, me hearties, heave away_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2a349c9</samp>

* Add a warning message to the `Recycle Bin` section of the documentation to inform users about the potential risks and challenges of using the recycle bin feature ([link](https://github.com/pimcore/pimcore/pull/15633/files?diff=unified&w=0#diff-5f10ae449ba735b4f4bb99413714150ea9ee53b72a44ddea0dbac3fb74fe4937L74-R75))
* Fix a typo in the word `several` in the `General` section of the documentation ([link](https://github.com/pimcore/pimcore/pull/15633/files?diff=unified&w=0#diff-21c6198803e15a8707afe87152bc1ea93d6ce4419cb57fc49b343f6391c32289L5-R5))
* Clarify the `Recycle Bin` permission in the `System Permissions` section of the documentation to inform users that it also grants access to see all the deleted elements by any user, not just their own ([link](https://github.com/pimcore/pimcore/pull/15633/files?diff=unified&w=0#diff-21c6198803e15a8707afe87152bc1ea93d6ce4419cb57fc49b343f6391c32289L45-R45))
