### PR TITLE
Relations: Wrong return php docs

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -41,7 +41,7 @@ trait Relation
                 $resolver = \Pimcore::getContainer()->get('pimcore.class.resolver.document');
                 foreach ($documentTypes as $item) {
                     if ($className = $this->resolveClassName($factory, $resolver, $item['documentTypes'])) {
-                        $types[] = $className;
+                        $types[] = '\\' . $className;
                     }
                 }
             } else {
@@ -57,7 +57,7 @@ trait Relation
                 $resolver = \Pimcore::getContainer()->get('pimcore.class.resolver.asset');
                 foreach ($assetTypes as $item) {
                     if ($className = $this->resolveClassName($factory, $resolver, $item['assetTypes'])) {
-                        $types[] = $className;
+                        $types[] = '\\' . $className;
                     }
                 }
             } else {

--- a/models/DataObject/ClassDefinition/Data/Extension/Relation.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/Relation.php
@@ -41,7 +41,10 @@ trait Relation
                 $resolver = \Pimcore::getContainer()->get('pimcore.class.resolver.document');
                 foreach ($documentTypes as $item) {
                     if ($className = $this->resolveClassName($factory, $resolver, $item['documentTypes'])) {
-                        $types[] = '\\' . $className;
+                        if (str_starts_with($className, '\\') === false) {
+                            $className = '\\' . $className;
+                        }
+                        $types[] = $className;
                     }
                 }
             } else {
@@ -57,7 +60,10 @@ trait Relation
                 $resolver = \Pimcore::getContainer()->get('pimcore.class.resolver.asset');
                 foreach ($assetTypes as $item) {
                     if ($className = $this->resolveClassName($factory, $resolver, $item['assetTypes'])) {
-                        $types[] = '\\' . $className;
+                        if (str_starts_with($className, '\\') === false) {
+                            $className = '\\' . $className;
+                        }
+                        $types[] = $className;
                     }
                 }
             } else {


### PR DESCRIPTION
The php docs have no `\` sign at the beginning.

Before:
```
/**
* Get relationField - classtest.relationField
* @return Pimcore\Bundle\PersonalizationBundle\Model\Document\Page[]
*/
```

After:
```
/**
* Get relationField - classtest.relationField
* @return \Pimcore\Bundle\PersonalizationBundle\Model\Document\Page[]
*/
```