### PR TITLE
[Translations] Admins should be able to edit all languages in shared translations

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -592,10 +592,15 @@ final class User extends User\UserRole
     {
         if (null === $this->mergedWebsiteTranslationLanguagesView) {
             $this->mergedWebsiteTranslationLanguagesView = $this->getWebsiteTranslationLanguagesView();
-            foreach ($this->getRoles() as $role) {
-                /** @var User\UserRole $userRole */
-                $userRole = User\UserRole::getById($role);
-                $this->mergedWebsiteTranslationLanguagesView = array_merge($this->mergedWebsiteTranslationLanguagesView, $userRole->getWebsiteTranslationLanguagesView());
+
+            if(!$this->isAdmin()) {
+                foreach ($this->getRoles() as $role) {
+                    /** @var User\UserRole $userRole */
+                    $userRole = User\UserRole::getById($role);
+                    $this->mergedWebsiteTranslationLanguagesView = array_merge($this->mergedWebsiteTranslationLanguagesView, $userRole->getWebsiteTranslationLanguagesView());
+                }
+            } else {
+                $this->mergedWebsiteTranslationLanguagesView = Tool::getValidLanguages();
             }
 
             $this->mergedWebsiteTranslationLanguagesView = array_values(array_unique($this->mergedWebsiteTranslationLanguagesView));


### PR DESCRIPTION
Steps to reproduce bug:

1. Set up languages `English` and `German` in system settings
1. Create role `Abc` with `language permissions` `English` to be editable:
    <img width="572" alt="Bildschirmfoto 2023-08-09 um 13 57 40" src="https://github.com/pimcore/pimcore/assets/8749138/78dc91fe-d54e-4041-ba6f-8560258a9a86">
3. Create user `Test` and assign role `Abc`
4. Log in with user `Test`, go to Tools -> Translations > Translations
    --> user is only able to edit English
5. Now change user `Test` to be an `admin`
6. Log in with user `Test` -> go to Tools -> Translations > Translations
    --> user is still only able to edit English

The cause is that role `Abc` is still assigned to the user in the database. First question: Is this a good idea or should we remove assigned roles for admins?

In https://github.com/pimcore/pimcore/blob/133bfbfa8542b9d55d6c9bd106e905e7001a6e34/models/User.php#L574-L575 the editable languages get fetched. As `$this->isAdmin()` is `true` we get forwarded to https://github.com/pimcore/pimcore/blob/133bfbfa8542b9d55d6c9bd106e905e7001a6e34/models/User.php#L592-L597 and there the languages of the role get fetched. In the above case this is only English. And so we do not get to the `isAdmin()` fallback case in https://github.com/pimcore/pimcore/blob/133bfbfa8542b9d55d6c9bd106e905e7001a6e34/models/User.php#L576-L578

With this PR admin users can edit all languages, independent of any previously set roles.