### PR TITLE
[Task]: Avoid collation change when renaming o_type

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20221003115124.php
+++ b/bundles/CoreBundle/src/Migrations/Version20221003115124.php
@@ -31,7 +31,7 @@ final class Version20221003115124 extends AbstractMigration
     {
         $this->addSql('ALTER TABLE objects CHANGE o_id id int(11) unsigned auto_increment NOT NULL;');
         $this->addSql('ALTER TABLE objects CHANGE o_parentId parentId int(11) unsigned DEFAULT NULL NULL;');
-        $this->addSql("ALTER TABLE objects CHANGE o_type `type` enum('object','folder','variant') CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL NULL;");
+        $this->addSql("ALTER TABLE objects CHANGE o_type `type` enum('object','folder','variant') DEFAULT NULL NULL;");
         $this->addSql("ALTER TABLE objects CHANGE o_key `key` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin DEFAULT '' NULL;");
         $this->addSql('ALTER TABLE objects CHANGE o_path `path` varchar(765) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin DEFAULT NULL NULL;');
         $this->addSql('ALTER TABLE objects CHANGE o_index `index` int(11) unsigned DEFAULT 0 NULL;');
@@ -71,7 +71,7 @@ final class Version20221003115124 extends AbstractMigration
     {
         $this->addSql('ALTER TABLE objects CHANGE id o_id int(11) unsigned auto_increment NOT NULL;');
         $this->addSql('ALTER TABLE objects CHANGE parentId o_parentId int(11) unsigned DEFAULT NULL NULL;');
-        $this->addSql("ALTER TABLE objects CHANGE `type` `o_type` enum('object','folder','variant') CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL NULL;");
+        $this->addSql("ALTER TABLE objects CHANGE `type` `o_type` enum('object','folder','variant') DEFAULT NULL NULL;");
         $this->addSql("ALTER TABLE objects CHANGE `key` `o_key` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin DEFAULT '' NULL;");
         $this->addSql('ALTER TABLE objects CHANGE `path` `o_path` varchar(765) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin DEFAULT NULL NULL;');
         $this->addSql('ALTER TABLE objects CHANGE `index` `o_index` int(11) unsigned DEFAULT 0 NULL;');


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15647

## Additional info
See https://github.com/pimcore/pimcore/issues/15647#issuecomment-1665586075 , if the tables collations are somehow different, then it would break. The migration shouldn't be changing them and let the default table/db collation take care of it. Alternatively, it should change for every other table (assets,documents,object_relations_*) retroactively as well but that's not the purpose of that migration

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5401b46</samp>

This pull request updates a migration script to rename some columns of the `objects` table and fix the character set and collation of the `type` column. This improves the database schema consistency and compatibility.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5401b46</samp>

> _Oh we're the brave developers of the `objects` table_
> _We'll rename the columns and make the schema stable_
> _We'll drop and add the `type` with a clever migration script_
> _And we'll heave away and haul away and hope the tests don't trip_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5401b46</samp>

*  Rename the columns `o_type`, `o_key`, `o_path`, and `o_index` of the `objects` table to `type`, `key`, `path`, and `index`, respectively, to make them consistent with the rest of the database schema ([link](https://github.com/pimcore/pimcore/pull/15696/files?diff=unified&w=0#diff-e9d8683f1f55005a75f458146bb9ec54da64b3a62e6a43a2340a7829e2ee2fe1L34-R34),[link](https://github.com/pimcore/pimcore/pull/15696/files?diff=unified&w=0#diff-e9d8683f1f55005a75f458146bb9ec54da64b3a62e6a43a2340a7829e2ee2fe1L74-R74))
