### PR TITLE
Fix: index attribute of Data must be a boolean

### DIFF
--- a/models/DataObject/ClassDefinition/Data.php
+++ b/models/DataObject/ClassDefinition/Data.php
@@ -37,7 +37,7 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
 
     public bool $noteditable = false;
 
-    public int|bool|null $index = null;
+    public bool $index = false;
 
     public bool $locked = false;
 
@@ -174,6 +174,9 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         return $this->permissions;
     }
 
+    /**
+     * @return $this
+     */
     public function setName(string $name): static
     {
         $this->name = $name;
@@ -181,6 +184,9 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function setTitle(string $title): static
     {
         $this->title = $title;
@@ -188,6 +194,9 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function setMandatory(bool $mandatory): static
     {
         $this->mandatory = $mandatory;
@@ -195,6 +204,9 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function setPermissions(array|string|null $permissions): static
     {
         $this->permissions = $permissions;
@@ -202,6 +214,9 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function setValues(array $data = [], array $blockedKeys = []): static
     {
         foreach ($data as $key => $value) {
@@ -223,6 +238,9 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         return $this->noteditable;
     }
 
+    /**
+     * @return $this
+     */
     public function setNoteditable(bool $noteditable): static
     {
         $this->noteditable = $noteditable;
@@ -230,12 +248,15 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         return $this;
     }
 
-    public function getIndex(): ?int
+    public function getIndex(): bool
     {
         return $this->index;
     }
 
-    public function setIndex(?int $index): static
+    /**
+     * @return $this
+     */
+    public function setIndex(bool $index): static
     {
         $this->index = $index;
 
@@ -247,9 +268,12 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         return $this->style;
     }
 
+    /**
+     * @return $this
+     */
     public function setStyle(?string $style): static
     {
-        $this->style = (string)$style;
+        $this->style = $style;
 
         return $this;
     }
@@ -259,6 +283,9 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         return $this->locked;
     }
 
+    /**
+     * @return $this
+     */
     public function setLocked(bool $locked): static
     {
         $this->locked = $locked;
@@ -271,9 +298,12 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         return $this->tooltip;
     }
 
+    /**
+     * @return $this
+     */
     public function setTooltip(?string $tooltip): static
     {
-        $this->tooltip = (string)$tooltip;
+        $this->tooltip = $tooltip;
 
         return $this;
     }
@@ -288,9 +318,12 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         return $this->invisible;
     }
 
-    public function setInvisible(bool|int|null $invisible): static
+    /**
+     * @return $this
+     */
+    public function setInvisible(bool $invisible): static
     {
-        $this->invisible = (bool)$invisible;
+        $this->invisible = $invisible;
 
         return $this;
     }
@@ -300,9 +333,12 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         return $this->visibleGridView;
     }
 
-    public function setVisibleGridView(bool|int|null $visibleGridView): static
+    /**
+     * @return $this
+     */
+    public function setVisibleGridView(bool $visibleGridView): static
     {
-        $this->visibleGridView = (bool)$visibleGridView;
+        $this->visibleGridView = $visibleGridView;
 
         return $this;
     }
@@ -312,9 +348,12 @@ abstract class Data implements DataObject\ClassDefinition\Data\TypeDeclarationSu
         return $this->visibleSearch;
     }
 
-    public function setVisibleSearch(bool|int|null $visibleSearch): static
+    /**
+     * @return $this
+     */
+    public function setVisibleSearch(bool $visibleSearch): static
     {
-        $this->visibleSearch = (bool)$visibleSearch;
+        $this->visibleSearch = $visibleSearch;
 
         return $this;
     }

--- a/tests/Support/Helper/AbstractDefinitionHelper.php
+++ b/tests/Support/Helper/AbstractDefinitionHelper.php
@@ -53,7 +53,7 @@ abstract class AbstractDefinitionHelper extends Module
         }
     }
 
-    public function createDataChild(string $type, ?string $name = null, bool $mandatory = false, int $index = 0, bool $visibleInGridView = true, bool $visibleInSearchResult = true): Data
+    public function createDataChild(string $type, ?string $name = null, bool $mandatory = false, bool $index = false, bool $visibleInGridView = true, bool $visibleInSearchResult = true): Data
     {
         if (!$name) {
             $name = $type;

--- a/tests/Unit/Models/DataObject/ClassDefinition/Data/UserTest.php
+++ b/tests/Unit/Models/DataObject/ClassDefinition/Data/UserTest.php
@@ -28,7 +28,7 @@ class UserTest extends TestCase
         'tooltip' => '',
         'mandatory' => false,
         'noteditable' => false,
-        'index' => 0,
+        'index' => false,
         'locked' => false,
         'style' => '',
         'permissions' => null,


### PR DESCRIPTION
Fix https://github.com/pimcore/pimcore/discussions/15635

I make the changes in the php docs also for Pimcore 10.6 in https://github.com/pimcore/pimcore/pull/15570

Steps to reproduce:
1. Create a empty pimcore skeleton instance
2. Enable strict mode in `vendor/pimcore/pimcore/models/DataObject/ClassDefinition/Data.php`
3. Try to create a class with one input field
4. 
![image](https://github.com/pimcore/pimcore/assets/998558/3e6da9ad-0ab3-40eb-bd01-f46682ce3596)
