### PR TITLE
[Bug]: Fix multisite internal link when using document preview

### DIFF
--- a/doc/Development_Documentation/02_MVC/04_Routing_and_URLs/08_Working_with_Sites.md
+++ b/doc/Development_Documentation/02_MVC/04_Routing_and_URLs/08_Working_with_Sites.md
@@ -90,3 +90,6 @@ The functionality should be pretty self-explanatory:
 \Pimcore\Tool\Frontend::isDocumentInCurrentSite($document);
 \Pimcore\Tool\Frontend::isDocumentInSite($site, $document);
 ```
+
+#### Document Preview Navigation with Sites
+Please keep in mind that when previewing documents that have links to different Sites, the navigation may not be working properly due the Iframe Content Security Policies and Cross-origin resource sharing (CORS) policy, please set your own security rules accordingly to your own needs.

--- a/models/Document.php
+++ b/models/Document.php
@@ -869,12 +869,12 @@ class Document extends Element\AbstractElement
         if (!$link && Tool::isFrontend()) {
             $differentDomain = false;
             $site = FrontendTool::getSiteForDocument($this);
-            if ($site instanceof Site){
+            if (Tool::isFrontendRequestByAdmin() && $site instanceof Site){
                 $differentDomain = $site->getMainDomain() != $request->getHost();
             }
 
             if ((Site::isSiteRequest() && !FrontendTool::isDocumentInCurrentSite($this))
-                || (Tool::isFrontendRequestByAdmin() && $differentDomain)){
+                || $differentDomain){
                 if ($mainRequest && ($mainDocument = $mainRequest->get(DynamicRouter::CONTENT_KEY))) {
                     if ($mainDocument instanceof WrapperInterface) {
                         $hardlinkPath = '';


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15336

## Additional info
Since it's already working for the frontend without any issues, refining/loosing up the IF block conditions 
https://github.com/pimcore/pimcore/compare/10.6...fix-multisite-link?expand=1#diff-48235de7b392a4ff9ed273062d750e2732a5b1f8355cd76109abf4c5538a6c45L868  
does the trick.
`isDocumentInCurrentSite` defaults to `true` when not a siteRequest, which is the case when in main site backend 
https://github.com/pimcore/pimcore/blob/727ab1a73020f540ac1d2c12386292909e6b3125/lib/Tool/Frontend.php#L49

The rest is just indentation and some minor refactor
Added some documentation notes, since it may trigger unwanted CSP (Pimcore 11+) and CORS errors in console.


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab221b7</samp>

This pull request fixes a bug in the `getFullPath` function of the `Document` class that affected document links for different sites, and updates the documentation to warn users about the preview navigation issues when using sites with links. The changes improve the code quality and the user experience of the admin interface.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ab221b7</samp>

> _If you work with documents from sites_
> _You may face some previewing plights_
> _The docs warn of frames_
> _And CORS policy names_
> _That may block or distort your sights_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab221b7</samp>

*  Fix a bug that caused incorrect links to be generated for documents that are not part of the current site when previewing them from the admin interface ([link](https://github.com/pimcore/pimcore/pull/15724/files?diff=unified&w=0#diff-48235de7b392a4ff9ed273062d750e2732a5b1f8355cd76109abf4c5538a6c45L868-R918))
* Simplify and unify the code style by removing unnecessary namespace prefixes from the `Tool`, `Site`, and `Model` classes ([link](https://github.com/pimcore/pimcore/pull/15724/files?diff=unified&w=0#diff-48235de7b392a4ff9ed273062d750e2732a5b1f8355cd76109abf4c5538a6c45L844-R844), [link](https://github.com/pimcore/pimcore/pull/15724/files?diff=unified&w=0#diff-48235de7b392a4ff9ed273062d750e2732a5b1f8355cd76109abf4c5538a6c45L938-R946), [link](https://github.com/pimcore/pimcore/pull/15724/files?diff=unified&w=0#diff-48235de7b392a4ff9ed273062d750e2732a5b1f8355cd76109abf4c5538a6c45L966-R974))
* Assign the current request object to a variable `$request` for readability and consistency in the `getFullPath` function of `models/Document.php` ([link](https://github.com/pimcore/pimcore/pull/15724/files?diff=unified&w=0#diff-48235de7b392a4ff9ed273062d750e2732a5b1f8355cd76109abf4c5538a6c45R858))
* Add a new subsection to the documentation about working with sites, warning the users about the possible issues with document preview navigation when using different sites with links ([link](https://github.com/pimcore/pimcore/pull/15724/files?diff=unified&w=0#diff-cac7fbec00e9439520d8d17395810dfb9a5ddfc744ca386b50892c281b23f7c3R93-R95))
