### PR TITLE
Fix: toNumeric returns a string, when integer and decimalSize is set

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Numeric.php
+++ b/models/DataObject/ClassDefinition/Data/Numeric.php
@@ -467,6 +467,10 @@ class Numeric extends Data implements ResourcePersistenceAwareInterface, QueryRe
 
     private function toNumeric(mixed $value): float|int|string
     {
+        if ($this->getInteger()) {
+            return (int) $value;
+        }
+
         $value = str_replace(',', '.', (string) $value);
 
         if ($this->isDecimalType()) {


### PR DESCRIPTION
Fix https://github.com/pimcore/pimcore/discussions/15639

### Steps to reproduce

1. Go to Pimcore demo admin interface (https://demo.pimcore.fun/admin/)
2. Change the Car class: Set the "Decimal size" of the field productionYear to 2
3. Try to save a Car object
![image](https://github.com/pimcore/pimcore/assets/998558/6792d26a-0a4e-47e9-910e-f19dda6a4ecd)
```
Message: Pimcore\Model\DataObject\Car::setProductionYear(): Argument #1 ($productionYear) must be of type ?int, string given, called in /var/www/html/vendor/pimcore/pimcore/models/DataObject/AbstractObject.php on line 973
```