### PR TITLE
Make the title and label translated in workflows

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/WorkflowController.php
+++ b/bundles/AdminBundle/Controller/Admin/WorkflowController.php
@@ -249,7 +249,7 @@ class WorkflowController extends AdminAbstractController implements KernelContro
             $globalActions = $actionsButtonService->getGlobalActions($workflow, $this->element);
 
             $data[] = [
-                'workflowName' => $workflowConfig->getLabel(),
+                'workflowName' =>  $this->translator->trans($workflowConfig->getLabel(), [], 'admin'),
                 'placeInfo' => $placeStatusInfo->getAllPalacesHtml($this->element, $workflow->getName()),
                 'graph' => $msg ?: '<a href="' . $url .'" target="_blank"><div class="workflow-graph-preview">'.$svg.'</div></a>',
                 'allowedTransitions' => $allowedTransitions,

--- a/bundles/CoreBundle/Resources/views/Workflow/statusinfo/allPlacesStatusInfo.html.twig
+++ b/bundles/CoreBundle/Resources/views/Workflow/statusinfo/allPlacesStatusInfo.html.twig
@@ -4,7 +4,7 @@
 <div>
     {% for place in places %}
 
-        <div class="pimcore-workflow-place-indicator" style="background-color: {{ place.backgroundColor }}; color:{{ place.fontColor }}; border: 1px solid {{ place.borderColor }};" title="{{ place.title }}">
+        <div class="pimcore-workflow-place-indicator" style="background-color: {{ place.backgroundColor }}; color:{{ place.fontColor }}; border: 1px solid {{ place.borderColor }};" title="{{ translator.trans(place.title,[],'admin') }}">
             {{ translator.trans(place.label,[],'admin') }}
         </div>
     {% endfor %}

--- a/bundles/CoreBundle/Resources/views/Workflow/statusinfo/toolbarStatusInfo.html.twig
+++ b/bundles/CoreBundle/Resources/views/Workflow/statusinfo/toolbarStatusInfo.html.twig
@@ -4,7 +4,7 @@
 <div class="pimcore-workflow-place-indicator-wrapper">
     {% for place in places %}
 
-        <div class="pimcore-workflow-place-indicator" style="background-color: {{ place.backgroundColor }}; color:{{ place.fontColor }}; border: 1px solid {{ place.borderColor }};"  title="{{ place.title }}">
+        <div class="pimcore-workflow-place-indicator" style="background-color: {{ place.backgroundColor }}; color:{{ place.fontColor }}; border: 1px solid {{ place.borderColor }};"  title="{{ translator.trans(place.title,[],'admin') }}">
             {{ translator.trans(place.label,[],'admin') }}
         </div>
     {% endfor %}


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves https://github.com/pimcore/pimcore/issues/15457

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dcbf2c0</samp>

Translate workflow and place labels using the `translator` service. This enables localization of the workflow UI in the admin panel and the status info components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at dcbf2c0</samp>

> _`translator` helps_
> _localize workflow labels_
> _autumn of changes_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dcbf2c0</samp>

*  Translate workflow name using `translator` service in `WorkflowController` ([link](https://github.com/pimcore/pimcore/pull/15736/files?diff=unified&w=0#diff-afe9eadf2a11eac75771a3dfbc96bbc953d86c128f8adbe99d303655cb72867fL252-R252))
*  Translate place label using `translator` service in twig templates for status info panel and toolbar status info ([link](https://github.com/pimcore/pimcore/pull/15736/files?diff=unified&w=0#diff-340a8445fd6c622e947ddfa69bc3e6e19df9ab69c583e36c95a79535a27dc057L7-R7), [link](https://github.com/pimcore/pimcore/pull/15736/files?diff=unified&w=0#diff-5b666172dce2dcb06013ceb3c9ca6b7bd716b79b0eb8d4716ba90908401bb962L7-R7))
