### PR TITLE
Fix Codeception and PHP Stan errors

### DIFF
--- a/models/Asset/Thumbnail/ImageThumbnailInterface.php
+++ b/models/Asset/Thumbnail/ImageThumbnailInterface.php
@@ -34,13 +34,13 @@ interface ImageThumbnailInterface
      */
     public function reset(): void;
 
-    public function getWidth(): int;
+    public function getWidth(): ?int;
 
-    public function getHeight(): int;
+    public function getHeight(): ?int;
 
-    public function getRealWidth(): int;
+    public function getRealWidth(): ?int;
 
-    public function getRealHeight(): int;
+    public function getRealHeight(): ?int;
 
     public function getDimensions(): array;
 


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `10.5`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `10.5` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Follow up to https://github.com/pimcore/pimcore/pull/14337. 
The return type of methods getWidth(), getHeight(), getRealWidth() and getRealHeight() can include null also now. Please see https://github.com/pimcore/pimcore/pull/15680

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 386ee4e</samp>

Changed return types of some methods in `ImageThumbnailInterface` to allow for `null` values. This improves the support for SVG and vector thumbnails in Pimcore.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 386ee4e</samp>

> _`?int` returns_
> _SVG and vector thumbs_
> _cutting through winter_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 386ee4e</samp>

*  Change the return types of thumbnail methods to allow `null` values ([link](https://github.com/pimcore/pimcore/pull/15744/files?diff=unified&w=0#diff-814c207470253f1ab8640bbcb80aae44e3061b7061a904881ccfaaf0920d6327L37-R43)). This affects the `ImageThumbnailInterface` and all classes that implement it, such as `ImageThumbnail`, `SVGImageThumbnail`, and `VectorImageThumbnail`. This change enables more flexibility for thumbnails that do not have a fixed size, such as SVG or vector formats.
