### PR TITLE
[Thumbnails] WebP support was accidentically(?) removed

### DIFF
--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -145,6 +145,11 @@ class Processor
         }
 
         $image = Asset\Image::getImageTransformInstance();
+
+        if ($optimizedFormat && isset(Config::getAutoFormats()['webp'])) {
+            $format = 'webp';
+        }
+
         $thumbDir = rtrim($asset->getRealPath(), '/').'/'.$asset->getId().'/image-thumb__'.$asset->getId().'__'.$config->getName();
         $filename = preg_replace("/\." . preg_quote(pathinfo($asset->getFilename(), PATHINFO_EXTENSION), '/') . '$/i', '', $asset->getFilename());
 

--- a/models/Asset/Image/Thumbnail/Processor.php
+++ b/models/Asset/Image/Thumbnail/Processor.php
@@ -417,7 +417,7 @@ class Processor
                     }
                 }
 
-                if ($optimizedFormat) {
+                if ($optimizedFormat && !isset(Config::getAutoFormats()['webp'])) {
                     $format = $image->getContentOptimizedFormat();
                 }
 


### PR DESCRIPTION
Steps to reproduce bug:

0. Assure that config `bin/console debug:config pimcore assets.image.thumbnails.auto_formats.webp.enabled` returns true, otherwise enable it
1. Create thumbnail definition `webp` with format=`Auto (Web-optimized - recommended)` and enable `List as option in download section on image detail view` in advanced settings
2. Upload an image, e.g. 
![automotive-car-classic-149813(1)](https://github.com/pimcore/pimcore/assets/8749138/7d5fb82f-5a5f-4ea2-aee9-19d49558a70d)
3. Download the image thumbnail with definition `webp` on the right side under "Download thumbnail".

Expected behaviour: You should get a *.webp file

Current behaviour: A *JPG* file gets provided for download.

Expected behaviour: A *WebP* file gets provided for download.
Cause:
`Auto (Web-optimized - recommended)` means `$format = 'source'` in https://github.com/pimcore/pimcore/blob/0cee68048c70ac9696c2a8ba195fb26b596a9467/models/Asset/Image/Thumbnail/Processor.php#L106-L112 
And there the format gets set to `pjpeg`. And in the following code this never gets set to `webp`. In the past this existed in https://github.com/pimcore/pimcore/blob/9abfc484d0a17516bd4c65cf336c59a6a510ec1d/models/Asset/Image/Thumbnail/Processor.php#L143-L145 but it got removed during a merge in https://github.com/pimcore/pimcore/commit/05d3ad303948939aa9723736ee0d71f586afad13#diff-16840b1fd40929e8fda46a67eae733c84fc71dc91da6a38097ba58b5da0c321c - somehow this is not shown in Github but in PhpStorm this merge looks like this:
<img width="1546" alt="Bildschirmfoto 2023-08-03 um 11 26 54" src="https://github.com/pimcore/pimcore/assets/8749138/b6455029-fb31-44e2-9fe4-c3ec79a2f8f8">