### PR TITLE
[Bug]: Fix `pimcore:build:classes` requiring DB and Cache

### DIFF
--- a/bundles/CoreBundle/Command/ClassesDefinitionsBuildCommand.php
+++ b/bundles/CoreBundle/Command/ClassesDefinitionsBuildCommand.php
@@ -52,6 +52,8 @@ class ClassesDefinitionsBuildCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $cacheStatus = \Pimcore\Cache::isEnabled();
+        \Pimcore\Cache::disable();
         $objectClassesFolders = array_unique([PIMCORE_CLASS_DEFINITION_DIRECTORY, PIMCORE_CUSTOM_CONFIGURATION_CLASS_DEFINITION_DIRECTORY]);
 
         foreach ($objectClassesFolders as $objectClassesFolder) {
@@ -79,6 +81,9 @@ class ClassesDefinitionsBuildCommand extends AbstractCommand
             $this->collectionClassDumper->dumpPHPClass($fcDefinition);
         }
 
+        if ($cacheStatus){
+            \Pimcore\Cache::enable();
+        }
         return 0;
     }
 }

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -169,6 +169,26 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
         'unit' => 'varchar(64)',
     ];
 
+    public function __wakeup()
+    {
+        $this->init();
+    }
+
+    /**
+     * @internal
+     *
+     * @return TargetGroup
+     */
+    protected function init(): static
+    {
+        $options = $this->getValidUnits();
+        if (\Pimcore::inAdmin() || empty($options)) {
+            $this->configureOptions();
+        }
+
+        return $this;
+    }
+
     /**
      * @return string|int
      */
@@ -505,6 +525,8 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
      */
     public function getDataForResource($data, $object = null, $params = [])
     {
+        $this->init();
+
         $data = $this->handleDefaultValue($data, $object, $params);
 
         if ($data instanceof Model\DataObject\Data\AbstractQuantityValue) {
@@ -827,7 +849,9 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
     {
         $obj = parent::__set_state($data);
 
-        $obj->configureOptions();
+        if (\Pimcore::inAdmin()) {
+            $obj->configureOptions();
+        }
 
         return $obj;
     }

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -169,7 +169,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
         'unit' => 'varchar(64)',
     ];
 
-    public function __wakeup()
+    public function __wakeup(): void
     {
         $this->init();
     }

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -177,7 +177,7 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
     /**
      * @internal
      *
-     * @return TargetGroup
+     * @return $this
      */
     protected function init(): static
     {

--- a/models/DataObject/ClassDefinition/Data/QuantityValue.php
+++ b/models/DataObject/ClassDefinition/Data/QuantityValue.php
@@ -179,10 +179,10 @@ class QuantityValue extends Data implements ResourcePersistenceAwareInterface, Q
      *
      * @return $this
      */
-    protected function init(): static
+    private function init(): static
     {
         $options = $this->getValidUnits();
-        if (\Pimcore::inAdmin() || empty($options)) {
+        if (empty($options)) {
             $this->configureOptions();
         }
 

--- a/models/DataObject/ClassDefinition/Data/TargetGroup.php
+++ b/models/DataObject/ClassDefinition/Data/TargetGroup.php
@@ -30,6 +30,26 @@ class TargetGroup extends Model\DataObject\ClassDefinition\Data\Select
      */
     public $fieldtype = 'targetGroup';
 
+    public function __wakeup()
+    {
+        $this->init();
+    }
+
+    /**
+     * @internal
+     *
+     * @return TargetGroup
+     */
+    protected function init(): static
+    {
+        $options = $this->getOptions();
+        if (\Pimcore::inAdmin() || empty($options)) {
+            $this->configureOptions();
+        }
+
+        return $this;
+    }
+
     /**
      * @see ResourcePersistenceAwareInterface::getDataFromResource
      *
@@ -63,6 +83,7 @@ class TargetGroup extends Model\DataObject\ClassDefinition\Data\Select
      */
     public function getDataForResource($data, $object = null, $params = [])
     {
+        $this->init();
         if (!empty($data)) {
             try {
                 $this->checkValidity($data, true, $params);
@@ -123,8 +144,7 @@ class TargetGroup extends Model\DataObject\ClassDefinition\Data\Select
     public static function __set_state($data)
     {
         $obj = parent::__set_state($data);
-        $options = $obj->getOptions();
-        if (\Pimcore::inAdmin() || empty($options)) {
+        if (\Pimcore::inAdmin()) {
             $obj->configureOptions();
         }
 

--- a/models/DataObject/ClassDefinition/Data/TargetGroup.php
+++ b/models/DataObject/ClassDefinition/Data/TargetGroup.php
@@ -30,7 +30,7 @@ class TargetGroup extends Model\DataObject\ClassDefinition\Data\Select
      */
     public $fieldtype = 'targetGroup';
 
-    public function __wakeup()
+    public function __wakeup(): void
     {
         $this->init();
     }

--- a/models/DataObject/ClassDefinition/Data/TargetGroup.php
+++ b/models/DataObject/ClassDefinition/Data/TargetGroup.php
@@ -38,7 +38,7 @@ class TargetGroup extends Model\DataObject\ClassDefinition\Data\Select
     /**
      * @internal
      *
-     * @return TargetGroup
+     * @return $this
      */
     protected function init(): static
     {

--- a/models/DataObject/ClassDefinition/Data/TargetGroup.php
+++ b/models/DataObject/ClassDefinition/Data/TargetGroup.php
@@ -40,10 +40,10 @@ class TargetGroup extends Model\DataObject\ClassDefinition\Data\Select
      *
      * @return $this
      */
-    protected function init(): static
+    private function init(): static
     {
         $options = $this->getOptions();
-        if (\Pimcore::inAdmin() || empty($options)) {
+        if (empty($options)) {
             $this->configureOptions();
         }
 

--- a/models/DataObject/ClassDefinition/Data/TargetGroupMultiselect.php
+++ b/models/DataObject/ClassDefinition/Data/TargetGroupMultiselect.php
@@ -38,7 +38,7 @@ class TargetGroupMultiselect extends Model\DataObject\ClassDefinition\Data\Multi
     /**
      * @internal
      *
-     * @return TargetGroup
+     * @return $this
      */
     protected function init(): static
     {

--- a/models/DataObject/ClassDefinition/Data/TargetGroupMultiselect.php
+++ b/models/DataObject/ClassDefinition/Data/TargetGroupMultiselect.php
@@ -30,7 +30,7 @@ class TargetGroupMultiselect extends Model\DataObject\ClassDefinition\Data\Multi
      */
     public $fieldtype = 'targetGroupMultiselect';
 
-    public function __wakeup()
+    public function __wakeup(): void
     {
         $this->init();
     }

--- a/models/DataObject/ClassDefinition/Data/TargetGroupMultiselect.php
+++ b/models/DataObject/ClassDefinition/Data/TargetGroupMultiselect.php
@@ -30,6 +30,26 @@ class TargetGroupMultiselect extends Model\DataObject\ClassDefinition\Data\Multi
      */
     public $fieldtype = 'targetGroupMultiselect';
 
+    public function __wakeup()
+    {
+        $this->init();
+    }
+
+    /**
+     * @internal
+     *
+     * @return TargetGroup
+     */
+    protected function init(): static
+    {
+        $options = $this->getOptions();
+        if (\Pimcore::inAdmin() || empty($options)) {
+            $this->configureOptions();
+        }
+
+        return $this;
+    }
+
     /**
      * @internal
      */
@@ -61,12 +81,20 @@ class TargetGroupMultiselect extends Model\DataObject\ClassDefinition\Data\Multi
     public static function __set_state($data)
     {
         $obj = parent::__set_state($data);
-        $options = $obj->getOptions();
-        if (\Pimcore::inAdmin() || empty($options)) {
+        if (\Pimcore::inAdmin()) {
             $obj->configureOptions();
         }
 
         return $obj;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDataForResource($data, $object = null, $params = [])
+    {
+        $this->init();
+        return parent::getDataForResource($data, $object, $params);
     }
 
     /**

--- a/models/DataObject/ClassDefinition/Data/TargetGroupMultiselect.php
+++ b/models/DataObject/ClassDefinition/Data/TargetGroupMultiselect.php
@@ -40,10 +40,10 @@ class TargetGroupMultiselect extends Model\DataObject\ClassDefinition\Data\Multi
      *
      * @return $this
      */
-    protected function init(): static
+    private function init(): static
     {
         $options = $this->getOptions();
-        if (\Pimcore::inAdmin() || empty($options)) {
+        if (empty($options)) {
             $this->configureOptions();
         }
 


### PR DESCRIPTION
…options when on cli

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15520

## Additional info
Following https://github.com/pimcore/pimcore/pull/13752 approach and what's on `models/DataObject/ClassDefinition/Data/User.php`

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a10f63d</samp>

This pull request enhances the performance and reliability of several data object field types and the class definitions build command. It reduces unnecessary database queries, optimizes the initialization of options, and prevents cache issues by using serialization hooks and disabling the cache temporarily. It affects the files `ClassesDefinitionsBuildCommand.php`, `QuantityValue.php`, `TargetGroup.php`, and `TargetGroupMultiselect.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a10f63d</samp>

> _We are the masters of the cache_
> _We disable and restore with a flash_
> _We optimize the queries and the fields_
> _We unleash the power of the class definitions_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a10f63d</samp>

*  Disable and re-enable cache for class definitions build command ([link](https://github.com/pimcore/pimcore/pull/15726/files?diff=unified&w=0#diff-26ffe385bbb10aac34e10682fddb7958ce4ebb4375a578b885f653ac0c47334fR55-R56),[link](https://github.com/pimcore/pimcore/pull/15726/files?diff=unified&w=0#diff-26ffe385bbb10aac34e10682fddb7958ce4ebb4375a578b885f653ac0c47334fR84-R86))
*  Add `__wakeup` and `init` methods to `QuantityValue`, `TargetGroup`, and `TargetGroupMultiselect` classes to initialize options from database when unserialized ([link](https://github.com/pimcore/pimcore/pull/15726/files?diff=unified&w=0#diff-d2564b1d2701cc3ab300240f945b53cb21a2466232ad24ad2e5d75f10f5789faL172-R192),[link](https://github.com/pimcore/pimcore/pull/15726/files?diff=unified&w=0#diff-29d45b2bf798808223d848c490cedf99866bcfd2a11e3a2801a1495ce9bd94adL33-R53),[link](https://github.com/pimcore/pimcore/pull/15726/files?diff=unified&w=0#diff-3814f98239105bcbfdf441a881bfdf74bf58acf84ad6178813f4e5566caeb71eL33-R55))
*  Call `init` methods in `getDataForResource` methods of `QuantityValue`, `TargetGroup`, and `TargetGroupMultiselect` classes to ensure options are initialized before returning data ([link](https://github.com/pimcore/pimcore/pull/15726/files?diff=unified&w=0#diff-d2564b1d2701cc3ab300240f945b53cb21a2466232ad24ad2e5d75f10f5789faR528-R529),[link](https://github.com/pimcore/pimcore/pull/15726/files?diff=unified&w=0#diff-29d45b2bf798808223d848c490cedf99866bcfd2a11e3a2801a1495ce9bd94adR86),[link](https://github.com/pimcore/pimcore/pull/15726/files?diff=unified&w=0#diff-3814f98239105bcbfdf441a881bfdf74bf58acf84ad6178813f4e5566caeb71eR92-R100))
*  Modify `__set_state` methods of `QuantityValue`, `TargetGroup`, and `TargetGroupMultiselect` classes to only call `configureOptions` methods if in admin mode, to avoid unnecessary database queries when cached ([link](https://github.com/pimcore/pimcore/pull/15726/files?diff=unified&w=0#diff-d2564b1d2701cc3ab300240f945b53cb21a2466232ad24ad2e5d75f10f5789faL830-R854),[link](https://github.com/pimcore/pimcore/pull/15726/files?diff=unified&w=0#diff-29d45b2bf798808223d848c490cedf99866bcfd2a11e3a2801a1495ce9bd94adL126-R147),[link](https://github.com/pimcore/pimcore/pull/15726/files?diff=unified&w=0#diff-3814f98239105bcbfdf441a881bfdf74bf58acf84ad6178813f4e5566caeb71eL64-R84))
