### PR TITLE
[Sites] Do not throw exception on missing documents permission when loading sites on startup

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/ClassController.php
@@ -31,6 +31,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -91,8 +92,14 @@ class ClassController extends AdminAbstractController implements KernelControlle
      */
     public function getTreeAction(Request $request)
     {
-        // we need to check objects permission for listing in pimcore.model.objecttypes ext model
-        $this->checkPermission('objects');
+        try {
+            // we need to check objects permission for listing in pimcore.model.objecttypes ext model
+            $this->checkPermission('objects');
+        } catch (AccessDeniedHttpException $e) {
+            Logger::log('[Startup] Object types are not loaded as "objects" permission is missing');
+            //return empty string to avoid error on startup
+            return $this->adminJson([]);
+        }
 
         $defaultIcon = '/bundles/pimcoreadmin/img/flat-color-icons/class.svg';
 


### PR DESCRIPTION


  

## Changes in this pull request  
Follow up to #15530

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 686ee13</samp>

Fixed a bug in `SettingsController` that prevented users without site permissions from accessing the admin interface. Improved error handling and logging for `getAvailableSitesAction`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 686ee13</samp>

> _No site permissions, no way to start_
> _A bug of doom that breaks your heart_
> _But `getAvailableSitesAction` is here to save the day_
> _With logging and exception handling, it clears the way_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 686ee13</samp>

* Import and use `Logger` class to log messages ([link](https://github.com/pimcore/pimcore/pull/15668/files?diff=unified&w=0#diff-ea06636172bbd5182617cdd5e57da91c132fe16c02e481a32191c1462639a083R28), [link](https://github.com/pimcore/pimcore/pull/15668/files?diff=unified&w=0#diff-ea06636172bbd5182617cdd5e57da91c132fe16c02e481a32191c1462639a083L1072-R1081))
* Import and handle `AccessDeniedHttpException` in `getAvailableSitesAction` method ([link](https://github.com/pimcore/pimcore/pull/15668/files?diff=unified&w=0#diff-ea06636172bbd5182617cdd5e57da91c132fe16c02e481a32191c1462639a083R50), [link](https://github.com/pimcore/pimcore/pull/15668/files?diff=unified&w=0#diff-ea06636172bbd5182617cdd5e57da91c132fe16c02e481a32191c1462639a083L1072-R1081))
* Return empty array instead of error in `getAvailableSitesAction` method to fix startup bug ([link](https://github.com/pimcore/pimcore/pull/15668/files?diff=unified&w=0#diff-ea06636172bbd5182617cdd5e57da91c132fe16c02e481a32191c1462639a083L1072-R1081))
