### PR TITLE
fix: disable login throttling on AdminSessionAuthenticator #15671

### DIFF
--- a/bundles/AdminBundle/RateLimiter/AdminRequestRateLimiter.php
+++ b/bundles/AdminBundle/RateLimiter/AdminRequestRateLimiter.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\AdminBundle\RateLimiter;
+
+use Pimcore\Bundle\AdminBundle\Security\Authenticator\AdminSessionAuthenticator;
+use Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\RateLimiter\Policy\NoLimiter;
+use Symfony\Component\RateLimiter\RateLimit;
+
+/**
+ * @internal
+ * Disables rate limit on the \Pimcore\Bundle\AdminBundle\Security\Authenticator\AdminSessionAuthenticator
+ */
+class AdminRequestRateLimiter implements RequestRateLimiterInterface
+{
+    public function __construct(
+        private RequestRateLimiterInterface $decorated,
+    ) {}
+
+    public function consume(Request $request): RateLimit
+    {
+        if ($request->attributes->get(AdminSessionAuthenticator::REQUEST_ATTRIBUTE_SESSION_AUTHENTICATED)) {
+            return (new NoLimiter())->consume();
+        }
+
+        return $this->decorated->consume($request);
+    }
+
+    public function reset(Request $request): void
+    {
+        if ($request->attributes->get(AdminSessionAuthenticator::REQUEST_ATTRIBUTE_SESSION_AUTHENTICATED)) {
+            return;
+        }
+
+        $this->decorated->reset($request);
+    }
+}

--- a/bundles/AdminBundle/Resources/config/security_services.yaml
+++ b/bundles/AdminBundle/Resources/config/security_services.yaml
@@ -36,6 +36,13 @@ services:
             version: '10.6'
             message: 'The "%service_id%" service is deprecated and will be removed in Pimcore 11.'
 
+    # Decorate RequestRateLimiter to skip rate limiting on the AdminSessionAuthenticator
+    Pimcore\Bundle\AdminBundle\RateLimiter\AdminRequestRateLimiter:
+        decorates: security.login_throttling.pimcore_admin.limiter
+        # The rate limiter is not available when "enable_authenticator_manager" is not enabled within the application,
+        # ignore our decorator in that case
+        decoration_on_invalid: ignore
+
     # Authenticators for handling admin login and session authentications
     Pimcore\Bundle\AdminBundle\Security\Authenticator\AdminLoginAuthenticator:
         public: false

--- a/bundles/AdminBundle/Security/Authenticator/AdminSessionAuthenticator.php
+++ b/bundles/AdminBundle/Security/Authenticator/AdminSessionAuthenticator.php
@@ -31,6 +31,8 @@ use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPasspor
  */
 class AdminSessionAuthenticator extends AdminAbstractAuthenticator
 {
+    public const REQUEST_ATTRIBUTE_SESSION_AUTHENTICATED = '_pimcore_admin_session_authenticated';
+
     /**
      * @var User|null
      */
@@ -63,6 +65,10 @@ class AdminSessionAuthenticator extends AdminAbstractAuthenticator
         $badges = [
             new PreAuthenticatedUserBadge(),
         ];
+
+        // Mark request as "session authenticated" to prevent login throttling
+        /** @see \Pimcore\Bundle\AdminBundle\RateLimiter\AdminRequestRateLimiter */
+        $request->attributes->set(static::REQUEST_ATTRIBUTE_SESSION_AUTHENTICATED, true);
 
         return new SelfValidatingPassport(
             new UserBadge($this->user->getUsername()),


### PR DESCRIPTION
## Changes in this pull request  
Resolves #15671

## Additional info
@dvesh3 @dpfaffenbauer I saw your discussion going on within the issue and was able to reproduce this bug. I also already noticed this issue on one of our production environments so for me fixing this had some priority. Decorating the rate limiter service can fix this bug. Because Symfony creates a rate limiter per firewall, these changes only affects the "pimcore_admin" firewall.

Tested with both "enable_authenticator_manager: true" as the legacy authenticator