### PR TITLE
Dispatch InstallerStepEvent 'complete'

### DIFF
--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -454,6 +454,7 @@ class Installer
         $this->markMigrationsAsDone();
 
         $this->clearKernelCacheDir($kernel);
+        $this->dispatchStepEvent('complete');
 
         return $errors;
     }


### PR DESCRIPTION
'complete' is [already defined in Installer::stepEvents](https://github.com/pimcore/pimcore/blob/a29dcebb3232e26078c018d6e435c823e14bcf4b/bundles/InstallBundle/src/Installer.php#L152) but never dispatched.
I added the event after everything is done and the cache cleared as a suggestion.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a29dceb</samp>

Dispatch a `complete` event after installation in `Installer.php`. This enables custom post-installation actions by other listeners.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a29dceb</samp>

> _`complete` event_
> _after installation done_
> _autumn leaves fall_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a29dceb</samp>

* Dispatch 'complete' event after installation ([link](https://github.com/pimcore/pimcore/pull/15719/files?diff=unified&w=0#diff-4eee5188dd424c74c2215a7595b21d4bde4443e3732f5b86d71484393076c498R457))
* Add event constants and docblocks to InstallerEvents class ([link](https://github.com/pimcore/pimcore/pull/15719/files?diff=unified&w=0#diff-4eee5188dd424c74c2215a7595b21d4bde4443e3732f5b86d71484393076c498R457))
