### PR TITLE
Update Service.php

### DIFF
--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1633,7 +1633,7 @@ class Service extends Model\Element\Service
                 case DataObject\ClassDefinition\Data\CalculatedValue::CALCULATOR_TYPE_CLASS:
                     $className = $fd->getCalculatorClass();
                     $calculator = Model\DataObject\ClassDefinition\Helper\CalculatorClassResolver::resolveCalculatorClass($className);
-                    if (!$calculator instanceof DataObject\ClassDefinition\CalculatorClassInterface) {
+                    if (!$calculator instanceof ClassDefinition\CalculatorClassInterface) {
                         Logger::error('Class does not exist or is not valid: ' . $className);
 
                         return null;


### PR DESCRIPTION
In the DataObject if there is a calculated field with option of calculation class.
The calculation does not happen and the field always shows blank.
The root of the cause is in the service.php file.

The calculated field function, has the checking condition of class instance wrong. 
So the code execution always created and error and would NULL.


<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves # DataObject Calculated field result

