### PR TITLE
[Bug]: Fix text selection support on disabled field text

### DIFF
--- a/bundles/AdminBundle/Resources/public/css/ext-modifications.css
+++ b/bundles/AdminBundle/Resources/public/css/ext-modifications.css
@@ -665,12 +665,10 @@ body > .x-mask {
     z-index: 1;
 }
 
-/* Ext override for making disabled fields show tooltip on mouseover - should be fixed in 6.2.0 */
-.x-item-disabled, .x-item-disabled * {
+.x-item-disabled *:not(.x-mask) {
     cursor: default;
-    pointer-events: all !important; /* enables tooltip for disabled elements */
+    pointer-events: auto!important;
 }
-
 
 /** ExtJS7 changes starting from here */
 /* base color is #5fa2dd */

--- a/bundles/AdminBundle/Resources/public/css/ext-modifications.css
+++ b/bundles/AdminBundle/Resources/public/css/ext-modifications.css
@@ -665,6 +665,7 @@ body > .x-mask {
     z-index: 1;
 }
 
+/* Ext override for making the text in disabled fields selectable */
 .x-item-disabled *:not(.x-mask) {
     cursor: default;
     pointer-events: auto!important;


### PR DESCRIPTION
Alternative to https://github.com/pimcore/admin-ui-classic-bundle/pull/190, https://github.com/pimcore/admin-ui-classic-bundle/pull/191

We are on ExtJS 7, so former workaround tips are not useful anymore, however all beside the `.x-mask` need to be changed to be able to click through. 
`point-events` value set as `all` is [only for SVG.](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events#:~:text=pointer%2Devents%3A%20all%3B%20/*%20SVG%20only%20*/)


## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9ba251c</samp>

Fix CSS selector for disabled elements in ExtJS 7. This change allows clicking on buttons or links that are covered by a loading mask in the admin UI.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9ba251c</samp>

> _`mask` element hides_
> _but does not disable clicks_
> _autumn leaves fall through_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9ba251c</samp>

*  Exclude the mask element from the disabled CSS selector to prevent blocking mouse events of underlying elements ([link](https://github.com/pimcore/pimcore/pull/15720/files?diff=unified&w=0#diff-8a24c4478e68925c664ead8ef431cc17cdcce5144de82e947f3d0d2b7f09fa50L668-R672))
