### PR TITLE
Install required bundles if '--install-bundles' list is empty

### DIFF
--- a/bundles/InstallBundle/src/Command/InstallCommand.php
+++ b/bundles/InstallBundle/src/Command/InstallCommand.php
@@ -115,6 +115,7 @@ class InstallCommand extends Command
             'install-bundles' => [
                 'description' => sprintf('Installable bundles: %s', $this->generateBundleDescription()),
                 'mode' => InputOption::VALUE_OPTIONAL,
+                'default' => false,
                 'group' => 'bundles',
             ],
         ];
@@ -195,9 +196,16 @@ class InstallCommand extends Command
         if ($input->getOption('skip-database-data-dump')) {
             $this->installer->setImportDatabaseDataDump(false);
         }
-        if ($input->getOption('install-bundles')) {
+        $bundleOption = $input->getOption('install-bundles');
+        if (false !== $bundleOption) {
             $bundleSetupEvent = $this->installer->dispatchBundleSetupEvent();
-            $bundles = explode(',', $input->getOption('install-bundles'));
+            
+            if (null === $bundleOption) {
+                $bundles = [];
+            } else {
+                $bundles = explode(',', $bundleOption);
+            }
+            
             $installableBundles = $bundleSetupEvent->getInstallableBundles($bundles);
             $this->installer->setBundlesToInstall($installableBundles, $bundleSetupEvent->getAvailableBundles(), $bundleSetupEvent->getExcludeBundlesFromPhpBundles());
         }

--- a/doc/01_Getting_Started/02_Advanced_Installation_Topics/README.md
+++ b/doc/01_Getting_Started/02_Advanced_Installation_Topics/README.md
@@ -38,18 +38,22 @@ $ PIMCORE_INSTALL_MYSQL_USERNAME=username PIMCORE_INSTALL_MYSQL_PASSWORD=passwor
 
 ### Installing Bundles
 
-The `--install-bundles` flag will install and enable the specified bundles.  
-Attention: The bundles will be added to `config/bundles.php` automatically.
+#### Overview of Bundle Lists
 
-```bash
-./vendor/bin/pimcore-install --admin-username=admin --admin-password=admin \
---mysql-username=username --mysql-password=password --mysql-database=pimcore \
---mysql-host-socket=127.0.0.1 --mysql-port=3306 \
---install-bundles=PimcoreApplicationLoggerBundle,PimcoreCustomReportsBundle \
---no-interaction
-```
+When installing, you will [interact with](#modifying-required-bundles-and-bundle-recommendations) two lists of
+bundles: **Recommended Bundles** and **Required Bundles**.
 
-Available bundles for installation: 
+- **Recommended Bundles**:
+    - Displayed to users during interactive mode.
+    - These are the bundles users can specify when using the `--install-bundles=commaSeparatedBundleList` option.
+
+- **Required Bundles**:
+    - These bundles will automatically be installed in interactive mode, if the user choses to install bundles.
+    - They are installed whenever the `--install-bundles` option is set.
+
+#### Default Recommended Bundles
+
+By default, here's what's included in the Recommended Bundles list:
 
 - [PimcoreApplicationLoggerBundle](../../18_Tools_and_Features/17_Application_Logger.md)
 - [PimcoreCustomReportsBundle](../../18_Tools_and_Features/29_Custom_Reports.md)
@@ -62,11 +66,30 @@ Available bundles for installation:
 - PimcoreWordExportBundle (for import/export functionality for translations in Word format)
 - PimcoreXliffBundle (for import/export functionality for translations in Xliff format)
 
-#### Adding or Removing Bundles / Bundle Recommendations
-Before bundles are displayed in the installation process, the `BundleSetupEvent` is fired.
-You can listen or subscribe to this event to add/remove bundles.
-Note that a recommendation will only be added if the bundle is already in the bundles list.
-For more info, you can take a look at the [Pimcore Skeleton](https://github.com/pimcore/skeleton) to see how the [Admin UI Classic Bundle](https://github.com/pimcore/admin-ui-classic-bundle) is installed.
+#### Automating Bundle Installation
+
+To install specific bundles automatically, use the `--install-bundles[=bundleList]` flag. This flag installs and
+activates all required bundles and any specified bundles, provided they are part of the recommended bundles list.
+
+**Note**: The bundles will be automatically added to `config/bundles.php`.
+
+```bash
+./vendor/bin/pimcore-install --admin-username=admin --admin-password=admin \
+--mysql-username=username --mysql-password=password --mysql-database=pimcore \
+--mysql-host-socket=127.0.0.1 --mysql-port=3306 \
+--install-bundles=PimcoreApplicationLoggerBundle,PimcoreCustomReportsBundle \
+--no-interaction
+```
+
+#### Modifying Required Bundles and Bundle Recommendations
+The `BundleSetupEvent` is triggered under two circumstances:
+
+1. To preset the installable (recommended) and automatically installed (required) bundles for the `--install-bundles` option.
+2. To modify a list of recommended bundles in interactive mode. Required bundles are not installed if the user declines to install bundles.
+
+By subscribing or listening to the `BundleSetupEvent`, you can add or remove bundles from the required or recommended lists.
+
+For practical examples, refer to the [Pimcore Skeleton](https://github.com/pimcore/skeleton). It shows how the [Admin UI Classic Bundle](https://github.com/pimcore/admin-ui-classic-bundle) is integrated.
 
 ```php
 <?php
@@ -91,7 +114,7 @@ class BundleSetupSubscriber implements EventSubscriberInterface
 
     public function bundleSetup(BundleSetupEvent $event): void
     {
-        // add installable bundle and recommend it
+        // make bundle installable (using --install-bundles) and recommend it in interactive installation
         $event->addInstallableBundle('PimcoreAdminBundle', PimcoreAdminBundle::class, true);
 
         // add required bundle


### PR DESCRIPTION
## Changes in this pull request  
With this change, the comma-separated bundle list for the option `--install-bundles` now is optional. If the list is empty, the installer will still install the required bundles. 

Before the change, `--install-bundles` with an empty list would not even install the required bundles, so it was ineffective.

I also rewrote the documentation on bundle installation (hopefully) for better clarity.

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4041403</samp>

This pull request enhances the bundle installation feature of the Pimcore setup process. It adds a new `install-bundles` option to the `InstallCommand` class, which lets the user control which bundles are installed. It also updates the `README.md` documentation to reflect the changes and clarify the bundle installation process.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4041403</samp>

> _`install-bundles` /_
> _Choose your Pimcore features /_
> _BundleSetupEvent_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4041403</samp>

*  Add a default value of `false` to the `install-bundles` option in the `InstallCommand` class ([link](https://github.com/pimcore/pimcore/pull/15722/files?diff=unified&w=0#diff-b2d6459dddd923201b6eba5251a26962ca98cb62a12750986a9223f5bb908c06R118))
*  Modify the logic of the `InstallCommand` class to handle the cases when the `install-bundles` option is `false` or `null` and dispatch the `bundleSetupEvent` to get the required bundles ([link](https://github.com/pimcore/pimcore/pull/15722/files?diff=unified&w=0#diff-b2d6459dddd923201b6eba5251a26962ca98cb62a12750986a9223f5bb908c06L198-R208))
*  Update the documentation in the `README.md` file to explain the new behavior of the `install-bundles` option and the concepts of recommended and required bundles ([link](https://github.com/pimcore/pimcore/pull/15722/files?diff=unified&w=0#diff-540c36629e2154d3a73b4979fa578e62f0ce60da1796a9f201781da62721d73fL41-R57), [link](https://github.com/pimcore/pimcore/pull/15722/files?diff=unified&w=0#diff-540c36629e2154d3a73b4979fa578e62f0ce60da1796a9f201781da62721d73fL65-R93), [link](https://github.com/pimcore/pimcore/pull/15722/files?diff=unified&w=0#diff-540c36629e2154d3a73b4979fa578e62f0ce60da1796a9f201781da62721d73fL94-R117))
