### PR TITLE
[Docs] Add notice for deadlock issue on doctrine messenger transport

### DIFF
--- a/doc/Development_Documentation/01_Getting_Started/00_Installation.md
+++ b/doc/Development_Documentation/01_Getting_Started/00_Installation.md
@@ -68,7 +68,6 @@ have a look at the logs as a starting point when debugging installation issues.
 
 
 ## 5. Maintenance Cron Job
-
 Maintenance tasks are handled with Symfony Messenger. The `pimcore:maintenance` command will add the maintenance
 messages to the bus and runs them afterwards immediately from the queue. However, it is  recommended to set up independent
 workers that process the queues, by running `bin/console messenger:consume pimcore_core pimcore_maintenance pimcore_image_optimize` (using e.g.
@@ -88,23 +87,7 @@ the queue directly.
 
 Keep in mind, that the cron job has to run as the same user as the web interface to avoid permission issues (eg. `www-data`).
 
-### Handle Failed jobs
-If there are maintenance jobs that are failed in the processing, after defined retries they are discarded from the respective transport. 
-However, you can move the failed jobs to a new transport e.g. `pimcore_failed_jobs` instead of discarding them completely, with following config:
-```yaml
-framework:
-    messenger:
-        transports:
-            pimcore_failed_jobs:
-                dsn: "doctrine://default?queue_name=pimcore_failed_jobs&table_name=messenger_messages_pimcore_failed"
-
-            pimcore_core:
-                dsn: "doctrine://default?queue_name=pimcore_core"
-                failure_transport: pimcore_failed_jobs
-```
-which can be re-processed later after fixing the underlying issue with command `bin/console messenger:consume pimcore_failed_jobs`.
-
-Please follow the [Symfony docs](https://symfony.com/doc/current/messenger.html#saving-retrying-failed-messages) for options on failed jobs processing.
+Read more about the maintenance tasks here: [Maintenance Tasks](./08_Maintenance_Tasks.md)
 
 ## 6. Additional Information & Help
 

--- a/doc/Development_Documentation/01_Getting_Started/08_Maintenance_Tasks.md
+++ b/doc/Development_Documentation/01_Getting_Started/08_Maintenance_Tasks.md
@@ -1,0 +1,24 @@
+### Doctrine Transport
+Pimcore ships with a Doctrine Transport for the Messenger component. This is done to reduce the dependencies and get the setup running more quickly.
+If you are using Doctrine Transport for your maintenance jobs, you might face deadlock issue when running multiple workers.
+We recommend to use a proper message queue like RabbitMQ or Redis for production environments. 
+
+Read more Symfony Messenger Transports [here](https://symfony.com/doc/current/messenger.html#transport-configuration).
+
+### Handle Failed jobs
+If there are maintenance jobs that are failed in the processing, after defined retries they are discarded from the respective transport.
+However, you can move the failed jobs to a new transport e.g. `pimcore_failed_jobs` instead of discarding them completely, with following config:
+```yaml
+framework:
+    messenger:
+        transports:
+            pimcore_failed_jobs:
+                dsn: "doctrine://default?queue_name=pimcore_failed_jobs&table_name=messenger_messages_pimcore_failed"
+
+            pimcore_core:
+                dsn: "doctrine://default?queue_name=pimcore_core"
+                failure_transport: pimcore_failed_jobs
+```
+which can be re-processed later after fixing the underlying issue with command `bin/console messenger:consume pimcore_failed_jobs`.
+
+Please follow the [Symfony docs](https://symfony.com/doc/current/messenger.html#saving-retrying-failed-messages) for options on failed jobs processing.


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15698

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5672743</samp>

This pull request enhances the installation documentation by creating a new section on maintenance tasks and fixing a formatting issue. It also explains how to deal with failed jobs and doctrine transport in `08_Maintenance_Tasks.md`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5672743</samp>

> _To install the app with no hassle_
> _The docs had to fix a small tassel_
> _They moved maintenance tasks_
> _To `08_Maintenance_Tasks`_
> _And explained failed jobs and doctrine `transport`_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5672743</samp>

*  Remove empty code block from installation documentation ([link](https://github.com/pimcore/pimcore/pull/15714/files?diff=unified&w=0#diff-d875910eed5015570bbe4577091b0fad971b2eba0f929c2809dcf81d8fdb3b8eL71))
*  Refactor content about handling failed jobs and doctrine transport to a new file `08_Maintenance_Tasks.md` ([link](https://github.com/pimcore/pimcore/pull/15714/files?diff=unified&w=0#diff-d875910eed5015570bbe4577091b0fad971b2eba0f929c2809dcf81d8fdb3b8eL91-R91), [link](https://github.com/pimcore/pimcore/pull/15714/files?diff=unified&w=0#diff-1e971c43fafe7683d16790619b29e96150ea9ac7da818e1b0c55062445216815R1-R24))
*  Add introductory text and link to Symfony messenger transports documentation in `08_Maintenance_Tasks.md` ([link](https://github.com/pimcore/pimcore/pull/15714/files?diff=unified&w=0#diff-1e971c43fafe7683d16790619b29e96150ea9ac7da818e1b0c55062445216815R1-R24))
