### PR TITLE
[Bug]: Fix Imagick compositeImage argument type error

### DIFF
--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -836,7 +836,7 @@ class Imagick extends Adapter
             }
 
             $newImage->evaluateImage(\Imagick::EVALUATE_MULTIPLY, $alpha, \Imagick::CHANNEL_ALPHA);
-            $this->resource->compositeImage($newImage, constant('Imagick::' . $composite), intval($x), intval($y));
+            $this->resource->compositeImage($newImage, constant('Imagick::' . $composite), (int)$x, (int)$y);
         }
 
         $this->postModify();

--- a/lib/Image/Adapter/Imagick.php
+++ b/lib/Image/Adapter/Imagick.php
@@ -836,7 +836,7 @@ class Imagick extends Adapter
             }
 
             $newImage->evaluateImage(\Imagick::EVALUATE_MULTIPLY, $alpha, \Imagick::CHANNEL_ALPHA);
-            $this->resource->compositeImage($newImage, constant('Imagick::' . $composite), $x, $y);
+            $this->resource->compositeImage($newImage, constant('Imagick::' . $composite), intval($x), intval($y));
         }
 
         $this->postModify();


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves `"Imagick::compositeImage(): Argument https://github.com/pimcore/pimcore/pull/3 ($x) must be of type int, float given".` It appears when creating thumbnail template with "Add Overlay (Imagick)" and "Origin: center"

Rebased PR of https://github.com/pimcore/pimcore/pull/15632


## Additional info
It's caused by `round()` always returning a [float](https://www.php.net/manual/en/function.round.php#:~:text=%E2%80%94%20Rounds%20a-,float,-Description%20%C2%B6) few [lines](https://github.com/pimcore/pimcore/pull/15738/files?w=1#diff-aa0869d1a589a6e48391adddef6c4e08b08dfb5c3943d560d758b7dd38bc1518R834-R835) above

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0cb488f</samp>

Cast float parameters to int for Imagick `compositeImage` method. This prevents a warning and improves compatibility with different Imagick versions in `lib/Image/Adapter/Imagick.php`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0cb488f</samp>

> _`$x` and `$y`_
> _cast to integers for Imagick_
> _autumn leaves no trace_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0cb488f</samp>

* Cast `$x` and `$y` parameters to integers to avoid Imagick warning ([link](https://github.com/pimcore/pimcore/pull/15738/files?diff=unified&w=0#diff-aa0869d1a589a6e48391adddef6c4e08b08dfb5c3943d560d758b7dd38bc1518L839-R839))
