### PR TITLE
Update README.md: correct type in "Event API and Event Manger"

### DIFF
--- a/doc/20_Extending_Pimcore/README.md
+++ b/doc/20_Extending_Pimcore/README.md
@@ -22,7 +22,7 @@ Following a list of ways to extend Pimcore. See detail pages for additional info
 * [**Parent Class for Objects**](./07_Parent_Class_for_Objects.md) to inject additional functionality
  to Pimcore object classes. 
  
-* [**Event API and Event Manger**](../20_Extending_Pimcore/11_Event_API_and_Event_Manager.md) for hooking into standard
+* [**Event API and Event Manager**](../20_Extending_Pimcore/11_Event_API_and_Event_Manager.md) for hooking into standard
  Pimcore functions like creating, updating, deleting elements etc. 
  
 * Use [**Maintenance Mode**](./15_Maintenance_Mode.md) to show users a maintenance page when 


### PR DESCRIPTION
Correct type in "Event API and Event Manger"

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f0f1ca</samp>

Fixed a typo in the Extending Pimcore documentation. The link text for the Event API and Event Manager section now correctly spells `Manager` instead of `Manger`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1f0f1ca</samp>

> _`Manger` no more_
> _Link text corrected with care_
> _Winter of typos_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f0f1ca</samp>

* Fix a typo in the link text for the Event API and Event Manager documentation ([link](https://github.com/pimcore/pimcore/pull/15677/files?diff=unified&w=0#diff-df30cad7dec525f501b91ef1575041bd0c34ad6112e878355713b5da2d0612c2L25-R25))
