### PR TITLE
[Bug]: Workflow and Dirty Element saving issues

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/elementservice.js
@@ -1022,10 +1022,26 @@ pimcore.elementservice.getWorkflowActionsButton = function(workflows, elementTyp
                     handler: function (workflow, transition) {
 
                         transition.isGlobalAction = false;
-                        if (transition.notes) {
-                            new pimcore.workflow.transitionPanel(elementType, elementId, elementEditor, workflow.name, transition);
-                        } else {
-                            pimcore.workflow.transitions.perform(elementType, elementId, elementEditor, workflow.name, transition);
+
+                        if(elementEditor.isDirty()) {
+                            Ext.Msg.confirm(t('warning'), t('you_have_unsaved_changes')
+                                + "<br />" + t("continue") + "?",
+                                function(btn){
+                                    if (btn === 'yes'){
+                                        if (transition.notes) {
+                                            new pimcore.workflow.transitionPanel(elementType, elementId, elementEditor, workflow.name, transition);
+                                        } else {
+                                            pimcore.workflow.transitions.perform(elementType, elementId, elementEditor, workflow.name, transition);
+                                        }
+                                    }
+                                }.bind(this)
+                            );
+                        }else {
+                            if (transition.notes) {
+                                new pimcore.workflow.transitionPanel(elementType, elementId, elementEditor, workflow.name, transition);
+                            } else {
+                                pimcore.workflow.transitions.perform(elementType, elementId, elementEditor, workflow.name, transition);
+                            }
                         }
 
 


### PR DESCRIPTION
## Changes in this pull request  
Potentially Resolves https://github.com/pimcore/pimcore/issues/15715

Asks for confirmation when detecting unsaved changes before proceeding any workflow transition

## Additional info

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eddd617</samp>

Add confirmation dialog for workflow transitions with unsaved changes. This improves the user experience and data integrity when using workflows for `elementservice.js`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at eddd617</samp>

> _`elementService`_
> _warns of unsaved changes - pause_
> _autumn leaves falling_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eddd617</samp>

* Add a confirmation dialog before performing a workflow transition if the element editor has unsaved changes ([link](https://github.com/pimcore/pimcore/pull/15745/files?diff=unified&w=0#diff-9d9bcbb5d9a089108c6e32c3b3885884382b70ce63550e82ddebbc81d33a39eeL1025-R1044))
