### PR TITLE
Remove addition of inheritedCount to maxItems

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/objectbricks.js
@@ -242,7 +242,7 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
                 this.inheritedCount++;
             }
 
-            if (this.fieldConfig.maxItems && this.getCurrentElementsCount() >= this.fieldConfig.maxItems + this.inheritedCount) {
+            if (this.fieldConfig.maxItems && this.getCurrentElementsCount() >= this.fieldConfig.maxItems) {
                 Ext.Msg.alert(t("error"), t("limit_reached"));
                 return;
             }


### PR DESCRIPTION
### Situation

- Make a DataObject Class and add the possibility to add ObjectBricks. 
- Set the Limit (e.g. 1) of ObjectBricks can added to ObjectBrick Container. 
- Activate inheritance on DataObject Class. 
- Create Parent and Child.
- Add Object Brick to Parent Object
- Open Child
- Add second Object Brick to Container with Limit 1

### Behaviour

Can add additional ObjectBricks over the set limit on childs

### Expected Behaviour

Can NOT add additional ObjectBricks over the set limit on childs

### Console Log:
![Bildschirmfoto 2023-08-03 um 10 57 47](https://github.com/pimcore/pimcore/assets/131146705/e8551bc1-702d-4594-bb9a-184fd21df6c2)