### PR TITLE
Fix saving problem with classification-store fields inside object issue.

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Classificationstore.php
+++ b/models/DataObject/ClassDefinition/Data/Classificationstore.php
@@ -304,9 +304,9 @@ class Classificationstore extends Data implements CustomResourcePersistingInterf
             $classificationStore = new DataObject\Classificationstore();
         }
 
-        $data = $data['data'];
         $activeGroups = $data['activeGroups'] ?? [];
         $groupCollectionMapping = $data['groupCollectionMapping'] ?? [];
+        $data = $data['data'];
 
         $correctedMapping = [];
 


### PR DESCRIPTION
Reproduce error:
- Add a classification-store “group” and enter some data → save → reload
- Add another classification-store “group” and enter some data to this → save → reload => first added “group” has vanished
- Add another classification-store “group” but don’t add any data to this → save → reload => both “groups” has vanished

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
models/DataObject/ClassDefinition/Data/Classificationstore.php: 307-309

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a350bc5</samp>

Fixed a notice in `Classificationstore` data type when data is missing. Changed the order of assignments in `models/DataObject/ClassDefinition/Data/Classificationstore.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a350bc5</samp>

> _`$data['data']`_
> _Avoid notice, fix the bug_
> _Winter of errors_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a350bc5</samp>

* Fix a notice when `$data['data']` is not set by changing the order of the assignments in `getDataFromResource()` ([link](https://github.com/pimcore/pimcore/pull/15684/files?diff=unified&w=0#diff-d5e2db6cf7e1d7b788bc054ec65949fa41b9524e600aff4655231db843024f89L307-R309))
