### PR TITLE
Allow realName to be null in Editable

### DIFF
--- a/models/Document/Editable.php
+++ b/models/Document/Editable.php
@@ -54,7 +54,7 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
      *
      * @internal
      */
-    protected string $realName = '';
+    protected ?string $realName = '';
 
     /**
      * Contains parent hierarchy names (used when building elements inside a block/areablock hierarchy)
@@ -325,10 +325,6 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
      */
     public function addConfig(string $name, mixed $value): static
     {
-        if (!is_array($this->config)) {
-            $this->config = [];
-        }
-
         $this->config[$name] = $value;
 
         return $this;
@@ -336,7 +332,7 @@ abstract class Editable extends Model\AbstractModel implements Model\Document\Ed
 
     public function getRealName(): string
     {
-        return $this->realName;
+        return $this->realName ?? '';
     }
 
     public function setRealName(string $realName): void


### PR DESCRIPTION
Same as in #15709 but with proper base
  

## Changes in this pull request  
Resolves #

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee7e13e</samp>

Improved PHP 8.0 compatibility and code quality of the `Editable` class in `models/Document/Editable.php`. Fixed potential null pointer issues with `$realName` property.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ee7e13e</samp>

> _`Editable` class_
> _refactored for PHP eight_
> _autumn of strict types_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee7e13e</samp>

*  Allow null values for `$realName` property of `Editable` class to support PHP 8.0 strict typing ([link](https://github.com/pimcore/pimcore/pull/15713/files?diff=unified&w=0#diff-629c3ab163921129218936956cf2db0761d23c958f2b554ad5e5225acc699cd8L57-R57))
*  Simplify `addConfig` method of `Editable` class by removing redundant array check for `$this->config` ([link](https://github.com/pimcore/pimcore/pull/15713/files?diff=unified&w=0#diff-629c3ab163921129218936956cf2db0761d23c958f2b554ad5e5225acc699cd8L328-L331))
*  Prevent type error in `getRealName` method of `Editable` class by returning empty string instead of null ([link](https://github.com/pimcore/pimcore/pull/15713/files?diff=unified&w=0#diff-629c3ab163921129218936956cf2db0761d23c958f2b554ad5e5225acc699cd8L339-R335))
